### PR TITLE
[diffusion] Job control: client request IDs, idempotent dispatch, status, and cancel

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -46,6 +46,7 @@ from sglang.multimodal_gen.runtime.managers.job_registry import (
     JobStatusReq,
     RequestCancelledError,
     RequestConflictError,
+    RequestOverloadedError,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
@@ -59,6 +60,15 @@ def _request_fingerprint(request: ImageGenerationsRequest) -> str:
     payload = request.model_dump(mode="json", exclude={"request_id"})
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(encoded).hexdigest()
+
+
+async def _process_image_batch(batch):
+    try:
+        return await process_generation_batch(async_scheduler_client, batch)
+    except (RequestCancelledError, RequestConflictError) as error:
+        raise HTTPException(status_code=409, detail=str(error)) from error
+    except RequestOverloadedError as error:
+        raise HTTPException(status_code=429, detail=str(error)) from error
 
 
 def _get_extra_field(request, field_name):
@@ -317,14 +327,7 @@ async def generations(
         # Add diffusers_kwargs if provided
         if request.diffusers_kwargs:
             batch.extra["diffusers_kwargs"] = request.diffusers_kwargs
-        try:
-            save_file_path_list, result = await process_generation_batch(
-                async_scheduler_client, batch
-            )
-        except RequestCancelledError as e:
-            raise HTTPException(status_code=409, detail=str(e))
-        except RequestConflictError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+        save_file_path_list, result = await _process_image_batch(batch)
         save_file_path = save_file_path_list[0]
         resp_format = (request.response_format or "b64_json").lower()
         if (
@@ -476,9 +479,7 @@ async def edits(
             sampling_params=sampling,
             external_trace_header=trace_headers,
         )
-        save_file_path_list, result = await process_generation_batch(
-            async_scheduler_client, batch
-        )
+        save_file_path_list, result = await _process_image_batch(batch)
         save_file_path = save_file_path_list[0]
         resp_format = (response_format or "b64_json").lower()
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -311,7 +311,6 @@ async def generations(
                 async_scheduler_client, batch
             )
         except RequestCancelledError as e:
-            # surface job cancellation as a structured conflict, not a bare 500
             raise HTTPException(status_code=409, detail=str(e))
         save_file_path = save_file_path_list[0]
         resp_format = (request.response_format or "b64_json").lower()
@@ -469,7 +468,6 @@ async def edits(
                 async_scheduler_client, batch
             )
         except RequestCancelledError as e:
-            # surface job cancellation as a structured conflict, not a bare 500
             raise HTTPException(status_code=409, detail=str(e))
         save_file_path = save_file_path_list[0]
         resp_format = (response_format or "b64_json").lower()
@@ -582,7 +580,6 @@ async def job_status(request_id: str):
 
 @router.delete("/jobs/{request_id}")
 async def cancel_job(request_id: str):
-    """DELETE-as-cancel: reaches queued jobs immediately and running denoise
-    work at the next step boundary."""
+    """Cancel a job by request id."""
     _require_job_control()
     return await async_scheduler_client.job_control(CancelReq(request_id=request_id))

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import contextlib
+import hashlib
 import json
 import os
 import time
@@ -25,6 +26,7 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
     ImageGenerationsRequest,
     ImageResponse,
     ImageResponseData,
+    JobRequestId,
 )
 from sglang.multimodal_gen.runtime.entrypoints.openai.storage import cloud_storage
 from sglang.multimodal_gen.runtime.entrypoints.openai.stores import IMAGE_STORE
@@ -43,6 +45,7 @@ from sglang.multimodal_gen.runtime.managers.job_registry import (
     CancelReq,
     JobStatusReq,
     RequestCancelledError,
+    RequestConflictError,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
@@ -50,6 +53,12 @@ from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.srt.observability.trace import extract_trace_headers
 
 router = APIRouter(prefix="/v1/images", tags=["images"])
+
+
+def _request_fingerprint(request: ImageGenerationsRequest) -> str:
+    payload = request.model_dump(mode="json", exclude={"request_id"})
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
 
 
 def _get_extra_field(request, field_name):
@@ -303,6 +312,8 @@ async def generations(
             sampling_params=sampling,
             external_trace_header=trace_headers,
         )
+        if request.request_id is not None:
+            batch.extra["job_request_fingerprint"] = _request_fingerprint(request)
         # Add diffusers_kwargs if provided
         if request.diffusers_kwargs:
             batch.extra["diffusers_kwargs"] = request.diffusers_kwargs
@@ -311,6 +322,8 @@ async def generations(
                 async_scheduler_client, batch
             )
         except RequestCancelledError as e:
+            raise HTTPException(status_code=409, detail=str(e))
+        except RequestConflictError as e:
             raise HTTPException(status_code=409, detail=str(e))
         save_file_path = save_file_path_list[0]
         resp_format = (request.response_format or "b64_json").lower()
@@ -463,12 +476,9 @@ async def edits(
             sampling_params=sampling,
             external_trace_header=trace_headers,
         )
-        try:
-            save_file_path_list, result = await process_generation_batch(
-                async_scheduler_client, batch
-            )
-        except RequestCancelledError as e:
-            raise HTTPException(status_code=409, detail=str(e))
+        save_file_path_list, result = await process_generation_batch(
+            async_scheduler_client, batch
+        )
         save_file_path = save_file_path_list[0]
         resp_format = (response_format or "b64_json").lower()
 
@@ -567,19 +577,38 @@ def _require_job_control() -> None:
     if not get_global_server_args().job_control_enabled:
         raise HTTPException(
             status_code=503,
-            detail="job control requires a single-rank scheduler in v1",
+            detail="job control is unavailable for this server configuration",
         )
 
 
+async def _job_control(request):
+    try:
+        reply = await async_scheduler_client.job_control(request)
+    except TimeoutError as e:
+        raise HTTPException(
+            status_code=504, detail="scheduler job-control channel timed out"
+        ) from e
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=503, detail="scheduler job-control channel is unavailable"
+        ) from e
+    if reply.get("error"):
+        raise HTTPException(status_code=503, detail=reply["error"])
+    return reply
+
+
 @router.get("/jobs/{request_id}")
-async def job_status(request_id: str):
+async def job_status(request_id: JobRequestId):
     """Observable job status from the scheduler's job-control channel."""
     _require_job_control()
-    return await async_scheduler_client.job_control(JobStatusReq(request_id=request_id))
+    return await _job_control(JobStatusReq(request_id=request_id))
 
 
 @router.delete("/jobs/{request_id}")
-async def cancel_job(request_id: str):
+async def cancel_job(request_id: JobRequestId):
     """Cancel a job by request id."""
     _require_job_control()
-    return await async_scheduler_client.job_control(CancelReq(request_id=request_id))
+    reply = await _job_control(CancelReq(request_id=request_id))
+    if reply.get("overloaded"):
+        raise HTTPException(status_code=429, detail="precancel capacity is exhausted")
+    return reply

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -6,7 +6,7 @@ import contextlib
 import json
 import os
 import time
-from typing import Any, List, Optional
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -39,6 +39,11 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     temp_dir_if_disabled,
 )
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.managers.job_registry import (
+    CancelReq,
+    JobStatusReq,
+    RequestCancelledError,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
@@ -234,7 +239,7 @@ async def generations(
     request: ImageGenerationsRequest,
     raw_request: Request,
 ):
-    request_id = generate_request_id()
+    request_id = request.request_id or generate_request_id()
     server_args = get_global_server_args()
     is_cosmos3 = "cosmos3" in (server_args.model_path or "").lower()
     ext = (
@@ -301,10 +306,13 @@ async def generations(
         # Add diffusers_kwargs if provided
         if request.diffusers_kwargs:
             batch.extra["diffusers_kwargs"] = request.diffusers_kwargs
-
-        save_file_path_list, result = await process_generation_batch(
-            async_scheduler_client, batch
-        )
+        try:
+            save_file_path_list, result = await process_generation_batch(
+                async_scheduler_client, batch
+            )
+        except RequestCancelledError as e:
+            # surface job cancellation as a structured conflict, not a bare 500
+            raise HTTPException(status_code=409, detail=str(e))
         save_file_path = save_file_path_list[0]
         resp_format = (request.response_format or "b64_json").lower()
         if (
@@ -365,31 +373,31 @@ async def generations(
 @router.post("/edits", response_model=ImageResponse)
 async def edits(
     raw_request: Request,
-    image: Optional[List[UploadFile]] = File(None),
-    image_array: Optional[List[UploadFile]] = File(None, alias="image[]"),
-    url: Optional[List[str]] = Form(None),
-    url_array: Optional[List[str]] = Form(None, alias="url[]"),
+    image: list[UploadFile] | None = File(None),
+    image_array: list[UploadFile] | None = File(None, alias="image[]"),
+    url: list[str] | None = Form(None),
+    url_array: list[str] | None = Form(None, alias="url[]"),
     prompt: str = Form(...),
-    mask: Optional[UploadFile] = File(None),
-    model: Optional[str] = Form(None),
-    n: Optional[int] = Form(1),
-    response_format: Optional[str] = Form(None),
-    size: Optional[str] = Form(None),
-    output_format: Optional[str] = Form(None),
-    background: Optional[str] = Form("auto"),
-    seed: Optional[int] = Form(None),
-    generator_device: Optional[str] = Form("cuda"),
-    user: Optional[str] = Form(None),
-    negative_prompt: Optional[str] = Form(None),
-    guidance_scale: Optional[float] = Form(None),
-    true_cfg_scale: Optional[float] = Form(None),
-    num_inference_steps: Optional[int] = Form(None),
-    output_quality: Optional[str] = Form("default"),
-    output_compression: Optional[int] = Form(None),
-    enable_teacache: Optional[bool] = Form(False),
-    enable_upscaling: Optional[bool] = Form(False),
-    upscaling_model_path: Optional[str] = Form(None),
-    upscaling_scale: Optional[int] = Form(4),
+    mask: UploadFile | None = File(None),
+    model: str | None = Form(None),
+    n: int | None = Form(1),
+    response_format: str | None = Form(None),
+    size: str | None = Form(None),
+    output_format: str | None = Form(None),
+    background: str | None = Form("auto"),
+    seed: int | None = Form(None),
+    generator_device: str | None = Form("cuda"),
+    user: str | None = Form(None),
+    negative_prompt: str | None = Form(None),
+    guidance_scale: float | None = Form(None),
+    true_cfg_scale: float | None = Form(None),
+    num_inference_steps: int | None = Form(None),
+    output_quality: str | None = Form("default"),
+    output_compression: int | None = Form(None),
+    enable_teacache: bool | None = Form(False),
+    enable_upscaling: bool | None = Form(False),
+    upscaling_model_path: str | None = Form(None),
+    upscaling_scale: int | None = Form(4),
     num_frames: int = Form(1),
 ):
     request_id = generate_request_id()
@@ -424,7 +432,7 @@ async def edits(
         except Exception as e:
             raise HTTPException(
                 status_code=400,
-                detail=f"Failed to process image source: {str(e)}",
+                detail=f"Failed to process image source: {e!s}",
             )
 
         ext = choose_output_image_ext(output_format, background)
@@ -456,9 +464,13 @@ async def edits(
             sampling_params=sampling,
             external_trace_header=trace_headers,
         )
-        save_file_path_list, result = await process_generation_batch(
-            async_scheduler_client, batch
-        )
+        try:
+            save_file_path_list, result = await process_generation_batch(
+                async_scheduler_client, batch
+            )
+        except RequestCancelledError as e:
+            # surface job cancellation as a structured conflict, not a bare 500
+            raise HTTPException(status_code=409, detail=str(e))
         save_file_path = save_file_path_list[0]
         resp_format = (response_format or "b64_json").lower()
 
@@ -515,7 +527,7 @@ async def edits(
 
 @router.get("/{image_id}/content")
 async def download_image_content(
-    image_id: str = Path(...), variant: Optional[str] = Query(None)
+    image_id: str = Path(...), variant: str | None = Query(None)
 ):
     item = await IMAGE_STORE.get(image_id)
     if not item:
@@ -551,3 +563,26 @@ async def download_image_content(
     return FileResponse(
         path=file_path, media_type=media_type, filename=os.path.basename(file_path)
     )
+
+
+def _require_job_control() -> None:
+    if not get_global_server_args().job_control_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="job control requires a single-rank scheduler in v1",
+        )
+
+
+@router.get("/jobs/{request_id}")
+async def job_status(request_id: str):
+    """Observable job status from the scheduler's job-control channel."""
+    _require_job_control()
+    return await async_scheduler_client.job_control(JobStatusReq(request_id=request_id))
+
+
+@router.delete("/jobs/{request_id}")
+async def cancel_job(request_id: str):
+    """DELETE-as-cancel: reaches queued jobs immediately and running denoise
+    work at the next step boundary."""
+    _require_job_control()
+    return await async_scheduler_client.job_control(CancelReq(request_id=request_id))

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -9,62 +9,61 @@ from pydantic import BaseModel, ConfigDict, Field
 
 # Image API protocol models
 class ImageResponseData(BaseModel):
-    b64_json: str | None = None
-    url: str | None = None
-    revised_prompt: str | None = None
-    file_path: str | None = None
+    b64_json: Optional[str] = None
+    url: Optional[str] = None
+    revised_prompt: Optional[str] = None
+    file_path: Optional[str] = None
 
 
 class ImageResponse(BaseModel):
     id: str
     created: int = Field(default_factory=lambda: int(time.time()))
-    data: list[ImageResponseData]
-    peak_memory_mb: float | None = None
-    inference_time_s: float | None = None
+    data: List[ImageResponseData]
+    peak_memory_mb: Optional[float] = None
+    inference_time_s: Optional[float] = None
 
 
 class ImageGenerationsRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     prompt: str
-    model: str | None = None
-    n: int | None = 1
-    quality: str | None = "auto"
-    response_format: str | None = "url"  # url | b64_json
-    size: str | None = "1024x1024"  # e.g., 1024x1024
-    style: str | None = "vivid"
-    background: str | None = "auto"  # transparent | opaque | auto
-    output_format: str | None = None  # png | jpeg | webp
-    user: str | None = None
+    model: Optional[str] = None
+    n: Optional[int] = 1
+    quality: Optional[str] = "auto"
+    response_format: Optional[str] = "url"  # url | b64_json
+    size: Optional[str] = "1024x1024"  # e.g., 1024x1024
+    style: Optional[str] = "vivid"
+    background: Optional[str] = "auto"  # transparent | opaque | auto
+    output_format: Optional[str] = None  # png | jpeg | webp
+    user: Optional[str] = None
     # SGLang extensions
-    width: int | None = None
-    height: int | None = None
-    num_inference_steps: int | None = None
-    guidance_scale: float | None = None
-    true_cfg_scale: float | None = (
+    width: Optional[int] = None
+    height: Optional[int] = None
+    num_inference_steps: Optional[int] = None
+    guidance_scale: Optional[float] = None
+    true_cfg_scale: Optional[float] = (
         None  # for CFG vs guidance distillation (e.g., QwenImage)
     )
-    seed: int | list[int] | None = None
-    generator_device: str | None = "cuda"
-    negative_prompt: str | None = None
-    output_quality: str | None = "default"
-    output_compression: int | None = None
-    enable_teacache: bool | None = False
-    max_sequence_length: int | None = None
-    flow_shift: float | None = None
+    seed: Optional[Union[int, List[int]]] = None
+    generator_device: Optional[str] = "cuda"
+    negative_prompt: Optional[str] = None
+    output_quality: Optional[str] = "default"
+    output_compression: Optional[int] = None
+    enable_teacache: Optional[bool] = False
+    max_sequence_length: Optional[int] = None
+    flow_shift: Optional[float] = None
     # Upscaling
-    enable_upscaling: bool | None = False
-    upscaling_model_path: str | None = None
-    upscaling_scale: int | None = 4
-    diffusers_kwargs: dict[str, Any] | None = None  # kwargs for diffusers backend
-    # Client-supplied id for idempotent dispatch, status, and cancel (job control)
-    request_id: str | None = None
+    enable_upscaling: Optional[bool] = False
+    upscaling_model_path: Optional[str] = None
+    upscaling_scale: Optional[int] = 4
+    diffusers_kwargs: Optional[Dict[str, Any]] = None  # kwargs for diffusers backend
     # Performance profiling
-    perf_dump_path: str | None = None
+    request_id: Optional[str] = None
+    perf_dump_path: Optional[str] = None
     # Progressive resolution generation
-    progressive_mode: str | None = None
-    progressive_levels: int | None = None
-    progressive_delta: float | None = None
+    progressive_mode: Optional[str] = None
+    progressive_levels: Optional[int] = None
+    progressive_delta: Optional[float] = None
 
 
 # Video API protocol models
@@ -153,27 +152,27 @@ class VideoRemixRequest(BaseModel):
 class RealtimeVideoGenerationsRequest(VideoGenerationsRequest):
     type: Literal["init"]
     # WebSocket does not support multipart/form-data image uploads
-    first_frame: bytes | str | None = None
-    condition_inputs: dict[str, Any] | None = None
-    max_chunks: int | None = Field(default=None, ge=1)
-    seed: int | None = 42
-    guidance_scale: float | None = 1.0
-    size: str | None = "832x480"
-    profile: bool | None = False
-    num_profiled_timesteps: int | None = None
-    profile_all_stages: bool | None = False
-    realtime_output_format: Literal["raw", "webp", "jpeg"] | None = None
-    realtime_preview_max_width: int | None = None
-    realtime_output_pacing: bool | None = False
-    realtime_causal_sink_size: int | None = None
-    realtime_causal_kv_cache_num_frames: int | None = None
+    first_frame: Optional[bytes | str] = None
+    condition_inputs: Optional[Dict[str, Any]] = None
+    max_chunks: Optional[int] = Field(default=None, ge=1)
+    seed: Optional[int] = 42
+    guidance_scale: Optional[float] = 1.0
+    size: Optional[str] = "832x480"
+    profile: Optional[bool] = False
+    num_profiled_timesteps: Optional[int] = None
+    profile_all_stages: Optional[bool] = False
+    realtime_output_format: Optional[Literal["raw", "webp", "jpeg"]] = None
+    realtime_preview_max_width: Optional[int] = None
+    realtime_output_pacing: Optional[bool] = False
+    realtime_causal_sink_size: Optional[int] = None
+    realtime_causal_kv_cache_num_frames: Optional[int] = None
 
 
 class RealtimeEvent(BaseModel):
     type: Literal["event"]
     kind: str
     payload: Any = None
-    event_id: int | None = None
+    event_id: Optional[int] = None
 
 
 # Mesh API protocol models
@@ -185,37 +184,37 @@ class MeshResponse(BaseModel):
     progress: int = 0
     created_at: int = Field(default_factory=lambda: int(time.time()))
     format: str = "glb"
-    url: str | None = None
-    completed_at: int | None = None
-    expires_at: int | None = None
-    error: dict[str, Any] | None = None
-    file_path: str | None = None
-    file_size_bytes: int | None = None
-    peak_memory_mb: float | None = None
-    inference_time_s: float | None = None
+    url: Optional[str] = None
+    completed_at: Optional[int] = None
+    expires_at: Optional[int] = None
+    error: Optional[Dict[str, Any]] = None
+    file_path: Optional[str] = None
+    file_size_bytes: Optional[int] = None
+    peak_memory_mb: Optional[float] = None
+    inference_time_s: Optional[float] = None
 
 
 class MeshGenerationsRequest(BaseModel):
     prompt: str = "generate 3d mesh"
-    input_image: str | None = None
-    model: str | None = None
-    seed: int | list[int] | None = None
-    generator_device: str | None = "cuda"
-    num_inference_steps: int | None = None
-    guidance_scale: float | None = None
-    negative_prompt: str | None = None
-    output_format: str | None = "glb"
+    input_image: Optional[str] = None
+    model: Optional[str] = None
+    seed: Optional[Union[int, List[int]]] = None
+    generator_device: Optional[str] = "cuda"
+    num_inference_steps: Optional[int] = None
+    guidance_scale: Optional[float] = None
+    negative_prompt: Optional[str] = None
+    output_format: Optional[str] = "glb"
 
 
 class MeshListResponse(BaseModel):
-    data: list[MeshResponse]
+    data: List[MeshResponse]
     object: str = "list"
 
 
 @dataclass
 class BaseReq(ABC):
-    rid: str | list[str] | None = field(default=None, kw_only=True)
-    http_worker_ipc: str | None = field(default=None, kw_only=True)
+    rid: Optional[Union[str, List[str]]] = field(default=None, kw_only=True)
+    http_worker_ipc: Optional[str] = field(default=None, kw_only=True)
 
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
@@ -228,5 +227,5 @@ class BaseReq(ABC):
 
 @dataclass
 class VertexGenerateReqInput(BaseReq):
-    instances: list[dict]
-    parameters: dict | None = None
+    instances: List[dict]
+    parameters: Optional[dict] = None

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -2,7 +2,7 @@ import time
 import uuid
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -21,6 +21,16 @@ class ImageResponse(BaseModel):
     data: List[ImageResponseData]
     peak_memory_mb: Optional[float] = None
     inference_time_s: Optional[float] = None
+
+
+JobRequestId = Annotated[
+    str,
+    Field(
+        min_length=1,
+        max_length=128,
+        pattern=r"^[A-Za-z0-9][A-Za-z0-9._:-]*$",
+    ),
+]
 
 
 class ImageGenerationsRequest(BaseModel):
@@ -57,8 +67,8 @@ class ImageGenerationsRequest(BaseModel):
     upscaling_model_path: Optional[str] = None
     upscaling_scale: Optional[int] = 4
     diffusers_kwargs: Optional[Dict[str, Any]] = None  # kwargs for diffusers backend
+    request_id: Optional[JobRequestId] = None
     # Performance profiling
-    request_id: Optional[str] = None
     perf_dump_path: Optional[str] = None
     # Progressive resolution generation
     progressive_mode: Optional[str] = None

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -2,67 +2,69 @@ import time
 import uuid
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Optional, Union
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
 
 # Image API protocol models
 class ImageResponseData(BaseModel):
-    b64_json: Optional[str] = None
-    url: Optional[str] = None
-    revised_prompt: Optional[str] = None
-    file_path: Optional[str] = None
+    b64_json: str | None = None
+    url: str | None = None
+    revised_prompt: str | None = None
+    file_path: str | None = None
 
 
 class ImageResponse(BaseModel):
     id: str
     created: int = Field(default_factory=lambda: int(time.time()))
-    data: List[ImageResponseData]
-    peak_memory_mb: Optional[float] = None
-    inference_time_s: Optional[float] = None
+    data: list[ImageResponseData]
+    peak_memory_mb: float | None = None
+    inference_time_s: float | None = None
 
 
 class ImageGenerationsRequest(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     prompt: str
-    model: Optional[str] = None
-    n: Optional[int] = 1
-    quality: Optional[str] = "auto"
-    response_format: Optional[str] = "url"  # url | b64_json
-    size: Optional[str] = "1024x1024"  # e.g., 1024x1024
-    style: Optional[str] = "vivid"
-    background: Optional[str] = "auto"  # transparent | opaque | auto
-    output_format: Optional[str] = None  # png | jpeg | webp
-    user: Optional[str] = None
+    model: str | None = None
+    n: int | None = 1
+    quality: str | None = "auto"
+    response_format: str | None = "url"  # url | b64_json
+    size: str | None = "1024x1024"  # e.g., 1024x1024
+    style: str | None = "vivid"
+    background: str | None = "auto"  # transparent | opaque | auto
+    output_format: str | None = None  # png | jpeg | webp
+    user: str | None = None
     # SGLang extensions
-    width: Optional[int] = None
-    height: Optional[int] = None
-    num_inference_steps: Optional[int] = None
-    guidance_scale: Optional[float] = None
-    true_cfg_scale: Optional[float] = (
+    width: int | None = None
+    height: int | None = None
+    num_inference_steps: int | None = None
+    guidance_scale: float | None = None
+    true_cfg_scale: float | None = (
         None  # for CFG vs guidance distillation (e.g., QwenImage)
     )
-    seed: Optional[Union[int, List[int]]] = None
-    generator_device: Optional[str] = "cuda"
-    negative_prompt: Optional[str] = None
-    output_quality: Optional[str] = "default"
-    output_compression: Optional[int] = None
-    enable_teacache: Optional[bool] = False
-    max_sequence_length: Optional[int] = None
-    flow_shift: Optional[float] = None
+    seed: int | list[int] | None = None
+    generator_device: str | None = "cuda"
+    negative_prompt: str | None = None
+    output_quality: str | None = "default"
+    output_compression: int | None = None
+    enable_teacache: bool | None = False
+    max_sequence_length: int | None = None
+    flow_shift: float | None = None
     # Upscaling
-    enable_upscaling: Optional[bool] = False
-    upscaling_model_path: Optional[str] = None
-    upscaling_scale: Optional[int] = 4
-    diffusers_kwargs: Optional[Dict[str, Any]] = None  # kwargs for diffusers backend
+    enable_upscaling: bool | None = False
+    upscaling_model_path: str | None = None
+    upscaling_scale: int | None = 4
+    diffusers_kwargs: dict[str, Any] | None = None  # kwargs for diffusers backend
+    # Client-supplied id for idempotent dispatch, status, and cancel (job control)
+    request_id: str | None = None
     # Performance profiling
-    perf_dump_path: Optional[str] = None
+    perf_dump_path: str | None = None
     # Progressive resolution generation
-    progressive_mode: Optional[str] = None
-    progressive_levels: Optional[int] = None
-    progressive_delta: Optional[float] = None
+    progressive_mode: str | None = None
+    progressive_levels: int | None = None
+    progressive_delta: float | None = None
 
 
 # Video API protocol models
@@ -151,27 +153,27 @@ class VideoRemixRequest(BaseModel):
 class RealtimeVideoGenerationsRequest(VideoGenerationsRequest):
     type: Literal["init"]
     # WebSocket does not support multipart/form-data image uploads
-    first_frame: Optional[bytes | str] = None
-    condition_inputs: Optional[Dict[str, Any]] = None
-    max_chunks: Optional[int] = Field(default=None, ge=1)
-    seed: Optional[int] = 42
-    guidance_scale: Optional[float] = 1.0
-    size: Optional[str] = "832x480"
-    profile: Optional[bool] = False
-    num_profiled_timesteps: Optional[int] = None
-    profile_all_stages: Optional[bool] = False
-    realtime_output_format: Optional[Literal["raw", "webp", "jpeg"]] = None
-    realtime_preview_max_width: Optional[int] = None
-    realtime_output_pacing: Optional[bool] = False
-    realtime_causal_sink_size: Optional[int] = None
-    realtime_causal_kv_cache_num_frames: Optional[int] = None
+    first_frame: bytes | str | None = None
+    condition_inputs: dict[str, Any] | None = None
+    max_chunks: int | None = Field(default=None, ge=1)
+    seed: int | None = 42
+    guidance_scale: float | None = 1.0
+    size: str | None = "832x480"
+    profile: bool | None = False
+    num_profiled_timesteps: int | None = None
+    profile_all_stages: bool | None = False
+    realtime_output_format: Literal["raw", "webp", "jpeg"] | None = None
+    realtime_preview_max_width: int | None = None
+    realtime_output_pacing: bool | None = False
+    realtime_causal_sink_size: int | None = None
+    realtime_causal_kv_cache_num_frames: int | None = None
 
 
 class RealtimeEvent(BaseModel):
     type: Literal["event"]
     kind: str
     payload: Any = None
-    event_id: Optional[int] = None
+    event_id: int | None = None
 
 
 # Mesh API protocol models
@@ -183,37 +185,37 @@ class MeshResponse(BaseModel):
     progress: int = 0
     created_at: int = Field(default_factory=lambda: int(time.time()))
     format: str = "glb"
-    url: Optional[str] = None
-    completed_at: Optional[int] = None
-    expires_at: Optional[int] = None
-    error: Optional[Dict[str, Any]] = None
-    file_path: Optional[str] = None
-    file_size_bytes: Optional[int] = None
-    peak_memory_mb: Optional[float] = None
-    inference_time_s: Optional[float] = None
+    url: str | None = None
+    completed_at: int | None = None
+    expires_at: int | None = None
+    error: dict[str, Any] | None = None
+    file_path: str | None = None
+    file_size_bytes: int | None = None
+    peak_memory_mb: float | None = None
+    inference_time_s: float | None = None
 
 
 class MeshGenerationsRequest(BaseModel):
     prompt: str = "generate 3d mesh"
-    input_image: Optional[str] = None
-    model: Optional[str] = None
-    seed: Optional[Union[int, List[int]]] = None
-    generator_device: Optional[str] = "cuda"
-    num_inference_steps: Optional[int] = None
-    guidance_scale: Optional[float] = None
-    negative_prompt: Optional[str] = None
-    output_format: Optional[str] = "glb"
+    input_image: str | None = None
+    model: str | None = None
+    seed: int | list[int] | None = None
+    generator_device: str | None = "cuda"
+    num_inference_steps: int | None = None
+    guidance_scale: float | None = None
+    negative_prompt: str | None = None
+    output_format: str | None = "glb"
 
 
 class MeshListResponse(BaseModel):
-    data: List[MeshResponse]
+    data: list[MeshResponse]
     object: str = "list"
 
 
 @dataclass
 class BaseReq(ABC):
-    rid: Optional[Union[str, List[str]]] = field(default=None, kw_only=True)
-    http_worker_ipc: Optional[str] = field(default=None, kw_only=True)
+    rid: str | list[str] | None = field(default=None, kw_only=True)
+    http_worker_ipc: str | None = field(default=None, kw_only=True)
 
     def regenerate_rid(self):
         """Generate a new request ID and return it."""
@@ -226,5 +228,5 @@ class BaseReq(ABC):
 
 @dataclass
 class VertexGenerateReqInput(BaseReq):
-    instances: List[dict]
-    parameters: Optional[dict] = None
+    instances: list[dict]
+    parameters: dict | None = None

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -2,7 +2,7 @@ import time
 import uuid
 from abc import ABC
 from dataclasses import dataclass, field
-from typing import Any, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/stores.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/stores.py
@@ -28,6 +28,16 @@ class AsyncDictStore:
             item.update(updates)
             return item
 
+    async def update_fields_if_status(
+        self, key: str, updates: Dict[str, Any], allowed_statuses: set[str]
+    ) -> Optional[Dict[str, Any]]:
+        async with self._lock:
+            item = self._items.get(key)
+            if item is None or item.get("status") not in allowed_statuses:
+                return None
+            item.update(updates)
+            return item
+
     async def get(self, key: str) -> Optional[Dict[str, Any]]:
         async with self._lock:
             return self._items.get(key)

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -28,6 +28,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.managers.job_registry import (
     RequestCancelledError,
     RequestConflictError,
+    RequestOverloadedError,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
@@ -360,6 +361,8 @@ async def process_generation_batch(
             and result.raw_frame_batches is None
         ):
             error_msg = result.error or "Unknown error"
+            if result.overloaded:
+                raise RequestOverloadedError(error_msg)
             if result.idempotency_conflict:
                 raise RequestConflictError(error_msg)
             if result.cancelled:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -6,9 +6,8 @@ import os
 import shutil
 import tempfile
 import time
-from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Generator, List, Optional, Type, Union
+from typing import Any, Generator, List, Optional, Union
 
 import httpx
 from fastapi import HTTPException, UploadFile
@@ -26,8 +25,8 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
     format_lora_message,
     save_outputs,
 )
-from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.common import parse_size
@@ -41,11 +40,11 @@ from sglang.multimodal_gen.runtime.utils.trace_wrapper import trace_req
 
 # re-export LoRA protocol types for backward compatibility
 __all__ = [
-    "ListLorasReq",
-    "MergeLoraWeightsReq",
     "SetLoraReq",
-    "ShutdownReq",
+    "MergeLoraWeightsReq",
     "UnmergeLoraWeightsReq",
+    "ListLorasReq",
+    "ShutdownReq",
     "format_lora_message",
 ]
 
@@ -114,7 +113,9 @@ def temp_dir_if_disabled(
             shutil.rmtree(tmp, ignore_errors=True)
 
 
-def choose_output_image_ext(output_format: str | None, background: str | None) -> str:
+def choose_output_image_ext(
+    output_format: Optional[str], background: Optional[str]
+) -> str:
     fmt = (output_format or "").lower()
     if fmt in {"png", "webp", "jpeg", "jpg"}:
         return "jpg" if fmt == "jpeg" else fmt
@@ -180,7 +181,7 @@ def build_sampling_params(request_id: str, **kwargs) -> SamplingParams:
 
 
 async def save_image_to_path(
-    image: UploadFile | bytes | str,
+    image: Union[UploadFile, bytes, str],
     target_path: str,
     *,
     prefer_remote_source: bool = False,
@@ -194,7 +195,9 @@ async def save_image_to_path(
 
 
 # Helpers
-async def _save_upload_to_path(upload: UploadFile | bytes, target_path: str) -> str:
+async def _save_upload_to_path(
+    upload: Union[UploadFile, bytes], target_path: str
+) -> str:
     os.makedirs(os.path.dirname(target_path), exist_ok=True)
     if isinstance(upload, bytes):
         content = upload
@@ -332,7 +335,7 @@ async def _save_url_image_to_path(image_url: str, target_path: str) -> str:
     except Exception as e:
         final_error = last_error or e
         raise Exception(
-            f"Failed to download image from URL {image_url}: {final_error!s}"
+            f"Failed to download image from URL {image_url}: {str(final_error)}"
         )
 
 
@@ -397,7 +400,7 @@ async def process_generation_batch(
     return save_file_path_list, result
 
 
-def merge_image_input_list(*inputs: list | Any | None) -> list:
+def merge_image_input_list(*inputs: Union[List, Any, None]) -> List:
     """
     Merge multiple image input sources into a single list.
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -25,8 +25,11 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
     format_lora_message,
     save_outputs,
 )
+from sglang.multimodal_gen.runtime.managers.job_registry import (
+    RequestCancelledError,
+    RequestConflictError,
+)
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
-from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.common import parse_size
@@ -357,6 +360,8 @@ async def process_generation_batch(
             and result.raw_frame_batches is None
         ):
             error_msg = result.error or "Unknown error"
+            if result.idempotency_conflict:
+                raise RequestConflictError(error_msg)
             if result.cancelled:
                 raise RequestCancelledError(error_msg)
             raise RuntimeError(

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -8,7 +8,7 @@ import tempfile
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any
+from typing import Any, Generator, List, Optional, Type, Union
 
 import httpx
 from fastapi import HTTPException, UploadFile

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -6,8 +6,9 @@ import os
 import shutil
 import tempfile
 import time
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import Any, Generator, List, Optional, Union
+from typing import Any
 
 import httpx
 from fastapi import HTTPException, UploadFile
@@ -25,6 +26,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
     format_lora_message,
     save_outputs,
 )
+from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
@@ -39,11 +41,11 @@ from sglang.multimodal_gen.runtime.utils.trace_wrapper import trace_req
 
 # re-export LoRA protocol types for backward compatibility
 __all__ = [
-    "SetLoraReq",
-    "MergeLoraWeightsReq",
-    "UnmergeLoraWeightsReq",
     "ListLorasReq",
+    "MergeLoraWeightsReq",
+    "SetLoraReq",
     "ShutdownReq",
+    "UnmergeLoraWeightsReq",
     "format_lora_message",
 ]
 
@@ -112,9 +114,7 @@ def temp_dir_if_disabled(
             shutil.rmtree(tmp, ignore_errors=True)
 
 
-def choose_output_image_ext(
-    output_format: Optional[str], background: Optional[str]
-) -> str:
+def choose_output_image_ext(output_format: str | None, background: str | None) -> str:
     fmt = (output_format or "").lower()
     if fmt in {"png", "webp", "jpeg", "jpg"}:
         return "jpg" if fmt == "jpeg" else fmt
@@ -180,7 +180,7 @@ def build_sampling_params(request_id: str, **kwargs) -> SamplingParams:
 
 
 async def save_image_to_path(
-    image: Union[UploadFile, bytes, str],
+    image: UploadFile | bytes | str,
     target_path: str,
     *,
     prefer_remote_source: bool = False,
@@ -194,9 +194,7 @@ async def save_image_to_path(
 
 
 # Helpers
-async def _save_upload_to_path(
-    upload: Union[UploadFile, bytes], target_path: str
-) -> str:
+async def _save_upload_to_path(upload: UploadFile | bytes, target_path: str) -> str:
     os.makedirs(os.path.dirname(target_path), exist_ok=True)
     if isinstance(upload, bytes):
         content = upload
@@ -334,7 +332,7 @@ async def _save_url_image_to_path(image_url: str, target_path: str) -> str:
     except Exception as e:
         final_error = last_error or e
         raise Exception(
-            f"Failed to download image from URL {image_url}: {str(final_error)}"
+            f"Failed to download image from URL {image_url}: {final_error!s}"
         )
 
 
@@ -356,6 +354,8 @@ async def process_generation_batch(
             and result.raw_frame_batches is None
         ):
             error_msg = result.error or "Unknown error"
+            if result.cancelled:
+                raise RequestCancelledError(error_msg)
             raise RuntimeError(
                 f"Model generation returned no output. Error from scheduler: {error_msg}"
             )
@@ -397,7 +397,7 @@ async def process_generation_batch(
     return save_file_path_list, result
 
 
-def merge_image_input_list(*inputs: Union[List, Any, None]) -> List:
+def merge_image_input_list(*inputs: list | Any | None) -> list:
     """
     Merge multiple image input sources into a single list.
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -986,6 +986,11 @@ async def download_video_content(
         )
 
     file_path = _select_video_variant_path(job, variant)
+    if job.get("status") == "cancelled":
+        raise HTTPException(
+            status_code=404,
+            detail="Video content is unavailable for a cancelled generation",
+        )
     if job.get("status") not in {"completed", "failed"}:
         raise HTTPException(status_code=404, detail="Generation is still in-progress")
     if not file_path or not os.path.exists(file_path):

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -883,8 +883,6 @@ async def delete_video(video_id: str = Path(...)):
     job = await VIDEO_STORE.get(video_id)
     if not job:
         raise HTTPException(status_code=404, detail="Video not found")
-    # DELETE-as-cancel: reach queued work immediately and running denoise
-    # work at the next step boundary (job control). best-effort for finished jobs
     from sglang.multimodal_gen.runtime.managers.job_registry import CancelReq
     from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -64,6 +64,23 @@ _VIDEO_EXTENSIONS = {
 }
 
 
+def _require_trackable_video_batch(
+    server_args, scheduler_batches: list[Req] | None
+) -> None:
+    if (
+        server_args.job_control_enabled
+        and scheduler_batches is not None
+        and len(scheduler_batches) != 1
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "job control does not support grouped multi-output video requests; "
+                "use one output or start the server with --disable-job-control"
+            ),
+        )
+
+
 def _extra_value(request: VideoGenerationsRequest, name: str) -> Any:
     return (request.model_extra or {}).get(name)
 
@@ -492,7 +509,15 @@ async def _dispatch_job_async(
     except RequestCancelledError as e:
         logger.info(f"video {job_id} cancelled: {e}")
         await VIDEO_STORE.update_fields(
-            job_id, {"status": "cancelled", "error": {"message": str(e)}}
+            job_id,
+            {
+                "status": "cancelled",
+                "error": {"message": str(e)},
+                "url": None,
+                "file_path": None,
+                "file_paths": None,
+                "num_outputs": None,
+            },
         )
     except Exception as e:
         logger.error(f"{e}")
@@ -810,6 +835,7 @@ async def create_video(
         scheduler_batches = sampling_params.expand_video_request_outputs_for_queue(
             batch
         )
+        _require_trackable_video_batch(server_args, scheduler_batches)
         job = _video_job_from_sampling(request_id, req, sampling_params)
         job.update(sampling_params.project_video_queued_job_fields(batch))
         await VIDEO_STORE.upsert(request_id, job)
@@ -883,17 +909,51 @@ async def delete_video(video_id: str = Path(...)):
     job = await VIDEO_STORE.get(video_id)
     if not job:
         raise HTTPException(status_code=404, detail="Video not found")
+    if job.get("status") in {"completed", "failed", "cancelled"}:
+        raise HTTPException(status_code=409, detail=f"video is already {job['status']}")
     from sglang.multimodal_gen.runtime.managers.job_registry import CancelReq
     from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
 
-    if get_global_server_args().job_control_enabled:
-        try:
-            await async_scheduler_client.job_control(CancelReq(request_id=video_id))
-        except (TimeoutError, RuntimeError):
-            pass
-    job = await VIDEO_STORE.pop(video_id) or job
-    job["status"] = "cancelled"
-    return VideoResponse(**job)
+    if not get_global_server_args().job_control_enabled:
+        raise HTTPException(
+            status_code=503,
+            detail="video cancellation requires supported single-request job control",
+        )
+    try:
+        reply = await async_scheduler_client.job_control(CancelReq(request_id=video_id))
+    except TimeoutError as e:
+        raise HTTPException(
+            status_code=504, detail="scheduler job-control channel timed out"
+        ) from e
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=503, detail="scheduler job-control channel is unavailable"
+        ) from e
+    if not isinstance(reply, dict) or reply.get("error"):
+        detail = reply.get("error") if isinstance(reply, dict) else "invalid reply"
+        raise HTTPException(
+            status_code=503, detail=f"scheduler job-control failure: {detail}"
+        )
+    if reply.get("overloaded"):
+        raise HTTPException(status_code=429, detail="precancel capacity is exhausted")
+    if not reply.get("cancelled"):
+        raise HTTPException(
+            status_code=409,
+            detail=f"video is already {reply.get('status', 'terminal')}",
+        )
+    updated = await VIDEO_STORE.update_fields_if_status(
+        video_id,
+        {"status": "cancelling"},
+        {"queued", "running", "in_progress", "cancelling"},
+    )
+    if updated is not None:
+        return VideoResponse(**updated)
+    latest = await VIDEO_STORE.get(video_id)
+    if latest is None:
+        raise HTTPException(status_code=404, detail="Video not found")
+    if latest.get("status") == "cancelled":
+        return VideoResponse(**latest)
+    raise HTTPException(status_code=409, detail=f"video is already {latest['status']}")
 
 
 def _select_video_variant_path(job: dict, variant: str | None) -> str | None:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 import time
-from typing import Any
+from typing import Any, Dict, Optional
 
 from fastapi import (
     APIRouter,

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/video_api.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import tempfile
 import time
-from typing import Any, Dict, Optional
+from typing import Any
 
 from fastapi import (
     APIRouter,
@@ -42,6 +42,7 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
     save_image_to_path,
 )
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
+from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -282,9 +283,9 @@ def _resolve_sound_duration(
 
 def _cosmos3_sampling_param_kwargs(
     req: VideoGenerationsRequest, *, num_frames: int, fps: int
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Map HTTP/API aliases to Cosmos3SamplingParams field names."""
-    kwargs: Dict[str, Any] = {}
+    kwargs: dict[str, Any] = {}
 
     sound_duration = _resolve_sound_duration(req, num_frames=num_frames, fps=fps)
     if sound_duration is not None:
@@ -389,7 +390,7 @@ def _build_video_sampling_params(request_id: str, request: VideoGenerationsReque
 # extract metadata which http_server needs to know
 def _video_job_from_sampling(
     request_id: str, req: VideoGenerationsRequest, sampling: SamplingParams
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     size_str = f"{sampling.width}x{sampling.height}"
     seconds = int(round((sampling.num_frames or 0) / float(sampling.fps or 24)))
     return {
@@ -488,6 +489,11 @@ async def _dispatch_job_async(
         )
         update_fields.update(final_media_fields)
         await VIDEO_STORE.update_fields(job_id, update_fields)
+    except RequestCancelledError as e:
+        logger.info(f"video {job_id} cancelled: {e}")
+        await VIDEO_STORE.update_fields(
+            job_id, {"status": "cancelled", "error": {"message": str(e)}}
+        )
     except Exception as e:
         logger.error(f"{e}")
         await VIDEO_STORE.update_fields(
@@ -706,7 +712,7 @@ async def create_video(
             body = {}
         try:
             # If client uses extra_body, merge it into the top-level payload
-            payload: Dict[str, Any] = dict(body or {})
+            payload: dict[str, Any] = dict(body or {})
             extra = payload.pop("extra_body", None)
             if isinstance(extra, str):
                 extra = json.loads(extra)
@@ -753,7 +759,7 @@ async def create_video(
                 except Exception as e:
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Failed to process image source: {str(e)}",
+                        detail=f"Failed to process image source: {e!s}",
                     )
                 payload["input_reference"] = input_path
             req = VideoGenerationsRequest(**payload)
@@ -838,9 +844,9 @@ async def create_video(
 
 @router.get("", response_model=VideoListResponse)
 async def list_videos(
-    after: Optional[str] = Query(None),
-    limit: Optional[int] = Query(None, ge=1, le=100),
-    order: Optional[str] = Query("desc"),
+    after: str | None = Query(None),
+    limit: int | None = Query(None, ge=1, le=100),
+    order: str | None = Query("desc"),
 ):
     # Normalize order
     order = (order or "desc").lower()
@@ -872,14 +878,23 @@ async def retrieve_video(video_id: str = Path(...)):
     return VideoResponse(**job)
 
 
-# TODO: support aborting a job.
 @router.delete("/{video_id}", response_model=VideoResponse)
 async def delete_video(video_id: str = Path(...)):
-    job = await VIDEO_STORE.pop(video_id)
+    job = await VIDEO_STORE.get(video_id)
     if not job:
         raise HTTPException(status_code=404, detail="Video not found")
-    # Mark as deleted in response semantics
-    job["status"] = "deleted"
+    # DELETE-as-cancel: reach queued work immediately and running denoise
+    # work at the next step boundary (job control). best-effort for finished jobs
+    from sglang.multimodal_gen.runtime.managers.job_registry import CancelReq
+    from sglang.multimodal_gen.runtime.scheduler_client import async_scheduler_client
+
+    if get_global_server_args().job_control_enabled:
+        try:
+            await async_scheduler_client.job_control(CancelReq(request_id=video_id))
+        except (TimeoutError, RuntimeError):
+            pass
+    job = await VIDEO_STORE.pop(video_id) or job
+    job["status"] = "cancelled"
     return VideoResponse(**job)
 
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -485,8 +485,6 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                 output_batch = OutputBatch()
             output_batch.error = f"request cancelled: {e}"
             output_batch.cancelled = True
-            if torch.cuda.is_initialized():
-                torch.cuda.empty_cache()
         except Exception as e:
             logger.error(
                 f"Error executing {error_context}: {e}",

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -44,6 +44,7 @@ from sglang.multimodal_gen.runtime.entrypoints.utils import (
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     configure_layerwise_offload_modules,
 )
+from sglang.multimodal_gen.runtime.managers.job_registry import RequestCancelledError
 from sglang.multimodal_gen.runtime.managers.memory_managers.memory_occupation_controller import (
     MemoryOccupationController,
 )
@@ -478,6 +479,14 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
                     meta={"model": self.server_args.model_path},
                     tag="server_perf_dump",
                 )
+        except RequestCancelledError as e:
+            logger.info(f"Cancelled {error_context}: {e}")
+            if output_batch is None:
+                output_batch = OutputBatch()
+            output_batch.error = f"request cancelled: {e}"
+            output_batch.cancelled = True
+            if torch.cuda.is_initialized():
+                torch.cuda.empty_cache()
         except Exception as e:
             logger.error(
                 f"Error executing {error_context}: {e}",

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -9,7 +9,7 @@ import tempfile
 import time
 from contextlib import ExitStack
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Union
+from typing import Any, Callable, List, Optional, Set, Union
 
 import numpy as np
 import torch

--- a/python/sglang/multimodal_gen/runtime/managers/job_registry.py
+++ b/python/sglang/multimodal_gen/runtime/managers/job_registry.py
@@ -19,6 +19,7 @@ _PRECANCEL_CAP = 1024
 _FINISHED_HARD_CAP = 4 * _FINISHED_RETENTION
 _WAITER_CAP = 64
 _REPLAY_BYTES_CAP = 128 << 20
+_LIVE_JOB_CAP = 1024
 
 QUEUED = "queued"
 RUNNING = "running"
@@ -33,6 +34,10 @@ class RequestCancelledError(Exception):
 
 
 class RequestConflictError(Exception):
+    pass
+
+
+class RequestOverloadedError(Exception):
     pass
 
 
@@ -155,6 +160,7 @@ class JobRegistry:
         self._jobs: dict[str, JobHandle] = {}
         self._finished: list[str] = []
         self._precancelled: dict[str, float] = {}
+        self._live_jobs = 0
         self._replay_bytes = 0
         self._lock = threading.Lock()
 
@@ -179,10 +185,13 @@ class JobRegistry:
                     self._finished.append(request_id)
                     self._trim_finished()
                     return ("cancelled", None)
+                if self._live_jobs >= _LIVE_JOB_CAP:
+                    return ("capacity", None)
                 handle = JobHandle(request_id, fingerprint)
                 self._jobs[request_id] = handle
+                self._live_jobs += 1
                 return ("new", handle)
-            if handle.fingerprint != fingerprint:
+            if handle.fingerprint is None or handle.fingerprint != fingerprint:
                 return ("conflict", None)
             if handle.status in _TERMINAL:
                 return ("replay", handle.output)
@@ -214,6 +223,7 @@ class JobRegistry:
                     handle.status = COMPLETED
                 handle.finished_at_monotonic = time.monotonic()
                 self._finished.append(request_id)
+                self._live_jobs -= 1
             self._drop_replay(handle)
             replay_size = _replay_size(output)
             if handle.fingerprint is None and not output.cancelled and not output.error:

--- a/python/sglang/multimodal_gen/runtime/managers/job_registry.py
+++ b/python/sglang/multimodal_gen/runtime/managers/job_registry.py
@@ -39,7 +39,7 @@ def contains_file_refs(value: Any) -> bool:
 
 def _is_replayable(output: Any) -> bool:
     """Only lightweight terminal payloads are worth retaining for idempotent
-    replay; bulk payloads (raw realtime frames, trajectory tensors) would pin
+    replay. Bulk payloads (raw realtime frames, trajectory tensors) would pin
     GPU-scale buffers for the whole retention window."""
     return (
         not contains_file_refs(output.output)

--- a/python/sglang/multimodal_gen/runtime/managers/job_registry.py
+++ b/python/sglang/multimodal_gen/runtime/managers/job_registry.py
@@ -1,15 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Scheduler-side job control: identity, idempotency, cancel, status.
-
-The registry is the authority on request lifecycle. Admission dedupes on the
-client-supplied request id before dispatch, cancellation reaches GPU work
-through a between-step check in the denoise loop, and a side-channel socket
-serves cancel/status while the event loop is blocked inside a forward.
-Job control is active on single-rank schedulers only in v1: admission
-filtering and queued-request drops must be identical on every rank, which
-requires broadcasting the decisions alongside the requests (documented
-follow-up, mirroring the TP>1 scoping of realtime job control).
-"""
+"""Scheduler-side job control: identity, idempotency, cancel, status."""
 
 from __future__ import annotations
 
@@ -22,10 +12,8 @@ import msgspec
 from sglang.multimodal_gen.runtime.ipc_array import NumpyArrayFileRef
 
 _FINISHED_RETENTION = 64
-# terminal jobs stay replayable for at least this long even past the cap
 _FINISHED_TTL_S = 300.0
 _PRECANCEL_CAP = 1024
-# absolute bound on retained finished jobs, TTL notwithstanding
 _FINISHED_HARD_CAP = 4 * _FINISHED_RETENTION
 
 QUEUED = "queued"
@@ -41,8 +29,7 @@ class RequestCancelledError(Exception):
 
 
 def contains_file_refs(value: Any) -> bool:
-    """Spilled arrays are single-consumer; a payload holding refs to them
-    cannot be replayed to a second reader."""
+    """True if the payload holds single-consumer spilled array refs."""
     if isinstance(value, NumpyArrayFileRef):
         return True
     if isinstance(value, (list, tuple)):
@@ -96,19 +83,13 @@ class JobRegistry:
     def __init__(self) -> None:
         self._jobs: dict[str, JobHandle] = {}
         self._finished: list[str] = []
-        # cancels for ids the event loop has not received yet (it may be
-        # blocked inside a forward); honored at admission, TTL-bounded so a
-        # cancel for an id that never arrives cannot poison a future reuse
         self._precancelled: dict[str, float] = {}
         self._lock = threading.Lock()
 
     def admit(
         self, request_id: str, identity: bytes | None
     ) -> tuple[str, JobHandle | Any | None]:
-        """Idempotency before dispatch: ("new", handle) for a fresh id,
-        ("wait", handle) after attaching the duplicate as a waiter,
-        ("replay", output) for a finished job with its cached result, or
-        ("cancelled", None) when the id was cancelled before arrival."""
+        """Return ("new"|"wait"|"replay"|"cancelled", handle_or_output)."""
         with self._lock:
             handle = self._jobs.get(request_id)
             if handle is None:
@@ -140,19 +121,12 @@ class JobRegistry:
             return handle
 
     def finish(self, request_id: str, output: Any) -> list[bytes]:
-        """Terminal transition; returns waiter identities owed a reply.
-
-        Waiters attached before the transition still receive the live payload
-        (the caller replies from its own reference); only the retained replay
-        copy is dropped when the payload is not replayable.
-        """
+        """Mark terminal and return waiter identities owed a reply."""
         with self._lock:
             handle = self._jobs.get(request_id)
             if handle is None:
                 return []
             if handle.status not in _TERMINAL:
-                # classify from what actually happened: a cancel that arrived
-                # too late to abort the forward is a completion, not a cancel
                 if output.cancelled:
                     handle.status = CANCELLED
                 elif output.error:
@@ -184,8 +158,6 @@ class JobRegistry:
                 and now - oldest.finished_ts < _FINISHED_TTL_S
                 and len(self._finished) <= _FINISHED_HARD_CAP
             ):
-                # young entries stay for idempotent replay, up to a hard cap
-                # that bounds retained output payloads under sustained load
                 break
             self._jobs.pop(self._finished.pop(0), None)
 
@@ -193,7 +165,6 @@ class JobRegistry:
         with self._lock:
             handle = self._jobs.get(request_id)
             if handle is None:
-                # not received yet (the loop may be mid-forward); honor later
                 self._expire_precancelled()
                 if len(self._precancelled) >= _PRECANCEL_CAP:
                     self._precancelled.pop(next(iter(self._precancelled)), None)
@@ -242,7 +213,6 @@ def check_current_step(step_index: int, total_steps: int) -> None:
     for handle in jobs:
         handle.step = step_index
         handle.total_steps = total_steps
-    # a merged dynamic batch aborts only when every member is cancelled
     if not all(handle.cancel_event.is_set() for handle in jobs):
         return
     raise RequestCancelledError(f"cancelled at denoise step {step_index}/{total_steps}")

--- a/python/sglang/multimodal_gen/runtime/managers/job_registry.py
+++ b/python/sglang/multimodal_gen/runtime/managers/job_registry.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+import sys
 import threading
 import time
 from typing import Any
@@ -15,6 +17,8 @@ _FINISHED_RETENTION = 64
 _FINISHED_TTL_S = 300.0
 _PRECANCEL_CAP = 1024
 _FINISHED_HARD_CAP = 4 * _FINISHED_RETENTION
+_WAITER_CAP = 64
+_REPLAY_BYTES_CAP = 128 << 20
 
 QUEUED = "queued"
 RUNNING = "running"
@@ -28,25 +32,90 @@ class RequestCancelledError(Exception):
     pass
 
 
+class RequestConflictError(Exception):
+    pass
+
+
 def contains_file_refs(value: Any) -> bool:
     """True if the payload holds single-consumer spilled array refs."""
     if isinstance(value, NumpyArrayFileRef):
         return True
     if isinstance(value, (list, tuple)):
         return any(contains_file_refs(item) for item in value)
+    if isinstance(value, dict):
+        return any(contains_file_refs(item) for item in value.values())
     return False
 
 
-def _is_replayable(output: Any) -> bool:
-    """Only lightweight terminal payloads are worth retaining for idempotent
-    replay. Bulk payloads (raw realtime frames, trajectory tensors) would pin
-    GPU-scale buffers for the whole retention window."""
-    return (
-        not contains_file_refs(output.output)
-        and output.raw_frame_batches is None
-        and output.trajectory_latents is None
-        and output.rollout_trajectory_data is None
-    )
+def _value_nbytes(value: Any, seen: set[int] | None = None) -> int | None:
+    if value is None:
+        return 0
+    if seen is None:
+        seen = set()
+    value_id = id(value)
+    if value_id in seen:
+        return 0
+    seen.add(value_id)
+    if isinstance(value, NumpyArrayFileRef):
+        return None
+    dtype = getattr(value, "dtype", None)
+    if getattr(dtype, "hasobject", False):
+        return None
+    device = getattr(value, "device", None)
+    if device is not None and str(device) != "cpu":
+        return None
+    nbytes = getattr(value, "nbytes", None)
+    if isinstance(nbytes, int):
+        size = max(sys.getsizeof(value), nbytes)
+        storage = getattr(value, "untyped_storage", None)
+        if callable(storage):
+            try:
+                size = max(size, storage().nbytes())
+            except (AttributeError, RuntimeError, TypeError):
+                return None
+        backing = getattr(value, "base", None)
+        if backing is None:
+            backing = getattr(value, "_base", None)
+        if backing is None and isinstance(value, memoryview):
+            backing = value.obj
+        if backing is not None:
+            backing_size = _value_nbytes(backing, seen)
+            return None if backing_size is None else size + backing_size
+        return size
+    size = sys.getsizeof(value)
+    if isinstance(value, (list, tuple, set, frozenset)):
+        sizes = [_value_nbytes(item, seen) for item in value]
+    elif isinstance(value, dict):
+        sizes = [_value_nbytes(item, seen) for pair in value.items() for item in pair]
+    elif isinstance(value, (str, bytes, bytearray, memoryview, bool, int, float)):
+        return size
+    elif hasattr(value, "__dict__"):
+        sizes = [_value_nbytes(vars(value), seen)]
+    elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+        sizes = [
+            _value_nbytes(getattr(value, field.name), seen)
+            for field in dataclasses.fields(value)
+        ]
+    else:
+        return None
+    return None if any(item is None for item in sizes) else size + sum(sizes)
+
+
+def _replay_size(output: Any) -> int | None:
+    """Return total retained bytes, or None for unsafe payloads."""
+    if (
+        getattr(output, "output_file_paths", None)
+        or getattr(output, "raw_frame_batches", None) is not None
+        or getattr(output, "audio", None) is not None
+        or getattr(output, "action_pred", None) is not None
+        or getattr(output, "trajectory_timesteps", None) is not None
+        or getattr(output, "trajectory_latents", None) is not None
+        or getattr(output, "trajectory_decoded", None) is not None
+        or getattr(output, "rollout_trajectory_data", None) is not None
+        or getattr(output, "noise_pred", None) is not None
+    ):
+        return None
+    return _value_nbytes(output)
 
 
 class CancelReq(msgspec.Struct):
@@ -58,16 +127,18 @@ class JobStatusReq(msgspec.Struct):
 
 
 class JobHandle:
-    def __init__(self, request_id: str) -> None:
+    def __init__(self, request_id: str, fingerprint: str | None = None) -> None:
         self.request_id = request_id
+        self.fingerprint = fingerprint
         self.status = QUEUED
         self.created_ts = time.time()
-        self.finished_ts: float | None = None
+        self.finished_at_monotonic: float | None = None
         self.step: int | None = None
         self.total_steps: int | None = None
         self.cancel_event = threading.Event()
         self.waiters: list[bytes] = []
         self.output: Any | None = None
+        self.output_bytes = 0
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -84,32 +155,40 @@ class JobRegistry:
         self._jobs: dict[str, JobHandle] = {}
         self._finished: list[str] = []
         self._precancelled: dict[str, float] = {}
+        self._replay_bytes = 0
         self._lock = threading.Lock()
 
     def admit(
-        self, request_id: str, identity: bytes | None
+        self,
+        request_id: str,
+        identity: bytes | None,
+        fingerprint: str | None = None,
     ) -> tuple[str, JobHandle | Any | None]:
-        """Return ("new"|"wait"|"replay"|"cancelled", handle_or_output)."""
+        """Return an admission verdict and its handle or cached output."""
         with self._lock:
             handle = self._jobs.get(request_id)
             if handle is None:
                 self._expire_precancelled()
                 if request_id in self._precancelled:
                     del self._precancelled[request_id]
-                    handle = JobHandle(request_id)
+                    handle = JobHandle(request_id, fingerprint)
                     handle.status = CANCELLED
                     handle.cancel_event.set()
-                    handle.finished_ts = time.time()
+                    handle.finished_at_monotonic = time.monotonic()
                     self._jobs[request_id] = handle
                     self._finished.append(request_id)
                     self._trim_finished()
                     return ("cancelled", None)
-                handle = JobHandle(request_id)
+                handle = JobHandle(request_id, fingerprint)
                 self._jobs[request_id] = handle
                 return ("new", handle)
+            if handle.fingerprint != fingerprint:
+                return ("conflict", None)
             if handle.status in _TERMINAL:
                 return ("replay", handle.output)
             if identity is not None:
+                if len(handle.waiters) >= _WAITER_CAP:
+                    return ("overloaded", None)
                 handle.waiters.append(identity)
             return ("wait", handle)
 
@@ -133,15 +212,23 @@ class JobRegistry:
                     handle.status = FAILED
                 else:
                     handle.status = COMPLETED
-                handle.finished_ts = time.time()
+                handle.finished_at_monotonic = time.monotonic()
                 self._finished.append(request_id)
-                self._trim_finished()
-            handle.output = output if _is_replayable(output) else None
+            self._drop_replay(handle)
+            replay_size = _replay_size(output)
+            if handle.fingerprint is None and not output.cancelled and not output.error:
+                replay_size = None
+            if replay_size is not None and replay_size <= _REPLAY_BYTES_CAP:
+                handle.output = output
+                handle.output_bytes = replay_size
+                self._replay_bytes += replay_size
+            self._trim_finished()
+            self._trim_replay_bytes()
             waiters, handle.waiters = handle.waiters, []
             return waiters
 
     def _expire_precancelled(self) -> None:
-        now = time.time()
+        now = time.monotonic()
         self._precancelled = {
             request_id: expiry
             for request_id, expiry in self._precancelled.items()
@@ -149,26 +236,53 @@ class JobRegistry:
         }
 
     def _trim_finished(self) -> None:
-        now = time.time()
+        now = time.monotonic()
         while len(self._finished) > _FINISHED_RETENTION:
             oldest = self._jobs.get(self._finished[0])
             if (
                 oldest is not None
-                and oldest.finished_ts is not None
-                and now - oldest.finished_ts < _FINISHED_TTL_S
+                and oldest.finished_at_monotonic is not None
+                and now - oldest.finished_at_monotonic < _FINISHED_TTL_S
                 and len(self._finished) <= _FINISHED_HARD_CAP
             ):
                 break
-            self._jobs.pop(self._finished.pop(0), None)
+            evicted = self._jobs.pop(self._finished.pop(0), None)
+            if evicted is not None:
+                self._drop_replay(evicted)
+
+    def _drop_replay(self, handle: JobHandle) -> None:
+        self._replay_bytes -= handle.output_bytes
+        handle.output = None
+        handle.output_bytes = 0
+
+    def _trim_replay_bytes(self) -> None:
+        for request_id in self._finished:
+            if self._replay_bytes <= _REPLAY_BYTES_CAP:
+                break
+            handle = self._jobs.get(request_id)
+            if handle is not None:
+                self._drop_replay(handle)
 
     def cancel(self, request_id: str) -> dict[str, Any]:
         with self._lock:
             handle = self._jobs.get(request_id)
             if handle is None:
                 self._expire_precancelled()
+                if request_id in self._precancelled:
+                    self._precancelled[request_id] = time.monotonic() + _FINISHED_TTL_S
+                    return {
+                        "request_id": request_id,
+                        "status": "unknown",
+                        "cancelled": True,
+                    }
                 if len(self._precancelled) >= _PRECANCEL_CAP:
-                    self._precancelled.pop(next(iter(self._precancelled)), None)
-                self._precancelled[request_id] = time.time() + _FINISHED_TTL_S
+                    return {
+                        "request_id": request_id,
+                        "status": "unknown",
+                        "cancelled": False,
+                        "overloaded": True,
+                    }
+                self._precancelled[request_id] = time.monotonic() + _FINISHED_TTL_S
                 return {
                     "request_id": request_id,
                     "status": "unknown",
@@ -192,27 +306,27 @@ class JobRegistry:
             return handle.to_dict()
 
 
-_current_jobs: list[JobHandle] = []
+_current_job: JobHandle | None = None
 
 
-def set_current_jobs(handles: list[JobHandle]) -> None:
-    global _current_jobs
-    _current_jobs = list(handles)
+def set_current_job(handle: JobHandle | None) -> None:
+    global _current_job
+    _current_job = handle
 
 
-def clear_current_jobs() -> None:
-    global _current_jobs
-    _current_jobs = []
+def clear_current_job() -> None:
+    global _current_job
+    _current_job = None
 
 
 def check_current_step(step_index: int, total_steps: int) -> None:
     """Between-step cancellation and progress point for denoise loops."""
-    jobs = _current_jobs
-    if not jobs:
+    job = _current_job
+    if job is None:
         return
-    for handle in jobs:
-        handle.step = step_index
-        handle.total_steps = total_steps
-    if not all(handle.cancel_event.is_set() for handle in jobs):
-        return
-    raise RequestCancelledError(f"cancelled at denoise step {step_index}/{total_steps}")
+    job.step = step_index
+    job.total_steps = total_steps
+    if job.cancel_event.is_set():
+        raise RequestCancelledError(
+            f"cancelled at denoise step {step_index}/{total_steps}"
+        )

--- a/python/sglang/multimodal_gen/runtime/managers/job_registry.py
+++ b/python/sglang/multimodal_gen/runtime/managers/job_registry.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Scheduler-side job control: identity, idempotency, cancel, status.
+
+The registry is the authority on request lifecycle. Admission dedupes on the
+client-supplied request id before dispatch, cancellation reaches GPU work
+through a between-step check in the denoise loop, and a side-channel socket
+serves cancel/status while the event loop is blocked inside a forward.
+Job control is active on single-rank schedulers only in v1: admission
+filtering and queued-request drops must be identical on every rank, which
+requires broadcasting the decisions alongside the requests (documented
+follow-up, mirroring the TP>1 scoping of realtime job control).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+import msgspec
+
+from sglang.multimodal_gen.runtime.ipc_array import NumpyArrayFileRef
+
+_FINISHED_RETENTION = 64
+# terminal jobs stay replayable for at least this long even past the cap
+_FINISHED_TTL_S = 300.0
+_PRECANCEL_CAP = 1024
+# absolute bound on retained finished jobs, TTL notwithstanding
+_FINISHED_HARD_CAP = 4 * _FINISHED_RETENTION
+
+QUEUED = "queued"
+RUNNING = "running"
+COMPLETED = "completed"
+FAILED = "failed"
+CANCELLED = "cancelled"
+_TERMINAL = (COMPLETED, FAILED, CANCELLED)
+
+
+class RequestCancelledError(Exception):
+    pass
+
+
+def contains_file_refs(value: Any) -> bool:
+    """Spilled arrays are single-consumer; a payload holding refs to them
+    cannot be replayed to a second reader."""
+    if isinstance(value, NumpyArrayFileRef):
+        return True
+    if isinstance(value, (list, tuple)):
+        return any(contains_file_refs(item) for item in value)
+    return False
+
+
+def _is_replayable(output: Any) -> bool:
+    """Only lightweight terminal payloads are worth retaining for idempotent
+    replay; bulk payloads (raw realtime frames, trajectory tensors) would pin
+    GPU-scale buffers for the whole retention window."""
+    return (
+        not contains_file_refs(output.output)
+        and output.raw_frame_batches is None
+        and output.trajectory_latents is None
+        and output.rollout_trajectory_data is None
+    )
+
+
+class CancelReq(msgspec.Struct):
+    request_id: str
+
+
+class JobStatusReq(msgspec.Struct):
+    request_id: str
+
+
+class JobHandle:
+    def __init__(self, request_id: str) -> None:
+        self.request_id = request_id
+        self.status = QUEUED
+        self.created_ts = time.time()
+        self.finished_ts: float | None = None
+        self.step: int | None = None
+        self.total_steps: int | None = None
+        self.cancel_event = threading.Event()
+        self.waiters: list[bytes] = []
+        self.output: Any | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "request_id": self.request_id,
+            "status": self.status,
+            "created_ts": self.created_ts,
+            "step": self.step,
+            "total_steps": self.total_steps,
+        }
+
+
+class JobRegistry:
+    def __init__(self) -> None:
+        self._jobs: dict[str, JobHandle] = {}
+        self._finished: list[str] = []
+        # cancels for ids the event loop has not received yet (it may be
+        # blocked inside a forward); honored at admission, TTL-bounded so a
+        # cancel for an id that never arrives cannot poison a future reuse
+        self._precancelled: dict[str, float] = {}
+        self._lock = threading.Lock()
+
+    def admit(
+        self, request_id: str, identity: bytes | None
+    ) -> tuple[str, JobHandle | Any | None]:
+        """Idempotency before dispatch: ("new", handle) for a fresh id,
+        ("wait", handle) after attaching the duplicate as a waiter,
+        ("replay", output) for a finished job with its cached result, or
+        ("cancelled", None) when the id was cancelled before arrival."""
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            if handle is None:
+                self._expire_precancelled()
+                if request_id in self._precancelled:
+                    del self._precancelled[request_id]
+                    handle = JobHandle(request_id)
+                    handle.status = CANCELLED
+                    handle.cancel_event.set()
+                    handle.finished_ts = time.time()
+                    self._jobs[request_id] = handle
+                    self._finished.append(request_id)
+                    self._trim_finished()
+                    return ("cancelled", None)
+                handle = JobHandle(request_id)
+                self._jobs[request_id] = handle
+                return ("new", handle)
+            if handle.status in _TERMINAL:
+                return ("replay", handle.output)
+            if identity is not None:
+                handle.waiters.append(identity)
+            return ("wait", handle)
+
+    def mark_running(self, request_id: str) -> JobHandle | None:
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            if handle is not None and handle.status == QUEUED:
+                handle.status = RUNNING
+            return handle
+
+    def finish(self, request_id: str, output: Any) -> list[bytes]:
+        """Terminal transition; returns waiter identities owed a reply.
+
+        Waiters attached before the transition still receive the live payload
+        (the caller replies from its own reference); only the retained replay
+        copy is dropped when the payload is not replayable.
+        """
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            if handle is None:
+                return []
+            if handle.status not in _TERMINAL:
+                # classify from what actually happened: a cancel that arrived
+                # too late to abort the forward is a completion, not a cancel
+                if output.cancelled:
+                    handle.status = CANCELLED
+                elif output.error:
+                    handle.status = FAILED
+                else:
+                    handle.status = COMPLETED
+                handle.finished_ts = time.time()
+                self._finished.append(request_id)
+                self._trim_finished()
+            handle.output = output if _is_replayable(output) else None
+            waiters, handle.waiters = handle.waiters, []
+            return waiters
+
+    def _expire_precancelled(self) -> None:
+        now = time.time()
+        self._precancelled = {
+            request_id: expiry
+            for request_id, expiry in self._precancelled.items()
+            if expiry > now
+        }
+
+    def _trim_finished(self) -> None:
+        now = time.time()
+        while len(self._finished) > _FINISHED_RETENTION:
+            oldest = self._jobs.get(self._finished[0])
+            if (
+                oldest is not None
+                and oldest.finished_ts is not None
+                and now - oldest.finished_ts < _FINISHED_TTL_S
+                and len(self._finished) <= _FINISHED_HARD_CAP
+            ):
+                # young entries stay for idempotent replay, up to a hard cap
+                # that bounds retained output payloads under sustained load
+                break
+            self._jobs.pop(self._finished.pop(0), None)
+
+    def cancel(self, request_id: str) -> dict[str, Any]:
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            if handle is None:
+                # not received yet (the loop may be mid-forward); honor later
+                self._expire_precancelled()
+                if len(self._precancelled) >= _PRECANCEL_CAP:
+                    self._precancelled.pop(next(iter(self._precancelled)), None)
+                self._precancelled[request_id] = time.time() + _FINISHED_TTL_S
+                return {
+                    "request_id": request_id,
+                    "status": "unknown",
+                    "cancelled": True,
+                }
+            if handle.status in _TERMINAL:
+                return {**handle.to_dict(), "cancelled": False}
+            handle.cancel_event.set()
+            return {**handle.to_dict(), "cancelled": True}
+
+    def is_cancelled(self, request_id: str) -> bool:
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            return handle is not None and handle.cancel_event.is_set()
+
+    def status(self, request_id: str) -> dict[str, Any]:
+        with self._lock:
+            handle = self._jobs.get(request_id)
+            if handle is None:
+                return {"request_id": request_id, "status": "unknown"}
+            return handle.to_dict()
+
+
+_current_jobs: list[JobHandle] = []
+
+
+def set_current_jobs(handles: list[JobHandle]) -> None:
+    global _current_jobs
+    _current_jobs = list(handles)
+
+
+def clear_current_jobs() -> None:
+    global _current_jobs
+    _current_jobs = []
+
+
+def check_current_step(step_index: int, total_steps: int) -> None:
+    """Between-step cancellation and progress point for denoise loops."""
+    jobs = _current_jobs
+    if not jobs:
+        return
+    for handle in jobs:
+        handle.step = step_index
+        handle.total_steps = total_steps
+    # a merged dynamic batch aborts only when every member is cancelled
+    if not all(handle.cancel_event.is_set() for handle in jobs):
+        return
+    raise RequestCancelledError(f"cancelled at denoise step {step_index}/{total_steps}")

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Iterator, List
+from typing import Any, Iterator
 
 import msgspec
 import zmq
@@ -1062,8 +1062,19 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             elif verdict == "conflict":
                 self._try_return(
                     OutputBatch(
-                        error=f"request_id {req.request_id!r} was reused with different parameters",
+                        error=(
+                            f"request_id {req.request_id!r} was reused without "
+                            "a matching idempotency fingerprint"
+                        ),
                         idempotency_conflict=True,
+                    ),
+                    identity,
+                )
+            elif verdict == "capacity":
+                self._try_return(
+                    OutputBatch(
+                        error="job-control admission capacity is exhausted",
+                        overloaded=True,
                     ),
                     identity,
                 )

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -178,9 +178,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._max_consecutive_errors = 3
         self._consecutive_error_count = 0
 
-        # Job control (single-rank only in v1: admission filtering and
-        # queued-request drops must be identical on every rank, which needs
-        # the decisions broadcast alongside the requests)
         self.jobs: JobRegistry | None = None
         self._job_control_thread: threading.Thread | None = None
         self._job_control_socket: zmq.Socket | None = None
@@ -1058,14 +1055,10 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 output = OutputBatch(
                     error="request cancelled before dispatch", cancelled=True
                 )
-                # retain the typed tombstone so later duplicates replay a
-                # cancel (409) instead of a bare not-replayable failure
                 self.jobs.finish(req.request_id, output)
                 self._try_return(output, identity)
             elif verdict == "replay":
                 if payload is None or contains_file_refs(payload.output):
-                    # spilled arrays are single-consumer; a second read would
-                    # hand out dead refs
                     payload = OutputBatch(
                         error=(
                             f"request {req.request_id} already finished; "
@@ -1156,7 +1149,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             except zmq.ZMQError:
                 # re-raise or handle appropriately to let the outer loop continue
                 raise
-            # admission runs before the broadcast so every rank sees one list
             recv_reqs = self._admit_new_reqs(recv_reqs)
         else:
             recv_reqs = None
@@ -1287,16 +1279,12 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     for _ in items
                 ]
 
-            # 3. return results; registry transitions happen before replies so
-            # a failed send cannot lose a terminal state or strand waiters
             for (identity, processed_req), output_batch in zip(
                 items, output_batches, strict=True
             ):
                 is_warmup = is_warmup_req(processed_req)
                 self._log_warmup_result(output_batch, processed_req, is_warmup)
                 waiters = self._job_waiters(processed_req, output_batch, is_warmup)
-                # the primary reply spills arrays to single-consumer file refs
-                # in place; waiters need their own spill from the raw output
                 pre_spill_output = output_batch.output
 
                 should_return_lightweight_warmup_result = (
@@ -1328,8 +1316,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._log_batch_metrics_summary()
 
         if self._job_control_thread is not None:
-            # _running is already False; let the side channel exit before the
-            # context is destroyed under its socket
             self._job_control_thread.join(timeout=2.0)
         if self.receiver is not None:
             self.receiver.close()

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -12,6 +12,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Iterator, List
 
+import msgspec
 import zmq
 
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
@@ -46,12 +47,10 @@ from sglang.multimodal_gen.runtime.managers.dynamic_batch_admission import (
 from sglang.multimodal_gen.runtime.managers.gpu_worker import GPUWorker
 from sglang.multimodal_gen.runtime.managers.job_registry import (
     CANCELLED,
-    CancelReq,
     JobRegistry,
-    JobStatusReq,
-    clear_current_jobs,
+    clear_current_job,
     contains_file_refs,
-    set_current_jobs,
+    set_current_job,
 )
 from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
@@ -317,7 +316,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     return self._build_dynamic_batch_error_outputs(
                         reqs=reqs,
                         error_msg=output_batch.error,
-                        cancelled=output_batch.cancelled,
                     )
 
                 split_outputs = self._split_batched_output(output_batch, reqs)
@@ -328,7 +326,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     return self._build_dynamic_batch_error_outputs(
                         reqs=reqs,
                         error_msg="Dynamic batching failed: could not split merged output.",
-                        cancelled=output_batch.cancelled,
                     )
 
                 logger.info(
@@ -361,7 +358,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 return self._build_dynamic_batch_error_outputs(
                     reqs=reqs,
                     error_msg=output_batch.error,
-                    cancelled=output_batch.cancelled,
                 )
 
             split_outputs = self._split_batched_output(output_batch, reqs)
@@ -372,7 +368,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 return self._build_dynamic_batch_error_outputs(
                     reqs=reqs,
                     error_msg="Native grouped execution failed: could not split output.",
-                    cancelled=output_batch.cancelled,
                 )
 
             logger.info(
@@ -641,10 +636,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self,
         reqs: list[Req],
         error_msg: str,
-        *,
-        cancelled: bool = False,
     ) -> list[OutputBatch]:
-        return [OutputBatch(error=error_msg, cancelled=cancelled) for _ in reqs]
+        return [OutputBatch(error=error_msg) for _ in reqs]
 
     def _should_return_lightweight_warmup_result(self, processed_req: Any) -> bool:
         req = get_first_generation_req(processed_req)
@@ -825,7 +818,6 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     output_batch.trajectory_decoded, start, end, total_items
                 ),
                 error=output_batch.error,
-                cancelled=output_batch.cancelled,
                 output_file_paths=self._slice_batched_value(
                     output_batch.output_file_paths, start, end, total_items
                 ),
@@ -993,13 +985,11 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         try:
             socket.bind(self.server_args.scheduler_cancel_endpoint)
         except zmq.ZMQError as e:
-            logger.error(
-                "job-control channel failed to bind %s; job control disabled: %s",
-                self.server_args.scheduler_cancel_endpoint,
-                e,
-            )
             socket.close(linger=0)
-            return
+            raise RuntimeError(
+                "job-control channel failed to bind "
+                f"{self.server_args.scheduler_cancel_endpoint}"
+            ) from e
         self._job_control_socket = socket
         self.jobs = JobRegistry()
         self._job_control_thread = threading.Thread(
@@ -1020,18 +1010,26 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 # drain all frames so REP alternation survives multipart input
                 payload = socket.recv_multipart()[-1]
                 try:
-                    request = pickle.loads(payload)
-                    if isinstance(request, CancelReq):
-                        reply = self.jobs.cancel(request.request_id)
-                    elif isinstance(request, JobStatusReq):
-                        reply = self.jobs.status(request.request_id)
+                    request = msgspec.msgpack.decode(payload)
+                    if not isinstance(request, dict):
+                        raise ValueError("malformed job control request")
+                    request_id = request.get("request_id")
+                    if (
+                        not isinstance(request_id, str)
+                        or not 1 <= len(request_id) <= 128
+                    ):
+                        raise ValueError("malformed job control request")
+                    if request.get("operation") == "cancel":
+                        reply = self.jobs.cancel(request_id)
+                    elif request.get("operation") == "status":
+                        reply = self.jobs.status(request_id)
                     else:
                         reply = {
-                            "error": f"unknown job control request: {type(request)}"
+                            "error": f"unknown job control operation: {request.get('operation')!r}"
                         }
                 except Exception as e:  # never kill the channel
                     reply = {"error": str(e)}
-                socket.send(pickle.dumps(reply))
+                socket.send(msgspec.msgpack.encode(reply))
             except zmq.ZMQError:
                 break  # context shut down
         socket.close(linger=0)
@@ -1048,7 +1046,11 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             if not isinstance(req, Req) or is_warmup_req(req) or not req.request_id:
                 admitted.append((identity, req))
                 continue
-            verdict, payload = self.jobs.admit(req.request_id, identity)
+            verdict, payload = self.jobs.admit(
+                req.request_id,
+                identity,
+                (req.extra or {}).get("job_request_fingerprint"),
+            )
             if verdict == "new":
                 admitted.append((identity, req))
             elif verdict == "cancelled":
@@ -1057,6 +1059,22 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 )
                 self.jobs.finish(req.request_id, output)
                 self._try_return(output, identity)
+            elif verdict == "conflict":
+                self._try_return(
+                    OutputBatch(
+                        error=f"request_id {req.request_id!r} was reused with different parameters",
+                        idempotency_conflict=True,
+                    ),
+                    identity,
+                )
+            elif verdict == "overloaded":
+                self._try_return(
+                    OutputBatch(
+                        error=f"request_id {req.request_id!r} has too many duplicate waiters",
+                        idempotency_conflict=True,
+                    ),
+                    identity,
+                )
             elif verdict == "replay":
                 if payload is None or contains_file_refs(payload.output):
                     payload = OutputBatch(
@@ -1064,6 +1082,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                             f"request {req.request_id} already finished; "
                             "result not replayable"
                         ),
+                        idempotency_conflict=True,
                         cancelled=(
                             self.jobs.status(req.request_id)["status"] == CANCELLED
                         ),
@@ -1076,7 +1095,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         try:
             self.return_result(output_batch, identity)
         except zmq.ZMQError as e:
-            logger.warning("job-control reply failed: %s", e)
+            logger.warning("scheduler job reply failed: %s", e)
 
     def _drop_cancelled_items(
         self, items: list[tuple[bytes | None, Any]]
@@ -1102,18 +1121,16 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 kept.append((identity, req))
         return kept
 
-    def _set_running_jobs(self, items: list[tuple[bytes | None, Any]]) -> None:
+    def _set_running_job(self, items: list[tuple[bytes | None, Any]]) -> None:
         if self.jobs is None:
             return
-        handles = [
-            handle
-            for _, req in items
-            if isinstance(req, Req)
-            and req.request_id
-            and not is_warmup_req(req)
-            and (handle := self.jobs.mark_running(req.request_id)) is not None
-        ]
-        set_current_jobs(handles)
+        for _, req in items:
+            if isinstance(req, Req) and req.request_id and not is_warmup_req(req):
+                handle = self.jobs.mark_running(req.request_id)
+                if handle is not None:
+                    set_current_job(handle)
+                    return
+        set_current_job(None)
 
     def _job_waiters(
         self, req: Any, output_batch: OutputBatch, is_warmup: bool
@@ -1246,7 +1263,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             if not items:
                 continue
 
-            self._set_running_jobs(items)
+            self._set_running_job(items)
             try:
                 handler_result = self._dispatch_items(items)
             except Exception as e:
@@ -1256,7 +1273,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 )
                 handler_result = OutputBatch(error=str(e))
             finally:
-                clear_current_jobs()
+                clear_current_job()
 
             if isinstance(handler_result, list):
                 output_batches = handler_result

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -1118,7 +1118,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
     def _job_waiters(
         self, req: Any, output_batch: OutputBatch, is_warmup: bool
     ) -> list[bytes]:
-        """Terminal registry transition; returns waiter identities owed a reply."""
+        """Terminal registry transition. Returns waiter identities owed a reply."""
         if self.jobs is None or is_warmup or not isinstance(req, Req):
             return []
         if not req.request_id:
@@ -1302,7 +1302,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                             output_batch, identity, should_not_return=is_warmup
                         )
                 except zmq.ZMQError as e:
-                    # Reply failed; log and keep loop alive to accept future requests
+                    # Reply failed. Log and keep loop alive to accept future requests.
                     logger.error(f"ZMQ error sending reply: {e}")
                 for waiter in waiters:
                     try:

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -10,7 +10,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
 from enum import Enum
-from typing import Any
+from typing import Any, Iterator, List
 
 import zmq
 

--- a/python/sglang/multimodal_gen/runtime/managers/scheduler.py
+++ b/python/sglang/multimodal_gen/runtime/managers/scheduler.py
@@ -3,12 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import dataclasses
 import pickle
+import threading
 import time
 from collections import deque
+from collections.abc import Iterator
 from contextlib import contextmanager
 from copy import deepcopy
 from enum import Enum
-from typing import Any, Iterator, List
+from typing import Any
 
 import zmq
 
@@ -42,6 +44,15 @@ from sglang.multimodal_gen.runtime.managers.dynamic_batch_admission import (
     BatchAdmissionController,
 )
 from sglang.multimodal_gen.runtime.managers.gpu_worker import GPUWorker
+from sglang.multimodal_gen.runtime.managers.job_registry import (
+    CANCELLED,
+    CancelReq,
+    JobRegistry,
+    JobStatusReq,
+    clear_current_jobs,
+    contains_file_refs,
+    set_current_jobs,
+)
 from sglang.multimodal_gen.runtime.pipelines_core import Req
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import (
     BatchMetricsWindow,
@@ -167,6 +178,15 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         self._max_consecutive_errors = 3
         self._consecutive_error_count = 0
 
+        # Job control (single-rank only in v1: admission filtering and
+        # queued-request drops must be identical on every rank, which needs
+        # the decisions broadcast alongside the requests)
+        self.jobs: JobRegistry | None = None
+        self._job_control_thread: threading.Thread | None = None
+        self._job_control_socket: zmq.Socket | None = None
+        if gpu_id == 0 and server_args.job_control_enabled:
+            self._start_job_control()
+
         self._init_disagg_state(server_args, local_rank)
 
         if self._batch_metrics_enabled:
@@ -181,14 +201,14 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return None
         return self._disagg_metrics.snapshot().to_dict()
 
-    def _handle_get_disagg_stats(self, _reqs: List[Any]) -> OutputBatch:
+    def _handle_get_disagg_stats(self, _reqs: list[Any]) -> OutputBatch:
         """Handle stats request — return disagg metrics via OutputBatch.output."""
         stats = self.get_disagg_metrics()
         return OutputBatch(
             output=stats or {"role": "monolithic", "message": "not in disagg mode"}
         )
 
-    def _handle_set_lora(self, reqs: List[Any]) -> OutputBatch:
+    def _handle_set_lora(self, reqs: list[Any]) -> OutputBatch:
         # TODO: return set status
         # TODO: return with SetLoRAResponse or something more appropriate
         req = reqs[0]
@@ -200,26 +220,26 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             req.merge_mode,
         )
 
-    def _handle_merge_lora(self, reqs: List[Any]):
+    def _handle_merge_lora(self, reqs: list[Any]):
         req = reqs[0]
         return self.worker.merge_lora_weights(req.target, req.strength)
 
-    def _handle_unmerge_lora(self, reqs: List[Any]) -> OutputBatch:
+    def _handle_unmerge_lora(self, reqs: list[Any]) -> OutputBatch:
         req = reqs[0]
         return self.worker.unmerge_lora_weights(req.target)
 
-    def _handle_list_loras(self, _reqs: List[Any]) -> OutputBatch:
+    def _handle_list_loras(self, _reqs: list[Any]) -> OutputBatch:
         return self.worker.list_loras()
 
-    def _handle_shutdown(self, _reqs: List[Any]) -> OutputBatch:
+    def _handle_shutdown(self, _reqs: list[Any]) -> OutputBatch:
         self._running = False
         return OutputBatch()
 
-    def _handle_release_realtime_session(self, reqs: List[Any]) -> OutputBatch:
+    def _handle_release_realtime_session(self, reqs: list[Any]) -> OutputBatch:
         req = reqs[0]
         return self.worker.release_realtime_session(req.session_id)
 
-    def _handle_update_weights_from_disk(self, reqs: List[Any]) -> OutputBatch:
+    def _handle_update_weights_from_disk(self, reqs: list[Any]) -> OutputBatch:
         """Handle update_weights_from_disk request for RL workflows."""
         if self.worker.is_sleeping():
             raise RuntimeError(
@@ -300,6 +320,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     return self._build_dynamic_batch_error_outputs(
                         reqs=reqs,
                         error_msg=output_batch.error,
+                        cancelled=output_batch.cancelled,
                     )
 
                 split_outputs = self._split_batched_output(output_batch, reqs)
@@ -310,6 +331,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     return self._build_dynamic_batch_error_outputs(
                         reqs=reqs,
                         error_msg="Dynamic batching failed: could not split merged output.",
+                        cancelled=output_batch.cancelled,
                     )
 
                 logger.info(
@@ -330,7 +352,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     error_msg=f"Dynamic batching failed: {e}",
                 )
 
-    def _execute_generation_grouped(self, reqs: List[Req]) -> List[OutputBatch]:
+    def _execute_generation_grouped(self, reqs: list[Req]) -> list[OutputBatch]:
         batch_size = len(reqs)
         try:
             output_batch = self.worker.execute_forward(reqs)
@@ -342,6 +364,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 return self._build_dynamic_batch_error_outputs(
                     reqs=reqs,
                     error_msg=output_batch.error,
+                    cancelled=output_batch.cancelled,
                 )
 
             split_outputs = self._split_batched_output(output_batch, reqs)
@@ -352,6 +375,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 return self._build_dynamic_batch_error_outputs(
                     reqs=reqs,
                     error_msg="Native grouped execution failed: could not split output.",
+                    cancelled=output_batch.cancelled,
                 )
 
             logger.info(
@@ -372,7 +396,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 error_msg=f"Native grouped execution failed: {e}",
             )
 
-    def _execute_generation_sequential(self, reqs: List[Req]) -> List[OutputBatch]:
+    def _execute_generation_sequential(self, reqs: list[Req]) -> list[OutputBatch]:
         return [self.worker.execute_forward([req]) for req in reqs]
 
     @staticmethod
@@ -618,10 +642,12 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
 
     def _build_dynamic_batch_error_outputs(
         self,
-        reqs: List[Req],
+        reqs: list[Req],
         error_msg: str,
-    ) -> List[OutputBatch]:
-        return [OutputBatch(error=error_msg) for _ in reqs]
+        *,
+        cancelled: bool = False,
+    ) -> list[OutputBatch]:
+        return [OutputBatch(error=error_msg, cancelled=cancelled) for _ in reqs]
 
     def _should_return_lightweight_warmup_result(self, processed_req: Any) -> bool:
         req = get_first_generation_req(processed_req)
@@ -671,7 +697,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                 stage_name, time.perf_counter() - start_time
             )
 
-    def _try_merge_generation_reqs(self, reqs: List[Req]) -> Req | None:
+    def _try_merge_generation_reqs(self, reqs: list[Req]) -> Req | None:
         """Create a batched generation request from compatible requests.
 
         Per-request seeds and output paths are stored in `extra` so downstream
@@ -742,8 +768,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         return deepcopy(value)
 
     def _split_batched_output(
-        self, output_batch: OutputBatch, reqs: List[Req]
-    ) -> List[OutputBatch] | None:
+        self, output_batch: OutputBatch, reqs: list[Req]
+    ) -> list[OutputBatch] | None:
         """Split a merged result only when outputs map one-to-one to requests."""
         per_req_counts = [req.num_outputs_per_prompt for req in reqs]
         total_items = sum(per_req_counts)
@@ -802,6 +828,7 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     output_batch.trajectory_decoded, start, end, total_items
                 ),
                 error=output_batch.error,
+                cancelled=output_batch.cancelled,
                 output_file_paths=self._slice_batched_value(
                     output_batch.output_file_paths, start, end, total_items
                 ),
@@ -961,7 +988,151 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             return [(identity, reqs)]
         return [(identity, req) for req in reqs]
 
-    def recv_reqs(self) -> List[tuple[bytes, Any]]:
+    def _start_job_control(self) -> None:
+        """Bind the side channel before creating the registry: a failed bind
+        must leave job control fully off (self.jobs is None, so admission is a
+        passthrough), not a live registry behind a dead cancel channel."""
+        socket = self.context.socket(zmq.REP)
+        try:
+            socket.bind(self.server_args.scheduler_cancel_endpoint)
+        except zmq.ZMQError as e:
+            logger.error(
+                "job-control channel failed to bind %s; job control disabled: %s",
+                self.server_args.scheduler_cancel_endpoint,
+                e,
+            )
+            socket.close(linger=0)
+            return
+        self._job_control_socket = socket
+        self.jobs = JobRegistry()
+        self._job_control_thread = threading.Thread(
+            target=self._job_control_loop, daemon=True, name="job-control"
+        )
+        self._job_control_thread.start()
+
+    def _job_control_loop(self) -> None:
+        """Side channel serving cancel/status while the event loop is blocked
+        inside a forward."""
+        socket = self._job_control_socket
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        while self._running:
+            try:
+                if not poller.poll(timeout=1000):
+                    continue
+                # drain all frames so REP alternation survives multipart input
+                payload = socket.recv_multipart()[-1]
+                try:
+                    request = pickle.loads(payload)
+                    if isinstance(request, CancelReq):
+                        reply = self.jobs.cancel(request.request_id)
+                    elif isinstance(request, JobStatusReq):
+                        reply = self.jobs.status(request.request_id)
+                    else:
+                        reply = {
+                            "error": f"unknown job control request: {type(request)}"
+                        }
+                except Exception as e:  # never kill the channel
+                    reply = {"error": str(e)}
+                socket.send(pickle.dumps(reply))
+            except zmq.ZMQError:
+                break  # context shut down
+        socket.close(linger=0)
+
+    def _admit_new_reqs(
+        self, new_reqs: list[tuple[bytes, Any]]
+    ) -> list[tuple[bytes, Any]]:
+        """Idempotency before dispatch: duplicates of a live job wait on it,
+        duplicates of a finished job replay its cached result."""
+        if self.jobs is None:
+            return new_reqs
+        admitted = []
+        for identity, req in new_reqs:
+            if not isinstance(req, Req) or is_warmup_req(req) or not req.request_id:
+                admitted.append((identity, req))
+                continue
+            verdict, payload = self.jobs.admit(req.request_id, identity)
+            if verdict == "new":
+                admitted.append((identity, req))
+            elif verdict == "cancelled":
+                output = OutputBatch(
+                    error="request cancelled before dispatch", cancelled=True
+                )
+                # retain the typed tombstone so later duplicates replay a
+                # cancel (409) instead of a bare not-replayable failure
+                self.jobs.finish(req.request_id, output)
+                self._try_return(output, identity)
+            elif verdict == "replay":
+                if payload is None or contains_file_refs(payload.output):
+                    # spilled arrays are single-consumer; a second read would
+                    # hand out dead refs
+                    payload = OutputBatch(
+                        error=(
+                            f"request {req.request_id} already finished; "
+                            "result not replayable"
+                        ),
+                        cancelled=(
+                            self.jobs.status(req.request_id)["status"] == CANCELLED
+                        ),
+                    )
+                self._try_return(payload, identity)
+        return admitted
+
+    def _try_return(self, output_batch: OutputBatch, identity: bytes | None) -> None:
+        """Out-of-band replies must not kill the loop on one dead client."""
+        try:
+            self.return_result(output_batch, identity)
+        except zmq.ZMQError as e:
+            logger.warning("job-control reply failed: %s", e)
+
+    def _drop_cancelled_items(
+        self, items: list[tuple[bytes | None, Any]]
+    ) -> list[tuple[bytes | None, Any]]:
+        """Cancelled-while-queued requests are answered without dispatch."""
+        if self.jobs is None:
+            return items
+        kept = []
+        for identity, req in items:
+            if (
+                isinstance(req, Req)
+                and not is_warmup_req(req)
+                and req.request_id
+                and self.jobs.is_cancelled(req.request_id)
+            ):
+                output = OutputBatch(
+                    error="request cancelled before dispatch", cancelled=True
+                )
+                self._try_return(output, identity)
+                for waiter in self.jobs.finish(req.request_id, output):
+                    self._try_return(output, waiter)
+            else:
+                kept.append((identity, req))
+        return kept
+
+    def _set_running_jobs(self, items: list[tuple[bytes | None, Any]]) -> None:
+        if self.jobs is None:
+            return
+        handles = [
+            handle
+            for _, req in items
+            if isinstance(req, Req)
+            and req.request_id
+            and not is_warmup_req(req)
+            and (handle := self.jobs.mark_running(req.request_id)) is not None
+        ]
+        set_current_jobs(handles)
+
+    def _job_waiters(
+        self, req: Any, output_batch: OutputBatch, is_warmup: bool
+    ) -> list[bytes]:
+        """Terminal registry transition; returns waiter identities owed a reply."""
+        if self.jobs is None or is_warmup or not isinstance(req, Req):
+            return []
+        if not req.request_id:
+            return []
+        return self.jobs.finish(req.request_id, output_batch)
+
+    def recv_reqs(self) -> list[tuple[bytes, Any]]:
         """
         For non-main schedulers, reqs are broadcasted from main using broadcast_pyobj
         """
@@ -985,6 +1156,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
             except zmq.ZMQError:
                 # re-raise or handle appropriately to let the outer loop continue
                 raise
+            # admission runs before the broadcast so every rank sees one list
+            recv_reqs = self._admit_new_reqs(recv_reqs)
         else:
             recv_reqs = None
 
@@ -1077,6 +1250,11 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                         time.sleep(remaining_ms / 1000.0)
                 continue
 
+            items = self._drop_cancelled_items(items)
+            if not items:
+                continue
+
+            self._set_running_jobs(items)
             try:
                 handler_result = self._dispatch_items(items)
             except Exception as e:
@@ -1085,6 +1263,8 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     exc_info=True,
                 )
                 handler_result = OutputBatch(error=str(e))
+            finally:
+                clear_current_jobs()
 
             if isinstance(handler_result, list):
                 output_batches = handler_result
@@ -1107,17 +1287,22 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                     for _ in items
                 ]
 
-            # 3. return results
-            try:
-                for (identity, processed_req), output_batch in zip(
-                    items, output_batches, strict=True
-                ):
-                    is_warmup = is_warmup_req(processed_req)
-                    self._log_warmup_result(output_batch, processed_req, is_warmup)
+            # 3. return results; registry transitions happen before replies so
+            # a failed send cannot lose a terminal state or strand waiters
+            for (identity, processed_req), output_batch in zip(
+                items, output_batches, strict=True
+            ):
+                is_warmup = is_warmup_req(processed_req)
+                self._log_warmup_result(output_batch, processed_req, is_warmup)
+                waiters = self._job_waiters(processed_req, output_batch, is_warmup)
+                # the primary reply spills arrays to single-consumer file refs
+                # in place; waiters need their own spill from the raw output
+                pre_spill_output = output_batch.output
 
-                    should_return_lightweight_warmup_result = (
-                        self._should_return_lightweight_warmup_result(processed_req)
-                    )
+                should_return_lightweight_warmup_result = (
+                    self._should_return_lightweight_warmup_result(processed_req)
+                )
+                try:
                     if should_return_lightweight_warmup_result:
                         # internal prewarm is a real-path request; reply but drop payloads
                         output_batch.drop_payload_for_warmup()
@@ -1128,13 +1313,24 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
                         self.return_result(
                             output_batch, identity, should_not_return=is_warmup
                         )
-            except zmq.ZMQError as e:
-                # Reply failed; log and keep loop alive to accept future requests
-                logger.error(f"ZMQ error sending reply: {e}")
-                continue
+                except zmq.ZMQError as e:
+                    # Reply failed; log and keep loop alive to accept future requests
+                    logger.error(f"ZMQ error sending reply: {e}")
+                for waiter in waiters:
+                    try:
+                        self.return_result(
+                            dataclasses.replace(output_batch, output=pre_spill_output),
+                            waiter,
+                        )
+                    except zmq.ZMQError as e:
+                        logger.error(f"ZMQ error sending duplicate reply: {e}")
 
         self._log_batch_metrics_summary()
 
+        if self._job_control_thread is not None:
+            # _running is already False; let the side channel exit before the
+            # context is destroyed under its socket
+            self._job_control_thread.join(timeout=2.0)
         if self.receiver is not None:
             self.receiver.close()
         self._cleanup_disagg()
@@ -1148,17 +1344,17 @@ class Scheduler(SchedulerWarmupMixin, SchedulerPostTrainingMixin, SchedulerDisag
         for pipe in self.task_pipes_to_slaves:
             pipe.send(task)
 
-    def _collect_slave_results(self) -> List[dict[str, Any]]:
+    def _collect_slave_results(self) -> list[dict[str, Any]]:
         """Collect results from all slave worker processes."""
         results = []
         for pipe in self.result_pipes_from_slaves:
             results.append(pipe.recv())
         return results
 
-    def _handle_release_memory_occupation(self, _reqs: List[Any]) -> OutputBatch:
+    def _handle_release_memory_occupation(self, _reqs: list[Any]) -> OutputBatch:
         logger.info(f"[SLEEP] handle_release_memory_occupation on rank={self.gpu_id}")
         return OutputBatch(output=self.worker.release_memory_occupation())
 
-    def _handle_resume_memory_occupation(self, _reqs: List[Any]) -> OutputBatch:
+    def _handle_resume_memory_occupation(self, _reqs: list[Any]) -> OutputBatch:
         logger.info(f"[WAKE] handle_resume_memory_occupation on rank={self.gpu_id}")
         return OutputBatch(output=self.worker.resume_memory_occupation())

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -467,6 +467,7 @@ class OutputBatch:
     # For ComfyUI integration: noise prediction from denoising stage
     noise_pred: torch.Tensor | None = None
     peak_memory_mb: float = 0.0
+    overloaded: bool = False
 
     def drop_payload_for_warmup(self) -> None:
         self.output = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -457,6 +457,7 @@ class OutputBatch:
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
     cancelled: bool = False
+    idempotency_conflict: bool = False
     output_file_paths: list[str] | None = None
 
     # logged metrics info, directly from Req.timings

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -456,7 +456,6 @@ class OutputBatch:
     rollout_trajectory_data: RolloutTrajectoryData | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
-    # typed cancellation marker (job control); never inferred from error text
     cancelled: bool = False
     output_file_paths: list[str] | None = None
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -456,6 +456,8 @@ class OutputBatch:
     rollout_trajectory_data: RolloutTrajectoryData | None = None
     trajectory_decoded: list[torch.Tensor] | None = None
     error: str | None = None
+    # typed cancellation marker (job control); never inferred from error text
+    cancelled: bool = False
     output_file_paths: list[str] | None = None
 
     # logged metrics info, directly from Req.timings

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
@@ -774,7 +774,6 @@ class CausalDMDDenoisingStage(DenoisingStage):
         attn_metadata = None
 
         for i, timestep in enumerate(timesteps):
-            # between-step cancellation and progress point (job control)
             check_current_step(i, len(timesteps))
             noise_latents = noise_latents_btchw
             latent_model_input = prepare_model_input(current_latents).to(target_dtype)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
@@ -13,6 +13,7 @@ from sglang.multimodal_gen.runtime.layers.kvcache.causal_attention_cache import 
     CrossAttentionKVCache,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.diffusion_scheduler_utils import (
     get_or_create_request_scheduler,
     pred_noise_to_pred_video,
@@ -773,6 +774,8 @@ class CausalDMDDenoisingStage(DenoisingStage):
         attn_metadata = None
 
         for i, timestep in enumerate(timesteps):
+            # between-step cancellation and progress point (job control)
+            check_current_step(i, len(timesteps))
             noise_latents = noise_latents_btchw
             latent_model_input = prepare_model_input(current_latents).to(target_dtype)
             x0_btchw, attn_metadata = self._predict_x0_btchw(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -18,9 +18,9 @@ from functools import lru_cache
 from typing import Any
 
 import torch
-from torch import nn
+import torch.nn as nn
 
-from sglang.multimodal_gen import envs
+import sglang.multimodal_gen.envs as envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
 from sglang.multimodal_gen.configs.pipeline_configs.flux import (
     Flux2PipelineConfig,
@@ -1629,7 +1629,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             ) as progress_bar,
         ):
             for step_index, t_host in enumerate(timesteps_cpu):
-                # between-step cancellation and progress point (job control)
                 check_current_step(step_index, ctx.num_inference_steps)
                 # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
                 # use non-integer timesteps keep their precision in markers.
@@ -2247,7 +2246,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 timesteps=timesteps_num,
             )
         elif STA_mode == STA_Mode.STA_INFERENCE:
-            from sglang.multimodal_gen import envs
+            import sglang.multimodal_gen.envs as envs
 
             config_file = envs.SGLANG_DIFFUSION_ATTENTION_CONFIG
             if config_file is None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 
-import sglang.multimodal_gen.envs as envs
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
 from sglang.multimodal_gen.configs.pipeline_configs.flux import (
     Flux2PipelineConfig,
@@ -1624,58 +1624,58 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 enabled=ctx.autocast_enabled,
             ),
             maybe_nvtx_range("denoising_loop", use_nvtx),
-            self.progress_bar(
-                total=ctx.num_inference_steps, batch=batch
-            ) as progress_bar,
         ):
-            for step_index, t_host in enumerate(timesteps_cpu):
-                check_current_step(step_index, ctx.num_inference_steps)
-                # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
-                # use non-integer timesteps keep their precision in markers.
-                step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
-                with (
-                    maybe_nvtx_range(step_marker, use_nvtx),
-                    StageProfiler(
-                        f"denoising_step_{step_index}",
-                        logger=logger,
-                        metrics=batch.metrics,
-                        perf_dump_path_provided=batch.perf_dump_path is not None,
-                        record_as_step=True,
-                    ),
-                ):
-                    step = self._prepare_step_state(
-                        ctx,
-                        batch,
-                        server_args,
-                        step_index,
-                        t_host,
-                        timesteps_cpu,
-                    )
-                    # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
-                    # x_{t_i} for rollout trajectory collection. Must run
-                    # BEFORE _run_denoising_step so ctx.latents is still the
-                    # pre-step value. Gated on batch.rollout to keep the
-                    # non-rollout path strictly untouched.
-                    if batch.rollout:
-                        batch._rollout_loop_step_index = step_index
-                        self._maybe_append_dit_trajectory_step(
-                            batch=batch,
-                            latents=ctx.latents,
-                            timestep_value=step.t_host,
-                            step_index=step_index,
-                        )
-                    self._run_denoising_step(ctx, step, batch, server_args)
-                    self._record_trajectory(ctx, step, batch, server_args)
-
-                    if step_index == num_timesteps - 1 or (
-                        (step_index + 1) > ctx.num_warmup_steps
-                        and (step_index + 1) % ctx.scheduler.order == 0
-                        and progress_bar is not None
+            with self.progress_bar(
+                total=ctx.num_inference_steps, batch=batch
+            ) as progress_bar:
+                for step_index, t_host in enumerate(timesteps_cpu):
+                    check_current_step(step_index, ctx.num_inference_steps)
+                    # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
+                    # use non-integer timesteps keep their precision in markers.
+                    step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
+                    with (
+                        maybe_nvtx_range(step_marker, use_nvtx),
+                        StageProfiler(
+                            f"denoising_step_{step_index}",
+                            logger=logger,
+                            metrics=batch.metrics,
+                            perf_dump_path_provided=batch.perf_dump_path is not None,
+                            record_as_step=True,
+                        ),
                     ):
-                        progress_bar.update()
+                        step = self._prepare_step_state(
+                            ctx,
+                            batch,
+                            server_args,
+                            step_index,
+                            t_host,
+                            timesteps_cpu,
+                        )
+                        # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
+                        # x_{t_i} for rollout trajectory collection. Must run
+                        # BEFORE _run_denoising_step so ctx.latents is still the
+                        # pre-step value. Gated on batch.rollout to keep the
+                        # non-rollout path strictly untouched.
+                        if batch.rollout:
+                            batch._rollout_loop_step_index = step_index
+                            self._maybe_append_dit_trajectory_step(
+                                batch=batch,
+                                latents=ctx.latents,
+                                timestep_value=step.t_host,
+                                step_index=step_index,
+                            )
+                        self._run_denoising_step(ctx, step, batch, server_args)
+                        self._record_trajectory(ctx, step, batch, server_args)
 
-                    if not ctx.is_warmup:
-                        self.step_profile()
+                        if step_index == num_timesteps - 1 or (
+                            (step_index + 1) > ctx.num_warmup_steps
+                            and (step_index + 1) % ctx.scheduler.order == 0
+                            and progress_bar is not None
+                        ):
+                            progress_bar.update()
+
+                        if not ctx.is_warmup:
+                            self.step_profile()
 
         denoising_end_time = time.time()
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -18,7 +18,7 @@ from functools import lru_cache
 from typing import Any
 
 import torch
-import torch.nn as nn
+from torch import nn
 
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
@@ -73,6 +73,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader i
     TransformerLoader,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
@@ -1623,57 +1624,59 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 enabled=ctx.autocast_enabled,
             ),
             maybe_nvtx_range("denoising_loop", use_nvtx),
-        ):
-            with self.progress_bar(
+            self.progress_bar(
                 total=ctx.num_inference_steps, batch=batch
-            ) as progress_bar:
-                for step_index, t_host in enumerate(timesteps_cpu):
-                    # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
-                    # use non-integer timesteps keep their precision in markers.
-                    step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
-                    with (
-                        maybe_nvtx_range(step_marker, use_nvtx),
-                        StageProfiler(
-                            f"denoising_step_{step_index}",
-                            logger=logger,
-                            metrics=batch.metrics,
-                            perf_dump_path_provided=batch.perf_dump_path is not None,
-                            record_as_step=True,
-                        ),
-                    ):
-                        step = self._prepare_step_state(
-                            ctx,
-                            batch,
-                            server_args,
-                            step_index,
-                            t_host,
-                            timesteps_cpu,
+            ) as progress_bar,
+        ):
+            for step_index, t_host in enumerate(timesteps_cpu):
+                # between-step cancellation and progress point (job control)
+                check_current_step(step_index, ctx.num_inference_steps)
+                # Use ``:.4g`` so flow-matching schedulers (e.g. FLUX) that
+                # use non-integer timesteps keep their precision in markers.
+                step_marker = f"denoising_step_{step_index}_t{t_host.item():.4g}"
+                with (
+                    maybe_nvtx_range(step_marker, use_nvtx),
+                    StageProfiler(
+                        f"denoising_step_{step_index}",
+                        logger=logger,
+                        metrics=batch.metrics,
+                        perf_dump_path_provided=batch.perf_dump_path is not None,
+                        record_as_step=True,
+                    ),
+                ):
+                    step = self._prepare_step_state(
+                        ctx,
+                        batch,
+                        server_args,
+                        step_index,
+                        t_host,
+                        timesteps_cpu,
+                    )
+                    # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
+                    # x_{t_i} for rollout trajectory collection. Must run
+                    # BEFORE _run_denoising_step so ctx.latents is still the
+                    # pre-step value. Gated on batch.rollout to keep the
+                    # non-rollout path strictly untouched.
+                    if batch.rollout:
+                        batch._rollout_loop_step_index = step_index
+                        self._maybe_append_dit_trajectory_step(
+                            batch=batch,
+                            latents=ctx.latents,
+                            timestep_value=step.t_host,
+                            step_index=step_index,
                         )
-                        # Capture the raw (pre-scale, pre-I2V-concat) noisy latent
-                        # x_{t_i} for rollout trajectory collection. Must run
-                        # BEFORE _run_denoising_step so ctx.latents is still the
-                        # pre-step value. Gated on batch.rollout to keep the
-                        # non-rollout path strictly untouched.
-                        if batch.rollout:
-                            batch._rollout_loop_step_index = step_index
-                            self._maybe_append_dit_trajectory_step(
-                                batch=batch,
-                                latents=ctx.latents,
-                                timestep_value=step.t_host,
-                                step_index=step_index,
-                            )
-                        self._run_denoising_step(ctx, step, batch, server_args)
-                        self._record_trajectory(ctx, step, batch, server_args)
+                    self._run_denoising_step(ctx, step, batch, server_args)
+                    self._record_trajectory(ctx, step, batch, server_args)
 
-                        if step_index == num_timesteps - 1 or (
-                            (step_index + 1) > ctx.num_warmup_steps
-                            and (step_index + 1) % ctx.scheduler.order == 0
-                            and progress_bar is not None
-                        ):
-                            progress_bar.update()
+                    if step_index == num_timesteps - 1 or (
+                        (step_index + 1) > ctx.num_warmup_steps
+                        and (step_index + 1) % ctx.scheduler.order == 0
+                        and progress_bar is not None
+                    ):
+                        progress_bar.update()
 
-                        if not ctx.is_warmup:
-                            self.step_profile()
+                    if not ctx.is_warmup:
+                        self.step_profile()
 
         denoising_end_time = time.time()
 
@@ -2244,7 +2247,7 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
                 timesteps=timesteps_num,
             )
         elif STA_mode == STA_Mode.STA_INFERENCE:
-            import sglang.multimodal_gen.envs as envs
+            from sglang.multimodal_gen import envs
 
             config_file = envs.SGLANG_DIFFUSION_ATTENTION_CONFIG
             if config_file is None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.models.schedulers.scheduling_flow_match_euler_discrete import (
     FlowMatchEulerDiscreteScheduler,
 )
@@ -100,6 +101,7 @@ class DmdDenoisingStage(DenoisingStage):
         denoising_loop_start_time = time.time()
         with self.progress_bar(total=len(timesteps), batch=batch) as progress_bar:
             for i, t in enumerate(timesteps):
+                check_current_step(i, len(timesteps))
                 # Skip if interrupted
                 if hasattr(self, "interrupt") and self.interrupt:
                     continue

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -986,7 +986,6 @@ class Cosmos3DenoisingStage(PipelineStage):
         )
 
         for i, t in progress_bar:
-            # between-step cancellation and progress point (job control)
             check_current_step(i, len(timesteps))
             timestep = t.unsqueeze(0) if t.dim() == 0 else t
             # Outside the CFG window the effective scale collapses to 1.0,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -16,7 +16,7 @@ from typing import Any
 import numpy as np
 import PIL.Image
 import torch
-import torch.nn as nn
+from torch import nn
 
 from sglang.multimodal_gen.configs.sample.sampling_params import DataType
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
@@ -30,6 +30,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_sp_world_size,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -985,6 +986,8 @@ class Cosmos3DenoisingStage(PipelineStage):
         )
 
         for i, t in progress_bar:
+            # between-step cancellation and progress point (job control)
+            check_current_step(i, len(timesteps))
             timestep = t.unsqueeze(0) if t.dim() == 0 else t
             # Outside the CFG window the effective scale collapses to 1.0,
             # which reduces CFG to the cond branch (cfg-parallel safe).

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
@@ -15,6 +15,7 @@ import torch.nn.functional as F
 
 from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
@@ -157,6 +158,9 @@ class HeliosChunkedDenoisingStage(PipelineStage):
         do_cfg = guidance_scale > 1.0
 
         for i, t in enumerate(timesteps):
+            check_current_step(
+                global_step_offset + i, global_step_offset + len(timesteps)
+            )
             with StageProfiler(
                 f"denoising_step_{global_step_offset + i}",
                 logger=logger,
@@ -355,6 +359,7 @@ class HeliosChunkedDenoisingStage(PipelineStage):
 
             # Denoising loop for this pyramid stage
             for idx, t in enumerate(timesteps):
+                check_current_step(step_counter, step_counter + len(timesteps) - idx)
                 with StageProfiler(
                     f"denoising_step_{step_counter}",
                     logger=logger,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
@@ -875,7 +875,6 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
             extra_step_kwargs["generator"] = generator
 
         for step_idx, t in enumerate(timesteps):
-            # between-step cancellation and progress point (job control)
             check_current_step(step_idx, len(timesteps))
             latents = rearrange(latents, "(b n) c h w -> b n c h w", n=num_in_batch)
             latent_model_input = torch.cat([latents] * 2) if do_cfg else latents

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
@@ -20,7 +20,6 @@ from sglang.multimodal_gen.configs.pipeline_configs.hunyuan3d import (
     Hunyuan3D2PipelineConfig,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
-from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -875,7 +874,6 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
             extra_step_kwargs["generator"] = generator
 
         for step_idx, t in enumerate(timesteps):
-            check_current_step(step_idx, len(timesteps))
             latents = rearrange(latents, "(b n) c h w -> b n c h w", n=num_in_batch)
             latent_model_input = torch.cat([latents] * 2) if do_cfg else latents
             latent_model_input = rearrange(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/hunyuan3d/paint.py
@@ -20,6 +20,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.hunyuan3d import (
     Hunyuan3D2PipelineConfig,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch, Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
     PipelineStage,
@@ -874,6 +875,8 @@ class Hunyuan3DPaintTexGenStage(PipelineStage):
             extra_step_kwargs["generator"] = generator
 
         for step_idx, t in enumerate(timesteps):
+            # between-step cancellation and progress point (job control)
+            check_current_step(step_idx, len(timesteps))
             latents = rearrange(latents, "(b n) c h w -> b n c h w", n=num_in_batch)
             latent_model_input = torch.cat([latents] * 2) if do_cfg else latents
             latent_model_input = rearrange(
@@ -1097,7 +1100,7 @@ class Hunyuan3DPaintPostprocessStage(PipelineStage):
 
 
 __all__ = [
+    "Hunyuan3DPaintPostprocessStage",
     "Hunyuan3DPaintPreprocessStage",
     "Hunyuan3DPaintTexGenStage",
-    "Hunyuan3DPaintPostprocessStage",
 ]

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longlive2.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longlive2.py
@@ -607,7 +607,6 @@ class LongLive2CausalDenoisingStage(CausalDMDDenoisingStage):
             current_latents = current_latents.clone()
 
         for current_timestep, timestep in enumerate(timesteps):
-            # between-step cancellation and progress point (job control)
             check_current_step(current_timestep, len(timesteps))
             with self._denoise_step_profiler(batch, start_frame, current_timestep):
                 if clamp_latent is not None:
@@ -706,7 +705,6 @@ class LongLive2CausalDenoisingStage(CausalDMDDenoisingStage):
             current_latents = current_latents.clone()
 
         for current_timestep, timestep in enumerate(timesteps):
-            # between-step cancellation and progress point (job control)
             check_current_step(current_timestep, len(timesteps))
             with self._denoise_step_profiler(batch, start_frame, current_timestep):
                 if clamp_latent is not None:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longlive2.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/longlive2.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import torch
 
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.causal_denoising import (
     CAUSAL_BLOCK_PROMPTS_KEY,
@@ -93,7 +94,7 @@ class LongLive2TextEncodingStage(TextEncodingStage):
             scene_cut_prefix=(
                 LONG_LIVE2_DEFAULT_SCENE_CUT_PREFIX
                 if getattr(batch, "scene_cut_prefix", None) is None
-                else getattr(batch, "scene_cut_prefix")
+                else batch.scene_cut_prefix
             ),
         )
         batch.extra[CAUSAL_BLOCK_PROMPTS_KEY] = block_prompts
@@ -606,6 +607,8 @@ class LongLive2CausalDenoisingStage(CausalDMDDenoisingStage):
             current_latents = current_latents.clone()
 
         for current_timestep, timestep in enumerate(timesteps):
+            # between-step cancellation and progress point (job control)
+            check_current_step(current_timestep, len(timesteps))
             with self._denoise_step_profiler(batch, start_frame, current_timestep):
                 if clamp_latent is not None:
                     current_latents[:, :, :context_frames] = clamp_latent
@@ -703,6 +706,8 @@ class LongLive2CausalDenoisingStage(CausalDMDDenoisingStage):
             current_latents = current_latents.clone()
 
         for current_timestep, timestep in enumerate(timesteps):
+            # between-step cancellation and progress point (job control)
+            check_current_step(current_timestep, len(timesteps))
             with self._denoise_step_profiler(batch, start_frame, current_timestep):
                 if clamp_latent is not None:
                     current_latents[:, :, :context_frames] = clamp_latent

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
@@ -16,6 +16,7 @@ import torch
 from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
     MINIMAX_H3_ADALN_MODALITY_NUM,
 )
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 
 MINIMAX_H3_IMGVID_COND_TIMESTEP = 0.999
 # ref2va audio reference anchor timestep
@@ -461,6 +462,7 @@ def minimax_h3_denoise_loop(
     video_denoised_scratch = torch.empty_like(video_rows[video_target_slice])
     audio_denoised_scratch = torch.empty_like(audio_rows[audio_target_slice])
     for step in range(num_steps):
+        check_current_step(step, num_steps)
         step_cm = step_profiler(step) if step_profiler is not None else nullcontext()
         with step_cm:
             s_v = sigmas_video[step]

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -37,6 +37,7 @@ from sglang.multimodal_gen.runtime.distributed.sp_shard_utils import (
     tail_attn_meta,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 
 # Both audio and video DiT use the same sinusoidal_embedding_1d function
 # Import from mova_video_dit where it's defined (mova_audio_dit re-exports it)
@@ -488,6 +489,7 @@ class MOVADenoisingStage(PipelineStage):
 
         with self.progress_bar(total=total_steps, batch=batch) as progress_bar:
             for idx_step in range(total_steps):
+                check_current_step(idx_step, total_steps)
                 with StageProfiler(
                     f"denoising_step_{idx_step}",
                     logger=logger,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
@@ -24,6 +24,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_classifier_free_guidance_world_size,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
@@ -965,6 +966,7 @@ class SanaWMDenoisingStage(DenoisingStage):
             self.transformer = transformer
 
             for step_idx, t in enumerate(self.progress_bar(timesteps, batch=batch)):
+                check_current_step(step_idx, len(timesteps))
                 if cfg_parallel:
                     latent_model_input = latents
                 else:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
@@ -20,6 +20,7 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_classifier_free_guidance_rank,
 )
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
@@ -662,6 +663,7 @@ class SanaWMLTX2RefinerStage(PipelineStage):
         n_context_tokens = sink_tokens.shape[1]
 
         for step_idx in range(len(sigmas) - 1):
+            check_current_step(step_idx, len(sigmas) - 1)
             sigma = sigmas[step_idx]
             denoised = self._predict_current_x0(
                 sink=sink,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming.py
@@ -24,6 +24,7 @@ import torch
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.managers.forward_context import set_forward_context
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentUse,
 )
@@ -98,7 +99,8 @@ def self_forcing_denoise_chunk(
     ctx = forward_ctx if forward_ctx is not None else (lambda _ts: nullcontext())
 
     scheduler.set_timesteps(sigmas=sigmas, device=device)
-    for t in scheduler.timesteps:
+    for step_idx, t in enumerate(scheduler.timesteps):
+        check_current_step(step_idx, len(scheduler.timesteps))
         chunk_lat = get_chunk()
         B, C = chunk_lat.shape[0], chunk_lat.shape[1]
         lat_in = torch.cat([chunk_lat, chunk_lat], dim=0) if do_cfg else chunk_lat

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming_refiner.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming_refiner.py
@@ -19,6 +19,7 @@ import torch
 from torch import nn
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.models.dits.sana_wm_refiner_transformer import (
     pack_latents,
     unpack_latents,
@@ -567,6 +568,7 @@ class RefinerChunkRunner:
         )
         active_positions = list(range(int(block_start), int(block_end)))
         for level in range(int(self.sigmas.numel()) - 1):
+            check_current_step(level, int(self.sigmas.numel()) - 1)
             sigma_cur = float(self.sigmas[level].item())
             sigma_next = float(self.sigmas[level + 1].item())
             pred_x0 = refiner._predict_x0_active_block(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
@@ -439,7 +439,6 @@ class ProgressiveDenoisingStage(DenoisingStage):
     ) -> None:
         """Run denoising steps [start_step, end_step) using the parent infrastructure."""
         for step_index in range(start_step, end_step):
-            # between-step cancellation and progress point (job control)
             check_current_step(step_index, ctx.num_inference_steps)
             t_host = timesteps_cpu[step_index]
             step = self._prepare_step_state(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/progressive_resolution/denoising.py
@@ -41,6 +41,7 @@ from sglang.multimodal_gen.runtime.distributed import (
     get_local_torch_device,
     get_sp_world_size,
 )
+from sglang.multimodal_gen.runtime.managers.job_registry import check_current_step
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
 from sglang.multimodal_gen.runtime.pipelines_core.stages.denoising import (
@@ -298,7 +299,6 @@ class ProgressiveDenoisingStage(DenoisingStage):
         new_w_pixel: int,
     ) -> None:
         """Called after each stage transition. Update resolution-dependent state."""
-        pass
 
     def _refresh_cache_dit_context(
         self, n_remaining: int, scm_preset: str | None
@@ -439,6 +439,8 @@ class ProgressiveDenoisingStage(DenoisingStage):
     ) -> None:
         """Run denoising steps [start_step, end_step) using the parent infrastructure."""
         for step_index in range(start_step, end_step):
+            # between-step cancellation and progress point (job control)
+            check_current_step(step_index, ctx.num_inference_steps)
             t_host = timesteps_cpu[step_index]
             step = self._prepare_step_state(
                 ctx, batch, server_args, step_index, t_host, timesteps_cpu

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -2,10 +2,12 @@ import pickle
 import time
 from typing import Any, Optional, Set
 
+import msgspec
 import zmq
 import zmq.asyncio
 
 from sglang.multimodal_gen.runtime.ipc_array import materialize_file_refs
+from sglang.multimodal_gen.runtime.managers.job_registry import CancelReq, JobStatusReq
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -199,13 +201,31 @@ class AsyncSchedulerClient:
             raise RuntimeError(
                 "AsyncSchedulerClient is not initialized. Call initialize() first."
             )
+        if isinstance(request, CancelReq):
+            operation = "cancel"
+        elif isinstance(request, JobStatusReq):
+            operation = "status"
+        else:
+            raise TypeError(f"unsupported job control request: {type(request)}")
         socket = self.context.socket(zmq.REQ)
         socket.setsockopt(zmq.LINGER, 0)
         socket.setsockopt(zmq.RCVTIMEO, 5000)
         socket.connect(self.server_args.scheduler_cancel_endpoint)
         try:
-            await socket.send(pickle.dumps(request))
-            return pickle.loads(await socket.recv())
+            await socket.send(
+                msgspec.msgpack.encode(
+                    {"operation": operation, "request_id": request.request_id}
+                )
+            )
+            try:
+                reply = msgspec.msgpack.decode(await socket.recv())
+            except msgspec.DecodeError as e:
+                raise RuntimeError(
+                    "Scheduler returned an invalid job-control reply."
+                ) from e
+            if not isinstance(reply, dict):
+                raise RuntimeError("Scheduler returned an invalid job-control reply.")
+            return reply
         except zmq.error.Again:
             raise TimeoutError("Scheduler job-control channel did not respond.")
         finally:

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -194,8 +194,7 @@ class AsyncSchedulerClient:
             socket.close()
 
     async def job_control(self, request: Any) -> Any:
-        """Round trip on the scheduler's job-control side channel, which
-        stays responsive while a forward runs (cancel/status)."""
+        """Cancel/status round trip on the job-control side channel."""
         if self.context is None:
             raise RuntimeError(
                 "AsyncSchedulerClient is not initialized. Call initialize() first."

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -1,6 +1,6 @@
 import pickle
 import time
-from typing import Any
+from typing import Any, Optional, Set
 
 import zmq
 import zmq.asyncio

--- a/python/sglang/multimodal_gen/runtime/scheduler_client.py
+++ b/python/sglang/multimodal_gen/runtime/scheduler_client.py
@@ -1,6 +1,6 @@
 import pickle
 import time
-from typing import Any, Optional
+from typing import Any
 
 import zmq
 import zmq.asyncio
@@ -59,7 +59,7 @@ class SchedulerClient:
         self.context = None
         self.scheduler_socket = None
         self.server_args = None
-        self.request_logger: Optional[DiffusionRequestLogger] = None
+        self.request_logger: DiffusionRequestLogger | None = None
 
     def initialize(self, server_args: ServerArgs):
         if self.context is not None and not self.context.closed:
@@ -149,7 +149,7 @@ class AsyncSchedulerClient:
     def __init__(self):
         self.context = None
         self.server_args = None
-        self.request_logger: Optional[DiffusionRequestLogger] = None
+        self.request_logger: DiffusionRequestLogger | None = None
 
     def initialize(self, server_args: ServerArgs):
         if self.context is not None and not self.context.closed:
@@ -190,6 +190,25 @@ class AsyncSchedulerClient:
         except zmq.error.Again:
             logger.error("Timeout waiting for response from scheduler.")
             raise TimeoutError("Scheduler did not respond in time.")
+        finally:
+            socket.close()
+
+    async def job_control(self, request: Any) -> Any:
+        """Round trip on the scheduler's job-control side channel, which
+        stays responsive while a forward runs (cancel/status)."""
+        if self.context is None:
+            raise RuntimeError(
+                "AsyncSchedulerClient is not initialized. Call initialize() first."
+            )
+        socket = self.context.socket(zmq.REQ)
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.RCVTIMEO, 5000)
+        socket.connect(self.server_args.scheduler_cancel_endpoint)
+        try:
+            await socket.send(pickle.dumps(request))
+            return pickle.loads(await socket.recv())
+        except zmq.error.Again:
+            raise TimeoutError("Scheduler job-control channel did not respond.")
         finally:
             socket.close()
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -21,6 +21,9 @@ import yaml
 
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import PipelineConfig
+from sglang.multimodal_gen.configs.pipeline_configs.diffusers_generic import (
+    DiffusersGenericPipelineConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
     LTX2PipelineConfig,
     is_ltx23_native_variant,
@@ -1006,7 +1009,7 @@ class ServerArgs(DisaggServerArgsMixin):
                 )
 
     def _settle_job_control_port(self):
-        """Reserve the cancel port when job control is enabled."""
+        """Select and validate the cancel port when job control is enabled."""
         if not self.job_control_enabled:
             return
         self.scheduler_cancel_port = (
@@ -1014,7 +1017,12 @@ class ServerArgs(DisaggServerArgsMixin):
         )
         taken_ports = {
             port
-            for port in (self.port, self.scheduler_port, self.master_port)
+            for port in (
+                self.port,
+                self.broker_port,
+                self.scheduler_port,
+                self.master_port,
+            )
             if port is not None
         }
         if self.strict_ports:
@@ -2089,21 +2097,25 @@ class ServerArgs(DisaggServerArgsMixin):
 
     @property
     def scheduler_cancel_endpoint(self):
-        scheduler_host = self.host
-        if scheduler_host is None or scheduler_host == "localhost":
-            scheduler_host = "127.0.0.1"
-        return f"tcp://{scheduler_host}:{self.scheduler_cancel_port}"
+        """Local-only endpoint for monolithic v1 job control."""
+        return f"tcp://127.0.0.1:{self.scheduler_cancel_port}"
 
     @property
     def job_control_enabled(self) -> bool:
-        """True when single-rank job cancel/status is enabled."""
+        """True for supported single-request image and video jobs."""
         return (
             not self.disable_job_control
             and self.disagg_role == RoleType.MONOLITHIC
+            and self.num_gpus == 1
             and self.sp_degree == 1
             and not self.enable_cfg_parallel
             and self.tp_size == 1
             and self.dp_size == 1
+            and self.batching_max_size == 1
+            and self.pipeline_config.task_type.is_visual_gen()
+            and not isinstance(self.pipeline_config, DiffusersGenericPipelineConfig)
+            and self.backend != Backend.DIFFUSERS
+            and self.pipeline_class_name != "DiffusersPipeline"
         )
 
     def settle_port(

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -356,9 +356,7 @@ class ServerArgs(DisaggServerArgsMixin):
     webui_port: int | None = 12312
 
     scheduler_port: int = 5555
-    # side channel for job cancel/status, reachable while a forward runs
     scheduler_cancel_port: int = 0
-    # opt out of job cancel/status endpoints and the cancel-port reservation
     disable_job_control: bool = False
     batching_mode: str = "dynamic"
     batching_max_size: int = 1
@@ -481,7 +479,6 @@ class ServerArgs(DisaggServerArgsMixin):
         self._adjust_network_ports()
         # adjust parallelism before attention backend
         self._adjust_parallelism()
-        # the cancel port gate reads resolved parallelism, so settle it after
         self._settle_job_control_port()
         self._adjust_attention_backend()
         self._adjust_platform_specific()
@@ -1009,11 +1006,7 @@ class ServerArgs(DisaggServerArgsMixin):
                 )
 
     def _settle_job_control_port(self):
-        """Reserve the cancel side channel only when the resolved config can
-        enable job control; runs after parallelism adjustment because the
-        gate depends on resolved sp/tp/cfg-parallel values. Under
-        --strict-ports the port must not be required when job control is off.
-        """
+        """Reserve the cancel port when job control is enabled."""
         if not self.job_control_enabled:
             return
         self.scheduler_cancel_port = (
@@ -2103,10 +2096,7 @@ class ServerArgs(DisaggServerArgsMixin):
 
     @property
     def job_control_enabled(self) -> bool:
-        """Job cancel/status is single-rank only in v1: admission filtering
-        and queued-request drops must be identical on every rank. The cancel
-        port is settled if and only if this holds (see
-        ``_settle_job_control_port``)."""
+        """True when single-rank job cancel/status is enabled."""
         return (
             not self.disable_job_control
             and self.disagg_role == RoleType.MONOLITHIC

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from dataclasses import field
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, List, Literal, Optional
 
 import addict
 import yaml

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from dataclasses import field
 from enum import Enum
-from typing import Any, List, Literal, Optional
+from typing import Any, Literal
 
 import addict
 import yaml
@@ -202,7 +202,7 @@ class ServerArgs(DisaggServerArgsMixin):
     )
 
     # Distributed executor backend
-    nccl_port: Optional[int] = None
+    nccl_port: int | None = None
 
     # HuggingFace specific parameters
     trust_remote_code: bool = False
@@ -356,6 +356,10 @@ class ServerArgs(DisaggServerArgsMixin):
     webui_port: int | None = 12312
 
     scheduler_port: int = 5555
+    # side channel for job cancel/status, reachable while a forward runs
+    scheduler_cancel_port: int = 0
+    # opt out of job cancel/status endpoints and the cancel-port reservation
+    disable_job_control: bool = False
     batching_mode: str = "dynamic"
     batching_max_size: int = 1
     batching_delay_ms: float = 0.0
@@ -427,7 +431,7 @@ class ServerArgs(DisaggServerArgsMixin):
     log_requests: bool = False
     log_requests_level: int = 2
     log_requests_format: str = "text"
-    log_requests_target: Optional[List[str]] = None
+    log_requests_target: list[str] | None = None
     uvicorn_access_log_exclude_prefixes: list[str] = field(default_factory=list)
 
     # Tracing
@@ -477,6 +481,8 @@ class ServerArgs(DisaggServerArgsMixin):
         self._adjust_network_ports()
         # adjust parallelism before attention backend
         self._adjust_parallelism()
+        # the cancel port gate reads resolved parallelism, so settle it after
+        self._settle_job_control_port()
         self._adjust_attention_backend()
         self._adjust_platform_specific()
         self._adjust_layerwise_offload_components()
@@ -1001,6 +1007,34 @@ class ServerArgs(DisaggServerArgsMixin):
                 self.master_port = self.settle_port(
                     self.master_port, 37, avoid=settled_ports
                 )
+
+    def _settle_job_control_port(self):
+        """Reserve the cancel side channel only when the resolved config can
+        enable job control; runs after parallelism adjustment because the
+        gate depends on resolved sp/tp/cfg-parallel values. Under
+        --strict-ports the port must not be required when job control is off.
+        """
+        if not self.job_control_enabled:
+            return
+        self.scheduler_cancel_port = (
+            self.scheduler_cancel_port or self.scheduler_port + 1
+        )
+        taken_ports = {
+            port
+            for port in (self.port, self.scheduler_port, self.master_port)
+            if port is not None
+        }
+        if self.strict_ports:
+            if self.scheduler_cancel_port in taken_ports:
+                raise RuntimeError(
+                    f"Job control port {self.scheduler_cancel_port} duplicates "
+                    "another server port and --strict-ports is enabled."
+                )
+            self._require_port(self.scheduler_cancel_port, "Job control")
+        else:
+            self.scheduler_cancel_port = self.settle_port(
+                self.scheduler_cancel_port, avoid=taken_ports
+            )
 
     def _adjust_parallelism(self):
         sp_unspecified = self.sp_degree is None
@@ -1803,6 +1837,21 @@ class ServerArgs(DisaggServerArgsMixin):
             help="Port for the scheduler server.",
         )
         parser.add_argument(
+            "--scheduler-cancel-port",
+            type=int,
+            default=ServerArgs.scheduler_cancel_port,
+            help="Port for the job-control side channel (0 = scheduler port + 1).",
+        )
+        parser.add_argument(
+            "--disable-job-control",
+            action=StoreBoolean,
+            default=ServerArgs.disable_job_control,
+            help=(
+                "Disable the job cancel/status endpoints and skip reserving "
+                "the job-control side-channel port."
+            ),
+        )
+        parser.add_argument(
             "--batching-mode",
             type=str,
             default=ServerArgs.batching_mode,
@@ -2044,6 +2093,28 @@ class ServerArgs(DisaggServerArgsMixin):
         if scheduler_host is None or scheduler_host == "localhost":
             scheduler_host = "127.0.0.1"
         return f"tcp://{scheduler_host}:{self.scheduler_port}"
+
+    @property
+    def scheduler_cancel_endpoint(self):
+        scheduler_host = self.host
+        if scheduler_host is None or scheduler_host == "localhost":
+            scheduler_host = "127.0.0.1"
+        return f"tcp://{scheduler_host}:{self.scheduler_cancel_port}"
+
+    @property
+    def job_control_enabled(self) -> bool:
+        """Job cancel/status is single-rank only in v1: admission filtering
+        and queued-request drops must be identical on every rank. The cancel
+        port is settled if and only if this holds (see
+        ``_settle_job_control_port``)."""
+        return (
+            not self.disable_job_control
+            and self.disagg_role == RoleType.MONOLITHIC
+            and self.sp_degree == 1
+            and not self.enable_cfg_parallel
+            and self.tp_size == 1
+            and self.dp_size == 1
+        )
 
     def settle_port(
         self,
@@ -2537,7 +2608,7 @@ class PortArgs:
 
     @staticmethod
     def from_server_args(
-        server_args: ServerArgs, dp_rank: Optional[int] = None
+        server_args: ServerArgs, dp_rank: int | None = None
     ) -> "PortArgs":
         if server_args.nccl_port is None:
             nccl_port = server_args.scheduler_port + random.randint(100, 1000)

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -14,7 +14,7 @@ import sys
 import tempfile
 from dataclasses import field
 from enum import Enum
-from typing import Any, List, Literal, Optional
+from typing import Any, Dict, List, Literal, Optional, Set
 
 import addict
 import yaml

--- a/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from pydantic import ValidationError
 
 from sglang.multimodal_gen.runtime.entrypoints.openai.image_api import (
+    _process_image_batch,
     _request_fingerprint,
     cancel_job,
     job_status,
@@ -29,6 +30,7 @@ from sglang.multimodal_gen.runtime.managers.job_registry import (
     CancelReq,
     RequestCancelledError,
     RequestConflictError,
+    RequestOverloadedError,
 )
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
@@ -285,7 +287,7 @@ class TestVideoDelete(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class TestConflictResponse(unittest.IsolatedAsyncioTestCase):
+class TestTypedSchedulerErrors(unittest.IsolatedAsyncioTestCase):
     async def test_typed_scheduler_conflict_is_preserved(self):
         client = SimpleNamespace(
             forward=AsyncMock(
@@ -308,6 +310,39 @@ class TestConflictResponse(unittest.IsolatedAsyncioTestCase):
         ):
             with self.assertRaises(RequestConflictError):
                 await process_generation_batch(client, batch)
+
+    async def test_typed_scheduler_overload_is_preserved(self):
+        client = SimpleNamespace(
+            forward=AsyncMock(
+                return_value=OutputBatch(
+                    error="job-control admission capacity is exhausted",
+                    overloaded=True,
+                )
+            )
+        )
+        batch = SimpleNamespace(trace_ctx=None, prompt="prompt")
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.utils.trace_req",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.utils.log_generation_timer",
+                return_value=nullcontext(),
+            ),
+        ):
+            with self.assertRaises(RequestOverloadedError):
+                await process_generation_batch(client, batch)
+
+    async def test_image_routes_map_scheduler_overload_to_429(self):
+        with patch(
+            "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.process_generation_batch",
+            new=AsyncMock(side_effect=RequestOverloadedError("at capacity")),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await _process_image_batch(object())
+        self.assertEqual(raised.exception.status_code, 429)
+        self.assertEqual(raised.exception.detail, "at capacity")
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
@@ -23,6 +23,7 @@ from sglang.multimodal_gen.runtime.entrypoints.openai.video_api import (
     _dispatch_job_async,
     _require_trackable_video_batch,
     delete_video,
+    download_video_content,
 )
 from sglang.multimodal_gen.runtime.managers.job_registry import (
     CancelReq,
@@ -272,6 +273,16 @@ class TestVideoDelete(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(job["status"], "cancelled")
         for field in ("url", "file_path", "file_paths", "num_outputs"):
             self.assertIsNone(job[field])
+
+    async def test_cancelled_content_is_not_reported_as_in_progress(self):
+        await VIDEO_STORE.update_fields("video-id", {"status": "cancelled"})
+        with self.assertRaises(HTTPException) as raised:
+            await download_video_content("video-id")
+        self.assertEqual(raised.exception.status_code, 404)
+        self.assertEqual(
+            raised.exception.detail,
+            "Video content is unavailable for a cancelled generation",
+        )
 
 
 class TestConflictResponse(unittest.IsolatedAsyncioTestCase):

--- a/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_control_api.py
@@ -1,0 +1,303 @@
+import unittest
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import msgspec
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from sglang.multimodal_gen.runtime.entrypoints.openai.image_api import (
+    _request_fingerprint,
+    cancel_job,
+    job_status,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.protocol import (
+    ImageGenerationsRequest,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.stores import VIDEO_STORE
+from sglang.multimodal_gen.runtime.entrypoints.openai.utils import (
+    process_generation_batch,
+)
+from sglang.multimodal_gen.runtime.entrypoints.openai.video_api import (
+    _dispatch_job_async,
+    _require_trackable_video_batch,
+    delete_video,
+)
+from sglang.multimodal_gen.runtime.managers.job_registry import (
+    CancelReq,
+    RequestCancelledError,
+    RequestConflictError,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.scheduler_client import AsyncSchedulerClient
+
+
+class TestImageJobIdentity(unittest.TestCase):
+    def test_request_id_is_bounded(self):
+        request = ImageGenerationsRequest(prompt="p", request_id="a" * 128)
+        self.assertEqual(len(request.request_id), 128)
+        with self.assertRaises(ValidationError):
+            ImageGenerationsRequest(prompt="p", request_id="a" * 129)
+        for invalid in ("", "bad/id", " leading"):
+            with self.subTest(invalid=invalid), self.assertRaises(ValidationError):
+                ImageGenerationsRequest(prompt="p", request_id=invalid)
+
+    def test_fingerprint_is_canonical_and_parameter_sensitive(self):
+        first = ImageGenerationsRequest(
+            prompt="p", request_id="id", diffusers_kwargs={"b": 2, "a": 1}
+        )
+        retry = ImageGenerationsRequest(
+            prompt="p", request_id="id", diffusers_kwargs={"a": 1, "b": 2}
+        )
+        changed = ImageGenerationsRequest(prompt="different", request_id="id")
+        self.assertEqual(_request_fingerprint(first), _request_fingerprint(retry))
+        self.assertNotEqual(_request_fingerprint(first), _request_fingerprint(changed))
+
+    def test_grouped_video_is_rejected_only_when_control_is_enabled(self):
+        _require_trackable_video_batch(SimpleNamespace(job_control_enabled=True), None)
+        with self.assertRaises(HTTPException) as raised:
+            _require_trackable_video_batch(
+                SimpleNamespace(job_control_enabled=True), [object(), object()]
+            )
+        self.assertEqual(raised.exception.status_code, 400)
+        _require_trackable_video_batch(
+            SimpleNamespace(job_control_enabled=False), [object(), object()]
+        )
+
+
+class TestImageJobRoutes(unittest.IsolatedAsyncioTestCase):
+    async def test_precancel_overload_maps_to_429(self):
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.async_scheduler_client.job_control",
+                new=AsyncMock(
+                    return_value={
+                        "status": "unknown",
+                        "cancelled": False,
+                        "overloaded": True,
+                    }
+                ),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await cancel_job("valid-id")
+        self.assertEqual(raised.exception.status_code, 429)
+
+    async def test_side_channel_uses_structured_msgpack(self):
+        class Socket:
+            def setsockopt(self, *_args):
+                pass
+
+            def connect(self, endpoint):
+                self.endpoint = endpoint
+
+            async def send(self, payload):
+                self.payload = payload
+
+            async def recv(self):
+                return msgspec.msgpack.encode(
+                    {"request_id": "valid-id", "status": "unknown"}
+                )
+
+            def close(self):
+                pass
+
+        socket = Socket()
+        client = AsyncSchedulerClient()
+        client.context = SimpleNamespace(socket=lambda _kind: socket)
+        client.server_args = SimpleNamespace(
+            scheduler_cancel_endpoint="tcp://127.0.0.1:5601"
+        )
+        reply = await client.job_control(CancelReq(request_id="valid-id"))
+        self.assertEqual(reply["status"], "unknown")
+        self.assertEqual(
+            msgspec.msgpack.decode(socket.payload),
+            {"operation": "cancel", "request_id": "valid-id"},
+        )
+
+    async def test_job_control_failures_have_http_statuses(self):
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.async_scheduler_client.job_control",
+                new=AsyncMock(side_effect=TimeoutError),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await job_status("valid-id")
+        self.assertEqual(raised.exception.status_code, 504)
+
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.image_api.async_scheduler_client.job_control",
+                new=AsyncMock(return_value={"error": "broken"}),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await cancel_job("valid-id")
+        self.assertEqual(raised.exception.status_code, 503)
+
+
+class TestVideoDelete(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        await VIDEO_STORE.upsert(
+            "video-id",
+            {
+                "id": "video-id",
+                "status": "running",
+                "size": "",
+                "seconds": "4",
+                "quality": "standard",
+            },
+        )
+
+    async def asyncTearDown(self):
+        await VIDEO_STORE.pop("video-id")
+
+    async def test_disabled_control_returns_503_without_removing_job(self):
+        with patch(
+            "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.get_global_server_args",
+            return_value=SimpleNamespace(job_control_enabled=False),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await delete_video("video-id")
+        self.assertEqual(raised.exception.status_code, 503)
+        self.assertIsNotNone(await VIDEO_STORE.get("video-id"))
+
+    async def test_negative_ack_returns_409_without_mutating_job(self):
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.scheduler_client.async_scheduler_client.job_control",
+                new=AsyncMock(return_value={"status": "completed", "cancelled": False}),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await delete_video("video-id")
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual((await VIDEO_STORE.get("video-id"))["status"], "running")
+
+    async def test_terminal_store_job_is_not_relabelled(self):
+        await VIDEO_STORE.update_fields("video-id", {"status": "completed"})
+        with self.assertRaises(HTTPException) as raised:
+            await delete_video("video-id")
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual((await VIDEO_STORE.get("video-id"))["status"], "completed")
+
+    async def test_positive_ack_marks_cancelling_without_removing_job(self):
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.scheduler_client.async_scheduler_client.job_control",
+                new=AsyncMock(return_value={"status": "running", "cancelled": True}),
+            ),
+        ):
+            response = await delete_video("video-id")
+        self.assertEqual(response.status, "cancelling")
+        self.assertEqual((await VIDEO_STORE.get("video-id"))["status"], "cancelling")
+
+    async def test_completion_race_is_not_regressed_to_cancelling(self):
+        async def complete_before_ack(_request):
+            await VIDEO_STORE.update_fields("video-id", {"status": "completed"})
+            return {"status": "running", "cancelled": True}
+
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.scheduler_client.async_scheduler_client.job_control",
+                new=AsyncMock(side_effect=complete_before_ack),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await delete_video("video-id")
+        self.assertEqual(raised.exception.status_code, 409)
+        self.assertEqual((await VIDEO_STORE.get("video-id"))["status"], "completed")
+
+    async def test_timeout_is_reported_and_job_is_retained(self):
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.get_global_server_args",
+                return_value=SimpleNamespace(job_control_enabled=True),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.scheduler_client.async_scheduler_client.job_control",
+                new=AsyncMock(side_effect=TimeoutError),
+            ),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await delete_video("video-id")
+        self.assertEqual(raised.exception.status_code, 504)
+        self.assertIsNotNone(await VIDEO_STORE.get("video-id"))
+
+    async def test_cancelled_dispatch_clears_media_locations(self):
+        await VIDEO_STORE.update_fields(
+            "video-id",
+            {
+                "url": "https://stale.invalid/video.mp4",
+                "file_path": "/tmp/stale.mp4",
+                "file_paths": ["/tmp/stale.mp4"],
+                "num_outputs": 1,
+            },
+        )
+        batch = SimpleNamespace(
+            sampling_params=SimpleNamespace(cleanup_video_request=lambda _batch: None)
+        )
+        with patch(
+            "sglang.multimodal_gen.runtime.entrypoints.openai.video_api.process_generation_batch",
+            new=AsyncMock(side_effect=RequestCancelledError("cancelled")),
+        ):
+            await _dispatch_job_async("video-id", batch)
+        job = await VIDEO_STORE.get("video-id")
+        self.assertEqual(job["status"], "cancelled")
+        for field in ("url", "file_path", "file_paths", "num_outputs"):
+            self.assertIsNone(job[field])
+
+
+class TestConflictResponse(unittest.IsolatedAsyncioTestCase):
+    async def test_typed_scheduler_conflict_is_preserved(self):
+        client = SimpleNamespace(
+            forward=AsyncMock(
+                return_value=OutputBatch(
+                    error="request_id was reused",
+                    idempotency_conflict=True,
+                )
+            )
+        )
+        batch = SimpleNamespace(trace_ctx=None, prompt="prompt")
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.utils.trace_req",
+                return_value=nullcontext(),
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.entrypoints.openai.utils.log_generation_timer",
+                return_value=nullcontext(),
+            ),
+        ):
+            with self.assertRaises(RequestConflictError):
+                await process_generation_batch(client, batch)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_job_registry.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_registry.py
@@ -1,6 +1,7 @@
 """Unit tests for runtime/managers/job_registry (job control)."""
 
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -78,13 +79,35 @@ class TestJobRegistry(unittest.TestCase):
         self.assertEqual(verdict, "conflict")
         self.assertIsNone(payload)
 
+    def test_missing_fingerprint_never_dedupes(self):
+        for first_fingerprint, retry_fingerprint in (
+            (None, None),
+            ("fingerprint", None),
+            (None, "fingerprint"),
+        ):
+            with self.subTest(
+                first=first_fingerprint,
+                retry=retry_fingerprint,
+            ):
+                registry = JobRegistry()
+                _, handle = registry.admit("same", b"first", first_fingerprint)
+                verdict, payload = registry.admit("same", b"second", retry_fingerprint)
+                self.assertEqual(verdict, "conflict")
+                self.assertIsNone(payload)
+                self.assertEqual(handle.waiters, [])
+
+                registry.finish("same", _Output())
+                verdict, payload = registry.admit("same", b"third", retry_fingerprint)
+                self.assertEqual(verdict, "conflict")
+                self.assertIsNone(payload)
+
     def test_duplicate_waiters_are_bounded(self):
         registry = JobRegistry()
-        registry.admit("a", b"original")
+        registry.admit("a", b"original", "fingerprint")
         for index in range(_WAITER_CAP):
-            verdict, _ = registry.admit("a", str(index).encode())
+            verdict, _ = registry.admit("a", str(index).encode(), "fingerprint")
             self.assertEqual(verdict, "wait")
-        verdict, payload = registry.admit("a", b"overflow")
+        verdict, payload = registry.admit("a", b"overflow", "fingerprint")
         self.assertEqual(verdict, "overloaded")
         self.assertIsNone(payload)
 
@@ -139,12 +162,12 @@ class TestJobRegistry(unittest.TestCase):
         terminal status but drops the payload, so a duplicate replays
         "not replayable" instead of the payload."""
         registry = JobRegistry()
-        _, handle = registry.admit("bulky", None)
+        _, handle = registry.admit("bulky", None, "fingerprint")
         registry.finish("bulky", _Output(raw_frame_batches=[[b"frame"]]))
         self.assertEqual(registry.status("bulky")["status"], COMPLETED)
         self.assertIsNone(handle.output)
 
-        verdict, payload = registry.admit("bulky", b"dup")
+        verdict, payload = registry.admit("bulky", b"dup", "fingerprint")
         self.assertEqual(verdict, "replay")
         self.assertIsNone(payload)
 
@@ -152,10 +175,56 @@ class TestJobRegistry(unittest.TestCase):
         """Waiters attached before the terminal transition are owed the real
         first reply. Only the retained replay copy may be dropped."""
         registry = JobRegistry()
-        registry.admit("bulky", b"c1")
-        registry.admit("bulky", b"c2")
+        registry.admit("bulky", b"c1", "fingerprint")
+        registry.admit("bulky", b"c2", "fingerprint")
         waiters = registry.finish("bulky", _Output(trajectory_latents=object()))
         self.assertEqual(waiters, [b"c2"])
+
+    def test_live_jobs_are_bounded_and_capacity_is_released(self):
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry._LIVE_JOB_CAP",
+            2,
+        ):
+            registry = JobRegistry()
+            registry.admit("first", b"first", "fingerprint")
+            registry.admit("second", b"second", "fingerprint")
+
+            verdict, payload = registry.admit("third", b"third", "fingerprint")
+            self.assertEqual(verdict, "capacity")
+            self.assertIsNone(payload)
+            self.assertEqual(registry.status("third")["status"], "unknown")
+
+            verdict, handle = registry.admit("first", b"waiter", "fingerprint")
+            self.assertEqual(verdict, "wait")
+            self.assertEqual(handle.waiters, [b"waiter"])
+
+            registry.finish("first", _Output())
+            verdict, _ = registry.admit("third", b"third", "fingerprint")
+            self.assertEqual(verdict, "new")
+            self.assertEqual(registry._live_jobs, 2)
+
+            registry.finish("first", _Output())
+            self.assertEqual(registry._live_jobs, 2)
+
+    def test_concurrent_admission_respects_live_job_cap(self):
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry._LIVE_JOB_CAP",
+            8,
+        ):
+            registry = JobRegistry()
+            with ThreadPoolExecutor(max_workers=16) as executor:
+                results = list(
+                    executor.map(
+                        lambda index: registry.admit(
+                            f"job-{index}", None, f"fingerprint-{index}"
+                        )[0],
+                        range(64),
+                    )
+                )
+
+            self.assertEqual(results.count("new"), 8)
+            self.assertEqual(results.count("capacity"), 56)
+            self.assertEqual(registry._live_jobs, 8)
 
     def test_replay_payloads_are_byte_bounded(self):
         small = np.zeros(8, dtype=np.uint8)
@@ -272,7 +341,7 @@ class TestJobRegistry(unittest.TestCase):
         self.assertTrue(acked["cancelled"])
         self.assertEqual(acked["status"], "unknown")
 
-        verdict, payload = registry.admit("not-yet-arrived", b"c1")
+        verdict, payload = registry.admit("not-yet-arrived", b"c1", "fingerprint")
         self.assertEqual(verdict, "cancelled")
         self.assertIsNone(payload)
         self.assertEqual(registry.status("not-yet-arrived")["status"], CANCELLED)
@@ -282,7 +351,7 @@ class TestJobRegistry(unittest.TestCase):
         # duplicate replays a typed cancel instead of "not replayable"
         tombstone = _Output(error="request cancelled before dispatch", cancelled=True)
         registry.finish("not-yet-arrived", tombstone)
-        verdict, payload = registry.admit("not-yet-arrived", b"c2")
+        verdict, payload = registry.admit("not-yet-arrived", b"c2", "fingerprint")
         self.assertEqual(verdict, "replay")
         self.assertIs(payload, tombstone)
         self.assertTrue(payload.cancelled)
@@ -384,6 +453,39 @@ class TestJobRegistry(unittest.TestCase):
         output, identity = scheduler._try_return.call_args.args
         self.assertEqual(identity, b"overflow")
         self.assertIn("too many duplicate waiters", output.error)
+
+    def test_scheduler_returns_typed_capacity_overload(self):
+        from unittest.mock import MagicMock
+
+        from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+        from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+        from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.jobs = JobRegistry()
+        scheduler._try_return = MagicMock()
+
+        first = Req(sampling_params=SamplingParams(prompt="first", request_id="first"))
+        second = Req(
+            sampling_params=SamplingParams(prompt="second", request_id="second")
+        )
+        first.extra["job_request_fingerprint"] = "first-fingerprint"
+        second.extra["job_request_fingerprint"] = "second-fingerprint"
+
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry._LIVE_JOB_CAP",
+            1,
+        ):
+            self.assertEqual(
+                scheduler._admit_new_reqs([(b"first", first)]),
+                [(b"first", first)],
+            )
+            self.assertEqual(scheduler._admit_new_reqs([(b"second", second)]), [])
+
+        output, identity = scheduler._try_return.call_args.args
+        self.assertEqual(identity, b"second")
+        self.assertTrue(output.overloaded)
+        self.assertFalse(output.idempotency_conflict)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_job_registry.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_registry.py
@@ -105,7 +105,7 @@ class TestJobRegistry(unittest.TestCase):
 
     def test_waiters_receive_live_reply_even_when_payload_is_dropped(self):
         """Waiters attached before the terminal transition are owed the real
-        first reply; only the retained replay copy may be dropped."""
+        first reply. Only the retained replay copy may be dropped."""
         registry = JobRegistry()
         registry.admit("bulky", b"c1")
         registry.admit("bulky", b"c2")

--- a/python/sglang/multimodal_gen/test/unit/test_job_registry.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_registry.py
@@ -1,10 +1,14 @@
 """Unit tests for runtime/managers/job_registry (job control)."""
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
+
+import numpy as np
 
 from sglang.multimodal_gen.runtime.managers.job_registry import (
     _FINISHED_HARD_CAP,
+    _WAITER_CAP,
     CANCELLED,
     COMPLETED,
     FAILED,
@@ -12,9 +16,10 @@ from sglang.multimodal_gen.runtime.managers.job_registry import (
     RUNNING,
     JobRegistry,
     RequestCancelledError,
+    _value_nbytes,
     check_current_step,
-    clear_current_jobs,
-    set_current_jobs,
+    clear_current_job,
+    set_current_job,
 )
 
 
@@ -27,6 +32,10 @@ class _Output:
         raw_frame_batches=None,
         trajectory_latents=None,
         rollout_trajectory_data=None,
+        output_file_paths=None,
+        audio=None,
+        action_pred=None,
+        noise_pred=None,
     ):
         self.error = error
         self.cancelled = cancelled
@@ -34,16 +43,20 @@ class _Output:
         self.raw_frame_batches = raw_frame_batches
         self.trajectory_latents = trajectory_latents
         self.rollout_trajectory_data = rollout_trajectory_data
+        self.output_file_paths = output_file_paths
+        self.audio = audio
+        self.action_pred = action_pred
+        self.noise_pred = noise_pred
 
 
 class TestJobRegistry(unittest.TestCase):
     def test_admit_dedupes_and_replays(self):
         registry = JobRegistry()
-        verdict, handle = registry.admit("a", b"c1")
+        verdict, handle = registry.admit("a", b"c1", "fingerprint")
         self.assertEqual(verdict, "new")
         self.assertEqual(handle.status, QUEUED)
 
-        verdict, same = registry.admit("a", b"c2")
+        verdict, same = registry.admit("a", b"c2", "fingerprint")
         self.assertEqual(verdict, "wait")
         self.assertEqual(same.waiters, [b"c2"])
 
@@ -52,9 +65,41 @@ class TestJobRegistry(unittest.TestCase):
         self.assertEqual(waiters, [b"c2"])
         self.assertEqual(registry.status("a")["status"], COMPLETED)
 
-        verdict, cached = registry.admit("a", b"c3")
+        verdict, cached = registry.admit("a", b"c3", "fingerprint")
         self.assertEqual(verdict, "replay")
         self.assertIs(cached, output)
+
+    def test_reused_id_with_different_fingerprint_conflicts(self):
+        registry = JobRegistry()
+        verdict, _ = registry.admit("a", b"c1", "fingerprint-a")
+        self.assertEqual(verdict, "new")
+
+        verdict, payload = registry.admit("a", b"c2", "fingerprint-b")
+        self.assertEqual(verdict, "conflict")
+        self.assertIsNone(payload)
+
+    def test_duplicate_waiters_are_bounded(self):
+        registry = JobRegistry()
+        registry.admit("a", b"original")
+        for index in range(_WAITER_CAP):
+            verdict, _ = registry.admit("a", str(index).encode())
+            self.assertEqual(verdict, "wait")
+        verdict, payload = registry.admit("a", b"overflow")
+        self.assertEqual(verdict, "overloaded")
+        self.assertIsNone(payload)
+
+    def test_path_backed_output_keeps_status_but_not_replay_payload(self):
+        registry = JobRegistry()
+        _, handle = registry.admit("path-backed", None, "fingerprint")
+        registry.finish(
+            "path-backed", _Output(output_file_paths=["/temporary/result.png"])
+        )
+        self.assertEqual(registry.status("path-backed")["status"], COMPLETED)
+        self.assertIsNone(handle.output)
+
+        verdict, payload = registry.admit("path-backed", b"duplicate", "fingerprint")
+        self.assertEqual(verdict, "replay")
+        self.assertIsNone(payload)
 
     def test_finish_classifies_from_output(self):
         registry = JobRegistry()
@@ -111,6 +156,80 @@ class TestJobRegistry(unittest.TestCase):
         registry.admit("bulky", b"c2")
         waiters = registry.finish("bulky", _Output(trajectory_latents=object()))
         self.assertEqual(waiters, [b"c2"])
+
+    def test_replay_payloads_are_byte_bounded(self):
+        small = np.zeros(8, dtype=np.uint8)
+        cap = _value_nbytes(_Output(output=small))
+        self.assertIsInstance(cap, int)
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry._REPLAY_BYTES_CAP",
+            cap,
+        ):
+            registry = JobRegistry()
+            _, first = registry.admit("first", None, "fingerprint")
+            registry.finish("first", _Output(output=small))
+            self.assertIsNotNone(first.output)
+
+            _, second = registry.admit("second", None, "fingerprint")
+            registry.finish("second", _Output(output=np.zeros(1, dtype=np.uint8)))
+            self.assertIsNone(first.output)
+            self.assertIsNotNone(second.output)
+            self.assertLessEqual(registry._replay_bytes, cap)
+
+            _, oversized = registry.admit("oversized", None, "fingerprint")
+            registry.finish(
+                "oversized", _Output(output=np.zeros(cap + 1, dtype=np.uint8))
+            )
+            self.assertIsNone(oversized.output)
+            self.assertIsNotNone(second.output)
+            self.assertLessEqual(registry._replay_bytes, cap)
+
+    def test_replay_cap_counts_error_and_metadata(self):
+        base_size = _value_nbytes(_Output())
+        self.assertIsInstance(base_size, int)
+        payloads = {
+            "error": "x" * 1024,
+            "raw_frame_metadata": {"blob": "x" * 1024},
+            "metrics": SimpleNamespace(blob="x" * 1024),
+            "metrics_list": [SimpleNamespace(blob="x" * 1024)],
+        }
+        for field, payload in payloads.items():
+            with self.subTest(field=field), patch(
+                "sglang.multimodal_gen.runtime.managers.job_registry._REPLAY_BYTES_CAP",
+                base_size + 128,
+            ):
+                output = _Output()
+                setattr(output, field, payload)
+                registry = JobRegistry()
+                _, handle = registry.admit(field, None, "fingerprint")
+                registry.finish(field, output)
+                self.assertIsNone(handle.output)
+                self.assertEqual(registry._replay_bytes, 0)
+
+    def test_replay_does_not_retain_device_tensors(self):
+        payload = SimpleNamespace(device="cuda:0", nbytes=1)
+        registry = JobRegistry()
+        _, handle = registry.admit("device-output", None, "fingerprint")
+        registry.finish("device-output", _Output(output=payload))
+        self.assertIsNone(handle.output)
+
+    def test_replay_rejects_secondary_device_payloads_and_large_containers(self):
+        payload = SimpleNamespace(device="cuda:0", nbytes=1)
+        for field in ("action_pred", "noise_pred"):
+            with self.subTest(field=field):
+                registry = JobRegistry()
+                _, handle = registry.admit(field, None, "fingerprint")
+                registry.finish(field, _Output(**{field: payload}))
+                self.assertIsNone(handle.output)
+
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry._REPLAY_BYTES_CAP",
+            128,
+        ):
+            registry = JobRegistry()
+            _, handle = registry.admit("large-list", None, "fingerprint")
+            registry.finish("large-list", _Output(output=[0] * 100))
+            self.assertIsNone(handle.output)
 
     def test_hard_cap_bounds_young_finished_jobs(self):
         """The TTL keeps young terminal jobs replayable, but sustained load
@@ -173,36 +292,29 @@ class TestJobRegistry(unittest.TestCase):
         registry.cancel("stale-id")
         future = unittest.mock.MagicMock(return_value=1e12)
         with patch(
-            "sglang.multimodal_gen.runtime.managers.job_registry.time.time", future
+            "sglang.multimodal_gen.runtime.managers.job_registry.time.monotonic", future
         ):
             verdict, _ = registry.admit("stale-id", b"c1")
         self.assertEqual(verdict, "new")
 
     def test_check_current_step_updates_progress_and_aborts(self):
         registry = JobRegistry()
-        _, first = registry.admit("m1", None)
-        _, second = registry.admit("m2", None)
-        set_current_jobs([first, second])
+        _, handle = registry.admit("job", None)
+        set_current_job(handle)
         try:
             check_current_step(3, 10)
-            self.assertEqual(first.step, 3)
-            self.assertEqual(second.total_steps, 10)
+            self.assertEqual(handle.step, 3)
+            self.assertEqual(handle.total_steps, 10)
 
-            # a merged batch aborts only when every member is cancelled
-            first.cancel_event.set()
-            check_current_step(4, 10)
-            second.cancel_event.set()
+            handle.cancel_event.set()
             with self.assertRaises(RequestCancelledError):
-                check_current_step(5, 10)
+                check_current_step(4, 10)
         finally:
-            clear_current_jobs()
+            clear_current_job()
         # no current jobs: the checkpoint is inert
-        check_current_step(6, 10)
+        check_current_step(5, 10)
 
-    def test_precancel_overflow_still_tombstones(self):
-        """DELETE promises the id will not run. With the table full, cancel
-        used to return cancelled=True without storing the tombstone, so the
-        later submit dispatched on GPU anyway."""
+    def test_precancel_overflow_preserves_acknowledged_tombstones(self):
         from sglang.multimodal_gen.runtime.managers.job_registry import (
             _PRECANCEL_CAP,
             JobRegistry,
@@ -214,10 +326,64 @@ class TestJobRegistry(unittest.TestCase):
         self.assertEqual(len(registry._precancelled), _PRECANCEL_CAP)
 
         ack = registry.cancel("overflow")
-        self.assertTrue(ack["cancelled"])
-        status, _ = registry.admit("overflow", None)
+        self.assertFalse(ack["cancelled"])
+        self.assertTrue(ack["overloaded"])
+
+        status, _ = registry.admit("filler-0", None)
         self.assertEqual(status, "cancelled")
+        status, _ = registry.admit("overflow", None)
+        self.assertEqual(status, "new")
         self.assertLessEqual(len(registry._precancelled), _PRECANCEL_CAP)
+
+    def test_job_control_bind_failure_is_fatal(self):
+        from unittest.mock import MagicMock
+
+        import zmq
+
+        from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.context = MagicMock()
+        socket = scheduler.context.socket.return_value
+        socket.bind.side_effect = zmq.ZMQError(zmq.EADDRINUSE)
+        scheduler.server_args = SimpleNamespace(
+            scheduler_cancel_endpoint="tcp://127.0.0.1:5601"
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "job-control channel failed to bind"):
+            scheduler._start_job_control()
+        socket.close.assert_called_once_with(linger=0)
+
+    def test_scheduler_returns_typed_admission_conflicts(self):
+        from unittest.mock import MagicMock
+
+        from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+        from sglang.multimodal_gen.runtime.managers.scheduler import Scheduler
+        from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.jobs = JobRegistry()
+        scheduler._try_return = MagicMock()
+
+        first = Req(sampling_params=SamplingParams(prompt="first", request_id="same"))
+        first.extra["job_request_fingerprint"] = "fingerprint-a"
+        self.assertEqual(
+            scheduler._admit_new_reqs([(b"first", first)]), [(b"first", first)]
+        )
+
+        second = Req(sampling_params=SamplingParams(prompt="second", request_id="same"))
+        second.extra["job_request_fingerprint"] = "fingerprint-b"
+        self.assertEqual(scheduler._admit_new_reqs([(b"second", second)]), [])
+        output, identity = scheduler._try_return.call_args.args
+        self.assertEqual(identity, b"second")
+        self.assertTrue(output.idempotency_conflict)
+
+        scheduler.jobs._jobs["same"].waiters = [b"waiter"] * _WAITER_CAP
+        first.extra["job_request_fingerprint"] = "fingerprint-a"
+        self.assertEqual(scheduler._admit_new_reqs([(b"overflow", first)]), [])
+        output, identity = scheduler._try_return.call_args.args
+        self.assertEqual(identity, b"overflow")
+        self.assertIn("too many duplicate waiters", output.error)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_job_registry.py
+++ b/python/sglang/multimodal_gen/test/unit/test_job_registry.py
@@ -1,0 +1,224 @@
+"""Unit tests for runtime/managers/job_registry (job control)."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.multimodal_gen.runtime.managers.job_registry import (
+    _FINISHED_HARD_CAP,
+    CANCELLED,
+    COMPLETED,
+    FAILED,
+    QUEUED,
+    RUNNING,
+    JobRegistry,
+    RequestCancelledError,
+    check_current_step,
+    clear_current_jobs,
+    set_current_jobs,
+)
+
+
+class _Output:
+    def __init__(
+        self,
+        error=None,
+        cancelled=False,
+        output=None,
+        raw_frame_batches=None,
+        trajectory_latents=None,
+        rollout_trajectory_data=None,
+    ):
+        self.error = error
+        self.cancelled = cancelled
+        self.output = output
+        self.raw_frame_batches = raw_frame_batches
+        self.trajectory_latents = trajectory_latents
+        self.rollout_trajectory_data = rollout_trajectory_data
+
+
+class TestJobRegistry(unittest.TestCase):
+    def test_admit_dedupes_and_replays(self):
+        registry = JobRegistry()
+        verdict, handle = registry.admit("a", b"c1")
+        self.assertEqual(verdict, "new")
+        self.assertEqual(handle.status, QUEUED)
+
+        verdict, same = registry.admit("a", b"c2")
+        self.assertEqual(verdict, "wait")
+        self.assertEqual(same.waiters, [b"c2"])
+
+        output = _Output()
+        waiters = registry.finish("a", output)
+        self.assertEqual(waiters, [b"c2"])
+        self.assertEqual(registry.status("a")["status"], COMPLETED)
+
+        verdict, cached = registry.admit("a", b"c3")
+        self.assertEqual(verdict, "replay")
+        self.assertIs(cached, output)
+
+    def test_finish_classifies_from_output(self):
+        registry = JobRegistry()
+        registry.admit("ok", None)
+        registry.finish("ok", _Output())
+        self.assertEqual(registry.status("ok")["status"], COMPLETED)
+
+        registry.admit("bad", None)
+        registry.finish("bad", _Output(error="exploded"))
+        self.assertEqual(registry.status("bad")["status"], FAILED)
+
+        registry.admit("halted", None)
+        registry.cancel("halted")
+        registry.finish(
+            "halted", _Output(error="request cancelled: step 3", cancelled=True)
+        )
+        self.assertEqual(registry.status("halted")["status"], CANCELLED)
+
+    def test_classification_is_typed_not_text_matched(self):
+        """The CANCELLED/FAILED split must come from the typed `cancelled`
+        flag: matching on error text would misclassify user prompts or error
+        messages that merely mention the word "cancelled"."""
+        registry = JobRegistry()
+        registry.admit("worded", None)
+        registry.finish(
+            "worded", _Output(error="upstream said: cancelled is a nice word")
+        )
+        self.assertEqual(registry.status("worded")["status"], FAILED)
+
+        registry.admit("typed", None)
+        registry.finish("typed", _Output(error="step aborted", cancelled=True))
+        self.assertEqual(registry.status("typed")["status"], CANCELLED)
+
+    def test_unreplayable_payload_is_dropped_but_status_kept(self):
+        """Bulk terminal payloads (raw realtime frames, trajectory tensors)
+        must not be pinned for the retention window: finish() keeps the
+        terminal status but drops the payload, so a duplicate replays
+        "not replayable" instead of the payload."""
+        registry = JobRegistry()
+        _, handle = registry.admit("bulky", None)
+        registry.finish("bulky", _Output(raw_frame_batches=[[b"frame"]]))
+        self.assertEqual(registry.status("bulky")["status"], COMPLETED)
+        self.assertIsNone(handle.output)
+
+        verdict, payload = registry.admit("bulky", b"dup")
+        self.assertEqual(verdict, "replay")
+        self.assertIsNone(payload)
+
+    def test_waiters_receive_live_reply_even_when_payload_is_dropped(self):
+        """Waiters attached before the terminal transition are owed the real
+        first reply; only the retained replay copy may be dropped."""
+        registry = JobRegistry()
+        registry.admit("bulky", b"c1")
+        registry.admit("bulky", b"c2")
+        waiters = registry.finish("bulky", _Output(trajectory_latents=object()))
+        self.assertEqual(waiters, [b"c2"])
+
+    def test_hard_cap_bounds_young_finished_jobs(self):
+        """The TTL keeps young terminal jobs replayable, but sustained load
+        must still be bounded by the hard cap on retained entries."""
+        registry = JobRegistry()
+        total = _FINISHED_HARD_CAP + 8
+        for index in range(total):
+            request_id = f"job-{index}"
+            registry.admit(request_id, None)
+            registry.finish(request_id, _Output())
+        self.assertEqual(len(registry._finished), _FINISHED_HARD_CAP)
+        self.assertEqual(registry.status("job-0")["status"], "unknown")
+        self.assertEqual(registry.status(f"job-{total - 1}")["status"], COMPLETED)
+
+    def test_late_cancel_of_successful_output_is_completed(self):
+        registry = JobRegistry()
+        registry.admit("late", None)
+        registry.mark_running("late")
+        # cancel lands after the last denoise step: the forward finished
+        self.assertTrue(registry.cancel("late")["cancelled"])
+        registry.finish("late", _Output())
+        self.assertEqual(registry.status("late")["status"], COMPLETED)
+
+    def test_cancel_transitions(self):
+        registry = JobRegistry()
+        registry.admit("job", None)
+        handle = registry.mark_running("job")
+        self.assertEqual(handle.status, RUNNING)
+        result = registry.cancel("job")
+        self.assertTrue(result["cancelled"])
+        self.assertTrue(registry.is_cancelled("job"))
+
+        registry.finish("job", _Output(error="request cancelled", cancelled=True))
+        # terminal jobs are not cancellable again
+        self.assertFalse(registry.cancel("job")["cancelled"])
+
+    def test_precancel_tombstone_honored_at_admission(self):
+        registry = JobRegistry()
+        acked = registry.cancel("not-yet-arrived")
+        self.assertTrue(acked["cancelled"])
+        self.assertEqual(acked["status"], "unknown")
+
+        verdict, payload = registry.admit("not-yet-arrived", b"c1")
+        self.assertEqual(verdict, "cancelled")
+        self.assertIsNone(payload)
+        self.assertEqual(registry.status("not-yet-arrived")["status"], CANCELLED)
+
+        # the scheduler records a typed tombstone via finish(): finish on an
+        # already-terminal handle must still retain the payload so every later
+        # duplicate replays a typed cancel instead of "not replayable"
+        tombstone = _Output(error="request cancelled before dispatch", cancelled=True)
+        registry.finish("not-yet-arrived", tombstone)
+        verdict, payload = registry.admit("not-yet-arrived", b"c2")
+        self.assertEqual(verdict, "replay")
+        self.assertIs(payload, tombstone)
+        self.assertTrue(payload.cancelled)
+
+    def test_precancel_tombstone_expires(self):
+        registry = JobRegistry()
+        registry.cancel("stale-id")
+        future = unittest.mock.MagicMock(return_value=1e12)
+        with patch(
+            "sglang.multimodal_gen.runtime.managers.job_registry.time.time", future
+        ):
+            verdict, _ = registry.admit("stale-id", b"c1")
+        self.assertEqual(verdict, "new")
+
+    def test_check_current_step_updates_progress_and_aborts(self):
+        registry = JobRegistry()
+        _, first = registry.admit("m1", None)
+        _, second = registry.admit("m2", None)
+        set_current_jobs([first, second])
+        try:
+            check_current_step(3, 10)
+            self.assertEqual(first.step, 3)
+            self.assertEqual(second.total_steps, 10)
+
+            # a merged batch aborts only when every member is cancelled
+            first.cancel_event.set()
+            check_current_step(4, 10)
+            second.cancel_event.set()
+            with self.assertRaises(RequestCancelledError):
+                check_current_step(5, 10)
+        finally:
+            clear_current_jobs()
+        # no current jobs: the checkpoint is inert
+        check_current_step(6, 10)
+
+    def test_precancel_overflow_still_tombstones(self):
+        """DELETE promises the id will not run. With the table full, cancel
+        used to return cancelled=True without storing the tombstone, so the
+        later submit dispatched on GPU anyway."""
+        from sglang.multimodal_gen.runtime.managers.job_registry import (
+            _PRECANCEL_CAP,
+            JobRegistry,
+        )
+
+        registry = JobRegistry()
+        for i in range(_PRECANCEL_CAP):
+            registry.cancel(f"filler-{i}")
+        self.assertEqual(len(registry._precancelled), _PRECANCEL_CAP)
+
+        ack = registry.cancel("overflow")
+        self.assertTrue(ack["cancelled"])
+        status, _ = registry.admit("overflow", None)
+        self.assertEqual(status, "cancelled")
+        self.assertLessEqual(len(registry._precancelled), _PRECANCEL_CAP)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -2185,8 +2185,14 @@ class TestJobControlEnabled(unittest.TestCase):
         enable_cfg_parallel=False,
         tp_size=1,
         dp_size=1,
+        num_gpus=1,
+        batching_max_size=1,
+        backend=None,
+        pipeline_config=None,
+        pipeline_class_name=None,
     ):
         from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+        from sglang.multimodal_gen.runtime.server_args import Backend
 
         sa = ServerArgs.__new__(ServerArgs)
         sa.disable_job_control = disable_job_control
@@ -2195,6 +2201,11 @@ class TestJobControlEnabled(unittest.TestCase):
         sa.enable_cfg_parallel = enable_cfg_parallel
         sa.tp_size = tp_size
         sa.dp_size = dp_size
+        sa.num_gpus = num_gpus
+        sa.batching_max_size = batching_max_size
+        sa.backend = Backend.AUTO if backend is None else backend
+        sa.pipeline_config = pipeline_config or QwenImagePipelineConfig()
+        sa.pipeline_class_name = pipeline_class_name
         return sa
 
     def test_enabled_for_single_rank_monolithic_defaults(self):
@@ -2202,6 +2213,22 @@ class TestJobControlEnabled(unittest.TestCase):
 
     def test_disable_flag_turns_it_off(self):
         self.assertFalse(self._args(disable_job_control=True).job_control_enabled)
+
+    def test_cancel_channel_is_loopback_only(self):
+        args = self._args()
+        args.host = "0.0.0.0"
+        args.scheduler_cancel_port = 5601
+        self.assertEqual(args.scheduler_cancel_endpoint, "tcp://127.0.0.1:5601")
+
+    def test_cancel_port_cannot_overlap_broker(self):
+        args = self._args()
+        args.port = 8000
+        args.scheduler_port = 5600
+        args.scheduler_cancel_port = args.broker_port
+        args.master_port = None
+        args.strict_ports = True
+        with self.assertRaisesRegex(RuntimeError, "duplicates another server port"):
+            args._settle_job_control_port()
 
     def test_dp_size_gt_one_turns_it_off(self):
         self.assertFalse(self._args(dp_size=2).job_control_enabled)
@@ -2219,6 +2246,40 @@ class TestJobControlEnabled(unittest.TestCase):
         from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
 
         self.assertFalse(self._args(disagg_role=RoleType.DENOISER).job_control_enabled)
+
+    def test_disabled_for_more_than_one_gpu(self):
+        self.assertFalse(self._args(num_gpus=2).job_control_enabled)
+
+    def test_disabled_for_dynamic_batching(self):
+        self.assertFalse(self._args(batching_max_size=2).job_control_enabled)
+
+    def test_disabled_for_diffusers_backend(self):
+        from sglang.multimodal_gen.runtime.server_args import Backend
+
+        self.assertFalse(self._args(backend=Backend.DIFFUSERS).job_control_enabled)
+
+    def test_disabled_for_diffusers_pipeline_config(self):
+        from sglang.multimodal_gen.configs.pipeline_configs.diffusers_generic import (
+            DiffusersGenericPipelineConfig,
+        )
+
+        self.assertFalse(
+            self._args(
+                pipeline_config=DiffusersGenericPipelineConfig()
+            ).job_control_enabled
+        )
+
+    def test_disabled_for_explicit_diffusers_pipeline(self):
+        self.assertFalse(
+            self._args(pipeline_class_name="DiffusersPipeline").job_control_enabled
+        )
+
+    def test_disabled_for_non_visual_task(self):
+        self.assertFalse(
+            self._args(
+                pipeline_config=PipelineConfig(task_type=ModelTaskType.VLA_ACTION)
+            ).job_control_enabled
+        )
 
 
 class TestDisaggTransferBackendArgs(unittest.TestCase):

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -2170,6 +2170,57 @@ class TestDisaggTimeoutArgs(unittest.TestCase):
         self.assertEqual(args.disagg_role, RoleType.DENOISER)
 
 
+class TestJobControlEnabled(unittest.TestCase):
+    """`job_control_enabled` gates on the resolved single-rank config: the
+    registry-based admission and queued-request drops are only correct when
+    every rank sees identical decisions, so any multi-rank dimension (or the
+    explicit opt-out) must turn the property off."""
+
+    def _args(
+        self,
+        *,
+        disable_job_control=False,
+        disagg_role=None,
+        sp_degree=1,
+        enable_cfg_parallel=False,
+        tp_size=1,
+        dp_size=1,
+    ):
+        from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+
+        sa = ServerArgs.__new__(ServerArgs)
+        sa.disable_job_control = disable_job_control
+        sa.disagg_role = RoleType.MONOLITHIC if disagg_role is None else disagg_role
+        sa.sp_degree = sp_degree
+        sa.enable_cfg_parallel = enable_cfg_parallel
+        sa.tp_size = tp_size
+        sa.dp_size = dp_size
+        return sa
+
+    def test_enabled_for_single_rank_monolithic_defaults(self):
+        self.assertTrue(self._args().job_control_enabled)
+
+    def test_disable_flag_turns_it_off(self):
+        self.assertFalse(self._args(disable_job_control=True).job_control_enabled)
+
+    def test_dp_size_gt_one_turns_it_off(self):
+        self.assertFalse(self._args(dp_size=2).job_control_enabled)
+
+    def test_disabled_for_tensor_parallel(self):
+        self.assertFalse(self._args(tp_size=2).job_control_enabled)
+
+    def test_disabled_for_sequence_parallel(self):
+        self.assertFalse(self._args(sp_degree=2).job_control_enabled)
+
+    def test_disabled_for_cfg_parallel(self):
+        self.assertFalse(self._args(enable_cfg_parallel=True).job_control_enabled)
+
+    def test_disabled_for_non_monolithic_disagg_role(self):
+        from sglang.multimodal_gen.runtime.disaggregation.roles import RoleType
+
+        self.assertFalse(self._args(disagg_role=RoleType.DENOISER).job_control_enabled)
+
+
 class TestDisaggTransferBackendArgs(unittest.TestCase):
     def test_transfer_backend_defaults_to_auto(self):
         args = _from_dict_without_model_resolution({"model_path": "/fake"})


### PR DESCRIPTION
## Motivation

Long image and video generation jobs need stable client identity, idempotent retry, observable progress, and cooperative cancellation. Without these contracts, retries can duplicate GPU work and abandoned requests continue denoising.

## Changes

- `POST /v1/images/generations` accepts an optional bounded `request_id`.
- A canonical request fingerprint is recorded before dispatch. A matching non-null fingerprint waits for live work or replays a retained result. A missing fingerprint on either side, a different fingerprint, and an unretained terminal result return 409.
- `GET /v1/images/jobs/{request_id}` reports queued, running, completed, failed, or cancelled state with denoise-step progress.
- `DELETE /v1/images/jobs/{request_id}` cancels queued work or signals a running job. Cancel-before-arrival is retained when capacity permits. A full precancel table returns 429.
- Video DELETE uses the existing server-generated ID, waits for scheduler acknowledgement, preserves completed or failed terminal state, and reports cancelled content as unavailable.
- Status and cancellation use a loopback-only structured-msgpack channel that remains responsive during model forwards. Timeout and unavailability map to 504 and 503.
- Supported native denoise loops check progress and cancellation between steps. Cancellation is propagated through the typed `OutputBatch.cancelled` field.
- Registry limits include 1,024 live jobs, 64 preferred terminal entries, a 300-second pressure-retention window, a 256-entry terminal hard cap, 64 attached duplicate waiters, 1,024 precancel tombstones, and 128 MiB of aggregate replay storage. A new unique request at the live cap returns 429 after same-ID wait or replay handling.
- Job control is enabled only for native monolithic single-GPU visual generation with `tp=dp=sp=1`, no CFG parallelism, `batching_max_size=1`, no diffusers backend, and no disaggregation.

## Validation

```bash
PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=python python -m pytest \
  -p no:cacheprovider -q \
  python/sglang/multimodal_gen/test/unit/test_job_registry.py \
  python/sglang/multimodal_gen/test/unit/test_job_control_api.py \
  python/sglang/multimodal_gen/test/unit/test_server_args.py::TestJobControlEnabled
```

- Focused job-control and API matrix: **42 passed and 12 subtests passed**.
- Including launch-policy adjacency: **57 passed and 12 subtests passed**.
- Black, isort, Ruff, and diff checks passed on all seven follow-up files.
- The submitted head previously passed H100 behavioral validation for duplicate fanout, cancellation, terminal races, and unsupported-topology rejection. The live-admission cap in this follow-up has CPU and concurrency coverage and was not rerun on GPU.
