### PR TITLE
Fix BCG circular import during server startup

### DIFF
--- a/python/sglang/srt/layers/cp/bcg.py
+++ b/python/sglang/srt/layers/cp/bcg.py
@@ -28,7 +28,6 @@ from sglang.srt.layers.cp.utils import (
     prepare_cp_forward,
 )
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
-from sglang.srt.model_executor.runner.shape_key import ShapeKey
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -197,6 +196,12 @@ def execute_prefill_cp_bcg(
     **kwargs,
 ):
     """Replay a CP-local body and run the global gather/logits tail eagerly."""
+    # Importing a runner submodule while server arguments are being resolved
+    # executes runner/__init__.py, which imports this module through the prefill
+    # runner. Defer the runtime-only dependency until runner initialization has
+    # completed to keep the server-argument compatibility check acyclic.
+    from sglang.srt.model_executor.runner.shape_key import ShapeKey
+
     cp_input = runner.prefill_cp_bcg_input
     assert cp_input is not None
     model = runner.model_runner.model


### PR DESCRIPTION
## Summary

Fixes the server startup circular import introduced by #33136 by deferring the `ShapeKey` import until BCG replay.

This is a startup-blocking regression for CUDA model launches that use the default prefill BCG backend, failing during argument processing before the server starts:

```text
ImportError: cannot import name 'PrefillCPBCGInput' from partially initialized module 'sglang.srt.layers.cp.bcg'
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30797549761](https://github.com/sgl-project/sglang/actions/runs/30797549761)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30797549578](https://github.com/sgl-project/sglang/actions/runs/30797549578)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->