### PR TITLE
[Scheduler] Support multimodal streaming sessions

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -137,6 +137,9 @@ class SessionParams(msgspec.Struct, kw_only=True, array_like=True):
     # from the accumulated context so the new turn sees only the original input.
     # Not supported in streaming sessions.
     drop_previous_output: Optional[bool] = None
+    # Streaming sessions only: exclude a sampled-but-unforwarded stop token
+    # from the next turn's committed context.
+    drop_trailing_stop_token: Optional[bool] = None
 
 
 # Type definitions for multimodal input data

--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -550,13 +550,19 @@ def _acknowledge_deferred_cuda_ipc_cache_hits(
     the equivalent single acknowledgement.  This preserves the fixed-pool
     lifecycle without reintroducing an unnecessary GPU-to-GPU copy.
     """
+    deferred_items = [
+        item for item in items if item.can_defer_cuda_ipc_feature_reconstruction()
+    ]
+    if not deferred_items:
+        return
+
     parallel = get_parallel()
     if parallel.attn_tp_rank != 0:
         return
     # The pool's recycler counts the whole TP group, so the acknowledgement must
     # match that count even when an attention subgroup is smaller.
     consumer_count = max(parallel.tp_size, 1)
-    for item in items:
+    for item in deferred_items:
         item.acknowledge_deferred_cuda_ipc_feature(consumer_count)
 
 
@@ -571,11 +577,14 @@ def _get_chunked_embedding_full(
 ) -> Tuple[Optional[torch.Tensor], torch.Tensor]:
     """
     Fallback: encode all items at once, cache combined result, extract chunk.
-    Used for non-bundled items or EVS results.
+    Used for non-bundled items or EVS results. Noncacheable items bypass the
+    process-wide static cache; a caller may still retain their result for the
+    current request or retry.
     """
+    cacheable = all(item.embedding_cacheable for item in embedding_items_per_req)
     item_hashes = [item.hash for item in embedding_items_per_req]
     embedding_items_hash = MultiModalStaticCache.combine_hashes(item_hashes)
-    embedding_per_req = embedding_cache.get(item_hashes)
+    embedding_per_req = embedding_cache.get(item_hashes) if cacheable else None
 
     if embedding_per_req is None:
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
@@ -590,7 +599,8 @@ def _get_chunked_embedding_full(
             if isinstance(embedding, torch.Tensor)
             else embedding
         )
-        embedding_cache.set(embedding_items_hash, embedding_per_req)
+        if cacheable:
+            embedding_cache.set(embedding_items_hash, embedding_per_req)
     else:
         _acknowledge_deferred_cuda_ipc_cache_hits(embedding_items_per_req)
 
@@ -633,16 +643,17 @@ def _batch_encode_per_image_misses(
     data_embedding_func: DataEmbeddingFunc,
     per_image_requests: List[PerImageRequestInfo],
     device: torch.device,
-) -> Dict[int, torch.Tensor]:
+) -> Dict[Tuple[bool, int], torch.Tensor]:
     """
     Collect cache misses across ALL per-image requests, deduplicate by hash,
     encode in a single ViT call, and populate the cache.
 
     Returns:
-        hash_to_embedding: mapping from item.hash to its full embedding tensor.
+        embedding_by_key: mapping from a cache key (or item identity for a
+        stateful item) to its full embedding tensor.
     """
-    unique_misses: Dict[int, Tuple[MultimodalDataItem, int]] = {}
-    hash_to_embedding: Dict[int, torch.Tensor] = {}
+    unique_misses: Dict[Tuple[bool, int], Tuple[MultimodalDataItem, int]] = {}
+    embedding_by_key: Dict[Tuple[bool, int], torch.Tensor] = {}
 
     # Phase 1a: find overlapping items per request and collect cache misses
     for req_info in per_image_requests:
@@ -658,20 +669,26 @@ def _batch_encode_per_image_misses(
         req_info.overlapping = overlapping
 
         for _idx, item, start, end in overlapping:
-            if item.hash in hash_to_embedding:
+            key = _embedding_lookup_key(item)
+            if key in embedding_by_key:
                 continue
-            cached = embedding_cache.get_single(item.hash)
+            cached = (
+                embedding_cache.get_single(item.hash)
+                if item.embedding_cacheable
+                else None
+            )
             if cached is not None:
-                hash_to_embedding[item.hash] = cached.embedding
-            elif item.hash not in unique_misses:
+                embedding_by_key[key] = cached.embedding
+                _acknowledge_deferred_cuda_ipc_cache_hits([item])
+            elif key not in unique_misses:
                 token_count = end - start + 1
-                unique_misses[item.hash] = (item, token_count)
+                unique_misses[key] = (item, token_count)
 
     # Phase 1b: single ViT call for all unique cache misses
     if unique_misses:
-        ordered_hashes = list(unique_misses.keys())
-        miss_items = [unique_misses[h][0] for h in ordered_hashes]
-        token_counts = [unique_misses[h][1] for h in ordered_hashes]
+        ordered_keys = list(unique_misses.keys())
+        miss_items = [unique_misses[key][0] for key in ordered_keys]
+        token_counts = [unique_misses[key][1] for key in ordered_keys]
 
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(miss_items, device)
@@ -694,12 +711,17 @@ def _batch_encode_per_image_misses(
                 -1, all_miss_embedding.shape[-1]
             )
             split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
-        for h, emb in zip(ordered_hashes, split_embeddings):
-            embedding_cache.set(h, EmbeddingResult(embedding=emb))
+        for key, item, emb in zip(ordered_keys, miss_items, split_embeddings):
+            if item.embedding_cacheable:
+                embedding_cache.set(item.hash, EmbeddingResult(embedding=emb))
             # Keep a local ref (no extra GPU memory) so assembly never fails due to LRU eviction.
-            hash_to_embedding[h] = emb
+            embedding_by_key[key] = emb
 
-    return hash_to_embedding
+    return embedding_by_key
+
+
+def _embedding_lookup_key(item: MultimodalDataItem) -> Tuple[bool, int]:
+    return (True, item.hash) if item.embedding_cacheable else (False, id(item))
 
 
 def _get_chunked_embedding_by_item(
@@ -711,7 +733,8 @@ def _get_chunked_embedding_by_item(
     device: torch.device,
 ) -> Optional[torch.Tensor]:
     """
-    Per-image chunk-aware encoding for one request.
+    Per-item chunk-aware encoding: only encode items overlapping with the
+    current chunk, caching each cacheable item individually.
     Items must already be split per-image (each item has exactly one offset).
     """
     chunk_start = extend_prefix_len
@@ -733,7 +756,8 @@ def _get_chunked_embedding_by_item(
     cached_embeddings = {}
     miss_items = []
     for idx, item, start, end in overlapping:
-        cached = embedding_cache.get_single(item.hash)
+        cacheable = item.embedding_cacheable
+        cached = embedding_cache.get_single(item.hash) if cacheable else None
         if cached is not None:
             cached_embeddings[idx] = cached.embedding
             _acknowledge_deferred_cuda_ipc_cache_hits([item])
@@ -767,7 +791,9 @@ def _get_chunked_embedding_by_item(
 
         for (idx, item, _, _), emb in zip(miss_items, split_embeddings):
             cached_embeddings[idx] = emb
-            embedding_cache.set(item.hash, EmbeddingResult(embedding=emb))
+            if item.embedding_cacheable:
+                emb_result = EmbeddingResult(embedding=emb)
+                embedding_cache.set(item.hash, emb_result)
 
     chunk_slices = []
     for idx, _, start, end in overlapping:
@@ -783,7 +809,7 @@ def _get_chunked_embedding_by_item(
 
 def _assemble_per_image_chunk(
     overlapping: List[Tuple[int, MultimodalDataItem, int, int]],
-    hash_to_embedding: Dict[int, torch.Tensor],
+    embedding_by_key: Dict[Tuple[bool, int], torch.Tensor],
     extend_prefix_len: int,
     extend_seq_len: int,
 ) -> Optional[torch.Tensor]:
@@ -799,7 +825,7 @@ def _assemble_per_image_chunk(
 
     chunk_slices = []
     for _idx, item, start, end in overlapping:
-        emb = hash_to_embedding[item.hash]  # shape: (end - start + 1, hidden)
+        emb = embedding_by_key[_embedding_lookup_key(item)]
         overlap_start = max(start, chunk_start)
         overlap_end = min(end, chunk_end - 1)  # inclusive
         local_start = overlap_start - start
@@ -877,9 +903,9 @@ def _get_chunked_prefill_embedding(
             full_path_requests.append(req_info)
 
     # Phase 1: batch encode all per-image cache misses in ONE ViT call
-    hash_to_embedding: Dict[int, torch.Tensor] = {}
+    embedding_by_key: Dict[Tuple[bool, int], torch.Tensor] = {}
     if per_image_requests:
-        hash_to_embedding = _batch_encode_per_image_misses(
+        embedding_by_key = _batch_encode_per_image_misses(
             data_embedding_func, per_image_requests, device
         )
 
@@ -887,7 +913,7 @@ def _get_chunked_prefill_embedding(
     for req_info in per_image_requests:
         chunk = _assemble_per_image_chunk(
             req_info.overlapping,
-            hash_to_embedding,
+            embedding_by_key,
             req_info.extend_prefix_len,
             req_info.extend_seq_len,
         )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -79,10 +79,7 @@ from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
 )
-from sglang.srt.mem_cache.allocation import (
-    alloc_for_decode,
-    alloc_for_extend,
-)
+from sglang.srt.mem_cache.allocation import alloc_for_decode, alloc_for_extend
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_reserve_per_decode
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
@@ -265,6 +262,20 @@ class FINISH_ABORT(BaseFinishReason):
         }
 
 
+class StreamingSessionAbortPolicy(Enum):
+    """How a streaming session handles an aborted active request.
+
+    ``RELEASE_SESSION`` discards the in-flight request boundary and releases
+    its streaming-cache slot, leaving any earlier committed boundary available
+    for a later re-prefill. ``COMMIT_FORWARDED`` retains tokens already sent to
+    the client while dropping the sampled-but-unforwarded tail token, then
+    saves that retained prefix as the next session boundary.
+    """
+
+    RELEASE_SESSION = auto()
+    COMMIT_FORWARDED = auto()
+
+
 class Modality(Enum):
     IMAGE = auto()
     VIDEO = auto()
@@ -296,7 +307,9 @@ class MultimodalDataItem:
     One MultimodalDataItem represents a single multimodal input (one image, one video, or one audio).
     For example, if there are 3 images and 1 audio, there will be 4 MultimodalDataItems.
 
-    Each item has its own hash and pad_value, enabling per-image RadixAttention caching.
+    Each item has its own hash and pad_value, enabling per-item embedding
+    caching. Stateful encoders set ``embedding_cacheable=False`` because their
+    output depends on stream history in addition to the hashed raw feature.
 
     We put the common fields first and the model-specific fields in model_specific_data.
     """
@@ -316,6 +329,11 @@ class MultimodalDataItem:
 
     # Model-specific data stored in a dictionary
     model_specific_data: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+    # Stateful encoders must run for every item even when its raw feature hash
+    # matches an earlier item. Stateless image/audio inputs keep the cacheable
+    # default.
+    embedding_cacheable: bool = True
 
     def __getattr__(self, name: str):
         if (
@@ -919,6 +937,14 @@ class Req(ReqDllmMixin):
         self.finished_reason: Optional[BaseFinishReason] = None
         # finished position (in output_ids), used when checking stop conditions with speculative decoding
         self.finished_len = None
+        # Streaming sessions: drop the trailing stop token from the committed
+        # sequence on finish (set from SessionParams in Session.create_req).
+        self.drop_trailing_stop_token = False
+        self.streaming_abort_policy = StreamingSessionAbortPolicy.RELEASE_SESSION
+        # A custom decode row replaces a one-token prefill. Scheduling and
+        # completion can be consumed in different overlap iterations.
+        self.custom_decode_needs_prefill_schedule = False
+        self.custom_decode_needs_prefill_completion = False
         # Whether this request has finished output
         self.finished_output = None
         # If we want to abort the request in the middle of the event loop,
@@ -1618,6 +1644,8 @@ class Req(ReqDllmMixin):
         self.dllm_initialized = False
         self.is_retracted = True
         self.retracted_stain = True
+        self.custom_decode_needs_prefill_schedule = False
+        self.custom_decode_needs_prefill_completion = False
         self.input_token_logprobs = None
         self.temp_input_top_logprobs_val = None
         self.temp_input_top_logprobs_idx = None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -58,6 +58,7 @@ from sglang.srt.mem_cache.multi_ended_allocator import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey, TreeNode
 from sglang.srt.server_args import ServerArgs
+from sglang.srt.session.streaming_session import get_streaming_session
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
@@ -462,6 +463,11 @@ class PrefillAdder:
     ):
         self.page_size = page_size
         self.tree_cache = tree_cache
+        self._session_state_cache = get_streaming_session(tree_cache)
+        self._streaming_lifecycle_enabled = (
+            self._session_state_cache is not None
+            and self._session_state_cache.has_attached_lifecycle
+        )
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.running_batch = running_batch
         self.new_token_ratio = new_token_ratio
@@ -715,13 +721,35 @@ class PrefillAdder:
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
 
+    def _next_prefill_chunk_end(self, req: Req, start: int, end: int) -> int:
+        if req.session is None or not req.session.streaming:
+            return end
+        chunk_end = self._session_state_cache.next_prefill_chunk_end(req, start, end)
+        if not start < chunk_end <= end:
+            raise RuntimeError(
+                "Streaming lifecycle returned an invalid prefill boundary: "
+                f"start={start} chunk_end={chunk_end} end={end}"
+            )
+        if chunk_end < end and self.rem_chunk_tokens is None:
+            raise RuntimeError(
+                "Streaming lifecycle prefill boundaries require chunked prefill"
+            )
+        if chunk_end < end and chunk_end % self.page_size != 0:
+            raise RuntimeError(
+                "Streaming lifecycle prefill boundary is not page-aligned: "
+                f"boundary={chunk_end} page_size={self.page_size}"
+            )
+        return chunk_end
+
     def budget_state(self):
         no_token = self.rem_total_tokens <= 0 or self.cur_rem_tokens <= 0
         if not no_token and self.is_hybrid_swa:
             no_token = self.rem_swa_tokens <= 0
-        # Gate new mamba slots separately: rem_total_tokens' full_evictable can't
-        # cover a mamba slot, which needs mamba-recoverable bytes (see __init__).
-        if not no_token and self.rem_mamba_slots is not None:
+        if (
+            not no_token
+            and self.rem_mamba_slots is not None
+            and not self._streaming_lifecycle_enabled
+        ):
             no_token = self.rem_mamba_slots <= 0
         if no_token:
             return AddReqResult.NO_TOKEN
@@ -737,6 +765,13 @@ class PrefillAdder:
                 return AddReqResult.OTHER
 
         return AddReqResult.CONTINUE
+
+    def _has_mamba_budget_for_req(self, req: Req) -> bool:
+        return (
+            self.rem_mamba_slots is None
+            or req.mamba_pool_idx is not None
+            or self.rem_mamba_slots >= 1
+        )
 
     def _update_prefill_budget(
         self,
@@ -899,6 +934,13 @@ class PrefillAdder:
         )
         truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
+        if self._streaming_lifecycle_enabled:
+            chunk_end = self._next_prefill_chunk_end(
+                req, len(req.prefix_indices), len(req.full_untruncated_fill_ids)
+            )
+            if chunk_end < len(req.full_untruncated_fill_ids):
+                new_len = min(new_len, chunk_end - len(req.prefix_indices))
+                truncated = True
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
@@ -1059,6 +1101,10 @@ class PrefillAdder:
     def add_one_req(
         self, req: Req, has_chunked_req: bool, truncation_align_size: Optional[int]
     ):
+        if self._streaming_lifecycle_enabled and not self._has_mamba_budget_for_req(
+            req
+        ):
+            return AddReqResult.NO_TOKEN
         # TODO support cp with multiple requests
         # Enabling context parallelism currently presents precision issues;
         # therefore, the prefill-batch setting is temporarily set to 1.
@@ -1182,6 +1228,18 @@ class PrefillAdder:
                 # - if the can_run_list is empty, always accept the first prefill request
                 return AddReqResult.OTHER
 
+            lifecycle_end = len(req.full_untruncated_fill_ids)
+            if self._streaming_lifecycle_enabled and self.dllm_config is None:
+                lifecycle_end = self._next_prefill_chunk_end(
+                    req, prefix_len, lifecycle_end
+                )
+                if lifecycle_end < len(req.full_untruncated_fill_ids):
+                    if truncation_align_size is not None:
+                        raise RuntimeError(
+                            "Streaming lifecycle prefill boundaries do not support "
+                            "deterministic truncation alignment"
+                        )
+
             if self.dllm_config is not None:
                 if self.rem_dllm_tokens <= 0:
                     return AddReqResult.OTHER
@@ -1192,7 +1250,9 @@ class PrefillAdder:
 
                 self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
-            elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
+            elif lifecycle_end == len(req.full_untruncated_fill_ids) and (
+                chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit
+            ):
                 # Non-chunked prefill — the whole sequence is committed this iter.
                 req.set_extend_range(
                     len(req.prefix_indices), len(req.full_untruncated_fill_ids)
@@ -1211,8 +1271,12 @@ class PrefillAdder:
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
                 )
             else:
+                if self._streaming_lifecycle_enabled and has_chunked_req:
+                    return AddReqResult.OTHER
                 # Make sure at least one page is available
                 trunc_len = chunk_tokens_limit // self.page_size * self.page_size
+                if lifecycle_end < len(req.full_untruncated_fill_ids):
+                    trunc_len = min(trunc_len, lifecycle_end - prefix_len)
 
                 if trunc_len <= 0:
                     return AddReqResult.OTHER
@@ -1251,6 +1315,8 @@ class PrefillAdder:
                     req.retracted_stain,
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
                 )
