### PR TITLE
[Scheduler] Gate SWA eviction on accumulated tokens

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -3231,14 +3231,23 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
             eviction_interval = max(1, envs.SGLANG_SWA_EVICTION_INTERVAL.get())
-            swa_maintenance_step = (self.forward_iter or 0) % eviction_interval == 0
             self.token_to_kv_pool_allocator.free_group_begin()
             for idx, req in enumerate(self.reqs):
                 if self.forward_mode.is_decode():
                     # We set evict_swa condition here with two reasons:
                     # 1. In overlap scheduler, we cannot evict swa when req.decode_batch_idx == 0 since the prev extend batch is still running.
-                    # 2. Evict swa every eviction_interval iterations to reduce the overhead.
-                    if swa_maintenance_step and req.decode_batch_idx >= 1:
+                    # 2. Evict only once >= eviction_interval tokens have slid
+                    # out of the window, amortizing eviction work while keeping
+                    # each request's overshoot within the interval the pool
+                    # budget reserves. Gating on accumulated tokens (rather
+                    # than an iteration-counter phase) cannot starve because
+                    # seqlen progress is monotonic per KV handle.
+                    if (
+                        req.decode_batch_idx >= 1
+                        and req.kv is not None
+                        and req.seqlen - 1 - sliding_window_size
+                        >= req.kv.swa_evicted_seqlen + eviction_interval
+                    ):
                         self._evict_swa(req, req.seqlen - 1)
 
                     # DSV4-NPU only (no-op elsewhere): the small paged compress-state


### PR DESCRIPTION
## Motivation

SWA eviction currently runs for every decode request on the same scheduler iterations. For large batches, that synchronizes maintenance work and creates periodic latency spikes.

A first attempt to stagger the work assigned each request a phase derived from its request-pool slot. That phase used `decode_batch_idx`, which resets when a request retracts and re-enters extend. Requests with short decode runs could repeatedly reset before reaching their assigned phase and skip SWA eviction indefinitely.

## Modifications

Gate eviction on accumulated out-of-window tokens instead of an iteration-counter phase:

```python
req.seqlen - 1 - sliding_window_size >= (
    req.kv.swa_evicted_seqlen + eviction_interval
)
```

`seqlen` progress relative to `swa_evicted_seqlen` is monotonic per KV handle, so eviction cannot starve across retract/extend cycles. Each request evicts after one configured interval of additional tokens has moved outside the window, naturally distributing work while keeping overshoot bounded by the interval reserved by pool sizing. The existing overlap-scheduler guard remains unchanged.

## Accuracy Tests

Not applicable; this only changes when existing SWA eviction maintenance runs.

## Speed Tests and Profiling

Not benchmarked. The configured per-request eviction interval is unchanged, while work is no longer synchronized on the global scheduler clock.

## Tests

- Starvation/overshoot regression simulation for repeated decode-counter resets
- Ruff selected checks
- Black
- codespell
- compileall

The focused SWA pytest requires the SGLang/Torch test environment and will run in CI.

## Checklist

- [x] Format and lint checks passed.
- [x] No documentation changes are needed.
- [x] The change follows the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

<!-- pr-states:end -->
