### PR TITLE
[diffusion] reject ring parallelism where it would silently miscompute

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -227,6 +227,14 @@ class UlyssesAttention(nn.Module):
         **extra_impl_args,
     ) -> None:
         super().__init__()
+        if get_ring_parallel_world_size() > 1:
+            raise NotImplementedError(
+                "UlyssesAttention's all-to-all spans the combined sequence "
+                "parallel group and is not ring-aware; it would silently "
+                "shuffle across ring ranks instead of rotating KV within "
+                "them. Ring parallelism is not supported for models still "
+                "using UlyssesAttention -- use USPAttention instead."
+            )
         if softmax_scale is None:
             self.softmax_scale = head_size**-0.5
         else:
@@ -1017,6 +1025,11 @@ class USPAttention(nn.Module):
         4. Concatenate [prefix_h_local, gathered_suffix] and run attention.
         5. Split output, all-to-all back the suffix, all-gather prefix heads.
         """
+        if get_ring_parallel_world_size() > 1:
+            raise NotImplementedError(
+                "USPAttention replicated-prefix/suffix path does not support "
+                "ring parallelism yet."
+            )
         sp_size = get_ulysses_parallel_world_size()
         sp_rank = get_sp_parallel_rank()
 
@@ -1124,6 +1137,11 @@ class USPAttention(nn.Module):
         ctx_attn_metadata,
     ) -> torch.Tensor:
         """split form avoids materializing full K/V before Ulysses all-to-all"""
+        if get_ring_parallel_world_size() > 1:
+            raise NotImplementedError(
+                "USPAttention replicated-kv-prefix path does not support "
+                "ring parallelism yet."
+            )
         sp_rank = get_sp_parallel_rank()
 
         if q.device.type == "cuda":


### PR DESCRIPTION
## Summary
Found while surveying which sglang-diffusion models are ready for cross-node Ulysses x Ring sequence parallelism (following the MiniMax-H3 pattern in #33327). Three shared attention paths currently accept `--ring-degree > 1` without any ring-aware KV rotation, silently producing incomplete/wrong attention instead of erroring:

- `USPAttention`'s replicated-prefix/suffix path and replicated-kv-prefix path only do the Ulysses all-to-all and never rotate KV across ring ranks. Used by Cosmos3's cross-attention, and by flux/flux_2/ernie_image/helios/joy_image/krea2/glm_image/qwen_image/zimage's joint text+image attention.
- `UlyssesAttention` (still used by HunyuanVideo's double/single-stream blocks, and by Wan's `UlyssesAttention_VSA` variant) does its all-to-all over the full combined sequence-parallel group instead of the ulysses-only subgroup, so `ring_degree > 1` would silently shuffle data across ring ranks rather than being rejected or handled correctly.

This adds three `NotImplementedError` guards, matching the existing guard style already used elsewhere in the same file (`USPAttention`'s masked path, `USPAttention.__init__`'s backend check).

## Test plan
- [x] `py_compile` on the changed file
- [x] Traced each guarded call site by hand against all callers (grepped every model file that reaches these three code paths) to confirm the guard doesn't block any currently-working configuration — none of the affected models have `ring_degree > 1` in any existing test or documented recipe

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30860934646](https://github.com/sgl-project/sglang/actions/runs/30860934646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30860934321](https://github.com/sgl-project/sglang/actions/runs/30860934321)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->