### PR TITLE
fix(router): preserve upstream response headers

### DIFF
--- a/experimental/sgl-router/src/proxy/mod.rs
+++ b/experimental/sgl-router/src/proxy/mod.rs
@@ -7,10 +7,10 @@ pub mod sse;
 
 use crate::health::circuit_breaker::CircuitBreaker;
 use crate::server::error::ApiError;
-use crate::server::header_utils::should_forward_request_header;
+use crate::server::header_utils::{copy_response_headers, should_forward_request_header};
 use anyhow::Context;
 use axum::body::Body;
-use axum::http::{HeaderMap, HeaderName, HeaderValue, Response};
+use axum::http::{header, HeaderMap, HeaderValue, Response};
 use bytes::Bytes;
 use reqwest::{Client, Url};
 use std::sync::Arc;
@@ -119,6 +119,7 @@ impl Proxy {
             Self::classify_reqwest_error_for(worker_url.clone(), e, path)
         })?;
         let status = resp.status();
+        let response_headers = copy_response_headers(resp.headers());
         // Defer breaker recording until after the body completes — a
         // worker that returns 2xx headers and then drops mid-body is
         // still failing the request, and crediting it as healthy lets
@@ -145,10 +146,10 @@ impl Proxy {
         }
         let mut out = Response::new(Body::from(bytes));
         *out.status_mut() = status;
-        out.headers_mut().insert(
-            HeaderName::from_static("content-type"),
-            HeaderValue::from_static("application/json"),
-        );
+        *out.headers_mut() = response_headers;
+        out.headers_mut()
+            .entry(header::CONTENT_TYPE)
+            .or_insert(HeaderValue::from_static("application/json"));
         Ok(out)
     }
 
@@ -201,9 +202,10 @@ impl Proxy {
             Self::classify_reqwest_error_for(worker_url.clone(), e, path)
         })?;
         let status = resp.status();
+        let response_headers = copy_response_headers(resp.headers());
         let upstream_ct = resp
             .headers()
-            .get(reqwest::header::CONTENT_TYPE)
+            .get(header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
             .unwrap_or("application/json")
             .to_string();
@@ -247,8 +249,9 @@ impl Proxy {
         );
         let mut out = Response::new(body);
         *out.status_mut() = status;
+        *out.headers_mut() = response_headers;
         out.headers_mut().insert(
-            HeaderName::from_static("content-type"),
+            header::CONTENT_TYPE,
             HeaderValue::from_str(&content_type)
                 .unwrap_or_else(|_| HeaderValue::from_static("application/json")),
         );

--- a/experimental/sgl-router/src/server/header_utils.rs
+++ b/experimental/sgl-router/src/server/header_utils.rs
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 The SGLang Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//! Header forwarding whitelist — mirrors SMG semantics.
+//! Header forwarding rules — mirrors SMG semantics.
 
-use axum::http::HeaderName;
+use axum::http::{header, HeaderMap, HeaderName};
 
 /// True if a request header from the inbound client should be forwarded
 /// to the upstream worker. Mirrors SMG's whitelist semantics.
@@ -14,6 +14,44 @@ pub fn should_forward_request_header(name: &HeaderName) -> bool {
         "authorization" | "x-request-id" | "x-correlation-id" | "traceparent" | "tracestate"
     ) || n.starts_with("x-request-id-")
         || n.starts_with("x-sgl-")
+}
+
+/// Copy end-to-end response headers while removing fields that apply only to
+/// the worker connection or must be regenerated for the client connection.
+pub fn copy_response_headers(headers: &HeaderMap) -> HeaderMap {
+    let mut connection_options = Vec::new();
+    for value in headers.get_all(header::CONNECTION) {
+        connection_options.extend(
+            value
+                .as_bytes()
+                .split(|byte| *byte == b',')
+                .filter_map(|name| HeaderName::from_bytes(name.trim_ascii()).ok()),
+        );
+    }
+
+    let mut copied = HeaderMap::with_capacity(headers.len());
+    for (name, value) in headers {
+        if should_forward_response_header(name) && !connection_options.contains(name) {
+            copied.append(name.clone(), value.clone());
+        }
+    }
+    copied
+}
+
+fn should_forward_response_header(name: &HeaderName) -> bool {
+    !matches!(
+        name.as_str(),
+        "connection"
+            | "content-length"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "proxy-connection"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+    )
 }
 
 #[cfg(test)]
@@ -113,5 +151,26 @@ mod tests {
             !should_forward_request_header(&HeaderName::from_static("foo-x-sgl-bar")),
             "foo-x-sgl-bar (substring, not prefix) must not forward",
         );
+    }
+
+    #[test]
+    fn response_headers_strip_connection_fields_and_preserve_multiple_values() {
+        let mut headers = HeaderMap::new();
+        headers.insert("connection", "keep-alive, x-worker-hop".parse().unwrap());
+        headers.insert("keep-alive", "timeout=5".parse().unwrap());
+        headers.insert("x-worker-hop", "private".parse().unwrap());
+        headers.insert("content-length", "123".parse().unwrap());
+        headers.insert("retry-after", "7".parse().unwrap());
+        headers.append("set-cookie", "a=1".parse().unwrap());
+        headers.append("set-cookie", "b=2".parse().unwrap());
+
+        let copied = copy_response_headers(&headers);
+
+        assert!(!copied.contains_key("connection"));
+        assert!(!copied.contains_key("keep-alive"));
+        assert!(!copied.contains_key("x-worker-hop"));
+        assert!(!copied.contains_key("content-length"));
+        assert_eq!(copied.get("retry-after").unwrap(), "7");
+        assert_eq!(copied.get_all("set-cookie").iter().count(), 2);
     }
 }

