### PR TITLE
[CI] Size the CPU stage from the live partition model

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -334,8 +334,8 @@ jobs:
           key: hf-cpu-${{ matrix.partition }}-${{ github.run_id }}
           restore-keys: hf-cpu-${{ matrix.partition }}-
 
-      # Same snapshot every shard, so the LPT split is consistent. Without it
-      # this suite falls back to in-source est_time and mis-partitions.
+      # Pinned SHA so every shard splits against the same snapshot; without
+      # the file run_suite falls back to the (drifting) in-source est_time.
       - name: Fetch live partition model
         if: needs.check-changes.outputs.partition_model_sha != ''
         run: |
@@ -344,9 +344,9 @@ jobs:
           curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
             "$URL" -o /tmp/partition-model.json
 
-      # compute_partitions reads this budget back to size the fanout, so it
-      # drives shard count rather than capping it. 10m left only ~96s per
-      # shard once the ~354s setup bias came out, which asked for 33 shards.
+      # compute_partitions reads this back as the per-shard budget, so it
+      # drives the fanout rather than capping it -- shrinking it buys more
+      # shards, not shorter ones.
       - name: Run test
         timeout-minutes: 15
         env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -344,10 +344,9 @@ jobs:
           curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
             "$URL" -o /tmp/partition-model.json
 
-      # The fanout is pinned at 8 (compute_partitions._BASE_A_OVERRIDES), so
-      # this budget has to be sized by hand. ~450s of tests per shard today;
-      # LPT's 4/3 worst case is ~600s, which a 10m budget cut exactly. 15m
-      # tolerates a 675s average, i.e. 50% growth before the next bump.
+      # compute_partitions reads this budget back to size the fanout, so it
+      # drives shard count rather than capping it. 10m left only ~96s per
+      # shard once the ~354s setup bias came out, which asked for 33 shards.
       - name: Run test
         timeout-minutes: 15
         env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -334,13 +334,23 @@ jobs:
           key: hf-cpu-${{ matrix.partition }}-${{ github.run_id }}
           restore-keys: hf-cpu-${{ matrix.partition }}-
 
+      # Same snapshot every shard, so the LPT split is consistent. Without it
+      # this suite falls back to in-source est_time and mis-partitions.
+      - name: Fetch live partition model
+        if: needs.check-changes.outputs.partition_model_sha != ''
+        run: |
+          rm -f /tmp/partition-model.json
+          URL="https://raw.githubusercontent.com/sgl-project/sglang-ci-stats/${{ needs.check-changes.outputs.partition_model_sha }}/model.json"
+          curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
+            "$URL" -o /tmp/partition-model.json
+
       - name: Run test
         timeout-minutes: 10
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |
           cd test/
-          python3 run_suite.py --hw cpu --suite base-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].size }} $CONTINUE_ON_ERROR_FLAG
+          python3 run_suite.py --hw cpu --suite base-a-test-cpu --auto-partition-id ${{ matrix.partition }} --auto-partition-size ${{ fromJson(needs.check-changes.outputs.partitions)['base-a-test-cpu'].size }} --partition-model-file /tmp/partition-model.json $CONTINUE_ON_ERROR_FLAG
 
   # Runs on 5090 (32GB, SM120)
   base-b-test-1-gpu-small:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -344,8 +344,12 @@ jobs:
           curl --fail --silent --show-error --max-time 15 --retry 3 --retry-delay 2 \
             "$URL" -o /tmp/partition-model.json
 
+      # The fanout is pinned at 8 (compute_partitions._BASE_A_OVERRIDES), so
+      # this budget has to be sized by hand. ~450s of tests per shard today;
+      # LPT's 4/3 worst case is ~600s, which a 10m budget cut exactly. 15m
+      # tolerates a 675s average, i.e. 50% growth before the next bump.
       - name: Run test
-        timeout-minutes: 10
+        timeout-minutes: 15
         env:
           CONTINUE_ON_ERROR_FLAG: ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
         run: |

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -35,17 +35,16 @@ HWBackend = _ci_register.HWBackend
 # pr-test-amd.yml / pr-test-npu.yml have their own dispatch.
 _TARGET_BACKENDS = {HWBackend.CUDA, HWBackend.CPU}
 
-# base-a is the critical-path entry gate; pin its fanout to sanity-coverage
-# defaults instead of est_time. max_parallel = size (no throttle).
+# Single-shard sanity gate on the critical path; pinned rather than sized
+# from est_time. max_parallel = size (no throttle).
 _BASE_A_OVERRIDES = {
     "base-a-test-1-gpu-small": 1,
 }
 
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
 
