### PR TITLE
fix(kimi-k3): mint opaque unique tool_call ids instead of positional name:ordinal

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1922,10 +1922,20 @@ class OpenAIServingChat(OpenAIServingBase):
         history_tool_calls_cnt: int,
     ) -> str:
         """Process for generating a new and unique `tool_call_id`"""
-        if self.tool_call_parser == "kimi_k3":
-            return f"{call_item.name}:{history_tool_calls_cnt + call_item.tool_index}"
         if self.tool_call_parser != "kimi_k2":
             # A simple uuid is sufficient for all models except for Kimi-K2.
+            #
+            # Kimi-K3 included: unlike K2, the K3 XTML wire format carries no id
+            # field at all (`<|open|>call tool="name" index="1"`), so the parser
+            # reads the function name from the `tool` attribute and derives
+            # `tool_index` positionally. The K3 chat encoding likewise documents
+            # `tool_call_id` as opaque and renders the `index` attribute from the
+            # `tool_calls` array position, never from the id string ("K3 drops the
+            # func:index format requirement"). A positional id therefore buys
+            # nothing for K3 and actively collides: it is derived from the tool
+            # call count of the *client-supplied* history, so any client that
+            # truncates, windows, or replays that history makes the server mint
+            # an id that already exists earlier in the conversation.
             tool_call_id = f"call_{uuid.uuid4().hex[:24]}"
             return tool_call_id
         tool_call_id = (

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1503,6 +1503,132 @@ class ServingChatTestCase(unittest.TestCase):
             tool_calls = payload["choices"][0]["delta"]["tool_calls"]
             self.assertEqual(tool_calls[0]["id"], "functions.get_weather:1")
 
+    def _kimi_k3_request_with_history(self):
+        """Request whose history already contains one assistant tool call."""
+        return ChatCompletionRequest(
+            model="x",
+            messages=[
+                {"role": "user", "content": "What's the weather today in paris?"},
+                {
+                    "role": "assistant",
+                    "content": "Let me do some search first.",
+                    "tool_calls": [
+                        {
+                            "id": "call_2b1f0a9c8d7e6f5a4b3c2d1e",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Paris"}',
+                            },
+                        }
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "content": "It's rainy in paris now.",
+                    "tool_call_id": "call_2b1f0a9c8d7e6f5a4b3c2d1e",
+                },
+                {"role": "assistant", "content": "It's rainy now."},
+                {"role": "user", "content": "What about LA and Tokyo?"},
+            ],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            stream=False,
+        )
+
+    def test_kimi_k3_tool_call_id_is_opaque_and_unique(self):
+        """kimi_k3 must mint opaque unique ids, not positional ``name:ordinal``.
+
+        The K3 XTML wire format carries no id field and its chat encoding treats
+        ``tool_call_id`` as opaque, so a positional id only creates collisions
+        once a client truncates or replays tool-call history.
+        """
+        self.chat.tool_call_parser = "kimi_k3"
+
+        call_info = Mock()
+        call_info.name = "get_weather"
+        call_info.tool_index = 0
+
+        # Same call item, same history count: ids must still differ.
+        first = self.chat._process_tool_call_id(call_info, 1)
+        second = self.chat._process_tool_call_id(call_info, 1)
+
+        self.assertNotEqual(first, second)
+        for tool_call_id in (first, second):
+            self.assertTrue(tool_call_id.startswith("call_"))
+            self.assertNotIn(":", tool_call_id)
+            self.assertNotIn(call_info.name, tool_call_id)
+
+    def test_kimi_k3_non_streaming_tool_call_ids_survive_frozen_history(self):
+        """Repeated identical requests must not reuse ids for kimi_k3.
+
+        A client that keeps replaying the same windowed history pins
+        ``history_tool_calls_cnt``. Under the old positional scheme every retry
+        minted the same ``name:ordinal`` id and collided with the earlier call.
+        """
+        self.chat.tool_call_parser = "kimi_k3"
+        req = self._kimi_k3_request_with_history()
+
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_chat.FunctionCallParser"
+        ) as ParserMock:
+            parser_instance = ParserMock.return_value
+
+            call_info = Mock()
+            call_info.name = "get_weather"
+            call_info.parameters = '{"city":"Los Angeles"}'
+            call_info.tool_index = 0
+
+            call_info2 = Mock()
+            call_info2.name = "get_weather"
+            call_info2.parameters = '{"city":"Tokyo"}'
+            call_info2.tool_index = 1
+
+            parser_instance.has_tool_call.return_value = True
+            parser_instance.parse_non_stream.return_value = (
+                "",
+                [call_info, call_info2],
+            )
+
+            tools = [{"type": "function", "function": {"name": "get_weather"}}]
+            history_tool_calls_cnt = self.chat._get_history_tool_calls_cnt(req)
+
+            seen = set()
+            for _ in range(2):
+                tool_calls, _, _ = self.chat._process_tool_calls(
+                    text="<|open|>tools<|sep|>...",
+                    tools=tools,
+                    finish_reason={"type": "stop", "matched": None},
+                    history_tool_calls_cnt=history_tool_calls_cnt,
+                )
+                self.assertIsNotNone(tool_calls)
+                self.assertEqual(len(tool_calls), 2)
+                for tool_call in tool_calls:
+                    self.assertTrue(tool_call.id.startswith("call_"))
+                    self.assertNotIn(tool_call.id, seen)
+                    seen.add(tool_call.id)
+
+            # history count is still derived from the array length only, so an
+            # opaque history id does not disturb it.
+            self.assertEqual(history_tool_calls_cnt, 1)
+            self.assertEqual(len(seen), 4)
+
+    def test_kimi_k2_tool_call_id_stays_positional(self):
+        """kimi_k2 keeps ``functions.{name}:{ordinal}``.
+
+        Unlike K3, the K2 wire format emits the id itself and its detector parses
+        the function name back out of it, so that contract must not change.
+        """
+        self.chat.tool_call_parser = "kimi_k2"
+
+        call_info = Mock()
+        call_info.name = "get_weather"
+        call_info.tool_index = 1
+
+        self.assertEqual(
+            self.chat._process_tool_call_id(call_info, 2),
+            "functions.get_weather:3",
+        )
+
     def test_dpsk_v32_encoding_path(self):
         """Test DeepSeek V3.2 encoding path detection and application."""
         from sglang.srt.parser.template_manager import TemplateManager


