### PR TITLE
[DSV4] Sync reasoning-effort modification to DeepSeek-V4-Flash-0731

### DIFF
--- a/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
+++ b/python/sglang/srt/entrypoints/openai/encoding_dsv4.py
@@ -60,11 +60,24 @@ tool_calls_block_name: str = "tool_calls"
 
 tool_output_template: str = "<tool_result>{content}</tool_result>"
 
-REASONING_EFFORT_MAX = (
-    "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
-    "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
-    "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
-)
+# Reasoning effort levels. In thinking mode, the prompt for the selected level
+# is prepended once at the very beginning of the conversation (index 0). "low"
+# is the default and adds nothing. Mirrors the DeepSeek-V4-Flash-0731 checkpoint
+# encoding: "high" carries the former "max" text, and "max" is escalated.
+REASONING_EFFORT_PROMPTS: Dict[str, str] = {
+    "low": "",
+    "high": (
+        "Reasoning Effort: Absolute maximum with no shortcuts permitted.\n"
+        "You MUST be very thorough in your thinking and comprehensively decompose the problem to resolve the root cause, rigorously stress-testing your logic against all potential paths, edge cases, and adversarial scenarios.\n"
+        "Explicitly write out your entire deliberation process, documenting every intermediate step, considered alternative, and rejected hypothesis to ensure absolutely no assumption is left unchecked.\n\n"
+    ),
+    "max": (
+        "Reasoning Effort: Beyond maximum — exhaustive, relentless, and uncompromising.\n"
+        "You MUST reason with the utmost depth and rigor, leaving absolutely nothing to chance: exhaustively decompose the problem into its most fundamental components, trace every causal chain to its root, and resolve the underlying cause rather than any surface symptom.\n"
+        "Do not stop reasoning until you have independently verified the solution from multiple angles and are certain that no assumption remains unchecked and no error remains undiscovered.\n\n"
+    ),
+}
+DEFAULT_REASONING_EFFORT = "low"
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -262,7 +275,8 @@ def render_message(
         messages: Full list of messages in the conversation.
         thinking_mode: Either "chat" or "thinking".
         drop_thinking: Whether to drop reasoning content from earlier turns.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            None is treated as "low" (the default).
 
     Returns:
         Encoded string for this message.
@@ -290,14 +304,14 @@ def render_message(
     if tool_calls:
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
-    # Reasoning effort prefix (only at index 0 in thinking mode with max effort)
-    assert reasoning_effort in [
-        "max",
-        None,
-        "high",
-    ], f"Invalid reasoning effort: {reasoning_effort}"
-    if index == 0 and thinking_mode == "thinking" and reasoning_effort == "max":
-        prompt += REASONING_EFFORT_MAX
+    # Reasoning effort prefix (only at index 0 in thinking mode; "low"/None adds
+    # nothing). None is normalized to the default ("low").
+    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
+    assert (
+        reasoning_effort in REASONING_EFFORT_PROMPTS
+    ), f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+    if index == 0 and thinking_mode == "thinking":
+        prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
 
     if role == "system":
         prompt += system_msg_template.format(content=content or "")
@@ -600,7 +614,8 @@ def encode_messages(
         drop_thinking: If True, drop reasoning_content from earlier assistant turns
                       (only keep reasoning for messages after the last user message).
         add_default_bos_token: Whether to prepend BOS token at conversation start.
-        reasoning_effort: Optional reasoning effort level ("max", "high", or None).
+        reasoning_effort: Reasoning effort level, one of "low", "high", "max".
+            None is treated as "low" (the default).
 
     Returns:
         The encoded prompt string.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1705,6 +1705,48 @@ class ServingChatTestCase(unittest.TestCase):
         )
         self.assertIn("<｜Assistant｜>", out)
 
+    def test_dsv4_reasoning_effort_preamble_mapping(self):
+        """Effort labels map to the DeepSeek-V4-Flash-0731 preambles.
+
+        The preamble strings are copied verbatim from the checkpoint's
+        `encoding_dsv4.py`; this pins that external spec so a silent drift
+        (e.g. reverting `high` back onto the old `max` text, or dropping the
+        `low`-default normalization) turns the case red. Only rendered in
+        thinking mode at the first turn.
+        """
+        from sglang.srt.entrypoints.openai import encoding_dsv4
+
+        HIGH = "Reasoning Effort: Absolute maximum"
+        MAX = "Reasoning Effort: Beyond maximum"
+        messages = [{"role": "user", "content": "hi"}]
+
+        def enc(effort, mode="thinking"):
+            return encoding_dsv4.encode_messages(
+                messages, thinking_mode=mode, reasoning_effort=effort
+            )
+
+        # low / None default -> no preamble.
+        for effort in (None, "low"):
+            out = enc(effort)
+            self.assertNotIn(HIGH, out)
+            self.assertNotIn(MAX, out)
+
+        # high -> former "max" text; max -> escalated text (mutually exclusive).
+        high_out = enc("high")
+        self.assertIn(HIGH, high_out)
+        self.assertNotIn(MAX, high_out)
+
+        max_out = enc("max")
+        self.assertIn(MAX, max_out)
+        self.assertNotIn(HIGH, max_out)
+
+        # Preamble is thinking-mode only: chat never emits it even with max.
+        self.assertNotIn(MAX, enc("max", mode="chat"))
+
+        # Unknown effort is rejected rather than silently dropped.
+        with self.assertRaises(AssertionError):
+            enc("bogus")
+
     def test_streaming_abort_yields_error(self):
         """Test that an abort finish reason during streaming correctly yields an error and stops."""
         err_msg = "Aborted by scheduler"


### PR DESCRIPTION
The bundled `encoding_dsv4.py` is selected by architecture (DeepseekV4 -> "dsv4"), so it must track the current DeepSeek-V4-Flash checkpoint. The 0731 checkpoint remapped the reasoning-effort preambles:

  - low  (new default; None normalizes to it): no preamble
  - high: the former "max" text ("Absolute maximum ...")
  - max : escalated "Beyond maximum ..." text

Previously only `max` was recognized (emitting the "Absolute maximum" text) and any other value silently produced no preamble. This replaces the single `REASONING_EFFORT_MAX` constant with the `REASONING_EFFORT_PROMPTS` mapping copied verbatim from the checkpoint, defaults None -> "low", and rejects unknown efforts with a clear message.

Adds a unit test pinning the effort -> preamble mapping (thinking-mode only) as an external-source literal.

Note: this aligns the encoder with the 0731 checkpoint; the pre-0731 `DeepSeek-V4-Flash` checkpoint used the old `max` text, so a deployment still serving that older checkpoint would see the escalated `max` prompt.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30812225348](https://github.com/sgl-project/sglang/actions/runs/30812225348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30812225092](https://github.com/sgl-project/sglang/actions/runs/30812225092)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->