### PR TITLE
feat: support FA3 MLA decode context parallelism

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
 
+from sglang.kernels.ops.attention.dcp_kernels import (
+    create_mla_kv_page_table_for_dcp,
+)
 from sglang.kernels.ops.attention.metadata import (
     draft_extend_set_metadata,
     normal_decode_set_metadata,
@@ -22,6 +26,7 @@ from sglang.srt.layers.attention.unified_mem_hooks import unified_mla_hooks
 from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
 from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dcp.layout import get_dcp_lens
 from sglang.srt.layers.radix_attention import AttentionType
 from sglang.srt.layers.utils.cp_utils import (
     cp_allgather_and_save_kv_cache,
@@ -30,7 +35,7 @@ from sglang.srt.layers.utils.cp_utils import (
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_schedule, get_spec
+from sglang.srt.runtime_context import get_parallel, get_schedule, get_spec
 from sglang.srt.speculative.ragged_verify import build_ragged_target_verify_geometry
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
@@ -47,6 +52,10 @@ from sglang.kernels.ops.attention.flash_attention import (
     flash_attn_varlen_func,
     flash_attn_with_kvcache,
 )
+
+# FA3 returns natural-log LSE, while the existing MLA DCP reducers consume
+# FlashInfer/FlashMLA-style base-2 LSE.
+_FA3_LSE_BASE2_FROM_NATURAL_LOG = math.log2(math.e)
 
 
 def _should_disable_scheduler_metadata_precompute(server_args) -> bool:
@@ -79,6 +88,10 @@ class FlashAttentionMetadata:
     window_size: tuple = (-1, -1)
     # Page table, the index of KV Cache Tables/Blocks
     page_table: torch.Tensor = None
+    # True when page_table already contains kernel-facing physical page ids.
+    # The regular eager path starts from virtual token ids and converts them at
+    # the end of init_forward_metadata; DCP builds physical ids directly.
+    page_table_is_kernel_ready: bool = False
     # Page table for Sliding Window Attention
     swa_page_table: torch.Tensor = None
 
@@ -352,6 +365,82 @@ class FlashAttentionBackend(AttentionBackend):
             has_softcap=self.has_softcap,
             num_splits=self.num_splits,
         )
+
+    def _use_mla_dcp(self) -> bool:
+        return self.use_mla and self.fa_impl_ver == 3 and get_parallel().dcp_enabled
+
+    @staticmethod
+    def _dcp_local_seq_lens(seq_lens: torch.Tensor) -> torch.Tensor:
+        parallel = get_parallel()
+        return get_dcp_lens(seq_lens, parallel.dcp_size, parallel.dcp_rank).to(
+            torch.int32
+        )
+
+    @staticmethod
+    def _dcp_local_max_seq_len(max_seq_len: int) -> int:
+        parallel = get_parallel()
+        return max(
+            max_seq_len // parallel.dcp_size
+            + int(parallel.dcp_rank < max_seq_len % parallel.dcp_size),
+            1,
+        )
+
+    def _fill_mla_dcp_decode_page_table(
+        self,
+        page_table: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        local_seq_lens: torch.Tensor,
+    ) -> None:
+        """Build FA3's physical page table for this rank's cyclic KV shard."""
+        parallel = get_parallel()
+        pages_per_block = 128
+        max_local_pages = (
+            self._dcp_local_max_seq_len(self.max_context_len) + self.page_size - 1
+        ) // self.page_size
+        num_page_blocks = max(
+            1,
+            (min(page_table.shape[1], max_local_pages) + pages_per_block - 1)
+            // pages_per_block,
+        )
+        create_mla_kv_page_table_for_dcp[(page_table.shape[0], num_page_blocks)](
+            self.req_to_token,
+            req_pool_indices,
+            local_seq_lens,
+            page_table,
+            self.req_to_token.stride(0),
+            page_table.stride(0),
+            PHYSICAL_PAGE_SIZE=self.page_size,
+            DCP_SIZE=parallel.dcp_size,
+            DCP_RANK=parallel.dcp_rank,
+            PAGES_PER_BLOCK=pages_per_block,
+        )
+
+    @staticmethod
+    def _build_mla_dcp_extend_page_table(
+        forward_batch: ForwardBatch, max_seq_len_k: int
+    ) -> torch.Tensor:
+        """Unpack the gathered DCP prefix/extend indices into FA3 row tables."""
+        dcp_metadata = forward_batch.attn_dcp_metadata
+        kv_indptr = dcp_metadata.dcp_kv_indptr
+        kv_indices = dcp_metadata.dcp_kv_indices
+        batch_size = forward_batch.batch_size
+        page_table = torch.zeros(
+            (batch_size, max_seq_len_k),
+            dtype=torch.int32,
+            device=forward_batch.seq_lens.device,
+        )
+        if kv_indices.numel() == 0 or max_seq_len_k == 0:
+            return page_table
+
+        positions = torch.arange(
+            max_seq_len_k, dtype=torch.int32, device=kv_indices.device
+        ).unsqueeze(0)
+        kv_lens = kv_indptr[1 : batch_size + 1] - kv_indptr[:batch_size]
+        valid = positions < kv_lens.unsqueeze(1)
+        flat_offsets = kv_indptr[:batch_size].unsqueeze(1) + positions
+        safe_offsets = flat_offsets.clamp(max=kv_indices.numel() - 1).to(torch.long)
+        page_table.copy_(torch.where(valid, kv_indices[safe_offsets], 0))
+        return page_table
 
     def _mxfp8_sf_kwargs(self, layer, forward_batch, q_descale=None):
         """Block-scaled UE8M0 scale factors for the FA4 MXFP8 attention path.
@@ -735,17 +824,42 @@ class FlashAttentionBackend(AttentionBackend):
                     self.forward_metadata_spec_decode_expand = metadata_expand
             else:
                 # Normal Decode
-                metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
-                metadata.max_seq_len_k = eager_max_k
+                if self._use_mla_dcp():
+                    metadata.cache_seqlens_int32 = self._dcp_local_seq_lens(
+                        seqlens_in_batch
+                    )
+                    metadata.max_seq_len_k = self._dcp_local_max_seq_len(eager_max_k)
+                else:
+                    metadata.cache_seqlens_int32 = seqlens_in_batch.to(torch.int32)
+                    metadata.max_seq_len_k = eager_max_k
                 metadata.cu_seqlens_q = torch.arange(
                     0, batch_size + 1, dtype=torch.int32, device=device
                 )
                 metadata.cu_seqlens_k = torch.nn.functional.pad(
-                    torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0)
+                    torch.cumsum(
+                        metadata.cache_seqlens_int32, dim=0, dtype=torch.int32
+                    ),
+                    (1, 0),
                 )
-                metadata.page_table = self.req_to_token_pool.req_to_token[
-                    forward_batch.req_pool_indices, : metadata.max_seq_len_k
-                ]
+                if self._use_mla_dcp():
+                    max_local_pages = (
+                        metadata.max_seq_len_k + self.page_size - 1
+                    ) // self.page_size
+                    metadata.page_table = torch.zeros(
+                        (batch_size, max_local_pages),
+                        dtype=torch.int32,
+                        device=device,
+                    )
+                    self._fill_mla_dcp_decode_page_table(
+                        metadata.page_table,
+                        forward_batch.req_pool_indices,
+                        metadata.cache_seqlens_int32,
+                    )
+                    metadata.page_table_is_kernel_ready = True
+                else:
+                    metadata.page_table = self.req_to_token_pool.req_to_token[
+                        forward_batch.req_pool_indices, : metadata.max_seq_len_k
+                    ]
 
                 if self.is_prefill_aware_swa and self.has_swa:
                     pa_max_len = min(
@@ -950,9 +1064,15 @@ class FlashAttentionBackend(AttentionBackend):
                 if pad_delta > 0:
                     metadata.max_seq_len_k += pad_delta
 
-            metadata.page_table = self.req_to_token_pool.req_to_token[
-                forward_batch.req_pool_indices, : metadata.max_seq_len_k
-            ]
+            if self._use_mla_dcp() and forward_batch.attn_dcp_metadata is not None:
+                metadata.page_table = self._build_mla_dcp_extend_page_table(
+                    forward_batch, metadata.max_seq_len_k
+                )
+                metadata.page_table_is_kernel_ready = True
+            else:
+                metadata.page_table = self.req_to_token_pool.req_to_token[
+                    forward_batch.req_pool_indices, : metadata.max_seq_len_k
+                ]
 
             if forward_batch.forward_mode.is_draft_extend_v2():
                 # Fixed-q window (num_draft_tokens, widened by num_front_tokens
@@ -1054,7 +1174,11 @@ class FlashAttentionBackend(AttentionBackend):
         # phys_page * L, the dense page id the kernel wants. One site then serves
         # both page sizes, and it inherits translate_kv_loc_dense's tombstone
         # clamp so an unwritten req_to_token slot lands in the page-0 sink.
-        if self._unified_dense and metadata.page_table is not None:
+        if (
+            self._unified_dense
+            and metadata.page_table is not None
+            and not metadata.page_table_is_kernel_ready
+        ):
             # Flattened: the page_size == 1 translate path uses index_select,
             # which rejects a 2-D index.
             pt = metadata.page_table
@@ -1065,7 +1189,7 @@ class FlashAttentionBackend(AttentionBackend):
             )
 
         # Convert the page table to a strided format which is needed by FA3 API
-        if self.page_size > 1:
+        if self.page_size > 1 and not metadata.page_table_is_kernel_ready:
             self.strided_indices = torch.arange(
                 0, metadata.page_table.shape[1], self.page_size, device=self.device
             )
@@ -1574,29 +1698,49 @@ class FlashAttentionBackend(AttentionBackend):
                 # call takes the same qv/ver arguments as this extend path.
                 assert self.fa_impl_ver in (3, 4), "Only FA3/FA4 support here"
                 # Do absorbed multi-latent attention
-                kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(
-                    q.dtype
+                dcp_metadata = forward_batch.attn_dcp_metadata
+                use_dcp_kv_buffer = (
+                    self._use_mla_dcp()
+                    and dcp_metadata is not None
+                    and dcp_metadata.dcp_kv_buffer is not None
                 )
-                k_rope = kv_cache[:, :, layer.v_head_dim :]
+                if use_dcp_kv_buffer:
+                    kv_cache = dcp_metadata.dcp_kv_buffer.to(q.dtype)
+                    kv_page_size = 1
+                else:
+                    kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(
+                        q.dtype
+                    )
+                    kv_page_size = self.page_size
+
+                rope_head_dim = layer.head_dim - layer.v_head_dim
+                only_qv = self.fa_impl_ver == 3 and rope_head_dim == 0
                 c_kv = kv_cache[:, :, : layer.v_head_dim]
-                k_rope_cache = k_rope.view(
-                    -1,
-                    self.page_size,
-                    layer.tp_k_head_num,
-                    layer.head_dim - layer.v_head_dim,
-                )
                 c_kv_cache = c_kv.view(
-                    -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
+                    -1, kv_page_size, layer.tp_v_head_num, layer.v_head_dim
                 )
+                if only_qv:
+                    k_rope_cache = None
+                else:
+                    k_rope_cache = kv_cache[:, :, layer.v_head_dim :].view(
+                        -1,
+                        kv_page_size,
+                        layer.tp_k_head_num,
+                        rope_head_dim,
+                    )
                 if q_rope is not None:
                     q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-                    q_rope = q_rope.view(
-                        -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+                    q_rope = (
+                        None
+                        if only_qv
+                        else q_rope.view(
+                            -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+                        )
                     )
                 else:
                     q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
                     q_nope = q_all[:, :, : layer.v_head_dim]
-                    q_rope = q_all[:, :, layer.v_head_dim :]
+                    q_rope = None if only_qv else q_all[:, :, layer.v_head_dim :]
 
                 if is_cp_mode:
                     # MLA CP: q is rank-local zigzag-split; run the
@@ -1609,7 +1753,7 @@ class FlashAttentionBackend(AttentionBackend):
                     assert (
                         not use_cascade_attn
                     ), "Cascade attention under MLA CP is not supported in v1."
-                    q_fused = torch.cat([q_nope, q_rope], dim=-1)
+                    q_fused = q_nope if only_qv else torch.cat([q_nope, q_rope], dim=-1)
 
                     def _mla_cp_attn(
                         q_chunk,
@@ -1617,12 +1761,16 @@ class FlashAttentionBackend(AttentionBackend):
                         cache_seqlens_cp,
                         max_seqlen_q_cp,
                     ):
-                        q_nope_chunk = q_chunk[..., : layer.v_head_dim]
-                        q_rope_chunk = q_chunk[..., layer.v_head_dim :]
+                        if only_qv:
+                            q_nope_chunk = q_chunk
+                            q_rope_chunk = None
+                        else:
+                            q_nope_chunk = q_chunk[..., : layer.v_head_dim]
+                            q_rope_chunk = q_chunk[..., layer.v_head_dim :]
                         return flash_attn_with_kvcache(
-                            q=q_rope_chunk,
+                            q=None if only_qv else q_rope_chunk,
                             qv=q_nope_chunk,
-                            k_cache=k_rope_cache,
+                            k_cache=None if only_qv else k_rope_cache,
                             v_cache=c_kv_cache,
                             page_table=page_table,
                             cache_seqlens=cache_seqlens_cp,
@@ -1636,6 +1784,7 @@ class FlashAttentionBackend(AttentionBackend):
                             softcap=layer.logit_cap,
                             k_descale=fa_k_descale,
                             v_descale=fa_v_descale,
+                            only_qv=only_qv,
                             num_splits=self.num_splits,
                             ver=self.fa_impl_ver,
                         )
@@ -1656,8 +1805,8 @@ class FlashAttentionBackend(AttentionBackend):
                         )
                 else:
                     result = flash_attn_with_kvcache(
-                        q=q_rope,
-                        k_cache=k_rope_cache,
+                        q=None if only_qv else q_rope,
+                        k_cache=None if only_qv else k_rope_cache,
                         v_cache=c_kv_cache,
                         qv=q_nope,
                         page_table=page_table,
@@ -1670,6 +1819,7 @@ class FlashAttentionBackend(AttentionBackend):
                         softcap=layer.logit_cap,
                         k_descale=fa_k_descale,
                         v_descale=fa_v_descale,
+                        only_qv=only_qv,
                         return_softmax_lse=use_cascade_attn,
                         num_splits=self.num_splits,
                         ver=self.fa_impl_ver,
@@ -1678,8 +1828,8 @@ class FlashAttentionBackend(AttentionBackend):
                         o, softmax_lse, *rest = result
                         o_expand, softmax_lse_expand, *rest_expand = (
                             flash_attn_with_kvcache(
-                                q=q_rope,
-                                k_cache=k_rope_cache,
+                                q=None if only_qv else q_rope,
+                                k_cache=None if only_qv else k_rope_cache,
                                 v_cache=c_kv_cache,
                                 qv=q_nope,
                                 page_table=self.forward_metadata_spec_decode_expand.page_table,
@@ -1693,6 +1843,7 @@ class FlashAttentionBackend(AttentionBackend):
                                 softcap=layer.logit_cap,
                                 k_descale=fa_k_descale,
                                 v_descale=fa_v_descale,
+                                only_qv=only_qv,
                                 return_softmax_lse=True,
                                 num_splits=self.num_splits,
                                 ver=self.fa_impl_ver,
@@ -1837,6 +1988,7 @@ class FlashAttentionBackend(AttentionBackend):
         if fa_k_descale is not None:
             kwargs["k_descale"] = fa_k_descale
             kwargs["v_descale"] = fa_v_descale
+        needs_dcp_lse = False
         if not self.use_mla:
             # Do multi-head attention
 
@@ -1974,32 +2126,41 @@ class FlashAttentionBackend(AttentionBackend):
         else:
             # Do absorbed multi-latent attention
             kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(q.dtype)
-            k_rope = kv_cache[:, :, layer.v_head_dim :]
+            rope_head_dim = layer.head_dim - layer.v_head_dim
+            only_qv = self.fa_impl_ver == 3 and rope_head_dim == 0
             c_kv = kv_cache[:, :, : layer.v_head_dim]
-            k_rope_cache = k_rope.view(
-                -1,
-                self.page_size,
-                layer.tp_k_head_num,
-                layer.head_dim - layer.v_head_dim,
-            )
             c_kv_cache = c_kv.view(
                 -1, self.page_size, layer.tp_v_head_num, layer.v_head_dim
             )
+            if only_qv:
+                k_rope_cache = None
+            else:
+                k_rope_cache = kv_cache[:, :, layer.v_head_dim :].view(
+                    -1,
+                    self.page_size,
+                    layer.tp_k_head_num,
+                    rope_head_dim,
+                )
 
             if q_rope is not None:
                 q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-                q_rope = q_rope.view(
-                    -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+                q_rope = (
+                    None
+                    if only_qv
+                    else q_rope.view(-1, layer.tp_q_head_num, rope_head_dim)
                 )
             else:
                 q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
                 q_nope = q_all[:, :, : layer.v_head_dim]
-                q_rope = q_all[:, :, layer.v_head_dim :]
+                q_rope = None if only_qv else q_all[:, :, layer.v_head_dim :]
             max_seqlen_q = metadata.max_seq_len_q
+            needs_dcp_lse = (
+                self._use_mla_dcp() and forward_batch.forward_mode.is_decode()
+            )
 
             result = flash_attn_with_kvcache(
-                q=q_rope,
-                k_cache=k_rope_cache,
+                q=None if only_qv else q_rope,
+                k_cache=None if only_qv else k_rope_cache,
                 v_cache=c_kv_cache,
                 qv=q_nope,
                 page_table=metadata.page_table,
@@ -2012,15 +2173,16 @@ class FlashAttentionBackend(AttentionBackend):
                 softcap=layer.logit_cap,
                 k_descale=fa_k_descale,
                 v_descale=fa_v_descale,
-                return_softmax_lse=use_cascade_attn,  # softmax_lse is needed for merge states
+                only_qv=only_qv,
+                return_softmax_lse=use_cascade_attn or needs_dcp_lse,
                 num_splits=self.num_splits,
                 ver=self.fa_impl_ver,
             )
             if use_cascade_attn:
                 o, softmax_lse, *rest = result
                 o_expand, softmax_lse_expand, *rest_expand = flash_attn_with_kvcache(
-                    q=q_rope,
-                    k_cache=k_rope_cache,
+                    q=None if only_qv else q_rope,
+                    k_cache=None if only_qv else k_rope_cache,
                     v_cache=c_kv_cache,
                     qv=q_nope,
                     page_table=self.forward_metadata_spec_decode_expand.page_table,
@@ -2034,6 +2196,7 @@ class FlashAttentionBackend(AttentionBackend):
                     softcap=layer.logit_cap,
                     k_descale=fa_k_descale,
                     v_descale=fa_v_descale,
+                    only_qv=only_qv,
                     return_softmax_lse=True,
                     num_splits=self.num_splits,
                     ver=self.fa_impl_ver,
@@ -2044,10 +2207,24 @@ class FlashAttentionBackend(AttentionBackend):
                     o_expand,
                     softmax_lse_expand.T.contiguous(),
                 )
+            elif needs_dcp_lse:
+                o, softmax_lse, *rest = result
             else:
                 o = result
 
-        return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+        output = o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
+        if self.use_mla and needs_dcp_lse:
+            output_by_head = output.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+            lse = softmax_lse.transpose(0, 1).contiguous()
+            lse.mul_(_FA3_LSE_BASE2_FROM_NATURAL_LOG)
+
+            # A rank may own no KV token for short requests. Make that partial
+            # state neutral so the model-side cross-rank merge ignores it.
+            zero_kv = metadata.cache_seqlens_int32 == 0
+            output_by_head.masked_fill_(zero_kv[:, None, None], 0)
+            lse.masked_fill_(zero_kv[:, None], float("-inf"))
+            return output, lse
+        return output
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Initialize CUDA graph state for the attention backend.
@@ -2459,6 +2636,7 @@ class FlashAttentionBackend(AttentionBackend):
                 metadata.page_table = self.decode_cuda_graph_metadata["page_table"][
                     :bs, :
                 ]
+                metadata.page_table_is_kernel_ready = self._use_mla_dcp()
                 if self.is_prefill_aware_swa:
                     metadata.pa_swa_page_table = metadata.page_table
                     metadata.pa_swa_cache_seqlens = metadata.cache_seqlens_int32
@@ -2730,7 +2908,28 @@ class FlashAttentionBackend(AttentionBackend):
             else:
                 # Normal Decode
                 metadata = self.decode_cuda_graph_metadata[bs]
-                if self.is_prefill_aware_swa:
+                if self._use_mla_dcp():
+                    local_seq_lens = self._dcp_local_seq_lens(seq_lens)
+                    metadata.cache_seqlens_int32.copy_(local_seq_lens)
+                    metadata.cu_seqlens_k[0].zero_()
+                    metadata.cu_seqlens_k[1:].copy_(
+                        torch.cumsum(local_seq_lens, dim=0, dtype=torch.int32)
+                    )
+                    global_max_seq_len = (
+                        seq_lens_cpu.max().item()
+                        if seq_lens_cpu is not None
+                        else self.max_context_len
+                    )
+                    metadata.max_seq_len_k = self._dcp_local_max_seq_len(
+                        global_max_seq_len
+                    )
+                    self._fill_mla_dcp_decode_page_table(
+                        metadata.page_table,
+                        req_pool_indices,
+                        local_seq_lens,
+                    )
+                    metadata.page_table_is_kernel_ready = True
+                elif self.is_prefill_aware_swa:
                     # Prefill-aware SWA still needs a host max to bound the
                     # per-batch page table built below.
                     max_len = self._host_max_seq_len(seq_lens_cpu, seq_lens)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3772,9 +3772,9 @@ class ServerArgs:
         handle_pd_disaggregation(self)
 
     def _handle_dcp_validation(self):
-        # Decode context parallel (DCP) is currently implemented and validated
-        # only on AMD HIP/ROCm. Reject invalid or unverified configurations
-        # early instead of letting them fail deeper in model initialization.
+        # Decode context parallel (DCP) is accelerator-specific. Reject invalid
+        # or unverified configurations early instead of letting them fail
+        # deeper in model initialization.
         if self.dcp_size < 1:
             raise ValueError(
                 "Decode context parallel size (--dcp-size / "
@@ -3807,6 +3807,12 @@ class ServerArgs:
                 )
         if not self.dcp_size > 1:
             return
+        if self.tp_size % self.dcp_size != 0:
+            raise ValueError(
+                "Tensor parallel size (--tp-size) must be divisible by decode "
+                "context parallel size (--dcp-size), but got "
+                f"tp_size={self.tp_size}, dcp_size={self.dcp_size}."
+            )
         if is_hip():
             return
         elif is_cuda():

--- a/test/registered/kernels/ops/attention/test_flash_attention_3_dcp.py
+++ b/test/registered/kernels/ops/attention/test_flash_attention_3_dcp.py
@@ -1,0 +1,242 @@
+"""FA3 absorbed-MLA correctness under cyclic decode context parallelism."""
+
+import math
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dcp_kernels import dcp_lse_combine_triton
+from sglang.kernels.ops.attention.flash_attention import flash_attn_with_kvcache
+from sglang.srt.layers.attention.flashattention_backend import (
+    _FA3_LSE_BASE2_FROM_NATURAL_LOG,
+    FlashAttentionBackend,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+skip_condition = not torch.cuda.is_available() or (
+    torch.cuda.get_device_capability()[0] != 9
+)
+
+
+def _pack_sequences(sequences):
+    batch_size = len(sequences)
+    lengths = torch.tensor(
+        [sequence.shape[0] for sequence in sequences],
+        dtype=torch.int32,
+        device=sequences[0].device,
+    )
+    max_len = max(int(lengths.max().item()), 1)
+    page_table = torch.zeros(
+        (batch_size, max_len), dtype=torch.int32, device=sequences[0].device
+    )
+
+    packed = []
+    offset = 0
+    for row, sequence in enumerate(sequences):
+        length = sequence.shape[0]
+        if length:
+            packed.append(sequence)
+            page_table[row, :length] = torch.arange(
+                offset,
+                offset + length,
+                dtype=torch.int32,
+                device=sequence.device,
+            )
+            offset += length
+
+    return torch.cat(packed, dim=0).unsqueeze(1), page_table, lengths
+
+
+def _run_absorbed_mla(q_rope, q_nope, k_sequences, v_sequences, only_qv):
+    v_cache, page_table, cache_seqlens = _pack_sequences(v_sequences)
+    if only_qv:
+        k_cache = None
+        q = None
+    else:
+        k_cache, k_page_table, k_seqlens = _pack_sequences(k_sequences)
+        torch.testing.assert_close(k_page_table, page_table)
+        torch.testing.assert_close(k_seqlens, cache_seqlens)
+        q = q_rope
+
+    batch_size, num_heads, _ = q_nope.shape
+    cu_seqlens_q = torch.arange(batch_size + 1, dtype=torch.int32, device=q_nope.device)
+    cu_seqlens_k = torch.nn.functional.pad(
+        torch.cumsum(cache_seqlens, dim=0, dtype=torch.int32), (1, 0)
+    )
+    qk_dim = q_nope.shape[-1] + (0 if only_qv else q_rope.shape[-1])
+    out, raw_lse, *rest = flash_attn_with_kvcache(
+        q=q,
+        k_cache=k_cache,
+        v_cache=v_cache,
+        qv=q_nope,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k_new=cu_seqlens_k,
+        max_seqlen_q=1,
+        softmax_scale=qk_dim**-0.5,
+        causal=True,
+        only_qv=only_qv,
+        return_softmax_lse=True,
+        num_splits=1,
+        ver=3,
+    )
+
+    assert out.shape == (batch_size, num_heads, q_nope.shape[-1])
+    # The backend feeds FA3 an unpadded [total_q, heads, dim] query. Pin the
+    # corresponding kernel-facing LSE layout before it is converted to [B, H].
+    assert raw_lse.shape == (num_heads, batch_size)
+    return out, raw_lse.transpose(0, 1).contiguous(), cache_seqlens
+
+
+def _check_cyclic_dcp_merge(only_qv):
+    torch.manual_seed(7)
+    device = "cuda"
+    dtype = torch.bfloat16
+    dcp_size = 4
+    batch_size = 3
+    num_heads = 8
+    v_head_dim = 512
+    rope_head_dim = 0 if only_qv else 64
+    seq_lens = (1, 67, 259)
+
+    q_nope = torch.randn(batch_size, num_heads, v_head_dim, dtype=dtype, device=device)
+    q_rope = (
+        None
+        if only_qv
+        else torch.randn(
+            batch_size, num_heads, rope_head_dim, dtype=dtype, device=device
+        )
+    )
+    v_sequences = [
+        torch.randn(length, 1, v_head_dim, dtype=dtype, device=device)
+        for length in seq_lens
+    ]
+    k_sequences = (
+        None
+        if only_qv
+        else [
+            torch.randn(length, 1, rope_head_dim, dtype=dtype, device=device)
+            for length in seq_lens
+        ]
+    )
+
+    full_out, full_lse, _ = _run_absorbed_mla(
+        q_rope, q_nope, k_sequences, v_sequences, only_qv
+    )
+
+    partial_outputs = []
+    partial_lses = []
+    for rank in range(dcp_size):
+        local_v = [sequence[rank::dcp_size] for sequence in v_sequences]
+        local_k = (
+            None if only_qv else [sequence[rank::dcp_size] for sequence in k_sequences]
+        )
+        local_out, local_lse, local_lens = _run_absorbed_mla(
+            q_rope, q_nope, local_k, local_v, only_qv
+        )
+
+        # Match the backend's neutral state for requests with no KV on this rank.
+        zero_kv = local_lens == 0
+        local_out.masked_fill_(zero_kv[:, None, None], 0)
+        local_lse.masked_fill_(zero_kv[:, None], float("-inf"))
+        partial_outputs.append(local_out)
+        partial_lses.append(local_lse)
+
+    partial_outputs = torch.stack(partial_outputs)
+    partial_lses = torch.stack(partial_lses)
+
+    # FA3 emits natural-log LSE. The production backend rebases it because the
+    # existing MLA DCP merge consumes base-2 LSE.
+    partial_lses_base2 = partial_lses * _FA3_LSE_BASE2_FROM_NATURAL_LOG
+    merged_out, _ = dcp_lse_combine_triton(
+        partial_outputs,
+        partial_lses_base2,
+        is_lse_base_on_e=False,
+        return_lse=False,
+    )
+
+    torch.testing.assert_close(
+        merged_out.float(), full_out.float(), atol=3e-2, rtol=3e-2
+    )
+    torch.testing.assert_close(
+        torch.logsumexp(partial_lses, dim=0),
+        full_lse,
+        atol=3e-2,
+        rtol=3e-2,
+    )
+    assert math.isclose(
+        _FA3_LSE_BASE2_FROM_NATURAL_LOG, 1.0 / math.log(2.0), rel_tol=1e-12
+    )
+
+
+@pytest.mark.skipif(
+    skip_condition, reason="FA3 DCP absorbed-MLA tests require Hopper (sm90)."
+)
+class TestFlashAttentionV3DCP(CustomTestCase):
+    def test_decode_page_table_uses_rank_local_physical_pages(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.page_size = 2
+        backend.max_context_len = 16
+        backend.req_to_token = torch.zeros(
+            (2, backend.max_context_len), dtype=torch.int32, device="cuda"
+        )
+        # dcp_size=4, rank=2 owns global positions 2, 6, 10, ...
+        # Each pair of local tokens forms one physical page.
+        backend.req_to_token[0, 2] = 42
+        backend.req_to_token[0, 10] = 82
+        backend.req_to_token[1, 2] = 122
+        req_pool_indices = torch.tensor([0, 1], dtype=torch.int32, device="cuda")
+        local_seq_lens = torch.tensor([3, 1], dtype=torch.int32, device="cuda")
+        page_table = torch.zeros((2, 2), dtype=torch.int32, device="cuda")
+
+        parallel = SimpleNamespace(dcp_size=4, dcp_rank=2)
+        with patch(
+            "sglang.srt.layers.attention.flashattention_backend.get_parallel",
+            return_value=parallel,
+        ):
+            backend._fill_mla_dcp_decode_page_table(
+                page_table, req_pool_indices, local_seq_lens
+            )
+
+        expected = torch.tensor([[5, 10], [15, 0]], dtype=torch.int32, device="cuda")
+        torch.testing.assert_close(page_table, expected)
+
+    def test_gathered_extend_indices_are_unpacked_per_request(self):
+        dcp_metadata = SimpleNamespace(
+            dcp_kv_indptr=torch.tensor([0, 3, 5, 5], dtype=torch.int32, device="cuda"),
+            dcp_kv_indices=torch.tensor(
+                [8, 1, 4, 7, 3], dtype=torch.int32, device="cuda"
+            ),
+        )
+        forward_batch = SimpleNamespace(
+            attn_dcp_metadata=dcp_metadata,
+            batch_size=3,
+            seq_lens=torch.tensor([3, 2, 0], dtype=torch.int32, device="cuda"),
+        )
+
+        page_table = FlashAttentionBackend._build_mla_dcp_extend_page_table(
+            forward_batch, max_seq_len_k=4
+        )
+        expected = torch.tensor(
+            [[8, 1, 4, 0], [7, 3, 0, 0], [0, 0, 0, 0]],
+            dtype=torch.int32,
+            device="cuda",
+        )
+        torch.testing.assert_close(page_table, expected)
+
+    def test_rope_mla(self):
+        _check_cyclic_dcp_merge(only_qv=False)
+
+    def test_nope_only_qv_mla(self):
+        _check_cyclic_dcp_merge(only_qv=True)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/unit/server_args/test_dcp_config.py
+++ b/test/registered/unit/server_args/test_dcp_config.py
@@ -5,6 +5,7 @@ validation in ``ServerArgs._handle_dcp_validation``:
   - a2a / fi_a2a require --dcp-size > 1
   - fi_a2a requires a CUDA platform (the authoritative MNNVL fabric probe runs
     later, at model-runner init)
+  - --dcp-size must divide --tp-size
   - dcp>1 requires CUDA or HIP (base behavior from the merged DCP PR)
 
 Tests construct with safe defaults (dcp_size=1) then mutate the fields and call
@@ -49,11 +50,12 @@ class TestDCPCommBackendValidation(CustomTestCase):
     """Verify ``_handle_dcp_validation`` accepts/rejects the right combos."""
 
     @staticmethod
-    def _make_args(dcp_size, dcp_comm_backend):
+    def _make_args(dcp_size, dcp_comm_backend, tp_size=None):
         # Construct with safe defaults (dcp_size=1) so __post_init__ never trips
         # the dcp>1 platform gate, then set the fields under test.
         args = ServerArgs(model_path="dummy")
         args.dcp_size = dcp_size
+        args.tp_size = dcp_size if tp_size is None else tp_size
         args.dcp_comm_backend = dcp_comm_backend
         return args
 
@@ -96,6 +98,13 @@ class TestDCPCommBackendValidation(CustomTestCase):
         args = self._make_args(dcp_size=8, dcp_comm_backend="ag_rs")
         args._handle_dcp_validation()  # no raise
         self.assertEqual(args.dcp_size, 8)
+
+    @patch("sglang.srt.server_args.is_hip", return_value=False)
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    def test_dcp_size_must_divide_tp_size(self, *_):
+        args = self._make_args(dcp_size=3, dcp_comm_backend="ag_rs", tp_size=8)
+        with self.assertRaisesRegex(ValueError, "must be divisible"):
+            args._handle_dcp_validation()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  ## Motivation

  Decode context parallelism (DCP) partitions the KV cache cyclically across tensor-parallel ranks.

  The FA3 absorbed-MLA backend previously used global sequence lengths and regular page-table conversion, and it did not return the rank-local log-sum-exp (LSE)
  required by the existing cross-rank MLA reduction. As a result, FA3 could not correctly execute MLA models with DCP enabled.

  This PR adds model-agnostic FA3 support for MLA DCP. It does not introduce or modify any model-specific implementation.

  ## Modifications

  - Add DCP-aware metadata handling to the FA3 MLA backend:
    - Compute rank-local sequence lengths for cyclic KV sharding.
    - Build kernel-facing physical page tables for eager decode.
    - Rebuild rank-local page tables during CUDA Graph replay.
    - Mark DCP page tables as kernel-ready to avoid applying the regular page-table conversion twice.

  - Support DCP extend/prefill:
    - Build per-request page tables from gathered DCP KV indices.
    - Use the gathered DCP KV buffer with a physical page size of 1.

  - Return rank-local attention output and LSE during DCP decode:
    - Convert FA3 natural-log LSE to the base-2 representation expected by the existing MLA DCP reducers.
    - Produce neutral partial states (`output=0`, `LSE=-inf`) when a rank owns no KV tokens for a request.

  - Wire the FA3 `only_qv` path into absorbed MLA when the RoPE head dimension is zero.

  - Validate that `--dcp-size` divides `--tp-size` before distributed groups are initialized.

  - Add tests covering:
    - Rank-local physical page-table construction.
    - Gathered extend-index unpacking.
    - Cyclic DCP output/LSE merging with RoPE MLA.
    - Cyclic DCP output/LSE merging with NoPE/`only_qv` MLA.
    - Invalid TP/DCP divisibility.


  The test compares full-sequence FA3 attention against four cyclic DCP shards followed by the production Triton LSE merge. It covers both:

  - RoPE MLA with a 64-dimensional RoPE component.
  Test configuration:

  - BF16
  - DCP size: 4
  - Output/LSE tolerance: `atol=3e-2`, `rtol=3e-2`

  Local static validation passed:

  - isort
  - Ruff (`F401`, `F821`, `UP037`)
  - Black
  - Python `compileall`
  - `git diff --check`
  - Registered-test validation

  The GPU accuracy test was not executed locally because the development host does not have PyTorch/CUDA or an SM90 GPU. It is expected to run in the registered
  SM90 CI job.

  ## Speed Tests and Profiling

  Not measured. This PR enables a previously unsupported FA3+DCP combination and does not make a performance claim.

  All new runtime behavior is gated by MLA, FA3, and DCP being enabled together, so non-DCP and FA4 execution paths are unchanged.
  - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no
  user-facing API or CLI option was added.)
  - [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-
  accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (SM90 accuracy execution is pending CI;
  no speed claim is made.)
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30780925519](https://github.com/sgl-project/sglang/actions/runs/30780925519)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30780925377](https://github.com/sgl-project/sglang/actions/runs/30780925377)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->