### PR TITLE
[Perf] Route long standard-dispatch deep_gemm prefill through the contiguous grouped GEMM

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -730,9 +730,8 @@ class Envs:
     SGLANG_DEEPGEMM_SANITY_CHECK = EnvBool(False)
     SGLANG_DEEPGEMM_PDL = EnvBool(True)
     SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP = EnvBool(False)
-    # Token count at which standard-dispatch prefill switches from the masked
-    # grouped GEMM to the contiguous one. Below it the per-expert padding
-    # (num_local_experts * 128 rows) outweighs the compaction win.
+    # Token floor for the contiguous grouped GEMM on standard-dispatch prefill;
+    # below it the per-expert padding outweighs the compaction win.
     SGLANG_DEEPGEMM_CONTIGUOUS_PREFILL_MIN_TOKENS = EnvInt(16384)
 
     # DeepSeek MHA Optimization

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -730,6 +730,10 @@ class Envs:
     SGLANG_DEEPGEMM_SANITY_CHECK = EnvBool(False)
     SGLANG_DEEPGEMM_PDL = EnvBool(True)
     SGLANG_PP_PARALLEL_DEEPGEMM_WARMUP = EnvBool(False)
+    # Token count at which standard-dispatch prefill switches from the masked
+    # grouped GEMM to the contiguous one. Below it the per-expert padding
+    # (num_local_experts * 128 rows) outweighs the compaction win.
+    SGLANG_DEEPGEMM_CONTIGUOUS_PREFILL_MIN_TOKENS = EnvInt(16384)
 
     # DeepSeek MHA Optimization
     SGLANG_CHUNKED_PREFIX_CACHE_THRESHOLD = EnvInt(8192)

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -678,6 +678,17 @@ def pre_permute_standard_to_deep_gemm(
     )
     topk_weights, topk_ids, _ = topk_output
 
+    # The masked grouped GEMM is a capacity-style interface designed for
+    # CUDA-graph decode (fixed shapes, unknown m). For prefill-sized eager
+    # forwards the contiguous grouped GEMM is the intended interface: tokens
+    # are compacted per expert, so no [E, m_max, ...] capacity buffers and
+    # far fewer kernels. Small batches (decode eager / graph warmup+capture)
+    # stay on the masked path.
+    if hidden_states.shape[0] >= 512 and not torch.cuda.is_current_stream_capturing():
+        return _pre_permute_standard_contiguous(
+            hidden_states, topk_ids, topk_weights, runner_config, running_state
+        )
+
     hidden_states_shape = hidden_states.shape
     hidden_states_dtype = hidden_states.dtype
     hidden_states_device = hidden_states.device
@@ -724,6 +735,85 @@ def pre_permute_standard_to_deep_gemm(
     )
 
 
