### PR TITLE
perf(kimi k3): eliminate redudant comm in mixed tp and ep

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1858,6 +1858,7 @@ def init_model_parallel_group(
 _TP: Optional[GroupCoordinator] = None
 _ATTN_TP: Optional[GroupCoordinator] = None
 _ATTN_CP: Optional[GroupCoordinator] = None
+_ATTN_DP: Optional[GroupCoordinator] = None
 _DCP: Optional[GroupCoordinator] = None
 
 # duplicate GroupCoordinator for prefill in PD-Multiplexing
@@ -1893,6 +1894,11 @@ def get_attn_cp_group() -> GroupCoordinator:
         _ATTN_CP is not None
     ), "attention context model parallel group is not initialized"
     return _ATTN_CP
+
+
+def get_attn_dp_group() -> GroupCoordinator:
+    assert _ATTN_DP is not None, "attention data parallel group is not initialized"
+    return _ATTN_DP
 
 
 def get_dcp_group_no_assert() -> Optional[GroupCoordinator]:
@@ -2343,6 +2349,32 @@ def initialize_model_parallel(
     attn_cp_size = attention_context_model_parallel_size
     attn_tp_size = tensor_model_parallel_size // attn_cp_size // attn_dp_size
 
+    global _ATTN_DP
+    assert _ATTN_DP is None, "attention data parallel group is already initialized"
+    if attn_dp_size > 1:
+        group_ranks = []
+        for tp_group_idx in range(num_tensor_model_parallel_groups):
+            tp_group_base = tp_group_idx * tensor_model_parallel_size
+            for cp_idx in range(attn_cp_size):
+                for attn_tp_idx in range(attn_tp_size):
+                    ranks = [
+                        tp_group_base
+                        + dp_idx * attn_cp_size * attn_tp_size
+                        + cp_idx * attn_tp_size
+                        + attn_tp_idx
+                        for dp_idx in range(attn_dp_size)
+                    ]
+                    group_ranks.append(ranks)
+        _ATTN_DP = init_model_parallel_group(
+            group_ranks,
+            get_world_group().local_rank,
+            backend,
+            group_name="attention_dp",
+            recovered_rank=recovered_rank,
+            rank_offset=rank_offset,
+            max_world_size=max_world_size,
+        )
+
     global _ATTN_CP
     assert (
         _ATTN_CP is None
@@ -2792,6 +2824,11 @@ def destroy_model_parallel():
     if _ATTN_TP:
         _ATTN_TP.destroy()
     _ATTN_TP = None
+
+    global _ATTN_DP
+    if _ATTN_DP:
+        _ATTN_DP.destroy()
+    _ATTN_DP = None
 
     global _PDMUX_PREFILL_TP_GROUP
     if _PDMUX_PREFILL_TP_GROUP:  # type: ignore[union-attr]

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -13,6 +13,7 @@ import triton.language as tl
 from sglang.srt.distributed import (
     GroupCoordinator,
     get_attn_cp_group,
+    get_attn_dp_group,
     get_attn_tensor_model_parallel_rank,
     get_attn_tensor_model_parallel_world_size,
     get_attn_tp_group,
@@ -504,6 +505,14 @@ def _dp_gather_via_all_gather(
             )
         else:
             get_tp_group().all_gather_into_tensor(global_tokens, local_tokens)
+        return
+
+    # Replicated inputs have already been reduced inside each attention-TP
+    # group. Gather one full local batch directly across matching TP ranks in
+    # the attention-DP groups instead of emulating it with RS(attn-TP) +
+    # AG(full-TP). For TP32/DP2 this replaces RS32 + AG64 with one AG2.
+    if not is_partial and not use_world and get_attn_cp_group().world_size == 1:
+        get_attn_dp_group().all_gather_into_tensor(global_tokens, local_tokens)
         return
 
     if not is_partial:

--- a/test/registered/unit/distributed/test_parallel_state.py
+++ b/test/registered/unit/distributed/test_parallel_state.py
@@ -154,6 +154,58 @@ def test_parallel_group_construction_tp8_attn_cp2():
             parallel_state.destroy_model_parallel()
 
 
+def test_parallel_group_construction_tp8_attn_dp2():
+    world_size = 8
+
+    with (
+        patch.object(parallel_state, "_WORLD", None),
+        patch.object(parallel_state, "_TP", None),
+        patch.object(parallel_state, "_ATTN_CP", None),
+        patch.object(parallel_state, "_ATTN_DP", None),
+        patch.object(parallel_state, "_ATTN_TP", None),
+        patch.object(parallel_state, "_PP", None),
+        patch("torch.distributed.is_initialized", return_value=True),
+        patch("torch.distributed.get_world_size", return_value=world_size),
+        patch("torch.distributed.get_rank", return_value=0),
+        patch("torch.distributed.get_backend", return_value="nccl"),
+    ):
+        created_groups = {}
+
+        def mock_init_model_parallel_group(group_ranks, local_rank, backend, **kwargs):
+            created_groups[kwargs.get("group_name", "unknown")] = group_ranks
+            mock_group = Mock()
+            mock_group.device_group = Mock()
+            return mock_group
+
+        with (
+            patch.object(
+                parallel_state,
+                "init_model_parallel_group",
+                side_effect=mock_init_model_parallel_group,
+            ),
+            patch.object(parallel_state, "get_world_group") as mock_world_group,
+        ):
+            mock_world = Mock()
+            mock_world.device_group = Mock()
+            mock_world.local_rank = 0
+            mock_world_group.return_value = mock_world
+
+            parallel_state.initialize_model_parallel(
+                tensor_model_parallel_size=8,
+                pipeline_model_parallel_size=1,
+                attention_data_parallel_size=2,
+            )
+
+            assert created_groups["attention_dp"] == [
+                [0, 4],
+                [1, 5],
+                [2, 6],
+                [3, 7],
+            ]
+
+            parallel_state.destroy_model_parallel()
+
+
 def test_parallel_group_construction_tp8_moe_ep4_cp2():
     """
     Test parallel group construction for 8 GPU configuration with:


### PR DESCRIPTION
## Motivation

When deploying Kimi K3 on H100 GPU with EP64/TP32/DP2, the post-attention path performs AR -> RS -> AG before entering MoE. The RS is redundant because the attention outputs are already replicated within each attention-TP group.

## Modifications

- Add attention-DP process groups that connect matching attention-TP ranks.
- For replicated inputs with CP=1, replace RS32 + AG64 with a direct AG2 across the attention-DP group.
- Keep the existing path as the fallback for other configurations.
- Add a unit test for attention-DP group construction.

### Communication Flow

Consider a smaller configuration with four ranks, attention TP2, DP2, and CP1. `A` and `B` are the complete local token tensors from the two DP replicas; `A0/A1` and `B0/B1` are their TP shards.

**Before: RS2 + AG4**

```mermaid
flowchart LR
    A0["DP0 after attention AR<br/>r0 = A, r1 = A"]
    B0["DP1 after attention AR<br/>r2 = B, r3 = B"]

    A1["Keep one replica<br/>r0 = A, r1 = 0"]
    B1["Keep one replica<br/>r2 = B, r3 = 0"]

    A2["RS2<br/>r0 = A0, r1 = A1"]
    B2["RS2<br/>r2 = B0, r3 = B1"]

    G["AG4 across r0-r3"]
    O["Every rank<br/>[A0, A1, B0, B1] = [A, B]"]

    A0 --> A1 --> A2 --> G
    B0 --> B1 --> B2 --> G
    G --> O
```

The old path splits tensors that are already replicated, then gathers the shards back together across the full TP group.

**After: direct AG2**

```mermaid
flowchart LR
    A["After attention AR<br/>r0 = A, r1 = A<br/>r2 = B, r3 = B"]

    G0["attention-DP group for TP rank 0<br/>{r0 = A, r2 = B}<br/>AG2"]
    G1["attention-DP group for TP rank 1<br/>{r1 = A, r3 = B}<br/>AG2"]

    O0["r0, r2 = [A, B]"]
    O1["r1, r3 = [A, B]"]

    A --> G0 --> O0
    A --> G1 --> O1
```

Both paths produce the same `[A, B]` tensor on every rank. The new path avoids reduce-scatter and uses a smaller DP-only all-gather group.

## Accuracy Tests

This is a communication-only optimization and does not change model computation. But feel free to ask if that's necessary.

## Speed Tests and Profiling

On Kimi K3 with H100 EP64/TP32/DP2, this change improves performance by approximately 20%.

Torch profiler traces before and after the optimization will be added below to show the reduction in communication kernels.

**Before**

<img width="2962" height="658" alt="image" src="https://github.com/user-attachments/assets/f4636082-612e-4447-90a2-a33038ed8751" />
<img width="2518" height="1420" alt="image" src="https://github.com/user-attachments/assets/8f014d9d-61af-46ed-91dd-aae51a92a0ca" />


**After**

<img width="1481" height="352" alt="image" src="https://github.com/user-attachments/assets/f14816a3-6552-4ad6-90e2-2c45cd1c8d02" />
<img width="2908" height="1638" alt="image" src="https://github.com/user-attachments/assets/0e194bf0-a9d7-4f96-a11f-ab2306ce6eba" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30813936106](https://github.com/sgl-project/sglang/actions/runs/30813936106)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30813935863](https://github.com/sgl-project/sglang/actions/runs/30813935863)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->