### PR TITLE
[misc] Deep-merge nested config overrides and parse request bodies with orjson

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -42,6 +42,7 @@ from typing import (
 
 import aiohttp
 import numpy as np
+import orjson
 import requests
 import uvicorn
 import uvloop
@@ -60,6 +61,7 @@ from fastapi import (
 from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
+from fastapi.routing import APIRoute
 
 from sglang.srt.configs.embedding_model_spec import resolved_embedding_plan
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
@@ -427,10 +429,37 @@ async def lifespan(fast_api_app: FastAPI):
 
 
 # Fast API
+class ORJSONRequest(Request):
+    """Request whose ``json()`` uses orjson.
+
+    Large multimodal chat bodies (data-URL images are tens of MB) otherwise
+    pay stdlib ``json.loads`` inside FastAPI's dependency resolution; orjson
+    parses the same bytes several times faster. It is stricter on two RFC
+    8259 violations stdlib accepts: bare NaN/Infinity, and integers wider
+    than 64 bits -- both now reject with 400 instead of being parsed.
+    """
+
+    async def json(self) -> Any:
+        if not hasattr(self, "_json"):
+            self._json = orjson.loads(await self.body())
+        return self._json
+
+
+class ORJSONRoute(APIRoute):
+    def get_route_handler(self):
+        original_handler = super().get_route_handler()
+
+        async def custom_handler(request: Request):
+            return await original_handler(ORJSONRequest(request.scope, request.receive))
+
+        return custom_handler
+
+
 app = FastAPI(
     lifespan=lifespan,
     openapi_url=None if get_bool_env_var("DISABLE_OPENAPI_DOC") else "/openapi.json",
 )
+app.router.route_class = ORJSONRoute
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -449,10 +478,13 @@ if envs.SGLANG_ENABLE_REQUEST_DECOMPRESSION.get():
 # Include routers
 from sglang.srt.entrypoints.v1_loads import router as v1_loads_router
 
+# route_class is per-router, so included routers need it set too.
+v1_loads_router.route_class = ORJSONRoute
 app.include_router(v1_loads_router)
 
 from sglang.srt.entrypoints.elastic_ep import router as elastic_ep_router
 
+elastic_ep_router.route_class = ORJSONRoute
 app.include_router(elastic_ep_router)
 
 

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -430,13 +430,9 @@ async def lifespan(fast_api_app: FastAPI):
 
 # Fast API
 class ORJSONRequest(Request):
-    """Request whose ``json()`` uses orjson.
-
-    Large multimodal chat bodies (data-URL images are tens of MB) otherwise
-    pay stdlib ``json.loads`` inside FastAPI's dependency resolution; orjson
-    parses the same bytes several times faster. It is stricter on two RFC
-    8259 violations stdlib accepts: bare NaN/Infinity, and integers wider
-    than 64 bits -- both now reject with 400 instead of being parsed.
+    """Request whose ``json()`` uses orjson, for the tens-of-MB multimodal
+    bodies FastAPI would otherwise hand to stdlib json. Stricter than stdlib
+    on bare NaN/Infinity and >64-bit ints: those now 400 instead of parsing.
     """
 
     async def json(self) -> Any:

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -254,11 +254,9 @@ def get_config(
     )
 
     if model_override_args:
-        # Deep-merge dict-valued overrides into existing sub-configs, e.g.
-        # --json-model-override-args '{"text_config": {"num_hidden_layers": 5}}'
-        # on a VLM. A plain update() would setattr the whole sub-config to a
-        # dict, dropping every other field and breaking attribute access
-        # downstream.
+        # A plain update() setattrs a dict-valued override straight onto the
+        # config, so '{"text_config": {...}}' on a VLM would replace the whole
+        # sub-config with a dict and break attribute access downstream.
         for key, value in model_override_args.items():
             current = getattr(config, key, None)
             if isinstance(value, dict) and isinstance(current, PretrainedConfig):

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -254,7 +254,17 @@ def get_config(
     )
 
     if model_override_args:
-        config.update(model_override_args)
+        # Deep-merge dict-valued overrides into existing sub-configs, e.g.
+        # --json-model-override-args '{"text_config": {"num_hidden_layers": 5}}'
+        # on a VLM. A plain update() would setattr the whole sub-config to a
+        # dict, dropping every other field and breaking attribute access
+        # downstream.
+        for key, value in model_override_args.items():
+            current = getattr(config, key, None)
+            if isinstance(value, dict) and isinstance(current, PretrainedConfig):
+                current.update(value)
+            else:
+                setattr(config, key, value)
 
     if is_gguf:
         if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:


### PR DESCRIPTION
Two independent server-side fixes.

**Nested config overrides.** `--json-model-override-args '{"text_config": {"num_hidden_layers": 5}}'` currently setattrs the whole `text_config` to a plain dict, dropping every other field and breaking attribute access downstream. Dict-valued overrides now merge into an existing `PretrainedConfig` sub-config instead of replacing it; scalar and plain-dict overrides keep the old path.

**orjson request bodies.** Large multimodal chat bodies (data-URL images run to tens of MB) pay stdlib `json.loads` inside FastAPI's dependency resolution. Routing requests through an orjson-backed `Request.json()` parses the same bytes several times faster. orjson is already a dependency. Note it is stricter than stdlib on two RFC 8259 violations -- bare NaN/Infinity and integers wider than 64 bits now reject with 400; the route class is also set on the included routers so parsing is uniform across every endpoint.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30790502966](https://github.com/sgl-project/sglang/actions/runs/30790502966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30790502803](https://github.com/sgl-project/sglang/actions/runs/30790502803)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->