### PR TITLE
[AMD][DI][CI] Add Kimi-K2.6 MXFP4 1P1D DI/CI recipes (base + MTP + DP8/EP8)

### DIFF
--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -356,3 +356,76 @@ kimik26-fp8-mi355x-mtp-sglang:
       search-space:
         - conc-list: [1, 8, 16, 32, 64, 128, 256]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
+
+# AMD MI355X 2-node 1P1D disaggregation for Kimi-K2.6 (MXFP4) over MORI. MXFP4
+# experts run the aiter MoE path (SGLANG_DSV4_FP4_EXPERTS, driven by precision).
+# Four variants mirroring the DeepSeek-V4 / GLM-5.2 basic tier:
+#   * (base)      : TP8, no MTP
+#   * -mtp        : TP8 + EAGLE3 external-draft MTP
+#   * -dp8ep8     : DP-attention 8 + narrow within-node EP8
+#   * -dp8ep8-mtp : DP8 + narrow EP8 + EAGLE3 MTP
+# Weights: amd/Kimi-K2.6-MXFP4. Split attention backends (aiter prefill / triton
+# decode); Kimi model env + parsers live in each recipe's model block.
+kimik26-fp4-mi355x-sglang:
+  model: amd/Kimi-K2.6-MXFP4
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--amd--Kimi-K2.6-MXFP4
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d.yaml
+
+kimik26-fp4-mi355x-mtp-sglang:
+  model: amd/Kimi-K2.6-MXFP4
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--amd--Kimi-K2.6-MXFP4
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-mtp.yaml
+
+kimik26-fp4-mi355x-dp8ep8-sglang:
+  model: amd/Kimi-K2.6-MXFP4
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--amd--Kimi-K2.6-MXFP4
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8.yaml
+
+kimik26-fp4-mi355x-dp8ep8-mtp-sglang:
+  model: amd/Kimi-K2.6-MXFP4
+  model-prefix: kimik26
+  model_path: /it-share/model_coverage/models--amd--Kimi-K2.6-MXFP4
+  runner: mi355x
+  precision: fp4
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8-mtp.yaml

--- a/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8-mtp.yaml
@@ -1,0 +1,81 @@
+# MI355X Kimi-K2.6 (MXFP4) 2-node 1P1D disaggregation recipe — DP8 + EP8 + EAGLE3 MTP.
+#
+# MXFP4-expert build of amd/Kimi-K2.6-MXFP4. DP-attention 8 + within-node EP8
+# (same topology as the dp8ep8 base) plus the EAGLE3 `mtp:` block with the
+# external Kimi-K2.6 draft checkpoint. MTP is applied to both prefill and decode.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+mtp:
+  enabled: true
+  algorithm: EAGLE3
+  num_steps: 3
+  eagle_topk: 1
+  num_draft_tokens: 4
+  draft_model_path: /it-share/model_coverage/models--lightseekorg--kimi-k2.6-eagle3.1-mla
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260722
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-dp8ep8.yaml
@@ -1,0 +1,73 @@
+# MI355X Kimi-K2.6 (MXFP4) 2-node 1P1D disaggregation recipe — DP8 + narrow EP8.
+#
+# MXFP4-expert build of amd/Kimi-K2.6-MXFP4. DP-attention 8 + within-node EP8,
+# same topology as the DeepSeek-V4 / GLM-5.2 dp8ep8 leg. MXFP4 enables
+# SGLANG_DSV4_FP4_EXPERTS in launch_mi355x.sh (driven by PRECISION).
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 8
+      data-parallel-size: 8
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260722
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-mtp.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d-mtp.yaml
@@ -1,0 +1,84 @@
+# MI355X Kimi-K2.6 (MXFP4) 2-node 1P1D disaggregation recipe (base + EAGLE3 MTP).
+#
+# MXFP4-expert build of amd/Kimi-K2.6-MXFP4. Self-contained (no inheritance):
+# same as 1p1d.yaml plus the `mtp:` block. Uses EAGLE3 speculative decoding with
+# an EXTERNAL draft checkpoint: the launcher resolves mtp.draft_model_path through
+# the HF-cache snapshot logic and appends --speculative-draft-model-path. The
+# draft dir must live under /it-share (the container's :ro mount). MTP is applied
+# to both prefill and decode.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+mtp:
+  enabled: true
+  algorithm: EAGLE3
+  num_steps: 3
+  eagle_topk: 1
+  num_draft_tokens: 4
+  draft_model_path: /it-share/model_coverage/models--lightseekorg--kimi-k2.6-eagle3.1-mla
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260722
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92

--- a/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp4/kimik26/1k1k/1p1d.yaml
@@ -1,0 +1,75 @@
+# MI355X Kimi-K2.6 (MXFP4) 2-node 1P1D disaggregation recipe (base).
+#
+# MXFP4-expert build of amd/Kimi-K2.6-MXFP4. MXFP4 enables SGLANG_DSV4_FP4_EXPERTS
+# in launch_mi355x.sh (driven by PRECISION), same as the DeepSeek-V4 / GLM-5.2
+# FP4 path. All Kimi-specific config lives in this recipe's `model:` block (docker
+# env + sglang server args) and `runtime` (split attention backends); nothing
+# about Kimi is hardcoded in launch_mi355x.sh.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime`, `bench`, `model`, `mtp`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (written verbatim via
+# model_flags.sh). Each server arg + value is a SEPARATE list item.
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    SGLANG_ROCM_FUSED_DECODE_MLA: 0
+  server_args:
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true}'
+    - --watchdog-timeout
+    - 1200
+    - --reasoning-parser
+    - kimi_k2
+    - --tool-call-parser
+    - kimi_k2
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260722
+  # Kimi uses split attention backends (aiter prefill / triton decode), not a
+  # single --attention-backend.
+  prefill_attention_backend: aiter
+  decode_attention_backend: triton
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.90
+  page_size: 256
+  max_running_requests: 256
+  chunked_prefill_size: 8192
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep. Mirrors the
+  # registered single-node Kimi-K2.6 eval (full GSM8K, 8-shot, accuracy > 0.92).
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    threshold: 0.92


### PR DESCRIPTION
## Summary

Adds Kimi-K2.6 MXFP4 2-node 1P1D DI/CI nightly recipes, mirroring the GLM-5.2 MXFP4 basic tier (#32120). Four legs over MORI:
- **(base)** — TP8, no MTP
- **-mtp** — TP8 + EAGLE3 external-draft MTP
- **-dp8ep8** — DP-attention 8 + narrow within-node EP8
- **-dp8ep8-mtp** — DP8 + narrow EP8 + EAGLE3 MTP

MXFP4 experts run the aiter MoE path (`SGLANG_DSV4_FP4_EXPERTS`, driven by `precision=fp4`), same as the DeepSeek-V4 / GLM-5.2 FP4 legs — no permute needed. Kimi specifics (split aiter-prefill / triton-decode attention, `kimi_k2` parsers, EAGLE3 external draft) live in each recipe's model block. Weights: `amd/Kimi-K2.6-MXFP4`; KV stays fp8.

## Changes
- `recipes/mi355x-fp4/kimik26/1k1k/1p1d{,-mtp,-dp8ep8,-dp8ep8-mtp}.yaml`
- `nightly-configs.yaml`: `kimik26-fp4-mi355x-{,mtp-,dp8ep8-,dp8ep8-mtp-}sglang`

Draft — pending mi355x validation once the MXFP4 weights finish staging.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30784875112](https://github.com/sgl-project/sglang/actions/runs/30784875112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30784874963](https://github.com/sgl-project/sglang/actions/runs/30784874963)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->