### PR TITLE
route collectives through nccl2

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -172,9 +172,12 @@ class CustomAllreduce:
 
     @staticmethod
     def free_shared_buffer(
-        pointers: List[int], group: Optional[ProcessGroup] = None
+        pointers: List[int],
+        group: Optional[ProcessGroup] = None,
+        rank: Optional[int] = None,
     ) -> None:
-        rank = dist.get_rank(group=group)
+        if rank is None:
+            rank = dist.get_rank(group=group)
         lib = CudaRTLibrary()
         lib.cudaFree(ctypes.c_void_p(pointers[rank]))
 
@@ -333,8 +336,13 @@ class CustomAllreduce:
             if ops is not None:
                 ops.dispose(self._ptr)
             if _is_cuda:
-                self.free_shared_buffer(self.meta_ptrs)
-                self.free_shared_buffer(self.buffer_ptrs)
+                # Pass the cached group rank explicitly: `pointers` is indexed
+                # by rank *within self.group*, and close() may run after the
+                # group has been destroyed, in which case resolving the rank
+                # from the group is either wrong (get_rank(None) returns the
+                # global rank) or an error.
+                self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+                self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
             self._ptr = 0
 
     def __del__(self):

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -155,10 +155,22 @@ class CustomAllReduceV2:
         return self._all_reduce(input)
 
     def close(self):
-        if not self.disabled and hasattr(self, "obj"):
-            self.obj.free(self.group)
-        if hasattr(self, "_vmm_graph_input_manager"):
-            self._vmm_graph_input_manager.close()
+        # `obj.free()` closes the peers' IPC handles, barriers on `self.group`
+        # so that no peer is still mapping the storage, and only then frees it.
+        # That barrier makes close() order-sensitive: it has to run while the
+        # group is still alive (the owner calls it before destroying the group)
+        # and it has to run exactly once. So drop `obj` up front -- otherwise a
+        # later `__del__` re-enters free() on a group that is gone by then, the
+        # barrier raises inside a destructor where the exception is swallowed,
+        # and the storage is never freed (there is no C++ destructor).
+        obj = getattr(self, "obj", None)
+        self.obj = None
+        manager = getattr(self, "_vmm_graph_input_manager", None)
+        self._vmm_graph_input_manager = None
+        if not self.disabled and obj is not None:
+            obj.free(self.group)
+        if manager is not None:
+            manager.close()
 
     def _all_reduce(self, input: torch.Tensor) -> torch.Tensor:
         """Perform the actual all-reduce via JIT kernel."""

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -79,6 +79,45 @@ REDUCE_OP_SUM = int(torch.distributed.ReduceOp.SUM)
 # creation so runtime collectives do not silently fall back to backend defaults.
 _MODEL_PARALLEL_GROUP_TIMEOUT: Optional[timedelta] = None
 
+# Backend strings for the in-tree "nccl2" backend.
+#
+# The world PG must be device-qualified: "nccl2" is a CUSTOM backend rather than
+# a device default, so a bare "nccl2" recorded in the parent PG's pg_map cannot
+# be parsed by split_group (_parse_backend_string only resolves bare names via
+# default_device_backend_map). The world also carries "cpu:gloo" so CPU
+# subgroups can be split out of it.
+NCCL2_WORLD_BACKEND = "cpu:gloo,cuda:nccl2"
+# Filter for a device (CUDA collective) subgroup split off the world PG.
+NCCL2_DEVICE_BACKEND = "cuda:nccl2"
+# Filter for a CPU-coordination subgroup split off the world PG. It has to keep
+# "cuda:nccl2" as well: ProcessGroup::splitGroup requires the deviceTypes filter
+# to include the parent's default backend device type (cuda here), so a pure
+# "cpu:gloo" split is rejected outright. The resulting group is compound, which
+# is fine for CPU collectives and for dist.monitored_barrier (it checks for a
+# CPU-capable backend via group._device_types, not for the literal "gloo" name).
+NCCL2_CPU_BACKEND = "cpu:gloo,cuda:nccl2"
+
+
+def is_nccl2_world() -> bool:
+    """Whether the default (world) PG is the device-bound nccl2 group.
+
+    Derived from the live world PG rather than from the requested backend
+    string, because the world may have been initialized by someone other than
+    ``init_distributed_environment`` (an embedding trainer, or
+    ``multimodal_gen``, which does not route ``nccl`` -> ``nccl2``). Splitting a
+    stock-``nccl`` parent with ``backend="cuda:nccl2"`` would fail with a
+    backend mismatch, so those worlds must keep the upstream ``new_group`` path.
+    """
+    if not torch.distributed.is_initialized():
+        return False
+    world_pg = torch.distributed.group.WORLD
+    if world_pg is None:
+        return False
+    # split_group requires an eagerly device-bound parent communicator.
+    if getattr(world_pg, "bound_device_id", None) is None:
+        return False
+    return "nccl2" in torch.distributed.get_backend(world_pg)
+
 
 def get_torch_distributed_pg_options(group_name=None):
     if not _is_npu:
