### PR TITLE
[Docs] Fix overlapping quality-profile table headers on MiniMax-H3 page

### DIFF
--- a/docs_new/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs_new/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -485,7 +485,7 @@ latency-sensitive previews and high-throughput generation.
 
 The measured trade-off is:
 
-| `quality` | Mean inference latency | Speedup | SSIM vs lossless | PSNR vs lossless | Expected trade-off |
+| `quality` | Mean <br />inference <br />latency | Speedup | SSIM vs <br />lossless | PSNR vs <br />lossless | Expected <br />trade-off |
 | --- | ---: | ---: | ---: | ---: | --- |
 | `lossless` | 75.10 s | 1.00× | 1.000 | exact | Native reference path |
 | `high` | 53.70 s | 1.40× | 0.931 | 28.16 dB | Smallest same-seed visual change |


### PR DESCRIPTION
## Motivation

The quality-profile table in the MiniMax-H3 cookbook page renders with colliding header text: `Mean inference latency` and `Speedup` run together, as do `SSIM vs lossless` and `PSNR vs lossless`.

Root cause, measured on the live page: the Mintlify theme sets `white-space: nowrap` on `th`. This table has six columns, so once the sidebar and right-hand TOC are visible the content column drops to ~512px and each column is squeezed to ~79px. Four headers need more than that and overflow into their neighbours:

| header | column width | width needed |
| --- | ---: | ---: |
| `Mean inference latency` | 79px | 172px |
| `SSIM vs lossless` | 79px | 126px |
| `PSNR vs lossless` | 79px | 129px |
| `Expected trade-off` | 79px | 141px |

The 7-column table further down the same page is unaffected because all of its headers are single words.

## Modifications

Insert explicit line breaks into the header cells of that one table. `white-space: nowrap` only suppresses *automatic* wrapping, so `<br />` still breaks the line — this drops every column below the available width while keeping the original header wording, the numbers, and the body cells untouched.

The space before each `<br />` is intentional: MDX preserves it in the DOM text node, so `textContent` remains the original phrase (`Mean inference latency`) and the headers stay findable with Ctrl+F and copy cleanly. It has no layout effect.

Diff is one line.

## Accuracy Tests

Not applicable — documentation-only change, no model output affected.

## Speed Tests and Profiling

Not applicable.

## Verification

Measured rather than eyeballed:

- Injected the new header markup into the live page at the failing width (512px content column): headers overflowing their cell went from **4 to 0**, and row height dropped from 119px to 57px.
- Local `mint dev`: confirmed `<br />` compiles to real `<br>` elements (not escaped text), the table structure is intact, and each header's `textContent` is still the original phrase.
- Zero overflow at 512 / 600 / 760 / 960px content widths; right-alignment of the numeric columns is unchanged (8px gap in every line box, same as before).
- `mint validate` passes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30786621509](https://github.com/sgl-project/sglang/actions/runs/30786621509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30786621420](https://github.com/sgl-project/sglang/actions/runs/30786621420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->