### PR TITLE
[HiCache] Decide load-back from a group-agreed capacity snapshot

### DIFF
--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -203,6 +203,8 @@ class UnifiedRadixCache(BasePrefixCache):
         self.pp_size = params.pp_size
         self.work_list: list[torch.distributed.Work] = []
 
+        self._init_group_capacity()
+
         # HiCache D↔H defaults (overridden by init_hicache)
         self.cache_controller: Optional[HybridCacheController] = None
         self.host_pool_group = None  # set by attach_hybrid_pool_to_unified_cache
@@ -297,6 +299,11 @@ class UnifiedRadixCache(BasePrefixCache):
         self.prefetch_loaded_tokens_by_reqid: dict[str, int] = {}
         self.ongoing_prefetch: dict[str, _OngoingPrefetch] = {}
         self.ongoing_backup: dict[int, tuple[NodeId, DecLockRefParams]] = {}
+        # The tree is gone, so the snapshot describes a pool that no longer
+        # exists; wait for the next sync rather than carry it across. This is a
+        # new epoch, so re-arm reporting too: a load-back arriving before the
+        # next sync is a different occurrence than any already reported.
+        self._init_group_capacity()
 
         if self.cache_controller is not None:
             self.cache_controller.reset()
@@ -1021,17 +1028,62 @@ class UnifiedRadixCache(BasePrefixCache):
             self.dec_host_lock_ref(node_id, host_anchor_params)
             return False
 
-        if self.supports_swa():
-            avail = self.token_to_kv_pool_allocator.full_available_size()
-        else:
-            avail = self.token_to_kv_pool_allocator.available_size()
-        if avail < kv_tokens:
-            needed = kv_tokens - avail
-            result = self.evict(EvictParams(num_tokens=needed))
-            if result.num_tokens_evicted < needed:
+        # WHY THIS READS A SNAPSHOT INSTEAD OF THE POOL.
+        # Device pool state drifts between TP ranks under load. Load-back sets
+        # how much of a request's prefix counts as cached, so a rank deciding
+        # from its own pool can disagree with its peers, and the ranks then
+        # enter the per-layer TP all_reduce with differently-sized tensors and
+        # both GPU streams deadlock. check_hicache_events reduces capacity to a
+        # group minimum (over the first pipeline stage's TP ranks) and hands
+        # every rank the same starting numbers.
+        #
+        # The snapshot below is a running budget, so it stays rank-identical
+        # only while ranks walk the same request sequence. PrefillAdder does
+        # guarantee that: a rank that rejects a request also breaks out of the
+        # admission loop, so an unequal number of load-backs implies an already
+        # divergent batch. Keep this path collective-free anyway -- a collective
+        # here would convert that divergence into an immediate scheduler-thread
+        # hang, and it would be wrong outright for any future caller whose
+        # reach is genuinely rank-local.
+        if self._group_avail is None:
+            self._warn_missing_group_capacity()
+            self.dec_lock_ref(node_id, ancestor_lock_params)
+            self.dec_host_lock_ref(node_id, host_anchor_params)
+            return False
+
+        if self._group_avail < kv_tokens:
+            if self._group_avail + self._group_evictable < kv_tokens:
+                if self.metrics_collector is not None:
+                    self.metrics_collector.increment_load_back_group_veto()
                 self.dec_lock_ref(node_id, ancestor_lock_params)
                 self.dec_host_lock_ref(node_id, host_anchor_params)
                 return False
+            # `needed` is a function of kv_tokens and the group snapshot, so it
+            # is identical on every rank. How many tokens evict() actually
+            # frees is not: it is deliberately not consulted, because branching
+            # on a rank-local measurement is what deadlocked TP.
+            needed = kv_tokens - self._group_avail
+            evicted = self.evict(EvictParams(num_tokens=needed)).num_tokens_evicted
+            # Credit only what was asked for. evict() usually over-delivers --
+            # it frees whole nodes -- but crediting the surplus would need
+            # another collective to agree on it, so the budget lands on exactly
+            # zero and a second load-back this step will evict again even when
+            # the pool already has room. Costs cache hits under pressure; the
+            # next refresh recovers it.
+            self._group_avail += needed
+            self._group_evictable -= needed
+            if evicted < needed:
+                self._evict_shortfall_this_step += 1
+                self._evict_shortfall_tokens_this_step += needed - evicted
+                if self.metrics_collector is not None:
+                    self.metrics_collector.increment_load_back_evict_shortfall_num_tokens(
+                        needed - evicted
+                    )
+
+        # Spend the budget before attempting the load, so both outcomes move the
+        # snapshot by the same group-agreed amount. Refunding only on success
+        # would let one rank's allocation failure desync the snapshot itself.
+        self._group_avail -= kv_tokens
 
         # Load H→D
         aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
@@ -1044,6 +1096,21 @@ class UnifiedRadixCache(BasePrefixCache):
 
         self.dec_lock_ref(node_id, ancestor_lock_params)
         if device_indices is None:
+            # The group granted capacity and this rank still could not allocate.
+            # Sole rank-local verdict left in this function: aux (SWA/mamba/
+            # sidecar) pools are outside the group snapshot. Reported once per
+            # scheduler step by _flush_load_back_step_report -- this condition
+            # persists across steps, so logging it per request would flood.
+            self._alloc_failures_this_step += 1
+            self._alloc_failure_context = (
+                node_id,
+                kv_tokens,
+                self._group_avail,
+                self._group_evictable,
+                len(aux_xfers),
+            )
+            if self.metrics_collector is not None:
+                self.metrics_collector.increment_load_back_alloc_failed()
             self.dec_host_lock_ref(node_id, host_anchor_params)
             return False
 
@@ -1794,8 +1861,12 @@ class UnifiedRadixCache(BasePrefixCache):
                 else ()
             )
 
