### PR TITLE
[CI] Build the Rust extensions with the pinned toolchain instead of the image default

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -175,6 +175,19 @@ clean_site_packages() {
     bash "${SCRIPT_DIR}/../utils/install_rust_protoc.sh"
     export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
 
+    # Select the workspace's pinned toolchain for the cargo runs that
+    # setuptools-rust makes later in this same step. install_rustup.sh exports
+    # this too, but as a child process it can only reach subsequent steps - the
+    # same reason the PATH export above is repeated here. Runner images that ship
+    # an older rustc otherwise build with it and fail on crates requiring the
+    # pin, and rust-toolchain.toml does not cover this because setuptools-rust
+    # runs cargo from python/, outside the pin's cwd scope.
+    RUST_PINNED_CHANNEL=$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' "${REPO_ROOT}/rust/rust-toolchain.toml" 2>/dev/null || true)
+    if [ -n "${RUST_PINNED_CHANNEL}" ]; then
+        export RUSTUP_TOOLCHAIN="${RUST_PINNED_CHANNEL}"
+        echo "Using pinned Rust toolchain ${RUST_PINNED_CHANNEL} for this install"
+    fi
+
     mark_step_done "${FUNCNAME[0]}"
 }
 

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -175,13 +175,11 @@ clean_site_packages() {
     bash "${SCRIPT_DIR}/../utils/install_rust_protoc.sh"
     export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
 
-    # Select the workspace's pinned toolchain for the cargo runs that
-    # setuptools-rust makes later in this same step. install_rustup.sh exports
-    # this too, but as a child process it can only reach subsequent steps - the
-    # same reason the PATH export above is repeated here. Runner images that ship
-    # an older rustc otherwise build with it and fail on crates requiring the
-    # pin, and rust-toolchain.toml does not cover this because setuptools-rust
-    # runs cargo from python/, outside the pin's cwd scope.
+    # Same-step counterpart of the PATH export above: install_rustup.sh exports
+    # RUSTUP_TOOLCHAIN too, but as a child process only reaches later steps.
+    # rust-toolchain.toml does not cover it either - setuptools-rust runs cargo
+    # from python/, outside the pin's cwd scope - so without this an image's own
+    # older rustc builds the crates and fails their MSRV.
     RUST_PINNED_CHANNEL=$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' "${REPO_ROOT}/rust/rust-toolchain.toml" 2>/dev/null || true)
     if [ -n "${RUST_PINNED_CHANNEL}" ]; then
         export RUSTUP_TOOLCHAIN="${RUST_PINNED_CHANNEL}"

--- a/scripts/ci/utils/install_rustup.sh
+++ b/scripts/ci/utils/install_rustup.sh
@@ -125,5 +125,25 @@ fi
 
 install_workspace_pinned_toolchain
 
+# A runner image that already ships a usable rustc takes the "rust already
+# installed" path above, so the image's own toolchain stays selected and crates
+# requiring the pin fail to build.
+#
+# Select it with RUSTUP_TOOLCHAIN rather than `rustup default`: the latter
+# rewrites ~/.rustup for every later job on this self-hosted runner, and jobs
+# sharing that directory would race on it. The env var also outranks the
+# rust-toolchain.toml pin, so it applies where the pin does not - cargo runs
+# started outside rust/, which is how setuptools-rust invokes it.
+#
+# This only reaches subsequent steps, since callers run this script as a child
+# process; anything building within the same step exports it itself.
+export RUSTUP_TOOLCHAIN="${DEFAULT_CHANNEL}"
+if [ -n "${GITHUB_ENV:-}" ]; then
+    # Self-heal a missing _runner_file_commands/, as with GITHUB_PATH above.
+    mkdir -p "$(dirname "${GITHUB_ENV}")" 2>/dev/null || true
+    echo "RUSTUP_TOOLCHAIN=${DEFAULT_CHANNEL}" >> "${GITHUB_ENV}" || true
+fi
+
+# Reports what RUSTUP_TOOLCHAIN just selected, not the image default.
 rustc --version
 cargo --version

--- a/scripts/ci/utils/install_rustup.sh
+++ b/scripts/ci/utils/install_rustup.sh
@@ -125,18 +125,14 @@ fi
 
 install_workspace_pinned_toolchain
 
-# A runner image that already ships a usable rustc takes the "rust already
-# installed" path above, so the image's own toolchain stays selected and crates
-# requiring the pin fail to build.
+# An image that already ships a usable rustc takes the "rust already installed"
+# path above, leaving its own toolchain selected so crates needing the pin fail.
 #
-# Select it with RUSTUP_TOOLCHAIN rather than `rustup default`: the latter
-# rewrites ~/.rustup for every later job on this self-hosted runner, and jobs
-# sharing that directory would race on it. The env var also outranks the
-# rust-toolchain.toml pin, so it applies where the pin does not - cargo runs
-# started outside rust/, which is how setuptools-rust invokes it.
-#
-# This only reaches subsequent steps, since callers run this script as a child
-# process; anything building within the same step exports it itself.
+# RUSTUP_TOOLCHAIN rather than `rustup default`: the latter rewrites the shared
+# ~/.rustup on this self-hosted runner, which concurrent jobs would race on. It
+# also outranks rust-toolchain.toml, so it covers cargo runs started outside
+# rust/, which is how setuptools-rust invokes it. As a child process this only
+# reaches later steps; same-step builders export it themselves.
 export RUSTUP_TOOLCHAIN="${DEFAULT_CHANNEL}"
 if [ -n "${GITHUB_ENV:-}" ]; then
     # Self-heal a missing _runner_file_commands/, as with GITHUB_PATH above.
@@ -144,6 +140,5 @@ if [ -n "${GITHUB_ENV:-}" ]; then
     echo "RUSTUP_TOOLCHAIN=${DEFAULT_CHANNEL}" >> "${GITHUB_ENV}" || true
 fi
 
-# Reports what RUSTUP_TOOLCHAIN just selected, not the image default.
 rustc --version
 cargo --version


### PR DESCRIPTION
Runner images that already ship a usable `rustc` take the early-return path in `install_rustup.sh`, so the image's own toolchain stays selected even though `install_workspace_pinned_toolchain` installed the pin. `rust-toolchain.toml` does not cover this because setuptools-rust runs cargo from `python/`, outside the pin's cwd scope, so a 1.90 image fails on crates requiring 1.92. Selects the pin via `RUSTUP_TOOLCHAIN` rather than `rustup default`, which would rewrite `~/.rustup` for every later job on a self-hosted runner.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30861576104](https://github.com/sgl-project/sglang/actions/runs/30861576104)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30861575952](https://github.com/sgl-project/sglang/actions/runs/30861575952)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->