### PR TITLE
[Test] Cover tokenizer requirements in sampling params

### DIFF
--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -17,6 +17,7 @@ from sglang.srt.sampling.sampling_params import (
     TOP_K_ALL,
     SamplingParams,
     get_max_seq_length,
+    raise_if_tokenizer_required,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -384,6 +385,62 @@ class TestSamplingParamsNormalize(CustomTestCase):
         tokenizer = self._mock_tokenizer()
         sp.normalize(tokenizer=tokenizer)
         self.assertEqual(sp.stop_regex_max_len, 3)
+
+
+class TestRaiseIfTokenizerRequired(CustomTestCase):
+
+    def test_tokenizer_allows_tokenizer_dependent_features(self):
+        tokenizer = MagicMock()
+
+        raise_if_tokenizer_required(
+            tokenizer,
+            stop_strs=["done"],
+            stop_regex_strs=[r"end\d+"],
+            min_new_tokens=1,
+        )
+
+    def test_unused_features_do_not_require_tokenizer(self):
+        for stop_strs, stop_regex_strs in ((None, None), ([], [])):
+            with self.subTest(stop_strs=stop_strs, stop_regex_strs=stop_regex_strs):
+                raise_if_tokenizer_required(
+                    None,
+                    stop_strs=stop_strs,
+                    stop_regex_strs=stop_regex_strs,
+                    min_new_tokens=0,
+                )
+
+    def test_stop_strs_require_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"stop=\['done'\].*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=["done"],
+                stop_regex_strs=[],
+                min_new_tokens=0,
+            )
+
+    def test_stop_regex_strs_require_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"stop_regex=\['end\\\\d\+'\].*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=[],
+                stop_regex_strs=[r"end\d+"],
+                min_new_tokens=0,
+            )
+
+    def test_positive_min_new_tokens_requires_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"min_new_tokens=1.*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=[],
+                stop_regex_strs=[],
+                min_new_tokens=1,
+            )
 
 
 class TestSamplingParamsMsgspecStruct(CustomTestCase):

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -17,6 +17,7 @@ from sglang.srt.sampling.sampling_params import (
     TOP_K_ALL,
     SamplingParams,
     get_max_seq_length,
+    raise_if_tokenizer_required,
 )
 from sglang.test.test_utils import CustomTestCase
 
@@ -364,6 +365,62 @@ class TestSamplingParamsNormalize(CustomTestCase):
         tokenizer = self._mock_tokenizer()
         sp.normalize(tokenizer=tokenizer)
         self.assertEqual(sp.stop_regex_max_len, 3)
+
+
+class TestRaiseIfTokenizerRequired(CustomTestCase):
+
+    def test_tokenizer_allows_tokenizer_dependent_features(self):
+        tokenizer = MagicMock()
+
+        raise_if_tokenizer_required(
+            tokenizer,
+            stop_strs=["done"],
+            stop_regex_strs=[r"end\d+"],
+            min_new_tokens=1,
+        )
+
+    def test_unused_features_do_not_require_tokenizer(self):
+        for stop_strs, stop_regex_strs in ((None, None), ([], [])):
+            with self.subTest(stop_strs=stop_strs, stop_regex_strs=stop_regex_strs):
+                raise_if_tokenizer_required(
+                    None,
+                    stop_strs=stop_strs,
+                    stop_regex_strs=stop_regex_strs,
+                    min_new_tokens=0,
+                )
+
+    def test_stop_strs_require_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"stop=\['done'\].*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=["done"],
+                stop_regex_strs=[],
+                min_new_tokens=0,
+            )
+
+    def test_stop_regex_strs_require_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"stop_regex=\['end\\\\d\+'\].*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=[],
+                stop_regex_strs=[r"end\d+"],
+                min_new_tokens=0,
+            )
+
+    def test_positive_min_new_tokens_requires_tokenizer(self):
+        with self.assertRaisesRegex(
+            ValueError, r"min_new_tokens=1.*skip_tokenizer_init=True"
+        ):
+            raise_if_tokenizer_required(
+                None,
+                stop_strs=[],
+                stop_regex_strs=[],
+                min_new_tokens=1,
+            )
 
 
 class TestSamplingParamsMsgspecStruct(CustomTestCase):


### PR DESCRIPTION
## Motivation

`raise_if_tokenizer_required()` validates that tokenizer-dependent sampling features are not used with `skip_tokenizer_init=True`, but its error and no-op paths did not have focused unit coverage.

Related to #20865.

## Modifications

- Cover the valid path when a tokenizer is available.
- Cover the valid no-op paths when tokenizer-dependent features are unused.
- Cover the missing-tokenizer errors for `stop`, `stop_regex`, and positive `min_new_tokens`.
- Assert that the errors identify both the offending argument and `skip_tokenizer_init=True`.

## Test

`python -m pytest test/registered/unit/sampling/test_sampling_params.py::TestRaiseIfTokenizerRequired -v`

Result: 5 passed, 2 subtests passed.

Full sampling-params unit file: 76 passed, 13 subtests passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32340265278](https://github.com/sgl-project/sglang/actions/runs/32340265278)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32340265150](https://github.com/sgl-project/sglang/actions/runs/32340265150)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32340265343](https://github.com/sgl-project/sglang/actions/runs/32340265343)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->