### PR TITLE
route multimodal_gen collectives through nccl2

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
@@ -24,6 +24,12 @@ from sglang.multimodal_gen.runtime.distributed.device_communicators.base_device_
 from sglang.multimodal_gen.runtime.distributed.device_communicators.cpu_communicator import (
     CpuCommunicator,
 )
+from sglang.multimodal_gen.runtime.distributed.utils import (
+    NCCL2_CPU_BACKEND,
+    NCCL2_DEVICE_BACKEND,
+    NCCL2_P2P_BACKEND,
+    is_nccl2_world,
+)
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     init_logger,
@@ -168,20 +174,52 @@ class GroupCoordinator:
         self.device_group = None
         self.cpu_group = None
 
-        for ranks in group_ranks:
-            device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
+        # Over an nccl2 world an eager new_group() with asymmetric membership is
+        # fatal: the *non-member* ranks take the no-color-split path in
+        # _new_process_group_helper and call perform_nocolor_split(), which
+        # ProcessGroupNCCL2 does not implement. The hazard is EAGER-vs-
+        # members-only, not the requested backend -- _get_split_source inspects
+        # the parent's CUDA backend, so backend="gloo" does not save you either.
+        # So on the nccl2 path both subgroups are carved off the world PG with
+        # split_group, a single collective over the parent that hands every rank
+        # the split it belongs to (or NON_GROUP_MEMBER).
+        if is_nccl2_world():
+            # group_ranks is a partition (RankGenerator output), so one
+            # split_group call replaces the whole loop. It must NOT be called
+            # per-iteration: each call creates a distinct communicator.
+            device_group = torch.distributed.split_group(
+                split_ranks=group_ranks, backend=NCCL2_DEVICE_BACKEND
             )
-            # a group with `gloo` backend, to allow direct coordination between
-            # processes through the CPU.
+            # A group carrying a `gloo` CPU backend, to allow direct
+            # coordination between processes through the CPU. The split
+            # necessarily keeps the parent's cuda:nccl2 backend alongside
+            # cpu:gloo (see NCCL2_CPU_BACKEND).
             with suppress_stdout():
-                cpu_group = torch.distributed.new_group(ranks, backend="gloo")
-            if self.rank in ranks:
-                self.ranks = ranks
-                self.world_size = len(ranks)
-                self.rank_in_group = ranks.index(self.rank)
-                self.device_group = device_group
-                self.cpu_group = cpu_group
+                cpu_group = torch.distributed.split_group(
+                    split_ranks=group_ranks, backend=NCCL2_CPU_BACKEND
+                )
+            for ranks in group_ranks:
+                if self.rank in ranks:
+                    self.ranks = ranks
+                    self.world_size = len(ranks)
+                    self.rank_in_group = ranks.index(self.rank)
+                    self.device_group = device_group
+                    self.cpu_group = cpu_group
+        else:
+            for ranks in group_ranks:
+                device_group = torch.distributed.new_group(
+                    ranks, backend=torch_distributed_backend
+                )
+                # a group with `gloo` backend, to allow direct coordination between
+                # processes through the CPU.
+                with suppress_stdout():
+                    cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+                if self.rank in ranks:
+                    self.ranks = ranks
+                    self.world_size = len(ranks)
+                    self.rank_in_group = ranks.index(self.rank)
+                    self.device_group = device_group
+                    self.cpu_group = cpu_group
 
         assert self.cpu_group is not None, f"{group_ranks=}, {local_rank=}"
         assert self.device_group is not None
@@ -792,17 +830,20 @@ class GroupCoordinator:
         return tensor
 
     def destroy(self) -> None:
+        # Tear the communicators down before the process groups they were
+        # built from: they resolve ranks and buffers against those groups, so
+        # closing them afterwards works on a group that no longer exists.
+        if self.srt_custom_allreduce is not None:
+            self.srt_custom_allreduce.close()
+            self.srt_custom_allreduce = None
+        if self.device_communicator is not None:
+            self.device_communicator.destroy()
         if self.device_group is not None:
             torch.distributed.destroy_process_group(self.device_group)
             self.device_group = None
         if self.cpu_group is not None:
             torch.distributed.destroy_process_group(self.cpu_group)
             self.cpu_group = None
-        if self.device_communicator is not None:
-            self.device_communicator.destroy()
-        if self.srt_custom_allreduce is not None:
-            self.srt_custom_allreduce.close()
-            self.srt_custom_allreduce = None
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
@@ -845,15 +886,51 @@ class PipelineGroupCoordinator(GroupCoordinator):
         self.cpu_group = None
         self.cpu_groups = []
         self.device_groups = []
+        # The pipeline device groups are used exclusively for per-peer P2P
+        # (isend/irecv/batch_isend_irecv), so on the nccl2 path they use the
+        # "nccl-lazy" backend built members-only with
+        # use_local_synchronization=True: lazy per-peer communicators let
+        # send/recv to different stages overlap, and the members-only form
+        # short-circuits non-members before they would reach the eager
+        # no-color-split path that ProcessGroupNCCL2 does not implement.
+        #
+        # The CPU groups stay collective splits off the world PG. Note the
+        # ordering constraint that makes this safe: new_group(
+        # use_local_synchronization=True) returns before _process_group_name(),
+        # so it does NOT advance _world.group_count on non-members, while
+        # split_group advances it on every rank. Because the pipeline
+        # group_ranks partition the ranks, every rank is a member of exactly one
+        # group per loop, so counts re-converge at the end of each loop; the
+        # split_group calls therefore must be hoisted out of the loop (they are
+        # single collectives anyway) rather than interleaved with it.
+        use_nccl2 = is_nccl2_world()
+        p2p_device_id = (
+            torch.device(f"cuda:{local_rank}")
+            if use_nccl2 and current_platform.is_cuda_alike()
+            else None
+        )
         if len(group_ranks[0]) > 2 or len(group_ranks[0]) == 1:
