### PR TITLE
[Feture] update glm image usage

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/image_api.py
@@ -225,6 +225,8 @@ def _build_image_response_kwargs(
         )
 
     ret = add_common_data_to_response(ret, request_id=request_id, result=result)
+    if ret.get("usage") is not None:
+        ret["usage"]["image_count"] = len(save_file_path_list)
 
     return ret
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -15,12 +15,22 @@ class ImageResponseData(BaseModel):
     file_path: Optional[str] = None
 
 
+class ImageUsage(BaseModel):
+    prompt_tokens: Optional[int] = None
+    total_tokens: Optional[int] = None
+    completion_tokens: Optional[int] = None
+    prompt_tokens_details: Optional[Any] = None
+    reasoning_tokens: Optional[int] = 0
+    image_count: Optional[int] = None
+
+
 class ImageResponse(BaseModel):
     id: str
     created: int = Field(default_factory=lambda: int(time.time()))
     data: List[ImageResponseData]
     peak_memory_mb: Optional[float] = None
     inference_time_s: Optional[float] = None
+    usage: Optional[ImageUsage] = None
 
 
 class ImageGenerationsRequest(BaseModel):

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/protocol.py
@@ -15,11 +15,15 @@ class ImageResponseData(BaseModel):
     file_path: Optional[str] = None
 
 
+class ImagePromptTokensDetails(BaseModel):
+    cached_tokens: int = 0
+
+
 class ImageUsage(BaseModel):
     prompt_tokens: Optional[int] = None
     total_tokens: Optional[int] = None
     completion_tokens: Optional[int] = None
