### PR TITLE
[Scheduler] Dev-only --debug-mode: survive a failed batch instead of the process

### DIFF
--- a/.claude/skills/debug-cuda-crash/SKILL.md
+++ b/.claude/skills/debug-cuda-crash/SKILL.md
@@ -15,6 +15,11 @@ When your code crashes with CUDA errors such as illegal memory access, device-si
 - Track tensor shapes, dtypes, and values through the call boundary that triggered the crash
 - Detect numerical issues such as NaN, Inf, or obviously wrong shapes
 
+If the failure is a plain **Python** exception during a forward pass rather than a CUDA
+fault, see [`debug-serving-fault`](../debug-serving-fault/SKILL.md) instead: `--debug-mode`
+keeps the process (and its weights and captured graphs) alive across the exception, so
+each reproduction costs seconds instead of a full restart.
+
 ## Why Use Kernel API Logging?
 
 **Problem**: CUDA errors often crash the program before normal debugging output is flushed.

--- a/.claude/skills/debug-serving-fault/SKILL.md
+++ b/.claude/skills/debug-serving-fault/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: debug-serving-fault
+description: Iterate quickly on a serving-time exception in the SGLang scheduler using --debug-mode, which discards the failed batch and keeps the process (weights + captured CUDA graphs) alive instead of crashing. Use when reproducing a NaN, sampling, attention, or batch-result bug that raises a Python exception during a forward pass, and each crash costs a full weight load + graph capture.
+---
+
+# Debugging a serving-time fault without restarting the server
+
+## Goal
+
+A Python exception raised while a batch runs (NaN guard, sampling assertion, attention
+metadata mismatch, batch-result bookkeeping) normally kills the scheduler process. On a
+large model that means paying weight load + CUDA graph capture again for every single
+reproduction, which makes iterating on the bug very slow.
+
+`--debug-mode` turns that crash into a per-batch abort: the failed batch's requests are
+aborted, the loop resumes, and the process keeps its weights and captured graphs. You
+send the next request and see the next reproduction in seconds.
+
+## When this applies
+
+Use it when **all** of these hold:
+
+- The failure is a **CPU-side Python exception** raised inside `run_batch` or
+  `process_batch_result`.
+- You can reproduce it by sending requests to a server you control.
+- Restart cost is what is slowing you down.
+
+Do **not** reach for it when:
+
+| Symptom | Use instead |
+|---|---|
+| CUDA illegal memory access, device-side assert | [`debug-cuda-crash`](../debug-cuda-crash/SKILL.md) — the CUDA context is poisoned, the process cannot continue |
+| Hang / no progress, no exception | [`debug-distributed-hang`](../debug-distributed-hang/SKILL.md) |
+| Numerical drift with no exception | [`msprobe`](../../../docs_new/docs/developer_guide/msprobe_debugging_guide.mdx) |
+| Production incident triage | [`sglang-prod-incident-triage`](../sglang-prod-incident-triage/SKILL.md) |
+
+`--debug-mode` is **dev-only**. Never enable it on a production server: it converts a
+loud crash into an aborted request, which is exactly the wrong trade-off when you want
+a restart and an alert.
+
+## Step 1: Launch with `--debug-mode`
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path MODEL_PATH \
+    --debug-mode
+```
+
+Constraints enforced at startup (the flag errors out rather than silently doing nothing):
+
+- `tp_size == pp_size == dp_size == 1`. Multi-rank runs are in lockstep, so one rank
+  discarding a batch would desync the others.
+- No PD disaggregation, no PD multiplexing — they run different event loops.
+- Overlap schedule is **force-disabled** (you will see a warning). Only
+  `event_loop_normal` handles a failed batch.
+
+If your bug only reproduces under TP > 1 or with the overlap scheduler, `--debug-mode`
+cannot help; fall back to the normal crash-and-restart loop.
+
+## Step 2: Reproduce, read the log, repeat
+
+Each failure logs the traceback plus the rids it aborted:
+
+```
+Batch forward failed with 3 request(s) in flight. --debug-mode is on; aborting the
+batch's requests and resuming the event loop instead of tearing down the process.
+Traceback (most recent call last):
+  ...
+RuntimeError: <your bug>
+
+Discarded the failed batch (aborted rids: ['abc...', 'def...']); resuming the event loop.
+```
+
+The client that sent a request in the failed batch receives a normal abort
+(`finish_reason.type == "abort"`), so your repro script can loop without hanging.
+
+**Requests that were not in the failed batch keep running.** The fault is scoped to the
+batch: the waiting queue, the memory pools and the rest of the scheduler state are
+untouched. This matters for reproduction — you can keep a background load running while
+you poke at the failing input.
+
+## Step 3: Narrow the input
+
+Because the process stays warm, bisecting the trigger is cheap. Practical loop:
+
+1. Send the failing request. Note the traceback.
+2. Send a variant (shorter prompt, different sampling params, `max_new_tokens=1`,
+   no logprobs, no grammar). If it survives, the difference is a candidate cause.
+3. Keep halving until you have the minimal request that still raises.
+
+Combine with the usual instrumentation — the process surviving is what makes these
+practical to iterate on:
+
+```bash
+# eager execution through the graph path, to rule the graph in or out
+--debug-cuda-graph
+
+# per-forward tensor dumps
+--debug-tensor-dump-output-folder DIR --debug-tensor-dump-layers N
+```
+
+## Step 4: Verify you have not been misled by a leak
+
+The discard releases each aborted request's KV through the normal
+`release_kv_cache` path, but a bug in your own patch can still leak. Arm the
+scheduler's own invariant checker so a leak is a hard failure rather than a warning:
+
+```bash
+SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=1
+```
+
+The checker runs in `on_idle`, which is **outside** the debug-mode `try`, so a leak
+still crashes the process — the flag does not hide it. If your run survives a fault and
+then goes idle without raising, the pools are intact.
+
+To compare quantitatively, read `token_capacity` from `/get_internal_state` once the
+server is idle, before and after the fault. It must be identical.
+
+## What is deliberately not recovered
+
+Only the batch forward is guarded. Exceptions in request intake
+(`process_input_requests`) or batch scheduling (`get_next_batch_to_run`) still tear the
+process down, because a half-built batch has no owner for the requests it already
+popped off the waiting queue — there is no honest way to resume. If your bug is in
+scheduling rather than the forward, you are back to crash-and-restart.
+
+## Injecting a fault (for testing the mechanism itself)
+
+There is no built-in fault injector. To exercise the path — e.g. when changing the
+discard logic — add a temporary raise at the top of `Scheduler.run_batch` guarded by an
+env var, and remove it before committing:
+
+```python
+# TEMPORARY -- do not commit
+_inject = os.environ.get("SGLANG_TEST_INJECT_FAULT_AT")
+if _inject and self.forward_ct == int(_inject):
+    raise RuntimeError(f"injected fault at forward_ct={self.forward_ct}")
+```
+
+A single one-shot fault (`SGLANG_TEST_INJECT_FAULT_AT=40`) is more informative than a
+recurring one: it lets you check that requests outside the failed batch still complete.
+Cover a decode batch, a prefill batch, and a mid-chunk chunked prefill (small
+`--chunked-prefill-size` plus a long prompt) — the chunked case is the one that exercises
+the `chunked_req` pointer.
+
+## Where the code lives
+
+- `python/sglang/srt/managers/scheduler.py` — `event_loop_normal` (the guarded block)
+  and `_discard_failed_batch` (which scheduler fields are cleared).
+- `python/sglang/srt/managers/scheduler_components/debug_fault_handler.py` — the
+  per-request teardown.
+- `test/registered/unit/managers/test_scheduler_debug_mode.py` — CPU unit tests.
+
+If you extend the teardown, keep it scoped to the batch. A whole-scheduler reset has to
+enumerate every loop-carried field (queues, chunked slots, pending health-check IPCs,
+dLLM staging, ...) and rots as scheduler state grows; a batch already carries its own
+request list. The `test_discards_batch_and_clears_only_pointers_to_it` test pins this.

--- a/docs_new/docs.json
+++ b/docs_new/docs.json
@@ -1011,6 +1011,7 @@
                 "pages": [
                   "docs/developer_guide/development_guide_using_docker",
                   "docs/developer_guide/development_jit_kernel_guide",
+                  "docs/developer_guide/debug_mode",
                   "docs/developer_guide/quantization_contribution_guide"
                 ]
               },

--- a/docs_new/docs/developer_guide/debug_mode.mdx
+++ b/docs_new/docs/developer_guide/debug_mode.mdx
@@ -1,0 +1,109 @@
+---
+title: "Debug Mode: iterating on serving-time faults"
+metatags:
+    description: "Use SGLang's dev-only --debug-mode to keep the scheduler process alive across a serving-time exception, so a bug can be reproduced repeatedly without paying weight load and CUDA graph capture on every crash."
+---
+
+When a Python exception is raised while a batch runs — a NaN guard, a sampling
+assertion, an attention metadata mismatch, a batch-result bookkeeping bug — the
+scheduler process normally exits. On a large model, every reproduction then costs a full
+weight load plus CUDA graph capture, which is usually the slowest part of fixing the bug.
+
+`--debug-mode` turns that crash into a per-batch abort. The failed batch's requests are
+aborted, the event loop resumes, and the process keeps its loaded weights and captured
+graphs. You send the next request and get the next reproduction in seconds.
+
+<Warning>
+  `--debug-mode` is for development only. Never enable it on a production server: it
+  converts a loud crash into an aborted request, which suppresses exactly the signal you
+  want a restart and an alert for.
+</Warning>
+
+## Prerequisites
+
+The flag is rejected at startup unless all of the following hold, so it never silently
+does nothing:
+
+- `--tp-size 1`, `--pp-size 1`, `--dp-size 1`. Multi-rank runs advance in lockstep, so
+  one rank discarding a batch would desync the others.
+- No PD disaggregation and no PD multiplexing — those run different event loops.
+- The non-overlap scheduler. If overlap is enabled, `--debug-mode` force-disables it and
+  logs a warning.
+
+## Usage
+
+```bash
+python3 -m sglang.launch_server \
+    --model-path MODEL_PATH \
+    --debug-mode
+```
+
+Each failure logs the traceback and the request ids it aborted:
+
+```text
+Batch forward failed with 3 request(s) in flight. --debug-mode is on; aborting the
+batch's requests and resuming the event loop instead of tearing down the process.
+Traceback (most recent call last):
+  ...
+RuntimeError: <your bug>
+
+Discarded the failed batch (aborted rids: [...]); resuming the event loop.
+```
+
+Clients whose requests were in the failed batch receive a normal abort
+(`finish_reason.type == "abort"`), so a reproduction script loops instead of hanging.
+
+## What is and is not discarded
+
+The fault is scoped to the failed batch:
+
+| | Behavior on a failed batch |
+|---|---|
+| Requests in the batch | Aborted; their KV cache and request-pool slots are released |
+| Requests in the waiting queue | **Untouched** — they run as soon as the loop resumes |
+| Requests in other in-flight state | Untouched |
+| KV cache / memory pools | **Not** wiped; only the aborted requests' allocations are freed |
+| Weights, CUDA graphs | Kept — this is the point of the flag |
+
+Because the queue survives, you can keep a background load running while you narrow down
+a failing input.
+
+## What is not recovered
+
+Only the batch forward is guarded. Exceptions during request intake or batch scheduling
+still tear the process down: a half-built batch has no owner for the requests it already
+removed from the waiting queue, so there is no correct way to resume. If your bug lives
+in scheduling rather than in the forward pass, use the normal crash-and-restart loop.
+
+GPU-side faults — illegal memory access, device-side asserts — are also out of scope.
+They poison the CUDA context, so the process cannot continue regardless. See the
+kernel-API logging approach for those.
+
+Recovery is best-effort: if the teardown itself raises, the original exception is
+re-raised and the normal crash path takes over, so the worst case equals the behavior
+without the flag.
+
+## Verifying you are not chasing a leak
+
+The discard releases KV through the same path a normally finished request uses. To make
+any leak a hard failure rather than a warning, arm the scheduler's invariant checker:
+
+```bash
+SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=1 python3 -m sglang.launch_server \
+    --model-path MODEL_PATH \
+    --debug-mode
+```
+
+That check runs when the scheduler goes idle, which is outside the guarded block, so a
+leak still crashes the process — the flag cannot hide it. For a quantitative check, read
+`token_capacity` from `/get_internal_state` while the server is idle, before and after a
+fault; the two values must match.
+
+## Related
+
+- [MSProbe debugging guide](/docs/developer_guide/msprobe_debugging_guide) — numerical
+  drift with no exception.
+- `--debug-cuda-graph` — run every operation eagerly through the CUDA graph
+  capture/replay path, to rule the graph in or out.
+- `--debug-tensor-dump-output-folder` / `--debug-tensor-dump-layers` — per-forward tensor
+  dumps.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -200,6 +200,9 @@ from sglang.srt.managers.schedule_policy import (
 from sglang.srt.managers.scheduler_components.batch_result_processor import (
     SchedulerBatchResultProcessor,
 )
+from sglang.srt.managers.scheduler_components.debug_fault_handler import (
+    SchedulerDebugFaultHandler,
+)
 from sglang.srt.managers.scheduler_components.dp_attn import SchedulerDPAttnAdapter
 from sglang.srt.managers.scheduler_components.flush_wrapper import SchedulerFlushWrapper
 from sglang.srt.managers.scheduler_components.idle_sleeper import (
@@ -635,6 +638,8 @@ class Scheduler(
         self.init_pool_stats_observer()
 
         self.init_invariant_checker()
+
+        self.maybe_init_debug_fault_handler()
 
         self.init_kv_events_publisher()
 
@@ -1647,8 +1652,16 @@ class Scheduler(
 
             # Launch the current batch
             if batch:
-                result = self.run_batch(batch)
-                self.process_batch_result(batch, result)
+                try:
+                    result = self.run_batch(batch)
+                    self.process_batch_result(batch, result)
+                except Exception as exc:
+                    # Re-raise so run_scheduler_process tears the process down.
+                    # --debug-mode instead discards this batch and keeps serving.
+                    if self.debug_fault_handler is None:
+                        raise
+                    self._discard_failed_batch(batch, exc)
+                    continue
             else:
                 # When the server is idle, do self-check and re-init some states.
                 self.on_idle()
@@ -1969,6 +1982,17 @@ class Scheduler(
             pool_stats_observer=self.pool_stats_observer,
             get_last_batch=lambda: self.last_batch,
             get_running_batch=lambda: self.running_batch,
+        )
+
+    def maybe_init_debug_fault_handler(self) -> None:
+        self.debug_fault_handler: Optional[SchedulerDebugFaultHandler] = None
+        if not get_schedule().debug_mode:
+            return
+        self.debug_fault_handler = SchedulerDebugFaultHandler(
+            tree_cache=self.tree_cache,
+            hisparse_coordinator=self.hisparse_coordinator,
+            ipc_channels=self.ipc_channels,
+            enable_hicache_storage=lambda: self.enable_hicache_storage,
         )
 
     def init_kv_events_publisher(self) -> None:
@@ -4091,6 +4115,51 @@ class Scheduler(
             )
             success = False
         return success
+
+    def _discard_failed_batch(self, batch: ScheduleBatch, exc: Exception) -> None:
+        """Debug-mode only: drop the batch whose forward pass raised, then keep serving.
+
+        Only the requests owned by ``batch`` are torn down. The waiting queue, the
+        memory pools and every other scheduler field are left alone, so the next
+        iteration rebuilds from them through the normal path: the aborted requests are
+        ``finished()``, so ``update_running_batch``'s ``filter_batch`` drops them from
+        ``running_batch`` the same way it drops any completed request.
+
+        Best-effort. If the teardown itself raises, the state is unknown (e.g. a
+        poisoned CUDA context after an illegal memory access), so the original
+        exception is re-raised and the normal crash path (SIGQUIT in
+        run_scheduler_process) takes over. Recovers CPU-side exceptions only.
+        """
+        logger.error(
+            f"Batch forward failed with {len(batch.reqs)} request(s) in flight. "
+            "--debug-mode is on; aborting the batch's requests and resuming the "
+            "event loop instead of tearing down the process.\n"
+            f"{get_exception_traceback()}"
+        )
+        try:
+            aborted_rids = self.debug_fault_handler.discard_batch(batch)
+        except Exception:
+            logger.error(
+                "Failed to discard the batch; the scheduler state is unrecoverable. "
+                f"Falling back to the normal crash path.\n{get_exception_traceback()}"
+            )
+            raise exc
+
+        # Drop the pointers to the discarded batch. `last_batch` is cleared rather than
+        # set to `batch`: get_next_batch_to_run would otherwise merge a batch whose
+        # requests no longer own any KV.
+        self.last_batch = None
+        self.cur_batch_for_debug = None
+        self.running_batch.batch_is_full = False
+        if self.chunked_req is not None and self.chunked_req in batch.reqs:
+            # Also drop the deferred-abort marker so process_pending_chunked_abort
+            # does not touch a released request on the next iteration.
+            self.chunked_req = None
+            self._pending_chunked_abort_req = None
+        logger.warning(
+            f"Discarded the failed batch (aborted rids: {aborted_rids}); "
+            "resuming the event loop."
+        )
 
     def get_internal_state(self, recv_req: GetInternalStateReq):
         # Resolved config (pristine server_args + post-publish overrides) so a

--- a/python/sglang/srt/managers/scheduler_components/debug_fault_handler.py
+++ b/python/sglang/srt/managers/scheduler_components/debug_fault_handler.py
@@ -1,0 +1,81 @@
+"""Dev-only handling for a batch whose forward pass raised (see ``--debug-mode``).
+
+Tears down the requests the failed batch owns so the event loop can continue with the
+weights and captured CUDA graphs still in memory. The teardown is scoped to the batch:
+the waiting queue, the memory pools and the rest of the scheduler state are untouched,
+and the aborted requests are left ``finished()`` so ``filter_batch`` drops them from
+``running_batch`` on the next iteration through the normal path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable, List, Optional
+
+from sglang.srt.disaggregation.utils import prepare_abort
+from sglang.srt.managers.io_struct import AbortReq
+from sglang.srt.managers.scheduler_components.ipc_channels import SchedulerIpcChannels
+from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
+from sglang.srt.mem_cache.common import release_kv_cache
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+
+logger = logging.getLogger(__name__)
+
+ABORT_MESSAGE = "Aborted by --debug-mode after a serving-time exception."
+
+
+class SchedulerDebugFaultHandler:
+    def __init__(
+        self,
+        *,
+        tree_cache: BasePrefixCache,
+        hisparse_coordinator: Optional[HiSparseCoordinator],
+        ipc_channels: SchedulerIpcChannels,
+        # Callable, not a bool: attach/detach_hicache_storage flips this at runtime.
+        enable_hicache_storage: Callable[[], bool],
+    ) -> None:
+        self._tree_cache = tree_cache
+        self._hisparse_coordinator = hisparse_coordinator
+        self._ipc_channels = ipc_channels
+        self._enable_hicache_storage = enable_hicache_storage
+
+    def discard_batch(self, batch: ScheduleBatch) -> List[str]:
+        """Abort every unfinished request in ``batch`` and free its resources.
+
+        Returns the aborted rids. Requests that already carry a finish reason are
+        skipped: the normal path streamed their final output and released their KV
+        before the exception, so touching them again would send an abort for a
+        completed rid and double-free.
+        """
+        aborted_rids = []
+        for req in batch.reqs:
+            if req.finished():
+                continue
+            self._abort_req(req)
+            aborted_rids.append(req.rid)
+        return aborted_rids
+
+    def _abort_req(self, req: Req) -> None:
+        """Finish ``req`` as aborted without another forward pass.
+
+        Mirrors ``Scheduler.process_pending_chunked_abort``. HiSparse retraction runs
+        first because it is only valid while the request is unfinished, the same
+        ordering ``release_req`` uses.
+        """
+        if self._hisparse_coordinator is not None:
+            self._hisparse_coordinator.retract_req(req)
+        prepare_abort(req, ABORT_MESSAGE)
+        req.time_stats.trace_ctx.abort(abort_info={"reason": ABORT_MESSAGE})
+        # prepare_abort populates the finish metadata; drop the staged finish reason
+        # so nothing re-applies it after the request is gone.
+        req.to_finish = None
+        if self._enable_hicache_storage():
+            self._tree_cache.release_aborted_request(req.rid)
+        release_kv_cache(req, self._tree_cache, is_insert=False)
+        self._ipc_channels.send_to_tokenizer.send_output(
+            AbortReq(rid=req.rid, abort_message=ABORT_MESSAGE), req
+        )
+        logger.debug(f"Discarded request from the failed batch. {req.rid=}")

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1851,6 +1851,20 @@ class ServerArgs:
         "Enable debug/eager mode for CUDA graph using breakable CUDA graph. When enabled, graph breaks are inserted so every operation runs eagerly while still going through the CUDA graph capture / replay path. Useful for debugging CUDA graph capture / replay issues.",
         NS("exec.graph"),
     ] = False
+    debug_mode: A[
+        bool,
+        "Dev-only debug mode (never use in production). Keeps the process alive when a "
+        "batch's forward pass raises inside the scheduler event loop: the failed batch "
+        "is discarded (its requests are aborted and their KV released) and the loop "
+        "resumes, so a serving-time bug can be reproduced repeatedly without paying "
+        "weight load + CUDA graph capture on every crash. The waiting queue, the memory "
+        "pools and the rest of the scheduler state are left untouched, so requests that "
+        "were not in the failed batch keep running. Exceptions outside the batch forward "
+        "(request intake, batch scheduling) still tear the process down as usual. Only "
+        "supported with tp_size=pp_size=dp_size=1 and the non-overlap scheduler "
+        "(overlap is force-disabled).",
+        NS("schedule"),
+    ] = False
 
     # -------------------------------------------------------------------------
     # Communication and kernels
@@ -8051,6 +8065,36 @@ class ServerArgs:
         if is_in_ci() and self.soft_watchdog_timeout is None:
             logger.info("Set soft_watchdog_timeout since in CI")
             self.soft_watchdog_timeout = 300
+
+        if self.debug_mode:
+            self._handle_debug_mode()
+
+    def _handle_debug_mode(self):
+        # Only the plain single-rank event_loop_normal handles a failed batch.
+        # Reject any configuration that resolves to a different event loop so the
+        # flag never silently does nothing.
+        if self.tp_size != 1 or self.pp_size != 1 or self.dp_size != 1:
+            raise ValueError(
+                "--debug-mode is only supported with tp_size=pp_size=dp_size=1 (a "
+                "single scheduler process with no cross-rank lockstep). Got "
+                f"tp_size={self.tp_size}, pp_size={self.pp_size}, "
+                f"dp_size={self.dp_size}."
+            )
+        if self.disaggregation_mode != "null" or self.enable_pdmux:
+            raise ValueError(
+                "--debug-mode is not supported with PD disaggregation or PD "
+                "multiplexing; those run different event loops. Got "
+                f"disaggregation_mode={self.disaggregation_mode!r}, "
+                f"enable_pdmux={self.enable_pdmux}."
+            )
+        if not self.disable_overlap_schedule:
+            # Nothing later in the pipeline re-enables overlap, so this write
+            # stands (the other writers only ever disable it too).
+            logger.warning(
+                "--debug-mode only handles failures in the non-overlap scheduler "
+                "loop; force-disabling overlap schedule."
+            )
+            self.disable_overlap_schedule = True
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):

--- a/test/registered/unit/managers/test_scheduler_debug_mode.py
+++ b/test/registered/unit/managers/test_scheduler_debug_mode.py
@@ -1,0 +1,202 @@
+"""Unit tests for the dev-only --debug-mode failed-batch handling.
+
+Two layers:
+
+1. ``SchedulerDebugFaultHandler.discard_batch`` -- the teardown primitive, built with
+   narrow fakes (no Scheduler, no model, no GPU).
+2. ``Scheduler._discard_failed_batch`` -- the orchestration around it: which scheduler
+   fields it is allowed to touch, and the best-effort re-raise contract.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.debug_fault_handler import (
+    ABORT_MESSAGE,
+    SchedulerDebugFaultHandler,
+)
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class _FakeReq:
+    """Only the fields the teardown path reads or writes."""
+
+    def __init__(self, rid: str, finished: bool = False):
+        self.rid = rid
+        self.finished_reason = "done" if finished else None
+        self.to_finish = "staged"
+        self.time_stats = MagicMock()
+        self.return_logprob = False
+        self.req_pool_idx = 0
+
+    def finished(self) -> bool:
+        return self.finished_reason is not None
+
+
+def _fake_batch(rids, finished_rids=()):
+    return MagicMock(reqs=[_FakeReq(r, finished=r in finished_rids) for r in rids])
+
+
+def _make_handler(**overrides):
+    kwargs = dict(
+        tree_cache=MagicMock(),
+        hisparse_coordinator=None,
+        ipc_channels=MagicMock(),
+        enable_hicache_storage=lambda: False,
+    )
+    kwargs.update(overrides)
+    return SchedulerDebugFaultHandler(**kwargs), kwargs
+
+
+def _notified_rids(ipc_channels) -> set:
+    return {
+        call.args[0].rid
+        for call in ipc_channels.send_to_tokenizer.send_output.call_args_list
+    }
+
+
+class TestDebugFaultHandler(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        # release_kv_cache needs the real pool objects and resolved config; the
+        # contract here is that we delegate to it once per discarded request.
+        patcher = patch(
+            "sglang.srt.managers.scheduler_components.debug_fault_handler.release_kv_cache"
+        )
+        self.release_kv_cache = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_discard_batch_aborts_and_releases_each_unfinished_req(self):
+        handler, kwargs = _make_handler()
+        batch = _fake_batch(("r1", "r2"))
+
+        aborted = handler.discard_batch(batch)
+
+        self.assertEqual(sorted(aborted), ["r1", "r2"])
+        # Each request ends up finished, which is what lets the next filter_batch
+        # drop it from running_batch, and its KV is released -- the forward pass that
+        # would normally do both is what failed.
+        for req in batch.reqs:
+            self.assertTrue(req.finished())
+            self.assertIsNone(req.to_finish)
+        self.assertEqual(
+            {call.args[0].rid for call in self.release_kv_cache.call_args_list},
+            {"r1", "r2"},
+        )
+        # An aborted request's partial KV must never be inserted into the radix tree.
+        for call in self.release_kv_cache.call_args_list:
+            self.assertFalse(call.kwargs["is_insert"])
+        # The client is told once per request, with the debug-mode reason.
+        self.assertEqual(_notified_rids(kwargs["ipc_channels"]), {"r1", "r2"})
+        for call in kwargs["ipc_channels"].send_to_tokenizer.send_output.call_args_list:
+            self.assertEqual(call.args[0].abort_message, ABORT_MESSAGE)
+
+    def test_discard_batch_skips_already_finished_reqs(self):
+        # A request that finished normally before the exception already had its final
+        # output streamed and its KV released. Touching it again would send an abort
+        # for a completed rid and double-free.
+        handler, kwargs = _make_handler()
+        batch = _fake_batch(("done", "live"), finished_rids=("done",))
+
+        aborted = handler.discard_batch(batch)
+
+        self.assertEqual(aborted, ["live"])
+        self.assertEqual(_notified_rids(kwargs["ipc_channels"]), {"live"})
+        self.assertEqual(
+            [call.args[0].rid for call in self.release_kv_cache.call_args_list],
+            ["live"],
+        )
+
+    def test_discard_batch_retracts_hisparse_before_abort(self):
+        # HiSparse retraction is only valid while the request is unfinished, so it
+        # must run before prepare_abort sets the finish reason.
+        seen_finished = []
+        coordinator = MagicMock()
+        coordinator.retract_req.side_effect = lambda req: seen_finished.append(
+            req.finished()
+        )
+        handler, _ = _make_handler(hisparse_coordinator=coordinator)
+
+        handler.discard_batch(_fake_batch(("r1",)))
+
+        self.assertEqual(seen_finished, [False])
+
+
+def _make_scheduler_stub(*, batch, chunked_req=None, discard_raises=False) -> Scheduler:
+    """A Scheduler carrying only what _discard_failed_batch reads or writes, built
+    without the heavy __init__ (no model, no GPU)."""
+    sched = Scheduler.__new__(Scheduler)
+    sched.running_batch = MagicMock(reqs=[], batch_is_full=True)
+    sched.last_batch = batch
+    sched.cur_batch_for_debug = batch
+    sched.chunked_req = chunked_req
+    sched._pending_chunked_abort_req = chunked_req
+    sched.waiting_queue = [_FakeReq("queued")]
+    sched.debug_fault_handler = MagicMock()
+    if discard_raises:
+        sched.debug_fault_handler.discard_batch.side_effect = RuntimeError("teardown")
+    else:
+        sched.debug_fault_handler.discard_batch.return_value = ["r1"]
+    return sched
+
+
+class TestDiscardFailedBatchOrchestration(CustomTestCase):
+    def test_discards_batch_and_clears_only_pointers_to_it(self):
+        batch = _fake_batch(("r1",))
+        sched = _make_scheduler_stub(batch=batch)
+
+        sched._discard_failed_batch(batch, RuntimeError("boom"))  # must not raise
+
+        sched.debug_fault_handler.discard_batch.assert_called_once_with(batch)
+        # The pointers to the discarded batch are dropped...
+        self.assertIsNone(sched.last_batch)
+        self.assertIsNone(sched.cur_batch_for_debug)
+        self.assertFalse(sched.running_batch.batch_is_full)
+        # ...and nothing else is: the fault is scoped to the batch, so the waiting
+        # queue keeps its requests and the memory pools are never wiped. Widening the
+        # teardown to more scheduler state must fail this assertion.
+        self.assertEqual([r.rid for r in sched.waiting_queue], ["queued"])
+
+    def test_clears_chunked_req_only_when_it_was_in_the_failed_batch(self):
+        chunked = _FakeReq("c1")
+        batch = _fake_batch(("r1",))
+        batch.reqs.append(chunked)
+        sched = _make_scheduler_stub(batch=batch, chunked_req=chunked)
+
+        sched._discard_failed_batch(batch, RuntimeError("boom"))
+
+        self.assertIsNone(sched.chunked_req)
+        self.assertIsNone(sched._pending_chunked_abort_req)
+
+    def test_keeps_chunked_req_that_survived_the_failed_batch(self):
+        chunked = _FakeReq("c1")
+        batch = _fake_batch(("r1",))
+        sched = _make_scheduler_stub(batch=batch, chunked_req=chunked)
+
+        sched._discard_failed_batch(batch, RuntimeError("boom"))
+
+        self.assertIs(sched.chunked_req, chunked)
+
+    def test_reraises_original_exception_when_teardown_fails(self):
+        # If the teardown fails the state is unknown, so the original exception must
+        # propagate to the normal crash path rather than being swallowed.
+        batch = _fake_batch(("r1",))
+        sched = _make_scheduler_stub(batch=batch, discard_raises=True)
+        original = RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            sched._discard_failed_batch(batch, original)
+        self.assertIs(ctx.exception, original)
+        # State must not be half-updated when bailing out to the crash path.
+        self.assertIs(sched.last_batch, batch)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Motivation

A Python exception raised while a batch runs — a NaN guard, a sampling assertion, an attention metadata mismatch, batch-result bookkeeping — tears down the scheduler process. On a large model every reproduction then pays a full weight load plus CUDA graph capture, which is usually what makes fixing such a bug slow.

`--debug-mode` (off by default, dev-only) turns that crash into a per-batch abort: the failed batch's requests are aborted and their KV released, the event loop resumes, and the process keeps its loaded weights and captured graphs.

This is an alternative implementation of #32026 by @shuwang21 (phase 1 of #31021), credited as co-author. Same user-visible feature; the fault domain is narrowed from the whole event-loop iteration to the batch whose forward pass raised.

## Design: the fault is scoped to the batch

```python
if batch:
    try:
        result = self.run_batch(batch)
        self.process_batch_result(batch, result)
    except Exception as exc:
        if self.debug_fault_handler is None:
            raise                       # default behavior unchanged
        self._discard_failed_batch(batch, exc)
        continue