### PR DESCRIPTION
## Summary

The `kimi_k3` tool-call parser synthesized server-side `tool_call` ids as `{name}:{history_cnt + tool_index}` (positional, conversation-global). The ordinal is computed from the tool-call count of the **client-supplied** history, so any client that truncates, windows, or replays its history makes the server mint an id that **already exists earlier in the conversation**.

Non-unique ids break client-side tool_use/tool_result pairing and id-based dedup layers. We hit this in production: an agent's history froze one step behind, every retried request re-minted the same `exec:80` id, id-based dedup treated each new call as a duplicate of the old one, and the agent locked into a permanently frozen request loop (byte-identical request bodies for 60+ iterations).

The positional id aligns with a format **K3 officially does not use**. Let K3 fall through to the generic `call_<uuid>` branch like every other model.

## Why K3 does not need positional ids (K2 does)

| | K2 (`kimi_k2`) | K3 (`kimi_k3`) |
|---|---|---|
| Wire format contains id? | ✅ `<\|tool_call_begin\|>functions.ReadFile:0<...` | ❌ `<\|open\|>call tool="name" index="1"` — no id field |
| Function name source | Parsed **out of the id** (`tool_call_id_regex`) | Read directly from the XTML `tool` attribute |
| `tool_index` source | Extracted from id | `enumerate()` / `current_tool_id` counter |
| Pathological id if history is windowed? | possible (kept unchanged) | **this fix** |

Renderer side, the K3 chat encoding (`encoding_k3.py` in the HF repo, which SGLang consumes via `chat_encoding.py`) renders the `index` attribute from the `tool_calls` **array position** (`enumerate(tool_calls, start=1)`), never from the id string, and matches tool results by id as an **opaque key**. Its own docstring: *"K3 drops the func:index format requirement"*.

## Validation

**Live-server A/B against a running K3 deployment** (single tool round-trip, multiple parallel calls, **out-of-order** tool results; positional vs uuid vs arbitrarily long ids):

- Model output byte-identical across all id formats, including correct result re-sorting
- `prompt_tokens` identical (269) for id lengths 1 / 6 / 29 / 40 chars → **the id string never enters the prompt**
- Streaming path unaffected (id sent on first chunk, `None` on argument deltas — unchanged)
- History-count derivation counts array length only, not id content

**Unit tests** (3 added, following the existing kimi_k2 tests in the same file):

- `test_kimi_k3_tool_call_id_is_opaque_and_unique` — same call item + same history count must mint differing opaque ids
- `test_kimi_k3_non_streaming_tool_call_ids_survive_frozen_history` — repeated identical requests must not reuse ids (the production failure mode)
- `test_kimi_k2_tool_call_id_stays_positional` — regression pin: K2's `functions.{name}:{ordinal}` contract unchanged (K2's wire format really does emit the id)

Against a live environment: 3/3 new tests pass on the patched tree, both new K3 tests fail on the unpatched tree, full `test_serving_chat.py` module suite shows no regressions.

## Risk

- **Model-side: none.** Id is invisible to the model (token-level proof above).
- **Server-side: none.** `tool_index`, history count, and result matching are all id-format-independent.
- **Client-visible behavior change:** K3 `tool_call` ids change shape from `exec:0` to `call_<hex>`, matching the shape every other parser already returns. A client that regexes `^\w+:\d+$` on K3 ids specifically would notice; anything handling OpenAI tool calls generically is unaffected.
- **Scope:** `kimi_k3` only. `kimi_k2` untouched. One deleted branch, one comment block, no new code paths.

Co-Authored-By: Cha <cha@jetd.one> via OpenClaw

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30786528550](https://github.com/sgl-project/sglang/actions/runs/30786528550)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30786528392](https://github.com/sgl-project/sglang/actions/runs/30786528392)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->