### PR TITLE
fix(dsv4): preserve BF16 precision in KV cache

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1115,6 +1115,9 @@ class Envs:
     # Quantize the SWA fp8 KV cache from bf16-rounded values (matches
     # trainer-side QAT and the DSA-CP path) instead of fp32 registers.
     SGLANG_DSV4_USE_BF16_KV_QUANT_SOURCE = EnvBool(False)
+    # Store the SWA/compressed attention KV cache as plain BF16. The DSV4
+    # indexer cache remains in its existing FP8/FP4 layout.
+    SGLANG_DSV4_BF16_KV = EnvBool(False)
 
     # CUDA kernels
     SGLANG_OPT_DEEPGEMM_HC_PRENORM = EnvBool(True)

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -46,6 +46,10 @@ from sglang.srt.layers.attention.dsv4.compressor_v2 import (
     FusedCompressMetadata,
     create_paged_compressor_data,
 )
+from sglang.srt.layers.attention.dsv4.bf16_kv_cache import (
+    build_bf16_sparse_decode_inputs,
+    gather_bf16_kv_cache_paged,
+)
 from sglang.srt.layers.attention.dsv4.indexer import C4IndexerBackendMixin
 from sglang.srt.layers.attention.dsv4.metadata import (
     _LARGE_INDEXER_QUERY_THRESHOLD,
@@ -1591,6 +1595,13 @@ class DeepseekV4AttnBackend(
         self, layer_id: int, swa_k: torch.Tensor, forward_batch: ForwardBatch
     ) -> None:
         swa_loc = self.get_swa_out_cache_loc(forward_batch)
+        if envs.SGLANG_DSV4_BF16_KV.get():
+            self.token_to_kv_pool.set_swa_key_buffer_radix_bf16(
+                layer_id=layer_id,
+                swa_loc=swa_loc,
+                cache_k=swa_k,
+            )
+            return
         if envs.SGLANG_OPT_USE_FUSED_STORE_CACHE.get():
             self.token_to_kv_pool.set_swa_key_buffer_radix_fused(
                 layer_id=layer_id,
@@ -1643,6 +1654,20 @@ class DeepseekV4AttnBackend(
                 extra_k_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
                 extra_indices = core_attn_metadata.c128_page_indices
                 extra_topk_lengths = core_attn_metadata.c128_topk_lengths_clamp1
+
+            if envs.SGLANG_DSV4_BF16_KV.get() and not (
+                forward_batch.forward_mode.is_extend_without_speculative()
+            ):
+                return self._forward_sparse_bf16(
+                    q=q,
+                    layer_id=layer_id,
+                    compress_ratio=compress_ratio,
+                    token_to_kv_pool=token_to_kv_pool,
+                    core_attn_metadata=core_attn_metadata,
+                    extra_indices=extra_indices,
+                    extra_topk_lengths=extra_topk_lengths,
+                    attn_sink=attn_sink,
+                )
 
             swa_window_size = token_to_kv_pool.swa_window_size
             assert swa_k_cache.ndim == 2
@@ -1705,6 +1730,7 @@ class DeepseekV4AttnBackend(
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+                    or envs.SGLANG_DSV4_BF16_KV.get()
                 )
             ):
                 return self._forward_prefill_sparse(
@@ -1761,6 +1787,53 @@ class DeepseekV4AttnBackend(
             return o
 
         raise NotImplementedError("ragged attention")
+
+    def _forward_sparse_bf16(
+        self,
+        q: torch.Tensor,
+        layer_id: int,
+        compress_ratio: Literal[0, 4, 128],
+        token_to_kv_pool: DeepSeekV4TokenToKVPool,
+        core_attn_metadata: DSV4AttnMetadata,
+        extra_indices: Optional[torch.Tensor],
+        extra_topk_lengths: Optional[torch.Tensor],
+        attn_sink: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run sparse decode against the plain BF16 SWA/compressed caches."""
+        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+        if q.ndim == 3:
+            q = q.unsqueeze(1)
+        assert q.ndim == 4
+        assert attn_sink is not None
+
+        extra_cache = None
+        extra_page_size = None
+        if compress_ratio != 0:
+            assert extra_indices is not None and extra_topk_lengths is not None
+            extra_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
+            extra_page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
+
+        workspace, indices, lengths = build_bf16_sparse_decode_inputs(
+            swa_cache=token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
+            swa_indices=core_attn_metadata.swa_page_indices,
+            swa_lengths=core_attn_metadata.swa_topk_lengths,
+            swa_page_size=token_to_kv_pool.swa_page_size,
+            extra_cache=extra_cache,
+            extra_indices=extra_indices,
+            extra_lengths=extra_topk_lengths,
+            extra_page_size=extra_page_size,
+        )
+        o, _, _ = flash_mla_sparse_fwd(
+            q=q.squeeze(1),
+            kv=workspace,
+            indices=indices,
+            sm_scale=self.softmax_scale,
+            d_v=self.head_dim_v,
+            attn_sink=attn_sink,
+            topk_length=lengths,
+        )
+        return o
 
     def _forward_prefill_sparse(
         self,
@@ -1843,19 +1916,34 @@ class DeepseekV4AttnBackend(
             compressed_slice = workspace[:n_compressed]
             swa_slice = workspace[n_compressed:]
 
-        if compressed_slice is not None:
-            dequantize_k_cache_paged(
-                extra_k_cache,
-                flat_token_ids,
-                page_size=extra_page_size,
-                out=compressed_slice,
+        if envs.SGLANG_DSV4_BF16_KV.get():
+            if compressed_slice is not None:
+                gather_bf16_kv_cache_paged(
+                    extra_k_cache,
+                    flat_token_ids,
+                    page_size=extra_page_size,
+                    out=compressed_slice,
+                )
+            gather_bf16_kv_cache_paged(
+                token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
+                cache.swa_token_ids,
+                page_size=cache.swa_page_size,
+                out=swa_slice,
             )
-        dequantize_k_cache_paged(
-            token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
-            cache.swa_token_ids,
-            page_size=cache.swa_page_size,
-            out=swa_slice,
-        )
+        else:
+            if compressed_slice is not None:
+                dequantize_k_cache_paged(
+                    extra_k_cache,
+                    flat_token_ids,
+                    page_size=extra_page_size,
+                    out=compressed_slice,
+                )
+            dequantize_k_cache_paged(
+                token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
+                cache.swa_token_ids,
+                page_size=cache.swa_page_size,
+                out=swa_slice,
+            )
         kv = workspace
 
         o, _, _ = flash_mla_sparse_fwd(

--- a/python/sglang/srt/layers/attention/dsv4/bf16_kv_cache.py
+++ b/python/sglang/srt/layers/attention/dsv4/bf16_kv_cache.py
@@ -1,0 +1,175 @@
+"""BF16 KV-cache helpers for the DSV4 sparse-attention path.
+
+The regular DSV4 cache stores a packed FP8-nope/BF16-rope representation.  The
+BF16 path deliberately uses a separate, plain ``(page, token, 1, 512)`` view so
+that the sparse FlashMLA kernel receives the same values that were produced by
+the model, without an FP8 round trip.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+BF16_KV_HEAD_DIM = 512
+SPARSE_DECODE_TOPK_ALIGNMENT = 128
+
+
+def _is_cuda_graph_capturing() -> bool:
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+def _normalize_indices(indices: torch.Tensor) -> torch.Tensor:
+    if indices.ndim == 3:
+        assert indices.shape[1] == 1, (
+            f"expected one query per decode row, got {indices.shape}"
+        )
+        indices = indices[:, 0]
+    assert indices.ndim == 2, f"expected [batch, topk] indices, got {indices.shape}"
+    return indices
+
+
+def _as_flat_bf16_cache(cache: torch.Tensor, page_size: int) -> torch.Tensor:
+    assert cache.dtype == torch.bfloat16, f"expected BF16 cache, got {cache.dtype}"
+    assert cache.is_contiguous(), "BF16 cache must be contiguous"
+    if cache.ndim == 4:
+        assert cache.shape[1] == page_size and cache.shape[2] == 1
+        assert cache.shape[3] == BF16_KV_HEAD_DIM
+        return cache.reshape(-1, 1, BF16_KV_HEAD_DIM)
+    if cache.ndim == 3:
+        assert cache.shape[1] == page_size
+        assert cache.shape[2] == BF16_KV_HEAD_DIM
+        return cache.reshape(-1, 1, BF16_KV_HEAD_DIM)
+    assert cache.ndim == 2, f"expected 2D, 3D, or 4D cache, got {cache.shape}"
+    assert cache.shape[1] == page_size * BF16_KV_HEAD_DIM
+    return cache.reshape(-1, 1, BF16_KV_HEAD_DIM)
+
+
+def gather_bf16_kv_cache_paged(
+    cache: torch.Tensor,
+    token_ids: torch.Tensor,
+    *,
+    page_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Gather physical token locations from a plain BF16 paged cache."""
+
+    flat_cache = _as_flat_bf16_cache(cache, page_size)
+    token_ids = token_ids.to(dtype=torch.int64)
+    assert token_ids.ndim == 1
+    # Do not convert CUDA tensors to Python bools during CUDA Graph capture.
+    # The indices are produced by the scheduler and are validated on the
+    # non-capture path.
+    if not _is_cuda_graph_capturing():
+        assert (token_ids >= 0).all() and (token_ids < flat_cache.shape[0]).all()
+    gathered = flat_cache.index_select(0, token_ids)
+    if out is not None:
+        assert out.shape == gathered.shape and out.dtype == torch.bfloat16
+        out.copy_(gathered)
+        return out
+    return gathered
+
+
+def build_bf16_sparse_decode_inputs(
+    *,
+    swa_cache: torch.Tensor,
+    swa_indices: torch.Tensor,
+    swa_lengths: torch.Tensor,
+    swa_page_size: int,
+    extra_cache: Optional[torch.Tensor] = None,
+    extra_indices: Optional[torch.Tensor] = None,
+    extra_lengths: Optional[torch.Tensor] = None,
+    extra_page_size: Optional[int] = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build a fixed-shape BF16 workspace and sparse indices for one decode.
+
+    Preserve the historical ``[extra region, SWA region]`` slot layout used by
+    the branch whose BF16-KV precision was validated end to end. Invalid slots
+    are represented by ``-1`` indices. ``topk_length`` therefore covers the
+    complete aligned index width, allowing FlashMLA to visit valid SWA slots
+    after a short extra region while skipping the holes.
+    """
+
+    swa_indices = _normalize_indices(swa_indices)
+    assert swa_lengths.ndim == 1 and swa_lengths.shape[0] == swa_indices.shape[0]
+    batch_size, swa_width = swa_indices.shape
+    if not _is_cuda_graph_capturing():
+        assert (swa_lengths >= 0).all() and (swa_lengths <= swa_width).all()
+
+    has_extra = extra_cache is not None
+    if has_extra:
+        assert extra_indices is not None
+        assert extra_lengths is not None
+        assert extra_page_size is not None
+        extra_indices = _normalize_indices(extra_indices)
+        assert extra_indices.shape[0] == batch_size
+        assert extra_lengths.ndim == 1 and extra_lengths.shape[0] == batch_size
+        extra_width = extra_indices.shape[1]
+        if not _is_cuda_graph_capturing():
+            assert (extra_lengths >= 0).all() and (
+                extra_lengths <= extra_width
+            ).all()
+    else:
+        extra_width = 0
+
+    def gather_region(
+        cache: torch.Tensor,
+        indices: torch.Tensor,
+        lengths: torch.Tensor,
+        page_size: int,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        cols = torch.arange(indices.shape[1], device=indices.device)
+        valid = (indices >= 0) & (cols[None, :] < lengths[:, None])
+        safe_indices = indices.reshape(-1).masked_fill(~valid.reshape(-1), 0)
+        values = gather_bf16_kv_cache_paged(
+            cache,
+            safe_indices,
+            page_size=page_size,
+        )
+        return values, valid
+
+    def workspace_indices(valid: torch.Tensor, offset: int) -> torch.Tensor:
+        rows, width = valid.shape
+        indices = torch.arange(
+            rows * width, device=valid.device, dtype=torch.int32
+        ).view(rows, width)
+        return (indices + offset).masked_fill(~valid, -1)
+
+    swa_workspace, swa_valid = gather_region(
+        swa_cache,
+        swa_indices,
+        swa_lengths,
+        swa_page_size,
+    )
+    if has_extra:
+        extra_workspace, extra_valid = gather_region(
+            extra_cache,
+            extra_indices,
+            extra_lengths,
+            extra_page_size,
+        )
+        workspace = torch.cat([extra_workspace, swa_workspace], dim=0)
+        combined_indices = torch.cat(
+            [
+                workspace_indices(extra_valid, offset=0),
+                workspace_indices(swa_valid, offset=extra_workspace.shape[0]),
+            ],
+            dim=1,
+        )
+    else:
+        workspace = swa_workspace
+        combined_indices = workspace_indices(swa_valid, offset=0)
+
+    padding = (-combined_indices.shape[1]) % SPARSE_DECODE_TOPK_ALIGNMENT
+    if padding:
+        combined_indices = torch.nn.functional.pad(
+            combined_indices, (0, padding), value=-1
+        )
+    full_lengths = torch.full(
+        (batch_size,),
+        combined_indices.shape[1],
+        dtype=torch.int32,
+        device=combined_indices.device,
+    )
+    return workspace, combined_indices.unsqueeze(1), full_lengths

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -248,6 +248,7 @@ class CompressorBackendMixin:
                 assert compress_kv_pool is not None
                 kv_cache = token_to_kv_pool.get_extra_key_buffer(layer_id)
                 page_size = token_to_kv_pool.get_extra_key_page_size(layer_id)
+                bf16_store = envs.SGLANG_DSV4_BF16_KV.get()
                 if hasattr(compress_kv_pool, "translate_loc_to_hisparse_device"):
                     out_loc = compress_kv_pool._translate_loc_to_hisparse_device(
                         out_loc

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -79,6 +79,16 @@ class DeepSeekV4SingleKVPool(KVCache):
         self.quantize_block_size = 64
         self.rope_storage_dtype = torch.bfloat16
         self.k_with_scale_buffer_dtype = torch.int8
+        self.bf16_kv = envs.SGLANG_DSV4_BF16_KV.get()
+        if self.bf16_kv:
+            assert qk_nope_head_dim + qk_rope_head_dim == 512, (
+                "DSV4 BF16 KV cache expects head_dim=512, got "
+                f"{qk_nope_head_dim + qk_rope_head_dim}"
+            )
+            logger.info(
+                "DSV4 BF16 KV cache enabled: plain BF16 head_dim=512, "
+                "bytes_per_token=1024"
+            )
         self._create_buffers()
 
     def _create_buffers(self):
@@ -96,6 +106,10 @@ class DeepSeekV4SingleKVPool(KVCache):
                 ]
 
     def get_bytes_per_token(self) -> int:
+        if self.bf16_kv:
+            return (
+                self.qk_nope_head_dim + self.qk_rope_head_dim
+            ) * torch.bfloat16.itemsize
         dim_per_token = (
             self.qk_nope_head_dim
             + self.qk_rope_head_dim * self.rope_storage_dtype.itemsize
@@ -106,8 +120,18 @@ class DeepSeekV4SingleKVPool(KVCache):
 
     def create_buffer(self, *, num_pages: int):
         bytes_per_token = self.get_bytes_per_token()
-        self.kv_cache_total_dim = bytes_per_token
         bytes_per_page_non_padded = self.page_size * bytes_per_token
+        if self.bf16_kv:
+            self.kv_cache_total_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+            self.bytes_per_page_padded = bytes_per_page_non_padded
+            return torch.zeros(
+                num_pages,
+                bytes_per_page_non_padded,
+                dtype=torch.uint8,
+                device=self.device,
+            )
+
+        self.kv_cache_total_dim = bytes_per_token
         self.bytes_per_page_padded = ceil_div(bytes_per_page_non_padded, 576) * 576
 
         assert bytes_per_token == 448 + 64 * 2 + 8, (
@@ -129,6 +153,7 @@ class DeepSeekV4SingleKVPool(KVCache):
         loc: torch.Tensor,
         cache_nope_fp8_rope_bf16_pack: NopeFp8RopeBf16Pack,
     ):
+        assert not self.bf16_kv, "BF16 KV cache requires set_key_buffer_bf16"
         dsv4_index_buf_accessor.SetKAndS.execute(
             pool=self,
             buf=self.kv_buffer[layer_id],
@@ -136,12 +161,28 @@ class DeepSeekV4SingleKVPool(KVCache):
             nope_fp8_rope_bf16_pack=cache_nope_fp8_rope_bf16_pack,
         )
 
+    def set_key_buffer_bf16(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        assert self.bf16_kv, "BF16 KV cache is not enabled"
+        assert cache_k.dtype == torch.bfloat16
+        cache_k = cache_k.reshape(-1, self.kv_cache_total_dim)
+        cache = self.kv_buffer[layer_id].view(torch.bfloat16).view(
+            -1, self.kv_cache_total_dim
+        )
+        cache[loc.to(torch.int64)] = cache_k
+
     def set_key_buffer_fused(
         self,
         layer_id: int,
         loc: torch.Tensor,
         cache_k: torch.Tensor,
     ) -> None:
+        if self.bf16_kv:
+            return self.set_key_buffer_bf16(layer_id, loc, cache_k)
         return fused_store_cache(
             input=cache_k,
             cache=self.kv_buffer[layer_id],
@@ -151,6 +192,8 @@ class DeepSeekV4SingleKVPool(KVCache):
         )
 
     def get_key_buffer(self, layer_id: int):
+        if self.bf16_kv:
+            return self.kv_buffer[layer_id - self.start_layer].view(torch.bfloat16)
         if self.store_dtype != self.dtype:
             return self.kv_buffer[layer_id - self.start_layer].view(self.dtype)
 
@@ -241,6 +284,15 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
     ) -> None:
         loc = self.translate_loc_to_hisparse_device(loc)
         return super().set_key_buffer_fused(layer_id, loc, cache_k)
+
+    def set_key_buffer_bf16(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        loc = self.translate_loc_to_hisparse_device(loc)
+        return super().set_key_buffer_bf16(layer_id, loc, cache_k)
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         raise NotImplementedError("HiSparseC4DevicePool does not support get_cpu_copy")
@@ -1055,6 +1107,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         return layer_id - self._stage_start
 
     def get_swa_raw_buffer(self, layer_id: int) -> torch.Tensor:
+        if self.swa_kv_pool.bf16_kv:
+            return self.swa_kv_pool.get_key_buffer(self._swa_local_layer_id(layer_id))
         return self.swa_kv_pool.kv_buffer[self._swa_local_layer_id(layer_id)]
 
     def get_swa_key_buffer(self, layer_id: int) -> torch.Tensor:
@@ -1069,6 +1123,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> None:
         self.swa_kv_pool.set_key_buffer(
             self._swa_local_layer_id(layer_id), loc, cache_nope_fp8_rope_bf16_pack
+        )
+
+    def set_swa_key_buffer_bf16(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        self.swa_kv_pool.set_key_buffer_bf16(
+            self._swa_local_layer_id(layer_id), loc, cache_k
         )
 
     def get_extra_key_page_size(self, layer_id: int) -> int:
@@ -1093,6 +1157,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         compress_kv_pool.set_key_buffer(
             compress_layer_id, loc, cache_nope_fp8_rope_bf16_pack
         )
+
+    def set_extra_key_buffer_bf16(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        _, compress_layer_id, compress_kv_pool = self.layer_mapping[layer_id]
+        assert compress_kv_pool is not None
+        compress_kv_pool.set_key_buffer_bf16(compress_layer_id, loc, cache_k)
 
     def get_index_k_page_size(self) -> int:
         return self.c4_indexer_kv_pool.page_size
@@ -1155,6 +1229,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
     ) -> None:
         self.swa_kv_pool.set_key_buffer(
             self._swa_local_layer_id(layer_id), swa_loc, cache_nope_fp8_rope_bf16_pack
+        )
+
+    def set_swa_key_buffer_radix_bf16(
+        self,
+        layer_id: int,
+        swa_loc: torch.Tensor,
+        cache_k: torch.Tensor,
+    ) -> None:
+        self.swa_kv_pool.set_key_buffer_bf16(
+            self._swa_local_layer_id(layer_id), swa_loc, cache_k
         )
 
     def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -757,6 +757,12 @@ class MQALayer(MqaAttentionBase):
         Replaces the bf16-kv-intermediate path. Used everywhere except the DSA
         prefill-CP case (which needs bf16 kv for the cross-rank all-gather).
         """
+        if envs.SGLANG_DSV4_BF16_KV.get():
+            kv = self._compute_kv_bf16(x, positions, qkv_a=qkv_a)
+            attn_backend.store_cache(
+                layer_id=self.layer_id, swa_k=kv, forward_batch=forward_batch
+            )
+            return
         if envs.SGLANG_DSV4_USE_BF16_KV_QUANT_SOURCE.get():
             # Quantize the nope payload from bf16-rounded values (the fused
             # kernel quantizes from fp32 registers; the bf16 rounding moves
@@ -956,6 +962,7 @@ class MQALayer(MqaAttentionBase):
                 swa_page_size=swa_page_size,
                 q_out=q_out,
                 dtype=x.dtype,
+                bf16_store=envs.SGLANG_DSV4_BF16_KV.get(),
             )
         else:
             q_lora = self.q_norm(q_lora)
@@ -1042,7 +1049,7 @@ class MQALayer(MqaAttentionBase):
                 swa_loc = attn_backend.get_swa_out_cache_loc(forward_batch)
                 swa_page_size, bf16_store = (
                     token_to_kv_pool.swa_kv_pool.page_size,
-                    False,
+                    envs.SGLANG_DSV4_BF16_KV.get(),
                 )
 
             from sglang.kernels.ops.attention.fused_qk_norm_rope_store import (

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -860,8 +860,6 @@ class MQALayer(MqaAttentionBase):
                 x_linear, positions, forward_batch, attn_backend, qkv_a=qkv_a
             )
 
-        del qkv_a
-
         if self.compressor is not None:
             with torch.cuda.stream(stream_compressor):
                 attn_backend.forward_core_compressor(
@@ -872,6 +870,12 @@ class MQALayer(MqaAttentionBase):
         current_stream.wait_stream(stream_kv)
         current_stream.wait_stream(stream_compressor)
         current_stream.wait_stream(stream_indexer)
+
+        # qkv_a is produced on the current stream and consumed asynchronously
+        # by stream_kv. Keep the allocation alive until the current stream has
+        # been ordered after stream_kv; otherwise CUDA Graph's memory pool may
+        # reuse it for _compute_q_b while the KV branch is still reading it.
+        del qkv_a
 
         return q
 

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
@@ -553,6 +553,41 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
                 )
 
 
+class TestDSV4Bf16SparseDecodeInputs(CustomTestCase):
+    def test_short_extra_region_does_not_create_hole_before_swa(self):
+        from sglang.srt.layers.attention.dsv4.bf16_kv_cache import (
+            build_bf16_sparse_decode_inputs,
+        )
+
+        page_size = 8
+        cache = torch.arange(
+            2 * page_size * 512, dtype=torch.int32
+        ).reshape(2, page_size * 512).to(torch.bfloat16)
+        extra_indices = torch.arange(8, dtype=torch.int32).view(1, 8)
+        swa_indices = torch.arange(8, 12, dtype=torch.int32).view(1, 4)
+
+        workspace, indices, lengths = build_bf16_sparse_decode_inputs(
+            swa_cache=cache,
+            swa_indices=swa_indices,
+            swa_lengths=torch.tensor([3], dtype=torch.int32),
+            swa_page_size=page_size,
+            extra_cache=cache,
+            extra_indices=extra_indices,
+            extra_lengths=torch.tensor([2], dtype=torch.int32),
+            extra_page_size=page_size,
+        )
+
+        self.assertEqual(lengths.tolist(), [5])
+        self.assertEqual(indices[0, 0, :5].tolist(), [0, 1, 2, 3, 4])
+        self.assertTrue((indices[0, 0, 5:] == -1).all())
+        rows = workspace.view(-1, 1, 512)[:, 0]
+        torch.testing.assert_close(rows[0], cache.view(-1, 512)[0])
+        torch.testing.assert_close(rows[1], cache.view(-1, 512)[1])
+        torch.testing.assert_close(rows[2], cache.view(-1, 512)[8])
+        torch.testing.assert_close(rows[3], cache.view(-1, 512)[9])
+        torch.testing.assert_close(rows[4], cache.view(-1, 512)[10])
+
+
 class TestDSV4SwaOutCacheLocResolution(CustomTestCase):
     """`get_swa_out_cache_loc`: cached fast path vs store-time fallback.
 

--- a/test/registered/kernels/ops/attention/test_dsv4_bf16_kv_cache.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_bf16_kv_cache.py
@@ -1,0 +1,112 @@
+import torch
+from unittest.mock import patch
+
+from sglang.srt.layers.attention.dsv4.bf16_kv_cache import (
+    BF16_KV_HEAD_DIM,
+    build_bf16_sparse_decode_inputs,
+)
+
+
+def _paged_cache(num_pages: int, page_size: int, offset: int) -> torch.Tensor:
+    values = torch.arange(
+        offset,
+        offset + num_pages * page_size * BF16_KV_HEAD_DIM,
+        dtype=torch.float32,
+    )
+    return values.view(num_pages, page_size, 1, BF16_KV_HEAD_DIM).to(
+        torch.bfloat16
+    )
+
+
+def test_bf16_sparse_decode_preserves_historical_slot_layout():
+    swa_cache = _paged_cache(num_pages=2, page_size=4, offset=0)
+    extra_cache = _paged_cache(num_pages=2, page_size=2, offset=100000)
+
+    swa_indices = torch.tensor([[1, 4, 7], [0, 3, 6]], dtype=torch.int32)
+    swa_lengths = torch.tensor([3, 2], dtype=torch.int32)
+    extra_indices = torch.tensor([[0, 3], [1, 2]], dtype=torch.int32)
+    extra_lengths = torch.tensor([2, 1], dtype=torch.int32)
+
+    workspace, combined_indices, combined_lengths = build_bf16_sparse_decode_inputs(
+        swa_cache=swa_cache,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        swa_page_size=4,
+        extra_cache=extra_cache,
+        extra_indices=extra_indices,
+        extra_lengths=extra_lengths,
+        extra_page_size=2,
+    )
+
+    assert workspace.shape == (10, 1, BF16_KV_HEAD_DIM)
+    assert combined_indices.shape == (2, 1, 128)
+    assert combined_lengths.tolist() == [128, 128]
+
+    # Historical layout stores all extra rows first, then all SWA rows. The
+    # complete aligned length is intentional: FlashMLA must scan past the -1
+    # hole in row 1 to reach its valid SWA slots.
+    assert combined_indices[0, 0, :5].tolist() == [0, 1, 4, 5, 6]
+    assert combined_indices[1, 0, :5].tolist() == [2, -1, 7, 8, -1]
+    assert (combined_indices[:, 0, 5:] == -1).all()
+
+    flat_extra = extra_cache.reshape(-1, 1, BF16_KV_HEAD_DIM)
+    flat_swa = swa_cache.reshape(-1, 1, BF16_KV_HEAD_DIM)
+    torch.testing.assert_close(workspace[0], flat_extra[0])
+    torch.testing.assert_close(workspace[1], flat_extra[3])
+    torch.testing.assert_close(workspace[2], flat_extra[1])
+    torch.testing.assert_close(workspace[4], flat_swa[1])
+    torch.testing.assert_close(workspace[5], flat_swa[4])
+    torch.testing.assert_close(workspace[6], flat_swa[7])
+    torch.testing.assert_close(workspace[7], flat_swa[0])
+    torch.testing.assert_close(workspace[8], flat_swa[3])
+
+
+def test_bf16_sparse_decode_supports_swa_only():
+    swa_cache = _paged_cache(num_pages=1, page_size=4, offset=0)
+    swa_indices = torch.tensor([[0, 2, 3]], dtype=torch.int32)
+    swa_lengths = torch.tensor([2], dtype=torch.int32)
+
+    workspace, combined_indices, combined_lengths = build_bf16_sparse_decode_inputs(
+        swa_cache=swa_cache,
+        swa_indices=swa_indices,
+        swa_lengths=swa_lengths,
+        swa_page_size=4,
+    )
+
+    assert combined_lengths.tolist() == [128]
+    assert combined_indices[0, 0, :2].tolist() == [0, 1]
+    assert (combined_indices[0, 0, 2:] == -1).all()
+    expected = swa_cache.reshape(-1, 1, BF16_KV_HEAD_DIM)[[0, 2]]
+    torch.testing.assert_close(workspace[:2], expected)
+
+
+def test_bf16_sparse_decode_skips_python_bool_checks_during_cuda_graph_capture():
+    swa_cache = _paged_cache(num_pages=1, page_size=4, offset=0)
+    extra_cache = _paged_cache(num_pages=1, page_size=2, offset=100000)
+
+    # CUDA Graph capture rejects converting a CUDA scalar tensor to a Python
+    # bool. Simulate that restriction on CPU so this regression test is
+    # runnable without a CUDA device.
+    with patch.object(torch.cuda, "is_available", return_value=True):
+        with patch.object(
+            torch.cuda, "is_current_stream_capturing", return_value=True
+        ):
+            with patch.object(
+                torch.Tensor,
+                "__bool__",
+                side_effect=AssertionError("unexpected Tensor-to-bool conversion"),
+            ):
+                workspace, indices, lengths = build_bf16_sparse_decode_inputs(
+                    swa_cache=swa_cache,
+                    swa_indices=torch.tensor([[0, 2]], dtype=torch.int32),
+                    swa_lengths=torch.tensor([2], dtype=torch.int32),
+                    swa_page_size=4,
+                    extra_cache=extra_cache,
+                    extra_indices=torch.tensor([[0]], dtype=torch.int32),
+                    extra_lengths=torch.tensor([1], dtype=torch.int32),
+                    extra_page_size=2,
+                )
+
+    assert workspace.shape == (3, 1, BF16_KV_HEAD_DIM)
+    assert indices[0, 0, :3].tolist() == [0, 1, 2]
+    assert lengths.tolist() == [128]


### PR DESCRIPTION
## Summary

- Store SWA and compressed attention KV cache in plain BF16 instead of the packed FP8-nope/BF16-rope representation
- Add BF16 sparse decode path using `flash_mla_sparse_fwd` and BF16 prefill cache gather path using `gather_bf16_kv_cache_paged`
- Keep the DSV4 indexer KV cache on the existing quantized FP8/FP4 layout
- Add BF16 KV cache unit tests for sparse decode inputs and CUDA graph capture compatibility
- Controlled by `SGLANG_DSV4_BF16_KV` env var (default: `False`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30904897773](https://github.com/sgl-project/sglang/actions/runs/30904897773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30904897592](https://github.com/sgl-project/sglang/actions/runs/30904897592)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->