### PR TITLE
[AMD] Enable block-fp8 + quick INT4 all-reduce in MiniMax-M3 MI35x nightly Test

### DIFF
--- a/test/registered/amd/accuracy/mi35x/test_minimax_m3_tp4_eval_mi35x.py
+++ b/test/registered/amd/accuracy/mi35x/test_minimax_m3_tp4_eval_mi35x.py
@@ -72,12 +72,17 @@ class ModelConfig:
 
 
 MI35X_MINIMAX_M3_TP4_MODELS = [
+    # MXFP8 + aiter attn + fp8 KV, with the block-fp8 linear path (PR #32036)
+    # and custom/quick INT4 all-reduce (PR #32230) opted in. Both are opt-in
+    # via env: on gfx950 block convert is not automatic
+    # (mxfp8_block_convert_required() is False), and the M3 overrides otherwise
+    # force --disable-custom-all-reduce.
     ModelConfig(
         model_path="MiniMaxAI/MiniMax-M3-MXFP8",
         tp_size=4,
         accuracy_threshold=0.95,
         timeout=5400,
-        variant="TP4+MXFP8+aiterAttn+fp8KV",
+        variant="TP4+MXFP8+aiterAttn+fp8KV+blockFP8+quickAR",
         other_args=[
             "--quantization",
             "mxfp8",
@@ -102,6 +107,15 @@ MI35X_MINIMAX_M3_TP4_MODELS = [
             # router GEMM (torch.mm(bf16, bf16, out_dtype=float32)); force the
             # fp32 router path. Also gives more precise expert routing.
             "SGLANG_OPT_USE_BF16_ROUTER_GEMM": "0",
+            # Block-fp8 linear path (PR #32036): convert MXFP8 linear weights to
+            # block-fp8 [128,128] and run them through the tuned block-scale
+            # (bpreshuffle) GEMM on gfx950.
+            "SGLANG_FORCE_MXFP8_BLOCK_CONVERT": "1",
+            # Custom / quick all-reduce (PR #32230): keep custom all-reduce on so
+            # the INT4 quick-reduce path is used for the TP all-reduce.
+            "SGLANG_M3_ALLOW_CUSTOM_AR": "1",
+            "ROCM_QUICK_REDUCE_QUANTIZATION": "INT4",
+            "ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16": "1",
         },
     ),
 ]


### PR DESCRIPTION
## Motivation
The block-fp8 linear path (#32036) and custom/quick INT4 all-reduce (#32230) for MiniMax-M3 are now merged. This updates the MI35x TP4 nightly accuracy test to serve M3 with both opted in, so the nightly tracks the config we run in production.
## Modifications
`test/registered/amd/accuracy/mi35x/test_minimax_m3_tp4_eval_mi35x.py` — add to the MiniMax-M3-MXFP8 TP4 config's env:
- `SGLANG_FORCE_MXFP8_BLOCK_CONVERT=1` — block-fp8 linear path (#32036); not
  automatic on gfx950.
- `SGLANG_M3_ALLOW_CUSTOM_AR=1`, `ROCM_QUICK_REDUCE_QUANTIZATION=INT4`,
  `ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=1` — custom/quick INT4 all-reduce (#32230);
  the M3 overrides otherwise force `--disable-custom-all-reduce`.
Variant → `TP4+MXFP8+aiterAttn+fp8KV+blockFP8+quickAR`. Test-config only, no runtime code changed.
## Accuracy Tests
MiniMax-M3 MI35x TP4 nightly (GSM8K chat+thinking, TP4, threshold 0.95) triggered on this branch:
- ROCm 7.0: https://github.com/sgl-project/sglang/actions/runs/30827125199
- ROCm 7.2: https://github.com/sgl-project/sglang/actions/runs/30827127221
## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30826911794](https://github.com/sgl-project/sglang/actions/runs/30826911794)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30826911180](https://github.com/sgl-project/sglang/actions/runs/30826911180)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->