### PR TITLE
[Bugfix] auto-round GPTQ MoE: un-invert the Marlin branch (experts silently ran on the Triton fallback)

### DIFF
--- a/python/sglang/srt/layers/quantization/auto_round.py
+++ b/python/sglang/srt/layers/quantization/auto_round.py
@@ -372,7 +372,6 @@ class AutoRoundConfig(QuantizationConfig):
             from sglang.srt.layers.quantization.gptq import (
                 GPTQMarlinConfig,
                 GPTQMarlinLinearMethod,
-                GPTQMarlinMoEMethod,
             )
 
             quant_args_marlin = GPTQMarlinConfig(
@@ -396,20 +395,29 @@ class AutoRoundConfig(QuantizationConfig):
             )
 
         if isinstance(layer, FusedMoE):
-            if use_marlin:
-                from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
+            # Delegate to MoeWNA16, which re-runs the Marlin eligibility check
+            # itself and picks the Marlin MoE method when it passes. Two things
+            # kept that delegation from ever reaching Marlin: the config
+            # handed over lacked the `desc_act` key, and
+            # GPTQMarlinConfig.is_gptq_marlin_compatible treats a missing key
+            # as ineligible; and the `use_marlin=False` arm constructed
+            # GPTQMarlinMoEMethod from a variable that only exists in the
+            # marlin branch -- a latent NameError, so the split had no working
+            # non-marlin arm either. One delegation with a complete config
+            # covers both cases: MoeWNA16 routes to Marlin when eligible and
+            # to the Triton runner when not. auto-round has no act-order
+            # concept, so desc_act is always False for its checkpoints.
+            from sglang.srt.layers.quantization.moe_wna16 import MoeWNA16Config
 
-                config = {
-                    "quant_method": "gptq",
-                    "bits": weight_bits,
-                    "group_size": group_size,
-                    "sym": sym,
-                    "lm_head": False,
-                }
-                return MoeWNA16Config.from_config(config).get_quant_method(
-                    layer, prefix
-                )
-            return GPTQMarlinMoEMethod(quant_args_marlin)
+            config = {
+                "quant_method": "gptq",
+                "bits": weight_bits,
+                "group_size": group_size,
+                "sym": sym,
+                "desc_act": False,
+                "lm_head": False,
+            }
+            return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
 
         if isinstance(layer, (LinearBase, ParallelLMHead)):
             if use_marlin:


### PR DESCRIPTION
## Motivation

`AutoRoundConfig.apply_gptq_quant_layer` delegates FusedMoE layers to `MoeWNA16Config`, which re-runs the Marlin eligibility check itself (`GPTQMarlinConfig.is_gptq_marlin_compatible`) and picks the Marlin MoE method when it passes. Two defects kept that delegation from ever reaching Marlin:

1. **The delegated config lacked the `desc_act` key**, and `is_gptq_marlin_compatible` treats a missing key as ineligible (`if ... or desc_act is None: return False`). So the delegation always landed on the Triton wna16 runner, on every architecture, for every GPTQ-packed auto-round MoE checkpoint.
2. **The `use_marlin=False` arm constructed `GPTQMarlinMoEMethod(quant_args_marlin)` — a variable only defined in the marlin branch.** That arm is a latent `NameError`: the split had no working non-marlin path, which also explains why neither arm had test coverage catching this.

Easy to observe on any such deployment: every rank logs `Using default MoE kernel config. Performance might be sub-optimal!` (Triton runner) while the dense layers log the Marlin bf16 hint — the model runs half on Marlin, half off it. Observed on DeepSeek-V4-Flash-0731 W4A16 (auto-round, gptq packing, sym, group 128) on 8x A800, where the experts are the bulk of decode compute. I will post before/after decode numbers from a controlled A/B on that deployment in a comment.

## Modifications

Collapse the split into one delegation with a complete config (`desc_act: False` — auto-round has no act-order concept), mirroring how the rest of the file trusts MoeWNA16's own routing: it picks the Marlin MoE method when eligible and the Triton runner when not. No behavior change for AWQ packings, dense layers, or native-GPTQ configs (different entry point). The dead NameError arm is gone.

## Checklist

- [x] Format your code with pre-commit
- [x] The defect and fix are visible in the diff; existing auto-round tests exercise the linear path. Happy to add a FusedMoE method-selection test if reviewers prefer it in this PR rather than a follow-up.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30836784310](https://github.com/sgl-project/sglang/actions/runs/30836784310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30836783669](https://github.com/sgl-project/sglang/actions/runs/30836783669)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->