-    prompt_tokens_details: Optional[Any] = None
+    prompt_tokens_details: Optional[ImagePromptTokensDetails] = None
     reasoning_tokens: Optional[int] = 0
     image_count: Optional[int] = None
 

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -430,6 +430,9 @@ def add_common_data_to_response(
     if result.metrics and result.metrics.total_duration_s > 0:
         response["inference_time_s"] = result.metrics.total_duration_s
 
+    if result.usage is not None:
+        response["usage"] = dict(result.usage)
+
     response["id"] = request_id
 
     if result.action_pred is not None:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/utils.py
@@ -431,7 +431,19 @@ def add_common_data_to_response(
         response["inference_time_s"] = result.metrics.total_duration_s
 
     if result.usage is not None:
-        response["usage"] = dict(result.usage)
+        usage = dict(result.usage)
+        cached_tokens = usage.pop("cached_tokens", None)
+        enable_cache_report = getattr(
+            get_global_server_args(), "enable_cache_report", False
+        )
+        if (
+            enable_cache_report
+            and cached_tokens is not None
+            and int(cached_tokens) > 0
+            and usage.get("prompt_tokens_details") is None
+        ):
+            usage["prompt_tokens_details"] = {"cached_tokens": int(cached_tokens)}
+        response["usage"] = usage
 
     response["id"] = request_id
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -728,6 +728,7 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
             audio=getattr(result, "audio", None),
             audio_sample_rate=getattr(result, "audio_sample_rate", None),
             metrics=result.metrics,
+            usage=getattr(result, "usage", None),
             trajectory_timesteps=getattr(result, "trajectory_timesteps", None),
             trajectory_latents=getattr(result, "trajectory_latents", None),
             rollout_trajectory_data=getattr(result, "rollout_trajectory_data", None),
@@ -762,6 +763,14 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         if output_batch.error is not None and merged.error is None:
             merged.error = output_batch.error
         merged.peak_memory_mb = max(merged.peak_memory_mb, output_batch.peak_memory_mb)
+        if output_batch.usage is not None:
+            if merged.usage is None:
+                merged.usage = {}
+            for key, value in output_batch.usage.items():
+                if isinstance(value, int):
+                    merged.usage[key] = int(merged.usage.get(key, 0)) + value
+                else:
+                    merged.usage[key] = value
         if (
             merged.trajectory_timesteps is None
             and output_batch.trajectory_timesteps is not None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/schedule_batch.py
@@ -205,6 +205,7 @@ class Req:
 
     # stage logging
     metrics: Optional[RequestMetrics] = None
+    usage: dict[str, Any] | None = None
 
     # tracing context (TraceReqContext or TraceNullContext)
     trace_ctx: Union[TraceReqContext, TraceNullContext] = field(
@@ -465,6 +466,7 @@ class OutputBatch:
     # For ComfyUI integration: noise prediction from denoising stage
     noise_pred: torch.Tensor | None = None
     peak_memory_mb: float = 0.0
+    usage: dict[str, Any] | None = None
 
     def drop_payload_for_warmup(self) -> None:
         self.output = None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/decoding.py
@@ -327,6 +327,7 @@ class DecodingStage(PipelineStage):
             trajectory_decoded=trajectory_decoded,
             metrics=batch.metrics,
             noise_pred=None,
+            usage=batch.usage,
         )
 
         return output_batch

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/glm_image.py
@@ -1,7 +1,7 @@
 import inspect
 import re
 import time
-from typing import List, Optional, Tuple, Union
+from typing import Any, List, Optional, Tuple, Union
 
 import numpy as np
 import PIL
@@ -153,6 +153,32 @@ def _repeat_to_batch(tensor: Optional[torch.Tensor], batch_size: int):
     return tensor.repeat(*repeat_shape)
 
 
+def _extract_srt_usage(meta_info: dict[str, Any] | None) -> dict[str, int] | None:
+    if not isinstance(meta_info, dict):
+        return None
+
+    usage = {
+        "prompt_tokens": int(meta_info.get("prompt_tokens", 0) or 0),
+        "completion_tokens": int(meta_info.get("completion_tokens", 0) or 0),
+        "reasoning_tokens": int(meta_info.get("reasoning_tokens", 0) or 0),
+        "cached_tokens": int(meta_info.get("cached_tokens", 0) or 0),
+    }
+    usage["total_tokens"] = usage["prompt_tokens"] + usage["completion_tokens"]
+    return usage
+
+
+def _merge_srt_usage(
+    total_usage: dict[str, Any] | None, usage: dict[str, int] | None
+) -> dict[str, Any] | None:
+    if usage is None:
+        return total_usage
+    if total_usage is None:
+        total_usage = {}
+    for key, value in usage.items():
+        total_usage[key] = int(total_usage.get(key, 0)) + int(value)
+    return total_usage
+
+
 class GlmImageAR(PipelineStage):
     r"""
     Pipeline for text-to-image generation using GLM-Image.
@@ -222,7 +248,7 @@ class GlmImageAR(PipelineStage):
         server_args: ServerArgs,
         image: Optional[List[PIL.Image.Image]] = None,
         factor: int = 32,
-    ) -> Tuple[torch.Tensor, int, int]:
+    ) -> Tuple[torch.Tensor, Optional[List[torch.Tensor]], Optional[dict[str, int]]]:
         """
         Generate prior tokens using the AR (vision_language_encoder) model.
 
@@ -332,6 +358,7 @@ class GlmImageAR(PipelineStage):
 
             data = response.json()
             generated_ids = data.get("output_ids")
+            usage = _extract_srt_usage(data.get("meta_info"))
         else:
             if image is not None:
                 source_grids = image_grid_thw[:-1]
@@ -366,6 +393,7 @@ class GlmImageAR(PipelineStage):
             )
             input_len = inputs["input_ids"].shape[-1]
             generated_ids = outputs[0][input_len:]
+            usage = None
 
         expected_output_len = large_image_offset + token_h * token_w
         actual_output_len = 0 if generated_ids is None else len(generated_ids)
@@ -386,7 +414,7 @@ class GlmImageAR(PipelineStage):
             prior_token_ids_d32, token_h, token_w
         )
 
-        return prior_token_ids, prior_token_image_ids
+        return prior_token_ids, prior_token_image_ids, usage
 
     @torch.no_grad()
     def forward(
@@ -425,10 +453,11 @@ class GlmImageAR(PipelineStage):
 
         prior_token_ids = []
         prior_token_image_ids = None
+        usage = None
         for output_idx in range(num_outputs):
             output_seed = _seed_for_output(seed, output_idx)
             if output_seed is None:
-                prior_token_id, output_prior_token_image_ids = (
+                prior_token_id, output_prior_token_image_ids, output_usage = (
                     self.generate_prior_tokens(
                         prompt=prompt,
                         image=ar_condition_images,
@@ -444,7 +473,7 @@ class GlmImageAR(PipelineStage):
                     device_type=rng_device_type,
                 ):
                     torch.manual_seed(output_seed)
-                    prior_token_id, output_prior_token_image_ids = (
+                    prior_token_id, output_prior_token_image_ids, output_usage = (
                         self.generate_prior_tokens(
                             prompt=prompt,
                             image=ar_condition_images,
@@ -454,6 +483,7 @@ class GlmImageAR(PipelineStage):
                         )
                     )
             prior_token_ids.append(prior_token_id)
+            usage = _merge_srt_usage(usage, output_usage)
             if prior_token_image_ids is None:
                 prior_token_image_ids = output_prior_token_image_ids
 
@@ -466,6 +496,8 @@ class GlmImageAR(PipelineStage):
         batch.prior_token_image_ids = prior_token_image_ids
         batch.height = height
         batch.width = width
+        if usage is not None:
+            batch.usage = usage
 
         return batch
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -424,6 +424,7 @@ class ServerArgs(DisaggServerArgsMixin):
     log_requests_format: str = "text"
     log_requests_target: Optional[List[str]] = None
     uvicorn_access_log_exclude_prefixes: list[str] = field(default_factory=list)
+    enable_cache_report: bool = False
 
     # Tracing
     enable_trace: bool = False
@@ -1956,6 +1957,12 @@ class ServerArgs(DisaggServerArgsMixin):
             help="Exclude uvicorn access logs whose request path starts with any of these prefixes. "
             "Defaults to empty (disabled). "
             "Example: --uvicorn-access-log-exclude-prefixes /metrics /health",
+        )
+        parser.add_argument(
+            "--enable-cache-report",
+            action="store_true",
+            default=ServerArgs.enable_cache_report,
+            help="Return number of cached tokens in usage.prompt_tokens_details for each OpenAI-compatible request.",
         )
         parser.add_argument(
             "--backend",

--- a/python/sglang/multimodal_gen/test/unit/test_glm_image_ar.py
+++ b/python/sglang/multimodal_gen/test/unit/test_glm_image_ar.py
@@ -4,6 +4,10 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.multimodal_gen.runtime.entrypoints.openai.image_api import (
+    _build_image_response_kwargs,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.glm_image import (
     GlmImageAR,
 )
@@ -29,11 +33,15 @@ class _FakeProcessor:
 
 
 class _FakeResponse:
-    def __init__(self, output_ids):
+    def __init__(self, output_ids, meta_info=None):
         self._output_ids = output_ids
+        self._meta_info = meta_info
 
     def json(self):
-        return {"output_ids": self._output_ids}
+        data = {"output_ids": self._output_ids}
+        if self._meta_info is not None:
+            data["meta_info"] = self._meta_info
+        return data
 
 
 class TestGlmImageARSrtBackend(unittest.TestCase):
@@ -60,7 +68,7 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
         mock_post.return_value = _FakeResponse(list(range(1025)))
         stage = GlmImageAR(processor=_FakeProcessor(), vision_language_encoder=None)
 
-        prior_token_ids, _ = stage.generate_prior_tokens(
+        prior_token_ids, _, usage = stage.generate_prior_tokens(
             prompt="A simple product sketch",
             height=1024,
             width=1024,
@@ -71,6 +79,84 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
         self.assertTrue(payload["sampling_params"]["ignore_eos"])
         self.assertEqual(payload["sampling_params"]["max_new_tokens"], 1025)
         self.assertEqual(prior_token_ids.shape, (1, 4096))
+        self.assertIsNone(usage)
+
+    @patch(
+        "sglang.multimodal_gen.runtime.pipelines_core.stages."
+        "model_specific_stages.glm_image.get_local_torch_device",
+        return_value=torch.device("cpu"),
+    )
+    @patch(
+        "sglang.multimodal_gen.runtime.pipelines_core.stages."
+        "model_specific_stages.glm_image.requests.post"
+    )
+    def test_srt_ar_extracts_usage_from_meta_info(self, mock_post, _mock_device):
+        set_global_server_args(self._server_args())
+        mock_post.return_value = _FakeResponse(
+            list(range(1025)),
+            meta_info={
+                "prompt_tokens": 13,
+                "completion_tokens": 25,
+                "reasoning_tokens": 0,
+                "cached_tokens": 5,
+            },
+        )
+        stage = GlmImageAR(processor=_FakeProcessor(), vision_language_encoder=None)
+
+        _, _, usage = stage.generate_prior_tokens(
+            prompt="A simple product sketch",
+            height=1024,
+            width=1024,
+            server_args=self._server_args(),
+        )
+
+        self.assertEqual(
+            usage,
+            {
+                "prompt_tokens": 13,
+                "completion_tokens": 25,
+                "reasoning_tokens": 0,
+                "cached_tokens": 5,
+                "total_tokens": 38,
+            },
+        )
+
+    @patch(
+        "sglang.multimodal_gen.runtime.pipelines_core.stages."
+        "model_specific_stages.glm_image.get_local_torch_device",
+        return_value=torch.device("cpu"),
+    )
+    @patch(
+        "sglang.multimodal_gen.runtime.pipelines_core.stages."
+        "model_specific_stages.glm_image.requests.post"
+    )
+    def test_srt_ar_forward_aggregates_usage(self, mock_post, _mock_device):
+        set_global_server_args(self._server_args())
+        mock_post.side_effect = [
+            _FakeResponse(
+                list(range(1025)),
+                meta_info={"prompt_tokens": 13, "completion_tokens": 25},
+            ),
+            _FakeResponse(
+                list(range(1025)),
+                meta_info={"prompt_tokens": 13, "completion_tokens": 25},
+            ),
+        ]
+        stage = GlmImageAR(processor=_FakeProcessor(), vision_language_encoder=None)
+        batch = SimpleNamespace(
+            prompt="A simple product sketch",
+            height=1025,
+            width=1001,
+            image_path=None,
+            num_outputs_per_prompt=2,
+            seed=None,
+        )
+
+        batch = stage.forward(batch, self._server_args())
+
+        self.assertEqual(batch.usage["prompt_tokens"], 26)
+        self.assertEqual(batch.usage["completion_tokens"], 50)
+        self.assertEqual(batch.usage["total_tokens"], 76)
 
     @patch(
         "sglang.multimodal_gen.runtime.pipelines_core.stages."
@@ -96,6 +182,26 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
                 width=1024,
                 server_args=self._server_args(),
             )
+
+    def test_image_response_adds_image_count_to_usage(self):
+        response = _build_image_response_kwargs(
+            ["/tmp/glm-image-0.jpg", "/tmp/glm-image-1.jpg"],
+            "b64_json",
+            "A simple product sketch",
+            "req-0",
+            OutputBatch(
+                usage={
+                    "prompt_tokens": 13,
+                    "completion_tokens": 25,
+                    "total_tokens": 38,
+                    "reasoning_tokens": 0,
+                }
+            ),
+            b64_list=["aGVsbG8=", "d29ybGQ="],
+            is_persistent=False,
+        )
+
+        self.assertEqual(response["usage"]["image_count"], 2)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_glm_image_ar.py
+++ b/python/sglang/multimodal_gen/test/unit/test_glm_image_ar.py
@@ -184,6 +184,7 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
             )
 
     def test_image_response_adds_image_count_to_usage(self):
+        set_global_server_args(SimpleNamespace(enable_cache_report=False))
         response = _build_image_response_kwargs(
             ["/tmp/glm-image-0.jpg", "/tmp/glm-image-1.jpg"],
             "b64_json",
@@ -195,6 +196,7 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
                     "completion_tokens": 25,
                     "total_tokens": 38,
                     "reasoning_tokens": 0,
+                    "cached_tokens": 5,
                 }
             ),
             b64_list=["aGVsbG8=", "d29ybGQ="],
@@ -202,6 +204,33 @@ class TestGlmImageARSrtBackend(unittest.TestCase):
         )
 
         self.assertEqual(response["usage"]["image_count"], 2)
+        self.assertNotIn("prompt_tokens_details", response["usage"])
+        self.assertNotIn("cached_tokens", response["usage"])
+
+    def test_image_response_reports_cached_tokens_when_cache_report_enabled(self):
+        set_global_server_args(SimpleNamespace(enable_cache_report=True))
+        response = _build_image_response_kwargs(
+            ["/tmp/glm-image-0.jpg"],
+            "b64_json",
+            "A simple product sketch",
+            "req-0",
+            OutputBatch(
+                usage={
+                    "prompt_tokens": 13,
+                    "completion_tokens": 25,
+                    "total_tokens": 38,
+                    "reasoning_tokens": 0,
+                    "cached_tokens": 5,
+                }
+            ),
+            b64_list=["aGVsbG8="],
+            is_persistent=False,
+        )
+
+        self.assertEqual(
+            response["usage"]["prompt_tokens_details"], {"cached_tokens": 5}
+        )
+        self.assertNotIn("cached_tokens", response["usage"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

This PR adds usage information to GLM-Image image generation responses.

Before this change, `/v1/images/generations` only returned image data, latency, and memory info. In AR/DiT separated deployment, the token usage from the AR stage was not included in the final response.

After this change, the final image response includes prompt/completion/total token usage. Cached token details are still only returned when `--enable-cache-report` is enabled.

## Modifications

- Propagate AR-stage usage information through the GLM-Image pipeline and include it in the final OpenAI-compatible image generation response.
- Add `usage.image_count` to report the number of generated images.
- Add `--enable-cache-report` support for image generation usage reporting.
- Hide internal `cached_tokens` by default.
- When `--enable-cache-report` is enabled, expose cached token count through `usage.prompt_tokens_details.cached_tokens`, aligned with existing OpenAI-compatible usage behavior.
- Add unit tests for GLM-Image image response usage reporting and cache-report behavior.

Previous response: 
```json
{
  "id": "38f9b169-8fde-4a98-9f79-3563765357fe",
  "created": 1785723586,
  "data": [
    {
      "b64_json": "/9j...base64...string",
      "url": "None",
      "revised_prompt": "\n revised_prompt \n",
      "file_path": "/workspace/outputs/38f9b169-8fde-4a98-9f79-3563765357fe.jpg"
    }
  ],
  "peak_memory_mb": 23112.0,
  "inference_time_s": 71.34896494995337
}
```

Current response, without `--enable-cache-report`, the response includes token usage but does not include cached token details:

```json
{
  "id": "38f9b169-8fde-4a98-9f79-3563765357fe",
  "created": 1785723586,
  "data": [
    {
      "b64_json": "/9j...base64...string",
      "url": "None",
      "revised_prompt": "\n revised_prompt \n",
      "file_path": "/workspace/outputs/38f9b169-8fde-4a98-9f79-3563765357fe.jpg"
    }
  ],
  "peak_memory_mb": 23112.0,
  "inference_time_s": 71.34896494995337,
  "usage": {
    "prompt_tokens": 21,
    "total_tokens": 434,
    "completion_tokens": 413,
    "prompt_tokens_details": null,
    "reasoning_tokens": 0,
    "image_count": 1
  }
}

```

With --enable-cache-report, cached tokens are reported under prompt_tokens_details:

```json
{
  "id": "38f9b169-8fde-4a98-9f79-3563765357fe",
  "created": 1785723586,
  "data": [
    {
      "b64_json": "/9j...base64...string",
      "url": "None",
      "revised_prompt": "\n revised_prompt \n",
      "file_path": "/workspace/outputs/38f9b169-8fde-4a98-9f79-3563765357fe.jpg"
    }
  ],
  "peak_memory_mb": 23112.0,
  "inference_time_s": 71.34896494995337,
  "usage": {
    "prompt_tokens": 21,
    "total_tokens": 434,
    "completion_tokens": 413,
    "prompt_tokens_details": {
      "cached_tokens": 256
    },
    "reasoning_tokens": 0,
    "image_count": 1
  }
}

```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30801258553](https://github.com/sgl-project/sglang/actions/runs/30801258553)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30801258409](https://github.com/sgl-project/sglang/actions/runs/30801258409)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->