### PR TITLE
[AMD] Fix Kimi-K3 SiTU JIT compile failure on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/kimi_k3/situ_and_mul.cuh
+++ b/python/sglang/kernels/jit/csrc/kimi_k3/situ_and_mul.cuh
@@ -18,9 +18,11 @@
 #include <tvm/ffi/container/tensor.h>
 
 #include <cstdint>
-#include <cuda_fp8.h>
 #include <limits>
 #include <type_traits>
+#ifndef USE_ROCM
+#include <cuda_fp8.h>
+#endif
 
 namespace sglang {
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
The Kimi-K3 SiTU activation kernels cannot be JIT-compiled on ROCm.`situ_and_mul.cuh` includes `<cuda_fp8.h>` unconditionally, which is a CUDA-only header, so hipcc fails with:
```
/sgl-workspace/sglang/python/sglang/kernels/jit/csrc/kimi_k3/situ_and_mul.cuh:21:10: fatal error: 'cuda_fp8.h' file not found
   21 | #include <cuda_fp8.h>
      |          ^~~~~~~~~~~~
1 error generated when compiling for gfx950.
```

## Modifications

<!-- Detail the changes made in this pull request. -->
Guard the `<cuda_fp8.h>` include with `#ifndef USE_ROCM`

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30865989327](https://github.com/sgl-project/sglang/actions/runs/30865989327)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30865989193](https://github.com/sgl-project/sglang/actions/runs/30865989193)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->