### PR TITLE
[sgl-router]: Fix sgl-router Docker port and CLI usage

### DIFF
--- a/docker/sgl-router.Dockerfile
+++ b/docker/sgl-router.Dockerfile
@@ -20,10 +20,11 @@
 #
 # Build (from the repo root):
 #   docker build -f docker/sgl-router.Dockerfile -t sgl-router:dev .
-# Run:
-#   docker run --rm -p 8090:8090 \
-#       -v $(pwd)/docker/sgl-router.sample.yaml:/etc/sgl-router/sgl-router.yaml \
-#       sgl-router:dev --config /etc/sgl-router/sgl-router.yaml
+# Run (replace worker.example.com with a worker reachable from the container):
+#   docker run --rm -p 30000:30000 sgl-router:dev \
+#       --host 0.0.0.0 --port 30000 \
+#       --model-id Qwen/Qwen3-0.6B \
+#       --worker-urls http://worker.example.com:30000
 #
 # Image budget: < 100 MB stripped (M6 acceptance). Verify with
 #   `docker image inspect sgl-router:dev --format '{{.Size}}'`.
@@ -82,9 +83,7 @@ FROM gcr.io/distroless/cc-debian12:nonroot AS runtime
 
 COPY --from=builder /work/target/release/sgl-router /usr/local/bin/sgl-router
 
-# Default config path; mount your own via `-v <host-path>:/etc/sgl-router`.
-ENV SGL_ROUTER_CONFIG=/etc/sgl-router/sgl-router.yaml
-EXPOSE 8090
+EXPOSE 30000
 
 # distroless `nonroot` runs as uid 65532. The router doesn't need root.
 USER nonroot:nonroot

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -50,6 +50,32 @@ Omit `--service-discovery-namespace` to watch all namespaces (requires
 cluster-wide RBAC). For prefill/decode disaggregation, replace `--selector`
 with `--prefill-selector` and `--decode-selector`.
 
+## Docker
+
+Build the image from the repository root:
+
+```bash
+docker build -f docker/sgl-router.Dockerfile -t sgl-router:dev .
+```
+
+The image uses the same CLI-only configuration as the native binary. Bind the
+router to `0.0.0.0` so its port is reachable outside the container, and pass a
+worker URL that the container can resolve and reach:
+
+```bash
+docker run --rm -p 30000:30000 \
+  sgl-router:dev \
+  --host 0.0.0.0 --port 30000 \
+  --model-id Qwen/Qwen3-0.6B \
+  --worker-urls http://worker.example.com:30000
+```
+
+Replace `worker.example.com` with the worker's DNS name or IP address. If the
+worker also runs in Docker, attach both containers to the same Docker network
+and use the worker container name. Add `--tokenizer-path` and mount a local
+`tokenizer.json` when the router should not download the tokenizer from
+HuggingFace.
+
 ## License
 
 Apache-2.0.


### PR DESCRIPTION
## Summary

This PR updates the `sgl-router` Dockerfile and README to match the router's current CLI-only configuration and default port.

The previous Docker example referenced the removed YAML `--config` interface and exposed port `8090`, while the router defaults to port `30000`.

## Changes

- Expose port `30000` in the Docker image.
- Replace the obsolete YAML configuration example with the current CLI arguments.
- Remove the unused `SGL_ROUTER_CONFIG` environment variable.
- Document how to build and run the Docker image.
- Document container networking and optional local tokenizer mounting.

## Validation

- `git diff --check`
- `cargo +stable run --release -- --help`
- Confirmed that the default port is `30000`.
- Confirmed that all documented CLI arguments are available.

The Docker image build was not executed because Docker is unavailable in the current development environment.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30798296590](https://github.com/sgl-project/sglang/actions/runs/30798296590)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30798296464](https://github.com/sgl-project/sglang/actions/runs/30798296464)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->