### PR TITLE
[Fix] anthropic: report cumulative input usage on message_delta

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -1104,9 +1104,14 @@ class AnthropicServing:
                 return
 
             if chunk.usage is not None:
+                # The Messages API reports cumulative usage on ``message_delta``
+                # as well, repeating the input-side counters already sent on
+                # ``message_start`` rather than replacing them. Clients that read
+                # final usage from the last event therefore expect the input
+                # counters to be present here too.
                 final_usage = _anthropic_usage_from_openai(
                     chunk.usage,
-                    include_input=False,
+                    include_input=True,
                     include_output=True,
                 )
 

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -301,7 +301,7 @@ class TestAnthropicServing(unittest.TestCase):
         ]
         self.assertEqual(sig_deltas, [])
 
-    def test_stream_usage_subtracts_cache_read_and_omits_final_input_tokens(self):
+    def test_stream_usage_subtracts_cache_read_and_repeats_final_input_tokens(self):
         usage = {
             "prompt_tokens": 10,
             "completion_tokens": 0,
@@ -337,8 +337,46 @@ class TestAnthropicServing(unittest.TestCase):
         self.assertEqual(
             message_start["message"]["usage"]["cache_read_input_tokens"], 4
         )
-        self.assertNotIn("input_tokens", message_delta["usage"])
+        # Usage on ``message_delta`` is cumulative: the input-side counters are
+        # repeated verbatim from ``message_start`` so a client that only reads
+        # the final event still sees the full accounting.
+        self.assertEqual(message_delta["usage"]["input_tokens"], 6)
+        self.assertEqual(message_delta["usage"]["cache_read_input_tokens"], 4)
         self.assertEqual(message_delta["usage"]["output_tokens"], 2)
+
+    def test_stream_final_usage_matches_message_start_without_cache(self):
+        """Without cache hits the final delta still carries ``input_tokens``.
+
+        Clients that track context consumption from the last usage payload
+        (the Anthropic SDK's accumulated final message, usage-metering
+        proxies, CLI context meters) see zero input otherwise.
+        """
+        usage = {"prompt_tokens": 25, "completion_tokens": 0, "total_tokens": 25}
+        final_usage = {"prompt_tokens": 25, "completion_tokens": 15, "total_tokens": 40}
+        serving = self._serving(
+            [
+                _chunk([_choice({"role": "assistant", "content": ""})]),
+                _chunk([_choice({"content": "hi"})], usage=usage),
+                _chunk([], usage=final_usage),
+                "data: [DONE]\n\n",
+            ]
+        )
+
+        events = asyncio.run(
+            _collect_anthropic_events(serving, self._anthropic_request())
+        )
+        message_start = next(e for e in events if e["type"] == "message_start")
+        message_delta = next(e for e in events if e["type"] == "message_delta")
+
+        self.assertEqual(
+            message_delta["usage"]["input_tokens"],
+            message_start["message"]["usage"]["input_tokens"],
+        )
+        self.assertEqual(message_delta["usage"]["input_tokens"], 25)
+        self.assertEqual(message_delta["usage"]["output_tokens"], 15)
+        # No cache hits: the optional cache counter stays absent on both events.
+        self.assertNotIn("cache_read_input_tokens", message_start["message"]["usage"])
+        self.assertNotIn("cache_read_input_tokens", message_delta["usage"])
 
     def test_non_streaming_usage_subtracts_cache_read_tokens(self):
         response = ChatCompletionResponse.model_validate(


### PR DESCRIPTION
## Summary

The Messages API reports usage on `message_delta` cumulatively: the final event repeats the input-side counters already sent on `message_start` instead of replacing them. SGLang omits them, so a streamed response ends with

```
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":16}}
```

where the reference API sends

```
event: message_delta
data: {"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"input_tokens":8,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":16}}
```

## Root cause

This was introduced deliberately in #25876, which lists among its changes:

> Enable continuous streaming usage, defer `message_start` until real prompt usage is available, and **omit `input_tokens` from the final `message_delta` usage**.

That PR was fixing the opposite defect reported in #20678, where `message_start` carried `input_tokens: 0` and only the final `message_delta` held the real value. Populating `message_start` was correct; treating the two events as mutually exclusive was not — the reference API populates both, with identical input-side values.

 #20678 was auto-closed for inactivity, so the remaining half was never revisited.

## Impact

Clients that take final usage from the last event observe zero input tokens for every streamed response:

- SDK stream accumulators that merge `message_delta.usage` into the accumulated final message
- usage-metering / billing proxies that keep only the last usage payload seen in an SSE stream
- CLI context meters and auto-compaction heuristics driven by input token counts
- clients that treat a final usage payload without `input_tokens` as malformed and fail the request

Non-streaming responses are unaffected — that path already passes `include_input=True`.

## Reproduction

```bash
curl -N http://localhost:30000/v1/messages \
  -H "Content-Type: application/json" \
  -H "anthropic-version: 2023-06-01" \
  -d '{
    "model": "<model>",
    "messages": [{"role": "user", "content": "hi"}],
    "max_tokens": 16,
    "stream": true
  }'
```

Observe that `message_delta` carries only `output_tokens`, while `message_start` carries the input-side counters.

## Modifications

- Build the `message_delta` usage with `include_input=True`, so `input_tokens` (and `cache_read_input_tokens` when non-zero) are repeated on the final event. `message_start` behaviour is unchanged and both events carry identical input-side values, so clients reading either one get the same accounting and clients reading both do not double count.
- `test_stream_usage_subtracts_cache_read_and_omits_final_input_tokens` → `..._repeats_final_input_tokens`, flipping the `assertNotIn("input_tokens", message_delta["usage"])` assertion that locked in the omission.
- Added `test_stream_final_usage_matches_message_start_without_cache` covering the no-cache path, asserting the final delta matches `message_start` and that the optional cache counter stays absent on both events.

## Test Plan

- `python -m pytest test/registered/unit/entrypoints/anthropic/test_serving.py -k usage` — 5 passed
- `black --check` and `isort --check-only --profile black` clean on both touched files
- `python -m py_compile` clean

Opened as a draft pending one more round of verification on my side.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30874359079](https://github.com/sgl-project/sglang/actions/runs/30874359079)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30874358935](https://github.com/sgl-project/sglang/actions/runs/30874358935)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->