### PR TITLE
[AMD] Enable aiter MLA for 12-head models via 12->16 zero-pad (Kimi-K3)

### DIFF
--- a/python/sglang/kernels/ops/kvcache/cache_ops.py
+++ b/python/sglang/kernels/ops/kvcache/cache_ops.py
@@ -9,6 +9,7 @@ def concat_and_cast_mha_k_kernel(
     k_nope_ptr,
     k_rope_ptr,
     head_cnt: tl.constexpr,
+    head_pad: tl.constexpr,
     k_stride0: tl.constexpr,
     k_stride1: tl.constexpr,
     nope_stride0: tl.constexpr,
@@ -18,7 +19,10 @@ def concat_and_cast_mha_k_kernel(
     rope_dim: tl.constexpr,
 ):
     pid_loc = tl.program_id(0)
-    head_range = tl.arange(0, head_cnt)
+    # tl.arange needs a power-of-2 range; head_cnt may be non-pow2 (e.g. 12 =
+    # Kimi-K3 96 heads at TP8), so iterate the padded range and mask the tail.
+    head_range = tl.arange(0, head_pad)
+    head_mask = head_range < head_cnt
 
     k_head_ptr = k_ptr + pid_loc * k_stride0 + head_range[:, None] * k_stride1
 
@@ -32,14 +36,14 @@ def concat_and_cast_mha_k_kernel(
     )
     dst_nope_ptr = k_head_ptr + nope_offs[None, :]
 
-    src_nope = tl.load(src_nope_ptr)
-    tl.store(dst_nope_ptr, src_nope)
+    src_nope = tl.load(src_nope_ptr, mask=head_mask[:, None], other=0)
+    tl.store(dst_nope_ptr, src_nope, mask=head_mask[:, None])
 
     rope_offs = tl.arange(0, rope_dim)
     src_rope_ptr = k_rope_ptr + pid_loc * rope_stride0 + rope_offs[None, :]
     dst_rope_ptr = k_head_ptr + nope_dim + rope_offs[None, :]
     src_rope = tl.load(src_rope_ptr)
-    tl.store(dst_rope_ptr, src_rope)
+    tl.store(dst_rope_ptr, src_rope, mask=head_mask[:, None])
 
 
 def concat_and_cast_mha_k_triton(
@@ -70,6 +74,7 @@ def concat_and_cast_mha_k_triton(
         k_nope,
         k_rope,
         k.shape[1],
+        triton.next_power_of_2(k.shape[1]),
         k.stride(0),
         k.stride(1),
         k_nope.stride(0),

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -286,17 +286,24 @@ class AiterAttnBackend(AttentionBackend):
         self.forward_metadata: ForwardMetadata = None
 
         if self.use_mla:
-            _valid_heads = self.num_head in (4, 8) or (
+            _valid_heads = self.num_head in (4, 8, 12) or (
                 self.num_head % 16 == 0 and 16 <= self.num_head <= 128
             )
             assert _valid_heads, (
-                f"Aiter MLA supports num_head of 4, 8, or multiples of 16 "
+                f"Aiter MLA supports num_head of 4, 8, 12, or multiples of 16 "
                 f"in [16, 128].\n"
                 f"Provided {self.num_head} number of heads.\n"
                 "Try adjusting tensor_parallel_size value."
             )
             self.num_head_padded = 16 if self.num_head < 16 else self.num_head
             self.head_repeat_factor = 16 // self.num_head if self.num_head < 16 else 1
+            # num_head=12 (Kimi-K3 at TP8: 96 attention heads) cannot use the
+            # repeat-interleave head pad below (16/12 is non-integral). Instead
+            # zero-pad q to 16 heads for the aiter MLA kernels and slice the
+            # output back; decode PS metadata is already built from
+            # num_head_padded upstream, so a 16-head q matches the kernel's
+            # work partition.
+            self.mla_head_zero_pad = self.num_head == 12
 
             self.enable_dp_attention = is_dp_attention_enabled()
             self.qo_indptr_ = torch.zeros(
@@ -765,12 +772,36 @@ class AiterAttnBackend(AttentionBackend):
             mla_decode_fwd(q_in, k_buffer_flat, o, **kwargs)
             return o[:, :: self.head_repeat_factor, :]
         else:
+            if self.mla_head_zero_pad:
+                # 12 -> 16 heads: zero-pad q, run the decode kernel at 16
+                # heads (metadata is built from num_head_padded), slice the
+                # 12 real heads back out. Strided slice return mirrors the
+                # repeat-interleave branch -- no extra copy kernel.
+                q_zp = q.new_zeros((q.shape[0], self.num_head_padded, q.shape[-1]))
+                q_zp[:, : layer.tp_q_head_num, :] = q
+                o = q.new_empty(
+                    (q.shape[0], self.num_head_padded, layer.v_head_dim),
+                    dtype=self.input_dtype,
+                )
+                mla_decode_fwd(q_zp, k_buffer_flat, o, **kwargs)
+                return o[:, : layer.tp_q_head_num, :]
             o = q.new_empty(
                 (q.shape[0], layer.tp_q_head_num, layer.v_head_dim),
                 dtype=self.input_dtype,
             )
             mla_decode_fwd(q, k_buffer_flat, o, **kwargs)
             return o
+
+    def _zero_pad_mla_q_heads(
+        self, q: torch.Tensor, layer: RadixAttention
+    ) -> torch.Tensor:
+        """Zero-pad q heads num_head -> num_head_padded (12 -> 16) for the
+        aiter MLA prefill kernels. Input/return are 3-D (T, H, D); the extra
+        heads compute garbage outputs that are sliced away after the kernel."""
+        q3 = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        q_pad = q3.new_zeros((q3.shape[0], self.num_head_padded, q3.shape[-1]))
+        q_pad[:, : layer.tp_q_head_num, :] = q3
+        return q_pad
 
     def mla_fp8_prefill_attn(
         self,
@@ -1298,7 +1329,12 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map = None
                 fp8_prefill_kv_indices = None
 
-                if _use_fp8_prefill_attn:
+                # fp8 PS-ASM prefill memory-faults on gfx950 for a 12-head
+                # (zero-pad) model even with tensors and PS metadata fully
+                # consistent at the padded head count; keep it off for them
+                # (bf16 absorbed prefill covers the fast path). Fencing here
+                # also skips the per-batch CPU-sync metadata work.
+                if _use_fp8_prefill_attn and not self.mla_head_zero_pad:
                     tile_q = 256
                     qlen_granularity = tile_q // (self.num_head // self.num_kv_head)
                     (
@@ -2022,7 +2058,7 @@ class AiterAttnBackend(AttentionBackend):
             ):
                 extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
                 if kv_indices.shape[0] == 0 or extend_no_prefix:
-                    if _use_fp8_prefill_attn:
+                    if _use_fp8_prefill_attn and not self.mla_head_zero_pad:
                         output = self.mla_fp8_prefill_attn(
                             q,
                             k,
@@ -2056,6 +2092,7 @@ class AiterAttnBackend(AttentionBackend):
 
                     if (
                         _use_fp8_prefill_attn
+                        and not self.mla_head_zero_pad
                         and layer.kv_b_proj.weight.dtype == torch.uint8
                     ):
                         # MXFP4 weights + FP8 prefill: fuse GEMM, nope/v split, and k_pe cat
@@ -2095,7 +2132,7 @@ class AiterAttnBackend(AttentionBackend):
                         == forward_batch.extend_seq_lens.shape
                     )
 
-                    if _use_fp8_prefill_attn:
+                    if _use_fp8_prefill_attn and not self.mla_head_zero_pad:
                         return self.mla_fp8_prefill_attn(q, k, v, layer)
                     else:
                         return flash_attn_varlen_func(
@@ -2111,17 +2148,30 @@ class AiterAttnBackend(AttentionBackend):
                         )
 
                 else:
-                    if layer.qk_head_dim != layer.v_head_dim:
+                    if self.mla_head_zero_pad:
+                        # 12 heads/rank (Kimi-K3 TP8): zero-pad q to 16 heads,
+                        # run the aiter MLA prefill kernel, slice 12 back.
+                        q_in = self._zero_pad_mla_q_heads(q, layer)
                         o = q.new_empty(
-                            (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+                            (q.shape[0], self.num_head_padded, layer.v_head_dim)
                         )
                     else:
-                        o = torch.empty_like(q)
+                        q_in = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+                        if layer.qk_head_dim != layer.v_head_dim:
+                            o = q.new_empty(
+                                (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+                            )
+                        else:
+                            o = torch.empty_like(q)
 
                     mla_prefill_fwd(
-                        q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
+                        q_in,
                         K_Buffer.view(-1, 1, 1, layer.qk_head_dim),
-                        o.view(-1, layer.tp_q_head_num, layer.v_head_dim),
+                        (
+                            o.view(-1, self.num_head_padded, layer.v_head_dim)
+                            if self.mla_head_zero_pad
+                            else o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+                        ),
                         qo_indptr,
                         kv_indptr,
                         kv_indices,
@@ -2131,6 +2181,12 @@ class AiterAttnBackend(AttentionBackend):
                         layer.logit_cap,
                     )
                     K_Buffer = K_Buffer.view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                    if self.mla_head_zero_pad:
+                        return (
+                            o[:, : layer.tp_q_head_num, :]
+                            .contiguous()
+                            .view(q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+                        )
                     return o
             elif forward_batch.forward_mode.is_target_verify():
                 work_metadata = self.forward_metadata.work_metadata

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -981,7 +981,14 @@ class DeepseekMLAForwardMixin:
                         ),
                     )
         else:
-            if _use_aiter_gfx95 and self.current_attention_backend == "aiter":
+            # rotary_emb=None means NoPE-style MLA (Kimi-K3, skip_rope=True):
+            # there is no rope to fuse into the aiter kernel -- and no cos/sin
+            # cache to feed it -- so keep the plain cat path, same as triton.
+            if (
+                _use_aiter_gfx95
+                and self.current_attention_backend == "aiter"
+                and self.rotary_emb is not None
+            ):
                 cos = self.rotary_emb.cos_cache
                 sin = self.rotary_emb.sin_cache
 
@@ -1274,7 +1281,13 @@ class DeepseekMLAForwardMixin:
         when running aiter-backend MLA on gfx95 (i.e., the `else` branch in forward_absorb_core
         that calls fused_qk_rope_cat_and_cache_mla).
         """
-        return _use_aiter_gfx95 and self.current_attention_backend == "aiter"
+        # NoPE models (rotary_emb=None, e.g. Kimi-K3) have no rope for the
+        # fused kernel to apply; keep both prepare and core on the plain path.
+        return (
+            self.rotary_emb is not None
+            and _use_aiter_gfx95
+            and self.current_attention_backend == "aiter"
+        )
 
 
 # Fuses the absorb BMM (`q_nope @ w_kc`) with `unified_attention_with_output`


### PR DESCRIPTION

## Motivation

To enable Aiter backend works on K3 models

## Modifications

- aiter_backend: accept num_head=12 (Kimi-K3 TP8: 96 heads -> 12/rank). Zero-pad q 12->16 heads and slice the output back in the absorbed mla_prefill_fwd prefill path and in _mla_decode_fwd_with_head_pad (decode/target-verify/draft-extend). Decode PS metadata is already parameterized by num_head_padded, so a 16-head q matches the kernel work partition.
- aiter_backend: fence off the fp8 PS-ASM prefill kernel for 12-head models; it memory-faults on gfx950 with the padded geometry even with consistent metadata (bf16 absorbed prefill covers the fast path).
- cache_ops: mask tl.arange lanes in concat_and_cast_mha_k_kernel so non-power-of-2 head counts work (12 at TP8). Supersedes #23261.
- forward_mla: guard the gfx95 fused-roped-MLA fast path on rotary_emb is not None; NoPE models (Kimi-K3 skip_rope) keep the plain path on both prepare and core sides.

sglang serve     --model-path moonshotai/Kimi-K3     --trust-remote-code     --tp-size 8      --dtype bfloat16     --mem-fraction-static 0.95     --context-length 1048576     --chunked-prefill-size 16384     --max-mamba-cache-size 160     --max-running-requests 32     --cuda-graph-max-bs-decode 32        --reasoning-parser kimi_k3     --tool-call-parser kimi_k3     --host 0.0.0.0     --port 30000  --attention-backend aiter --speculative-algorithm DSPARK     --speculative-draft-model-path RadixArk/Kimi-K3-DSpark     --speculative-dspark-block-size 4     --speculative-draft-attention-backend aiter

## Accuracy Tests
GSM8K
Accuracy: 0.976
Invalid: 0.000
Latency: 583.983 s
Output throughput: 476.197 token/s

## Speed Tests and Profiling
### Benchmark Summary: Aiter MOE vs. Triton MOE Baseline (`moonshotai/Kimi-K3`)

#### Scenario 1: Low Concurrency / Medium Context
> `--num-prompts 16 --max-concurrency 1 --random-input-len 1024 --random-output-len 512`

| Metric | Baseline (Triton MOE) | Optimized (Aiter MOE) | Performance Uplift |
| :--- | :--- | :--- | :--- |
| **Benchmark Duration (s)** | 38.82 | **32.98** | **+15.0% faster** |
| **Request Throughput (req/s)** | 0.41 | **0.49** | **+19.5%** |
| **Output Token Throughput (tok/s)** | 114.98 | **135.35** | **+17.7%** |
| **Total Token Throughput (tok/s)** | 250.00 | **294.29** | **+17.7%** |
| **Accept Length** | 3.71 | **2.84** | -23.5% |
| **Mean E2E Latency (ms)** | 2424.33 | **2059.32** | **-15.1%** (1.18x) |
| **Median E2E Latency (ms)** | 1947.62 | **1788.17** | **-8.2%** |
| **P90 E2E Latency (ms)** | 4145.01 | **3261.09** | **-21.3%** |
| **Mean TTFT (ms)** | 305.66 | **217.64** | **-28.8%** (1.40x) |
| **Mean TPOT (ms)** | 7.36 | **6.48** | **-12.0%** (1.14x) |
| **Mean ITL (ms)** | 7.62 | **6.62** | **-13.1%** |

---

#### Scenario 2: High Concurrency / Long Context & Output
> `--num-prompts 16 --max-concurrency 16 --random-input-len 10240 --random-output-len 2048`

| Metric | Baseline (Triton MOE) | Optimized (Aiter MOE) | Performance Uplift |
| :--- | :--- | :--- | :--- |
| **Benchmark Duration (s)** | 33.09 | **13.39** | **+59.5% faster** |
| **Request Throughput (req/s)** | 0.48 | **1.19** | **+147.9%** (2.48x) |
| **Output Token Throughput (tok/s)** | 445.67 | **1101.05** | **+147.1%** (2.47x) |
| **Total Token Throughput (tok/s)** | 2612.86 | **6455.21** | **+147.1%** (2.47x) |
| **Accept Length** | 4.53 | **4.96** | **+9.5%** |
| **Mean E2E Latency (ms)** | 21760.92 | **6830.62** | **-68.6%** (3.19x) |
| **Median E2E Latency (ms)** | 20947.62 | **6268.33** | **-70.1%** (3.34x) |
| **P90 E2E Latency (ms)** | 30957.28 | **11258.20** | **-63.6%** (2.75x) |
| **Mean TTFT (ms)** | 6632.98 | **696.28** | **-89.5%** (9.53x) |
| **Mean TPOT (ms)** | 25.90 | **6.97** | **-73.1%** (3.72x) |
| **Mean ITL (ms)** | 16.43 | **6.66** | **-59.5%** (2.47x) |


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Thanks to KIMI K3 model to assist me through this jorney!



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30785312477](https://github.com/sgl-project/sglang/actions/runs/30785312477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30785312358](https://github.com/sgl-project/sglang/actions/runs/30785312358)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->