### PR TITLE
[PD][Spec] Support DFLASH and DSPARK in PD disagg

### DIFF
--- a/python/sglang/srt/speculative/dflash_disaggregation.py
+++ b/python/sglang/srt/speculative/dflash_disaggregation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.srt.managers.overlap_utils import RelayPayload
+from sglang.srt.speculative.draft_worker_common import make_draft_input_v2
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.overlap_utils import FutureMap
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+    from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+
+
+def build_dflash_family_disagg_draft_input(
+    batch: ScheduleBatch,
+    last_tokens_tensor: torch.Tensor,
+    future_map: FutureMap,
+) -> DFlashDraftInputV2:
+    spec_info = make_draft_input_v2(
+        bonus_tokens=last_tokens_tensor,
+        new_seq_lens=batch.seq_lens,
+    )
+
+    if batch.enable_overlap:
+        spec_info.future_indices = batch.req_pool_indices
+        future_map.publish(spec_info.future_indices, batch.seq_lens)
+        future_map.stash(
+            spec_info.future_indices,
+            RelayPayload(bonus_tokens=last_tokens_tensor),
+        )
+
+    return spec_info

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -184,6 +184,14 @@ class SpeculativeAlgorithm(Enum):
             return build_eagle_disagg_draft_input(
                 batch, server_args, last_tokens_tensor, future_map
             )
+        if self.is_dflash_family():
+            from sglang.srt.speculative.dflash_disaggregation import (
+                build_dflash_family_disagg_draft_input,
+            )
+
+            return build_dflash_family_disagg_draft_input(
+                batch, last_tokens_tensor, future_map
+            )
         return None
 
     def need_topk(self) -> bool:

--- a/test/registered/disaggregation/test_disaggregation_dflash.py
+++ b/test/registered/disaggregation/test_disaggregation_dflash.py
@@ -1,0 +1,47 @@
+"""Regression for resuming DFLASH decode after disaggregated prefill."""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import (
+    DEFAULT_DRAFT_MODEL_DFLASH,
+    DEFAULT_TARGET_MODEL_DFLASH,
+)
+
+register_cuda_ci(est_time=500, stage="base-b", runner_config="2-gpu-large")
+
+_DFLASH_ARGS = [
+    "--speculative-algorithm",
+    "DFLASH",
+    "--speculative-draft-model-path",
+    DEFAULT_DRAFT_MODEL_DFLASH,
+    "--attention-backend",
+    "flashinfer",
+    "--max-running-requests",
+    "64",
+    "--mem-fraction-static",
+    "0.7",
+]
+
+
+class TestDisaggregationDFlash(PDDisaggregationServerBase, GSM8KMixin):
+    model = DEFAULT_TARGET_MODEL_DFLASH
+    gsm8k_accuracy_thres = 0.70
+    gsm8k_num_questions = 200
+    gsm8k_num_threads = 64
+
+    extra_prefill_args = _DFLASH_ARGS
+    extra_decode_args = _DFLASH_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.launch_all()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/disaggregation/test_disaggregation_dsv4_dspark.py
+++ b/test/registered/disaggregation/test_disaggregation_dsv4_dspark.py
@@ -1,0 +1,50 @@
+"""H200 regression for DSpark P/D bootstrap."""
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
+from sglang.test.server_fixtures.disaggregation_fixture import (
+    PDDisaggregationServerBase,
+)
+from sglang.test.test_utils import try_cached_model
+
+register_cuda_ci(est_time=700, stage="base-c", runner_config="8-gpu-h200")
+
+DSV4_DSPARK_MODEL = os.getenv(
+    "DEEPSEEK_V4_DSPARK_MODEL_PATH",
+    "deepseek-ai/DeepSeek-V4-Flash-0731",
+)
+
+_DSPARK_ARGS = [
+    "--speculative-algorithm",
+    "DSPARK",
+    "--moe-runner-backend",
+    "marlin",
+    "--watchdog-timeout",
+    "900",
+]
+
+
+class TestDisaggregationDSV4DSpark(PDDisaggregationServerBase, GSM8KMixin):
+    prefill_tp_size = 4
+    decode_tp_size = 4
+    decode_base_gpu_id = 4
+
+    gsm8k_accuracy_thres = 0.93
+    gsm8k_num_questions = 200
+    gsm8k_num_threads = 64
+
+    extra_prefill_args = _DSPARK_ARGS
+    extra_decode_args = _DSPARK_ARGS
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.model = try_cached_model(DSV4_DSPARK_MODEL)
+        cls.launch_all()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

DFLASH-family speculative decoding previously assumed a monolithic worker lifecycle: prefill initialized the draft state, and decode continued from it on the same worker. In P/D mode, the decode worker instead receives the prefetched request through the disaggregation handoff, so its first decode batch had no DFlashDraftInputV2 to resume speculative decoding.

## Modifications

* Rebuild the initial DFLASH/DSpark draft input on the decode worker from the sampled bonus token and committed sequence lengths.

## Accuracy Tests

Prefill:
```
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --disaggregation-mode prefill \
  --disaggregation-bootstrap-port 21500 \
  --disaggregation-transfer-backend mooncake \
  --tp 4 \
  --speculative-algorithm DSPARK \
  --moe-runner-backend marlin \
  --host 127.0.0.1 \
  --port 21100
```

Decode:
```
sglang serve \
  --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
  --disaggregation-mode decode \
  --disaggregation-bootstrap-port 21500 \
  --disaggregation-transfer-backend mooncake \
  --tp 4 \
  --base-gpu-id 4 \
  --speculative-algorithm DSPARK \
  --moe-runner-backend marlin \
  --host 127.0.0.1 \
  --port 21200
```

Router:
```
python3 -m sglang_router.launch_router \
  --pd-disaggregation \
  --mini-lb \
  --prefill http://127.0.0.1:21100 \
  --decode http://127.0.0.1:21200 \
  --host 127.0.0.1 \
  --port 21000
```

Test (+debug output for acc len):
```
python3 -m sglang.test.few_shot_gsm8k \
  --num-questions 200 \
  --port 21000
```

Result:
```
Accuracy: 0.970
Latency: 27.239 s
Output throughput: 627.593 token/s
DSpark average acceptance length: 4.0211
```

Related to https://github.com/sgl-project/sglang/issues/30344

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30833891010](https://github.com/sgl-project/sglang/actions/runs/30833891010)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30833890524](https://github.com/sgl-project/sglang/actions/runs/30833890524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->