-            for ranks in group_ranks:
-                device_group = torch.distributed.new_group(
-                    ranks, backend=torch_distributed_backend
-                )
-                # a group with `gloo` backend, to allow direct coordination between
-                # processes through the CPU.
+            if use_nccl2:
                 with suppress_stdout():
-                    cpu_group = torch.distributed.new_group(ranks, backend="gloo")
+                    cpu_group = torch.distributed.split_group(
+                        split_ranks=group_ranks, backend=NCCL2_CPU_BACKEND
+                    )
+            for ranks in group_ranks:
+                if use_nccl2:
+                    device_group = torch.distributed.new_group(
+                        ranks,
+                        backend=NCCL2_P2P_BACKEND,
+                        use_local_synchronization=True,
+                        device_id=p2p_device_id,
+                    )
+                else:
+                    device_group = torch.distributed.new_group(
+                        ranks, backend=torch_distributed_backend
+                    )
+                    # a group with `gloo` backend, to allow direct coordination between
+                    # processes through the CPU.
+                    with suppress_stdout():
+                        cpu_group = torch.distributed.new_group(ranks, backend="gloo")
                 if self.rank in ranks:
                     self.ranks = ranks
                     self.world_size = len(ranks)
@@ -867,18 +944,53 @@ class PipelineGroupCoordinator(GroupCoordinator):
         # *_group_1_0 represents the group for communication from device 1 to
         #   device 0.
         elif len(group_ranks[0]) == 2:
-            for ranks in group_ranks:
-                device_group_0_1 = torch.distributed.new_group(
-                    ranks, backend=torch_distributed_backend
-                )
-                device_group_1_0 = torch.distributed.new_group(
-                    ranks, backend=torch_distributed_backend
-                )
-                # a group with `gloo` backend, to allow direct coordination between
-                # processes through the CPU.
+            if use_nccl2:
+                # The two groups have IDENTICAL membership; they exist purely so
+                # each direction gets its own communicator. split_group's
+                # split_ranks must partition, but two *separate* split_group
+                # calls over the same partition are fine: each is its own
+                # collective and _process_group_name() salts the hashed group
+                # name with the (collective-consistent) _world.group_count, so
+                # the second call yields a distinct communicator.
                 with suppress_stdout():
-                    cpu_group_0_1 = torch.distributed.new_group(ranks, backend="gloo")
-                    cpu_group_1_0 = torch.distributed.new_group(ranks, backend="gloo")
+                    cpu_group_0_1 = torch.distributed.split_group(
+                        split_ranks=group_ranks, backend=NCCL2_CPU_BACKEND
+                    )
+                    cpu_group_1_0 = torch.distributed.split_group(
+                        split_ranks=group_ranks, backend=NCCL2_CPU_BACKEND
+                    )
+            for ranks in group_ranks:
+                if use_nccl2:
+                    # Two members-only nccl-lazy comms over the same 2 ranks,
+                    # one per direction.
+                    device_group_0_1 = torch.distributed.new_group(
+                        ranks,
+                        backend=NCCL2_P2P_BACKEND,
+                        use_local_synchronization=True,
+                        device_id=p2p_device_id,
+                    )
+                    device_group_1_0 = torch.distributed.new_group(
+                        ranks,
+                        backend=NCCL2_P2P_BACKEND,
+                        use_local_synchronization=True,
+                        device_id=p2p_device_id,
+                    )
+                else:
+                    device_group_0_1 = torch.distributed.new_group(
+                        ranks, backend=torch_distributed_backend
+                    )
+                    device_group_1_0 = torch.distributed.new_group(
+                        ranks, backend=torch_distributed_backend
+                    )
+                    # a group with `gloo` backend, to allow direct coordination between
+                    # processes through the CPU.
+                    with suppress_stdout():
+                        cpu_group_0_1 = torch.distributed.new_group(
+                            ranks, backend="gloo"
+                        )
+                        cpu_group_1_0 = torch.distributed.new_group(
+                            ranks, backend="gloo"
+                        )
                 if self.rank in ranks:
                     self.ranks = ranks
                     self.world_size = len(ranks)
@@ -911,12 +1023,49 @@ class PipelineGroupCoordinator(GroupCoordinator):
         ] = None
         self.skip_device_group = None
         for ranks in group_ranks:
-            skip_device_group = torch.distributed.new_group(
-                ranks, backend=torch_distributed_backend
-            )
+            if use_nccl2:
+                # Also pure P2P (_pipeline_isend_skip / _pipeline_irecv_skip),
+                # so members-only nccl-lazy like the other pipeline device
+                # groups.
+                skip_device_group = torch.distributed.new_group(
+                    ranks,
+                    backend=NCCL2_P2P_BACKEND,
+                    use_local_synchronization=True,
+                    device_id=p2p_device_id,
+                )
+            else:
+                skip_device_group = torch.distributed.new_group(
+                    ranks, backend=torch_distributed_backend
+                )
             if self.rank in ranks:
                 self.skip_device_group = skip_device_group
         assert self.skip_device_group is not None
