### PR TITLE
feat: 1/N DeepSeek V4 CP Cache LayerSplit: Common Infrastructure

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -183,7 +183,7 @@ class CommonKVManager(BaseKVManager):
         self.pp_rank = self.kv_args.pp_rank
         self.local_ip = get_local_ip_auto()
         cp_sharded_prefill = self.attn_cp_size > 1 and (
-            self.is_hybrid_mla_backend or get_parallel().enable_dsa_cache_layer_split
+            self.is_hybrid_mla_backend or get_parallel().enable_cp_cache_layer_split
         )
 
         hybrid_decode_pulls_all_ranks = (
@@ -704,7 +704,7 @@ class CommonKVManager(BaseKVManager):
             "page_size": self.kv_args.page_size,
             "kv_cache_dtype": self.kv_cache_dtype_str,
             "load_balance_method": get_parallel().load_balance_method,
-            "enable_dsa_cache_layer_split": get_parallel().enable_dsa_cache_layer_split,
+            "enable_dsa_cache_layer_split": get_parallel().enable_cp_cache_layer_split,
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a
             # router-injected pd_rebootstrap_prefill_url.
@@ -1165,7 +1165,7 @@ class CommonKVSender(BaseKVSender):
 
         if (
             self.kv_mgr.enable_all_cp_ranks_for_transfer
-            and not get_parallel().enable_dsa_cache_layer_split
+            and not get_parallel().enable_cp_cache_layer_split
         ):
             kv_indices, index_slice = filter_kv_indices_for_cp_rank(
                 self.kv_mgr,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1099,7 +1099,7 @@ class MooncakeKVManager(CommonKVManager):
         if (
             self.attn_cp_size > 1
             and self.attn_cp_rank != 0
-            and not get_parallel().enable_dsa_cache_layer_split
+            and not get_parallel().enable_cp_cache_layer_split
         ):
             skip_state = True
 

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -15,7 +15,7 @@
 """Public import facade and runtime helpers for context parallel strategies."""
 
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Optional, Tuple
+from typing import Any, Optional, Tuple
 
 from sglang.srt.layers.cp.base import (
     BaseContextParallelMetadata,
@@ -34,10 +34,6 @@ from sglang.srt.layers.cp.zigzag import (
     ZigzagContextParallelMetadata,
     ZigzagCPStrategy,
 )
-from sglang.srt.runtime_context import get_parallel
-
-if TYPE_CHECKING:
-    from sglang.srt.model_executor.model_runner import ModelRunner
 
 CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
     {
@@ -50,82 +46,6 @@ CP_V2_DEFAULT_MODEL_CLASSES = frozenset(
         "DeepseekV3ForCausalLM",
     }
 )
-
-
-def is_glm_dsa_cache_layer_split_enabled(model_runner: "ModelRunner") -> bool:
-    """Whether DSA GPU KV/indexer cache layers are sharded across CP ranks.
-
-    Layer split is a prefill-CP-only optimization for DSA (DeepSeek Sparse
-    Attention) MLA models (e.g. GLM-5.2). Draft workers keep the full cache.
-    """
-    from sglang.srt.configs.model_config import is_deepseek_dsa
-
-    return (
-        not model_runner.is_draft_worker
-        and model_runner.server_args.enable_dsa_cache_layer_split
-        and model_runner.use_mla_backend
-        and is_deepseek_dsa(model_runner.model_config.hf_config)
-    )
-
-
-def get_glm_dsa_cp_layer_shard_info(
-    model_runner: "ModelRunner",
-) -> Tuple[Optional[int], int]:
-    """Return ``(layer_shard_rank, layer_shard_size)`` for the DSA KV pool.
-
-    ``(None, 1)`` disables sharding (feature off or only one CP rank).
-    """
-    if not is_glm_dsa_cache_layer_split_enabled(model_runner):
-        return None, 1
-    shard_size = get_parallel().attn_cp_size
-    if shard_size <= 1:
-        return None, 1
-    return get_parallel().attn_cp_rank, shard_size
-
-
-def get_glm_dsa_layer_split_effective_num_layers(
-    model_runner: "ModelRunner", num_layers: int
-) -> int:
-    """Per-rank owned layer count used when sizing the DSA KV cell.
-
-    Under layer split each CP rank only stores ``ceil(num_layers / shard_size)``
-    layers, plus one extra layer for the remote scratch buffer used when reading
-    a layer owned by another CP rank.
-    """
-    if not is_glm_dsa_cache_layer_split_enabled(model_runner):
-        return num_layers
-    shard_size = get_parallel().attn_cp_size
-    if shard_size <= 1:
-        return num_layers
-    owned_layers_upper_bound = (num_layers + shard_size - 1) // shard_size
-    return max(1, owned_layers_upper_bound + 1)
-
-
-def get_layer_shard_range(
-    rank: int, shard_size: int, total_layers: int
-) -> Tuple[int, int]:
-    """Contiguous ``[start, end)`` local-layer range owned by ``rank``.
-
-    Layers are split as evenly as possible; the first ``total_layers %
-    shard_size`` ranks own one extra layer.
-    """
-    base = total_layers // shard_size
-    rem = total_layers % shard_size
-    start = rank * base + min(rank, rem)
-    end = start + base + (1 if rank < rem else 0)
-    return start, end
-
-
-def get_layer_owner(local_layer_idx: int, shard_size: int, total_layers: int) -> int:
-    """CP rank that owns ``local_layer_idx`` under the contiguous split."""
-    for rank in range(shard_size):
-        start, end = get_layer_shard_range(rank, shard_size, total_layers)
-        if start <= local_layer_idx < end:
-            return rank
-    raise ValueError(
-        f"Invalid local_layer_idx={local_layer_idx} for "
-        f"shard_size={shard_size}, total_layers={total_layers}"
-    )
 
 
 def enable_cp_v2() -> bool:
@@ -298,9 +218,4 @@ __all__ = [
     "cp_shard_position_ids",
     "cp_split_before_forward",
     "prepare_cp_forward",
-    "is_glm_dsa_cache_layer_split_enabled",
-    "get_glm_dsa_cp_layer_shard_info",
-    "get_glm_dsa_layer_split_effective_num_layers",
-    "get_layer_shard_range",
-    "get_layer_owner",
 ]

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/__init__.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/__init__.py
@@ -1,0 +1,11 @@
+"""CP Cache LayerSplit public helpers."""
+
+from sglang.srt.mem_cache.cp_cache_layer_split.pool_base import (
+    CpCacheLayerSplitPoolBase,
+    is_cp_cache_layer_split_pool,
+)
+
+__all__ = [
+    "CpCacheLayerSplitPoolBase",
+    "is_cp_cache_layer_split_pool",
+]

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/broadcast.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/broadcast.py
@@ -1,0 +1,80 @@
+"""Slot-keyed async broadcast plumbing for CP Cache LayerSplit."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Optional
+
+import torch
+
+
+@dataclass
+class PendingBroadcast:
+    """State for one in-flight owner-to-peer broadcast."""
+
+    stream: Optional[torch.cuda.Stream] = None
+    layer_id: Optional[int] = None
+    active: bool = False
+
+
+class BroadcastSlots:
+    """Per-pool slot registry for in-flight LayerSplit broadcasts."""
+
+    def __init__(self, slot_kinds: Iterable[str]) -> None:
+        self._slots: dict[str, PendingBroadcast] = {
+            kind: PendingBroadcast() for kind in slot_kinds
+        }
+
+    def kinds(self) -> tuple[str, ...]:
+        return tuple(self._slots.keys())
+
+    def pending(self, kind: str) -> PendingBroadcast:
+        try:
+            return self._slots[kind]
+        except KeyError:
+            raise ValueError(f"unknown broadcast kind: {kind}")
+
+    @contextmanager
+    def launch(self, kind: str, layer_id: int, device: torch.device) -> Iterator[None]:
+        """Run work on a slot's side stream and track it until consumption."""
+        self.clear(kind)
+        pending = self.pending(kind)
+        device_module = torch.get_device_module(device)
+        if pending.stream is None:
+            pending.stream = device_module.Stream(device=device)
+        pending.stream.wait_stream(device_module.current_stream(device))
+        pending.layer_id = layer_id
+        pending.active = True
+        try:
+            with device_module.stream(pending.stream):
+                yield
+        except Exception:
+            self.clear(kind)
+            raise
+
+    def clear(self, kind: str) -> None:
+        """Wait on the slot's side stream so the current stream can proceed."""
+        pending = self.pending(kind)
+        if not pending.active:
+            return
+        if pending.stream is not None:
+            device_module = torch.get_device_module(pending.stream.device)
+            device_module.current_stream(pending.stream.device).wait_stream(
+                pending.stream
+            )
+        pending.layer_id = None
+        pending.active = False
+
+    def finish(self, kind: str, layer_id: int) -> None:
+        """Wait for the pending broadcast; ``layer_id`` must match."""
+        pending = self.pending(kind)
+        if not pending.active:
+            return
+        if pending.layer_id != layer_id:
+            raise RuntimeError(
+                "CP Cache LayerSplit tried to finish an unexpected "
+                f"{kind} broadcast: pending_layer={pending.layer_id}, "
+                f"layer={layer_id}"
+            )
+        self.clear(kind)

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/dsa.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/dsa.py
@@ -23,8 +23,7 @@ buffer into a small per-rank remote scratch buffer.
 This subclass keeps the core ``KVCache`` / ``MLATokenToKVPool`` /
 ``DSATokenToKVPool`` pools untouched: all sharding, broadcast, and remote-scratch
 bookkeeping lives here. Layer split is only ever enabled for DSA MLA models on
-PD prefill workers under prefill-CP (see
-``sglang.srt.layers.cp.utils.is_glm_dsa_cache_layer_split_enabled``).
+PD prefill workers under prefill-CP.
 """
 
 from __future__ import annotations
@@ -36,7 +35,10 @@ from typing import TYPE_CHECKING, Optional
 import torch
 
 from sglang.kernels.ops.attention.dsa import index_buf_accessor
-from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
+from sglang.srt.mem_cache.cp_cache_layer_split.broadcast import BroadcastSlots
+from sglang.srt.mem_cache.cp_cache_layer_split.pool_base import (
+    CpCacheLayerSplitPoolBase,
+)
 from sglang.srt.mem_cache.memory_pool import (
     GPU_MEMORY_TYPE_KV_CACHE,
     DSATokenToKVPool,
@@ -53,7 +55,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
+def get_dsa_layer_split_effective_num_layers(num_layers: int, shard_size: int) -> int:
+    """Per-rank DSA layers used for KV cell sizing, including remote scratch."""
+    if shard_size <= 1:
+        return num_layers
+    owned_layers_upper_bound = (num_layers + shard_size - 1) // shard_size
+    return max(1, owned_layers_upper_bound + 1)
+
+
+class LayerSplitDSATokenToKVPool(CpCacheLayerSplitPoolBase, DSATokenToKVPool):
     """DSA KV pool that shards layers across CP ranks with owner-broadcast reads."""
 
     def __init__(
@@ -66,49 +76,24 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         assert (
             layer_shard_rank is not None and layer_shard_size > 1
         ), "LayerSplitDSATokenToKVPool requires layer_shard_size > 1"
+
+        layer_num = kwargs["layer_num"]
+        start_layer = kwargs.get("start_layer") or 0
+
         self.layer_shard_rank = layer_shard_rank
         self.layer_shard_size = layer_shard_size
         self.layer_shard_enabled = True
         self.layer_broadcast_comm = None
+        self._init_cp_cache_layer_split(
+            cp_rank=layer_shard_rank,
+            cp_size=layer_shard_size,
+            layer_shard_start_layer=start_layer,
+            layer_shard_layer_num=layer_num,
+        )
         super().__init__(*args, **kwargs)
         # First global layer index owned by this rank (used by PD transfer to
         # label the contiguous owned-buffer range).
-        my_start, _ = self._owned_local_layer_range()
-        self.layer_shard_start = self.start_layer + my_start
-
-    # ---- layer ownership helpers ------------------------------------------
-
-    def _local_layer_idx(self, layer_id: int) -> int:
-        return layer_id - self.start_layer
-
-    def _owned_local_layer_range(self) -> tuple[int, int]:
-        return get_layer_shard_range(
-            self.layer_shard_rank, self.layer_shard_size, self.layer_num
-        )
-
-    def _is_layer_owned(self, layer_id: int) -> bool:
-        local_idx = self._local_layer_idx(layer_id)
-        owned_start, owned_end = self._owned_local_layer_range()
-        return owned_start <= local_idx < owned_end
-
-    def _get_layer_owner_rank(self, layer_id: int) -> int:
-        return get_layer_owner(
-            self._local_layer_idx(layer_id), self.layer_shard_size, self.layer_num
-        )
-
-    def _log_layer_shard_plan(self) -> None:
-        partitions = []
-        for rank in range(self.layer_shard_size):
-            st, ed = get_layer_shard_range(rank, self.layer_shard_size, self.layer_num)
-            partitions.append(f"r{rank}:[{st},{ed})")
-        my_start, my_end = self._owned_local_layer_range()
-        logger.info(
-            "Layer shard plan (continuous): "
-            f"layer_num={self.layer_num}, shard_size={self.layer_shard_size}, "
-            f"rank={self.layer_shard_rank}, local=[{my_start},{my_end}), "
-            f"global=[{self.start_layer + my_start},{self.start_layer + my_end}), "
-            f"partitions={'; '.join(partitions)}"
-        )
+        self.layer_shard_start, _ = self._owned_global_layer_range()
 
     # ---- broadcast plumbing -----------------------------------------------
 
@@ -197,10 +182,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                     device=self.device,
                 )
                 self.remote_kv_layer_id: Optional[int] = None
-                self.device_module = torch.get_device_module(self.device)
-                self.kv_broadcast_stream = self.device_module.Stream()
-                self.pending_remote_kv_layer_id: Optional[int] = None
-                self.pending_remote_kv_broadcast = False
+                self._broadcast_slots = BroadcastSlots(("kv",))
         self._init_layer_broadcast_comm()
 
     def _create_index_buffers(self):
@@ -288,7 +270,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         layer_id = layer.layer_id
         assert not self.dsa_kv_cache_store_fp8
         # A write invalidates any cached remote copy for this layer.
-        if self.pending_remote_kv_layer_id == layer_id:
+        if self._broadcast_slots.pending("kv").layer_id == layer_id:
             self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
         if self.remote_kv_layer_id == layer_id:
             self.remote_kv_layer_id = None
@@ -312,7 +294,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     ):
         maybe_detect_oob(loc, 0, self.size + self.page_size, "set_mla_kv_buffer (MLA)")
         layer_id = layer.layer_id
-        if self.pending_remote_kv_layer_id == layer_id:
+        if self._broadcast_slots.pending("kv").layer_id == layer_id:
             self._finalize_pending_kv_broadcast(set_remote_layer_id=True)
         remote_kv_updatable = self.remote_kv_layer_id == layer_id
         if remote_kv_updatable:
@@ -333,13 +315,13 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
     def _finalize_pending_kv_broadcast(
         self, *, set_remote_layer_id: bool = True
     ) -> None:
-        if not self.pending_remote_kv_broadcast:
+        pending = self._broadcast_slots.pending("kv")
+        if not pending.active:
             return
-        self.device_module.current_stream().wait_stream(self.kv_broadcast_stream)
-        self.pending_remote_kv_broadcast = False
-        if set_remote_layer_id and self.pending_remote_kv_layer_id is not None:
-            self.remote_kv_layer_id = self.pending_remote_kv_layer_id
-        self.pending_remote_kv_layer_id = None
+        pending_layer_id = pending.layer_id
+        self._broadcast_slots.clear("kv")
+        if set_remote_layer_id and pending_layer_id is not None:
+            self.remote_kv_layer_id = pending_layer_id
 
     def prefetch_kv_buffer(
         self,
@@ -355,8 +337,9 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
         """
         if self.remote_kv_layer_id == layer_id:
             return
-        if self.pending_remote_kv_broadcast:
-            if self.pending_remote_kv_layer_id == layer_id:
+        pending = self._broadcast_slots.pending("kv")
+        if pending.active:
+            if pending.layer_id == layer_id:
                 return
             self._finalize_pending_kv_broadcast(set_remote_layer_id=False)
 
@@ -374,8 +357,7 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
             self.remote_kv_layer_id = layer_id
             return
 
-        self.kv_broadcast_stream.wait_stream(self.device_module.current_stream())
-        with self.device_module.stream(self.kv_broadcast_stream):
+        with self._broadcast_slots.launch("kv", layer_id, self.remote_kv_buffer.device):
             if layer_transfer_counter is not None and layer_transfer_idx is not None:
                 layer_transfer_counter.wait_until(layer_transfer_idx)
             self._broadcast_tensor_from_owner(
@@ -384,13 +366,12 @@ class LayerSplitDSATokenToKVPool(DSATokenToKVPool):
                 src_tensor=src_tensor,
                 use_layer_broadcast_comm=True,
             )
-        self.pending_remote_kv_layer_id = layer_id
-        self.pending_remote_kv_broadcast = True
 
     def _get_broadcastable_kv_buffer(self, layer_id: int) -> torch.Tensor:
-        if self.pending_remote_kv_broadcast:
+        pending = self._broadcast_slots.pending("kv")
+        if pending.active:
             self._finalize_pending_kv_broadcast(
-                set_remote_layer_id=self.pending_remote_kv_layer_id == layer_id
+                set_remote_layer_id=pending.layer_id == layer_id
             )
         if self.remote_kv_layer_id != layer_id:
             local_idx = self._local_layer_idx(layer_id)

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/pool_base.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/pool_base.py
@@ -65,9 +65,8 @@ class CpCacheLayerSplitPoolBase:
         )
 
     def _is_layer_owned(self, layer_id: int) -> bool:
-        local_idx = self._local_layer_idx(layer_id)
-        owned_start, owned_end = self._owned_local_layer_range()
-        return owned_start <= local_idx < owned_end
+        owned_start, owned_end = self._owned_global_layer_range()
+        return owned_start <= layer_id < owned_end
 
     def _get_layer_owner_rank(self, layer_id: int) -> int:
         return get_layer_owner(
@@ -84,26 +83,15 @@ class CpCacheLayerSplitPoolBase:
         }
 
     def _log_layer_shard_plan(self) -> None:
-        partitions = []
-        for rank in range(self.cp_size):
-            start, end = get_global_layer_shard_range(
-                rank,
-                self.cp_size,
-                self._layer_shard_start_layer,
-                self._layer_shard_layer_num,
-            )
-            partitions.append(f"r{rank}:[{start},{end})")
         owned_start, owned_end = self._owned_global_layer_range()
         logger.info(
-            "Cache LayerSplit plan: stage=[%s,%s), cp_rank=%s, cp_size=%s, "
-            "owned=[%s,%s), partitions=%s",
+            "Cache LayerSplit shard: stage=[%s,%s), cp_rank=%s/%s, owned=[%s,%s)",
             self._layer_shard_start_layer,
             self._layer_shard_start_layer + self._layer_shard_layer_num,
             self.cp_rank,
             self.cp_size,
             owned_start,
             owned_end,
-            "; ".join(partitions),
         )
 
 

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/pool_base.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/pool_base.py
@@ -1,0 +1,112 @@
+"""Common ownership contract for CP Cache LayerSplit pools."""
+
+from __future__ import annotations
+
+import logging
+
+from sglang.srt.mem_cache.cp_cache_layer_split.utils import (
+    get_global_layer_shard_range,
+    get_layer_owner,
+    get_layer_shard_range,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CpCacheLayerSplitPoolBase:
+    """Stage-local layer ownership shared by all Cache LayerSplit pools."""
+
+    def _init_cp_cache_layer_split(
+        self,
+        *,
+        cp_rank: int,
+        cp_size: int,
+        layer_shard_start_layer: int,
+        layer_shard_layer_num: int,
+    ) -> None:
+        """Initialize the stage-local layer ownership state."""
+        if cp_size <= 1:
+            raise ValueError(f"Cache LayerSplit requires cp_size > 1, got {cp_size}")
+        if not 0 <= cp_rank < cp_size:
+            raise ValueError(f"Invalid cp_rank={cp_rank} for cp_size={cp_size}")
+        if layer_shard_start_layer < 0 or layer_shard_layer_num <= 0:
+            raise ValueError(
+                "Invalid Cache LayerSplit stage: "
+                f"start_layer={layer_shard_start_layer}, "
+                f"layer_num={layer_shard_layer_num}"
+            )
+
+        self.cp_rank = cp_rank
+        self.cp_size = cp_size
+        self._layer_shard_start_layer = layer_shard_start_layer
+        self._layer_shard_layer_num = layer_shard_layer_num
+
+    def _local_layer_idx(self, layer_id: int) -> int:
+        local_layer_idx = layer_id - self._layer_shard_start_layer
+        if not 0 <= local_layer_idx < self._layer_shard_layer_num:
+            raise ValueError(
+                f"Layer {layer_id} is outside Cache LayerSplit stage "
+                f"[{self._layer_shard_start_layer}, "
+                f"{self._layer_shard_start_layer + self._layer_shard_layer_num})"
+            )
+        return local_layer_idx
+
+    def _owned_local_layer_range(self) -> tuple[int, int]:
+        return get_layer_shard_range(
+            self.cp_rank, self.cp_size, self._layer_shard_layer_num
+        )
+
+    def _owned_global_layer_range(self) -> tuple[int, int]:
+        return get_global_layer_shard_range(
+            self.cp_rank,
+            self.cp_size,
+            self._layer_shard_start_layer,
+            self._layer_shard_layer_num,
+        )
+
+    def _is_layer_owned(self, layer_id: int) -> bool:
+        local_idx = self._local_layer_idx(layer_id)
+        owned_start, owned_end = self._owned_local_layer_range()
+        return owned_start <= local_idx < owned_end
+
+    def _get_layer_owner_rank(self, layer_id: int) -> int:
+        return get_layer_owner(
+            self._local_layer_idx(layer_id),
+            self.cp_size,
+            self._layer_shard_layer_num,
+        )
+
+    def _build_owned_layer_local_index_map(self) -> dict[int, int]:
+        owned_start, owned_end = self._owned_global_layer_range()
+        return {
+            layer_id: layer_id - owned_start
+            for layer_id in range(owned_start, owned_end)
+        }
+
+    def _log_layer_shard_plan(self) -> None:
+        partitions = []
+        for rank in range(self.cp_size):
+            start, end = get_global_layer_shard_range(
+                rank,
+                self.cp_size,
+                self._layer_shard_start_layer,
+                self._layer_shard_layer_num,
+            )
+            partitions.append(f"r{rank}:[{start},{end})")
+        owned_start, owned_end = self._owned_global_layer_range()
+        logger.info(
+            "Cache LayerSplit plan: stage=[%s,%s), cp_rank=%s, cp_size=%s, "
+            "owned=[%s,%s), partitions=%s",
+            self._layer_shard_start_layer,
+            self._layer_shard_start_layer + self._layer_shard_layer_num,
+            self.cp_rank,
+            self.cp_size,
+            owned_start,
+            owned_end,
+            "; ".join(partitions),
+        )
+
+
+def is_cp_cache_layer_split_pool(pool) -> bool:
+    """True when ``pool`` participates in CP Cache LayerSplit (any model)."""
+    return isinstance(pool, CpCacheLayerSplitPoolBase)

--- a/python/sglang/srt/mem_cache/cp_cache_layer_split/utils.py
+++ b/python/sglang/srt/mem_cache/cp_cache_layer_split/utils.py
@@ -1,0 +1,78 @@
+"""Common configuration and ownership helpers for CP Cache LayerSplit."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from sglang.srt.runtime_context import get_parallel
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+def should_use_cp_cache_layer_split_pool(model_runner: ModelRunner) -> bool:
+    """Whether this model runner should construct a Cache LayerSplit pool."""
+    return (
+        not model_runner.is_draft_worker
+        and model_runner.server_args.enable_cp_cache_layer_split
+    )
+
+
+def get_cp_cache_layer_shard_info(
+    model_runner: ModelRunner,
+) -> tuple[Optional[int], int]:
+    """Return ``(cp_rank, cp_size)`` for a Cache LayerSplit pool.
+
+    ``(None, 1)`` means that this model runner should use its regular pool.
+    """
+    if not should_use_cp_cache_layer_split_pool(model_runner):
+        return None, 1
+
+    parallel = get_parallel()
+    if parallel.attn_cp_size <= 1:
+        return None, 1
+    return parallel.attn_cp_rank, parallel.attn_cp_size
+
+
+def get_layer_shard_range(
+    rank: int, shard_size: int, total_layers: int
+) -> tuple[int, int]:
+    """Contiguous ``[start, end)`` local-layer range owned by ``rank``.
+
+    Layers are split as evenly as possible; the first ``total_layers %
+    shard_size`` ranks own one extra layer.
+    """
+    base = total_layers // shard_size
+    rem = total_layers % shard_size
+    start = rank * base + min(rank, rem)
+    end = start + base + (1 if rank < rem else 0)
+    return start, end
+
+
+def get_global_layer_shard_range(
+    rank: int,
+    shard_size: int,
+    start_layer: int,
+    layer_num: int,
+) -> tuple[int, int]:
+    """Global layer range owned by ``rank`` within one pipeline stage."""
+    if shard_size <= 0 or not 0 <= rank < shard_size:
+        raise ValueError(f"Invalid rank={rank} for shard_size={shard_size}")
+    if start_layer < 0 or layer_num <= 0:
+        raise ValueError(
+            f"Invalid stage start_layer={start_layer}, layer_num={layer_num}"
+        )
+    local_start, local_end = get_layer_shard_range(rank, shard_size, layer_num)
+    return start_layer + local_start, start_layer + local_end
+
+
+def get_layer_owner(local_layer_idx: int, shard_size: int, total_layers: int) -> int:
+    """CP rank that owns ``local_layer_idx`` under the contiguous split."""
+    for rank in range(shard_size):
+        start, end = get_layer_shard_range(rank, shard_size, total_layers)
+        if start <= local_layer_idx < end:
+            return rank
+    raise ValueError(
+        f"Invalid local_layer_idx={local_layer_idx} for "
+        f"shard_size={shard_size}, total_layers={total_layers}"
+    )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -39,6 +39,9 @@ from sglang.srt.mem_cache.allocator.swa import (
     PureSWATokenToKVPoolAllocator,
     SWATokenToKVPoolAllocator,
 )
+from sglang.srt.mem_cache.cp_cache_layer_split.utils import (
+    get_cp_cache_layer_shard_info,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.mem_cache.hisparse_memory_pool import HiSparseDSATokenToKVPool
 from sglang.srt.mem_cache.memory_pool import (
@@ -1129,12 +1132,10 @@ class KVCacheConfigurator:
         return token_to_kv_pool
 
     def _build_dsa_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
-        from sglang.srt.layers.cp.utils import get_glm_dsa_cp_layer_shard_info
-
         (
             dsa_cp_layer_shard_rank,
             dsa_cp_layer_shard_size,
-        ) = get_glm_dsa_cp_layer_shard_info(self)
+        ) = get_cp_cache_layer_shard_info(self)
         pool_kwargs = {}
         if get_memory().enable_hisparse:
             PoolCls = HiSparseDSATokenToKVPool
@@ -1145,7 +1146,7 @@ class KVCacheConfigurator:
             ).host_to_device_ratio
         elif dsa_cp_layer_shard_rank is not None:
             # DSA cache layer split: shard KV/indexer layers across CP ranks.
-            from sglang.srt.mem_cache.dsa_cache_layer_split import (
+            from sglang.srt.mem_cache.cp_cache_layer_split.dsa import (
                 LayerSplitDSATokenToKVPool,
             )
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -31,6 +31,9 @@ from sglang.srt.configs.model_config import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
+from sglang.srt.mem_cache.cp_cache_layer_split.utils import (
+    should_use_cp_cache_layer_split_pool,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.runtime_context import get_parallel
@@ -185,13 +188,19 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
         # args to config cell size
         model_config = kvc.model_config
         kv_cache_dtype = kvc.kv_cache_dtype
-        from sglang.srt.layers.cp.utils import (
-            get_glm_dsa_layer_split_effective_num_layers,
-        )
+        effective_num_layers = num_layers
+        if (
+            should_use_cp_cache_layer_split_pool(kvc)
+            and kvc.use_mla_backend
+            and is_deepseek_dsa(model_config.hf_config)
+        ):
+            from sglang.srt.mem_cache.cp_cache_layer_split.dsa import (
+                get_dsa_layer_split_effective_num_layers,
+            )
 
-        effective_num_layers = get_glm_dsa_layer_split_effective_num_layers(
-            kvc, num_layers
-        )
+            effective_num_layers = get_dsa_layer_split_effective_num_layers(
+                num_layers, get_parallel().attn_cp_size
+            )
 
         kv_size = torch._utils._element_size(kv_cache_dtype)
         tp_size = get_parallel().attn_tp_size

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1090,10 +1090,13 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = None
-    # Split DSA GPU KV/indexer cache layers across CP ranks.
-    enable_dsa_cache_layer_split: A[
+    # Split GPU cache layers across CP ranks.
+    enable_cp_cache_layer_split: A[
         bool,
-        "Split DSA (DeepSeek Sparse Attention) GPU KV/indexer cache layers across context-parallel ranks to reduce per-rank KV memory. Currently only supported with the mooncake transfer backend (mooncake / mooncake_tcp); mori/nixl support will be added later by the community.",
+        Arg(
+            help="Split GPU cache layers across context-parallel ranks to reduce per-rank cache memory. Currently supported for DSA models with the mooncake transfer backend.",
+            aliases=["--enable-dsa-cache-layer-split"],
+        ),
         NS("parallel"),
     ] = False
     enable_dsa_prefill_context_parallel: A[bool, Arg(no_cli=True), NS("parallel")] = (
@@ -5039,9 +5042,9 @@ class ServerArgs:
         hf_config = self.get_model_config().hf_config
         model_arch = hf_config.architectures[0]
 
-        if self.enable_dsa_cache_layer_split and not is_deepseek_dsa(hf_config):
+        if self.enable_cp_cache_layer_split and not is_deepseek_dsa(hf_config):
             raise ValueError(
-                "--enable-dsa-cache-layer-split is only supported for DSA "
+                "--enable-cp-cache-layer-split is only supported for DSA "
                 "(DeepSeek Sparse Attention) models."
             )
 
@@ -5158,26 +5161,26 @@ class ServerArgs:
                         self.disaggregation_mode != "decode"
                     ), "CP is only supported for prefill when PD disaggregation, please remove --enable-prefill-cp."
                 if (
-                    self.enable_dsa_cache_layer_split
+                    self.enable_cp_cache_layer_split
                     and self.disaggregation_mode != "prefill"
                 ):
                     if self.disaggregation_mode == "decode":
                         raise ValueError(
-                            "--enable-dsa-cache-layer-split is not supported on "
+                            "--enable-cp-cache-layer-split is not supported on "
                             "decode workers. This flag is a prefill-CP "
                             "optimization; decode receives full cache shards "
                             "through PD transfer."
                         )
                     raise ValueError(
-                        "--enable-dsa-cache-layer-split is only supported on PD "
+                        "--enable-cp-cache-layer-split is only supported on PD "
                         "prefill workers. Non-PD workers also run decode and "
                         "require ordinary local decode cache semantics."
                     )
-                if self.enable_dsa_cache_layer_split and (
+                if self.enable_cp_cache_layer_split and (
                     not self.enable_prefill_cp or self.cp_strategy != "interleave"
                 ):
                     raise ValueError(
-                        "--enable-dsa-cache-layer-split requires "
+                        "--enable-cp-cache-layer-split requires "
                         "--enable-prefill-cp and --cp-strategy interleave "
                         "(or legacy --enable-nsa-prefill-context-parallel with "
                         "--nsa-prefill-cp-mode round-robin-split)."
@@ -5186,19 +5189,19 @@ class ServerArgs:
                 # transfer path. mori/nixl support is a temporary limitation
                 # and will be added later by the community.
                 if (
-                    self.enable_dsa_cache_layer_split
+                    self.enable_cp_cache_layer_split
                     and self.disaggregation_transfer_backend != "mooncake"
                 ):
                     raise ValueError(
-                        "--enable-dsa-cache-layer-split currently only supports "
+                        "--enable-cp-cache-layer-split currently only supports "
                         "the mooncake transfer backend (mooncake / mooncake_tcp). "
                         f"Got --disaggregation-transfer-backend "
                         f"{self.disaggregation_transfer_backend!r}. mori/nixl "
                         "support will be added later by the community."
                     )
-                if self.enable_dsa_cache_layer_split and self.pp_size > 1:
+                if self.enable_cp_cache_layer_split and self.pp_size > 1:
                     raise ValueError(
-                        "--enable-dsa-cache-layer-split is not supported with "
+                        "--enable-cp-cache-layer-split is not supported with "
                         "pipeline parallelism (pp_size > 1) yet. It requires "
                         "prefill context parallelism, and CP + PP has not been "
                         "validated for this feature."

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -17,7 +17,7 @@ class TestRegisterToBootstrap(CustomTestCase):
 
     def setUp(self):
         # register_to_bootstrap reads get_parallel().load_balance_method /
-        # .enable_dsa_cache_layer_split and get_serving().port from the
+        # .enable_cp_cache_layer_split and get_serving().port from the
         # published config.
         override = get_context().override_server_args(
             load_balance_method="follow_bootstrap_room", port=30000

--- a/test/registered/unit/mem_cache/test_cp_cache_layer_split_ownership.py
+++ b/test/registered/unit/mem_cache/test_cp_cache_layer_split_ownership.py
@@ -1,0 +1,90 @@
+"""Unit tests for CP Cache LayerSplit ownership helpers."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.mem_cache.cp_cache_layer_split.pool_base import (
+    CpCacheLayerSplitPoolBase,
+)
+from sglang.srt.mem_cache.cp_cache_layer_split.utils import (
+    get_cp_cache_layer_shard_info,
+    get_layer_owner,
+    get_layer_shard_range,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _OwnershipOnlyPool(CpCacheLayerSplitPoolBase):
+    def __init__(self, cp_rank, cp_size, start_layer, layer_num):
+        self._init_cp_cache_layer_split(
+            cp_rank=cp_rank,
+            cp_size=cp_size,
+            layer_shard_start_layer=start_layer,
+            layer_shard_layer_num=layer_num,
+        )
+
+
+class TestCpCacheLayerSplitOwnership(CustomTestCase):
+    def test_balanced_layer_ranges_and_owners(self):
+        ranges = [get_layer_shard_range(rank, 4, 10) for rank in range(4)]
+        self.assertEqual(ranges, [(0, 3), (3, 6), (6, 8), (8, 10)])
+        self.assertEqual(
+            [get_layer_owner(i, 4, 10) for i in range(10)],
+            [0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
+        )
+
+        covered = [layer_id for start, end in ranges for layer_id in range(start, end)]
+        self.assertEqual(covered, list(range(10)))
+        self.assertEqual(
+            [get_layer_shard_range(rank, 4, 2) for rank in range(4)],
+            [(0, 1), (1, 2), (2, 2), (2, 2)],
+        )
+
+    def test_shard_info_respects_pool_selection(self):
+        runner = SimpleNamespace(
+            is_draft_worker=False,
+            server_args=SimpleNamespace(enable_cp_cache_layer_split=True),
+        )
+        parallel = SimpleNamespace(attn_cp_rank=2, attn_cp_size=4)
+
+        with patch(
+            "sglang.srt.mem_cache.cp_cache_layer_split.utils.get_parallel",
+            return_value=parallel,
+        ):
+            self.assertEqual(get_cp_cache_layer_shard_info(runner), (2, 4))
+            runner.is_draft_worker = True
+            self.assertEqual(get_cp_cache_layer_shard_info(runner), (None, 1))
+            runner.is_draft_worker = False
+            runner.server_args.enable_cp_cache_layer_split = False
+            self.assertEqual(get_cp_cache_layer_shard_info(runner), (None, 1))
+
+    def test_invalid_cp_rank_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "Invalid cp_rank"):
+            _OwnershipOnlyPool(2, 2, 0, 4)
+
+    def test_stage_local_ranges_and_indices(self):
+        pools = [_OwnershipOnlyPool(rank, 4, 20, 20) for rank in range(4)]
+        ranges = [pool._owned_global_layer_range() for pool in pools]
+        self.assertEqual(ranges, [(20, 25), (25, 30), (30, 35), (35, 40)])
+
+        covered = [layer_id for start, end in ranges for layer_id in range(start, end)]
+        self.assertEqual(covered, list(range(20, 40)))
+        mapping = pools[2]._build_owned_layer_local_index_map()
+
+        self.assertEqual(set(mapping), set(range(30, 35)))
+        self.assertEqual(mapping[30], 0)
+        self.assertEqual(mapping[34], 4)
+
+    def test_layer_outside_stage_is_rejected(self):
+        pool = _OwnershipOnlyPool(0, 2, 10, 4)
+
+        with self.assertRaisesRegex(ValueError, "outside Cache LayerSplit stage"):
+            pool._get_layer_owner_rank(9)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_cp_cache_layer_split_ownership.py
+++ b/test/registered/unit/mem_cache/test_cp_cache_layer_split_ownership.py
@@ -79,9 +79,11 @@ class TestCpCacheLayerSplitOwnership(CustomTestCase):
         self.assertEqual(mapping[30], 0)
         self.assertEqual(mapping[34], 4)
 
-    def test_layer_outside_stage_is_rejected(self):
+    def test_layer_outside_stage_is_not_owned_and_has_no_owner(self):
         pool = _OwnershipOnlyPool(0, 2, 10, 4)
 
+        self.assertFalse(pool._is_layer_owned(9))
+        self.assertFalse(pool._is_layer_owned(14))
         with self.assertRaisesRegex(ValueError, "outside Cache LayerSplit stage"):
             pool._get_layer_owner_rank(9)
 

--- a/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
+++ b/test/registered/unit/mem_cache/test_dsa_layer_shard_utils.py
@@ -1,10 +1,15 @@
 import unittest
+from contextlib import nullcontext
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import torch
 
-from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
-from sglang.srt.mem_cache.dsa_cache_layer_split import LayerSplitDSATokenToKVPool
+from sglang.srt.mem_cache.cp_cache_layer_split.broadcast import BroadcastSlots
+from sglang.srt.mem_cache.cp_cache_layer_split.dsa import (
+    LayerSplitDSATokenToKVPool,
+    get_dsa_layer_split_effective_num_layers,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -12,30 +17,16 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class TestDSALayerShardUtils(CustomTestCase):
-    def test_balanced_layer_ranges_cover_all_layers_once(self):
-        ranges = [get_layer_shard_range(rank, 4, 10) for rank in range(4)]
-        self.assertEqual(ranges, [(0, 3), (3, 6), (6, 8), (8, 10)])
-
-        covered = [layer_id for start, end in ranges for layer_id in range(start, end)]
-        self.assertEqual(covered, list(range(10)))
-
-    def test_owner_matches_uneven_layer_ranges(self):
-        self.assertEqual(
-            [get_layer_owner(i, 4, 10) for i in range(10)],
-            [0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
-        )
-
-    def test_empty_tail_shards_have_empty_ranges(self):
-        ranges = [get_layer_shard_range(rank, 4, 2) for rank in range(4)]
-        self.assertEqual(ranges, [(0, 1), (1, 2), (2, 2), (2, 2)])
+    def test_effective_layer_count_includes_remote_scratch(self):
+        self.assertEqual(get_dsa_layer_split_effective_num_layers(10, 4), 4)
+        self.assertEqual(get_dsa_layer_split_effective_num_layers(10, 1), 10)
 
     def test_prefetch_uses_sync_fallback_without_dedicated_communicator(self):
         broadcasts = []
         counter = SimpleNamespace(wait_until=lambda _: self.fail("unexpected wait"))
         pool = SimpleNamespace(
             remote_kv_layer_id=None,
-            pending_remote_kv_broadcast=False,
-            pending_remote_kv_layer_id=None,
+            _broadcast_slots=BroadcastSlots(("kv",)),
             layer_broadcast_comm=None,
             remote_kv_buffer=object(),
             kv_buffer=[object()],
@@ -63,21 +54,35 @@ class TestDSALayerShardUtils(CustomTestCase):
     def test_finalize_pending_broadcast_promotes_layer_id(self):
         # After an async prefetch, finalizing must promote pending -> remote so a
         # subsequent read of the same layer reuses the broadcast result.
+        device = torch.device("cuda")
+        current_stream = MagicMock()
+        side_stream = MagicMock()
+        side_stream.device = device
+        device_module = MagicMock()
+        device_module.current_stream.return_value = current_stream
+        device_module.Stream.return_value = side_stream
+        device_module.stream.return_value = nullcontext()
+        slots = BroadcastSlots(("kv",))
         pool = SimpleNamespace(
-            pending_remote_kv_broadcast=True,
-            pending_remote_kv_layer_id=7,
+            _broadcast_slots=slots,
             remote_kv_layer_id=None,
-            device_module=SimpleNamespace(
-                current_stream=lambda: SimpleNamespace(wait_stream=lambda _stream: None)
-            ),
-            kv_broadcast_stream=object(),
         )
-        LayerSplitDSATokenToKVPool._finalize_pending_kv_broadcast(
-            pool, set_remote_layer_id=True
-        )
-        self.assertFalse(pool.pending_remote_kv_broadcast)
+
+        with patch(
+            "sglang.srt.mem_cache.cp_cache_layer_split.broadcast."
+            "torch.get_device_module",
+            return_value=device_module,
+        ):
+            with slots.launch("kv", 7, device):
+                pass
+            LayerSplitDSATokenToKVPool._finalize_pending_kv_broadcast(
+                pool, set_remote_layer_id=True
+            )
+
+        self.assertFalse(slots.pending("kv").active)
         self.assertEqual(pool.remote_kv_layer_id, 7)
-        self.assertIsNone(pool.pending_remote_kv_layer_id)
+        side_stream.wait_stream.assert_called_once_with(current_stream)
+        current_stream.wait_stream.assert_called_once_with(side_stream)
 
     def test_get_broadcastable_kv_buffer_returns_owner_contents(self):
         # A non-owner read must return the *owner's* KV bytes, copied into the
@@ -96,8 +101,7 @@ class TestDSALayerShardUtils(CustomTestCase):
             layer_shard_size=shard_size,
             start_layer=0,
             remote_kv_layer_id=None,
-            pending_remote_kv_broadcast=False,
-            pending_remote_kv_layer_id=None,
+            _broadcast_slots=BroadcastSlots(("kv",)),
             remote_kv_buffer=remote,
         )
         pool._local_layer_idx = lambda layer_id: layer_id - pool.start_layer

--- a/test/registered/unit/mem_cache/test_dsa_layer_split_broadcast.py
+++ b/test/registered/unit/mem_cache/test_dsa_layer_split_broadcast.py
@@ -59,7 +59,7 @@ def _run(rank: int, world: int, port: int):
         attention_context_model_parallel_size=world,
     )
 
-    from sglang.srt.mem_cache.dsa_cache_layer_split import (
+    from sglang.srt.mem_cache.cp_cache_layer_split.dsa import (
         LayerSplitDSATokenToKVPool,
     )
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -123,7 +123,7 @@ def _make_model_runner(
     sa.max_running_requests = max_running_requests
     sa.disaggregation_decode_extra_slots = disaggregation_decode_extra_slots
     sa.enable_hisparse = False
-    sa.enable_dsa_cache_layer_split = False
+    sa.enable_cp_cache_layer_split = False
     sa.kv_cache_dtype = "auto"
     mr.server_args = sa
 

--- a/test/registered/unit/server_args/test_cp_cache_layer_split.py
+++ b/test/registered/unit/server_args/test_cp_cache_layer_split.py
@@ -1,0 +1,29 @@
+"""Unit tests for the CP Cache LayerSplit CLI surface."""
+
+import argparse
+import unittest
+
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestCpCacheLayerSplitCli(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(cls.parser)
+
+    def test_canonical_and_dsa_alias_enable_the_same_field(self):
+        for option in (
+            "--enable-cp-cache-layer-split",
+            "--enable-dsa-cache-layer-split",
+        ):
+            with self.subTest(option=option):
+                parsed = self.parser.parse_args(["--model", "dummy", option])
+                self.assertTrue(parsed.enable_cp_cache_layer_split)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The original [DeepSeek V4 CP KV LayerSplit PR](https://github.com/sgl-project/sglang/pull/29187) contains the complete end-to-end implementation. Following review feedback, it is being split into smaller, easier-to-review PRs.

This first PR introduces reusable CP Cache LayerSplit infrastructure while preserving the behavior of the existing DSA implementation. It does not add DeepSeek V4 runtime support.

## Modifications

- Add common layer ownership, pool, and broadcast primitives under `cp_cache_layer_split`.
- Migrate the existing DSA LayerSplit implementation to the common infrastructure.
- Introduce `--enable-cp-cache-layer-split`, keeping `--enable-dsa-cache-layer-split` as an alias.
- Add focused unit tests and preserve existing behavior when LayerSplit is disabled.

## Planned Follow-up PRs

1. Generic descriptor-matched PD cache transfer for heterogeneous per-rank cache layouts.
2. DeepSeek V4 LayerSplit storage and ownership.
3. DeepSeek V4 runtime integration.
4. HiCache integration.
5. MTP support.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30829300902](https://github.com/sgl-project/sglang/actions/runs/30829300902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30829297524](https://github.com/sgl-project/sglang/actions/runs/30829297524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->