+def _pre_permute_standard_contiguous(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> DeepGemmRunnerInput:
+    """Standard-dispatch -> contiguous grouped GEMM layout.
+
+    Mirrors the deepep_normal pre-permute (ep_scatter + m_indices), except the
+    per-expert counts come from a GPU histogram instead of dispatch metadata.
+    To avoid a GPU->CPU sync per layer, buffers are sized to the worst-case
+    bound (topk_numel + E * BLOCK_E); rows beyond the real aligned total keep
+    m_indices == -1 and are skipped by the GEMM.
+    """
+    from sglang.kernels.ops.moe.ep_moe_kernels import ep_scatter
+    from sglang.kernels.ops.quantization.fp8_kernel import per_token_group_quant_fp8
+
+    BLOCK_E = 128  # ep_scatter's per-expert alignment
+    num_local = runner_config.num_local_experts
+    device = hidden_states.device
+
+    running_state["topk_ids"] = topk_ids
+    running_state["topk_weights"] = topk_weights
+    running_state["hidden_states_shape"] = hidden_states.shape
+    running_state["hidden_states_dtype"] = hidden_states.dtype
+    running_state["hidden_states_device"] = device
+    running_state["contiguous"] = True
+
+    K = hidden_states.shape[1]
+    flat = topk_ids.view(-1)
+    cnt = torch.zeros(num_local, device=device, dtype=torch.int32)
+    cnt.scatter_add_(0, flat.clamp_min(0).to(torch.int64), (flat >= 0).to(torch.int32))
+    aligned_cnt = ((cnt + BLOCK_E - 1) // BLOCK_E) * BLOCK_E
+
+    bound = ceil_div(topk_ids.numel(), BLOCK_E) * BLOCK_E + num_local * BLOCK_E
+    running_state["all_tokens"] = bound
+
+    # fp8-quantize the tokens once, then scatter quantized rows + scales.
+    hs_fp8, hs_scale = per_token_group_quant_fp8(hidden_states, 128)
+
+    input_tensor = torch.empty((bound, K), device=device, dtype=hs_fp8.dtype)
+    # Scatter fp32 scales row-major, then do one e8m0 cast over the whole
+    # buffer (the GEMM1-proven pipeline). Zero-init: padding rows inside each
+    # aligned expert block keep scale == 0 (cast -> 2^-127), so their garbage
+    # payload contributes ~exact zeros.
+    input_tensor_scale = torch.zeros(
+        (bound, K // 128), device=device, dtype=torch.float32
+    )
+    m_indices = torch.full((bound,), -1, device=device, dtype=torch.int32)
+    output_index = torch.empty_like(topk_ids)
+    expert_start_loc = torch.empty_like(cnt)
+
+    ep_scatter(
+        hs_fp8,
+        hs_scale,
+        topk_ids,
+        aligned_cnt,
+        expert_start_loc,
+        input_tensor,
+        input_tensor_scale,
+        m_indices,
+        output_index,
+        scale_ue8m0=False,
+    )
+    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+        input_tensor_scale = _cast_to_e8m0_with_rounding_up(
+            input_tensor_scale.unsqueeze(0)
+        ).squeeze(0)
+    running_state["output_index"] = output_index
+
+    return DeepGemmRunnerInput(
+        hidden_states=input_tensor,
+        hidden_states_scale=input_tensor_scale,
+        use_masked_gemm=False,
+        m_indices=m_indices,
+    )
+
+
 @register_post_permute("deep_gemm", "standard")
 def post_permute_deep_gemm_to_standard(
     runner_output: DeepGemmRunnerOutput,
@@ -731,15 +821,32 @@ def post_permute_deep_gemm_to_standard(
     runner_config: MoeRunnerConfig,
     running_state: dict,
 ) -> StandardCombineInput:
-    from sglang.kernels.ops.moe.ep_moe_kernels import post_reorder_deepgemm
+    from sglang.kernels.ops.moe.ep_moe_kernels import ep_gather, post_reorder_deepgemm
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
 
     hidden_states_shape = running_state["hidden_states_shape"]
     hidden_states_dtype = running_state["hidden_states_dtype"]
     hidden_states_device = running_state["hidden_states_device"]
-    src2dst = running_state["src2dst"]
     topk_ids = running_state["topk_ids"]
     topk_weights = running_state["topk_weights"]
+
+    if running_state.get("contiguous", False):
+        gather_out = torch.zeros(
+            hidden_states_shape, dtype=hidden_states_dtype, device=hidden_states_device
+        )
+        ep_gather(
+            runner_output.hidden_states,
+            topk_ids,
+            topk_weights,
+            running_state["output_index"],
+            gather_out,
+        )
+        dispose_tensor(runner_output.hidden_states)
+        if runner_config.routed_scaling_factor is not None:
+            gather_out *= runner_config.routed_scaling_factor
+        return StandardCombineInput(hidden_states=gather_out)
+
+    src2dst = running_state["src2dst"]
 
     with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
         output = torch.empty(

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -679,18 +679,19 @@ def pre_permute_standard_to_deep_gemm(
     topk_weights, topk_ids, _ = topk_output
 
     # The masked grouped GEMM is a capacity-style interface designed for
-    # CUDA-graph decode (fixed shapes, unknown m). For prefill-sized eager
-    # forwards the contiguous grouped GEMM is the intended interface: tokens
-    # are compacted per expert, so no [E, m_max, ...] capacity buffers and
-    # far fewer kernels. Small batches (decode eager / graph warmup+capture)
-    # stay on the masked path, as do quant configs the contiguous pre-permute
-    # cannot express (it re-quantizes activations at fp8 group 128).
+    # CUDA-graph decode (fixed shapes, unknown m). For long eager prefills the
+    # contiguous grouped GEMM is the intended interface: tokens are compacted
+    # per expert, so no [E, m_max, ...] capacity buffers and far fewer kernels.
+    # It only pays off once the real rows (tokens * topk) dwarf the per-expert
+    # padding (num_local_experts * BLOCK_E) the compaction adds, hence the
+    # token floor. Quant configs whose activation recipe is not fp8 group 128
+    # stay on the masked path too -- that is the only recipe this pre-permute
+    # can produce (bf16 weights leave block_shape unset; mxfp8 pins [1, 32]).
     if (
         quant_info.use_fp8
-        and not quant_info.use_mxfp8
-        and not quant_info.is_fp4_experts
         and quant_info.block_shape == [128, 128]
-        and hidden_states.shape[0] >= 512
+        and hidden_states.shape[0]
+        >= envs.SGLANG_DEEPGEMM_CONTIGUOUS_PREFILL_MIN_TOKENS.get()
         and not torch.cuda.is_current_stream_capturing()
     ):
         return _pre_permute_standard_contiguous(

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -683,8 +683,16 @@ def pre_permute_standard_to_deep_gemm(
     # forwards the contiguous grouped GEMM is the intended interface: tokens
     # are compacted per expert, so no [E, m_max, ...] capacity buffers and
     # far fewer kernels. Small batches (decode eager / graph warmup+capture)
-    # stay on the masked path.
-    if hidden_states.shape[0] >= 512 and not torch.cuda.is_current_stream_capturing():
+    # stay on the masked path, as do quant configs the contiguous pre-permute
+    # cannot express (it re-quantizes activations at fp8 group 128).
+    if (
+        quant_info.use_fp8
+        and not quant_info.use_mxfp8
+        and not quant_info.is_fp4_experts
+        and quant_info.block_shape == [128, 128]
+        and hidden_states.shape[0] >= 512
+        and not torch.cuda.is_current_stream_capturing()
+    ):
         return _pre_permute_standard_contiguous(
             hidden_states, topk_ids, topk_weights, runner_config, running_state
         )
@@ -831,9 +839,14 @@ def post_permute_deep_gemm_to_standard(
     topk_weights = running_state["topk_weights"]
 
     if running_state.get("contiguous", False):
-        gather_out = torch.zeros(
-            hidden_states_shape, dtype=hidden_states_dtype, device=hidden_states_device
-        )
+        with use_symmetric_memory(
+            get_tp_group(), disabled=not is_allocation_symmetric()
+        ):
+            gather_out = torch.zeros(
+                hidden_states_shape,
+                dtype=hidden_states_dtype,
+                device=hidden_states_device,
+            )
         ep_gather(
             runner_output.hidden_states,
             topk_ids,

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -678,15 +678,14 @@ def pre_permute_standard_to_deep_gemm(
     )
     topk_weights, topk_ids, _ = topk_output
 
-    # The masked grouped GEMM is a capacity-style interface designed for
-    # CUDA-graph decode (fixed shapes, unknown m). For long eager prefills the
-    # contiguous grouped GEMM is the intended interface: tokens are compacted
-    # per expert, so no [E, m_max, ...] capacity buffers and far fewer kernels.
-    # It only pays off once the real rows (tokens * topk) dwarf the per-expert
-    # padding (num_local_experts * BLOCK_E) the compaction adds, hence the
-    # token floor. Quant configs whose activation recipe is not fp8 group 128
-    # stay on the masked path too -- that is the only recipe this pre-permute
-    # can produce (bf16 weights leave block_shape unset; mxfp8 pins [1, 32]).
+    # The masked grouped GEMM is a capacity interface for CUDA-graph decode
+    # (fixed shapes, unknown m); compacting tokens per expert drops the
+    # [E, m_max, ...] buffers and most of the kernels. It only pays off once
+    # the real rows (tokens * topk) dwarf the per-expert padding the
+    # compaction adds (num_local_experts * BLOCK_E), hence the token floor.
+    # The quant gate is exhaustive, not conservative: fp8 group 128 is the
+    # only recipe this pre-permute produces (bf16 leaves block_shape unset,
+    # mxfp8 pins [1, 32]).
     if (
         quant_info.use_fp8
         and quant_info.block_shape == [128, 128]
@@ -782,14 +781,13 @@ def _pre_permute_standard_contiguous(
     bound = ceil_div(topk_ids.numel(), BLOCK_E) * BLOCK_E + num_local * BLOCK_E
     running_state["all_tokens"] = bound
 
-    # fp8-quantize the tokens once, then scatter quantized rows + scales.
     hs_fp8, hs_scale = per_token_group_quant_fp8(hidden_states, 128)
 
     input_tensor = torch.empty((bound, K), device=device, dtype=hs_fp8.dtype)
-    # Scatter fp32 scales row-major, then do one e8m0 cast over the whole
-    # buffer (the GEMM1-proven pipeline). Zero-init: padding rows inside each
-    # aligned expert block keep scale == 0 (cast -> 2^-127), so their garbage
-    # payload contributes ~exact zeros.
+    # Scales scatter row-major as fp32, then one e8m0 cast over the whole
+    # buffer. Zero-init matters: padding rows inside an aligned expert block
+    # keep scale == 0 (cast -> 2^-127), so their garbage payload contributes
+    # ~exact zeros.
     input_tensor_scale = torch.zeros(
         (bound, K // 128), device=device, dtype=torch.float32
     )


### PR DESCRIPTION
Long eager prefills on the deep_gemm MoE runner currently go through the masked grouped GEMM, a capacity-style interface built for CUDA-graph decode: it allocates [E, m_max, ...] buffers and launches far more kernels than the contiguous grouped GEMM the DeepEP paths already use. This adds a standard-dispatch contiguous pre-permute (ep_scatter + m_indices, per-expert counts from a GPU histogram so there is no per-layer device sync) and routes prefills above a token floor to it.

Scope: only the (standard dispatch, deep_gemm) pre-permute, and only for fp8 activations at block_shape [128, 128] -- the sole recipe this pre-permute can produce. bf16 weights (block_shape unset) and mxfp8 (block_shape [1, 32]) keep the masked path.

The token floor is `SGLANG_DEEPGEMM_CONTIGUOUS_PREFILL_MIN_TOKENS`, default 16384. Below it the per-expert padding the compaction adds (num_local_experts * 128 rows) outweighs the win; measured on Qwen3-30B-A3B-FP8 (H200, 128 experts) and a DeepSeek-V4-shaped FP4 checkpoint (B300 tp8/ep8, 384 experts), 512-8192 tokens regress 15-30%, while at 16384 the masked path cannot run at all -- it tries to allocate an 8.12 GiB capacity buffer and OOMs where the contiguous path completes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30786245106](https://github.com/sgl-project/sglang/actions/runs/30786245106)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30786244959](https://github.com/sgl-project/sglang/actions/runs/30786244959)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->