+
+        if len(self.device_groups) == 2:
+            self._init_dual_direction_comms()
+
+    def _init_dual_direction_comms(self) -> None:
+        """Open both per-direction communicators in a rank-independent order.
+
+        The pipeline-parallel-degree-2 path keeps one group per direction
+        (`device_groups[0]` carries 0->1, `device_groups[1]` carries 1->0) so
+        the two directions do not serialize.  The communicator behind a group
+        is only built on its first send/recv, and the routing is
+        rank-dependent: rank 0 sends on `device_groups[0]` and receives on
+        `device_groups[1]`, rank 1 does the reverse.  A simultaneous
+        bidirectional exchange therefore has rank 0 open group 0 first and
+        rank 1 open group 1 first, and each blocks in the other's
+        communicator rendezvous -- a deadlock, since that rendezvous requires
+        both members.  Open them here instead, walking the groups in index
+        order, which is the same order on every rank.
+        """
+        token = torch.zeros(1, dtype=torch.uint8, device=self.device)
+        for direction, group in enumerate(self.device_groups):
+            # device_groups[i] is the group rank_in_group == i sends on.
+            if self.rank_in_group == direction:
+                torch.distributed.isend(token, dst=self.next_rank, group=group).wait()
+            else:
+                torch.distributed.irecv(token, src=self.prev_rank, group=group).wait()
 
     def reset_buffer(self):
         self.recv_tasks_queue = []

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_groups.py
@@ -3,6 +3,11 @@
 
 import torch
 
+from sglang.multimodal_gen.runtime.distributed.utils import (
+    NCCL2_DEVICE_BACKEND,
+    is_nccl2_world,
+)
+
 
 class Singleton:
     _instance = None
@@ -56,36 +61,72 @@ def set_seq_parallel_pg_by_sp_groups(
     def _map_indices_to_ranks(ranks: list[int], indices: list[int]) -> list[int]:
         return [ranks[i] for i in indices]
 
-    # Important: call torch.distributed.new_group in the same order on all ranks.
+    # Collect the rank lists first. Both families are partitions: the ulysses
+    # groups partition each SP group, and so do the ring groups (with a strided
+    # index pattern), and the SP groups are themselves disjoint.
+    ulysses_rank_groups: list[list[int]] = []
+    ring_rank_groups: list[list[int]] = []
     for sp_ranks in sp_groups:
         if use_ulysses_low:
             for i in range(num_ulysses_pgs):
                 idx = list(range(i * sp_ulysses_degree, (i + 1) * sp_ulysses_degree))
-                ulysses_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ulysses_ranks)
-                if rank in ulysses_ranks:
-                    ulyssess_pg = group
-
+                ulysses_rank_groups.append(_map_indices_to_ranks(sp_ranks, idx))
             for i in range(num_ring_pgs):
                 idx = list(range(i, sp_degree, num_ring_pgs))
-                ring_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ring_ranks)
-                if rank in ring_ranks:
-                    ring_pg = group
+                ring_rank_groups.append(_map_indices_to_ranks(sp_ranks, idx))
         else:
             for i in range(num_ring_pgs):
                 idx = list(range(i * sp_ring_degree, (i + 1) * sp_ring_degree))
-                ring_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ring_ranks)
-                if rank in ring_ranks:
-                    ring_pg = group
-
+                ring_rank_groups.append(_map_indices_to_ranks(sp_ranks, idx))
             for i in range(num_ulysses_pgs):
                 idx = list(range(i, sp_degree, num_ulysses_pgs))
-                ulysses_ranks = _map_indices_to_ranks(sp_ranks, idx)
-                group = torch.distributed.new_group(ulysses_ranks)
-                if rank in ulysses_ranks:
-                    ulyssess_pg = group
+                ulysses_rank_groups.append(_map_indices_to_ranks(sp_ranks, idx))
+
+    if is_nccl2_world():
+        # These groups have asymmetric membership, so an eager new_group() over
+        # an nccl2 world would blow up on the non-member ranks with
+        # "'ProcessGroupNCCL2' object has no attribute
+        # 'perform_nocolor_split'". Carve them off the world PG instead: one
+        # collective split per family (NOT one per group -- split_group already
+        # handles the whole partition in a single call).
+        #
+        # split_group preserves the order of ranks within each split, so the
+        # strided ring ordering is kept. Note this differs from new_group, which
+        # sorts by default (sort_ranks=True); for the index patterns used here
+        # both orderings coincide because sp_groups are ascending.
+        def _split(rank_groups: list[list[int]]):
+            if not rank_groups:
+                return None
+            pg = torch.distributed.split_group(
+                split_ranks=rank_groups, backend=NCCL2_DEVICE_BACKEND
+            )
+            # Match the legacy behaviour: ranks outside every group get None.
+            if pg is torch.distributed.GroupMember.NON_GROUP_MEMBER:
+                return None
+            return pg
+
+        if use_ulysses_low:
+            ulyssess_pg = _split(ulysses_rank_groups)
+            ring_pg = _split(ring_rank_groups)
+        else:
+            ring_pg = _split(ring_rank_groups)
+            ulyssess_pg = _split(ulysses_rank_groups)
+    else:
+        # Important: call torch.distributed.new_group in the same order on all ranks.
+        def _new_groups(rank_groups: list[list[int]]):
+            my_pg = None
+            for group_ranks in rank_groups:
+                group = torch.distributed.new_group(group_ranks)
+                if rank in group_ranks:
+                    my_pg = group
+            return my_pg
+
+        if use_ulysses_low:
+            ulyssess_pg = _new_groups(ulysses_rank_groups)
+            ring_pg = _new_groups(ring_rank_groups)
+        else:
+            ring_pg = _new_groups(ring_rank_groups)
+            ulyssess_pg = _new_groups(ulysses_rank_groups)
 
     PROCESS_GROUP.ULYSSES_PG = ulyssess_pg
     PROCESS_GROUP.RING_PG = ring_pg

