### PR TITLE
[Diffusion] Fix stale [T] annotation: rollout dit_trajectory timesteps is [T+1]

### DIFF
--- a/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
@@ -51,7 +51,7 @@ class RolloutDitTrajectory:
     # [B, T+1, ...]: per-step noisy latents x_{t_0..t_{T-1}} followed by the
     # final denoised latent x_{t_T} (last scheduler.step output).
     latents: torch.Tensor | None = None
-    timesteps: torch.Tensor | None = None  # [T]
+    timesteps: torch.Tensor | None = None  # [T+1]
     # [T+1] scheduler.sigmas snapshot (post-shift, includes terminal 0).
     sigmas: torch.Tensor | None = None
 

--- a/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
@@ -206,10 +206,14 @@ class TestSerializeRolloutTrajectory(unittest.TestCase):
             ),
             dit_trajectory=RolloutDitTrajectory(
                 latents=torch.randn(1, 5, 4, 2, 2, 2),
-                timesteps=torch.tensor([1.0, 0.75, 0.5, 0.25]),
+                timesteps=torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
                 sigmas=torch.tensor([1.0, 0.75, 0.5, 0.25, 0.0]),
             ),
         )
+        dit = rtd.dit_trajectory
+        self.assertEqual(dit.timesteps.shape[0], dit.latents.shape[1])
+        self.assertEqual(dit.sigmas.shape[0], dit.latents.shape[1])
+        self.assertEqual(dit.timesteps[-1].item(), 0.0)
         _, _, env, dit_traj = _serialize_rollout_trajectory(
             rtd,
             serialized_dit_timesteps=_maybe_serialize(rtd.dit_trajectory.timesteps),


### PR DESCRIPTION
## Motivation

`RolloutDitTrajectory.timesteps` is annotated `# [T]`, but the runtime produces `[T+1]`: the denoising loop appends one entry per step (the per-step input timestep), and `_postprocess_rollout_outputs` appends a terminal `0.0` together with the final denoised latent, in lockstep with `latents` (`[B, T+1, ...]`). The stale annotation misleads post-training consumers that reconstruct schedule arrays from this field (e.g. assuming one fewer entry and no terminal zero).

## Modifications

- Fix the comment on `RolloutDitTrajectory.timesteps` to document the `[T+1]` shape and the terminal-zero entry.
- Update the `test_with_denoising_env` fixture in `test_rollout_api.py` to the real runtime shape and assert `len(timesteps) == len(sigmas) == latents.shape[1]` with `timesteps[-1] == 0`.

Comment/test-only change; no runtime behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30783917744](https://github.com/sgl-project/sglang/actions/runs/30783917744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30783917657](https://github.com/sgl-project/sglang/actions/runs/30783917657)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->