--- a/experimental/sgl-router/tests/proxy/common/mock_worker.rs
+++ b/experimental/sgl-router/tests/proxy/common/mock_worker.rs
@@ -31,6 +31,7 @@ pub struct CapturedHeaders {
 pub struct MockWorkerState {
     pub captured: Arc<Mutex<CapturedHeaders>>,
     pub stream_chunks: Arc<Vec<&'static str>>,
+    pub response_headers: HeaderMap,
 }
 
 /// A running mock SGLang worker. Shuts down on Drop via the oneshot sender.
@@ -49,10 +50,21 @@ impl MockWorker {
     /// chat-completion request arrives.
     #[allow(dead_code)] // Only used by some test files.
     pub async fn start(stream_chunks: Vec<&'static str>) -> Self {
+        Self::start_with_response_headers(stream_chunks, HeaderMap::new()).await
+    }
+
+    /// Start a worker that adds `response_headers` to both buffered and
+    /// streaming chat-completion responses.
+    #[allow(dead_code)] // Only used by some test files.
+    pub async fn start_with_response_headers(
+        stream_chunks: Vec<&'static str>,
+        response_headers: HeaderMap,
+    ) -> Self {
         let captured = Arc::new(Mutex::new(CapturedHeaders::default()));
         let state = MockWorkerState {
             captured: captured.clone(),
             stream_chunks: Arc::new(stream_chunks),
+            response_headers,
         };
         // /server_info advertises served_model_name="tiny" so the
         // worker-manager introspect step resolves model_ids for the
@@ -421,6 +433,7 @@ async fn chat(State(s): State<MockWorkerState>, headers: HeaderMap, body: Bytes)
             HeaderName::from_static("content-type"),
             "text/event-stream".parse().unwrap(),
         );
+        r.headers_mut().extend(s.response_headers.clone());
         return r;
     }
     let resp = serde_json::json!({
@@ -433,5 +446,7 @@ async fn chat(State(s): State<MockWorkerState>, headers: HeaderMap, body: Bytes)
             "finish_reason": "stop"
         }]
     });
-    Json(resp).into_response()
+    let mut response = Json(resp).into_response();
+    response.headers_mut().extend(s.response_headers.clone());
+    response
 }

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use axum::body::Body;
-use axum::http::Request;
+use axum::http::{HeaderMap, HeaderValue, Request};
 use sgl_router::config::{
     ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
     ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
@@ -120,5 +120,65 @@ async fn forwards_whitelisted_headers_strips_others() {
         captured_host,
         Some(&"example.com".to_string()),
         "router must not forward the inbound Host header to upstream"
+    );
+}
+
+#[tokio::test]
+async fn forwards_upstream_response_headers() {
+    use bytes::Bytes;
+    use sgl_router::health::circuit_breaker::CircuitBreaker;
+
+    let mut upstream_headers = HeaderMap::new();
+    upstream_headers.insert("retry-after", HeaderValue::from_static("7"));
+    upstream_headers.insert(
+        "x-request-id",
+        HeaderValue::from_static("upstream-request-42"),
+    );
+    let worker = crate::common::mock_worker::MockWorker::start_with_response_headers(
+        vec!["data: {\"token\":1}\n\n"],
+        upstream_headers,
+    )
+    .await;
+    let proxy = Proxy::new(Duration::from_secs(5)).unwrap();
+    let breaker = Arc::new(CircuitBreaker::new());
+    let request_headers = HeaderMap::new();
+
+    let buffered = proxy
+        .forward_json_to(
+            &worker.url,
+            &breaker,
+            "/v1/chat/completions",
+            &request_headers,
+            Bytes::from_static(br#"{"model":"tiny"}"#),
+        )
+        .await
+        .unwrap();
+    assert_response_headers(&buffered);
+
+    let streaming = proxy
+        .forward_streaming_to(
+            &worker.url,
+            &breaker,
+            "/v1/chat/completions",
+            &request_headers,
+            Bytes::from_static(br#"{"model":"tiny","stream":true}"#),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+    assert_response_headers(&streaming);
+}
+
+fn assert_response_headers(response: &axum::response::Response) {
+    assert_eq!(
+        response.headers().get("retry-after"),
+        Some(&HeaderValue::from_static("7")),
+        "retry guidance from the worker must reach the client",
+    );
+    assert_eq!(
+        response.headers().get("x-request-id"),
+        Some(&HeaderValue::from_static("upstream-request-42")),
+        "the worker request ID must reach the client for diagnostics",
     );
 }


### PR DESCRIPTION
## Motivation

The experimental router currently rebuilds worker responses with only the status and `Content-Type`. All other upstream response headers are dropped on both buffered and streaming paths.

This removes headers that clients rely on, including `Retry-After` for backoff and upstream request IDs for correlating worker logs. It also differs from normal reverse-proxy behavior and from the response-header handling in the existing model gateway.

## Modifications

- Preserve end-to-end worker response headers for buffered JSON and streaming responses.
- Strip connection-specific and framing headers, including fields named by `Connection`, before constructing the downstream response.
- Preserve repeated header values such as multiple `Set-Cookie` fields.
- Add unit coverage for header filtering and integration coverage for both proxy response paths.

## Accuracy Tests

Not applicable. This change does not alter request routing or model outputs.

## Speed Tests and Profiling

Not applicable. The change performs one bounded copy over the small upstream response header map and does not affect inference execution.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --release -- --skip parity_matrix` (431 library, 3 binary, 40 component, and 67 proxy tests passed)

The regression test fails before this change because `Retry-After` is absent from the downstream response, and passes after the fix for both buffered and streaming responses.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because this does not change configuration or public API usage.
- [x] Accuracy and speed benchmarks are not applicable because this does not affect model execution.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