else:
    self.on_idle()
```

The failed batch's own request list defines the blast radius, so nothing has to enumerate scheduler state. The waiting queue, the memory pools and every other field are left alone, and the aborted requests are left `finished()` — so `update_running_batch`'s existing `filter_batch` drops them from `running_batch` on the next iteration through the normal path. Only the three pointers to the discarded batch are cleared.

That is the same argument already written down for `pause_generation(mode="in_place")`: leaving scheduler state alone and letting the normal event loop clean up *"avoids duplicating batch manipulation logic and the accounting bugs that come with it."* Resetting the whole scheduler instead means keeping a hand-written field list in sync with the queues, chunked slots, pending health-check IPCs, dLLM staging and FutureMap — and nothing catches the drift when a field is added.

Keeping the guard narrow also stops it from swallowing exceptions it must not recover from: `on_idle` runs the memory-leak invariant checker, which **raises** under `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=1`. It sits outside the guarded block, so a leak still crashes rather than being "recovered".

The per-request teardown lives in a `SchedulerDebugFaultHandler` collaborator (narrow kwargs, no god object, unit-testable without a `Scheduler`) and reuses the existing primitives — `prepare_abort` + `release_kv_cache` + HiSparse retract — mirroring `process_pending_chunked_abort`, the established path for finishing a request that will never see another forward. Requests that already carry a finish reason are skipped, since `last_batch` usually holds the batch that just completed normally and re-notifying those rids would send an abort for a completed request.

Recovery is best-effort: if the teardown itself raises, the original exception is re-raised and the normal crash path (SIGQUIT) takes over, so the worst case equals today's behavior.

## Scope

Enforced in `ServerArgs._handle_debug_mode`: `tp_size=pp_size=dp_size=1`, no PD disaggregation or pdmux, overlap force-disabled. Only `event_loop_normal` handles a failed batch, and the flag errors out rather than silently doing nothing. The field carries `NS("schedule")`, matching `disable_overlap_schedule`.

**Deliberately not recovered:** exceptions in request intake or batch scheduling. A half-built batch has no owner for the requests it already popped off the waiting queue, so there is no correct way to resume — those keep crashing the process, and the help text says so. GPU-side faults (illegal access, device asserts) poison the CUDA context and are out of scope.

## Docs

Adds a `debug-serving-fault` skill and a developer-guide page, so this is discoverable as a development accelerator rather than an obscure flag — including when *not* to reach for it (GPU faults, hangs, numerical drift with no exception) and how to verify with the strict idle leak check. Cross-linked from the `debug-cuda-crash` skill.

## Verification

Qwen2.5-0.5B, 1× H200, every run with `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_IDLE=1` so the scheduler's own leak checker raises instead of warning:

| Scenario | Result |
|---|---|
| Decode-batch fault, 12 concurrent reqs, `max_running_requests=2` | 10 completed normally, exactly the 2 in the failed batch aborted; idle `token_capacity` identical to the clean round (4161282) → no leak; a second clean round served 12/12 |
| Prefill-batch fault | 11 completed, 1 aborted, no leak, 12/12 after |
| Mid-chunk chunked-prefill fault (`--chunked-prefill-size 64`) | chunked request aborted, engine then served both a short and another chunked request; idle capacity equal to the no-fault control |
| Without `--debug-mode` | same fault still logs `Scheduler hit an exception` and SIGQUITs |
| CPU unit tests | 7/7 |
| Server-args / runtime-context guardrails | namespaces, config bags, mutation ratchet, writer ratchet all pass |

The first row is the one that matters: requests outside the failed batch keep running, which is what lets you keep a load going while narrowing down a failing input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30787741702](https://github.com/sgl-project/sglang/actions/runs/30787741702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30787741605](https://github.com/sgl-project/sglang/actions/runs/30787741605)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->