### PR TITLE
fix(olmo2): reach the fused QK norm outside cuda-graph capture

### DIFF
--- a/python/sglang/srt/models/olmo2.py
+++ b/python/sglang/srt/models/olmo2.py
@@ -188,8 +188,16 @@ class Olmo2Attention(nn.Module):
             q = q_by_last.view(q_shape)
             k = k_by_last.view(k_shape)
         else:
-            q = self.q_norm.forward_native(q)
-            k = self.k_norm.forward_native(k)
+            # Same normalisation as the dual-stream branch above, minus the
+            # stream overlap: q and k arrive as [tokens, q_size] / [tokens,
+            # kv_size] and the norms are built over exactly those widths, so
+            # dispatching reaches the fused kernel here too. Calling
+            # forward_native instead left it unused on every path that is not
+            # cuda-graph capture, which is all of prefill.
+            q_shape = q.shape
+            k_shape = k.shape
+            q = self.q_norm(q.reshape(-1, q_shape[-1])).view(q_shape)
+            k = self.k_norm(k.reshape(-1, k_shape[-1])).view(k_shape)
 
         if self.tp_size > 1:
             splitter = partial(split_tensor_along_last_dim, num_partitions=self.tp_size)


### PR DESCRIPTION
Fixes #33415

## Motivation

`Olmo2Attention._apply_qk_norm` reaches its fused norm only under `get_is_capture_mode()`, and calls `forward_native` otherwise. Since that condition is true only *while capturing*, graphed decode replays the fused branch and looks fine, while **prefill is never captured and runs the decomposed norm every time** — as does all of decode when cuda graphs are disabled.

`q` and `k` arrive as `[tokens, q_size]` / `[tokens, kv_size]` out of the qkv split, and the norms are built over exactly those widths, so the fused path was always available on both branches. The eager call simply declines it.

Profiled decode with cuda graphs disabled shows **97 eager-norm-signature calls, 6.62% of kernel time, 6.06 per layer over 16 layers**. Sibling model OLMoE, which calls `self.q_norm(...)` plainly, shows 1.

## Modifications

Ten lines in `python/sglang/srt/models/olmo2.py`: the `else` branch now reshapes and dispatches the same way the dual-stream branch does, minus the stream overlap. No new kernel, no config, no flag.

## Accuracy Tests

The two paths are **bit-identical** on this model's shapes, so this is not an accuracy trade:

```
forward_native vs fused dispatch:  max abs diff 0.0,  torch.equal True
native vs fp64 reference : 0.1410%
fused  vs fp64 reference : 0.1410%
```

End-to-end checks, OLMo-2-0425-1B-Instruct on 1x H200:

| check | result |
|---|---|
| greedy generation, 8 prompts | **8/8 identical** |
| GSM8K, 400 questions, paired | 65.50% → 65.25%, **McNemar p = 1.000** (8 wins / 9 losses over 17 discordant pairs) |

The GSM8K arms are scored pairwise rather than against a reseeded baseline: greedy decoding is deterministic, so a reseeded run is identical by construction and would report a zero noise floor, making any difference look significant.

## Speed Tests and Profiling

Direct prefill measurement, bs=8 in=2048, triton backend, 1x H200:

```
before: 87.80 ms
after:  70.79 ms       1.24x
```

`bench_one_batch`, 7 repetitions per arm, Welch t-test:

| regime | decode | total throughput | p |
|---|---|---|---|
| decode bs=1 | 1.000x | −0.56% | 0.376 n.s. |
| decode bs=32 | 1.005x | −0.81% | 0.861 n.s. |
| decode bs=64 | 0.998x | +7.22% | 0.452 n.s. |
| **prefill-heavy** (bs=8, in=2048) | 0.984x | **+17.61%** | **0.000** |

**Decode being unchanged is the expected result, not a disappointment** — decode already replays a graph captured on the fused branch, so there is nothing there to win. The gain is confined to prefill, which is exactly what the mechanism predicts.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

**Note for reviewers**: this branch is based on a fork point behind current `main`; the change itself applies cleanly to `main` as of `89f4a80c1f`, where the two `forward_native` lines are unchanged. Happy to rebase.

**Unrelated pre-existing failure**: OLMo-2 with `--attention-backend fa3` and cuda graphs enabled dies with `cudaErrorIllegalAddress` on unpatched `main`. It reproduces on a clean checkout, so all measurements here use the triton backend. See #33415 for details.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30837063055](https://github.com/sgl-project/sglang/actions/runs/30837063055)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30837063499](https://github.com/sgl-project/sglang/actions/runs/30837063499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->