@@ -297,11 +336,32 @@ class GroupCoordinator:
             self.device = torch.device("cpu")
         self.device_module = torch.get_device_module(self.device)
 
+        # The world PG uses the in-tree "nccl2" backend and is created eagerly
+        # device-bound (see init_distributed_environment). Subgroups are carved
+        # from it with split_group, which requires the parent communicator to be
+        # initialized/bound up front. The device subgroup keeps only the parent's
+        # "cuda:nccl2" backend; the cpu subgroup additionally keeps "cpu:gloo"
+        # for direct CPU-side coordination.
+        #
+        # The pipeline-parallel group (group_name "pp") is the sole exception:
+        # its device subgroup uses the "nccl-lazy" backend for per-peer lazy P2P
+        # comms (send/recv overlap). nccl2 does not implement the eager new_group
+        # no-color-split path, so that nccl-lazy device group is built
+        # members-only via new_group with use_local_synchronization=True, which
+        # short-circuits non-members before they would reach that missing path.
+        # Its cpu group is split from the world PG like every other cpu group.
+        #
+        # Non-nccl2 paths (a plain gloo, mooncake, or NPU/XPU run, or a world PG
+        # that someone else initialized with stock nccl) fall back to the
+        # upstream new_group path.
+        is_mooncake = "mooncake" in torch_distributed_backend
+        use_nccl2 = is_nccl2_world()
+        is_pipeline = group_name == "pp"
         for ranks in group_ranks:
             active_ranks = torch.ones(len(ranks), dtype=torch.int32, device=self.device)
             active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
             subgroup_timeout = _MODEL_PARALLEL_GROUP_TIMEOUT
-            if "mooncake" in torch_distributed_backend:
+            if is_mooncake:
                 from mooncake.ep import MooncakeBackendOptions
 
                 device_group = torch.distributed.new_group(
@@ -315,6 +375,49 @@ class GroupCoordinator:
                     backend="mooncake-cpu",
                     pg_options=MooncakeBackendOptions(active_ranks_cpu, recovered_rank),
                     timeout=subgroup_timeout,
+                )
+            elif use_nccl2:
+                if is_pipeline:
+                    # Members-only nccl-lazy subgroup for per-peer P2P; bound to
+                    # this rank's real CUDA device so non-contiguous PP recv
+                    # lands on the right device.
+                    device_group = torch.distributed.new_group(
+                        ranks,
+                        backend="nccl-lazy",
+                        pg_options=get_torch_distributed_pg_options(group_name),
+                        use_local_synchronization=True,
+                        timeout=subgroup_timeout,
+                        device_id=torch.device(f"cuda:{local_rank}"),
+                    )
+                else:
+                    # split_group is collective over the parent (world) PG, so
+                    # every world rank enters this call with the same split;
+                    # ranks outside `ranks` get a non-group member handle that
+                    # is never used below.
+                    device_group = torch.distributed.split_group(
+                        split_ranks=[ranks],
+                        backend=NCCL2_DEVICE_BACKEND,
+                        pg_options=get_torch_distributed_pg_options(group_name),
+                        timeout=subgroup_timeout,
+                    )
+                # A group carrying a `gloo` CPU backend, to allow direct
+                # coordination between processes through the CPU. Also split
+                # from the world PG, and likewise collective over it.
+                #
+                # The split necessarily keeps the parent's cuda:nccl2 backend
+                # alongside cpu:gloo -- ProcessGroup::splitGroup requires the
+                # deviceTypes filter to contain the parent's default backend
+                # device type, so a pure cpu:gloo split is rejected. That is
+                # fine for CPU collectives, and dist.monitored_barrier (used on
+                # the TP cpu group during model load) accepts it: it checks for
+                # a CPU-capable backend via group._device_types rather than
+                # matching the literal "gloo" backend name. Note this does mean
+                # get_backend() on the cpu group returns the full
+                # "cpu:gloo,cuda:nccl2" config string.
+                cpu_group = torch.distributed.split_group(
+                    split_ranks=[ranks],
+                    backend=NCCL2_CPU_BACKEND,
+                    timeout=gloo_timeout,
                 )
             else:
                 pg_options = get_torch_distributed_pg_options(group_name)
