### PR TITLE
[Kimi K3] Use runtime config accessors and update linear attention tests

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -48,7 +48,7 @@ from sglang.srt.multimodal.mm_utils import (
     materialize_multimodal_features,
     run_dp_sharded_mrope_vision_model,
 )
-from sglang.srt.runtime_context import get_mm, get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_mm, get_parallel, get_server_args
 from sglang.srt.utils import add_prefix, is_cuda, is_npu
 
 logger = logging.getLogger(__name__)
@@ -440,7 +440,9 @@ class MoonViT3dEncoder(nn.Module):
         self.video_attn_type = video_attn_type
         qkv_hs = block_cfg.get("qkv_hidden_size") or block_cfg["hidden_dim"]
         self.rope_2d = Rope2DPosEmbRepeated(qkv_hs // block_cfg["num_heads"], 512, 512)
-        self.use_fused_rope = _is_cuda and get_server_args().rl_on_policy_target is None
+        self.use_fused_rope = (
+            _is_cuda and get_exec().deterministic.rl_on_policy_target is None
+        )
         self.blocks = nn.ModuleList(
             [
                 MoonViTEncoderLayer(

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -105,7 +105,7 @@ from sglang.srt.models.kimi_k3_vl import (
 from sglang.srt.models.transformers import maybe_prefix
 from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.multimodal.mm_utils import materialize_multimodal_features
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
 from sglang.srt.utils import is_blackwell_supported, is_hip, make_layers
 from sglang.srt.utils.common import (
     BumpAllocator,
@@ -790,7 +790,7 @@ class KimiK3MoE(nn.Module):
         # if that ever stops holding rather than silently dropping the remap.
         if not precomputed_topk_postprocess_is_noop(cfg):
             return False
-        if get_server_args().enable_deterministic_inference:
+        if get_exec().deterministic.enable_deterministic_inference:
             return False
         try:
             from sglang.kernels.ops.moe import moe_front
@@ -2639,7 +2639,7 @@ class KimiK3LinearForCausalLM(nn.Module):
                 config.hidden_size,
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "lm_head"),
-                use_attn_tp_group=get_server_args().enable_dp_lm_head,
+                use_attn_tp_group=get_parallel().enable_dp_lm_head,
             )
         else:
             self.lm_head = PPMissingLayer()

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -978,7 +978,7 @@ def commit_mamba_states_after_verify(
         mamba_track_indices = batch.mamba_track_indices
         mamba_steps_to_track = None
         if mamba_track_indices is not None:
-            ti = get_server_args().mamba_track_interval
+            ti = get_exec().mamba.mamba_track_interval
             seq_pre = batch.seq_lens
             seq_post = batch.seq_lens + accept_lens
             to_track_mask = seq_pre // ti != seq_post // ti

--- a/test/registered/unit/layers/attention/test_linear_attn_config.py
+++ b/test/registered/unit/layers/attention/test_linear_attn_config.py
@@ -21,18 +21,7 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 class TestLinearAttnConfig(CustomTestCase):
     def setUp(self):
-        saved = (
-            linear_utils.LINEAR_ATTN_DECODE_BACKEND,
-            linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
-        )
-
-        def restore():
-            (
-                linear_utils.LINEAR_ATTN_DECODE_BACKEND,
-                linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
-            ) = saved
-
-        self.addCleanup(restore)
+        self.addCleanup(linear_utils._BACKENDS.update, linear_utils._BACKENDS.copy())
 
     def _init(self, prefill_default=None, **fields):
         args = ServerArgs(model_path="dummy")
@@ -40,8 +29,8 @@ class TestLinearAttnConfig(CustomTestCase):
             setattr(args, key, value)
         initialize_linear_attn_config(args, prefill_default)
         return (
-            linear_utils.LINEAR_ATTN_PREFILL_BACKEND,
-            linear_utils.LINEAR_ATTN_DECODE_BACKEND,
+            linear_utils.get_linear_attn_prefill_backend(),
+            linear_utils.get_linear_attn_decode_backend(),
         )
 
     def test_default_applies_when_the_flag_is_unset(self):


### PR DESCRIPTION
## Summary

- read resolved runtime configuration through the namespace accessors in the Kimi and speculative paths
- update the linear-attention config test for the `_BACKENDS` registry

Stacked on #32541. The BCG startup-cycle fix is already in main through #33371 and is intentionally not duplicated here. The generic partition-loader regression is handled separately in #33410.

## Validation

- changed-file pre-commit
- `py_compile` for all changed Python files
- runtime-context direct-read AST ratchet scan
- linear-attention backend smoke

Registered unit tests will run in CI; the local workspace Python does not include torch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30832960769](https://github.com/sgl-project/sglang/actions/runs/30832960769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30832960665](https://github.com/sgl-project/sglang/actions/runs/30832960665)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->