+        # Capacity rides along on this reduce; see _load_back_transfers.
+        local_avail = self._local_available_size()
         ready_counts = torch.tensor(
             [
+                local_avail,
+                self.evictable_size(),
                 write_acks,
                 load_acks,
                 *storage_queue_sizes,
@@ -1806,12 +1877,139 @@ class UnifiedRadixCache(BasePrefixCache):
         self._all_reduce(ready_counts, torch.distributed.ReduceOp.MIN)
 
         count_values = list(map(int, ready_counts.tolist()))
+        self._set_group_capacity(count_values[0], count_values[1], local_avail)
         return (
-            count_values[0],
-            count_values[1],
-            tuple(count_values[2:]),
+            count_values[2],
+            count_values[3],
+            tuple(count_values[4:]),
             extra_pool_names,
         )
+
+    def _init_group_capacity(self) -> None:
+        """Seed the group-agreed device capacity that load-back decides from.
+
+        Refreshed by check_hicache_events; see _load_back_transfers for why
+        load-back may not consult rank-local pool state directly. Both fields
+        move together and stay None until the first refresh, so load-back skips
+        until the group has spoken. Also (re-)arms the per-epoch reporting, so
+        a flush starts a fresh epoch rather than inheriting a latched warning.
+        """
+        self._group_avail: Optional[int] = None
+        self._group_evictable: Optional[int] = None
+        self._warned_missing_group_capacity = False
+        self._alloc_failures_this_step = 0
+        self._alloc_failure_context: Optional[tuple] = None
+        self._evict_shortfall_this_step = 0
+        self._evict_shortfall_tokens_this_step = 0
+
+    def _flush_load_back_step_report(self) -> None:
+        """Emit one line per scheduler step for the per-request failure paths.
+
+        Both conditions are pool states that persist across steps, so logging
+        them per request would put unbounded synchronous stderr writes on the
+        scheduler thread -- and the volume is rank-asymmetric by construction,
+        which is the one shape this subsystem must not add. Aggregating per
+        step keeps the rate (the actual diagnostic content) without the flood.
+        """
+        if self._evict_shortfall_this_step:
+            logger.warning(
+                "evict under-delivered on %d load-back(s) this scheduler step, "
+                "%d tokens short in total; the group capacity snapshot overstated "
+                "this rank by that much until now",
+                self._evict_shortfall_this_step,
+                self._evict_shortfall_tokens_this_step,
+            )
+            self._evict_shortfall_this_step = 0
+            self._evict_shortfall_tokens_this_step = 0
+
+        if self._alloc_failures_this_step:
+            node_id, kv_tokens, group_avail, group_evictable, aux_pools = (
+                self._alloc_failure_context
+            )
+            logger.error(
+                "load_back allocation failed %d time(s) this scheduler step after "
+                "the group granted capacity; last: node=%s kv_tokens=%d "
+                "group_avail=%d group_evictable=%d aux_pools=%d. Aux (SWA/mamba/"
+                "sidecar) pools are outside the group snapshot; an uneven count "
+                "across a TP group is the fingerprint of an imminent hang",
+                self._alloc_failures_this_step,
+                node_id,
+                kv_tokens,
+                group_avail,
+                group_evictable,
+                aux_pools,
+            )
+            self._alloc_failures_this_step = 0
+            self._alloc_failure_context = None
+
+    def _warn_missing_group_capacity(self) -> None:
+        """Announce a load-back path that never saw a capacity sync.
+
+        Reachable from scheduler loops that build a PrefillAdder without
+        running check_hicache_events. Failing closed is right, but doing it
+        silently would collapse the cache hit rate with no other signal.
+        """
+        if self._warned_missing_group_capacity:
+            return
+        self._warned_missing_group_capacity = True
+        logger.error(
+            "load_back reached before the first group capacity sync; load-back "
+            "stays disabled on this scheduler loop until check_hicache_events "
+            "runs. Expect degraded cache hit rate."
+        )
+
+    def _local_available_size(self) -> int:
+        """This rank's free device capacity.
+
+        SWA-hybrid allocators report full-KV availability through a separate
+        accessor; load-back only ever draws on the full-KV pool.
+        """
+        if self.supports_swa():
+            return self.token_to_kv_pool_allocator.full_available_size()
+        return self.token_to_kv_pool_allocator.available_size()
+
+    def _set_group_capacity(self, avail: int, evictable: int, local_avail: int) -> None:
+        # One refresh == one scheduler step, so this is the natural epoch
+        # boundary for the per-request failure paths.
+        self._flush_load_back_step_report()
+        self._group_avail = avail
+        self._group_evictable = evictable
+        if self.metrics_collector is None:
+            return
+
+        if self.pp_rank != 0:
+            # Later stages receive stage 0's value measured against a different
+            # pool, so the interesting quantity is the overgrant, not a skew:
+            # it is what precedes an allocation failure on this stage.
+            self.metrics_collector.set_hicache_pp_capacity_overgrant(
+                max(0, avail - local_avail)
+            )
+            return
+
+        if avail > local_avail:
+            # MIN over a group that includes this rank cannot exceed it. Do not
+            # clamp: zero reads as "this rank is the tightest", i.e. healthy.
+            logger.error(
+                "group capacity reduction returned more than this rank holds "
+                "(group=%d local=%d); the reduce did not include this rank and "
+                "load-back budgets are no longer group-agreed",
+                avail,
+                local_avail,
+            )
+            return
+        self.metrics_collector.set_hicache_group_capacity_skew(local_avail - avail)
+
+    def _refresh_group_capacity(self) -> None:
+        """Reduce device capacity by itself, where no merged reduce is available."""
+        local_avail = self._local_available_size()
+        capacity = torch.tensor(
+            [local_avail, self.evictable_size()],
+            dtype=torch.int,
+            device="cpu",
+        )
+        self._all_reduce(capacity, torch.distributed.ReduceOp.MIN)
+        avail, evictable = (int(v) for v in capacity.tolist())
+        self._set_group_capacity(avail, evictable, local_avail)
 
     def writing_check(
         self, write_back: bool = False, finish_count: Optional[int] = None
@@ -1937,6 +2135,7 @@ class UnifiedRadixCache(BasePrefixCache):
         self._drain_async_work()
 
         if self.pp_size != 1:
+            self._refresh_group_capacity()
             self.writing_check()
             self.loading_check()
             if self.enable_storage:

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -1869,9 +1869,11 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
     ) -> None:
         # We need to import prometheus_client after setting the env variable `PROMETHEUS_MULTIPROC_DIR`
         from prometheus_client import Counter as _PromCounter
+        from prometheus_client import Gauge as _PromGauge
         from prometheus_client import Histogram as _PromHistogram
 
         Counter = self._counter_cls or _PromCounter
+        Gauge = self._gauge_cls or _PromGauge
         Histogram = self._histogram_cls or _PromHistogram
 
         self.labels = labels
@@ -1950,8 +1952,83 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
         )
 
+        self.load_back_group_veto = Counter(
+            name="sglang:load_back_group_veto_total",
+            documentation=(
+                "Load-backs skipped because the group's worst-case device headroom "
+                "could not cover them. Conservative: the minimum free and the "
+                "minimum evictable are reduced independently and may come from "
+                "different ranks, so this can fire when no single rank was short."
+            ),
+            labelnames=labels.keys(),
+        )
+
+        self.load_back_alloc_failed = Counter(
+            name="sglang:load_back_alloc_failed_total",
+            documentation=(
+                "Load-backs abandoned because this rank could not allocate device "
+                "slots after the group had granted capacity. This is rank-local, "
+                "and a rise on one rank of a TP group precedes a hang -- but these "
+                "labels carry no rank, and multiprocess mode sums the ranks of a "
+                "group into one series, so use the matching 'load_back allocation "
+                "failed' log line for per-rank attribution."
+            ),
+            labelnames=labels.keys(),
+        )
+
+        self.load_back_evict_shortfall_num_tokens = Counter(
+            name="sglang:load_back_evict_shortfall_tokens_total",
+            documentation=(
+                "Tokens an eviction was asked to free for a load-back and did not. "
+                "The group snapshot overstates this rank by that much until the "
+                "next refresh, which usually surfaces as load_back_alloc_failed."
+            ),
+            labelnames=labels.keys(),
+        )
+
+        # A level, not a flow: a Counter here would make rate() meaningless.
+        self.hicache_group_capacity_skew = Gauge(
+            name="sglang:hicache_group_capacity_skew_tokens",
+            documentation=(
+                "Free device capacity this rank gave up to match the tightest rank, "
+                "sampled once per scheduler step when the group snapshot is "
+                "refreshed (not per load-back). Stays near zero on whichever rank "
+                "is chronically tightest. Emitted only by the rank that runs the "
+                "reduction; later pipeline stages report capacity overgrant instead."
+            ),
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
+        self.hicache_pp_capacity_overgrant = Gauge(
+            name="sglang:hicache_pp_capacity_overgrant_tokens",
+            documentation=(
+                "Capacity a later pipeline stage was granted beyond what its own "
+                "pool holds. The group minimum is reduced over the first stage's "
+                "TP ranks only, so a persistently positive value here explains "
+                "load_back_alloc_failed on that stage."
+            ),
+            labelnames=labels.keys(),
+            multiprocess_mode="mostrecent",
+        )
+
     def increment_eviction_num_tokens(self, num_tokens: int) -> None:
         self.eviction_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def increment_load_back_group_veto(self) -> None:
+        self.load_back_group_veto.labels(**self.labels).inc()
+
+    def increment_load_back_alloc_failed(self) -> None:
+        self.load_back_alloc_failed.labels(**self.labels).inc()
+
+    def increment_load_back_evict_shortfall_num_tokens(self, num_tokens: int) -> None:
+        self.load_back_evict_shortfall_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def set_hicache_group_capacity_skew(self, num_tokens: int) -> None:
+        self.hicache_group_capacity_skew.labels(**self.labels).set(num_tokens)
+
+    def set_hicache_pp_capacity_overgrant(self, num_tokens: int) -> None:
+        self.hicache_pp_capacity_overgrant.labels(**self.labels).set(num_tokens)
 
     def increment_load_back_num_tokens(self, num_tokens: int) -> None:
         self.load_back_num_tokens.labels(**self.labels).inc(num_tokens)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -537,6 +537,10 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         cache.init_hicache(server_args, cache.cache_init_params)
         cache.write_through_threshold = 1 << 30
         cache.load_back_threshold = 0
+        # Mirror the scheduler, which refreshes the group capacity snapshot
+        # before the prefill adder can reach init_load_back. Single-rank here,
+        # so the reduce is a no-op; without it load-back always skips.
+        cache._sync_hicache_ready_counts()
 
     def _backup_node(self, cache, node):
         backed_up = _write_backup(cache, node, write_back=True)
@@ -544,6 +548,9 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         cache.writing_check(write_back=True)
 
     def _load_back_node(self, cache, node):
+        # Refresh the group capacity snapshot against the pool as the test has
+        # left it, the way a scheduler step would before admitting a request.
+        cache._sync_hicache_ready_counts()
         loaded = cache.load_back(node.id)
         self.assertTrue(loaded)
         producer_id = cache.ready_to_load_host_cache()
@@ -2882,6 +2889,10 @@ class UnifiedRadixCacheSuite:
         cache.init_hicache(server_args, cache.cache_init_params)
         cache.write_through_threshold = 1 << 30
         cache.load_back_threshold = 0
+        # Mirror the scheduler, which refreshes the group capacity snapshot
+        # before the prefill adder can reach init_load_back. Single-rank here,
+        # so the reduce is a no-op; without it load-back always skips.
+        cache._sync_hicache_ready_counts()
         if storage_backend is not None:
             # Unit fixtures size host/device pools equally, which makes the
             # production prefetch capacity limit (host - device) zero.  Keep the
@@ -2928,6 +2939,9 @@ class UnifiedRadixCacheSuite:
                 self._backup_node(cache, node)
 
     def _load_back_node(self, cache, node):
+        # Refresh the group capacity snapshot against the pool as the test has
+        # left it, the way a scheduler step would before admitting a request.
+        cache._sync_hicache_ready_counts()
         loaded = cache.load_back(node.id)
         self.assertTrue(loaded)
         producer_id = cache.ready_to_load_host_cache()
@@ -3348,6 +3362,7 @@ class UnifiedRadixCacheSuite:
             m = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", tokens))))
             anchor = cache.resolve_node_handle(m.best_match_node)
             if anchor is not cache.root_node and anchor.evicted:
+                cache._sync_hicache_ready_counts()
                 if cache.load_back(anchor.id):
                     self._finish_pending_loads(cache)
                     self._release_ongoing_load_back_locks(cache)
@@ -3870,6 +3885,7 @@ class UnifiedRadixCacheSuite:
         )
         self._apply_match_to_req(req, match)
 
+        cache._sync_hicache_ready_counts()
         new_indices, new_node = cache.init_load_back(
             InitLoadBackParams(
                 best_match_node=req.best_match_node,
@@ -3911,6 +3927,7 @@ class UnifiedRadixCacheSuite:
         )
         self._apply_match_to_req(req, match)
 
+        cache._sync_hicache_ready_counts()
         new_indices, new_node = cache.init_load_back(
             InitLoadBackParams(
                 best_match_node=req.best_match_node,
@@ -3953,6 +3970,7 @@ class UnifiedRadixCacheSuite:
         # (that allocation is what a called-off load-back must free + not publish).
         req.mamba_pool_idx = None
         avail_before = req_to_token_pool.mamba_allocator.available_size()
+        cache._sync_hicache_ready_counts()
         new_indices, new_node = cache.init_load_back(
             InitLoadBackParams(
                 best_match_node=req.best_match_node,
@@ -3999,6 +4017,7 @@ class UnifiedRadixCacheSuite:
         avail_before = req_to_token_pool.mamba_allocator.available_size()
         # H->D load fails after the mamba slot is pre-allocated -> must free it.
         with mock.patch.object(cache.cache_controller, "load", return_value=None):
+            cache._sync_hicache_ready_counts()
             new_indices, _ = cache.init_load_back(
                 InitLoadBackParams(
                     best_match_node=req.best_match_node,
@@ -4036,16 +4055,17 @@ class UnifiedRadixCacheSuite:
         # Simulate a request without its own mamba slot so load-back allocates one.
         req.mamba_pool_idx = None
         avail_before = req_to_token_pool.mamba_allocator.available_size()
-        # No device room and eviction frees nothing -> load-back bails after the
-        # mamba pre-alloc, which must still be freed.
+        # No device room and nothing evictable -> the group vetoes load-back,
+        # which must still free the mamba pre-alloc. Load-back now decides from
+        # the group capacity snapshot, so the mocked pool has to be reduced into
+        # it rather than read directly.
         with (
             mock.patch.object(
                 cache.token_to_kv_pool_allocator, "available_size", return_value=0
             ),
-            mock.patch.object(
-                cache, "evict", return_value=mock.Mock(num_tokens_evicted=0)
-            ),
+            mock.patch.object(cache, "evictable_size", return_value=0),
         ):
+            cache._sync_hicache_ready_counts()
             new_indices, _ = cache.init_load_back(
                 InitLoadBackParams(
                     best_match_node=req.best_match_node,
@@ -4113,6 +4133,7 @@ class UnifiedRadixCacheSuite:
         # cache_controller.load() failing (device alloc / transfer resolution)
         # must also return the slot this call allocated.
         with mock.patch.object(cache.cache_controller, "load", return_value=None):
+            cache._sync_hicache_ready_counts()
             loaded = cache.load_back(leaf.id, req=req)
 
         self.assertFalse(loaded)
@@ -4168,6 +4189,7 @@ class UnifiedRadixCacheSuite:
         req.mamba_pool_idx = None
         mamba_avail = req_to_token_pool.mamba_allocator.available_size()
 
+        cache._sync_hicache_ready_counts()
         loaded = cache.load_back(leaf.id, req=req)
 
         self.assertTrue(loaded)
@@ -4205,6 +4227,7 @@ class UnifiedRadixCacheSuite:
         req_to_token_pool.mamba_allocator.free(req.mamba_pool_idx.unsqueeze(0))
         req.mamba_pool_idx = None
 
+        cache._sync_hicache_ready_counts()
         loaded = cache.load_back(leaf.id, req=req)
         self.assertTrue(loaded)
         self.assertIsNotNone(req.mamba_pool_idx)
@@ -4748,6 +4771,9 @@ class UnifiedRadixCacheSuite:
             int(swa_xfer.host_indices.numel()),
         )
 
+        # Snapshot the pool as configured above, so the gate below is decided by
+        # the real Full-pool capacity rather than a reading from fixture setup.
+        cache._sync_hicache_ready_counts()
         with mock.patch.object(cache, "evict", wraps=cache.evict) as evict_mock:
             self.assertTrue(cache.load_back(leaf.id))
 
@@ -6241,6 +6267,10 @@ class TestUnifiedRadixPrefetchCorruption(CustomTestCase):
         cache.init_hicache(server_args, cache.cache_init_params)
         cache.write_through_threshold = 1 << 30
         cache.load_back_threshold = 0
+        # Mirror the scheduler, which refreshes the group capacity snapshot
+        # before the prefill adder can reach init_load_back. Single-rank here,
+        # so the reduce is a no-op; without it load-back always skips.
+        cache._sync_hicache_ready_counts()
 
     def _insert_device(self, cache, allocator, ids):
         """Insert a device-only chain (no auto-backup) and return its leaf id."""

--- a/test/registered/unit/mem_cache/test_unified_radix_load_back_tp_consensus.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_load_back_tp_consensus.py
@@ -1,0 +1,549 @@
+"""HiCache load-back must reach the same verdict on every TP rank.
+
+`UnifiedRadixCache._load_back_transfers` sets how much of a request's prefix
+counts as cached. Deciding that from rank-local pool state lets ranks disagree,
+and they then enter the per-layer TP all_reduce with differently-sized tensors
+and deadlock. See `_load_back_transfers` for the full rationale; these tests
+pin the two properties that follow from it.
+
+The second property is the subtle one: the load-back path must stay free of
+collectives. A rank rejected by the KV-budget gates in
+`PrefillAdder.add_one_req` also breaks out of the admission loop, so unequal
+load-back counts imply an already divergent batch -- but a collective here
+would turn that into an immediate scheduler-thread hang, and it would be wrong
+outright for any future caller whose reach is genuinely rank-local.
+
+    python -m pytest \
+      test/registered/unit/mem_cache/test_unified_radix_load_back_tp_consensus.py -v
+"""
+
+import json
+import os
+import tempfile
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import EvictResult
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=90, suite="base-a-test-cpu")
+
+PAGE_SIZE = 256
+KV_TOKENS = 4 * PAGE_SIZE
+# Distinct sentinels so a mis-indexed unpack cannot look like a correct one.
+WRITE_ACKS = 7
+LOAD_ACKS = 11
+STORAGE_SIZES = (21, 22, 23, 24)
+
+
+def _make_stub_cache(
+    avail, evictable, *, evicted=None, load_fails=False, enable_storage=False
+):
+    """A UnifiedRadixCache stubbed down to the load-back decision path.
+
+    The capacity snapshot comes from the production initializer rather than
+    being hand-set, so the stub cannot drift from what `__init__` actually
+    builds.
+    """
+    cache = object.__new__(UnifiedRadixCache)
+    UnifiedRadixCache._init_group_capacity(cache)
+
+    cache.load_back_threshold = 10
+    cache.ongoing_load_back = {}
+    cache.sidecar_pool_specs = []
+    cache.metrics_collector = None
+    cache.pp_rank = 0
+
+    host_indices = torch.arange(KV_TOKENS, dtype=torch.int64)
+    kv_xfer = SimpleNamespace(host_indices=host_indices)
+    # tree_core must exist first: enable_storage is a property that writes
+    # through to it.
+    cache.tree_core = SimpleNamespace(
+        build_load_back_spec=MagicMock(return_value=(kv_xfer, {})),
+        commit_load_back=MagicMock(return_value=[]),
+    )
+    cache.enable_storage = enable_storage
+    cache._build_sidecar_transfers = MagicMock(return_value=[])
+    cache._apply_cache_actions = MagicMock()
+
+    cache.supports_swa = MagicMock(return_value=True)
+    cache.token_to_kv_pool_allocator = SimpleNamespace(
+        full_available_size=MagicMock(return_value=avail),
+        available_size=MagicMock(return_value=avail),
+    )
+    cache.evictable_size = MagicMock(return_value=evictable)
+
+    # By default evict() reports back exactly what it was asked for; `evicted`
+    # forces an under-delivery, which the decision path must not branch on.
+    cache.evict = MagicMock(
+        side_effect=lambda params: EvictResult(
+            num_tokens_evicted=params.num_tokens if evicted is None else evicted
+        )
+    )
+    cache.dec_lock_ref = MagicMock()
+    cache.dec_host_lock_ref = MagicMock()
+    cache.inc_lock_ref = MagicMock(
+        return_value=SimpleNamespace(to_dec_params=MagicMock(return_value=None))
+    )
+    cache.cache_controller = SimpleNamespace(
+        load=MagicMock(
+            return_value=(
+                None if load_fails else torch.arange(KV_TOKENS, dtype=torch.int64)
+            )
+        ),
+        ack_write_queue=[],
+        ack_load_queue=[],
+        extra_host_mem_release_queues={},
+        prefetch_revoke_queue=SimpleNamespace(qsize=lambda: STORAGE_SIZES[0]),
+        prefetch_hit_queue=SimpleNamespace(qsize=lambda: STORAGE_SIZES[1]),
+        ack_backup_queue=SimpleNamespace(qsize=lambda: STORAGE_SIZES[2]),
+        host_mem_release_queue=SimpleNamespace(qsize=lambda: STORAGE_SIZES[3]),
+    )
+    cache._count_ready_acks = MagicMock(
+        side_effect=lambda q: (
+            WRITE_ACKS if q is cache.cache_controller.ack_write_queue else LOAD_ACKS
+        )
+    )
+    return cache
+
+
+def _drive(cache):
+    return cache._load_back_transfers(
+        node_id=1,
+        mem_quota=None,
+        req=None,
+        result=SimpleNamespace(delta=0),
+        ancestor_lock_params=None,
+        host_anchor_params=None,
+    )
+
+
+class TestLoadBackDecisionFromSnapshot(CustomTestCase):
+    """Holding the tree and quota fixed, the verdict depends only on the group
+    snapshot -- never on this rank's own pool."""
+
+    def _seeded(self, avail, evictable, group_avail, group_evictable, **kw):
+        cache = _make_stub_cache(avail, evictable, **kw)
+        cache._set_group_capacity(group_avail, group_evictable, avail)
+        return cache
+
+    def test_divergent_local_pools_do_not_change_the_verdict(self):
+        flush = self._seeded(
+            avail=99 * PAGE_SIZE,
+            evictable=0,
+            group_avail=2 * PAGE_SIZE,
+            group_evictable=8 * PAGE_SIZE,
+        )
+        tight = self._seeded(
+            avail=2 * PAGE_SIZE,
+            evictable=8 * PAGE_SIZE,
+            group_avail=2 * PAGE_SIZE,
+            group_evictable=8 * PAGE_SIZE,
+        )
+        # Pinned explicitly rather than only compared: under rank-local logic
+        # the flush rank would not evict at all.
+        self.assertTrue(_drive(flush))
+        self.assertTrue(_drive(tight))
+        for cache in (flush, tight):
+            self.assertEqual(
+                cache.evict.call_args[0][0].num_tokens, KV_TOKENS - 2 * PAGE_SIZE
+            )
+
+    def test_group_without_room_vetoes(self):
+        cache = self._seeded(
+            avail=8 * PAGE_SIZE,
+            evictable=8 * PAGE_SIZE,
+            group_avail=PAGE_SIZE,
+            group_evictable=PAGE_SIZE,
+        )
+        cache.metrics_collector = MagicMock()
+        self.assertFalse(_drive(cache))
+        cache.cache_controller.load.assert_not_called()
+        cache.metrics_collector.increment_load_back_group_veto.assert_called_once()
+
+    def test_ample_group_room_skips_eviction(self):
+        cache = self._seeded(
+            avail=PAGE_SIZE,
+            evictable=0,
+            group_avail=8 * PAGE_SIZE,
+            group_evictable=0,
+        )
+        cache.metrics_collector = MagicMock()
+        self.assertTrue(_drive(cache))
+        cache.evict.assert_not_called()
+        cache.metrics_collector.increment_load_back_group_veto.assert_not_called()
+
+    def test_budget_is_spent_so_one_step_cannot_double_allocate(self):
+        cache = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=KV_TOKENS + PAGE_SIZE,
+            group_evictable=0,
+        )
+        self.assertTrue(_drive(cache))
+        # One page of headroom left and nothing evictable, so the second load
+        # must be vetoed rather than handed the same capacity again.
+        self.assertFalse(_drive(cache))
+
+    def test_budget_is_spent_even_when_the_allocation_fails(self):
+        """Both exits must move the snapshot identically.
+
+        Refunding only on success would let one rank's allocation failure
+        desync the snapshot itself -- the very thing the snapshot prevents.
+        """
+        ok = self._seeded(
+            avail=0, evictable=0, group_avail=KV_TOKENS + PAGE_SIZE, group_evictable=0
+        )
+        failed = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=KV_TOKENS + PAGE_SIZE,
+            group_evictable=0,
+            load_fails=True,
+        )
+        failed.metrics_collector = MagicMock()
+        self.assertTrue(_drive(ok))
+        self.assertFalse(_drive(failed))
+        self.assertEqual(ok._group_avail, failed._group_avail)
+        failed.metrics_collector.increment_load_back_alloc_failed.assert_called_once()
+
+    def test_under_delivering_eviction_does_not_change_the_decision(self):
+        """The measured eviction amount is rank-local; branching on it deadlocks."""
+        full = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=2 * PAGE_SIZE,
+            group_evictable=8 * PAGE_SIZE,
+        )
+        short = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=2 * PAGE_SIZE,
+            group_evictable=8 * PAGE_SIZE,
+            evicted=0,
+        )
+        self.assertEqual(_drive(full), _drive(short))
+        self.assertEqual(full._group_avail, short._group_avail)
+        self.assertEqual(full._group_evictable, short._group_evictable)
+
+    def test_load_back_skipped_before_the_first_group_sync(self):
+        cache = _make_stub_cache(avail=99 * PAGE_SIZE, evictable=0)
+        cache.metrics_collector = MagicMock()
+        with self.assertLogs(
+            "sglang.srt.mem_cache.unified_radix_cache", level="ERROR"
+        ) as logs:
+            self.assertFalse(_drive(cache))
+        self.assertTrue(any("group capacity sync" in m for m in logs.output))
+        cache.cache_controller.load.assert_not_called()
+        # A missing snapshot is not a veto; conflating them would hide it.
+        cache.metrics_collector.increment_load_back_group_veto.assert_not_called()
+
+    def test_capacity_skew_uses_the_pre_reduce_reading(self):
+        cache = _make_stub_cache(avail=6 * PAGE_SIZE, evictable=0)
+        cache.metrics_collector = MagicMock()
+        # A second sample would read the later value; the skew must not.
+        cache.token_to_kv_pool_allocator.full_available_size.side_effect = [
+            999 * PAGE_SIZE
+        ]
+        cache._set_group_capacity(2 * PAGE_SIZE, 0, 6 * PAGE_SIZE)
+        cache.metrics_collector.set_hicache_group_capacity_skew.assert_called_once_with(
+            4 * PAGE_SIZE
+        )
+
+    def test_group_above_local_is_reported_not_clamped(self):
+        """MIN including this rank cannot exceed it; zero would read as healthy."""
+        cache = _make_stub_cache(avail=2 * PAGE_SIZE, evictable=0)
+        cache.metrics_collector = MagicMock()
+        with self.assertLogs(
+            "sglang.srt.mem_cache.unified_radix_cache", level="ERROR"
+        ) as logs:
+            cache._set_group_capacity(9 * PAGE_SIZE, 0, 2 * PAGE_SIZE)
+        self.assertTrue(any("did not include this rank" in m for m in logs.output))
+        cache.metrics_collector.set_hicache_group_capacity_skew.assert_not_called()
+
+    def test_later_pipeline_stage_reports_overgrant_instead_of_skew(self):
+        cache = _make_stub_cache(avail=2 * PAGE_SIZE, evictable=0)
+        cache.metrics_collector = MagicMock()
+        cache.pp_rank = 1
+        cache._set_group_capacity(9 * PAGE_SIZE, 0, 2 * PAGE_SIZE)
+        cache.metrics_collector.set_hicache_group_capacity_skew.assert_not_called()
+        cache.metrics_collector.set_hicache_pp_capacity_overgrant.assert_called_once_with(
+            7 * PAGE_SIZE
+        )
+        # The snapshot itself must still be applied.
+        self.assertEqual(cache._group_avail, 9 * PAGE_SIZE)
+
+    def test_failure_paths_report_once_per_step_not_once_per_request(self):
+        """Both conditions persist across steps; per-request logging would flood."""
+        cache = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=99 * KV_TOKENS,
+            group_evictable=0,
+            load_fails=True,
+        )
+        for _ in range(5):
+            self.assertFalse(_drive(cache))
+        self.assertEqual(cache._alloc_failures_this_step, 5)
+        with self.assertLogs(
+            "sglang.srt.mem_cache.unified_radix_cache", level="ERROR"
+        ) as logs:
+            cache._set_group_capacity(99 * KV_TOKENS, 0, 99 * KV_TOKENS)
+        self.assertEqual(len([m for m in logs.output if "allocation failed" in m]), 1)
+        self.assertTrue(any("5 time(s)" in m for m in logs.output))
+        self.assertEqual(cache._alloc_failures_this_step, 0)
+
+    def test_evict_shortfall_is_counted_and_reported(self):
+        cache = self._seeded(
+            avail=0,
+            evictable=0,
+            group_avail=2 * PAGE_SIZE,
+            group_evictable=8 * PAGE_SIZE,
+            evicted=0,
+        )
+        cache.metrics_collector = MagicMock()
+        self.assertTrue(_drive(cache))
+        shortfall = KV_TOKENS - 2 * PAGE_SIZE
+        counter = cache.metrics_collector.increment_load_back_evict_shortfall_num_tokens
+        counter.assert_called_once_with(shortfall)
+        with self.assertLogs(
+            "sglang.srt.mem_cache.unified_radix_cache", level="WARNING"
+        ) as logs:
+            cache._set_group_capacity(2 * PAGE_SIZE, 0, 2 * PAGE_SIZE)
+        self.assertTrue(any("under-delivered" in m for m in logs.output))
+
+    def test_reset_rearms_the_missing_snapshot_warning(self):
+        """A flush starts a new epoch; the second occurrence must not be silent."""
+        cache = _make_stub_cache(avail=0, evictable=0)
+        cache._set_group_capacity(PAGE_SIZE, 0, PAGE_SIZE)
+        cache._warned_missing_group_capacity = True
+        # _reset_full tears down a lot of tree state; only its epoch handling
+        # is under test, so let the rest be absorbed.
+        cache.tree_core = MagicMock()
+        cache.session = MagicMock()
+        cache.session_refs = MagicMock()
+        cache.cache_controller = None
+
+        cache._reset_full()
+
+        self.assertIsNone(cache._group_avail)
+        self.assertIsNone(cache._group_evictable)
+        self.assertFalse(cache._warned_missing_group_capacity)
+
+    def test_no_branch_reaches_a_collective(self):
+        """The guard the gloo test cannot give: every branch, collective-free.
+
+        Covers the statements of _load_back_transfers itself on every branch,
+        which the multi-process test cannot -- it only ever takes one. Callees
+        are stubbed, so a collective added inside evict() or the cache
+        controller is out of scope here.
+        """
+        # ample room / veto / evict / alloc-failure, each with its verdict
+        cases = [
+            (dict(group_avail=8 * PAGE_SIZE, group_evictable=0), True),
+            (dict(group_avail=PAGE_SIZE, group_evictable=PAGE_SIZE), False),
+            (dict(group_avail=2 * PAGE_SIZE, group_evictable=8 * PAGE_SIZE), True),
+            (
+                dict(group_avail=8 * PAGE_SIZE, group_evictable=0, load_fails=True),
+                False,
+            ),
+        ]
+        boom = MagicMock(side_effect=AssertionError("collective on the load-back path"))
+        collectives = ("all_reduce", "barrier", "recv", "isend", "broadcast")
+
+        def guarded(cache):
+            cache._all_reduce = boom
+            patches = [patch.object(torch.distributed, n, boom) for n in collectives]
+            for p in patches:
+                p.start()
+            try:
+                return _drive(cache)
+            finally:
+                for p in patches:
+                    p.stop()
+
+        for kw, expected in cases:
+            with self.subTest(**kw):
+                # Pinning the verdict stops a threshold change from silently
+                # collapsing every case into the same early return.
+                cache = self._seeded(avail=0, evictable=0, **kw)
+                self.assertEqual(guarded(cache), expected)
+        # And the no-snapshot branch, which takes none of the above.
+        self.assertFalse(guarded(_make_stub_cache(avail=0, evictable=0)))
+
+
+# --------------------------------------------------------------------------
+# Real gloo process group
+# --------------------------------------------------------------------------
+
+
+def _gloo_rank_main(
+    rank, store_path, avails, evictables, load_back_ranks, out_dir, enable_storage
+):
+    """Entry point for each spawned rank. Must stay module-level (picklable)."""
+    torch.distributed.init_process_group(
+        backend="gloo",
+        init_method=f"file://{store_path}",
+        world_size=2,
+        rank=rank,
+    )
+    try:
+        cache = _make_stub_cache(
+            avails[rank], evictables[rank], enable_storage=enable_storage
+        )
+        cache.attn_cp_group = None
+        cache.attn_tp_group = None
+        cache.tp_group = None  # default (world) group
+        cache.tp_world_size = 2
+        cache.pp_rank = 0
+        cache.pp_size = 1
+        cache.pp_group = None
+        cache.work_list = []
+
+        # The per-step merged reduce every rank reaches unconditionally.
+        counts = cache._sync_hicache_ready_counts()
+
+        verdict = None
+        if rank in load_back_ranks:
+            verdict = _drive(cache)
+        result = {
+            "verdict": verdict,
+            "group_avail": cache._group_avail,
+            "group_evictable": cache._group_evictable,
+            "write_acks": counts[0],
+            "load_acks": counts[1],
+            "storage_sizes": list(counts[2]),
+            "evict_calls": [c[0][0].num_tokens for c in cache.evict.call_args_list],
+        }
+        with open(os.path.join(out_dir, f"rank{rank}.json"), "w") as fh:
+            json.dump(result, fh)
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+def _run_gloo(
+    avails, evictables, load_back_ranks=(0, 1), timeout=120, enable_storage=False
+):
+    import torch.multiprocessing as mp
+
+    with tempfile.TemporaryDirectory() as out_dir:
+        # A file store avoids the bind-then-reconnect race of picking a port.
+        store_path = os.path.join(out_dir, "store")
+        ctx = mp.start_processes(
+            _gloo_rank_main,
+            args=(
+                store_path,
+                avails,
+                evictables,
+                load_back_ranks,
+                out_dir,
+                enable_storage,
+            ),
+            nprocs=2,
+            join=False,
+            daemon=True,
+            start_method="spawn",
+        )
+        try:
+            # ProcessContext.join() returns as soon as ANY rank exits, reporting
+            # False while others remain, so it has to be driven to completion.
+            deadline = time.monotonic() + timeout
+            while not ctx.join(timeout=max(0.0, deadline - time.monotonic())):
+                if time.monotonic() >= deadline:
+                    raise AssertionError(
+                        f"gloo ranks did not finish within {timeout}s -- deadlocked"
+                    )
+            results = []
+            for rank in range(2):
+                path = os.path.join(out_dir, f"rank{rank}.json")
+                if not os.path.exists(path):
+                    raise AssertionError(f"rank {rank} produced no result")
+                with open(path) as fh:
+                    results.append(json.load(fh))
+            return results
+        finally:
+            # Reap before the TemporaryDirectory is torn out from under them,
+            # so a real failure is not masked by an rmtree error.
+            for proc in ctx.processes:
+                if proc.is_alive():
+                    proc.terminate()
+            for proc in ctx.processes:
+                proc.join(timeout=10)
+                if proc.is_alive():
+                    proc.kill()
+
+
+@unittest.skipUnless(
+    torch.distributed.is_available() and torch.distributed.is_gloo_available(),
+    "gloo required",
+)
+class TestLoadBackTpConsensusGloo(CustomTestCase):
+    def test_storage_queue_sizes_land_after_the_capacity_and_ack_slots(self):
+        """With storage on, the variable tail must start at exactly index 4."""
+        results = _run_gloo(
+            avails=[8 * PAGE_SIZE, 2 * PAGE_SIZE],
+            evictables=[PAGE_SIZE, 5 * PAGE_SIZE],
+            enable_storage=True,
+        )
+        for r in results:
+            self.assertEqual(r["write_acks"], WRITE_ACKS)
+            self.assertEqual(r["load_acks"], LOAD_ACKS)
+            self.assertEqual(r["storage_sizes"], list(STORAGE_SIZES))
+
+    def test_merged_reduce_agrees_on_capacity_and_keeps_ack_layout(self):
+        """Capacity rides along without displacing the ack counts."""
+        results = _run_gloo(
+            avails=[8 * PAGE_SIZE, 2 * PAGE_SIZE],
+            evictables=[PAGE_SIZE, 5 * PAGE_SIZE],
+        )
+        self.assertEqual([r["group_avail"] for r in results], [2 * PAGE_SIZE] * 2)
+        self.assertEqual([r["group_evictable"] for r in results], [PAGE_SIZE] * 2)
+        # The two minima came from different ranks, which is what makes
+        # group_avail + group_evictable a safe lower bound for the veto.
+        for r in results:
+            self.assertEqual(r["write_acks"], WRITE_ACKS)
+            self.assertEqual(r["load_acks"], LOAD_ACKS)
+            self.assertEqual(r["storage_sizes"], [])
+
+    def test_divergent_availability_yields_one_shared_verdict(self):
+        results = _run_gloo(
+            avails=[8 * PAGE_SIZE, 2 * PAGE_SIZE],
+            evictables=[8 * PAGE_SIZE, 8 * PAGE_SIZE],
+        )
+        self.assertEqual([r["verdict"] for r in results], [True, True])
+        self.assertEqual(
+            [r["evict_calls"] for r in results],
+            [[KV_TOKENS - 2 * PAGE_SIZE]] * 2,
+        )
+
+    def test_group_veto_is_unanimous(self):
+        results = _run_gloo(
+            avails=[8 * PAGE_SIZE, PAGE_SIZE],
+            evictables=[8 * PAGE_SIZE, 0],
+        )
+        self.assertEqual([r["verdict"] for r in results], [False, False])
+
+    def test_one_sided_load_back_does_not_hang(self):
+        """The discriminating case: only one rank reaches load-back.
+
+        The KV-budget gates in PrefillAdder.add_one_req can return NO_TOKEN on a
+        tight rank while its peer proceeds to init_load_back, so a collective
+        inside the load-back path would block here forever.
+        """
+        results = _run_gloo(
+            avails=[8 * PAGE_SIZE, 2 * PAGE_SIZE],
+            evictables=[8 * PAGE_SIZE, 8 * PAGE_SIZE],
+            load_back_ranks=(0,),
+        )
+        self.assertEqual(results[0]["verdict"], True)
+        self.assertIsNone(results[1]["verdict"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`UnifiedRadixCache.load_back` decides whether to pull a cached prefix back from host memory using **rank-local** device pool state — `full_available_size()`, and how many tokens a local `evict()` actually freed. Those quantities drift between TP ranks under load.

The decision is not local. It sets how much of a request's prefix counts as cached, which becomes `req.prefix_indices` → `pfx_lens`/`ext_lens`. A rank that decides differently from its peers enters the per-layer TP `all_reduce` with a differently-sized tensor, and both GPU streams deadlock.

This was confirmed in production on a DeepSeek-V4-Flash TP2 deployment. GPU coredumps from a live wedge show both ranks inside the **same** custom all-reduce kernel with different element counts, parsed from `.cudbg.param`:

| rank | numel | shape (bf16) |
|---|---|---|
| TP0 | 7,327,744 | (1789, 4096) |
| TP1 | 8,376,320 | (2045, 4096) |

Δ = 256 tokens = exactly one page at `page_size=256`. The parse is self-validating — on both ranks the two buffer pointers in `AllReduceParams` differ by exactly `size × sizeof(bf16)`, and the `rank` field reads 0 and 1.

Across two independent coredump pairs plus seven previously measured cases, the delta is always a whole number of pages and TP1 is the short rank in **9 of 9**.

`hiradix_cache.py` and `hi_mamba_radix_cache.py` have the same shape and are **not** addressed here.

## Design

Device capacity is reduced to a group minimum once per scheduler step, inside the reduce that `_sync_hicache_ready_counts` already performs — two extra elements on an existing tensor rather than a new collective. `check_hicache_events` runs it, and load-back reads the snapshot.

**The load-back path itself stays collective-free.** A rank rejected by the KV-budget gates in `PrefillAdder.add_one_req` also breaks out of the admission loop, so unequal load-back counts imply an already-divergent batch — but a collective there would convert that into an immediate scheduler-thread hang, and would be wrong outright for any future caller whose reach is genuinely rank-local.

Feasibility is predicted from `group_avail + group_evictable`, and what `evict()` actually frees is deliberately **not** consulted: branching on a rank-local measurement is the defect being removed. The budget is spent *before* the load attempt so both outcomes move the snapshot by the same group-agreed amount; refunding only on success would let one rank's allocation failure desync the snapshot itself.

This trades cache-hit rate for correctness by design. Two minima are reduced independently and may come from different ranks, so the veto is conservative and can fire when no single rank was short.

## Modifications

- Reduce `available` + `evictable` in the existing merged per-step reduce; `_load_back_transfers` decides from the snapshot.
- `_refresh_group_capacity` for the `pp_size != 1` branch, which has no merged reduce to ride.
- Observability, since the original defect left zero trace in four hours of logs: `load_back_group_veto_total`, `load_back_alloc_failed_total`, `load_back_evict_shortfall_tokens_total`, and gauges `hicache_group_capacity_skew_tokens` / `hicache_pp_capacity_overgrant_tokens`. Both new log sites aggregate to one line per scheduler step — these are persistent pool states, and unbounded synchronous stderr writes on the scheduler thread would be rank-asymmetric by construction.
- Existing HiCache tests seed the snapshot the way a scheduler step does.

## Known gap

`cache_controller.load()` returning `None` is still a rank-local verdict. The snapshot covers the full-KV pool; aux (SWA / mamba / sidecar) device allocation inside `_resolve_pool_transfers_allocation` is not reduced, and has its own unreduced `evict_fn` retry. Closing it needs a reserve/commit/abort primitive able to reverse aux allocations — separate work. It is now logged and counted, so an uneven count across a TP group is visible rather than silent.

## Accuracy

`test_unified_radix_cache_unittest.py`: 1050 passed, 1030 skipped, 50 subtests (1×B300).
New `test_unified_radix_load_back_tp_consensus.py`: 19 passed (CPU + two-process gloo).

The new tests were checked in both directions — with the consensus neutered, 6 of the CPU cases fail with `[True, False] != [False, False]`, i.e. the production divergence reproduced; and stripping the fixture seeding fails 25 tests in the existing suite.

`test_one_sided_load_back_does_not_hang` is the discriminating case: only one rank reaches load-back. An earlier revision that put the collective directly in the load-back path blocks in `all_reduce → work.wait()` here; this design completes.

Not yet run: a multi-GPU TP>1 e2e under real memory pressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDAPTZTwY6r7zhAcMFw4LP

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30861744137](https://github.com/sgl-project/sglang/actions/runs/30861744137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30861744041](https://github.com/sgl-project/sglang/actions/runs/30861744041)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->