--- a/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/parallel_state.py
@@ -47,7 +47,12 @@ import torch.distributed
 from torch.distributed import ProcessGroup
 
 import sglang.multimodal_gen.envs as envs
-from sglang.multimodal_gen.runtime.distributed.utils import StatelessProcessGroup
+from sglang.multimodal_gen.runtime.distributed.utils import (
+    NCCL2_DEVICE_BACKEND,
+    StatelessProcessGroup,
+    is_nccl2_world,
+    route_world_backend,
+)
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 from ..utils.distributed import RankGenerator
@@ -140,6 +145,19 @@ def init_world_group(
 
 
 def _sync_srt_world_group() -> None:
+    """Publish our world GroupCoordinator into srt's global state.
+
+    Note on nccl2: srt derives ``is_nccl2_world()`` from the *live* default PG
+    (``torch.distributed.group.WORLD``), not from ``srt_parallel_state._WORLD``
+    and not from a requested backend string. So once we route our world onto
+    ``cpu:gloo,cuda:nccl2`` above, srt's predicate flips to True for
+    diffusion-initiated processes and any srt subgroup created afterwards takes
+    the split_group path -- which is exactly right, because that world *is*
+    splittable (device-qualified and device-bound). Nothing here
+    double-initializes: srt's ``init_distributed_environment`` short-circuits on
+    ``torch.distributed.is_initialized()``, and srt's GroupCoordinator is never
+    constructed from this assignment.
+    """
     import sglang.srt.distributed.parallel_state as srt_parallel_state
 
     if srt_parallel_state._WORLD is None:
@@ -258,8 +276,27 @@ def init_distributed_environment(
             extra_args["timeout"] = datetime.timedelta(seconds=timeout)
             logger.info(f"Setting distributed timeout to {timeout} seconds")
 
+        # Route the world backend onto the in-tree nccl2 backend, device
+        # qualified as "cpu:gloo,cuda:nccl2" (see route_world_backend /
+        # NCCL2_WORLD_BACKEND for why the qualification is mandatory and why the
+        # cpu:gloo leg is needed for the CPU subgroups).
+        world_backend = route_world_backend(backend)
+
+        # Bind the world PG to its CUDA device: split_group requires an eagerly
+        # initialized/device-bound parent communicator. Callers normally pass
+        # device_id already (see maybe_init_distributed_environment_and_model_parallel);
+        # fill it in defensively so a direct caller cannot end up with an
+        # unbound -- and therefore unsplittable -- world.
+        if (
+            world_backend != backend
+            and "device_id" in extra_args
+            and extra_args["device_id"] is None
+        ):
+            bind_local_rank = local_rank if local_rank >= 0 else envs.LOCAL_RANK
+            extra_args["device_id"] = torch.device(f"cuda:{bind_local_rank}")
+
         torch.distributed.init_process_group(
-            backend=backend,
+            backend=world_backend,
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
@@ -866,9 +903,18 @@ def init_dit_group(
 ) -> None:
     global _DIT
     assert _DIT is None, "DIT group is already initialized"
-    _DIT = torch.distributed.new_group(
-        ranks=list(range(dit_parallel_size)), backend=backend
-    )
+    dit_ranks = list(range(dit_parallel_size))
+    if is_nccl2_world():
+        # Asymmetric membership whenever dit_parallel_size < world_size (i.e.
+        # any VAE-parallel deployment), which an eager new_group() cannot
+        # express over an nccl2 parent. split_group is collective over the
+        # world; ranks outside dit_ranks get NON_GROUP_MEMBER, matching what
+        # new_group returned for them before.
+        _DIT = torch.distributed.split_group(
+            split_ranks=[dit_ranks], backend=NCCL2_DEVICE_BACKEND
+        )
+    else:
+        _DIT = torch.distributed.new_group(ranks=dit_ranks, backend=backend)
 
 
 def get_dit_group() -> ProcessGroup:
@@ -885,7 +931,14 @@ def init_vae_group(
     global _VAE
     assert _VAE is None, "VAE parallel group is already initialized"
     vae_ranks = list(range(dit_parallel_size, dit_parallel_size + vae_parallel_size))
-    _VAE = torch.distributed.new_group(ranks=vae_ranks, backend=backend)
+    if is_nccl2_world():
+        # Always asymmetric (the DiT ranks are never members), so this is one of
+        # the sites that fails immediately on an eager new_group over nccl2.
+        _VAE = torch.distributed.split_group(
+            split_ranks=[vae_ranks], backend=NCCL2_DEVICE_BACKEND
+        )
+    else:
+        _VAE = torch.distributed.new_group(ranks=vae_ranks, backend=backend)
 
 
 def destroy_model_parallel() -> None:

--- a/python/sglang/multimodal_gen/runtime/distributed/utils.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/utils.py
@@ -23,6 +23,72 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Backend routing for the in-tree "nccl2" c10d backend.
+#
+# sglang-diffusion owns its own world process group (see
+# ``parallel_state.init_distributed_environment``) and pushes it into srt's
+# globals, so the routing below decides the backend for *both* frameworks in a
+# diffusion-initiated process.
+# ---------------------------------------------------------------------------
+
+# The world PG must be device-qualified: "nccl2" is a CUSTOM backend rather than
+# a device default, so a bare "nccl2" recorded in the parent PG's pg_map cannot
+# be parsed by split_group (_parse_backend_string only resolves bare names via
+# default_device_backend_map). The world also carries "cpu:gloo" so CPU
+# subgroups can be split out of it.
+NCCL2_WORLD_BACKEND = "cpu:gloo,cuda:nccl2"
+
+# Filter for a device (CUDA collective) subgroup split off the world PG.
+NCCL2_DEVICE_BACKEND = "cuda:nccl2"
+
+# Filter for a CPU-coordination subgroup split off the world PG. It has to keep
+# "cuda:nccl2" as well: ProcessGroup::splitGroup requires the deviceTypes filter
+# to include the parent's default backend device type (cuda here), so a pure
+# "cpu:gloo" split is rejected outright. The resulting group is compound, which
+# is fine for CPU collectives/P2P and for dist.monitored_barrier (it checks for
+# a CPU-capable backend via group._device_types, not for the literal "gloo"
+# name).
+NCCL2_CPU_BACKEND = "cpu:gloo,cuda:nccl2"
+
+# Backend for genuinely per-peer P2P groups (pipeline parallel). "nccl-lazy"
+# defers communicator creation until first use so send/recv to different stages
+# can overlap. These groups are built members-only (see below).
+NCCL2_P2P_BACKEND = "nccl-lazy"
+
+
+def route_world_backend(backend: str | None) -> str | None:
+    """Route a requested world backend onto the in-tree nccl2 backend.
+
+    Mirrors ``sglang.srt.distributed.parallel_state.init_distributed_environment``:
+    ``nccl`` yields nccl2, there is no stock-nccl escape hatch. Non-CUDA
+    backends (gloo/hccl/...) are passed through untouched.
+    """
+    if backend in ("nccl", "cuda:nccl"):
+        return NCCL2_WORLD_BACKEND
+    return backend
+
+
+def is_nccl2_world() -> bool:
+    """Whether the default (world) PG is the device-bound nccl2 group.
+
+    Derived from the *live* world PG rather than from the requested backend
+    string: the world may have been initialized by someone else (srt, a test
+    harness, or an embedding trainer) with stock nccl or gloo, and splitting a
+    stock-nccl parent with ``backend="cuda:nccl2"`` fails with a backend
+    mismatch. Those worlds must keep the upstream ``new_group`` path.
+    """
+    if not torch.distributed.is_initialized():
+        return False
+    world_pg = torch.distributed.group.WORLD
+    if world_pg is None:
+        return False
+    # split_group requires an eagerly device-bound parent communicator.
+    if getattr(world_pg, "bound_device_id", None) is None:
+        return False
+    return "nccl2" in torch.distributed.get_backend(world_pg)
+
+
 def ensure_divisibility(numerator, denominator) -> None:
     """Ensure that numerator is divisible by the denominator."""
     assert numerator % denominator == 0, "{} is not divisible by {}".format(

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -172,9 +172,12 @@ class CustomAllreduce:
 
     @staticmethod
     def free_shared_buffer(
-        pointers: List[int], group: Optional[ProcessGroup] = None
+        pointers: List[int],
+        group: Optional[ProcessGroup] = None,
+        rank: Optional[int] = None,
     ) -> None:
-        rank = dist.get_rank(group=group)
+        if rank is None:
+            rank = dist.get_rank(group=group)
         lib = CudaRTLibrary()
         lib.cudaFree(ctypes.c_void_p(pointers[rank]))
 
@@ -333,8 +336,13 @@ class CustomAllreduce:
             if ops is not None:
                 ops.dispose(self._ptr)
             if _is_cuda:
-                self.free_shared_buffer(self.meta_ptrs)
-                self.free_shared_buffer(self.buffer_ptrs)
+                # Pass the cached group rank explicitly: `pointers` is indexed
+                # by rank *within self.group*, and close() may run after the
+                # group has been destroyed, in which case resolving the rank
+                # from the group is either wrong (get_rank(None) returns the
+                # global rank) or an error.
+                self.free_shared_buffer(self.meta_ptrs, rank=self.rank)
+                self.free_shared_buffer(self.buffer_ptrs, rank=self.rank)
             self._ptr = 0
 
     def __del__(self):

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce_v2.py
@@ -155,10 +155,22 @@ class CustomAllReduceV2:
         return self._all_reduce(input)
 
     def close(self):
-        if not self.disabled and hasattr(self, "obj"):
-            self.obj.free(self.group)
-        if hasattr(self, "_vmm_graph_input_manager"):
-            self._vmm_graph_input_manager.close()
+        # `obj.free()` closes the peers' IPC handles, barriers on `self.group`
+        # so that no peer is still mapping the storage, and only then frees it.
+        # That barrier makes close() order-sensitive: it has to run while the
+        # group is still alive (the owner calls it before destroying the group)
+        # and it has to run exactly once. So drop `obj` up front -- otherwise a
+        # later `__del__` re-enters free() on a group that is gone by then, the
+        # barrier raises inside a destructor where the exception is swallowed,
+        # and the storage is never freed (there is no C++ destructor).
+        obj = getattr(self, "obj", None)
+        self.obj = None
+        manager = getattr(self, "_vmm_graph_input_manager", None)
+        self._vmm_graph_input_manager = None
+        if not self.disabled and obj is not None:
+            obj.free(self.group)
+        if manager is not None:
+            manager.close()
 
     def _all_reduce(self, input: torch.Tensor) -> torch.Tensor:
         """Perform the actual all-reduce via JIT kernel."""

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -79,6 +79,45 @@ REDUCE_OP_SUM = int(torch.distributed.ReduceOp.SUM)
 # creation so runtime collectives do not silently fall back to backend defaults.
 _MODEL_PARALLEL_GROUP_TIMEOUT: Optional[timedelta] = None
 
+# Backend strings for the in-tree "nccl2" backend.
+#
+# The world PG must be device-qualified: "nccl2" is a CUSTOM backend rather than
+# a device default, so a bare "nccl2" recorded in the parent PG's pg_map cannot
+# be parsed by split_group (_parse_backend_string only resolves bare names via
+# default_device_backend_map). The world also carries "cpu:gloo" so CPU
+# subgroups can be split out of it.
+NCCL2_WORLD_BACKEND = "cpu:gloo,cuda:nccl2"
+# Filter for a device (CUDA collective) subgroup split off the world PG.
+NCCL2_DEVICE_BACKEND = "cuda:nccl2"
+# Filter for a CPU-coordination subgroup split off the world PG. It has to keep
+# "cuda:nccl2" as well: ProcessGroup::splitGroup requires the deviceTypes filter
+# to include the parent's default backend device type (cuda here), so a pure
+# "cpu:gloo" split is rejected outright. The resulting group is compound, which
+# is fine for CPU collectives and for dist.monitored_barrier (it checks for a
+# CPU-capable backend via group._device_types, not for the literal "gloo" name).
+NCCL2_CPU_BACKEND = "cpu:gloo,cuda:nccl2"
+
+
+def is_nccl2_world() -> bool:
+    """Whether the default (world) PG is the device-bound nccl2 group.
+
+    Derived from the live world PG rather than from the requested backend
+    string, because the world may have been initialized by someone other than
+    ``init_distributed_environment`` (an embedding trainer, or
+    ``multimodal_gen``, which does not route ``nccl`` -> ``nccl2``). Splitting a
+    stock-``nccl`` parent with ``backend="cuda:nccl2"`` would fail with a
+    backend mismatch, so those worlds must keep the upstream ``new_group`` path.
+    """
+    if not torch.distributed.is_initialized():
+        return False
+    world_pg = torch.distributed.group.WORLD
+    if world_pg is None:
+        return False
+    # split_group requires an eagerly device-bound parent communicator.
+    if getattr(world_pg, "bound_device_id", None) is None:
+        return False
+    return "nccl2" in torch.distributed.get_backend(world_pg)
+
 
 def get_torch_distributed_pg_options(group_name=None):
     if not _is_npu:
@@ -297,11 +336,32 @@ class GroupCoordinator:
             self.device = torch.device("cpu")
         self.device_module = torch.get_device_module(self.device)
 
+        # The world PG uses the in-tree "nccl2" backend and is created eagerly
+        # device-bound (see init_distributed_environment). Subgroups are carved
+        # from it with split_group, which requires the parent communicator to be
+        # initialized/bound up front. The device subgroup keeps only the parent's
+        # "cuda:nccl2" backend; the cpu subgroup additionally keeps "cpu:gloo"
+        # for direct CPU-side coordination.
+        #
+        # The pipeline-parallel group (group_name "pp") is the sole exception:
+        # its device subgroup uses the "nccl-lazy" backend for per-peer lazy P2P
+        # comms (send/recv overlap). nccl2 does not implement the eager new_group
+        # no-color-split path, so that nccl-lazy device group is built
+        # members-only via new_group with use_local_synchronization=True, which
+        # short-circuits non-members before they would reach that missing path.
+        # Its cpu group is split from the world PG like every other cpu group.
+        #
+        # Non-nccl2 paths (a plain gloo, mooncake, or NPU/XPU run, or a world PG
+        # that someone else initialized with stock nccl) fall back to the
+        # upstream new_group path.
+        is_mooncake = "mooncake" in torch_distributed_backend
+        use_nccl2 = is_nccl2_world()
+        is_pipeline = group_name == "pp"
         for ranks in group_ranks:
             active_ranks = torch.ones(len(ranks), dtype=torch.int32, device=self.device)
             active_ranks_cpu = torch.ones(len(ranks), dtype=torch.int32)
             subgroup_timeout = _MODEL_PARALLEL_GROUP_TIMEOUT
-            if "mooncake" in torch_distributed_backend:
+            if is_mooncake:
                 from mooncake.ep import MooncakeBackendOptions
 
                 device_group = torch.distributed.new_group(
@@ -315,6 +375,49 @@ class GroupCoordinator:
                     backend="mooncake-cpu",
                     pg_options=MooncakeBackendOptions(active_ranks_cpu, recovered_rank),
                     timeout=subgroup_timeout,
+                )
+            elif use_nccl2:
+                if is_pipeline:
+                    # Members-only nccl-lazy subgroup for per-peer P2P; bound to
+                    # this rank's real CUDA device so non-contiguous PP recv
+                    # lands on the right device.
+                    device_group = torch.distributed.new_group(
+                        ranks,
+                        backend="nccl-lazy",
+                        pg_options=get_torch_distributed_pg_options(group_name),
+                        use_local_synchronization=True,
+                        timeout=subgroup_timeout,
+                        device_id=torch.device(f"cuda:{local_rank}"),
+                    )
+                else:
+                    # split_group is collective over the parent (world) PG, so
+                    # every world rank enters this call with the same split;
+                    # ranks outside `ranks` get a non-group member handle that
+                    # is never used below.
+                    device_group = torch.distributed.split_group(
+                        split_ranks=[ranks],
+                        backend=NCCL2_DEVICE_BACKEND,
+                        pg_options=get_torch_distributed_pg_options(group_name),
+                        timeout=subgroup_timeout,
+                    )
+                # A group carrying a `gloo` CPU backend, to allow direct
+                # coordination between processes through the CPU. Also split
+                # from the world PG, and likewise collective over it.
+                #
+                # The split necessarily keeps the parent's cuda:nccl2 backend
+                # alongside cpu:gloo -- ProcessGroup::splitGroup requires the
+                # deviceTypes filter to contain the parent's default backend
+                # device type, so a pure cpu:gloo split is rejected. That is
+                # fine for CPU collectives, and dist.monitored_barrier (used on
+                # the TP cpu group during model load) accepts it: it checks for
+                # a CPU-capable backend via group._device_types rather than
+                # matching the literal "gloo" backend name. Note this does mean
+                # get_backend() on the cpu group returns the full
+                # "cpu:gloo,cuda:nccl2" config string.
+                cpu_group = torch.distributed.split_group(
+                    split_ranks=[ranks],
+                    backend=NCCL2_CPU_BACKEND,
+                    timeout=gloo_timeout,
                 )
             else:
                 pg_options = get_torch_distributed_pg_options(group_name)
@@ -1479,18 +1582,25 @@ class GroupCoordinator:
         return tensor
 
     def destroy(self):
+        # Close the communicators before the process groups they were built
+        # from, and close them explicitly rather than dropping the reference:
+        # CustomAllReduceV2.close() barriers on cpu_group between closing the
+        # peers' IPC handles and freeing its device storage, so running it from
+        # __del__ after cpu_group is gone raises inside a destructor, where the
+        # exception is swallowed and the storage is leaked.
+        if self.ca_comm is not None:
+            self.ca_comm.close()
+            self.ca_comm = None
+        if self.pymscclpp_comm is not None:
+            self.pymscclpp_comm.destroy()
+        if self.pynccl_comm is not None:
+            self.pynccl_comm = None
         if self.device_group is not None:
             torch.distributed.destroy_process_group(self.device_group)
             self.device_group = None
         if self.cpu_group is not None:
             torch.distributed.destroy_process_group(self.cpu_group)
             self.cpu_group = None
-        if self.pynccl_comm is not None:
-            self.pynccl_comm = None
-        if self.pymscclpp_comm is not None:
-            self.pymscclpp_comm.destroy()
-        if self.ca_comm is not None:
-            self.ca_comm = None
         if self.mq_broadcaster is not None:
             self.mq_broadcaster = None
 
@@ -1792,6 +1902,17 @@ def init_distributed_environment(
             ) from e
         mooncake_ep.set_host_ip(get_local_ip_auto())
 
+    # Resolve local_rank up front: it is not available on a torch ProcessGroup
+    # (see https://github.com/pytorch/pytorch/issues/122816) and is needed both
+    # for the world device binding below and for init_world_group.
+    if local_rank == -1:
+        # local rank not set, this usually happens in single-node setting,
+        # where we can use rank as local rank
+        if distributed_init_method == "env://":
+            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+        else:
+            local_rank = rank
+
     if not torch.distributed.is_initialized():
         global _MODEL_PARALLEL_GROUP_TIMEOUT
         assert distributed_init_method is not None, (
@@ -1814,30 +1935,37 @@ def init_distributed_environment(
         else:
             pg_options = get_torch_distributed_pg_options()
 
+        # Bind the world PG to its CUDA device so subgroups can be carved from it
+        # with split_group, which requires an eagerly initialized/bound parent
+        # communicator. Split subgroups reuse the c10d store, so no extra
+        # MASTER_PORT or per-backend env seeding is needed.
+        device_id = (
+            torch.device(f"cuda:{local_rank}")
+            if is_cuda_alike() and backend != "gloo"
+            else None
+        )
+
+        # Route the world backend to the in-tree nccl2 backend, device-qualified
+        # (see NCCL2_WORLD_BACKEND for why the qualification is mandatory).
+        world_backend = backend
+        if world_backend in ("nccl", "cuda:nccl"):
+            world_backend = NCCL2_WORLD_BACKEND
+
         # this backend is used for WORLD
         torch.distributed.init_process_group(
-            backend=backend,
+            backend=world_backend,
             init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
             timeout=timeout,
             pg_options=pg_options,
+            device_id=device_id,
         )
 
         # Create a global TCPStore for coordination (used by NIXL)
         if moe_a2a_backend == "nixl":
             _create_global_tcp_store(rank, world_size)
 
-    # set the local rank
-    # local_rank is not available in torch ProcessGroup,
-    # see https://github.com/pytorch/pytorch/issues/122816
-    if local_rank == -1:
-        # local rank not set, this usually happens in single-node
-        # setting, where we can use rank as local rank
-        if distributed_init_method == "env://":
-            local_rank = int(os.environ.get("LOCAL_RANK", "0"))
-        else:
-            local_rank = rank
     global _WORLD
     if _WORLD is None:
         ranks = list(range(torch.distributed.get_world_size()))
@@ -2139,15 +2267,25 @@ def initialize_model_parallel(
 
 
 def create_custom_parallel_group(
-    group_ranks: List[int], backend: str = "gloo"
+    group_ranks: List[int],
+    backend: str = "gloo",
+    timeout: Optional[timedelta] = None,
 ) -> Optional[torch.distributed.ProcessGroup]:
     """
     Create a custom parallel group based on the provided ranks.
 
+    This is collective over the whole world: every rank must call it, and the
+    per-rank ``group_ranks`` must together form a partition of the world.
+
     Args:
         group_ranks: The list of ranks that the CURRENT process wants to join.
                      (e.g., Rank 0 passes [0...7], Rank 8 passes [8...15])
-        backend: The communication backend (default: "gloo").
+        backend: The communication backend (default: "gloo"). Ignored on the
+                 nccl2 path, where the group is split off the world PG and so
+                 necessarily carries the parent's backends
+                 (``cpu:gloo,cuda:nccl2``).
+        timeout: Process group timeout. ``None`` keeps the backend default
+                 (30 minutes for gloo / for a device-qualified backend string).
 
     Returns:
         The ProcessGroup if the current rank is in group_ranks, else None.
@@ -2173,10 +2311,43 @@ def create_custom_parallel_group(
 
     unique_groups.sort(key=lambda x: x[0])
 
+    if is_nccl2_world():
+        # Over an nccl2 world an eager new_group() is fatal: non-member ranks
+        # take the no-color-split path in _new_process_group_helper and call
+        # perform_nocolor_split(), which ProcessGroupNCCL2 does not implement.
+        # Split the world PG instead -- a single collective that hands every
+        # rank the split it belongs to. All ranks already reach this point
+        # (the all_gather_object above is world-collective) and agree on
+        # `unique_groups`, so the split is consistent.
+        covered: set = set()
+        for g_ranks in unique_groups:
+            if covered & set(g_ranks):
+                raise ValueError(
+                    "create_custom_parallel_group requires disjoint groups on "
+                    f"the nccl2 path, but got overlapping splits: {unique_groups}"
+                )
+            covered |= set(g_ranks)
+        # split_ranks are ranks in the parent PG; the parent is the world PG,
+        # so they are the global ranks gathered above.
+        my_new_group = torch.distributed.split_group(
+            split_ranks=unique_groups,
+            backend=NCCL2_CPU_BACKEND,
+            timeout=timeout,
+        )
+        if my_new_group is torch.distributed.GroupMember.NON_GROUP_MEMBER:
+            my_new_group = None
+        else:
+            logger.debug(
+                f"Rank {rank} successfully created/joined custom group: {local_config}"
+            )
+        return my_new_group
+
     my_new_group = None
 
     for g_ranks in unique_groups:
-        group = torch.distributed.new_group(ranks=g_ranks, backend=backend)
+        group = torch.distributed.new_group(
+            ranks=g_ranks, backend=backend, timeout=timeout
+        )
 
         if set(g_ranks) == set(local_config):
             my_new_group = group


### PR DESCRIPTION

SGLang Diffusion owns its own process-group world and never routed nccl->nccl2,
so it ran entirely on stock NCCL while srt/ moved to nccl2. Route its world to
cpu:gloo,cuda:nccl2 (device-qualified and device-bound, since a bare nccl2 is a
custom backend that split_group cannot parse) and convert the 15 group-creation
sites to the sanctioned forms.

Flipping the world alone would have crashed: an eager new_group with asymmetric
membership over an nccl2 parent raises, on the non-member rank,
AttributeError: 'ProcessGroupNCCL2' object has no attribute
'perform_nocolor_split'. A negative control confirms all three original forms
fail this way, including backend="gloo" -- _get_split_source inspects the
parent's cuda backend, so requesting gloo does not avoid it.

Conversions: device and CPU collective subgroups go through split_group; the
ulysses/ring sequence-parallel families collapse from N eager new_groups into
one split_group each; pure-P2P pipeline groups use members-only nccl-lazy
new_group. CPU groups become compound cpu:gloo,cuda:nccl2 -- the only thing
splitGroup can produce over a cuda-default parent -- which monitored_barrier
accepts since it checks for a CPU-capable backend rather than the literal name.

is_nccl2_world() reads the live world PG rather than a requested backend string,
so a world initialized by someone else keeps the untouched legacy new_group path.

The split_group calls are hoisted out of their loops deliberately.
new_group(use_local_synchronization=True) returns before _process_group_name()
and so does not advance _world.group_count on non-members, while split_group
advances it everywhere; since group_count salts the group-name hash, evaluating
the two forms at interleaved counter values would make ranks compute different
names for the same group and deadlock in gloo's connectFullMesh.

Validated with a standalone driver over 11 parallelism layouts at 2 and 4 ranks,
each run twice (nccl2 and a stock baseline): backend classes, real collectives,
monitored_barrier on every CPU group, batch_isend_irecv on every PP group, and
byte-identical ulysses/ring memberships across arms. End-to-end diffusion is
unvalidated -- no model is available on this host.


Also initializes both pipeline-direction communicators in a fixed index order
at construction, so every rank agrees on the order.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/sgl-project/sglang/pull/33440).
* __->__ #33440
* #33439

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->