### PR TITLE
[CPU] Fix clang build: std::sqrt is not constexpr

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
+++ b/python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp
@@ -98,7 +98,7 @@ struct l2norm_kernel<at::BFloat16, D, has_scale> {
     __m512bh va[COLS];
     __m512 vrscale;
 
-    constexpr float scale = 1.f / std::sqrt(D);
+    const float scale = 1.f / std::sqrt(D);
     __m512 vscale = _mm512_set1_ps(scale);
 
     // step 1: load input and do reduce with avx512-bf16


### PR DESCRIPTION
## Motivation

`l2norm_kernel`'s AVX512 BFloat16 path builds a `constexpr` from `std::sqrt`:

```cpp
constexpr float scale = 1.f / std::sqrt(D);
```

`std::sqrt` is not `constexpr` until C++26. GCC allows it anyway as an extension, so GCC builds pass. Clang follows the standard and rejects it:

```
error: constexpr variable 'scale' must be initialized by a constant expression
note: non-constexpr function 'sqrt' cannot be used in a constant expression
```

So this file does not build under clang on any x86 target with AVX512 enabled. GCC users never see it.

### How this came up

vLLM vendors these kernels under `csrc/cpu/sgl-kernels/`. Their copy of this same construct broke their macOS Apple Silicon CI, which builds with Apple clang — fixed in vllm-project/vllm#50915. Sending the equivalent fix here so a future sync does not carry it back.

The vLLM break was in a generic vectorized `l2norm_kernel` that this repo does not have — the scalar path here is a `TORCH_CHECK(false)` stub. So this PR only covers the AVX512 specialization, which is the part that is shared.

## Modifications

One line in `python/sglang/kernels/aot/csrc/cpu/mamba/fla.cpp`:

```diff
-    constexpr float scale = 1.f / std::sqrt(D);
+    const float scale = 1.f / std::sqrt(D);
```

`scale` is only used as an ordinary value on the next line (`_mm512_set1_ps(scale)`), so it never needed to be a constant expression.

## Accuracy Tests

Not applicable — the generated code is identical.

`const` does not add a runtime `sqrt` call here. Clang still folds the expression to an immediate at -O2/-O3 (`1/sqrt(64)` → `0.125`, `1/sqrt(128)` → `0.088388348`), and the object file has no `sqrt` symbol left in it. Same instructions, same values, so there is no numerical behaviour to measure.

## Speed Tests and Profiling

Not applicable, for the same reason — no instruction-level change, so there is nothing to benchmark.

## Checklist

- [x] **Format** — `clang-format --style=file` leaves the changed line unchanged.
- [ ] **Unit tests** — none added. This is a compile-time fix with no behaviour change; there is no runtime condition a test could assert. The build itself is the check.
- [ ] **Documentation** — not applicable.
- [ ] **Accuracy and speed benchmarks** — not applicable, see the two sections above.
- [x] **Code style** — matches the surrounding code; `const` is what the neighbouring initializers in this function already use.

### One caveat, stated plainly

I could not build this file directly — the AVX512 path needs an x86 host with AVX512 and I only have arm64. What I did verify, on vLLM's copy of the identical construct: it fails to compile under Apple clang 21 with exactly the error above, compiles clean once changed to `const`, and the constant is still folded to an immediate afterwards. Happy to have someone with an AVX512 box confirm on this repo.