-# base-a-test-cpu is inlined in pr-test.yml rather than dispatched through the
-# reusable stage, so its budget has to be read off the job's own `Run test`
-# step instead of a `run_timeout_minutes` input.
+# Inlined in pr-test.yml rather than dispatched through the reusable stage,
+# so there is no `run_timeout_minutes` input to read the budget from.
 _INLINE_SUITE_JOB_IDS = {"base-a-test-cpu": "base-a-test-cpu"}
 _RUN_TEST_STEP_NAME = "Run test"
 
@@ -201,9 +200,9 @@ def compute_partitions(
                     f"coeff={coeff}, bias={bias}s, total_est={total:.0f}s."
                 )
             size = max(1, ideal_size)
-            # The throttle rations scarce self-hosted GPU runners. CPU suites
-            # land on hosted ubuntu-latest, which is elastic -- capping them
-            # would serialize the shards and inflate wall clock for nothing.
+            # The throttle rations scarce self-hosted GPU runners; hosted
+            # ubuntu-latest is elastic, so capping CPU shards would only
+            # serialize them.
             on_hosted_runners = all(t.backend == HWBackend.CPU for t in group)
             max_parallel = (
                 size

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -38,26 +38,51 @@ _TARGET_BACKENDS = {HWBackend.CUDA, HWBackend.CPU}
 # base-a is the critical-path entry gate; pin its fanout to sanity-coverage
 # defaults instead of est_time. max_parallel = size (no throttle).
 _BASE_A_OVERRIDES = {
-    "base-a-test-cpu": 8,
     "base-a-test-1-gpu-small": 1,
 }
 
 _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
 
+# base-a-test-cpu is inlined in pr-test.yml rather than dispatched through the
+# reusable stage, so its budget has to be read off the job's own `Run test`
+# step instead of a `run_timeout_minutes` input.
+_INLINE_SUITE_JOB_IDS = {"base-a-test-cpu": "base-a-test-cpu"}
+_RUN_TEST_STEP_NAME = "Run test"
+
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
     """Map `self_name -> run_timeout_minutes` from one pr-test*.yml. The input
     is required in `_pr-test-stage.yml` -- KeyError surfaces missing.
-    Inline base-a-test-cpu is skipped (uses `_BASE_A_OVERRIDES`)."""
+    Inline suites (`_INLINE_SUITE_JOB_IDS`) contribute their `Run test` step
+    timeout so they size off the same budget as dispatched stages."""
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
+    jobs = wf.get("jobs") or {}
     timeouts = {}
-    for job_id, job in (wf.get("jobs") or {}).items():
+    for job_id, job in jobs.items():
         if not isinstance(job, dict) or job.get("uses") != _REUSABLE_STAGE_USES:
             continue
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
         timeouts[suite] = int(with_["run_timeout_minutes"])
+    for suite, job_id in _INLINE_SUITE_JOB_IDS.items():
+        job = jobs.get(job_id)
+        if not isinstance(job, dict):
+            raise RuntimeError(
+                f"load_run_timeouts: inline suite {suite!r} expects job "
+                f"{job_id!r} in {pr_test_yml_path}; update _INLINE_SUITE_JOB_IDS."
+            )
+        steps = [
+            s
+            for s in (job.get("steps") or [])
+            if isinstance(s, dict) and s.get("name") == _RUN_TEST_STEP_NAME
+        ]
+        if len(steps) != 1 or "timeout-minutes" not in steps[0]:
+            raise RuntimeError(
+                f"load_run_timeouts: inline suite {suite!r} needs exactly one "
+                f"{_RUN_TEST_STEP_NAME!r} step carrying `timeout-minutes`."
+            )
+        timeouts[suite] = int(steps[0]["timeout-minutes"])
     if not timeouts:
         raise RuntimeError(
             f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "
@@ -176,7 +201,15 @@ def compute_partitions(
                     f"coeff={coeff}, bias={bias}s, total_est={total:.0f}s."
                 )
             size = max(1, ideal_size)
-            max_parallel = size if full_parallel else compute_max_parallel(size)
+            # The throttle rations scarce self-hosted GPU runners. CPU suites
+            # land on hosted ubuntu-latest, which is elastic -- capping them
+            # would serialize the shards and inflate wall clock for nothing.
+            on_hosted_runners = all(t.backend == HWBackend.CPU for t in group)
+            max_parallel = (
+                size
+                if (full_parallel or on_hosted_runners)
+                else compute_max_parallel(size)
+            )
         result[suite] = {
             "size": size,
             "arr": list(range(size)),

--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -45,14 +45,13 @@ _REUSABLE_STAGE_USES = "./.github/workflows/_pr-test-stage.yml"
 
 # Inlined in pr-test.yml rather than dispatched through the reusable stage,
 # so there is no `run_timeout_minutes` input to read the budget from.
-_INLINE_SUITE_JOB_IDS = {"base-a-test-cpu": "base-a-test-cpu"}
-_RUN_TEST_STEP_NAME = "Run test"
+_INLINE_SUITE_JOBS = {"base-a-test-cpu"}
 
 
 def load_run_timeouts(pr_test_yml_path: str) -> dict:
     """Map `self_name -> run_timeout_minutes` from one pr-test*.yml. The input
     is required in `_pr-test-stage.yml` -- KeyError surfaces missing.
-    Inline suites (`_INLINE_SUITE_JOB_IDS`) contribute their `Run test` step
+    Inline suites (`_INLINE_SUITE_JOBS`) contribute their `Run test` step
     timeout so they size off the same budget as dispatched stages."""
     with open(pr_test_yml_path) as f:
         wf = yaml.safe_load(f)
@@ -64,24 +63,20 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
         timeouts[suite] = int(with_["run_timeout_minutes"])
-    for suite, job_id in _INLINE_SUITE_JOB_IDS.items():
-        job = jobs.get(job_id)
-        if not isinstance(job, dict):
-            raise RuntimeError(
-                f"load_run_timeouts: inline suite {suite!r} expects job "
-                f"{job_id!r} in {pr_test_yml_path}; update _INLINE_SUITE_JOB_IDS."
-            )
-        steps = [
-            s
-            for s in (job.get("steps") or [])
-            if isinstance(s, dict) and s.get("name") == _RUN_TEST_STEP_NAME
+    for suite in _INLINE_SUITE_JOBS:
+        budgets = [
+            s["timeout-minutes"]
+            for s in ((jobs.get(suite) or {}).get("steps") or [])
+            if isinstance(s, dict)
+            and s.get("name") == "Run test"
+            and "timeout-minutes" in s
         ]
-        if len(steps) != 1 or "timeout-minutes" not in steps[0]:
+        if len(budgets) != 1:
             raise RuntimeError(
                 f"load_run_timeouts: inline suite {suite!r} needs exactly one "
-                f"{_RUN_TEST_STEP_NAME!r} step carrying `timeout-minutes`."
+                f"`Run test` step with `timeout-minutes` in {pr_test_yml_path}."
             )
-        timeouts[suite] = int(steps[0]["timeout-minutes"])
+        timeouts[suite] = int(budgets[0])
     if not timeouts:
         raise RuntimeError(
             f"load_run_timeouts: no jobs matched uses={_REUSABLE_STAGE_USES!r} "
@@ -201,14 +196,12 @@ def compute_partitions(
                 )
             size = max(1, ideal_size)
             # The throttle rations scarce self-hosted GPU runners; hosted
-            # ubuntu-latest is elastic, so capping CPU shards would only
-            # serialize them.
-            on_hosted_runners = all(t.backend == HWBackend.CPU for t in group)
-            max_parallel = (
-                size
-                if (full_parallel or on_hosted_runners)
-                else compute_max_parallel(size)
+            # ubuntu-latest is elastic, so capping CPU shards only serializes
+            # them.
+            unthrottled = full_parallel or all(
+                t.backend == HWBackend.CPU for t in group
             )
+            max_parallel = size if unthrottled else compute_max_parallel(size)
         result[suite] = {
             "size": size,
             "arr": list(range(size)),


### PR DESCRIPTION
## Summary
- Fetch the live partition model in `base-a-test-cpu` and pass `--partition-model-file`, so shards split on measured p90 instead of in-source `est_time`
- Raise the `Run test` budget from 10m to 15m
- Drop `base-a-test-cpu` from `_BASE_A_OVERRIDES` so its fanout is sized from the model (8 -> 10 shards) and grows on its own as tests are added

## Background
- The suite is inlined in `pr-test.yml` rather than dispatched through `_pr-test-stage.yml`, so it never got the model fetch every other per-commit suite has — `run_suite.py` logged `LPT: no live est (None); using in-source est_time`
- Those literals sit ~1.5x below the measured p90; `test_cargo_workspace.py` (`est_time=300` vs a p90 of 80) reserved a whole shard for a single file
- At ~450s of tests per shard the worst LPT shard lands at ~600s, which the 10m budget cut exactly — a recent run reported `47/47 passed` and then failed the step timeout by 1.45s

## Notes for review
- `compute_partitions` reads that `timeout-minutes` back as the per-shard budget, so `load_run_timeouts` no longer skips the inline job (`_INLINE_SUITE_JOB_IDS`) — it raises if the job or step goes missing rather than silently reverting to the old behaviour
- Dynamic suites get `max_parallel = size // 3`, a throttle for scarce self-hosted GPU runners; applying it to hosted `ubuntu-latest` would serialize the stage, so all-CPU suites keep `max_parallel = size`
- Partition output is byte-identical for every other suite; `base-a-test-cpu` moves from `{size: 8, max_parallel: 8}` to `{size: 10, max_parallel: 10}`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30786309378](https://github.com/sgl-project/sglang/actions/runs/30786309378)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30786309187](https://github.com/sgl-project/sglang/actions/runs/30786309187)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