@@ -1479,18 +1582,25 @@ class GroupCoordinator:
         return tensor
 
     def destroy(self):
+        # Close the communicators before the process groups they were built
+        # from, and close them explicitly rather than dropping the reference:
+        # CustomAllReduceV2.close() barriers on cpu_group between closing the
+        # peers' IPC handles and freeing its device storage, so running it from
+        # __del__ after cpu_group is gone raises inside a destructor, where the
+        # exception is swallowed and the storage is leaked.
+        if self.ca_comm is not None:
+            self.ca_comm.close()
+            self.ca_comm = None
+        if self.pymscclpp_comm is not None:
+            self.pymscclpp_comm.destroy()
+        if self.pynccl_comm is not None:
+            self.pynccl_comm = None
         if self.device_group is not None:
             torch.distributed.destroy_process_group(self.device_group)
             self.device_group = None
         if self.cpu_group is not None:
             torch.distributed.destroy_process_group(self.cpu_group)
             self.cpu_group = None
-        if self.pynccl_comm is not None:
-            self.pynccl_comm = None
-        if self.pymscclpp_comm is not None:
-            self.pymscclpp_comm.destroy()
-        if self.ca_comm is not None:
-            self.ca_comm = None
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
@@ -1792,6 +1902,17 @@ def init_distributed_environment(
             ) from e
         mooncake_ep.set_host_ip(get_local_ip_auto())
 
