### PR TITLE
Fix _pa_swa_prefill_lens off-by-one in FlashAttentionBackend

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -242,9 +242,12 @@ class FlashAttentionBackend(AttentionBackend):
                 "Prefill-aware SWA requires page_size=1, "
                 f"got page_size={self.page_size}"
             )
-            max_bs = model_runner.req_to_token_pool.size
+            # Indexed by raw req_pool_idx values (see the write below and
+            # _build_pa_page_table), which range over [0, size] (row 0 is the
+            # reserved padding slot) -- so this needs size+1, not size.
+            max_req_pool_idx = model_runner.req_to_token_pool.size
             self._pa_swa_prefill_lens = torch.zeros(
-                max_bs, dtype=torch.int32, device=model_runner.device
+                max_req_pool_idx + 1, dtype=torch.int32, device=model_runner.device
             )
             self._pa_swa_max_prefill_len = 0
 

--- a/test/registered/unit/layers/attention/test_flashattention_pa_swa_prefill_lens_size.py
+++ b/test/registered/unit/layers/attention/test_flashattention_pa_swa_prefill_lens_size.py
@@ -1,0 +1,110 @@
+"""Regression test for PR #32208 / base-b-test-1-gpu-large CI failure.
+
+FlashAttentionBackend's prefill-aware-SWA scratch buffer
+(``_pa_swa_prefill_lens``) is indexed directly by raw ``req_pool_idx`` values
+(``self._pa_swa_prefill_lens[forward_batch.req_pool_indices[:batch_size]] =
+...``), not by batch position. ``ReqToTokenPool`` reserves row 0 as a padding
+slot and hands out real slots ``1..size``, so the valid index range is
+``[0, size]`` -- the buffer must hold ``size + 1`` elements, not ``size``.
+
+Sizing it to ``size`` (the pre-fix code) is off-by-one: writing at
+``req_pool_idx == size`` overflows the buffer, which crashes on CUDA with an
+``index_put`` "index out of bounds" device assertion. This was latent under
+the old head-first ``ReqToTokenPool.alloc()`` (index ``size`` was only
+reachable once the pool was nearly saturated) and became immediately
+reachable once ``alloc()`` switched to popping free slots from the tail
+(``memory_pool.py``, "O(1) slot allocation in ReqToTokenPool.alloc()"): the
+very first request into a fresh pool gets ``req_pool_idx == size``.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+def _make_prefill_aware_swa_runner(*, pool_size: int, max_context_len: int = 64):
+    """A minimal fake ModelRunner that reaches FlashAttentionBackend.__init__'s
+    is_prefill_aware_swa branch (mirrors how models like
+    python/sglang/srt/models/unlimited_ocr.py opt in)."""
+    device = "cuda"
+    req_to_token_pool = SimpleNamespace(
+        size=pool_size,
+        req_to_token=torch.zeros(
+            pool_size + 1, max_context_len, dtype=torch.int32, device=device
+        ),
+    )
+    model_config = SimpleNamespace(
+        is_encoder_decoder=False,
+        context_len=max_context_len,
+        attention_arch=AttentionArch.MHA,
+        is_local_attention_model=False,
+        head_dim=8,
+        hf_text_config=SimpleNamespace(
+            num_attention_heads=2, attn_logit_softcapping=None
+        ),
+        get_num_kv_heads=lambda tp_size: 2,
+    )
+    server_args = SimpleNamespace(
+        speculative_eagle_topk=None,
+        enable_deterministic_inference=False,
+        is_embedding=False,
+        chunked_prefill_size=8192,
+        disable_radix_cache=False,
+        enable_prefill_cp=False,
+        enable_dp_attention=False,
+    )
+    return SimpleNamespace(
+        sliding_window_size=None,
+        model_config=model_config,
+        device=device,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool=object(),  # not a SWAKVPool instance -> use_sliding_window_kv_pool=False
+        # getattr(..., "full_v2p_page_table", None) is None -> unified_mla_hooks
+        # falls back to the static (disabled) hook set.
+        token_to_kv_pool_allocator=object(),
+        kv_cache_dtype=torch.float16,
+        kv_cache_dtype_str="auto",
+        page_size=1,
+        ps=SimpleNamespace(attn_cp_size=1, tp_size=1),
+        is_draft_worker=False,
+        server_args=server_args,
+        attention_chunk_size=None,
+        prefill_aware_swa=True,
+    )
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestPrefillAwareSwaPrefillLensBound(CustomTestCase):
+    def test_buffer_covers_full_req_pool_idx_range(self):
+        pool_size = 8
+        runner = _make_prefill_aware_swa_runner(pool_size=pool_size)
+
+        # __init__ reads get_spec().speculative_num_draft_tokens, which comes
+        # from the published runtime-context config bag, not model_runner /
+        # server_args -- publish a real (dummy) ServerArgs rather than faking
+        # the accessor (see the sglang-runtime-context skill).
+        with get_context().override_server_args():
+            backend = FlashAttentionBackend(runner)
+
+        # req_pool_idx ranges over [0, pool_size] inclusive (row 0 is the
+        # reserved CUDA-graph padding slot; real requests use 1..pool_size).
+        self.assertEqual(backend._pa_swa_prefill_lens.shape[0], pool_size + 1)
+
+        # This mirrors the exact write that crashed in CI: writing at the
+        # maximum valid req_pool_idx must stay in bounds.
+        max_req_pool_idx = torch.tensor([pool_size], device=runner.device)
+        backend._pa_swa_prefill_lens[max_req_pool_idx] = 7
+        self.assertEqual(backend._pa_swa_prefill_lens[pool_size].item(), 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`FlashAttentionBackend.__init__` allocates a prefill-aware-SWA scratch buffer for models that opt into `is_prefill_aware_swa()` (e.g. `python/sglang/srt/models/unlimited_ocr.py`):

```python
max_bs = model_runner.req_to_token_pool.size
self._pa_swa_prefill_lens = torch.zeros(max_bs, dtype=torch.int32, ...)
```

This buffer is not indexed by batch position — it's indexed directly by raw `req_pool_idx` values:

```python
self._pa_swa_prefill_lens[forward_batch.req_pool_indices[:batch_size]] = ...
```

(and read the same way inside the `_build_pa_page_table` Triton kernel). `ReqToTokenPool` reserves row 0 as a padding slot for CUDA-graph-padded batches and hands out real slots `1..size` (`_alloc_size = size + 1`), so the valid `req_pool_idx` range is `[0, size]` inclusive — `size + 1` distinct values. Sizing the buffer to `size` (valid indices `0..size-1`) is off-by-one: a request landing on `req_pool_idx == size` overflows it.

This was latent because `ReqToTokenPool.alloc()` used to pop free slots from the head of `free_slots` in ascending order (`1, 2, 3, ...`), so index `size` was only ever handed out once the pool was nearly fully saturated — unreachable in ordinary CI runs. It stopped being latent in #32208 ("O(1) slot allocation in `ReqToTokenPool.alloc()`"), which pops from the tail instead (descending: `size, size-1, ...`), so the very first allocation into a fresh pool now gets `req_pool_idx == size`. This surfaced as a CUDA `index_put` "index out of bounds" device assertion in `base-b-test-1-gpu-large` / `test_unlimited_ocr_server.py`, right after decode CUDA-graph capture, on the first real request: https://github.com/sgl-project/sglang/actions/runs/30669370441/job/91419918042.

Grepped the rest of `python/sglang/srt` for the same pattern (a buffer sized off `req_to_token_pool.size` but indexed by raw `req_pool_idx` rather than by batch position) and found no other occurrence — the many other `max_bs = req_to_token_pool.size`-sized buffers elsewhere (`kv_indptr`, `qo_indptr`, `kv_last_page_len`, etc.) are all indexed positionally (`[:bs]`), not by pool-slot id, so they're unaffected.

## Modifications

- Size `_pa_swa_prefill_lens` to `req_to_token_pool.size + 1`, matching `ReqToTokenPool`'s own allocation (`req_to_token.shape[0] == size + 1`), so every valid `req_pool_idx` in `[0, size]` is addressable regardless of which order `ReqToTokenPool.alloc()` hands out slots in.
- This fixes the actual bound bug rather than papering over it by reverting the allocator to low-index-first behavior, which would only make the off-by-one latent again.

## Accuracy Tests

Not applicable — this only changes the size of a preallocated scratch buffer; it does not change any tensor values, KV cache contents, or model outputs.

## Testing

Added `test/registered/unit/layers/attention/test_flashattention_pa_swa_prefill_lens_size.py`, registered on `base-b-test-1-gpu-small`. It builds a minimal fake `ModelRunner` that opts into `prefill_aware_swa`, constructs a real `FlashAttentionBackend`, and asserts:
- `_pa_swa_prefill_lens.shape[0] == req_to_token_pool.size + 1`
- writing at `req_pool_idx == req_to_token_pool.size` (the exact write that crashed in CI) stays in bounds.

Verified locally (stubbing the CUDA-only `sgl_kernel` import, running the real `__init__` on CPU) against both versions of the file:

```
pre-fix:  IndexError: index 8 is out of bounds for dimension 0 with size 8
post-fix: passes, buffer shape is 9 for pool_size=8
```

The pre-fix failure is the CPU equivalent of the CUDA `index_put` device assertion seen in the CI run above.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31208892737](https://github.com/sgl-project/sglang/actions/runs/31208892737)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #31208891969](https://github.com/sgl-project/sglang/actions/runs/31208891969)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->