+                if lifecycle_end < len(req.full_untruncated_fill_ids):
+                    return AddReqResult.OTHER
 
         return self.budget_state()
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -235,9 +235,7 @@ from sglang.srt.managers.scheduler_components.pool_stats_observer import (
 from sglang.srt.managers.scheduler_components.profiler_manager import (
     SchedulerProfilerManager,
 )
-from sglang.srt.managers.scheduler_components.recv_skipper import (
-    SchedulerRecvSkipper,
-)
+from sglang.srt.managers.scheduler_components.recv_skipper import SchedulerRecvSkipper
 from sglang.srt.managers.scheduler_components.request_receiver import (
     SchedulerRequestReceiver,
 )
@@ -246,6 +244,11 @@ from sglang.srt.managers.scheduler_components.weight_updater import (
 )
 from sglang.srt.managers.scheduler_input_blocker import SchedulerInputBlocker
 from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
+from sglang.srt.managers.scheduler_request_admission_mixin import (
+    QueueAdmissionResult,
+    RejectedRequestCleanup,
+    SchedulerRequestAdmissionMixin,
+)
 from sglang.srt.managers.utils import (
     EmbeddingBatchResult,
     GenerationBatchResult,
@@ -362,6 +365,7 @@ class Scheduler(
     SchedulerMultiplexMixin,
     SchedulerPPMixin,
     SchedulerDllmMixin,
+    SchedulerRequestAdmissionMixin,
     SchedulerMlxOverlapMixin,
 ):
     """A scheduler that manages a tensor parallel GPU worker."""
@@ -868,9 +872,7 @@ class Scheduler(
             self.external_corpus_manager = None
             return
 
-        from sglang.srt.speculative.draft_worker_common import (
-            draft_server_args_copy,
-        )
+        from sglang.srt.speculative.draft_worker_common import draft_server_args_copy
 
         # Launch a draft worker for speculative decoding
         draft_server_args = draft_server_args_copy(
@@ -2163,6 +2165,30 @@ class Scheduler(
             return MultimodalInputs.from_processor_output(mm_inputs_dict)
 
     @staticmethod
+    def _set_padded_mm_input_ids(req, padded_input_ids, prefix_len: int) -> None:
+        """Replace an MM suffix while preserving a carried streaming fill cache."""
+        padded_input_ids = array("q", padded_input_ids)
+        if not 0 <= prefix_len <= min(len(req.origin_input_ids), len(padded_input_ids)):
+            raise ValueError(
+                f"Invalid multimodal padding prefix: {prefix_len=} "
+                f"old_len={len(req.origin_input_ids)} new_len={len(padded_input_ids)}"
+            )
+        if padded_input_ids[:prefix_len] != req.origin_input_ids[:prefix_len]:
+            raise ValueError("Multimodal padding changed tokens before the MM suffix")
+        fill_ids = req.full_untruncated_fill_ids
+        if fill_ids:
+            if len(fill_ids) == len(req.origin_input_ids):
+                # Streaming append can carry the completed prefix without a
+                # rebuild. Keep that cache coherent when MM padding rewrites
+                # or expands the newly appended raw placeholder tokens.
+                fill_ids[prefix_len:] = padded_input_ids[prefix_len:]
+            else:
+                # A non-empty, differently sized cache cannot be updated by
+                # position. Force _refresh_fill_ids() to rebuild it.
+                req.full_untruncated_fill_ids = array("q")
+        req.origin_input_ids = padded_input_ids
+
+    @staticmethod
     def _try_apply_padded_mm_input_ids(recv_req, req, image_inputs) -> bool:
         """setup origin_input_ids with trying to reuse existing MultimodalInputs.padded_input_ids first,
         if absent, call pad_input_ids_func"""
@@ -2178,11 +2204,16 @@ class Scheduler(
         if prefix_len < 0:
             return False
 
-        padded_input_ids = array("q", padded_input_ids)
         if prefix_len == 0:
-            req.origin_input_ids = padded_input_ids
+            new_input_ids = padded_input_ids
         else:
-            req.origin_input_ids = req.origin_input_ids[:prefix_len] + padded_input_ids
+            new_input_ids = req.origin_input_ids[:prefix_len] + array(
+                "q", padded_input_ids
+            )
+        if req.session is not None and req.session.streaming:
+            Scheduler._set_padded_mm_input_ids(req, new_input_ids, prefix_len)
+        else:
+            req.origin_input_ids = array("q", new_input_ids)
         return True
 
     def _maybe_compute_mrope_positions(self, req) -> None:
@@ -2451,9 +2482,17 @@ class Scheduler(
                 not self._try_apply_padded_mm_input_ids(recv_req, req, image_inputs)
                 and self.pad_input_ids_func
             ):
-                req.origin_input_ids = array(
-                    "q", self.pad_input_ids_func(req.origin_input_ids, image_inputs)
+                padded_input_ids = self.pad_input_ids_func(
+                    req.origin_input_ids, image_inputs
                 )
+                if req.session is not None and req.session.streaming:
+                    recv_input_len = (
+                        len(recv_req.input_ids) if recv_req.input_ids is not None else 0
+                    )
+                    prefix_len = max(0, len(req.origin_input_ids) - recv_input_len)
+                    self._set_padded_mm_input_ids(req, padded_input_ids, prefix_len)
+                else:
+                    req.origin_input_ids = array("q", padded_input_ids)
             req.extend_image_inputs(image_inputs)
             self._maybe_compute_mrope_positions(req)
 
@@ -2575,6 +2614,12 @@ class Scheduler(
         if self.disaggregation_mode == DisaggregationMode.NULL:
             if self._abort_on_queued_limit(req):
                 return
+        if (
+            self._admit_request_to_queue(req, is_retracted=is_retracted)
+            is QueueAdmissionResult.REJECT
+        ):
+            return
+        if self.disaggregation_mode == DisaggregationMode.NULL:
             self._prefetch_kvcache(req)
             self.waiting_queue.append(req)
             req.time_stats.set_wait_queue_entry_time()
@@ -2613,6 +2658,7 @@ class Scheduler(
                 },
                 rid=req.rid,
             )
+            self._cleanup_rejected_queued_request(req)
             req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
             self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
             return False
@@ -2653,6 +2699,7 @@ class Scheduler(
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
 
+        self._cleanup_rejected_queued_request(req_to_abort)
         self.ipc_channels.send_to_tokenizer.send_output(
             AbortReq(
                 finished_reason={
@@ -2679,6 +2726,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     # Release prefetch events associated with the request
                     self.tree_cache.release_aborted_request(req.rid)
+                self._cleanup_rejected_queued_request(req)
                 self.ipc_channels.send_to_tokenizer.send_output(
                     AbortReq(
                         finished_reason={
@@ -2954,7 +3002,14 @@ class Scheduler(
             if running_batch.is_empty():
                 running_batch.batch_is_full = False
 
-        if self.dllm_config is not None:
+        running_batch, defer_prefill = self._merge_custom_decode_admission(
+            running_batch
+        )
+        if defer_prefill:
+            # A custom decode row with no sampled output cannot safely merge
+            # with a newly prefilling row that may activate penalty state.
+            new_batch = None
+        elif self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
         else:
             prefill_plan = self.get_new_batch_prefill(running_batch)
@@ -3163,11 +3218,16 @@ class Scheduler(
                 if loaded_tokens > 0:
                     req.storage_hit_length = loaded_tokens
 
+            admission_context = self._begin_request_prefill_admission(req)
             req.init_next_round_input(self.tree_cache)
             res = adder.add_one_req(
                 req,
                 has_chunked_req=(self.chunked_req is not None),
                 truncation_align_size=self.truncation_align_size,
+            )
+            admitted = bool(adder.can_run_list and req is adder.can_run_list[-1])
+            self._finish_request_prefill_admission(
+                req, admission_context, admitted=admitted
             )
 
             if self.enable_lora:
@@ -3186,8 +3246,7 @@ class Scheduler(
                 # Only free if the slot was freshly allocated in this batch (not
                 # pre-existing from a session). Session-held slots have their own
                 # lifecycle and freeing them here causes double-free.
-                added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
-                if not added:
+                if not admitted:
                     # init_next_round_input() may stage deferred Mamba COW/clear
                     # metadata before add_one_req() rejects the request.
                     req.mamba_cow_src_index = None
@@ -4269,9 +4328,12 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
-            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            cleanup = self._cleanup_rejected_queued_request(req)
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
-            if self.disaggregation_mode == DisaggregationMode.DECODE:
+            if (
+                self.disaggregation_mode == DisaggregationMode.DECODE
+                and cleanup is RejectedRequestCleanup.NOT_HANDLED
+            ):
                 release_kv_cache(req, self.tree_cache)
             # For disaggregation prefill mode, free the metadata buffer index
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -4291,8 +4353,10 @@ class Scheduler(
             if (
                 req.mamba_pool_idx is not None
                 and self.disaggregation_mode != DisaggregationMode.DECODE
+                and cleanup is RejectedRequestCleanup.NOT_HANDLED
             ):
                 release_kv_cache(req, self.tree_cache, is_insert=False)
+            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
             logger.debug(f"Abort queued request. {req.rid=}")
 
         if self.dllm_config is not None:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -2,14 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import (
-    TYPE_CHECKING,
-    Callable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Union
 
 import torch
 
@@ -23,10 +16,7 @@ from sglang.srt.managers.schedule_batch import (
     ScheduleBatch,
     mamba_lazy_spec_in_window,
 )
-from sglang.srt.mem_cache.common import (
-    maybe_cache_unfinished_req,
-    release_kv_cache,
-)
+from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     get_required_capture_hidden_mode,
@@ -39,6 +29,7 @@ from sglang.srt.runtime_context import (
     get_observability,
     get_server_args,
 )
+from sglang.srt.session.streaming_session import get_streaming_session
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.state_capturer.routed_experts import get_global_experts_capturer
@@ -59,10 +50,7 @@ if TYPE_CHECKING:
         SchedulerOutputStreamer,
     )
     from sglang.srt.managers.tp_worker import BaseTpWorker
-    from sglang.srt.managers.utils import (
-        EmbeddingBatchResult,
-        GenerationBatchResult,
-    )
+    from sglang.srt.managers.utils import EmbeddingBatchResult, GenerationBatchResult
     from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
     from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
     from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
@@ -269,6 +257,7 @@ class SchedulerBatchResultProcessor:
                     self._maybe_update_reasoning_tokens(req, next_token_id)
 
                     req.update_finish_state()
+                    self._maybe_record_streaming_session_decode(req)
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
@@ -304,6 +293,11 @@ class SchedulerBatchResultProcessor:
 
                 else:
                     # being chunked reqs' prefill is not finished
+                    self._maybe_record_streaming_session_prefill(
+                        req,
+                        start=batch.prefix_lens[i],
+                        end=batch.prefix_lens[i] + batch.extend_lens[i],
+                    )
                     req.inflight_middle_chunks -= 1
                     # There is only at most one request being currently chunked.
                     # Because this request does not finish prefill,
@@ -860,7 +854,7 @@ class SchedulerBatchResultProcessor:
             new_accept_len = len(next_token_id)
 
             self._maybe_update_reasoning_tokens(req, next_token_id)
-            req.time_stats.set_last_decode_finish_time()
+            self._record_decode_step_finish_time(req)
             req.update_finish_state(new_accept_len)
 
             self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
@@ -911,6 +905,31 @@ class SchedulerBatchResultProcessor:
             running_batch=batch,
             num_correct_drafts=result.num_correct_drafts,
         )
+
+    @staticmethod
+    def _record_decode_step_finish_time(req: Req) -> None:
+        if req.custom_decode_needs_prefill_completion:
+            req.custom_decode_needs_prefill_schedule = False
+            req.custom_decode_needs_prefill_completion = False
+            req.time_stats.set_prefill_finished_time()
+        else:
+            req.time_stats.set_last_decode_finish_time()
+
+    def _maybe_record_streaming_session_decode(self, req: Req) -> None:
+        if req.session is None or not req.session.streaming:
+            return
+        session_state_cache = get_streaming_session(self.tree_cache)
+        if session_state_cache is not None:
+            session_state_cache.record_decode_token(req)
+
+    def _maybe_record_streaming_session_prefill(
+        self, req: Req, *, start: int, end: int
+    ) -> None:
+        if req.session is None or not req.session.streaming:
+            return
+        session_state_cache = get_streaming_session(self.tree_cache)
+        if session_state_cache is not None:
+            session_state_cache.record_prefill_forward_complete(req, start, end)
 
     def _normalize_decode_outputs(
         self,
@@ -1016,6 +1035,9 @@ class SchedulerBatchResultProcessor:
         # Called here (after update_finish_state) so req.finished() is valid
         # for mamba_lazy_post_decode_at_boundary inside.
         self._mamba_prefix_cache_update(req, batch, result, i)
+        # Streaming checkpoints must capture post-boundary recurrent state
+        # before a finished request releases it.
+        self._maybe_record_streaming_session_decode(req)
 
         if (
             get_disagg().disaggregation_decode_enable_offload_kvcache

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -2,13 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    List,
-    Optional,
-)
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import torch
 import zmq
@@ -22,10 +16,7 @@ from sglang.srt.managers.io_struct import (
     CachedTokensDetails,
     wrap_as_pickle,
 )
-from sglang.srt.managers.schedule_batch import (
-    BaseFinishReason,
-    Req,
-)
+from sglang.srt.managers.schedule_batch import BaseFinishReason, Req
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.runtime_context import get_observability, get_serving
 from sglang.srt.server_args import ServerArgs
@@ -398,6 +389,10 @@ class _GenerationStreamAccumulator:
         )
         # Exclude the tokens after stop condition
         output_ids_ = req.output_ids_through_stop
+        # Unlike no_stop_trim (detokenizer presentation), this also aligns
+        # engine-side per-token metadata with the retained session history.
+        drop_trailing_stop_token = req.drop_trailing_stop_token
+        emit_len = len(output_ids_)
         self.output_ids.append(output_ids_[send_token_offset:])
         req.send_token_offset = len(output_ids_)
         self.prompt_tokens.append(len(req.origin_input_ids))
@@ -503,7 +498,7 @@ class _GenerationStreamAccumulator:
                 self.input_token_ids_logprobs_idx.append([])
 
             if req.return_logprob:
-                logprob_end = max(len(output_ids_), 1)
+                logprob_end = emit_len if drop_trailing_stop_token else max(emit_len, 1)
                 self.output_token_logprobs_val.append(
                     req.logprob.output_token_logprobs_val[
                         send_output_token_logprobs_offset:logprob_end
@@ -546,7 +541,11 @@ class _GenerationStreamAccumulator:
         if self.return_sampling_mask:
             if req.return_sampling_mask:
                 send_output_sampling_mask_offset = req.send_output_sampling_mask_offset
-                sampling_mask_end = len(req.output_token_sampling_mask)
+                sampling_mask_end = (
+                    emit_len
+                    if drop_trailing_stop_token
+                    else len(req.output_token_sampling_mask)
+                )
                 self.output_token_sampling_mask.append(
                     req.output_token_sampling_mask[
                         send_output_sampling_mask_offset:sampling_mask_end
@@ -567,15 +566,22 @@ class _GenerationStreamAccumulator:
                 if req.return_hidden_states == "last":
                     # Collection keeps this list bounded to the final valid
                     # accepted token, including speculative verify overshoot.
+                    hidden_state_index = (
+                        emit_len - 1 if drop_trailing_stop_token else -1
+                    )
                     self.output_hidden_states.append(
-                        req.hidden_states[-1] if req.hidden_states else None
+                        req.hidden_states[hidden_state_index]
+                        if req.hidden_states and emit_len
+                        else None
                     )
                 else:
                     # Mirror output_ids_through_stop: spec verify steps can
                     # overshoot finished_len.
                     hs = req.hidden_states
                     if req.finished_len is not None:
-                        hs = hs[: req.finished_len]
+                        hs = hs[
+                            : emit_len if drop_trailing_stop_token else req.finished_len
+                        ]
                     self.output_hidden_states.append(hs)
             else:
                 self.output_hidden_states.append(None)

--- a/python/sglang/srt/managers/scheduler_request_admission_mixin.py
+++ b/python/sglang/srt/managers/scheduler_request_admission_mixin.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from enum import Enum, auto
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
+
+
+class QueueAdmissionResult(Enum):
+    ADMIT = auto()
+    REJECT = auto()
+
+
+class RejectedRequestCleanup(Enum):
+    NOT_HANDLED = auto()
+    RESOURCES_RELEASED = auto()
+
+
+class SchedulerRequestAdmissionMixin:
+    """Extension points for model-specific request admission."""
+
+    def _admit_request_to_queue(
+        self, req: Req, is_retracted: bool = False
+    ) -> QueueAdmissionResult:
+        return QueueAdmissionResult.ADMIT
+
+    def _begin_request_prefill_admission(self, req: Req) -> Any:
+        return None
+
+    def _finish_request_prefill_admission(
+        self, req: Req, context: Any, *, admitted: bool
+    ) -> None:
+        return None
+
+    def _cleanup_rejected_queued_request(self, req: Req) -> RejectedRequestCleanup:
+        return RejectedRequestCleanup.NOT_HANDLED
+
+    def build_custom_decode_admission(
+        self, running_batch: ScheduleBatch
+    ) -> Optional[ScheduleBatch]:
+        return None
+
+    def _merge_custom_decode_admission(
+        self, running_batch: ScheduleBatch
+    ) -> tuple[ScheduleBatch, bool]:
+        custom_decode_batch = self.build_custom_decode_admission(running_batch)
+        if custom_decode_batch is not None:
+            if running_batch.is_empty():
+                running_batch = custom_decode_batch
+            else:
+                if running_batch.multimodal_inputs is None:
+                    running_batch.multimodal_inputs = [None] * len(running_batch.reqs)
+                running_batch.merge_batch(custom_decode_batch)
+
+        defer_prefill = any(
+            req.custom_decode_needs_prefill_completion for req in running_batch.reqs
+        )
+        return running_batch, defer_prefill

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -530,6 +530,11 @@ class TpModelWorker(BaseTpWorker):
             can_run_cuda_graph=can_run_cuda_graph,
         )
 
+    def customize_forward_batch(
+        self, batch: ScheduleBatch, forward_batch: ForwardBatch
+    ) -> None:
+        """Apply model-family-specific adjustments before the forward pass."""
+
     def forward_batch_generation(
         self,
         batch: Optional[ScheduleBatch],
@@ -551,6 +556,7 @@ class TpModelWorker(BaseTpWorker):
                 capture_hidden_mode=capture_hidden_mode,
                 return_hidden_states_before_norm=False,
             )
+            self.customize_forward_batch(batch, forward_batch)
         else:
             # FIXME(lsyin): unify the interface of forward_batch
             assert forward_batch is not None

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -288,9 +288,7 @@ class UnifiedRadixCache(BasePrefixCache):
         """Full reset: destroy entire tree and all state."""
         self.tree_core.reset()
         self.session_refs.reset()
-
-        # Reset Controller.
-        self.session.slots.clear()
+        self.session.reset_state()
         self.ongoing_write_through: dict[int, _OngoingWriteThrough] = {}
         self.ongoing_load_back: dict[int, _OngoingLoadBack] = {}
         self.enable_storage = False

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -52,12 +52,7 @@ from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     ForwardBatchDeepSeekMHAMixin,
 )
 from sglang.srt.runtime_context import get_exec, get_parallel
-from sglang.srt.utils import (
-    is_cuda,
-    is_hip,
-    is_npu,
-    support_triton,
-)
+from sglang.srt.utils import is_cuda, is_hip, is_npu, support_triton
 from sglang.srt.utils.common import ceil_align, is_pin_memory_available
 
 if TYPE_CHECKING:
@@ -1432,6 +1427,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # padding
         self._original_num_tokens = self.positions.shape[0]
         self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
+        if (
+            model_runner.forward_input_embeds_to_decode
+            and self.input_embeds is not None
+        ):
+            self.input_embeds = self._pad_tensor_to_size(self.input_embeds, num_tokens)
         self.req_pool_indices = self._pad_tensor_to_size(self.req_pool_indices, bs)
         if self.lora_ids is not None:
             self.lora_ids.extend((bs - len(self.lora_ids)) * [None])

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -26,11 +26,7 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.configs.load_config import LoadConfig
-from sglang.srt.configs.model_config import (
-    AttentionArch,
-    ModelConfig,
-    ModelImpl,
-)
+from sglang.srt.configs.model_config import AttentionArch, ModelConfig, ModelImpl
 from sglang.srt.configs.update_config import adjust_config_with_unaligned_cpu_tp
 from sglang.srt.debug_utils.dumper import dumper
 from sglang.srt.distributed import bootstrap
@@ -74,10 +70,7 @@ from sglang.srt.kv_canary.runner.canary_manager import context_tuple
 from sglang.srt.kv_canary.token_oracle.install import install_token_oracle_from_env
 from sglang.srt.layers import deep_gemm_wrapper, model_parallel
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
-from sglang.srt.layers.cp.utils import (
-    get_cp_strategy,
-    is_cp_v2_active,
-)
+from sglang.srt.layers.cp.utils import get_cp_strategy, is_cp_v2_active
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.sampler import create_sampler
 from sglang.srt.layers.torchao_utils import apply_torchao_config_to_model
@@ -87,17 +80,10 @@ from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.managers.schedule_batch import sanity_check_mm_pad_shift_value
 from sglang.srt.mem_cache import kv_cache_dtype
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.kv_cache_configurator import (
-    KVCacheConfigurator,
-)
+from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
-from sglang.srt.model_executor.cuda_graph_config import (
-    cuda_graph_fully_disabled,
-)
-from sglang.srt.model_executor.forward_batch_info import (
-    ForwardBatch,
-    PPProxyTensors,
-)
+from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.forward_context import (
     ForwardContext,
     forward_context,
@@ -157,10 +143,7 @@ from sglang.srt.model_executor.model_runner_components.weight_updater import (
     WeightUpdater,
 )
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.model_executor.runner import (
-    EagerRunner,
-    get_batch_sizes_to_capture,
-)
+from sglang.srt.model_executor.runner import EagerRunner, get_batch_sizes_to_capture
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
     get_context,
@@ -256,6 +239,10 @@ class ModelRunnerOutput:
 
 class ModelRunner:
     """ModelRunner runs the forward passes of the models."""
+
+    # Opt in when decode must consume externally composed ForwardBatch.input_embeds
+    # instead of deriving embeddings from input_ids.
+    forward_input_embeds_to_decode = False
 
     def __init__(
         self,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -37,10 +37,7 @@ from torch.profiler import ProfilerActivity, profile
 
 from sglang.srt.compilation import torch_compile_decoration
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
-from sglang.srt.distributed.parallel_state import (
-    graph_capture,
-    set_pdmux_status,
-)
+from sglang.srt.distributed.parallel_state import graph_capture, set_pdmux_status
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_enable_prefill_cp
@@ -78,12 +75,8 @@ from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend impor
     BreakableCudaGraphBackend,
 )
 from sglang.srt.model_executor.runner_backend.utils import resolve_decode_backend
-from sglang.srt.model_executor.runner_backend_utils import (
-    CUDA_GRAPH_CAPTURE_FAILED_MSG,
-)
-from sglang.srt.model_executor.runner_utils.buffers import (
-    DecodeInputBuffers,
-)
+from sglang.srt.model_executor.runner_backend_utils import CUDA_GRAPH_CAPTURE_FAILED_MSG
+from sglang.srt.model_executor.runner_utils.buffers import DecodeInputBuffers
 from sglang.srt.model_executor.runner_utils.capture_mode import (
     _set_capture_lora_variant,
     model_capture_mode,
@@ -225,6 +218,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.ngram_embedding_n = hf_config.ngram_embedding_n
             self.ngram_embedding_k = hf_config.ngram_embedding_k
         self.speculative_algorithm = model_runner.server_args.speculative_algorithm
+        self.require_decode_input_embeds = model_runner.forward_input_embeds_to_decode
+        self.capture_input_embeds = (
+            model_runner.spec_algorithm.is_dflash_family()
+            and model_runner.is_draft_worker
+        ) or self.require_decode_input_embeds
         self.enable_profile_cuda_graph = (
             model_runner.server_args.enable_profile_cuda_graph
         )
@@ -945,8 +943,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                         {k: v.clone() for k, v in pp_proxy_tensors.tensors.items()}
                     )
                 if (
-                    self.model_runner.spec_algorithm.is_dflash_family()
-                    and self.model_runner.is_draft_worker
+                    self.capture_input_embeds
                     and "input_embeds" in inspect.signature(forward).parameters
                     and not hasattr(self.model_runner.model, "forward_embed")
                 ):
@@ -1034,15 +1031,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 )
             self.buffers.input_ids[: self.raw_num_token].copy_(forward_batch.input_ids)
             self.buffers.positions[: self.raw_num_token].copy_(forward_batch.positions)
-            if (
-                not is_ragged
-                and self.model_runner.spec_algorithm.is_dflash_family()
-                and self.model_runner.is_draft_worker
-                and forward_batch.input_embeds is not None
-            ):
-                self.buffers.input_embeds[: self.raw_num_token].copy_(
-                    forward_batch.input_embeds
-                )
+            self._copy_decode_input_embeds(
+                forward_batch, self.raw_num_token, is_ragged=is_ragged
+            )
             variant_label = self._resolve_lora_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
             self._replay_graph_key = self._make_graph_key(
@@ -1096,13 +1087,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             pp_proxy_tensors=pp_proxy_tensors,
         )
 
-        if (
-            not is_ragged
-            and self.model_runner.spec_algorithm.is_dflash_family()
-            and self.model_runner.is_draft_worker
-            and forward_batch.input_embeds is not None
-        ):
-            buffers.input_embeds[:raw_num_token].copy_(forward_batch.input_embeds)
+        self._copy_decode_input_embeds(
+            forward_batch, raw_num_token, is_ragged=is_ragged
+        )
         # Padded tokens aren't read, so skip zeroing. Ragged input_ids arrive
         # from the planner already padded to the tier, invalid slots zeroed.
         if self.enable_two_batch_overlap:
@@ -1149,6 +1136,19 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self._replay_graph_key = self._make_graph_key(
             graph_size_key, stream_idx, variant_label
         )
+
+    def _copy_decode_input_embeds(
+        self, forward_batch: ForwardBatch, num_tokens: int, *, is_ragged: bool
+    ) -> None:
+        if is_ragged or not self.capture_input_embeds:
+            return
+        if forward_batch.input_embeds is None:
+            if self.require_decode_input_embeds:
+                raise RuntimeError(
+                    "Decode CUDA graph requires input_embeds for this model"
+                )
+            return
+        self.buffers.input_embeds[:num_tokens].copy_(forward_batch.input_embeds)
 
     def _ragged_graph_num_tokens(self, total_verify_tokens: int) -> int:
         from sglang.srt.speculative.ragged_verify import round_up_grid

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -31,9 +31,7 @@ from sglang.srt.layers.cp.utils import (
     prepare_cp_forward,
 )
 from sglang.srt.layers.pooler import EmbeddingPoolerOutput
-from sglang.srt.model_executor.cuda_graph_buffer_registry import (
-    build_eager_registry,
-)
+from sglang.srt.model_executor.cuda_graph_buffer_registry import build_eager_registry
 from sglang.srt.model_executor.forward_batch_deepseek_mha_mixin import (
     create_chunked_prefix_cache_kv_indices,
 )
@@ -237,6 +235,11 @@ class EagerRunner(BaseRunner):
             attn_backend.init_forward_metadata(forward_batch)
         # FIXME: add pp_proxy_tensors arg to all models
         kwargs = model_runner._pp_kwargs(pp_proxy_tensors)
+        if (
+            model_runner.forward_input_embeds_to_decode
+            and forward_batch.input_embeds is not None
+        ):
+            kwargs["input_embeds"] = forward_batch.input_embeds
 
         ctx = device_timer_ctx(model_runner.device_timer, "decode")
 

--- a/python/sglang/srt/observability/req_time_stats.py
+++ b/python/sglang/srt/observability/req_time_stats.py
@@ -48,6 +48,7 @@ SGLANG_TEST_REQUEST_TIME_STATS = get_bool_env_var("SGLANG_TEST_REQUEST_TIME_STAT
 
 logger = logging.getLogger(__name__)
 
+
 # Reduce system time calls by computing time.time() based on calibrated perf_counter() values.
 global_diff_realtime_monotonic = time.time() - time.perf_counter()
 
@@ -1226,7 +1227,16 @@ def set_schedule_time_batch(batch: ScheduleBatch):
         _attrs["forward_mode"] = "prebuilt"
 
     for req in batch.reqs:
-        req.time_stats.set_last_scheduled_time(batch.forward_mode, ts, _attrs)
+        forward_mode = batch.forward_mode
+        attrs = _attrs
+        if req.custom_decode_needs_prefill_schedule:
+            # Direct admission physically merges this request into a decode
+            # batch, but its first step replaces the one-token prefill. Preserve
+            # that semantic timing label once; later decode steps stay decode.
+            req.custom_decode_needs_prefill_schedule = False
+            forward_mode = ForwardMode.EXTEND
+            attrs = {**_attrs, "forward_mode": "prefill"}
+        req.time_stats.set_last_scheduled_time(forward_mode, ts, attrs)
 
 
 def set_time_batch(

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -16,6 +16,7 @@ import logging
 import time
 import uuid
 from array import array
+from copy import copy
 from typing import TYPE_CHECKING, Dict, Optional
 
 from sglang.srt.managers.io_struct import (
@@ -95,6 +96,7 @@ class Session:
         self.req_nodes: Dict[str, SessionReqNode] = {}
         self.close_on_finish: bool = False
         self._inflight: bool = False
+        self._inflight_req: Optional[Req] = None
         # Token-array lengths of last_req as of its finish_req. The share path
         # appends speculatively beyond these; only finish_req confirms them, so
         # _share_token_arrays trims back first (heals aborted turns).
@@ -316,38 +318,80 @@ class Session:
             time_stats=req.time_stats,
         )
         if last_req is not None:
-            new_req.multimodal_inputs = last_req.multimodal_inputs
+            new_req.multimodal_inputs = (
+                copy(last_req.multimodal_inputs)
+                if req.mm_inputs is not None and last_req.multimodal_inputs is not None
+                else last_req.multimodal_inputs
+            )
         new_req.tokenizer = tokenizer
         if carry_fill is not None:
             new_req.full_untruncated_fill_ids = carry_fill
+        new_req.drop_trailing_stop_token = bool(session_params.drop_trailing_stop_token)
 
         if abort:
             new_req.set_finish_with_abort(abort_message)
         elif self.streaming:
             # req_nodes is NOT updated here — finish_req() handles it.
             self._inflight = True
+            self._inflight_req = new_req
         else:
             new_req_node = SessionReqNode(new_req, last_req_node)
             self.req_nodes[req.rid] = new_req_node
 
         return new_req
 
-    def finish_req(self, req):
-        """Update req_nodes after a streaming request finishes successfully."""
-        self._inflight = False
+    def _set_streaming_boundary(self, req, *, inflight: bool) -> None:
+        if self._inflight_req is not req:
+            raise RuntimeError(
+                f"Request {req.rid} does not own streaming session {self.session_id}"
+            )
+        self._inflight = inflight
+        if not inflight:
+            self._inflight_req = None
         if self.req_nodes:
             [prev_node] = self.req_nodes.values()
-            prev_node.req.session = None
+            if prev_node.req is not req:
+                prev_node.req.session = None
             self.req_nodes.clear()
         self.req_nodes[req.rid] = SessionReqNode(req)
-        # Confirm this req's token arrays as the session's rollback point.
         self.committed_origin_len = len(req.origin_input_ids)
         self.committed_unpadded_len = len(req.origin_input_ids_unpadded)
         self.committed_fill_len = len(req.full_untruncated_fill_ids)
 
-    def abort_req(self):
-        """Clear inflight flag on abort (req_nodes stays unchanged)."""
+    def finish_req(self, req):
+        """Update req_nodes after a streaming request finishes successfully."""
+        self._set_streaming_boundary(req, inflight=False)
+
+    def checkpoint_retracted_req(self, req) -> None:
+        """Save resumable progress while keeping the streaming turn active."""
+        self._set_streaming_boundary(req, inflight=True)
+
+    def abort_req(self, req) -> bool:
+        """Clear the inflight owner on abort (req_nodes stays unchanged)."""
+        if self._inflight_req is not req:
+            return False
         self._inflight = False
+        self._inflight_req = None
+        return True
+
+    def replace_streaming_boundary(self, req) -> None:
+        """Replace the retained append boundary with an already-spliced request."""
+        if req is None:
+            raise ValueError("A streaming session boundary cannot be None")
+        self._inflight = False
+        self._inflight_req = None
+        for node in self.req_nodes.values():
+            node.req.session = None
+        self.req_nodes.clear()
+        req.session = self
+        self.req_nodes[req.rid] = SessionReqNode(req)
+        # Re-anchor the committed lengths to the (post-splice) boundary req.
+        # _share_token_arrays trims carry_fill/origin back to these on the next
+        # turn; leaving them at the pre-truncate values would re-admit the
+        # removed range as the prefix-match key.
+        self.committed_origin_len = len(req.origin_input_ids)
+        self.committed_unpadded_len = len(req.origin_input_ids_unpadded)
+        self.committed_fill_len = len(req.full_untruncated_fill_ids)
 
 
 class SessionController:
@@ -399,7 +443,7 @@ class SessionController:
             assert len(session.req_nodes) == 1
             [last_node] = session.req_nodes.values()
             req = last_node.req
-            if not req.finished():
+            if not req.finished() and req.session is session:
                 has_unfinished_request = True
 
         if has_unfinished_request:
@@ -468,7 +512,10 @@ class SessionController:
     def _all_requests_finished(session: Session) -> bool:
         if not session.req_nodes:
             return True
-        return all(node.req.finished() for node in session.req_nodes.values())
+        return all(
+            node.req.finished() or node.req.session is not session
+            for node in session.req_nodes.values()
+        )
 
     @staticmethod
     def adjust_mm_offsets(recv_req: TokenizedGenerateReqInput, req: Req, image_inputs):

--- a/python/sglang/srt/session/streaming_session.py
+++ b/python/sglang/srt/session/streaming_session.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol
 
 import torch
 
@@ -127,6 +127,54 @@ def _is_streaming(req: Optional[Req]) -> bool:
     return req is not None and req.session is not None and req.session.streaming
 
 
+class StreamingSessionLifecycle(Protocol):
+    def reset(self) -> None: ...
+
+    def on_request_start(self, req: Any, slot: SessionSlot) -> None: ...
+
+    def on_request_committed(
+        self, session_id: str, slot: SessionSlot, req: Any
+    ) -> None: ...
+
+    def on_session_released(self, session_id: str) -> None: ...
+
+    def next_prefill_chunk_end(self, req: Any, start: int, end: int) -> int: ...
+
+    def on_prefill_forward_complete(self, req: Any, start: int, end: int) -> None: ...
+
+    def on_decode_token(self, req: Any) -> None: ...
+
+    def held_mamba_slots(self) -> int: ...
+
+
+class _NoopStreamingSessionLifecycle:
+    def reset(self) -> None:
+        return None
+
+    def on_request_start(self, req: Any, slot: SessionSlot) -> None:
+        return None
+
+    def on_request_committed(
+        self, session_id: str, slot: SessionSlot, req: Any
+    ) -> None:
+        return None
+
+    def on_session_released(self, session_id: str) -> None:
+        return None
+
+    def next_prefill_chunk_end(self, req: Any, start: int, end: int) -> int:
+        return end
+
+    def on_prefill_forward_complete(self, req: Any, start: int, end: int) -> None:
+        return None
+
+    def on_decode_token(self, req: Any) -> None:
+        return None
+
+    def held_mamba_slots(self) -> int:
+        return 0
+
+
 class StreamingSession(BasePrefixCache):
     """Adds streaming-session KV save/restore on top of any BasePrefixCache.
 
@@ -140,6 +188,22 @@ class StreamingSession(BasePrefixCache):
     def __init__(self, inner: BasePrefixCache):
         self.inner = inner
         self.slots: Dict[str, SessionSlot] = {}
+        self._session_lifecycle: StreamingSessionLifecycle = (
+            _NoopStreamingSessionLifecycle()
+        )
+        self._has_attached_lifecycle = False
+
+    @property
+    def has_attached_lifecycle(self) -> bool:
+        return self._has_attached_lifecycle
+
+    def attach_session_lifecycle(
+        self, session_control: StreamingSessionLifecycle
+    ) -> None:
+        if self._has_attached_lifecycle:
+            raise RuntimeError("A streaming session control is already attached")
+        self._session_lifecycle = session_control
+        self._has_attached_lifecycle = True
 
     # -- Forward PrefixCacheTrait properties to inner cache --
 
@@ -188,6 +252,11 @@ class StreamingSession(BasePrefixCache):
     def has_slot(self, session_id: str) -> bool:
         return session_id in self.slots
 
+    def is_retained_boundary(self, req: Any) -> bool:
+        if not _is_streaming(req) or req.session.session_id not in self.slots:
+            return False
+        return any(node.req is req for node in req.session.req_nodes.values())
+
     def any_holding_kv(self) -> bool:
         return any(s.is_holding_kv for s in self.slots.values())
 
@@ -220,15 +289,20 @@ class StreamingSession(BasePrefixCache):
         if slot is None or slot.kv is None:
             return None
         if req.to_finish is not None:
-            req.session.abort_req()
+            req.session.abort_req(req)
             req.session = None
             return None
         return slot
 
     # -- BasePrefixCache abstract methods --
 
-    def reset(self):
+    def reset_state(self) -> None:
+        """Clear session-owned state without resetting the composed cache."""
+        self._session_lifecycle.reset()
         self.slots.clear()
+
+    def reset(self):
+        self.reset_state()
         self.inner.reset()
 
     # -- Streaming entries: contract with embedded composers (e.g.
@@ -241,9 +315,11 @@ class StreamingSession(BasePrefixCache):
         otherwise None (caller falls back to its raw match)."""
         slot = self.find_active_slot(params.req)
         if slot is None:
+            self._limit_first_prefill_match(params)
             return None
 
         req = params.req
+        self._session_lifecycle.on_request_start(req, slot)
         slot.restore_to_req(req)
 
         # token_ids = get_fill_ids()[:input_len-1] (1-token logit reserve
@@ -251,8 +327,8 @@ class StreamingSession(BasePrefixCache):
         # can exceed len(token_ids) by 1.
         prefix_len = min(req.kv_committed_len, len(params.key))
 
-        # Streaming sessions are append-only (session_controller rollback
-        # ensures req_nodes always points to the last successful req).
+        # Streaming sessions are append-only; truncation updates the session's
+        # append target before another request can start.
         assert prefix_len >= slot.cache_protected_len, (
             f"streaming session prefix shrank: {prefix_len=} < "
             f"{slot.cache_protected_len=}"
@@ -285,26 +361,57 @@ class StreamingSession(BasePrefixCache):
         if not _is_streaming(req):
             return False
 
-        from sglang.srt.managers.schedule_batch import FINISH_ABORT
+        from sglang.srt.managers.schedule_batch import (
+            FINISH_ABORT,
+            FINISH_MATCHED_TOKEN,
+            StreamingSessionAbortPolicy,
+        )
 
-        session_id = req.session.session_id
+        session = req.session
+        session_id = session.session_id
         slot = self.slots.get(session_id)
         is_first = slot is None
+        is_abort = isinstance(req.finished_reason, FINISH_ABORT)
 
-        # Mid-processing abort only. Pre-aborted reqs have session=None
-        # (set in find_active_slot) and never reach here.
-        # Nuke all KV via release_session, delete slot. Token IDs stay
-        # in req_nodes (finish_req was never called -> last successful
-        # req). Next request re-prefills from scratch.
-        if isinstance(req.finished_reason, FINISH_ABORT):
+        if is_abort and session._inflight_req is not req:
+            if not self.detach_queued_request(req):
+                raise RuntimeError(
+                    "A non-owning streaming request advanced beyond its "
+                    f"session boundary: session={session_id}"
+                )
+            self._release_unretained_multimodal_inputs(req, session)
+            return True
+
+        # Cancel keeps forwarded output. The sampled tail has not run a forward,
+        # so exclude it from both the token history and KV boundary.
+        if (
+            is_abort
+            and req.streaming_abort_policy
+            is StreamingSessionAbortPolicy.COMMIT_FORWARDED
+        ):
+            if is_first:
+                slot = SessionSlot()
+                self.slots[session_id] = slot
+            finished_len = max(0, len(req.output_ids) - 1)
+            self._trim_overshoot(req, finished_len)
+            slot.save_from_req(req, is_first=is_first)
+            target = len(req.origin_input_ids) + finished_len
+            slot.kv_committed_len = min(target, slot.kv.kv_allocated_len)
+            self._session_lifecycle.on_request_committed(session_id, slot, req)
+            req.session.finish_req(req)
+            return True
+
+        # Other mid-processing aborts release the slot. The session still points
+        # at its last successful request and can re-prefill on the next turn.
+        if is_abort:
+            retains_boundary = self.is_retained_boundary(req)
+            if not session.abort_req(req):
+                raise RuntimeError(
+                    f"Request {req.rid} lost ownership of session {session_id}"
+                )
             if slot is None:
-                # First-request mid-processing abort: create ephemeral
-                # slot from req state so release_session handles cleanup.
-                # Include last_node/cache_protected_len from the req so
-                # release_session calls dec_lock_ref on the tree lock.
-                # Also carry the mamba refs over so _free_slot_mamba can
-                # return the (possibly extra_buffer ping-pong) slots to
-                # the mamba pool; otherwise the abort orphans them.
+                # Transfer first-request resources into a temporary slot so the
+                # normal release path frees KV, tree locks, and recurrent state.
                 slot = SessionSlot(
                     req_pool_idx=req.req_pool_idx,
                     kv=copy.copy(req.kv),
@@ -326,8 +433,21 @@ class StreamingSession(BasePrefixCache):
             self.release_session(session_id)
             req.req_pool_idx = None
             req.kv = None
-            req.session.abort_req()
+            req.mamba_pool_idx = None
+            req.mamba_ping_pong_track_buffer = None
+            req.mamba_next_track_idx = None
+            req.mamba_last_track_seqlen = None
+            req.mamba_branching_seqlen = None
+            if not retains_boundary:
+                self._release_unretained_multimodal_inputs(req, session)
+                req.session = None
             return True
+
+        is_retraction = not req.finished()
+        if is_retraction and is_insert:
+            raise RuntimeError(
+                "An unfinished streaming request can only be cached for retraction"
+            )
 
         if is_first:
             slot = SessionSlot()
@@ -336,6 +456,14 @@ class StreamingSession(BasePrefixCache):
         finished_len = (
             req.finished_len if req.finished_len is not None else len(req.output_ids)
         )
+        # A matched stop is sampled but never forwarded, so it cannot be part of
+        # the next turn's committed context.
+        if (
+            req.drop_trailing_stop_token
+            and finished_len > 0
+            and isinstance(req.finished_reason, FINISH_MATCHED_TOKEN)
+        ):
+            finished_len -= 1
         target = len(req.origin_input_ids) + finished_len
         self._trim_overshoot(req, finished_len)
 
@@ -346,8 +474,12 @@ class StreamingSession(BasePrefixCache):
         # to keep committed <= allocated for prepare_for_decode.
         slot.kv_committed_len = min(target, slot.kv.kv_allocated_len)
 
-        # Update req_nodes to this successfully finished request.
-        req.session.finish_req(req)
+        self._session_lifecycle.on_request_committed(session_id, slot, req)
+
+        if is_retraction:
+            req.session.checkpoint_retracted_req(req)
+        else:
+            req.session.finish_req(req)
 
         return True
 
@@ -409,6 +541,7 @@ class StreamingSession(BasePrefixCache):
     # -- Session lifecycle --
 
     def release_session(self, session_id: str) -> None:
+        self._session_lifecycle.on_session_released(session_id)
         slot = self.slots.pop(session_id, None)
         if slot is None:
             return
@@ -511,6 +644,7 @@ class StreamingSession(BasePrefixCache):
                 total += slot.mamba_pool_idx.numel()
             if slot.mamba_ping_pong_track_buffer is not None:
                 total += slot.mamba_ping_pong_track_buffer.numel()
+        total += self._session_lifecycle.held_mamba_slots()
         return total
 
     def _free_slot_mamba(self, slot: SessionSlot) -> None:
@@ -525,7 +659,121 @@ class StreamingSession(BasePrefixCache):
             mamba_allocator.free(slot.mamba_ping_pong_track_buffer)
             slot.mamba_ping_pong_track_buffer = None
 
+    def record_decode_token(self, req: Any) -> None:
+        self._session_lifecycle.on_decode_token(req)
+
+    def next_prefill_chunk_end(self, req: Any, start: int, end: int) -> int:
+        if not _is_streaming(req):
+            return end
+        return self._session_lifecycle.next_prefill_chunk_end(req, start, end)
+
+    def record_prefill_forward_complete(self, req: Any, start: int, end: int) -> None:
+        if _is_streaming(req):
+            self._session_lifecycle.on_prefill_forward_complete(req, start, end)
+
+    def detach_queued_request(self, req: Any) -> bool:
+        """Detach a request that has not advanced beyond its saved session slot."""
+        if not _is_streaming(req):
+            return False
+        slot = self.slots.get(req.session.session_id)
+        if req.req_pool_idx is not None:
+            if slot is None or req.req_pool_idx != slot.req_pool_idx:
+                return False
+            if (
+                req.kv_committed_len != slot.kv_committed_len
+                or req.kv.kv_allocated_len != slot.kv.kv_allocated_len
+            ):
+                return False
+
+        for name in (
+            "mamba_pool_idx",
+            "mamba_ping_pong_track_buffer",
+        ):
+            req_value = getattr(req, name)
+            slot_value = None if slot is None else getattr(slot, name)
+            if req_value is not None and not self._same_slot_reference(
+                req_value, slot_value
+            ):
+                return False
+
+        session = req.session
+        session_id = session.session_id
+        owns_session = session.abort_req(req)
+        req.session = None
+        req.req_pool_idx = None
+        req.kv = None
+        req.mamba_pool_idx = None
+        req.mamba_ping_pong_track_buffer = None
+        req.mamba_next_track_idx = None
+        req.mamba_last_track_seqlen = None
+        req.mamba_branching_seqlen = None
+        if owns_session and slot is None:
+            self._session_lifecycle.on_session_released(session_id)
+        return True
+
+    @staticmethod
+    def _same_slot_reference(left: Any, right: Any) -> bool:
+        if right is None:
+            return False
+        if torch.is_tensor(left) and torch.is_tensor(right):
+            return bool(torch.equal(left, right))
+        return bool(left == right)
+
+    def truncate_kv(self, session_id: str, target: int) -> SessionSlot:
+        slot = self.slots.get(session_id)
+        if slot is None or not slot.is_holding_kv:
+            raise RuntimeError(f"Session {session_id} has no committed KV state")
+        if not 0 <= target <= slot.kv_committed_len:
+            raise ValueError(
+                f"Truncate target {target} is outside " f"[0, {slot.kv_committed_len}]"
+            )
+        if target < slot.cache_protected_len:
+            raise ValueError(
+                f"Truncate target {target} is below the protected session prefix "
+                f"{slot.cache_protected_len}"
+            )
+        self._free_kv_aligned(slot.req_pool_idx, target, slot.kv.kv_allocated_len)
+        slot.kv.kv_allocated_len = target
+        slot.kv_committed_len = target
+        slot.kv.swa_evicted_seqlen = min(slot.kv.swa_evicted_seqlen, target)
+        return slot
+
+    def get_kv_state(self, session_id: str) -> Optional[dict[str, Any]]:
+        slot = self.slots.get(session_id)
+        if slot is None:
+            return None
+        state: dict[str, Any] = {
+            "found": True,
+            "kv_committed_len": slot.kv_committed_len,
+            "kv_allocated_len": (
+                slot.kv.kv_allocated_len if slot.kv is not None else 0
+            ),
+            "is_holding_kv": slot.is_holding_kv,
+        }
+        return state
+
     # -- Internal helpers (streaming body bits) --
+
+    def _limit_first_prefill_match(self, params: MatchPrefixParams) -> None:
+        if not _is_streaming(params.req) or not self._has_attached_lifecycle:
+            return
+        current_limit = (
+            len(params.key.token_ids)
+            if params.key.limit is None
+            else min(params.key.limit, len(params.key.token_ids))
+        )
+        full_end = len(params.req.full_untruncated_fill_ids)
+        if not full_end:
+            return
+        chunk_end = self.next_prefill_chunk_end(params.req, 0, full_end)
+        if not 0 < chunk_end <= full_end:
+            raise RuntimeError(
+                "Streaming lifecycle returned an invalid first prefill "
+                f"boundary: chunk_end={chunk_end} end={full_end}"
+            )
+        match_limit = min(current_limit, chunk_end - 1)
+        if match_limit < current_limit:
+            params.key.limit = match_limit
 
     def _free_tail(self, slot: SessionSlot, req: Req, prefix_len: int) -> None:
         """match_prefix path: free orphaned KV in [prefix_len, kv_allocated_len)
@@ -569,6 +817,26 @@ class StreamingSession(BasePrefixCache):
         if start < end:
             tail = self.req_to_token_pool.req_to_token[pool_idx, start:end]
             self.token_to_kv_pool_allocator.free(tail)
+
+    @staticmethod
+    def _release_unretained_multimodal_inputs(req: Req, session: Any) -> None:
+        """Release aborted-turn features without clearing the saved boundary."""
+        mm_inputs = req.multimodal_inputs
+        if mm_inputs is None:
+            return
+
+        retained_item_ids = {
+            id(item)
+            for node in session.req_nodes.values()
+            if node.req is not req and node.req.multimodal_inputs is not None
+            for item in node.req.multimodal_inputs.mm_items
+        }
+        releasable = copy.copy(mm_inputs)
+        releasable.mm_items = [
+            item for item in mm_inputs.mm_items if id(item) not in retained_item_ids
+        ]
+        releasable.release_features()
+        req.multimodal_inputs = None
 
     # -- Pass-through methods --
 
@@ -640,3 +908,11 @@ class StreamingSession(BasePrefixCache):
     # sliding_window_size, all_values_flatten, etc.)
     def __getattr__(self, name):
         return getattr(self.inner, name)
+
+
+def get_streaming_session(cache: BasePrefixCache) -> Optional[StreamingSession]:
+    """Return a cache's direct or composed streaming-session component."""
+    if isinstance(cache, StreamingSession):
+        return cache
+    session = getattr(cache, "session", None)
+    return session if isinstance(session, StreamingSession) else None

--- a/test/registered/unit/managers/test_batch_result_processor_timing.py
+++ b/test/registered/unit/managers/test_batch_result_processor_timing.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch  # noqa: E402
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.srt.managers.scheduler_components.batch_result_processor import (  # noqa: E402
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardMode  # noqa: E402
+from sglang.srt.observability.req_time_stats import (  # noqa: E402
+    set_schedule_time_batch,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_custom_decode_first_step_completes_prefill_timing_once() -> None:
+    time_stats = SimpleNamespace(
+        set_prefill_finished_time=Mock(),
+        set_last_decode_finish_time=Mock(),
+    )
+    request = SimpleNamespace(
+        custom_decode_needs_prefill_schedule=True,
+        custom_decode_needs_prefill_completion=True,
+        time_stats=time_stats,
+    )
+
+    SchedulerBatchResultProcessor._record_decode_step_finish_time(request)
+
+    assert not request.custom_decode_needs_prefill_schedule
+    assert not request.custom_decode_needs_prefill_completion
+    time_stats.set_prefill_finished_time.assert_called_once_with()
+    time_stats.set_last_decode_finish_time.assert_not_called()
+
+    SchedulerBatchResultProcessor._record_decode_step_finish_time(request)
+
+    time_stats.set_prefill_finished_time.assert_called_once_with()
+    time_stats.set_last_decode_finish_time.assert_called_once_with()
+
+
+def test_custom_decode_first_schedule_uses_prefill_timing_once() -> None:
+    request = SimpleNamespace(
+        custom_decode_needs_prefill_schedule=True,
+        time_stats=SimpleNamespace(set_last_scheduled_time=Mock()),
+    )
+    batch = SimpleNamespace(reqs=[request], forward_mode=ForwardMode.DECODE)
+
+    with patch(
+        "sglang.srt.observability.req_time_stats.get_global_tracing_enabled",
+        return_value=True,
+    ):
+        set_schedule_time_batch(batch)
+        set_schedule_time_batch(batch)
+
+    first_call, second_call = request.time_stats.set_last_scheduled_time.call_args_list
+    assert first_call.args[0] is ForwardMode.EXTEND
+    assert first_call.args[2]["forward_mode"] == "prefill"
+    assert second_call.args[0] is ForwardMode.DECODE
+    assert second_call.args[2]["forward_mode"] == "decode"
+    assert not request.custom_decode_needs_prefill_schedule
+
+
+def test_pending_custom_decode_blocks_later_prefill_across_iterations() -> None:
+    time_stats = SimpleNamespace(
+        set_prefill_finished_time=Mock(),
+        set_last_decode_finish_time=Mock(),
+    )
+    custom_request = SimpleNamespace(
+        custom_decode_needs_prefill_schedule=False,
+        custom_decode_needs_prefill_completion=True,
+        time_stats=time_stats,
+    )
+    running_batch = SimpleNamespace(
+        reqs=[custom_request],
+        is_prefill_only=False,
+        is_empty=lambda: False,
+    )
+    penalized_request = SimpleNamespace(
+        sampling_params=SimpleNamespace(frequency_penalty=0.5)
+    )
+
+    scheduler = object.__new__(Scheduler)
+    scheduler.enable_fpm = False
+    scheduler.dllm_config = None
+    scheduler.chunked_req = None
+    scheduler.enable_hisparse = False
+    scheduler.require_mlp_sync = False
+    scheduler.waiting_queue = [penalized_request]
+    scheduler.process_pending_chunked_abort = Mock()
+    scheduler._abort_on_waiting_timeout = Mock()
+    scheduler._abort_on_running_timeout = Mock()
+    scheduler.build_custom_decode_admission = Mock(return_value=None)
+    scheduler.update_running_batch = Mock(return_value=running_batch)
+    scheduler.get_new_batch_prefill = Mock(
+        return_value=SimpleNamespace(
+            batch_to_run=None,
+            running_batch=running_batch,
+        )
+    )
+    scheduler.dp_attn_adapter = SimpleNamespace(
+        maybe_prepare_mlp_sync_batch=lambda batch, need_sync: batch
+    )
+    scheduler.ngram_embedding_manager = SimpleNamespace(
+        prepare_for_forward=lambda batch, chunked_req: batch
+    )
+
+    with patch("sglang.srt.managers.scheduler.set_schedule_time_batch"):
+        for _ in range(2):
+            plan = scheduler.get_next_batch_to_run(running_batch, last_batch=None)
+            assert plan.batch_to_run is running_batch
+
+        scheduler.get_new_batch_prefill.assert_not_called()
+
+        SchedulerBatchResultProcessor._record_decode_step_finish_time(custom_request)
+        scheduler.get_next_batch_to_run(running_batch, last_batch=None)
+
+    scheduler.get_new_batch_prefill.assert_called_once_with(running_batch)
+
+
+def test_batch_merge_preserves_direct_decode_timing_contract() -> None:
+    running_request = SimpleNamespace(
+        custom_decode_needs_prefill_completion=False,
+        return_logprob=False,
+        return_hidden_states=False,
+        grammar=None,
+    )
+    custom_request = SimpleNamespace(
+        custom_decode_needs_prefill_schedule=True,
+        custom_decode_needs_prefill_completion=True,
+        return_logprob=False,
+        return_hidden_states=False,
+        grammar=None,
+        time_stats=SimpleNamespace(
+            set_prefill_finished_time=Mock(),
+            set_last_decode_finish_time=Mock(),
+        ),
+    )
+
+    def make_batch(request, pool_index: int) -> ScheduleBatch:
+        return ScheduleBatch(
+            reqs=[request],
+            sampling_info=SimpleNamespace(merge_batch=Mock()),
+            model_config=SimpleNamespace(is_encoder_decoder=False),
+            req_pool_indices=torch.tensor([pool_index]),
+            req_pool_indices_cpu=torch.tensor([pool_index]),
+            seq_lens=torch.tensor([1]),
+            orig_seq_lens=torch.tensor([1], dtype=torch.int32),
+            seq_lens_cpu=torch.tensor([1]),
+            input_ids=None,
+            multimodal_inputs=[None],
+            return_logprob=False,
+            has_grammar=False,
+            return_hidden_states=False,
+            is_prefill_only=False,
+            spec_info=None,
+        )
+
+    running_batch = make_batch(running_request, 0)
+    custom_batch = make_batch(custom_request, 1)
+
+    running_batch.merge_batch(custom_batch)
+
+    merged_request = running_batch.reqs[1]
+    assert merged_request.custom_decode_needs_prefill_schedule
+    SchedulerBatchResultProcessor._record_decode_step_finish_time(merged_request)
+    assert not merged_request.custom_decode_needs_prefill_schedule
+    assert not merged_request.custom_decode_needs_prefill_completion

--- a/test/registered/unit/managers/test_mm_embedding_cache.py
+++ b/test/registered/unit/managers/test_mm_embedding_cache.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.managers.mm_utils import (
+    _get_chunked_embedding_full,
+    _get_chunked_prefill_embedding,
+    init_mm_embedding_cache,
+)
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.multimodal.evs import EVSEmbeddingResult
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _item(
+    *, cacheable: bool, item_hash: int = 1234, offset: tuple[int, int] = (0, 0)
+) -> MultimodalDataItem:
+    return MultimodalDataItem(
+        modality=Modality.AUDIO,
+        hash=item_hash,
+        offsets=[offset],
+        feature=torch.tensor([0.5]),
+        embedding_cacheable=cacheable,
+    )
+
+
+def _embed_once(item: MultimodalDataItem, encoder):
+    embedding, _ = _get_chunked_prefill_embedding(
+        data_embedding_func=encoder,
+        embedding_items=[item],
+        items_size=[0, 1],
+        prefix_length=[0],
+        extend_length=[1],
+        items_offset_list=[[(0, 0)]],
+        input_ids=torch.tensor([0]),
+    )
+    return embedding
+
+
+def test_embedding_cacheable_defaults_to_true() -> None:
+    item = MultimodalDataItem(modality=Modality.IMAGE)
+    assert item.embedding_cacheable
+
+
+def test_chunked_embedding_cache_reuses_stateless_items() -> None:
+    init_mm_embedding_cache(1 << 20)
+    calls = 0
+
+    def encoder(_items):
+        nonlocal calls
+        calls += 1
+        return torch.tensor([[float(calls)]])
+
+    first = _embed_once(_item(cacheable=True), encoder)
+    second = _embed_once(_item(cacheable=True), encoder)
+
+    assert calls == 1
+    assert torch.equal(first, second)
+
+
+def test_chunked_embedding_cache_never_skips_stateful_items() -> None:
+    init_mm_embedding_cache(1 << 20)
+    calls = 0
+
+    def stateful_encoder(_items):
+        nonlocal calls
+        calls += 1
+        return torch.tensor([[float(calls)]])
+
+    first = _embed_once(_item(cacheable=False), stateful_encoder)
+    second = _embed_once(_item(cacheable=False), stateful_encoder)
+
+    assert calls == 2
+    assert torch.equal(first, torch.tensor([[1.0]]))
+    assert torch.equal(second, torch.tensor([[2.0]]))
+
+
+def test_mixed_cacheability_reuses_only_stateless_item() -> None:
+    init_mm_embedding_cache(1 << 20)
+    encoded_hashes = []
+    items = [
+        _item(cacheable=True, item_hash=1, offset=(0, 0)),
+        _item(cacheable=False, item_hash=2, offset=(1, 1)),
+    ]
+
+    def encoder(misses):
+        encoded_hashes.append([item.hash for item in misses])
+        return torch.tensor([[float(item.hash)] for item in misses])
+
+    def embed():
+        result, _ = _get_chunked_prefill_embedding(
+            data_embedding_func=encoder,
+            embedding_items=items,
+            items_size=[0, 2],
+            prefix_length=[0],
+            extend_length=[2],
+            items_offset_list=[[(0, 0), (1, 1)]],
+            input_ids=torch.tensor([0, 0]),
+        )
+        return result
+
+    assert torch.equal(embed(), torch.tensor([[1.0], [2.0]]))
+    assert torch.equal(embed(), torch.tensor([[1.0], [2.0]]))
+    assert encoded_hashes == [[1, 2], [2]]
+
+
+def test_noncacheable_item_does_not_read_same_hash_cached_embedding() -> None:
+    init_mm_embedding_cache(1 << 20)
+    calls = 0
+
+    def encoder(_items):
+        nonlocal calls
+        calls += 1
+        return torch.tensor([[float(calls)]])
+
+    assert torch.equal(
+        _embed_once(_item(cacheable=True), encoder), torch.tensor([[1.0]])
+    )
+    assert torch.equal(
+        _embed_once(_item(cacheable=False), encoder), torch.tensor([[2.0]])
+    )
+
+
+def test_combined_path_bypasses_cache_if_any_item_is_stateful() -> None:
+    init_mm_embedding_cache(1 << 20)
+    calls = 0
+    item = _item(cacheable=False)
+    item.offsets = [(0, 0), (1, 1)]
+
+    def encoder(_items):
+        nonlocal calls
+        calls += 1
+        return torch.tensor([[float(calls)], [float(calls)]])
+
+    def embed():
+        result, _ = _get_chunked_prefill_embedding(
+            data_embedding_func=encoder,
+            embedding_items=[item],
+            items_size=[0, 1],
+            prefix_length=[0],
+            extend_length=[2],
+            items_offset_list=[[(0, 0), (1, 1)]],
+            input_ids=torch.tensor([0, 0]),
+        )
+        return result
+
+    assert torch.equal(embed(), torch.tensor([[1.0], [1.0]]))
+    assert torch.equal(embed(), torch.tensor([[2.0], [2.0]]))
+    assert calls == 2
+
+
+def test_evs_combined_result_obeys_cacheability() -> None:
+    init_mm_embedding_cache(1 << 20)
+    item = _item(cacheable=False)
+    item.offsets = [(0, 0), (1, 1)]
+    calls = 0
+
+    def encoder(_items):
+        nonlocal calls
+        calls += 1
+        return EVSEmbeddingResult(
+            embedding=torch.tensor([[float(calls)]]),
+            num_tokens_per_frame=[1],
+        )
+
+    with patch.object(
+        EVSEmbeddingResult,
+        "redistribute_pruned_frames_placeholders",
+        return_value=(torch.tensor([0]), [(0, 0)]),
+    ):
+        first, _ = _get_chunked_embedding_full(
+            encoder, [item], [(0, 0)], 0, 1, torch.tensor([0]), torch.device("cpu")
+        )
+        second, _ = _get_chunked_embedding_full(
+            encoder, [item], [(0, 0)], 0, 1, torch.tensor([0]), torch.device("cpu")
+        )
+
+    assert torch.equal(first, torch.tensor([[1.0]]))
+    assert torch.equal(second, torch.tensor([[2.0]]))

--- a/test/registered/unit/managers/test_output_streamer_customized_info.py
+++ b/test/registered/unit/managers/test_output_streamer_customized_info.py
@@ -1,6 +1,8 @@
 import unittest
 from types import SimpleNamespace
 
+import torch
+
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.managers.io_struct import unwrap_from_pickle
 from sglang.srt.managers.scheduler_components.output_streamer import (
@@ -28,6 +30,7 @@ class _FakeReq:
         )
         self.output_ids = output_ids
         self.output_ids_through_stop = output_ids
+        self.drop_trailing_stop_token = False
         self.send_token_offset = 0
         self.send_output_token_logprobs_offset = 0
         self.send_decode_id_offset = 0
@@ -54,10 +57,16 @@ class _FakeReq:
 
 
 class TestOutputStreamerCustomizedInfo(unittest.TestCase):
-    def test_customized_info_is_padded_for_mixed_batches(self):
-        accumulator = _GenerationStreamAccumulator(
-            return_logprob=False,
-            return_hidden_states=False,
+    @staticmethod
+    def _accumulator(
+        *,
+        return_logprob: bool = False,
+        return_hidden_states: bool = False,
+        return_sampling_mask: bool = False,
+    ):
+        return _GenerationStreamAccumulator(
+            return_logprob=return_logprob,
+            return_hidden_states=return_hidden_states,
             return_routed_experts=False,
             return_indexer_topk=False,
             spec_algorithm=SpeculativeAlgorithm.NONE,
@@ -65,7 +74,11 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
             default_stream_interval=1,
             default_force_stream_interval=1,
             get_cached_tokens_details=lambda req: None,
+            return_sampling_mask=return_sampling_mask,
         )
+
+    def test_customized_info_is_padded_for_mixed_batches(self):
+        accumulator = self._accumulator()
 
         accumulator.accept(req=_FakeReq("r0", [10, 11]))
         accumulator.accept(
@@ -89,6 +102,118 @@ class TestOutputStreamerCustomizedInfo(unittest.TestCase):
             customized_info["other"],
             [[None, None], [None, None, None], [300]],
         )
+
+    def test_dropped_stop_token_is_removed_from_every_per_token_channel(self):
+        for retained_ids in ([], [10]):
+            with self.subTest(retained_ids=retained_ids):
+                req = _FakeReq("r0", retained_ids + [99])
+                req.output_ids_through_stop = retained_ids
+                req.finished = lambda: True
+                req.drop_trailing_stop_token = True
+                req.return_logprob = True
+                req.input_logprob_sent = False
+                req.logprob = SimpleNamespace(
+                    input_token_logprobs_val=None,
+                    output_token_logprobs_val=[0.1, 0.2],
+                    output_token_logprobs_idx=[10, 99],
+                    output_top_logprobs_val=[[0.1], [0.2]],
+                    output_top_logprobs_idx=[[10], [99]],
+                    output_token_ids_logprobs_val=[[0.1], [0.2]],
+                    output_token_ids_logprobs_idx=[[10], [99]],
+                )
+                req.return_sampling_mask = True
+                req.send_output_sampling_mask_offset = 0
+                req.output_token_sampling_mask = [True, False]
+                req.output_token_sampling_logprobs = [0.1, 0.2]
+                req.return_hidden_states = True
+                req.hidden_states = torch.tensor([[1.0], [2.0]])
+                accumulator = self._accumulator(
+                    return_logprob=True,
+                    return_hidden_states=True,
+                    return_sampling_mask=True,
+                )
+
+                accumulator.accept(req=req)
+
+                expected_len = len(retained_ids)
+                self.assertEqual(accumulator.output_ids, [retained_ids])
+                self.assertEqual(
+                    len(accumulator.output_token_logprobs_val[0]), expected_len
+                )
+                self.assertEqual(accumulator.output_token_logprobs_idx[0], retained_ids)
+                self.assertEqual(
+                    len(accumulator.output_token_sampling_mask[0]), expected_len
+                )
+                self.assertEqual(
+                    accumulator.output_token_sampling_mask[0],
+                    [True][:expected_len],
+                )
+                self.assertEqual(
+                    accumulator.output_hidden_states[0].shape[0], expected_len
+                )
+                torch.testing.assert_close(
+                    accumulator.output_hidden_states[0],
+                    torch.tensor([[1.0]])[:expected_len],
+                )
+
+    def test_default_per_token_channel_boundaries_are_unchanged(self):
+        req = _FakeReq("r0", [10, 99])
+        req.output_ids_through_stop = [10]
+        req.finished = lambda: True
+        req.finished_len = 1
+        req.return_logprob = True
+        req.input_logprob_sent = False
+        req.logprob = SimpleNamespace(
+            input_token_logprobs_val=None,
+            output_token_logprobs_val=[0.1, 0.2],
+            output_token_logprobs_idx=[10, 99],
+            output_top_logprobs_val=[[0.1], [0.2]],
+            output_top_logprobs_idx=[[10], [99]],
+            output_token_ids_logprobs_val=[[0.1], [0.2]],
+            output_token_ids_logprobs_idx=[[10], [99]],
+        )
+        req.return_sampling_mask = True
+        req.send_output_sampling_mask_offset = 0
+        req.output_token_sampling_mask = [True, False]
+        req.output_token_sampling_logprobs = [0.1, 0.2]
+        req.return_hidden_states = True
+        req.hidden_states = torch.tensor([[1.0], [2.0]])
+        accumulator = self._accumulator(
+            return_logprob=True,
+            return_hidden_states=True,
+            return_sampling_mask=True,
+        )
+
+        accumulator.accept(req=req)
+
+        self.assertEqual(accumulator.output_token_logprobs_idx, [[10]])
+        self.assertEqual(accumulator.output_token_sampling_mask, [[True, False]])
+        torch.testing.assert_close(
+            accumulator.output_hidden_states[0], torch.tensor([[1.0]])
+        )
+
+    def test_default_empty_output_keeps_legacy_first_logprob(self):
+        req = _FakeReq("r0", [99])
+        req.output_ids_through_stop = []
+        req.finished = lambda: True
+        req.return_logprob = True
+        req.input_logprob_sent = False
+        req.logprob = SimpleNamespace(
+            input_token_logprobs_val=None,
+            output_token_logprobs_val=[0.2],
+            output_token_logprobs_idx=[99],
+            output_top_logprobs_val=[[0.2]],
+            output_top_logprobs_idx=[[99]],
+            output_token_ids_logprobs_val=[[0.2]],
+            output_token_ids_logprobs_idx=[[99]],
+        )
+        req.return_sampling_mask = False
+        req.return_hidden_states = False
+        accumulator = self._accumulator(return_logprob=True)
+
+        accumulator.accept(req=req)
+
+        self.assertEqual(accumulator.output_token_logprobs_idx, [[99]])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -4,11 +4,9 @@ from unittest.mock import MagicMock, patch
 
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.schedule_policy import AddReqResult, PrefillAdder
-from sglang.srt.mem_cache.base_prefix_cache import (
-    DecLockRefResult,
-    IncLockRefResult,
-)
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefResult, IncLockRefResult
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.session.streaming_session import StreamingSession
 from sglang.srt.utils.common import Range
 from sglang.test.ci.ci_register import (
     register_amd_ci,
@@ -97,6 +95,7 @@ class TestPrefillAdder(CustomTestCase):
         req.sampling_params = SimpleNamespace(max_new_tokens=max_new_tokens)
         req.time_stats = SimpleNamespace(wait_queue_entry_time=wait_time)
         req.retracted_stain = False
+        req.session = None
         req.finished.return_value = False
         req.needs_host_load_back.return_value = False
         return req
@@ -115,6 +114,22 @@ class TestPrefillAdder(CustomTestCase):
         )
         defaults.update(kwargs)
         return PrefillAdder(**defaults)
+
+    def test_mamba_budget_allows_preassigned_main_state(self):
+        adder = object.__new__(PrefillAdder)
+        adder.rem_mamba_slots = 0
+
+        self.assertTrue(
+            adder._has_mamba_budget_for_req(SimpleNamespace(mamba_pool_idx=object()))
+        )
+
+    def test_mamba_budget_rejects_new_state_when_pool_is_full(self):
+        adder = object.__new__(PrefillAdder)
+        adder.rem_mamba_slots = 0
+
+        self.assertFalse(
+            adder._has_mamba_budget_for_req(SimpleNamespace(mamba_pool_idx=None))
+        )
 
     def test_preempt_success_high_priority_values_first(self):
         params = [
@@ -776,6 +791,171 @@ class TestPrefillAdder(CustomTestCase):
         self.assertIsNone(result)
         req.set_extend_range.assert_called_once_with(0, 200)
         self.assertIn(req, adder.can_run_list)
+
+    def _attach_streaming_lifecycle(self, chunk_end: int) -> MagicMock:
+        lifecycle = MagicMock()
+        lifecycle.next_prefill_chunk_end.side_effect = lambda _req, start, end: min(
+            max(chunk_end, start + 1), end
+        )
+        session_cache = StreamingSession(self.mock_tree_cache)
+        session_cache.attach_session_lifecycle(lifecycle)
+        self.mock_tree_cache.session = session_cache
+        return lifecycle
+
+    def _create_streaming_prefill_req(self, num_tokens: int):
+        req = self.create_mock_req("streaming", priority=0, max_new_tokens=8)
+        req.full_untruncated_fill_ids = list(range(num_tokens))
+        req.host_hit_length = 0
+        req.swa_host_hit_length = 0
+        req.last_node = MagicMock()
+        req.session = SimpleNamespace(streaming=True, session_id="session")
+        req.sampling_params.ignore_eos = False
+        req.set_extend_range = MagicMock(
+            side_effect=lambda start, end: setattr(
+                req, "extend_range", Range(start, end)
+            )
+        )
+        return req
+
+    def test_lifecycle_boundary_forces_chunk(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        lifecycle = self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=100)
+        req = self._create_streaming_prefill_req(8)
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        req.set_extend_range.assert_called_once_with(0, 3)
+        self.assertIs(adder.new_chunked_req, req)
+        lifecycle.next_prefill_chunk_end.assert_called_once_with(req, 0, 8)
+
+    def test_lifecycle_chunk_continues_at_next_boundary(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=6)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=100)
+        req = self._create_streaming_prefill_req(8)
+        req.prefix_indices = [0, 1, 2]
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIs(result, req)
+        req.set_extend_range.assert_called_once_with(3, 6)
+
+    def test_resource_budget_can_cut_before_lifecycle_boundary(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=2)
+        req = self._create_streaming_prefill_req(8)
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        req.set_extend_range.assert_called_once_with(0, 2)
+        self.assertIs(adder.new_chunked_req, req)
+
+    def test_existing_chunk_latch_defers_new_lifecycle_chunk(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=100)
+        req = self._create_streaming_prefill_req(8)
+
+        result = adder.add_one_req(
+            req, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        req.set_extend_range.assert_not_called()
+        self.assertNotIn(req, adder.can_run_list)
+        self.assertIsNone(adder.new_chunked_req)
+
+    def test_existing_chunk_latch_defers_new_resource_chunk(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        lifecycle = self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=3)
+        req = self._create_streaming_prefill_req(8)
+        req.session = None
+
+        result = adder.add_one_req(
+            req, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        req.set_extend_range.assert_not_called()
+        self.assertNotIn(req, adder.can_run_list)
+        self.assertIsNone(adder.new_chunked_req)
+        lifecycle.next_prefill_chunk_end.assert_not_called()
+
+    def test_lifecycle_boundary_rejects_unsupported_page_alignment(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(
+            self.create_running_batch(), page_size=4, rem_chunk_tokens=100
+        )
+        req = self._create_streaming_prefill_req(8)
+
+        with self.assertRaisesRegex(RuntimeError, "not page-aligned"):
+            adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
+
+    def test_lifecycle_boundary_rejects_deterministic_alignment(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=100)
+        req = self._create_streaming_prefill_req(8)
+
+        with self.assertRaisesRegex(RuntimeError, "deterministic truncation"):
+            adder.add_one_req(req, has_chunked_req=False, truncation_align_size=2)
+
+    def test_non_streaming_request_ignores_lifecycle_boundary(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        lifecycle = self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch())
+        req = self._create_streaming_prefill_req(8)
+        req.session = None
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        req.set_extend_range.assert_called_once_with(0, 8)
+        lifecycle.next_prefill_chunk_end.assert_not_called()
+
+    def test_unattached_streaming_lifecycle_keeps_default_prefill_path(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self.mock_tree_cache.session = StreamingSession(self.mock_tree_cache)
+        adder = self.create_adder(self.create_running_batch())
+        req = self._create_streaming_prefill_req(8)
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        req.set_extend_range.assert_called_once_with(0, 8)
+
+    def test_lifecycle_boundary_requires_chunked_prefill(self):
+        self.mock_token_allocator.available_size.return_value = 10_000
+        self.mock_token_allocator.full_available_size.return_value = 10_000
+        self._attach_streaming_lifecycle(chunk_end=3)
+        adder = self.create_adder(self.create_running_batch(), rem_chunk_tokens=None)
+        req = self._create_streaming_prefill_req(8)
+
+        with self.assertRaisesRegex(RuntimeError, "require chunked prefill"):
+            adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_mm_padding.py
+++ b/test/registered/unit/managers/test_scheduler_mm_padding.py
@@ -1,0 +1,118 @@
+from array import array
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_mm_padding_keeps_streaming_fill_ids_coherent() -> None:
+    audio_token = 200038
+    audio_pad = 1 << 50
+    prefix = [10, 11, 12]
+    request = SimpleNamespace(
+        origin_input_ids=array("q", prefix + [audio_token]),
+        full_untruncated_fill_ids=array("q", prefix + [audio_token]),
+        session=SimpleNamespace(streaming=True),
+    )
+    received = SimpleNamespace(input_ids=array("q", [audio_token]))
+    mm_inputs = SimpleNamespace(padded_input_ids=[audio_pad])
+
+    assert Scheduler._try_apply_padded_mm_input_ids(received, request, mm_inputs)
+
+    expected = prefix + [audio_pad]
+    assert list(request.origin_input_ids) == expected
+    assert list(request.full_untruncated_fill_ids) == expected
+
+
+def test_mm_padding_invalidates_incoherent_streaming_fill_ids() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [10, 200038]),
+        full_untruncated_fill_ids=array("q", [10]),
+        session=SimpleNamespace(streaming=True),
+    )
+    received = SimpleNamespace(input_ids=array("q", [200038]))
+    mm_inputs = SimpleNamespace(padded_input_ids=[1 << 50])
+
+    assert Scheduler._try_apply_padded_mm_input_ids(received, request, mm_inputs)
+
+    assert request.full_untruncated_fill_ids == array("q")
+
+
+def test_mm_padding_keeps_legacy_non_streaming_fill_ids_untouched() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [10, 200038]),
+        full_untruncated_fill_ids=array("q", [10, 200038]),
+        session=None,
+    )
+    received = SimpleNamespace(input_ids=array("q", [200038]))
+    mm_inputs = SimpleNamespace(padded_input_ids=[1 << 50])
+
+    assert Scheduler._try_apply_padded_mm_input_ids(received, request, mm_inputs)
+
+    assert list(request.origin_input_ids) == [10, 1 << 50]
+    assert list(request.full_untruncated_fill_ids) == [10, 200038]
+
+
+def test_model_mm_padding_expands_only_carried_streaming_suffix() -> None:
+    prefix = [10, 11]
+    request = SimpleNamespace(
+        origin_input_ids=array("q", prefix + [200038]),
+        full_untruncated_fill_ids=array("q", prefix + [200038]),
+    )
+
+    Scheduler._set_padded_mm_input_ids(
+        request,
+        prefix + [1 << 50, 1 << 50],
+        prefix_len=len(prefix),
+    )
+
+    expected = prefix + [1 << 50, 1 << 50]
+    assert list(request.origin_input_ids) == expected
+    assert list(request.full_untruncated_fill_ids) == expected
+
+
+def test_mm_padding_with_zero_prefix_replaces_full_prompt() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [200038]),
+        full_untruncated_fill_ids=array("q", [200038]),
+    )
+
+    Scheduler._set_padded_mm_input_ids(request, [1 << 50, 1 << 50], prefix_len=0)
+
+    assert list(request.origin_input_ids) == [1 << 50, 1 << 50]
+    assert list(request.full_untruncated_fill_ids) == [1 << 50, 1 << 50]
+
+
+def test_mm_padding_preserves_empty_fill_cache() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [10, 200038]),
+        full_untruncated_fill_ids=array("q"),
+    )
+
+    Scheduler._set_padded_mm_input_ids(request, [10, 1 << 50], prefix_len=1)
+
+    assert request.full_untruncated_fill_ids == array("q")
+
+
+def test_mm_padding_rejects_malformed_prefix_length() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [10, 11, 200038]),
+        full_untruncated_fill_ids=array("q", [10, 11, 200038]),
+    )
+
+    with pytest.raises(ValueError, match="Invalid multimodal padding prefix"):
+        Scheduler._set_padded_mm_input_ids(request, [10], prefix_len=2)
+
+
+def test_mm_padding_rejects_fallback_that_rewrites_prefix() -> None:
+    request = SimpleNamespace(
+        origin_input_ids=array("q", [10, 200038]),
+        full_untruncated_fill_ids=array("q", [10, 200038]),
+    )
+
+    with pytest.raises(ValueError, match="changed tokens before"):
+        Scheduler._set_padded_mm_input_ids(request, [99, 1 << 50], prefix_len=1)

--- a/test/registered/unit/mem_cache/test_session_token_share_unit.py
+++ b/test/registered/unit/mem_cache/test_session_token_share_unit.py
@@ -15,21 +15,33 @@ register_cpu_ci(est_time=15, suite="base-a-test-cpu")
 import unittest
 from array import array
 from types import SimpleNamespace
+from unittest.mock import Mock
 
+from sglang.srt.managers.schedule_batch import (
+    MultimodalInputs,
+    StreamingSessionAbortPolicy,
+)
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.session.session_controller import Session
+from sglang.srt.session.streaming_session import SessionSlot, StreamingSession
 from sglang.test.test_utils import CustomTestCase
 
 VOCAB = 1 << 20
 
 
-def _recv(rid, input_ids, max_new_tokens=8):
+def _recv(rid, input_ids, max_new_tokens=8, mm_inputs=None):
     return SimpleNamespace(
         rid=rid,
         input_ids=array("q", input_ids),
-        mm_inputs=None,
+        mm_inputs=mm_inputs,
         session_params=SimpleNamespace(
-            id="s", rid=None, offset=None, replace=False, drop_previous_output=False
+            id="s",
+            rid=None,
+            offset=None,
+            replace=False,
+            drop_previous_output=False,
+            drop_trailing_stop_token=False,
         ),
         sampling_params=SamplingParams(max_new_tokens=max_new_tokens),
         lora_id=None,
@@ -56,9 +68,14 @@ class TestSessionTokenShare(CustomTestCase):
     def setUp(self):
         self.session = Session(capacity_of_str_len=0, session_id="s", streaming=True)
 
-    def _create(self, rid, input_ids, max_new_tokens=8):
+    def _create(self, rid, input_ids, max_new_tokens=8, mm_inputs=None):
         return self.session.create_req(
-            _recv(rid, input_ids, max_new_tokens=max_new_tokens),
+            _recv(
+                rid,
+                input_ids,
+                max_new_tokens=max_new_tokens,
+                mm_inputs=mm_inputs,
+            ),
             tokenizer=None,
             vocab_size=VOCAB,
         )
@@ -99,6 +116,35 @@ class TestSessionTokenShare(CustomTestCase):
         self.assertEqual(list(r3.origin_input_ids), in1 + out1 + in2 + out2 + [9])
         self.assertEqual(list(r3.full_untruncated_fill_ids), list(r3.origin_input_ids))
 
+    def test_bos_only_turn_forwards_retained_tail_before_boundary(self):
+        bos, empty_audio = 200000, 201472
+        first = self._create("first", [10], max_new_tokens=1)
+        self._decode_and_finish(first, [99])
+
+        direct_append = (
+            list(first.origin_input_ids) + list(first.output_ids) + [empty_audio]
+        )
+        self.assertEqual(direct_append[1:], [99, empty_audio])
+
+        drain = self.session.create_req(
+            _recv("drain", [bos], max_new_tokens=0),
+            tokenizer=SimpleNamespace(bos_token_id=bos),
+            vocab_size=VOCAB,
+        )
+        self.assertEqual(list(drain.origin_input_ids), [10, 99])
+        self.session.finish_req(drain)
+
+        boundary = self._create("boundary", [empty_audio])
+        self.assertEqual(list(boundary.origin_input_ids), [10, 99, empty_audio])
+        self.assertEqual(
+            list(boundary.origin_input_ids)[self.session.committed_origin_len :],
+            [empty_audio],
+        )
+
+    def test_streaming_boundary_replacement_rejects_none(self):
+        with self.assertRaisesRegex(ValueError, "cannot be None"):
+            self.session.replace_streaming_boundary(None)
+
     def test_mid_turn_abort_then_continue(self):
         in1, out1 = list(range(200, 210)), [1, 2, 3]
         r1 = self._create("r1", in1)
@@ -110,7 +156,7 @@ class TestSessionTokenShare(CustomTestCase):
         self.assertEqual(list(r2.origin_input_ids), in1 + out1 + [50, 51])
         r2.output_ids.extend([6, 7])
         r2._refresh_fill_ids()
-        self.session.abort_req()
+        self.session.abort_req(r2)
         self.assertEqual(self.session.committed_origin_len, len(in1))
 
         # Turn 3 must see exactly r1's history — no [50, 51], no doubled out1.
@@ -119,15 +165,174 @@ class TestSessionTokenShare(CustomTestCase):
         self.assertEqual(list(r3.full_untruncated_fill_ids), list(r3.origin_input_ids))
 
         # Two aborted attempts in a row heal idempotently.
-        self.session.abort_req()
+        self.session.abort_req(r3)
         r4 = self._create("r4", [70])
         self.assertEqual(list(r4.origin_input_ids), in1 + out1 + [70])
         self.assertEqual(list(r4.full_untruncated_fill_ids), list(r4.origin_input_ids))
 
-    def test_first_turn_abort(self):
-        self._create("r1", [1, 2, 3])
+    def test_retraction_checkpoint_keeps_turn_inflight(self):
+        r1 = self._create("r1", [1, 2, 3])
+        r1.output_ids.extend([4, 5])
+        r1._refresh_fill_ids()
+
+        self.session.checkpoint_retracted_req(r1)
+
         self.assertTrue(self.session._inflight)
-        self.session.abort_req()
+        [node] = self.session.req_nodes.values()
+        self.assertIs(node.req, r1)
+        with get_parallel().override(tp_rank=0):
+            overlapping = self._create("overlap", [6])
+        self.assertIsNotNone(overlapping.to_finish)
+        self.assertIn("already has an active request", overlapping.to_finish.message)
+
+        self.session.abort_req(r1)
+        resumed = self._create("resumed", [7])
+        self.assertEqual(list(resumed.origin_input_ids), [1, 2, 3, 4, 5, 7])
+
+    def test_detaching_rejected_concurrent_request_preserves_owner(self):
+        owner = self._create("owner", [1, 2, 3])
+        with get_parallel().override(tp_rank=0):
+            rejected = self._create("rejected", [4])
+        self.assertIsNotNone(rejected.to_finish)
+
+        cache = StreamingSession(SimpleNamespace())
+        control = Mock()
+        cache.attach_session_lifecycle(control)
+
+        self.assertTrue(cache.detach_queued_request(rejected))
+        self.assertIsNone(rejected.session)
+        self.assertTrue(self.session._inflight)
+        self.assertIs(self.session._inflight_req, owner)
+        control.on_session_released.assert_not_called()
+
+        self.assertTrue(cache.detach_queued_request(owner))
+        self.assertFalse(self.session._inflight)
+        self.assertIsNone(self.session._inflight_req)
+        control.on_session_released.assert_called_once_with("s")
+
+    def test_preaborted_concurrent_request_preserves_owner(self):
+        owner = self._create("owner", [1, 2, 3])
+        with get_parallel().override(tp_rank=0):
+            rejected = self._create("rejected", [4])
+        cache = StreamingSession(SimpleNamespace())
+        slot = SessionSlot(
+            req_pool_idx=1,
+            kv=SimpleNamespace(kv_allocated_len=0, swa_evicted_seqlen=0),
+        )
+        cache.slots["s"] = slot
+
+        self.assertIsNone(cache.find_active_slot(rejected))
+
+        self.assertIsNone(rejected.session)
+        self.assertTrue(self.session._inflight)
+        self.assertIs(self.session._inflight_req, owner)
+        self.assertIs(cache.slots["s"], slot)
+
+    def test_finishing_rejected_concurrent_request_preserves_owner(self):
+        owner = self._create("owner", [1, 2, 3])
+        with get_parallel().override(tp_rank=0):
+            rejected = self._create("rejected", [4])
+        rejected.finished_reason = rejected.to_finish
+
+        cache = StreamingSession(SimpleNamespace())
+        control = Mock()
+        cache.attach_session_lifecycle(control)
+        release_session = Mock(wraps=cache.release_session)
+        cache.release_session = release_session
+
+        self.assertTrue(cache.try_cache_finished_req(rejected))
+
+        self.assertIsNone(rejected.session)
+        self.assertIsNone(rejected.req_pool_idx)
+        self.assertIsNone(rejected.kv)
+        self.assertTrue(self.session._inflight)
+        self.assertIs(self.session._inflight_req, owner)
+        release_session.assert_not_called()
+        control.on_session_released.assert_not_called()
+
+    def test_canceling_rejected_concurrent_request_preserves_owner_slot(self):
+        retained_item = SimpleNamespace(feature=object())
+        boundary = self._create("boundary", [1, 2])
+        boundary.multimodal_inputs = MultimodalInputs(mm_items=[retained_item])
+        self._decode_and_finish(boundary, [])
+
+        owner = self._create("owner", [3])
+        with get_parallel().override(tp_rank=0):
+            rejected = self._create("rejected", [4])
+        rejected.finished_reason = rejected.to_finish
+        rejected.streaming_abort_policy = StreamingSessionAbortPolicy.COMMIT_FORWARDED
+        rejected_item = SimpleNamespace(feature=object())
+        rejected.multimodal_inputs = MultimodalInputs(
+            mm_items=[retained_item, rejected_item]
+        )
+
+        cache = StreamingSession(SimpleNamespace())
+        slot = SessionSlot(
+            req_pool_idx=1,
+            kv_committed_len=3,
+            kv=SimpleNamespace(kv_allocated_len=3, swa_evicted_seqlen=0),
+        )
+        cache.slots["s"] = slot
+        control = Mock()
+        cache.attach_session_lifecycle(control)
+        release_session = Mock(wraps=cache.release_session)
+        cache.release_session = release_session
+
+        self.assertTrue(cache.try_cache_finished_req(rejected))
+
+        self.assertIsNone(rejected.session)
+        self.assertTrue(self.session._inflight)
+        self.assertIs(self.session._inflight_req, owner)
+        self.assertIs(cache.slots["s"], slot)
+        self.assertIsNotNone(retained_item.feature)
+        self.assertIsNone(rejected_item.feature)
+        self.assertIsNone(rejected.multimodal_inputs)
+        release_session.assert_not_called()
+        control.on_request_committed.assert_not_called()
+        control.on_session_released.assert_not_called()
+
+    def test_resumed_retracted_request_finishes_without_self_detach(self):
+        r1 = self._create("r1", [1, 2, 3])
+        r1.output_ids.extend([4])
+        r1._refresh_fill_ids()
+        self.session.checkpoint_retracted_req(r1)
+
+        self.session.finish_req(r1)
+
+        self.assertFalse(self.session._inflight)
+        self.assertIs(r1.session, self.session)
+        [node] = self.session.req_nodes.values()
+        self.assertIs(node.req, r1)
+
+    def test_retracted_queue_rejection_retains_partial_append_boundary(self):
+        r1 = self._create("r1", [1, 2, 3])
+        r1.output_ids.extend([4, 5])
+        r1._refresh_fill_ids()
+        retained_mm = MultimodalInputs(mm_items=["retained-audio"])
+        r1.multimodal_inputs = retained_mm
+        r1.req_pool_idx = 0
+        r1.kv_committed_len = 5
+        r1.kv = SimpleNamespace(kv_allocated_len=5, swa_evicted_seqlen=0)
+        cache = StreamingSession(SimpleNamespace())
+
+        cache.cache_finished_req(r1, is_insert=False)
+        r1.reset_for_retract()
+
+        self.assertTrue(self.session._inflight)
+        self.assertTrue(cache.detach_queued_request(r1))
+        self.assertFalse(self.session._inflight)
+        self.assertIsNone(r1.session)
+        self.assertIs(r1.multimodal_inputs, retained_mm)
+        self.assertEqual(cache.slots["s"].kv_committed_len, 5)
+
+        r2 = self._create("r2", [6])
+        self.assertEqual(list(r2.origin_input_ids), [1, 2, 3, 4, 5, 6])
+        self.assertIs(r2.multimodal_inputs, retained_mm)
+
+    def test_first_turn_abort(self):
+        r1 = self._create("r1", [1, 2, 3])
+        self.assertTrue(self.session._inflight)
+        self.session.abort_req(r1)
         self.assertFalse(self.session._inflight)
         # No finish_req ran: nothing committed, next turn starts from scratch.
         self.assertIsNone(self.session.committed_origin_len)
@@ -136,6 +341,23 @@ class TestSessionTokenShare(CustomTestCase):
         self._decode_and_finish(r2, [9])
         r3 = self._create("r3", [6])
         self.assertEqual(list(r3.origin_input_ids), [4, 5, 9, 6])
+
+    def test_aborted_turn_does_not_mutate_committed_multimodal_history(self):
+        committed_mm = MultimodalInputs(mm_items=["committed"])
+        r1 = self._create("r1", [1])
+        r1.multimodal_inputs = committed_mm
+        self._decode_and_finish(r1, [2])
+
+        incoming_mm = MultimodalInputs(mm_items=["aborted"])
+        r2 = self._create("r2", [3], mm_inputs=incoming_mm)
+        self.assertIsNot(r2.multimodal_inputs, r1.multimodal_inputs)
+        r2.multimodal_inputs.merge(incoming_mm)
+        self.assertEqual(r2.multimodal_inputs.mm_items, ["committed", "aborted"])
+        self.session.abort_req(r2)
+
+        self.assertEqual(r1.multimodal_inputs.mm_items, ["committed"])
+        r3 = self._create("r3", [4], mm_inputs=MultimodalInputs(mm_items=["next"]))
+        self.assertEqual(r3.multimodal_inputs.mm_items, ["committed"])
 
     def test_max_new_tokens_overshoot_falls_back(self):
         in1 = list(range(300, 310))

--- a/test/registered/unit/mem_cache/test_streaming_session_unit.py
+++ b/test/registered/unit/mem_cache/test_streaming_session_unit.py
@@ -1,9 +1,21 @@
 from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
+import pytest
 import torch
 
-from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.srt.managers.schedule_batch import (
+    FINISH_ABORT,
+    FINISH_LENGTH,
+    FINISH_MATCHED_TOKEN,
+    StreamingSessionAbortPolicy,
+)
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.utils import GenerationBatchResult
 from sglang.srt.mem_cache.base_prefix_cache import MatchResult
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.session.streaming_session import SessionSlot, StreamingSession
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -16,6 +28,15 @@ class _FakeAllocator:
 
     def free(self, free_index: torch.Tensor):
         self.freed.append(free_index.clone())
+
+
+class _FakeMultimodalInputs:
+    def __init__(self, items):
+        self.mm_items = items
+
+    def release_features(self):
+        for item in self.mm_items:
+            item.feature = None
 
 
 class _FakeInnerCache:
@@ -54,9 +75,11 @@ class _FakeReq:
             session_id=session_id,
             streaming=True,
             finish_req=lambda req: None,
-            abort_req=lambda: None,
+            abort_req=lambda req=None: True,
+            req_nodes={},
             _inflight=False,
         )
+        self.session._inflight_req = self
         self.req_pool_idx = req_pool_idx
         self.kv_committed_len = committed
         self.kv = SimpleNamespace(
@@ -78,11 +101,311 @@ class _FakeReq:
         self.to_finish = None
         self.finished_reason = None
         self.finished_len = None
+        self.streaming_abort_policy = StreamingSessionAbortPolicy.RELEASE_SESSION
+        self.drop_trailing_stop_token = False
+        self.multimodal_inputs = None
+
+    def finished(self):
+        return self.finished_reason is not None
+
+
+def test_decode_result_finds_composed_streaming_session_control():
+    req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
+    inner = _FakeInnerCache(
+        SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+        _FakeAllocator(),
+        page_size=16,
+    )
+    streaming_session = StreamingSession(inner)
+    control = Mock()
+    streaming_session.attach_session_lifecycle(control)
+    processor = SimpleNamespace(
+        tree_cache=SimpleNamespace(session=streaming_session),
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=1, allocated=1)
+
+    SchedulerBatchResultProcessor._maybe_record_streaming_session_decode(processor, req)
+
+    control.on_decode_token.assert_called_once_with(req)
+
+
+def test_prefill_result_finds_composed_streaming_session_control():
+    req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
+    inner = _FakeInnerCache(
+        SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+        _FakeAllocator(),
+        page_size=16,
+    )
+    streaming_session = StreamingSession(inner)
+    control = Mock()
+    streaming_session.attach_session_lifecycle(control)
+    processor = SimpleNamespace(
+        tree_cache=SimpleNamespace(session=streaming_session),
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=1, allocated=1)
+
+    SchedulerBatchResultProcessor._maybe_record_streaming_session_prefill(
+        processor, req, start=0, end=1
+    )
+
+    control.on_prefill_forward_complete.assert_called_once_with(req, 0, 1)
+
+
+def test_first_streaming_request_caps_prefix_match_at_lifecycle_boundary():
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    control = Mock()
+    control.next_prefill_chunk_end.return_value = 4
+    tree_cache.attach_session_lifecycle(control)
+    req = _FakeReq("session-a", req_pool_idx=0, committed=0, allocated=0)
+    req.full_untruncated_fill_ids = list(range(8))
+    key = SimpleNamespace(token_ids=list(range(8)), limit=7)
+
+    assert tree_cache.try_match_prefix(SimpleNamespace(req=req, key=key)) is None
+
+    assert key.limit == 3
+    control.next_prefill_chunk_end.assert_called_once_with(req, 0, 8)
+
+
+def test_default_streaming_lifecycle_is_noop() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=0, allocated=0)
+    req.full_untruncated_fill_ids = list(range(8))
+    key = SimpleNamespace(token_ids=list(range(8)), limit=7)
+
+    assert not tree_cache.has_attached_lifecycle
+    assert tree_cache.try_match_prefix(SimpleNamespace(req=req, key=key)) is None
+    assert tree_cache.next_prefill_chunk_end(req, 0, 8) == 8
+    assert key.limit == 7
+    assert tree_cache.session_held_mamba_slots() == 0
+
+
+def test_non_streaming_request_does_not_apply_lifecycle_prefix_cap():
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    control = Mock()
+    tree_cache.attach_session_lifecycle(control)
+    req = _FakeReq("session-a", req_pool_idx=0, committed=0, allocated=0)
+    req.session = None
+    key = SimpleNamespace(token_ids=list(range(8)), limit=7)
+
+    assert tree_cache.try_match_prefix(SimpleNamespace(req=req, key=key)) is None
+
+    assert key.limit == 7
+    control.next_prefill_chunk_end.assert_not_called()
+
+
+@pytest.mark.parametrize("session", [None, SimpleNamespace(streaming=False)])
+def test_non_streaming_prefill_does_not_inspect_tree_cache(session):
+    processor = SimpleNamespace()
+    req = _FakeReq("session-a", req_pool_idx=0, committed=1, allocated=1)
+    req.session = session
+
+    SchedulerBatchResultProcessor._maybe_record_streaming_session_prefill(
+        processor, req, start=0, end=1
+    )
+
+
+def test_middle_prefill_uses_completion_hook_and_final_prefill_uses_decode_hook():
+    req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
+    streaming_session = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=16,
+        )
+    )
+    control = Mock()
+    streaming_session.attach_session_lifecycle(control)
+
+    req = _FakeReq("session-a", req_pool_idx=0, committed=1, allocated=1)
+    req.inflight_middle_chunks = 0
+    req.is_retracted = False
+    req.time_stats = Mock()
+    req.require_reasoning = False
+    req.return_sampling_mask = False
+    req.return_hidden_states = False
+    req.grammar = None
+    req.customized_info = None
+    finish_state_updated = False
+
+    def update_finish_state():
+        nonlocal finish_state_updated
+        finish_state_updated = True
+
+    req.update_finish_state = Mock(side_effect=update_finish_state)
+    sampled_token = 99
+
+    def assert_middle_callback_state(callback_req, start, end):
+        assert callback_req.output_ids == []
+        assert (start, end) == (0, 1)
+
+    def assert_final_callback_state(callback_req):
+        assert callback_req.output_ids == [sampled_token]
+        assert finish_state_updated
+
+    control.on_prefill_forward_complete.side_effect = assert_middle_callback_state
+    control.on_decode_token.side_effect = assert_final_callback_state
+
+    processor = SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=Mock(),
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        server_args=SimpleNamespace(enable_hisparse=False),
+        model_config=SimpleNamespace(think_end_ids=None),
+        token_to_kv_pool_allocator=Mock(),
+        tree_cache=SimpleNamespace(
+            session=streaming_session, cache_unfinished_req=Mock()
+        ),
+        hisparse_coordinator=None,
+        req_to_token_pool=Mock(),
+        decode_offload_manager=None,
+        metrics_collector=Mock(),
+        metrics_reporter=Mock(),
+        draft_worker=Mock(),
+        model_worker=Mock(),
+        logprob_result_processor=Mock(),
+        output_streamer=Mock(),
+        abort_request=Mock(),
+    )
+    batch = SimpleNamespace(
+        reqs=[req],
+        decoding_reqs=[],
+        return_logprob=False,
+        prefill_stats=Mock(),
+        dp_cooperation_info=None,
+        prefix_lens=[0],
+        extend_lens=[1],
+        return_hidden_states=False,
+        return_hidden_states_mode=CaptureHiddenMode.NULL,
+        spec_info=None,
+    )
+    result = GenerationBatchResult(
+        next_token_ids=torch.tensor([sampled_token]),
+        extend_input_len_per_req=[1],
+        extend_logprob_start_len_per_req=[0],
+    )
+
+    with patch(
+        "sglang.srt.managers.scheduler_components.batch_result_processor.get_memory",
+        return_value=SimpleNamespace(enable_hisparse=False),
+    ):
+        req.inflight_middle_chunks = 1
+        processor.process_batch_result_prefill(batch, result)
+        assert req.output_ids == []
+        control.on_prefill_forward_complete.assert_called_once_with(req, 0, 1)
+
+        req.inflight_middle_chunks = 0
+        batch.prefix_lens = [1]
+        processor.process_batch_result_prefill(batch, result)
+
+    control.on_prefill_forward_complete.assert_called_once_with(req, 0, 1)
+    control.on_decode_token.assert_called_once_with(req)
+
+
+def test_mixed_prefill_batch_dispatches_each_row_to_its_lifecycle():
+    req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
+    streaming_session = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=16,
+        )
+    )
+    control = Mock()
+    streaming_session.attach_session_lifecycle(control)
+
+    prefill_req = _FakeReq("session-prefill", 0, committed=1, allocated=1)
+    decode_req = _FakeReq("session-decode", 1, committed=1, allocated=1)
+    decode_req.output_ids = [77]
+    for req in (prefill_req, decode_req):
+        req.inflight_middle_chunks = 0
+        req.is_retracted = False
+        req.time_stats = Mock()
+        req.require_reasoning = False
+        req.return_sampling_mask = False
+        req.return_hidden_states = False
+        req.grammar = None
+        req.customized_info = None
+        req.update_finish_state = Mock()
+
+    processor = SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=Mock(),
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        server_args=SimpleNamespace(enable_hisparse=False),
+        model_config=SimpleNamespace(think_end_ids=None),
+        token_to_kv_pool_allocator=Mock(),
+        tree_cache=SimpleNamespace(
+            session=streaming_session, cache_unfinished_req=Mock()
+        ),
+        hisparse_coordinator=None,
+        req_to_token_pool=Mock(),
+        decode_offload_manager=None,
+        metrics_collector=Mock(),
+        metrics_reporter=Mock(),
+        draft_worker=Mock(),
+        model_worker=Mock(),
+        logprob_result_processor=Mock(),
+        output_streamer=Mock(),
+        abort_request=Mock(),
+    )
+    batch = SimpleNamespace(
+        reqs=[prefill_req, decode_req],
+        decoding_reqs=[decode_req],
+        return_logprob=False,
+        prefill_stats=Mock(),
+        dp_cooperation_info=None,
+        prefix_lens=[0, 1],
+        extend_lens=[1, 1],
+        return_hidden_states=False,
+        return_hidden_states_mode=CaptureHiddenMode.NULL,
+        spec_info=None,
+    )
+    result = GenerationBatchResult(
+        next_token_ids=torch.tensor([91, 92]),
+        extend_input_len_per_req=[1, 1],
+        extend_logprob_start_len_per_req=[0, 0],
+    )
+
+    with patch(
+        "sglang.srt.managers.scheduler_components.batch_result_processor.get_memory",
+        return_value=SimpleNamespace(enable_hisparse=False),
+    ):
+        processor.process_batch_result_prefill(batch, result)
+
+    control.on_prefill_forward_complete.assert_not_called()
+    assert [args.args[0] for args in control.on_decode_token.call_args_list] == [
+        prefill_req,
+        decode_req,
+    ]
+    assert decode_req.output_ids == [77, 92]
 
 
 def test_preabort_detaches_session_and_preserves_slot():
     """Pre-aborted req (to_finish set before match_prefix) is detached from
-    the session: session=None, abort_req() called. Slot stays intact."""
+    the session: session=None, abort_req(req) called. Slot stays intact."""
     req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
     req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
     allocator = _FakeAllocator()
@@ -127,6 +450,68 @@ def test_preabort_detaches_session_and_preserves_slot():
     assert len(result.device_indices) == 0
 
 
+def test_detach_first_queued_request_releases_pending_session_control() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    inner = _FakeInnerCache(
+        SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+        _FakeAllocator(),
+        page_size=1,
+    )
+    tree_cache = StreamingSession(inner)
+    control = Mock()
+    tree_cache.attach_session_lifecycle(control)
+    req = _FakeReq("session-a", req_pool_idx=0, committed=0, allocated=0)
+    req.req_pool_idx = None
+    session = req.session
+    session.abort_req = Mock()
+
+    assert tree_cache.detach_queued_request(req)
+
+    assert req.session is None
+    session.abort_req.assert_called_once_with(req)
+    control.on_session_released.assert_called_once_with("session-a")
+
+
+def test_unfinished_retraction_checkpoints_without_finishing_session() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=8, allocated=8)
+    session = req.session
+    session.checkpoint_retracted_req = Mock()
+    session.finish_req = Mock()
+
+    tree_cache.cache_finished_req(req, is_insert=False)
+
+    session.checkpoint_retracted_req.assert_called_once_with(req)
+    session.finish_req.assert_not_called()
+    assert tree_cache.slots["session-a"].req_pool_idx == 0
+    assert req.req_pool_idx is None
+
+
+def test_unfinished_streaming_cache_requires_retraction_mode() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=8, allocated=8)
+
+    with pytest.raises(RuntimeError, match="only be cached for retraction"):
+        tree_cache.cache_finished_req(req)
+
+    assert tree_cache.slots == {}
+    assert req.req_pool_idx == 0
+
+
 def test_first_mid_abort_nukes_ephemeral_slot():
     """First-request mid-processing abort: no slot exists yet, ephemeral
     slot is created from req state and nuked via release_session."""
@@ -139,6 +524,10 @@ def test_first_mid_abort_nukes_ephemeral_slot():
 
     # No slot exists yet (first request).
     req = _FakeReq("session-a", req_pool_idx=0, committed=0, allocated=20)
+    session = req.session
+    session.abort_req = Mock()
+    item = SimpleNamespace(feature=object())
+    req.multimodal_inputs = _FakeMultimodalInputs([item])
     req.finished_reason = FINISH_ABORT("input too long")
 
     tree_cache.cache_finished_req(req)
@@ -150,6 +539,11 @@ def test_first_mid_abort_nukes_ephemeral_slot():
     assert req_to_token_pool.free_slots == [0]
     assert len(allocator.freed) == 1
     assert allocator.freed[0].tolist() == list(range(20))
+    assert req.kv is None
+    assert req.session is None
+    assert req.multimodal_inputs is None
+    assert item.feature is None
+    session.abort_req.assert_called_once_with(req)
 
 
 def test_nth_mid_abort_nukes_session_slot():
@@ -158,22 +552,43 @@ def test_nth_mid_abort_nukes_session_slot():
     in req_nodes for next turn's re-prefill."""
     page_size = 1
     req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
-    req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
+    mamba_allocator = _FakeAllocator()
+    req_to_token_pool = SimpleNamespace(
+        req_to_token=req_to_token,
+        free_slots=[],
+        mamba_allocator=mamba_allocator,
+    )
     allocator = _FakeAllocator()
     inner = _FakeInnerCache(req_to_token_pool, allocator, page_size)
     tree_cache = StreamingSession(inner)
 
     # Session already has a slot from a previous turn.
+    mamba_pool_idx = torch.tensor(3)
+    ping_pong = torch.tensor([4, 5])
     tree_cache.slots["session-a"] = SessionSlot(
         req_pool_idx=0,
         kv_committed_len=50,
         kv=SimpleNamespace(kv_allocated_len=50, swa_evicted_seqlen=0),
         last_node=None,
         cache_protected_len=0,
+        mamba_pool_idx=mamba_pool_idx,
+        mamba_ping_pong_track_buffer=ping_pong,
     )
 
     # Mid-processing abort: req has the SESSION slot's pool_idx (restore_to_req ran).
     req = _FakeReq("session-a", req_pool_idx=0, committed=60, allocated=65)
+    session = req.session
+    session.abort_req = Mock()
+    old_item = SimpleNamespace(feature=object())
+    new_item = SimpleNamespace(feature=object())
+    previous_req = SimpleNamespace(multimodal_inputs=_FakeMultimodalInputs([old_item]))
+    session.req_nodes["previous"] = SimpleNamespace(req=previous_req)
+    req.multimodal_inputs = _FakeMultimodalInputs([old_item, new_item])
+    req.mamba_pool_idx = mamba_pool_idx
+    req.mamba_ping_pong_track_buffer = ping_pong
+    req.mamba_next_track_idx = 1
+    req.mamba_last_track_seqlen = 32
+    req.mamba_branching_seqlen = 16
     req.finished_reason = FINISH_ABORT("client disconnected")
 
     tree_cache.cache_finished_req(req)
@@ -186,6 +601,68 @@ def test_nth_mid_abort_nukes_session_slot():
     # Pool slot returned.
     assert req_to_token_pool.free_slots == [0]
     assert req.req_pool_idx is None
+    assert req.kv is None
+    assert req.session is None
+    assert req.multimodal_inputs is None
+    assert old_item.feature is not None
+    assert new_item.feature is None
+    assert previous_req.multimodal_inputs.mm_items == [old_item]
+    assert req.mamba_pool_idx is None
+    assert req.mamba_ping_pong_track_buffer is None
+    assert req.mamba_next_track_idx is None
+    assert req.mamba_last_track_seqlen is None
+    assert req.mamba_branching_seqlen is None
+    session.abort_req.assert_called_once_with(req)
+
+
+def test_mid_abort_preserves_retracted_request_boundary() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    mamba_allocator = _FakeAllocator()
+    req_to_token_pool = SimpleNamespace(
+        req_to_token=req_to_token,
+        free_slots=[],
+        mamba_allocator=mamba_allocator,
+    )
+    tree_cache = StreamingSession(
+        _FakeInnerCache(req_to_token_pool, _FakeAllocator(), page_size=1)
+    )
+    mamba_pool_idx = torch.tensor(3)
+    ping_pong = torch.tensor([4, 5])
+    tree_cache.slots["session-a"] = SessionSlot(
+        req_pool_idx=0,
+        kv_committed_len=50,
+        kv=SimpleNamespace(kv_allocated_len=50, swa_evicted_seqlen=0),
+        mamba_pool_idx=mamba_pool_idx,
+        mamba_ping_pong_track_buffer=ping_pong,
+    )
+
+    req = _FakeReq("session-a", req_pool_idx=0, committed=60, allocated=65)
+    session = req.session
+    session.abort_req = Mock()
+    session.req_nodes["current"] = SimpleNamespace(req=req)
+    item = SimpleNamespace(feature=object())
+    multimodal_inputs = _FakeMultimodalInputs([item])
+    multimodal_inputs.release_features = Mock()
+    req.multimodal_inputs = multimodal_inputs
+    req.mamba_pool_idx = mamba_pool_idx
+    req.mamba_ping_pong_track_buffer = ping_pong
+    req.mamba_next_track_idx = 1
+    req.mamba_last_track_seqlen = 32
+    req.mamba_branching_seqlen = 16
+    req.finished_reason = FINISH_ABORT("client disconnected")
+
+    tree_cache.cache_finished_req(req)
+
+    assert req.session is session
+    assert req.multimodal_inputs is multimodal_inputs
+    assert item.feature is not None
+    multimodal_inputs.release_features.assert_not_called()
+    assert req.mamba_pool_idx is None
+    assert req.mamba_ping_pong_track_buffer is None
+    assert req.mamba_next_track_idx is None
+    assert req.mamba_last_track_seqlen is None
+    assert req.mamba_branching_seqlen is None
+    session.abort_req.assert_called_once_with(req)
 
 
 def test_release_session_threads_mamba_skip_ids():
@@ -224,6 +701,91 @@ def test_release_session_threads_mamba_skip_ids():
 # code path in cache_finished_req no longer exists.
 
 
+def test_truncate_kv_rejects_the_radix_protected_prefix() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
+    tree_cache = StreamingSession(
+        _FakeInnerCache(req_to_token_pool, _FakeAllocator(), page_size=1)
+    )
+    tree_cache.slots["session-a"] = SessionSlot(
+        req_pool_idx=0,
+        kv_committed_len=20,
+        kv=SimpleNamespace(kv_allocated_len=20, swa_evicted_seqlen=0),
+        cache_protected_len=8,
+    )
+
+    with pytest.raises(ValueError, match="below the protected session prefix"):
+        tree_cache.truncate_kv("session-a", 7)
+
+    slot = tree_cache.slots["session-a"]
+    assert slot.kv_committed_len == 20
+    assert slot.kv.kv_allocated_len == 20
+
+
+def test_truncate_kv_frees_only_complete_pages_after_target() -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    allocator = _FakeAllocator()
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            allocator,
+            page_size=4,
+        )
+    )
+    tree_cache.slots["session-a"] = SessionSlot(
+        req_pool_idx=0,
+        kv_committed_len=12,
+        kv=SimpleNamespace(kv_allocated_len=12, swa_evicted_seqlen=0),
+        cache_protected_len=4,
+    )
+
+    slot = tree_cache.truncate_kv("session-a", 6)
+
+    assert slot.kv_committed_len == 6
+    assert slot.kv.kv_allocated_len == 6
+    assert allocator.freed[0].tolist() == [8, 9, 10, 11]
+
+
+@pytest.mark.parametrize("target", [-1, 13])
+def test_truncate_kv_rejects_target_outside_committed_range(target: int) -> None:
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    tree_cache.slots["session-a"] = SessionSlot(
+        req_pool_idx=0,
+        kv_committed_len=12,
+        kv=SimpleNamespace(kv_allocated_len=12, swa_evicted_seqlen=0),
+    )
+
+    with pytest.raises(ValueError, match="outside"):
+        tree_cache.truncate_kv("session-a", target)
+
+
+def test_detach_refuses_request_that_advanced_beyond_retained_slot() -> None:
+    req_to_token = torch.arange(256, dtype=torch.int32).reshape(2, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    tree_cache.slots["session-a"] = SessionSlot(
+        req_pool_idx=0,
+        kv_committed_len=10,
+        kv=SimpleNamespace(kv_allocated_len=10, swa_evicted_seqlen=0),
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=11, allocated=11)
+
+    assert not tree_cache.detach_queued_request(req)
+    assert req.session is not None
+
+
 def test_trim_overshoot_postcondition():
     """`_trim_overshoot` postcondition: every per-req KV field is capped at
     target = origin+finished_len, output_ids is truncated, and the tail
@@ -258,6 +820,73 @@ def test_trim_overshoot_postcondition():
     # Tail [38, 44) freed by _free_kv_aligned.
     assert len(allocator.freed) == 1
     assert allocator.freed[0].tolist() == list(range(38, 44))
+
+
+def test_cancel_keeps_forwarded_partial_output_and_session_slot():
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
+    allocator = _FakeAllocator()
+    tree_cache = StreamingSession(
+        _FakeInnerCache(req_to_token_pool, allocator, page_size=1)
+    )
+
+    req = _FakeReq("session-a", req_pool_idx=0, committed=7, allocated=8)
+    req.origin_input_ids = list(range(5))
+    req.output_ids = [5, 6, 7]
+    req.finished_reason = FINISH_ABORT()
+    req.streaming_abort_policy = StreamingSessionAbortPolicy.COMMIT_FORWARDED
+
+    tree_cache.cache_finished_req(req)
+
+    slot = tree_cache.slots["session-a"]
+    assert slot.kv_committed_len == 7
+    assert slot.kv.kv_allocated_len == 7
+    assert req.output_ids == [5, 6]
+    assert allocator.freed[0].tolist() == [7]
+
+
+def test_matched_stop_token_is_not_committed_when_requested():
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    req_to_token_pool = SimpleNamespace(req_to_token=req_to_token, free_slots=[])
+    allocator = _FakeAllocator()
+    tree_cache = StreamingSession(
+        _FakeInnerCache(req_to_token_pool, allocator, page_size=1)
+    )
+
+    req = _FakeReq("session-a", req_pool_idx=0, committed=7, allocated=8)
+    req.origin_input_ids = list(range(5))
+    req.output_ids = [5, 6, 200008]
+    req.finished_reason = FINISH_MATCHED_TOKEN(200008)
+    req.finished_len = 3
+    req.drop_trailing_stop_token = True
+
+    tree_cache.cache_finished_req(req)
+
+    assert tree_cache.slots["session-a"].kv_committed_len == 7
+    assert req.output_ids == [5, 6]
+    assert allocator.freed[0].tolist() == [7]
+
+
+def test_nonmatched_finish_keeps_trailing_output_token():
+    req_to_token = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    tree_cache = StreamingSession(
+        _FakeInnerCache(
+            SimpleNamespace(req_to_token=req_to_token, free_slots=[]),
+            _FakeAllocator(),
+            page_size=1,
+        )
+    )
+    req = _FakeReq("session-a", req_pool_idx=0, committed=8, allocated=8)
+    req.origin_input_ids = list(range(5))
+    req.output_ids = [5, 6, 7]
+    req.finished_reason = FINISH_LENGTH(3)
+    req.finished_len = 3
+    req.drop_trailing_stop_token = True
+
+    tree_cache.cache_finished_req(req)
+
+    assert tree_cache.slots["session-a"].kv_committed_len == 8
+    assert req.output_ids == [5, 6, 7]
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_unified_radix_streaming_reset.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_streaming_reset.py
@@ -1,0 +1,85 @@
+from unittest.mock import Mock
+
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    ComponentType,
+    EvictLayer,
+    TreeComponent,
+)
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.session.streaming_session import SessionSlot
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeFullComponent(TreeComponent):
+    component_type = ComponentType.FULL
+
+    def create_match_validator(self, match_device_only: bool = False):
+        return lambda node: True
+
+    def redistribute_on_node_split(self, new_parent, child):
+        return None
+
+    def _dec_session_coverage(self, session_id, leaf) -> None:
+        return None
+
+    def _advance_session_coverage(self, session_id, leaf, old_ancestor) -> None:
+        return None
+
+    def _recede_session_coverage(self, session_id, leaf, fallback) -> None:
+        return None
+
+    def evict_component(
+        self,
+        node,
+        device_frees,
+        host_frees,
+        target: EvictLayer = EvictLayer.DEVICE,
+    ) -> tuple[int, int]:
+        return 0, 0
+
+    def acquire_component_lock(self, node, result):
+        return result
+
+    def release_component_lock(self, node, params):
+        return None
+
+    def _evict_device_start(self, request_cnt) -> None:
+        pass
+
+    def _evict_device_next_node(self, tracker, device_frees, host_frees):
+        return None
+
+    def _evict_device_end(self) -> None:
+        pass
+
+
+def test_reset_clears_attached_streaming_session_lifecycle() -> None:
+    cache = UnifiedRadixCache(
+        params=CacheInitParams(
+            req_to_token_pool=ReqToTokenPool(
+                size=2,
+                max_context_len=8,
+                device="cpu",
+                enable_memory_saver=False,
+            ),
+            token_to_kv_pool_allocator=None,
+            page_size=1,
+            disable=True,
+            tree_components=(ComponentType.FULL,),
+            component_registry_override={ComponentType.FULL: _FakeFullComponent},
+        )
+    )
+    lifecycle = Mock()
+    cache.session.attach_session_lifecycle(lifecycle)
+    cache.session.slots["session"] = SessionSlot(req_pool_idx=1)
+
+    cache.reset()
+
+    lifecycle.reset.assert_called_once_with()
+    assert cache.session.slots == {}
+    cache.session.reset_state()
+    assert lifecycle.reset.call_count == 2

--- a/test/registered/unit/model_executor/test_decode_cuda_graph_input_embeds.py
+++ b/test/registered/unit/model_executor/test_decode_cuda_graph_input_embeds.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
+    DecodeCudaGraphRunner,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _runner(*, require_input_embeds: bool = True) -> DecodeCudaGraphRunner:
+    runner = object.__new__(DecodeCudaGraphRunner)
+    runner.capture_input_embeds = True
+    runner.require_decode_input_embeds = require_input_embeds
+    runner.buffers = SimpleNamespace(input_embeds=torch.zeros((2, 2)))
+    return runner
+
+
+def test_decode_graph_embedding_transport_copies_exact_rows() -> None:
+    runner = _runner()
+    embeddings = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    runner._copy_decode_input_embeds(
+        SimpleNamespace(input_embeds=embeddings), 2, is_ragged=False
+    )
+
+    assert torch.equal(runner.buffers.input_embeds, embeddings)
+
+
+def test_decode_graph_embedding_transport_fails_without_embeddings() -> None:
+    runner = _runner()
+
+    with pytest.raises(RuntimeError, match="requires input_embeds"):
+        runner._copy_decode_input_embeds(
+            SimpleNamespace(input_embeds=None), 1, is_ragged=False
+        )
+
+
+def test_legacy_optional_embedding_transport_skips_missing_embeddings() -> None:
+    runner = _runner(require_input_embeds=False)
+
+    runner._copy_decode_input_embeds(
+        SimpleNamespace(input_embeds=None), 1, is_ragged=False
+    )
+
+    assert torch.equal(runner.buffers.input_embeds, torch.zeros((2, 2)))

--- a/test/registered/unit/model_executor/test_eager_runner_input_embeds.py
+++ b/test/registered/unit/model_executor/test_eager_runner_input_embeds.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.runner.eager_runner import EagerRunner
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _runner(*, capture_input_embeds: bool) -> tuple[EagerRunner, Mock]:
+    runner = object.__new__(EagerRunner)
+    model = Mock()
+    runner.model_runner = SimpleNamespace(
+        forward_input_embeds_to_decode=capture_input_embeds,
+        model=model,
+        attn_backend=Mock(),
+        device_timer=None,
+        _pp_kwargs=Mock(return_value={"pp_proxy_tensors": "proxy"}),
+    )
+    runner.enable_pdmux = False
+    runner.load_batch = lambda forward_batch, _proxy: forward_batch
+    return runner, model
+
+
+def _forward_batch() -> SimpleNamespace:
+    return SimpleNamespace(
+        input_ids="ids",
+        input_embeds="embeds",
+        positions="positions",
+        needs_forward_metadata_init=lambda: False,
+    )
+
+
+def test_eager_decode_passes_captured_input_embeddings() -> None:
+    runner, model = _runner(capture_input_embeds=True)
+    forward_batch = _forward_batch()
+
+    runner._execute_decode(forward_batch, pp_proxy_tensors="proxy")
+
+    model.forward.assert_called_once_with(
+        "ids",
+        "positions",
+        forward_batch,
+        pp_proxy_tensors="proxy",
+        input_embeds="embeds",
+    )
+
+
+def test_eager_decode_keeps_default_input_id_path() -> None:
+    runner, model = _runner(capture_input_embeds=False)
+    forward_batch = _forward_batch()
+
+    runner._execute_decode(forward_batch, pp_proxy_tensors="proxy")
+
+    model.forward.assert_called_once_with(
+        "ids",
+        "positions",
+        forward_batch,
+        pp_proxy_tensors="proxy",
+    )
+
+
+@pytest.mark.parametrize("forward_input_embeds_to_decode", [False, True])
+def test_dp_padding_gates_composed_input_embeddings(
+    forward_input_embeds_to_decode: bool,
+) -> None:
+    forward_batch = object.__new__(ForwardBatch)
+    forward_batch.input_ids = torch.tensor([10, 11])
+    forward_batch.input_embeds = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    forward_batch.req_pool_indices = torch.tensor([0])
+    forward_batch.lora_ids = None
+    forward_batch.seq_lens_sum = 2
+    forward_batch.seq_lens = torch.tensor([2])
+    forward_batch.seq_lens_cpu = None
+    forward_batch.out_cache_loc = torch.tensor([20, 21])
+    forward_batch.encoder_lens = None
+    forward_batch.positions = torch.tensor([0, 1])
+    forward_batch.mamba_track_indices = None
+    forward_batch.mamba_track_mask = None
+    forward_batch.mamba_track_seqlens = None
+    forward_batch.mrope_positions = None
+    forward_batch.extend_seq_lens = None
+    forward_batch.rids_int = None
+    forward_batch.sampling_info = None
+    forward_batch.bootstrap_room_ids_int = None
+    forward_batch.spec_info = None
+    original_input_embeds = forward_batch.input_embeds
+    model_runner = SimpleNamespace(
+        forward_input_embeds_to_decode=forward_input_embeds_to_decode,
+        attn_backend=SimpleNamespace(get_cuda_graph_seq_len_fill_value=lambda: 0),
+    )
+
+    forward_batch._pad_inputs_to_size(model_runner, num_tokens=4, bs=2)
+
+    if forward_input_embeds_to_decode:
+        assert torch.equal(
+            forward_batch.input_embeds,
+            torch.tensor([[1.0, 2.0], [3.0, 4.0], [0.0, 0.0], [0.0, 0.0]]),
+        )
+    else:
+        assert forward_batch.input_embeds is original_input_embeds
+
+
+def test_tp_worker_invokes_forward_batch_customization_hook() -> None:
+    worker = object.__new__(TpModelWorker)
+    worker.set_hicache_consumer = Mock()
+    worker.customize_forward_batch = Mock()
+    worker.is_dllm = Mock(return_value=False)
+    worker.pp_group = SimpleNamespace(is_last_rank=False)
+    worker._model_runner = SimpleNamespace(
+        forward=Mock(
+            return_value=SimpleNamespace(
+                logits_output="proxy",
+                can_run_graph=False,
+                expert_distribution_metrics=None,
+            )
+        )
+    )
+    schedule_batch = SimpleNamespace(hicache_consumer_index=0)
+    forward_batch = SimpleNamespace(apply_deprecated_skip_attn_backend_init=Mock())
+
+    with patch.object(ForwardBatch, "init_new", return_value=forward_batch):
+        worker.forward_batch_generation(schedule_batch)
+
+    worker.customize_forward_batch.assert_called_once_with(
+        schedule_batch, forward_batch
+    )
+    worker.model_runner.forward.assert_called_once_with(
+        forward_batch, pp_proxy_tensors=None
+    )

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -23,11 +23,7 @@ from sglang.srt.arg_groups.overrides import (
     validate_declarations,
 )
 from sglang.srt.environ import envs
-from sglang.srt.runtime_context import (
-    get_context,
-    get_server_args,
-    reset_context,
-)
+from sglang.srt.runtime_context import get_context, get_server_args, reset_context
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -300,9 +296,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         return ServerArgs(model_path=config_dir, **server_kwargs)
 
     def _publish(self, server_args):
-        from sglang.srt.server_args import (
-            set_global_server_args_for_scheduler,
-        )
+        from sglang.srt.server_args import set_global_server_args_for_scheduler
 
         set_global_server_args_for_scheduler(server_args)
         return get_server_args()
@@ -846,10 +840,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
         )
 
     def test_deepseek_v4_sm120_moe_pass(self):
-        from sglang.srt.arg_groups.overrides import (
-            ResolvedView,
-            _deepseek_v4_sm120_moe,
-        )
+        from sglang.srt.arg_groups.overrides import ResolvedView, _deepseek_v4_sm120_moe
 
         def _view(arch="DeepseekV4ForCausalLM", **kw):
             hf = SimpleNamespace(architectures=[arch])
@@ -2010,7 +2001,9 @@ class TestGoldenModelOverrides(_IsolatedPublish):
 
         self.assertEqual(
             _a2a_ep_size(
-                ResolvedView(SimpleNamespace(moe_a2a_backend="deepep", tp_size=8))
+                ResolvedView(
+                    SimpleNamespace(moe_a2a_backend="deepep", ep_size=1, tp_size=8)
+                )
             ),
             {"ep_size": 8},
         )


### PR DESCRIPTION
## Summary

- Preserve cached multimodal inputs and embeddings as append-only streaming-session requests advance, with explicit acknowledge, release, and reset lifecycle hooks.
- Add opt-in one-token request admission for custom decode paths and propagate decode-time input embeddings through eager and CUDA graph runners.
- Keep emitted per-token metadata aligned with retained session history when a trailing stop token is removed.
- Add focused coverage for streaming cache ownership, multimodal embedding reuse and padding, request admission, output metadata, and model runner inputs.

## Testing

- Focused unit suite: 171 passed, 14 subtests passed.
- `isort --check-only` and `black --check` on all changed Python files.
- Registered-test and package-layout CI validators.
- Python AST and bytecode compilation checks.

## Original commits

- `ee6cdbfa0`
- `f7e740193`
- `8cc703527`
- `73307eccf`
- `9e82fd415`
- `7e856abd0`
- `4f193084d`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30831590463](https://github.com/sgl-project/sglang/actions/runs/30831590463)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30831590010](https://github.com/sgl-project/sglang/actions/runs/30831590010)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->