### PR TITLE
[CI] Skip absent inline suites when loading timeouts

### DIFF
--- a/scripts/ci/utils/compute_partitions.py
+++ b/scripts/ci/utils/compute_partitions.py
@@ -63,7 +63,7 @@ def load_run_timeouts(pr_test_yml_path: str) -> dict:
         with_ = job.get("with") or {}
         suite = with_.get("self_name", job_id)
         timeouts[suite] = int(with_["run_timeout_minutes"])
-    for suite in _INLINE_SUITE_JOBS:
+    for suite in _INLINE_SUITE_JOBS.intersection(jobs):
         budgets = [
             s["timeout-minutes"]
             for s in ((jobs.get(suite) or {}).get("steps") or [])


### PR DESCRIPTION
## Summary

Fix a regression on `main` that makes Extra CI fail during partition computation before any test job can be dispatched.

## Regression

#33329 taught `load_run_timeouts` to read the timeout of `base-a-test-cpu`. That job is inlined in `pr-test.yml`, so it cannot expose its timeout through the reusable stage inputs used by the other suites.

The same partition loader is shared by Base and Extra CI. Extra CI passes `pr-test-extra.yml`, which intentionally does not define the Base-only `base-a-test-cpu` job. The loader nevertheless iterated every configured inline suite, found no steps for that absent job, and raised:

```
load_run_timeouts: inline suite 'base-a-test-cpu' needs exactly one `Run test` step with `timeout-minutes` in .github/workflows/pr-test-extra.yml.
```

As a result, the `Compute partitions` step failed and every downstream Extra test job was skipped. This is visible in [PR Test Extra run #30794183183](https://github.com/sgl-project/sglang/actions/runs/30794183183/job/91623935768).

## Fix

Restrict inline timeout loading to `_INLINE_SUITE_JOBS.intersection(jobs)`, so each workflow only processes inline suites it actually defines.

This keeps the existing strict validation for present inline suites: if `base-a-test-cpu` exists but is missing its single `Run test` timeout, the loader still raises. Base CI behavior and CPU partition sizing are unchanged.

## Validation

- `python3 scripts/ci/utils/compute_partitions.py --pr-test-yml .github/workflows/pr-test-extra.yml --output-format json`
- `python3 scripts/ci/utils/compute_partitions.py --pr-test-yml .github/workflows/pr-test.yml --output-format json`
- `pre-commit run --files scripts/ci/utils/compute_partitions.py`
- [Base `check-changes` passed](https://github.com/sgl-project/sglang/actions/runs/30832884924/job/91750890578)
- [Extra `check-changes` passed](https://github.com/sgl-project/sglang/actions/runs/30832881466/job/91750877782)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30832884924](https://github.com/sgl-project/sglang/actions/runs/30832884924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30835787295](https://github.com/sgl-project/sglang/actions/runs/30835787295)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->