### PR TITLE
Enable post-capture KV sizing with DP attention

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4813,36 +4813,49 @@ class ServerArgs:
         # use_mla_backend is a method at args time but ModelRunner overwrites it
         # with a bool on global_server_args (see the FIXME there) -- handle both.
         use_mla = self.use_mla_backend
-        if not (
-            envs.SGLANG_ENABLE_POST_CAPTURE_KV_SIZING.get()
-            and self.device == "cuda"
-            and self.dcp_size == 1
-            and not (use_mla() if callable(use_mla) else use_mla)
-            and self.kv_cache_dtype != "fp4_e2m1"
-            and not self.prefill_only_disable_kv_cache
-            and not self.enable_memory_saver
-            and envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is None
-            # Accurate sizing assumes graph-covered execution (graphs retain the
-            # activation workspace, so it is measured post-capture). An eager
-            # phase would pay activations outside the measurement: DP attention
-            # runs prefill eager internally, and an explicitly disabled phase
-            # backend runs eager -- keep those on the heuristic reserve.
-            and not self.enable_dp_attention
-            and (
-                self.disaggregation_mode == "decode"
-                or self.cuda_graph_config.prefill.backend != Backend.DISABLED
-            )
-            and (
-                self.disaggregation_mode == "prefill"
-                or self.cuda_graph_config.decode.backend != Backend.DISABLED
-            )
+        mla_enabled = use_mla() if callable(use_mla) else use_mla
+        if not envs.SGLANG_ENABLE_POST_CAPTURE_KV_SIZING.get():
+            return False
+        if self.device != "cuda":
+            return False
+        if self.dcp_size != 1:
+            return False
+        if mla_enabled:
+            return False
+        if self.kv_cache_dtype == "fp4_e2m1":
+            return False
+        if self.prefill_only_disable_kv_cache:
+            return False
+        if self.enable_memory_saver:
+            return False
+        if envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is not None:
+            return False
+
+        if (
+            self.disaggregation_mode != "prefill"
+            and self.cuda_graph_config.decode.backend == Backend.DISABLED
         ):
             return False
+
+        if self.disaggregation_mode != "decode":
+            prefill_cfg = self.cuda_graph_config.prefill
+            # We can only skip eager activation headroom when the largest
+            # prefill forward batch size is already graph-captured. Otherwise,
+            # an eager forward will need more memory and lead to OOM.
+            if (
+                prefill_cfg.backend == Backend.DISABLED
+                or self.chunked_prefill_size <= 0
+                or self.max_prefill_buffer_tokens() > max(prefill_cfg.bs or (0,))
+            ):
+                return False
 
         from sglang.srt.configs.model_config import is_deepseek_v4, is_minimax_sparse
 
         hf_config = self.get_model_config().hf_config
-        return not (is_deepseek_v4(hf_config) or is_minimax_sparse(hf_config))
+        if is_deepseek_v4(hf_config) or is_minimax_sparse(hf_config):
+            return False
+
+        return True
 
     def pre_capture_activation_reserve_mb(self, gpu_mem: Optional[float]) -> float:
         # Runtime activation working-set reserve for eager decode above the captured


### PR DESCRIPTION
## Motivation

`ServerArgs.post_capture_kv_sizing_planned()` gates whether the
`mem_fraction_static` heuristic is allowed to skip the CUDA graph reserve and
let the runtime size the KV pool from measured free memory after capture.

It currently disables post-capture sizing outright whenever `enable_dp_attention`
is set. The reason for that exclusion is that post-capture sizing is only safe
when execution is graph-covered: graphs retain their activation workspace, so it
is included in the post-capture measurement, whereas an eager forward pays its
activation working set outside the measurement and can OOM. DP attention can run
prefill eagerly, hence the blanket exclusion.

But "DP attention is on" is a proxy, not the actual condition. The actual
condition is "the largest prefill forward is not graph-captured", which can be
checked directly — and which many DP attention configs satisfy. Those configs
are needlessly stuck on the conservative heuristic reserve.

## Modifications

- Replace the `not self.enable_dp_attention` blanket check with a direct
  prefill-coverage check (skipped when `disaggregation_mode == "decode"`, which
  has no prefill):
  - the prefill graph backend must not be `DISABLED`,
  - `chunked_prefill_size` must be positive,
  - `max_prefill_buffer_tokens()` must be `<= max(prefill_cfg.bs)`, i.e. the
    largest prefill forward batch size is actually captured.

  If any of these fail, an eager prefill forward is possible and we keep the
  heuristic reserve, exactly as before.
- Flatten the single `if not (... and ... and ...)` chain into one early return
  per condition. The chain had grown to nine terms with an embedded comment; one
  `if` per rejection reason is easier to read and to extend.

No behavior change for configs where prefill was already fully graph-captured
and DP attention was off. Configs with DP attention plus a fully graph-covered
prefill newly qualify for post-capture sizing. Configs where prefill is eager
(prefill graph disabled, chunked prefill off, or prefill buffer larger than the
captured batch sizes) are now rejected explicitly — previously the first two
were caught by the `Backend.DISABLED` term and the third was not checked at all,
so this also tightens a real gap.

## Accuracy Tests

No accuracy impact — this only affects memory-sizing policy at startup.

## Benchmarking and Profiling

Verified on an internal setup that a DP attention configuration with fully
graph-captured prefill now takes the post-capture sizing path and boots without
OOM, and that configurations with an eager prefill phase still fall back to the
heuristic reserve.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example guides as outlined in the [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as outlined in the [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

## Original commits

- `a68c4c3a1c`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30852766409](https://github.com/sgl-project/sglang/actions/runs/30852766409)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #30875857082](https://github.com/sgl-project/sglang/actions/runs/30875857082)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->