+    # Resolve local_rank up front: it is not available on a torch ProcessGroup
+    # (see https://github.com/pytorch/pytorch/issues/122816) and is needed both
+    # for the world device binding below and for init_world_group.
+    if local_rank == -1:
+        # local rank not set, this usually happens in single-node setting,
+        # where we can use rank as local rank
+        if distributed_init_method == "env://":
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        else:
+            local_rank = rank
+
     if not torch.distributed.is_initialized():
         global _MODEL_PARALLEL_GROUP_TIMEOUT
         assert distributed_init_method is not None, (
@@ -1814,30 +1935,37 @@ def init_distributed_environment(
         else:
             pg_options = get_torch_distributed_pg_options()
 
+        # Bind the world PG to its CUDA device so subgroups can be carved from it
+        # with split_group, which requires an eagerly initialized/bound parent
+        # communicator. Split subgroups reuse the c10d store, so no extra
+        # MASTER_PORT or per-backend env seeding is needed.
+        device_id = (
+            torch.device(f"cuda:{local_rank}")
+            if is_cuda_alike() and backend != "gloo"
+            else None
+        )
+
+        # Route the world backend to the in-tree nccl2 backend, device-qualified
+        # (see NCCL2_WORLD_BACKEND for why the qualification is mandatory).
+        world_backend = backend
+        if world_backend in ("nccl", "cuda:nccl"):
+            world_backend = NCCL2_WORLD_BACKEND
+
         # this backend is used for WORLD
         torch.distributed.init_process_group(
-            backend=backend,
+            backend=world_backend,
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
             timeout=timeout,
             pg_options=pg_options,
+            device_id=device_id,
         )
 
         # Create a global TCPStore for coordination (used by NIXL)
         if moe_a2a_backend == "nixl":
             _create_global_tcp_store(rank, world_size)
 
-    # set the local rank
-    # local_rank is not available in torch ProcessGroup,
-    # see https://github.com/pytorch/pytorch/issues/122816
-    if local_rank == -1:
-        # local rank not set, this usually happens in single-node
-        # setting, where we can use rank as local rank
-        if distributed_init_method == "env://":
-            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-        else:
-            local_rank = rank
     global _WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
@@ -2139,15 +2267,25 @@ def initialize_model_parallel(
 
 
 def create_custom_parallel_group(
-    group_ranks: List[int], backend: str = "gloo"
+    group_ranks: List[int],
+    backend: str = "gloo",
+    timeout: Optional[timedelta] = None,
 ) -> Optional[torch.distributed.ProcessGroup]:
     """
     Create a custom parallel group based on the provided ranks.
 
+    This is collective over the whole world: every rank must call it, and the
+    per-rank ``group_ranks`` must together form a partition of the world.
+
     Args:
         group_ranks: The list of ranks that the CURRENT process wants to join.
                      (e.g., Rank 0 passes [0...7], Rank 8 passes [8...15])
-        backend: The communication backend (default: "gloo").
+        backend: The communication backend (default: "gloo"). Ignored on the
+                 nccl2 path, where the group is split off the world PG and so
+                 necessarily carries the parent's backends
+                 (``cpu:gloo,cuda:nccl2``).
+        timeout: Process group timeout. ``None`` keeps the backend default
+                 (30 minutes for gloo / for a device-qualified backend string).
 
     Returns:
         The ProcessGroup if the current rank is in group_ranks, else None.
@@ -2173,10 +2311,43 @@ def create_custom_parallel_group(
 
     unique_groups.sort(key=lambda x: x[0])
 
+    if is_nccl2_world():
+        # Over an nccl2 world an eager new_group() is fatal: non-member ranks
+        # take the no-color-split path in _new_process_group_helper and call
+        # perform_nocolor_split(), which ProcessGroupNCCL2 does not implement.
+        # Split the world PG instead -- a single collective that hands every
+        # rank the split it belongs to. All ranks already reach this point
+        # (the all_gather_object above is world-collective) and agree on
+        # `unique_groups`, so the split is consistent.
+        covered: set = set()
+        for g_ranks in unique_groups:
+            if covered & set(g_ranks):
+                raise ValueError(
+                    "create_custom_parallel_group requires disjoint groups on "
+                    f"the nccl2 path, but got overlapping splits: {unique_groups}"
+                )
+            covered |= set(g_ranks)
+        # split_ranks are ranks in the parent PG; the parent is the world PG,
+        # so they are the global ranks gathered above.
+        my_new_group = torch.distributed.split_group(
+            split_ranks=unique_groups,
+            backend=NCCL2_CPU_BACKEND,
+            timeout=timeout,
+        )
+        if my_new_group is torch.distributed.GroupMember.NON_GROUP_MEMBER:
+            my_new_group = None
+        else:
+            logger.debug(
+                f"Rank {rank} successfully created/joined custom group: {local_config}"
+            )
+        return my_new_group
+
     my_new_group = None
 
     for g_ranks in unique_groups:
-        group = torch.distributed.new_group(ranks=g_ranks, backend=backend)
+        group = torch.distributed.new_group(
+            ranks=g_ranks, backend=backend, timeout=timeout
+        )
 
         if set(g_ranks) == set(local_config):
             my_new_group = group


### PR DESCRIPTION

Summary:
# Route sglang's distributed process groups through the in-tree nccl2 backend

## Summary

Routes sglang's process-group setup through PyTorch's in-tree `nccl2` backend.
The world PG is a device_id-bound `cpu:gloo,cuda:nccl2` group. Device collective
subgroups (TP/DP/etc.) are carved from it with `torch.distributed.split_group`
(`cuda:nccl2`). The pipeline-parallel device group uses `new_group(backend=
"nccl-lazy", use_local_synchronization=True, device_id=...)` for per-peer lazy
P2P (overlapping send/recv). CPU coordination groups use members-only
`new_group(backend="gloo", use_local_synchronization=True)`.

## Why this shape

nccl2 supports comm-split but not the stock eager-`new_group` no-color-split
path, so device collective subgroups are `split_group` (collective, hashed,
self-contained) and PP is `nccl-lazy` for P2P overlap.

CPU coordination groups are pure gloo `new_group`, NOT `split_group`: a
`split_group("cpu:gloo,cuda:nccl2")` group reports the mixed config string from
`get_backend()`, which breaks GLOO-only callers like `dist.monitored_barrier`
(used during model load); and `split_group` cannot produce a pure-gloo group
over an nccl2 parent anyway (the split filter must include the parent's default
cuda device). A members-only gloo `new_group` short-circuits non-members before
the nccl2 parent's (absent) eager no-color-split.

The world backend is qualified explicitly to `cpu:gloo,cuda:nccl2`, not bare
`nccl2`: `nccl2` is a CUSTOM backend (not a device default), so a bare `nccl2`
stored in the parent's `pg_map` cannot be parsed by `split_group`
(`_parse_backend_string`); and the world must carry `cpu:gloo` so the cpu groups
have a gloo backend available.

## What changed

### `parallel_state.py`

- `init_distributed_environment`: bind the world PG to its cuda device
  (`device_id`, from local_rank) and route the world backend to the
  device-qualified `cpu:gloo,cuda:nccl2` (`nccl` / `cuda:nccl` ->
  `cpu:gloo,cuda:nccl2`).
- `GroupCoordinator.__init__`: device collective groups via
  `split_group(cuda:nccl2)`; CPU coordination groups via members-only
  `new_group(gloo, use_local_synchronization=True)`; the PP group
  (`group_name == "pp"`) device group via `new_group(nccl-lazy,
  use_local_synchronization=True, device_id)`.

## Test Plan

4xH100, torchcomms conda env, `TORCH_DISTRIBUTED_USE_TORCHCOMMS=0` (required:
with it set, torch's split_group/new_group take the torchcomms-adapter path,
which the native `ProcessGroupNCCL2` does not implement). sglang mock functional
suite: unit tests pass; e2e tp=2 (32/32 requests served), pp=2 (exercises
`nccl-lazy`), spec-eagle, and perturb all PASS. `test_e2e_pd` fails only on the
pre-existing mooncake gap (`ModuleNotFoundError: mooncake`, after a clean nccl2
init) -- not an nccl2 issue. Group classes reconfirmed via a torchrun probe:
world/tp `ProcessGroupNCCL2`, pp `ProcessGroupNCCLLazy`, cpu `gloo`.

Authored with the assistance of an AI coding agent.
Enforce the nccl2 group-construction policy in srt/distributed. Route CPU
coordination groups through split_group instead of a members-only gloo new_group:
splitGroup requires the filter to include the parent's default backend device
type, so over a cuda-bound nccl2 world the child is always a compound
cpu:gloo,cuda:nccl2 group, never pure gloo. That is fine now that
monitored_barrier checks for a CPU-capable backend rather than matching the
literal 'gloo' name, which was the original reason for the exception.

Fixes a live crash in create_custom_parallel_group: it built groups with an eager
new_group, and an eager new_group with asymmetric membership over an nccl2 parent
raises AttributeError: 'ProcessGroupNCCL2' object has no attribute
'perform_nocolor_split' on the non-member rank. Reachable by any TP>1 run using
hierarchical-cache storage or the mooncake embedding cache.

Also fixes the use_nccl2 predicate, which was derived from the requested backend
string rather than the live world, so it read True against a stock-nccl world
supplied by an external trainer or by multimodal_gen and then failed with
'Backend mismatch for device cuda'.

Also folds in an inherited teardown bug that this world layout makes reachable.
CustomAllreduce.close() called free_shared_buffer(self.meta_ptrs) with no group=,
and free_shared_buffer resolved its index with dist.get_rank(group=group) -- with
group None that is the *global* rank, used to index a list whose length is the
size of self.group. Measured on 4 ranks with tp=2:

    [rank1] tp.ranks=[0,1] rank_in_group=1 global_rank=1 len(meta_ptrs)=2 -> pointers[1] ok
    [rank2] tp.ranks=[2,3] rank_in_group=0 global_rank=2 len(meta_ptrs)=2 -> pointers[2] IndexError

so every rank whose global rank is >= tp_size dies in teardown with "IndexError:
list index out of range", and n=2/tp=2 masks it entirely because there group rank
and global rank coincide. In srt the call reaches close() from __del__ at GC
time, where the exception is swallowed as "Exception ignored in ..." and the IPC
buffers simply leak. free_shared_buffer now takes an explicit rank= and close()
passes self.rank, the group rank cached in __init__ (close() is guarded by not
self.disabled, and disabled is only cleared after self.rank is assigned, so the
attribute is always there). This is the same change vLLM made upstream in
3e472d882, the commit that first made TP a strict subset of the world; sglang's
copy of the file predates it and never picked it up.

Honouring the group rank is only half of it: a caller that instead passed
group=self.group would have traded the IndexError for "ValueError: Group ... is
not registered", because destroy() tore the process groups down before closing
the communicators built from them. The matching reorder lands in the
multimodal_gen coordinator in the follow-up commit; it is safe in either
direction, since close() is ops.dispose() plus two cudaFrees with no collectives
and no store access, so running it while the groups are still alive cannot hang.

Verified on 4 ranks with tp=2 against both cpu:gloo,cuda:nccl and
cpu:gloo,cuda:nccl2: ranks 2 and 3 went from IndexError to "TEARDOWN OK" on all
four ranks, and the previously-masked 2-rank tp=2 case now runs with no
"Exception ignored" line.

Also folds in the srt half of that same teardown ordering, which this world
layout turns from latent into fatal. CustomAllReduceV2.close() calls
obj.free(self.group), and obj.free is free_ipc_handles() ->
dist.barrier(group) -> free_storage(). It does not *index* the group, it runs a
*collective* on it -- a strictly stronger requirement than v1's, which after the
change above needs no group at all. GroupCoordinator.destroy() destroyed
device_group and cpu_group first and only then dropped self.ca_comm = None; that
drop is the last reference, so __del__ -> close() ran immediately, with the
barrier on an already-destroyed group.

Whether that is fatal depends on what the cpu group is made of. On stock
sglang's pure-gloo cpu group the barrier survives by luck: Backend::shutdown()
is a no-op and ProcessGroupGloo does not override it, so destroy_process_group
only removes the Python bookkeeping while the C++ group -- still referenced by
ca_comm.group -- keeps working. This stack's cpu group is a
split_group("cpu:gloo,cuda:nccl2") child that inherits bound_device_id, so the
barrier is routed to the NCCL backend, which destroy_process_group genuinely
finalizes: "RuntimeError: ProcessGroupNCCL has been finalized". Said plainly:
the bad ordering predates this work, and this work is what makes it fail.
Unlike the IndexError above it is not masked at n=2/tp=2 -- nothing on this path
depends on a rank index, so n=2/tp=2 fails identically to n=4/tp=2.

The consequence is a leak, not just a noisy log. free_ipc_handles() has already
run by the time the barrier throws, so free_storage() never runs, and
free_storage() is the only cudaFree of the arena: CustomAllReduceBase
cudaMallocs m_storage in its constructor and has no C++ destructor at all.
Proven directly rather than argued -- obj.share_storage() is
cudaIpcGetMemHandle(m_storage) and free_storage() nulls m_storage, so
share_storage() still succeeding after teardown means the free never happened,
and it does succeed on every rank in the pre-fix arm. The byte count was not
measured: mem_get_info() reported a 0 MiB delta for obj.free() in both arms
while correctly tracking a 64 MiB control allocation, plausibly because the
storage is IPC-exported and the driver defers the release. So the arena's size
is read off the source, not weighed.

close() was also not idempotent, a third and separate defect: it left self.obj
in place, so a caller who closed explicitly while the group was still alive
still got a second close() from __del__, and that second one raised and was
swallowed. jit_kernel/mp.py's register_comm_cleanup already works around this by
delattr(comm, "obj") after closing, which is evidence of the defect rather than
a fix -- it covers the test path and not the product one.

The fix is in two places. close() pops obj and _vmm_graph_input_manager before
freeing anything, so the free runs exactly once and a later __del__ is a no-op
instead of a swallowed throw; that mirrors the self._ptr = 0 guard v1 already
has. destroy() closes ca_comm explicitly instead of dropping the reference, and
closes the communicators before destroying the groups they were built from --
the same shape as the reorder the follow-up commit makes in the multimodal_gen
coordinator. close() now really executes its barrier where before it always
threw instantly, but destroy_model_parallel walks the coordinators in the same
order on every rank, so every member enters that barrier at the same point.

One correction to the record above: the IndexError is not what this path raises.
v1 was already immune once close() started passing rank=self.rank, verified by
restoring the old destroy ordering and running v1 on 4 ranks with tp=2 -- no
unraisable on any rank. The live failure on the v2 path was only ever the
barrier.

Verified by A/B in a single binary, with a --unfix flag that monkeypatches
close() and destroy() back to their pre-fix versions: pre-fix destroy gives one
unraisable per rank plus leaked storage on all four, the fix gives zero
unraisable and freed storage. Green with the fix at n4/tp2 against a stock
cpu:gloo,cuda:nccl world, n4/tp2 nccl2, n4/tp4 nccl2, n2/tp2 nccl2, and n4/tp2
on v1. Plus test/registered/jit/test_custom_all_reduce.py --num-gpu 2 -k "dtype0
and ONE_SHOT_PULL", 20 passed, which exercises register_comm_cleanup and
close(). The limits, stated rather than glossed: there is no end-to-end srt
server run behind this, since no model is available on the host, so teardown is
driven directly through initialize_model_parallel / destroy_model_parallel,
which is what a server shutdown calls; and the ROCm, mscclpp and mooncake paths
are untested for want of hardware.

Known and deliberately not fixed here: qr_comm, the ROCm QuickAllReduce, is
never torn down by destroy() at all even though QuickAllReduce.close() exists,
so ops.qr_destroy only ever runs from __del__. Same class of defect, ROCm-only,
and untestable on this host.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sgl-project/sglang/pull/33434).
* #33435
* __->__ #33434

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->