### PR TITLE
fix(sgl-router): update Docker port 8090 to 30000

### DIFF
--- a/docker/sgl-router.Dockerfile
+++ b/docker/sgl-router.Dockerfile
@@ -21,7 +21,7 @@
 # Build (from the repo root):
 #   docker build -f docker/sgl-router.Dockerfile -t sgl-router:dev .
 # Run:
-#   docker run --rm -p 8090:8090 \
+#   docker run --rm -p 8090:30000 \
 #       -v $(pwd)/docker/sgl-router.sample.yaml:/etc/sgl-router/sgl-router.yaml \
 #       sgl-router:dev --config /etc/sgl-router/sgl-router.yaml
 #
@@ -84,7 +84,7 @@ COPY --from=builder /work/target/release/sgl-router /usr/local/bin/sgl-router
 
 # Default config path; mount your own via `-v <host-path>:/etc/sgl-router`.
 ENV SGL_ROUTER_CONFIG=/etc/sgl-router/sgl-router.yaml
-EXPOSE 8090
+EXPOSE 30000
 
 # distroless `nonroot` runs as uid 65532. The router doesn't need root.
 USER nonroot:nonroot


### PR DESCRIPTION
Fixes #33372

Updates sgl-router Dockerfile to expose port 30000 (the router default) instead of 8090.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30800665799](https://github.com/sgl-project/sglang/actions/runs/30800665799)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30800665405](https://github.com/sgl-project/sglang/actions/runs/30800665405)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->