### PR TITLE
[DCP] Bound a request by the aggregate KV pool, not one rank's share

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2080,7 +2080,10 @@ class Scheduler(
             min(
                 max_new_tokens,
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens - paged_input_len - self.page_size - 1,
+                self.max_total_num_tokens * self.server_args.dcp_size
+                - paged_input_len
+                - self.page_size
+                - 1,
             ),
         )
         # Clipping above can push max_new_tokens below min_new_tokens, which

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -385,7 +385,9 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens - 1,
+            self.model_runner.effective_max_total_num_tokens
+            * self.model_runner.dcp_size
+            - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
 
@@ -485,7 +487,9 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens - 1,
+            self.model_runner.effective_max_total_num_tokens
+            * self.model_runner.dcp_size
+            - 1,
         )
         return (
             self.model_runner.max_total_num_tokens,


### PR DESCRIPTION
Under DCP a sequence is sharded across ranks and charged `len / dcp_size` against
the per-rank KV pool, but two limits compare the raw length against that same
per-rank figure:

- `tp_worker.get_worker_info` — `max_req_len` / `max_req_input_len` derive from
  `effective_max_total_num_tokens`, so the request is rejected outright.
- `Scheduler` — the `max_new_tokens` clamp subtracts the un-sharded `input_len`
  from `max_total_num_tokens`, so a request that *is* admitted gets a zero
  generation budget and returns `finish_reason="length"` with empty content.

Both need fixing together: scaling only `tp_worker` turns the loud rejection into
a silent empty response. The `dcp_size` scaling matches existing usage a few
lines above the `Scheduler` clamp. No-op at `dcp_size == 1`.

## Repro

tp8/dcp8 with speculative decoding, where the per-rank pool is ~64k and the
aggregate ~512k:

```bash
python3 -m sglang.launch_server \
  --model-path <Kimi-K3> --trust-remote-code \
  --tp-size 8 --dcp-size 8 --mamba-full-memory-ratio 5.13 \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path <Kimi-K3-DSpark> \
  --speculative-dspark-block-size 7 --enable-gdn-replayssm-spec \
  --host 0.0.0.0 --port 30000
```

`repro.py`:

```python
import requests

MODEL = "<Kimi-K3>"
PROMPT = "the quick brown fox jumps over a lazy dog while counting numbers " * 11000

d = requests.post(
    "http://127.0.0.1:30000/v1/chat/completions",
    json={
        "model": MODEL,
        "messages": [{"role": "user", "content": PROMPT}],
        "max_tokens": 16,
        "temperature": 0,
    },
    timeout=900,
).json()

print("prompt_tokens    :", d["usage"]["prompt_tokens"])
print("completion_tokens:", d["usage"]["completion_tokens"])
print("finish_reason    :", d["choices"][0]["finish_reason"])
```

Before — rejected at admission:

```
Input length (128123 tokens) exceeds the maximum allowed length (64058 tokens).
```

With only `tp_worker` scaled — admitted, prefilled, no output:

```
prompt_tokens    : 128123
completion_tokens: 0
finish_reason    : length
```

After both fixes, 128k and 256k prompts serve normally:

| prompt | TTFT (s) | prefill tok/s | decode tok/s |
|---|---|---|---|
| 128,123 | 3.04 | 21,103 | 235.5 |
| 256,123 | 16.10 | 15,905 | 180.9 |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30870460456](https://github.com/sgl-project/sglang/actions/runs/30870460456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30870460282](https://github.com/sgl-project/sglang/actions/runs/30870460282)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->