### PR TITLE
[AMD] [Fix] Enable aiter hd256 FP8 prefill FMHA on gfx950

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2339,8 +2339,7 @@ class AiterAttnBackend(AttentionBackend):
                 window_size = (layer.sliding_window_size, -1)
 
             if (
-                get_bool_env_var("SGLANG_AITER_FMHA_FP8_ASM", "False")
-                and is_gfx95_supported()
+                is_gfx95_supported()
                 and forward_batch.forward_mode.is_extend()
                 and forward_batch.extend_prefix_lens_cpu is not None
                 and not any(forward_batch.extend_prefix_lens_cpu)
@@ -2361,9 +2360,9 @@ class AiterAttnBackend(AttentionBackend):
                     q_c.to(fp8_dtype),
                     k_c.to(fp8_dtype),
                     v_c.to(fp8_dtype),
-                    fp8_q_descale,
-                    k_descale,
-                    v_descale,
+                    fp8_q_descale.reshape(1),
+                    k_descale.reshape(1),
+                    v_descale.reshape(1),
                     self.qo_indptr[:bs0],
                     self.qo_indptr[:bs0],
                     self.forward_metadata.max_q_len,


### PR DESCRIPTION
## Motivation
Follow-up of https://github.com/sgl-project/sglang/pull/32046.

`AiterAttnBackend.forward_extend` has a fast path that routes head_dim-256 FP8 prefill attention to aiter's `flash_attn_varlen_fp8_pertensor_func`. It was gated behind `SGLANG_AITER_FMHA_FP8_ASM`, defaulting to `"False"` — because turning it on made every prefill die with:

```
RuntimeError: invalid argument for fmha_fwd
```

The error names the ck-tile kernel, so it reads like a missing ck-tile build. The actual trigger is a tensor *shape* two layers up.

**Root cause.** aiter only dispatches hd256 FP8 to the gfx950 ASM kernel (`fmha_fwd_hd256_fp8_causal_group_gfx950`) when `is_fmha_v3_fp8()` in `aiter/ops/mha.py` passes, and that predicate requires all three descales to be 1-D:

```python
ret = ret and (q_descale.shape == (1,) or q_descale.shape == (batch_size, nhead_k))
```

`BaseKVCacheMethod.create_weights` (`python/sglang/srt/layers/quantization/kv_cache.py`) creates `layer.k_scale` / `layer.v_scale` as **0-D** tensors (`torch.tensor(-1.0)`, `shape == ()`). Passing them straight through fails the check, so `can_impl_fmha_v3_fwd()` rejects hd256 and dispatch **silently** falls back to ck-tile `mha_varlen_fwd`. ck-tile's receipt-200 codegen filter emits FP8 group-mode instances only for hdim 128 and 192 — never 256 — so no instance matches, `aiter::mha_fwd` returns -1, and `TORCH_CHECK` raises.

Minimal reproduction, identical shapes, only the descale rank differs:

| descale | shape | result |
| --- | --- | --- |
| `torch.tensor([1.0])` | `(1,)` | OK — output `(2048, 16, 256)` |
| `torch.tensor(1.0)` | `()` | `RuntimeError: invalid argument for fmha_fwd` |

## Modifications

`python/sglang/srt/layers/attention/aiter_backend.py`, single call site:

- Reshape the q/k/v descales to 1-D (`.reshape(1)`) so `is_fmha_v3_fp8()` passes and the gfx950 ASM kernel is selected. These scales are always per-tensor scalars here, so the reshape is a pure view with no numerical effect.
- Drop the `SGLANG_AITER_FMHA_FP8_ASM` env-var gate. It only ever existed to keep a broken path switched off; the remaining conditions (`is_gfx95_supported()`, extend mode, no prefix, no SWA, no sinks, no logit cap, `qk_head_dim == v_head_dim == 256`, FP8 KV cache) already scope the path correctly.

Net diff is 4 insertions, 5 deletions.

Widening the ck-tile receipt-200 filter to hdim 256 also makes the crash go away, but only by providing a slow ck-tile fallback instead of the ASM kernel — that is not the fix, and it is not part of this PR.

## Accuracy Tests

Model `Qwen3.5-397B-A17B-MXFP4`, MI355 (gfx950), TP2, `--attention-backend aiter --kv-cache-dtype fp8_e4m3 --page-size 16`.

| | Accuracy | Invalid |
| --- | --- | --- |
| Before (path enabled) | n/a — server crashes on first prefill | n/a |
| After | **0.970** | 0.000 |

`python -m sglang.test.few_shot_gsm8k --num-questions 200 --parallel 100 --max-new-tokens 8192` (8192 output tokens because Qwen3.5 is a thinking model; a short cap depresses the score independently of this change).

Dispatch confirmed from the server log — the ASM kernel is actually the one running:

```
[aiter] LoadKernel: _ZN5aiter38fmha_fwd_hd256_fp8_causal_group_gfx950E
        hsaco: aiter/hsa/gfx950/fmha_v3_fwd/fwd_hd256_fp8_causal_group.co
```

Zero occurrences of `invalid argument for fmha_fwd` across server startup and the full eval.

## Benchmarking and Profiling

**No performance claim is made in this PR.** The prior state of this path was a hard crash, so there is no before/after throughput baseline to compare against — this is an enablement/correctness fix. A separate perf evaluation of the hd256 FP8 ASM kernel against the paged `mha_batch_prefill` path is left to follow-up work.

## Checklist

- [x] Format the code with `pre-commit run --all-files`
- [x] Add accuracy results (gsm8k above)
- [ ] Benchmark results — intentionally omitted, see above


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30824117809](https://github.com/sgl-project/sglang/actions/runs/30824117809)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30824535245](https://github.com/sgl-project/sglang/actions/runs/30824535245)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->