### PR TITLE
[Fix] multimodal: apply EXIF orientation when decoding images

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -86,7 +86,7 @@ import torch
 import torch.distributed as dist
 import triton
 from packaging import version as pkg_version
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageOps, UnidentifiedImageError
 from starlette.routing import Mount
 from torch import nn
 from torch.library import Library
@@ -1650,6 +1650,52 @@ def is_jpeg_with_cuda(image_bytes: bytes = b"", gpu_image_decode: bool = True) -
     return False
 
 
+def _get_exif_orientation(image_bytes: bytes) -> int:
+    """Return the EXIF orientation tag value (1-8) from raw image bytes.
+
+    Returns 1 (no rotation) when the image has no EXIF data, no orientation
+    tag, a value outside the valid 1-8 range, or malformed/missing EXIF.
+    This function never raises — EXIF parsing failure degrades to "no
+    rotation".
+    """
+    try:
+        with Image.open(BytesIO(image_bytes)) as img:
+            exif = img.getexif()
+            if exif is None:
+                return 1
+            orientation = exif.get(0x0112, 1)  # tag 274 = Orientation
+            if orientation not in (1, 2, 3, 4, 5, 6, 7, 8):
+                return 1
+            return orientation
+    except Exception:
+        return 1
+
+
+def _safe_exif_transpose(image: Image.Image) -> Image.Image:
+    """Apply EXIF orientation to a PIL Image, never raising.
+
+    Wraps ``PIL.ImageOps.exif_transpose`` so that malformed EXIF metadata
+    does not turn a decodable image into an exception. If the transpose
+    fails for any reason, the original image is returned unrotated.
+
+    Short-circuits when no EXIF orientation tag is present (or it is 1)
+    to avoid the unnecessary full-image copy that ``exif_transpose``
+    performs even when no transform is needed. This preserves the lazy
+    behaviour of ``Image.open`` for unrotated images, including
+    multi-frame formats like animated GIF/WebP.
+    """
+    try:
+        exif = image.getexif()
+        if exif is None:
+            return image
+        orientation = exif.get(0x0112, 1)  # tag 274 = Orientation
+        if orientation not in (2, 3, 4, 5, 6, 7, 8):
+            return image
+        return ImageOps.exif_transpose(image)
+    except Exception:
+        return image
+
+
 def _load_image(
     image_bytes: bytes = b"",
     image_file: str = "",
@@ -1663,15 +1709,24 @@ def _load_image(
     if image_file != "":
         image_bytes = get_image_bytes(image_file)
     if is_jpeg_with_cuda(image_bytes, gpu_image_decode):
-        try:
-            encoded_image = torch.frombuffer(image_bytes, dtype=torch.uint8)
-            image_tensor = decode_jpeg(encoded_image, device="cuda")
-            return image_tensor
-        except Exception as e:
-            logger.warning(
-                f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
-            )
-    return Image.open(BytesIO(image_bytes))
+        # nvJPEG returns raw sensor pixels without applying the EXIF orientation
+        # tag. When a non-trivial orientation is present, fall through to the PIL
+        # path which can apply exif_transpose, so the model sees the same pixels a
+        # human viewer sees. The header-only Image.open inside _get_exif_orientation
+        # is lazy and cheap, so this only adds overhead for rotated photos.
+        orientation = _get_exif_orientation(image_bytes)
+        if orientation == 1:
+            try:
+                encoded_image = torch.frombuffer(image_bytes, dtype=torch.uint8)
+                image_tensor = decode_jpeg(encoded_image, device="cuda")
+                return image_tensor
+            except Exception as e:
+                logger.warning(
+                    f"Failed to decode JPEG on GPU, falling back to CPU. Error: {e}"
+                )
+    image = Image.open(BytesIO(image_bytes))
+    image = _safe_exif_transpose(image)
+    return image
 
 
 def load_image(
@@ -1688,7 +1743,7 @@ def load_image(
     image = None
     image_size: Optional[tuple[int, int]] = None
     if isinstance(image_file, Image.Image):
-        image = image_file
+        image = _safe_exif_transpose(image_file)
         image_size = (image.width, image.height)
     elif isinstance(image_file, bytes):
         image = _load_image(image_bytes=image_file, gpu_image_decode=gpu_image_decode)

--- a/test/registered/unit/multimodal/test_base_processor_image_decode.py
+++ b/test/registered/unit/multimodal/test_base_processor_image_decode.py
@@ -21,10 +21,11 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 import requests
-from PIL import Image
+from PIL import Image, ImageOps
 
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.utils.common import _get_exif_orientation, load_image
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -120,6 +121,251 @@ class TestLoadSingleItemImageDecode(CustomTestCase):
         ):
             with self.assertRaisesRegex(RuntimeError, "unexpected loader bug"):
                 _StubProcessor._load_single_item(b"image", Modality.IMAGE)
+
+
+def _make_jpeg_with_orientation(width: int, height: int, orientation: int) -> bytes:
+    """Create a JPEG with the given EXIF orientation tag.
+
+    The image content is a simple gradient so that different orientations
+    produce visually distinct pixel arrangements.
+    """
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    for y in range(height):
+        for x in range(width):
+            arr[y, x] = [x % 256, y % 256, (x + y) % 256]
+    img = Image.fromarray(arr, "RGB")
+    buf = io.BytesIO()
+    # exif= expects an instance of PIL.ExifImage; build it via getexif
+    exif = img.getexif()
+    if orientation != 1:
+        exif[0x0112] = orientation
+        img.save(buf, format="JPEG", exif=exif)
+    else:
+        img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+class TestExifOrientation(CustomTestCase):
+    """Verify that image loading applies EXIF orientation so the model sees the
+    same pixels a human viewer sees.
+
+    Covers the three code paths in ``sglang.srt.utils.common``:
+    * ``_load_image`` CPU fallback (``Image.open`` + ``exif_transpose``)
+    * ``load_image`` direct-PIL branch (``isinstance(image_file, Image.Image)``)
+    * ``_get_exif_orientation`` helper (unit-tested without CUDA)
+    """
+
+    # ------------------------------------------------------------------
+    # _get_exif_orientation helper
+    # ------------------------------------------------------------------
+
+    def test_get_orientation_no_exif(self):
+        """A JPEG with no EXIF returns orientation 1."""
+        data = _make_jpeg_with_orientation(16, 12, orientation=1)
+        self.assertEqual(_get_exif_orientation(data), 1)
+
+    def test_get_orientation_all_values(self):
+        """All 8 EXIF orientation values are correctly read from raw bytes."""
+        for orientation in range(1, 9):
+            data = _make_jpeg_with_orientation(16, 12, orientation=orientation)
+            self.assertEqual(
+                _get_exif_orientation(data),
+                orientation,
+                f"orientation {orientation} not read correctly",
+            )
+
+    def test_get_orientation_non_jpeg_returns_1(self):
+        """PNG inputs have no EXIF orientation and return 1."""
+        data = _png_bytes("RGB")
+        self.assertEqual(_get_exif_orientation(data), 1)
+
+    def test_get_orientation_malformed_returns_1(self):
+        """Malformed bytes never raise — they degrade to orientation 1."""
+        self.assertEqual(_get_exif_orientation(b"not an image"), 1)
+        self.assertEqual(_get_exif_orientation(b""), 1)
+        # JPEG magic bytes but truncated body
+        self.assertEqual(_get_exif_orientation(b"\xff\xd8\xff\xe0"), 1)
+
+    def test_get_orientation_out_of_range_returns_1(self):
+        """Orientation values outside 1-8 are clamped to 1 (no rotation)."""
+        # Manually craft a JPEG with orientation=99 (invalid)
+        img = Image.new("RGB", (8, 8), color=(128, 128, 128))
+        exif = img.getexif()
+        exif[0x0112] = 99
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG", exif=exif)
+        self.assertEqual(_get_exif_orientation(buf.getvalue()), 1)
+
+    # ------------------------------------------------------------------
+    # _load_image CPU path (no CUDA required)
+    # ------------------------------------------------------------------
+
+    def test_load_image_cpu_all_orientations_match_exif_transpose(self):
+        """For every EXIF orientation value, ``_load_image`` on the CPU path
+        produces pixels identical to ``PIL.ImageOps.exif_transpose`` applied
+        to the same input. This single parity assertion eliminates every
+        transpose/flip sign error."""
+        from sglang.srt.utils.common import _load_image
+
+        for orientation in range(1, 9):
+            data = _make_jpeg_with_orientation(24, 16, orientation=orientation)
+            result = _load_image(image_bytes=data, gpu_image_decode=False)
+            self.assertIsInstance(result, Image.Image, f"orientation {orientation}")
+            ref = ImageOps.exif_transpose(Image.open(io.BytesIO(data)))
+            np.testing.assert_array_equal(
+                np.asarray(result),
+                np.asarray(ref),
+                err_msg=f"pixel mismatch for orientation {orientation}",
+            )
+
+    def test_load_image_cpu_no_exif_unchanged(self):
+        """JPEG without EXIF orientation must be returned as-is (no rotation)."""
+        from sglang.srt.utils.common import _load_image
+
+        data = _make_jpeg_with_orientation(16, 12, orientation=1)
+        result = _load_image(image_bytes=data, gpu_image_decode=False)
+        ref = Image.open(io.BytesIO(data))
+        np.testing.assert_array_equal(np.asarray(result), np.asarray(ref))
+
+    def test_load_image_cpu_malformed_exif_no_crash(self):
+        """Malformed EXIF must not cause a crash — image is returned unrotated."""
+        from sglang.srt.utils.common import _load_image
+
+        # Non-image garbage bytes should still go through the CPU path
+        # (Image.open will raise, but _load_image propagates that)
+        with self.assertRaises(Exception):
+            _load_image(image_bytes=b"not an image", gpu_image_decode=False)
+
+    def test_load_image_cpu_corrupt_exif_preserves_image(self):
+        """A valid JPEG with corrupt EXIF metadata must still decode and return
+        unrotated pixels, not raise. This guards against the regression where
+        exif_transpose itself raises on malformed EXIF."""
+        from sglang.srt.utils.common import _load_image
+
+        # Build a valid JPEG, then inject a corrupt APP1/EXIF segment
+        img = Image.new("RGB", (12, 10), color=(50, 100, 150))
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        valid_jpeg = buf.getvalue()
+
+        # Replace the image with one that has corrupt EXIF: prepend a malformed
+        # APP1 segment (valid marker + Exif header + garbage TIFF IFD)
+        import struct
+
+        corrupt_exif = b"Exif\x00\x00"  # Exif header
+        corrupt_exif += b"MM\x00\x2a"  # Big-endian byte order + TIFF magic
+        corrupt_exif += b"\xff\xff\xff\xff"  # IFD offset = huge (corrupt)
+        corrupt_exif += b"\x00" * 20  # garbage padding
+        app1_len = len(corrupt_exif) + 2
+        app1 = b"\xff\xe1" + struct.pack(">H", app1_len) + corrupt_exif
+        corrupt_jpeg = b"\xff\xd8" + app1 + valid_jpeg[2:]
+
+        # The image must decode without raising and return pixels (unrotated
+        # since the corrupt EXIF orientation degrades to 1).
+        result = _load_image(image_bytes=corrupt_jpeg, gpu_image_decode=False)
+        self.assertIsInstance(result, Image.Image)
+
+    def test_safe_exif_transpose_returns_image_on_failure(self):
+        """``_safe_exif_transpose`` must return the original image when
+        exif_transpose raises, never propagate the exception."""
+        from sglang.srt.utils.common import _safe_exif_transpose
+
+        # Use an image with orientation=6 so the code path actually reaches
+        # exif_transpose (orientation 1 short-circuits before calling it).
+        data = _make_jpeg_with_orientation(8, 8, orientation=6)
+        img = Image.open(io.BytesIO(data))
+        with patch(
+            "sglang.srt.utils.common.ImageOps.exif_transpose",
+            side_effect=RuntimeError("bad EXIF"),
+        ):
+            result = _safe_exif_transpose(img)
+            self.assertIs(result, img)
+
+    # ------------------------------------------------------------------
+    # load_image direct-PIL branch
+    # ------------------------------------------------------------------
+
+    def test_load_image_direct_pil_applies_exif_transpose(self):
+        """``load_image`` must normalize a directly-passed PIL Image, not just
+        bytes/paths. This covers the third touch point that vLLM missed in
+        their initial fix (PR #47566)."""
+        for orientation in range(1, 9):
+            data = _make_jpeg_with_orientation(24, 16, orientation=orientation)
+            raw_img = Image.open(io.BytesIO(data))
+            result, result_size = load_image(raw_img, gpu_image_decode=False)
+            self.assertIsInstance(result, Image.Image)
+            ref = ImageOps.exif_transpose(Image.open(io.BytesIO(data)))
+            np.testing.assert_array_equal(
+                np.asarray(result),
+                np.asarray(ref),
+                err_msg=f"direct-PIL pixel mismatch for orientation {orientation}",
+            )
+            self.assertEqual(result_size, (ref.width, ref.height))
+
+    def test_load_image_direct_pil_no_exif_unchanged(self):
+        """A PIL Image with no EXIF orientation must be returned as-is."""
+        img = Image.new("RGB", (16, 12), color=(100, 150, 200))
+        result, result_size = load_image(img, gpu_image_decode=False)
+        np.testing.assert_array_equal(np.asarray(result), np.asarray(img))
+        self.assertEqual(result_size, (16, 12))
+
+    def test_safe_exif_transpose_short_circuits_no_exif(self):
+        """When no EXIF orientation is present, ``_safe_exif_transpose`` must
+        return the exact same object (no copy), preserving lazy/multi-frame
+        image semantics."""
+        from sglang.srt.utils.common import _safe_exif_transpose
+
+        img = Image.new("RGB", (16, 12), color=(100, 150, 200))
+        result = _safe_exif_transpose(img)
+        self.assertIs(result, img)
+
+    # ------------------------------------------------------------------
+    # nvJPEG branch routing (mocked, so no CUDA is required)
+    # ------------------------------------------------------------------
+
+    def test_gpu_branch_skipped_for_nontrivial_orientation(self):
+        """The nvJPEG branch returns raw sensor pixels and cannot apply EXIF
+        orientation. When a non-trivial orientation is present, ``_load_image``
+        must not call ``decode_jpeg`` at all and must return an already-rotated
+        PIL Image instead.
+
+        This is the regression guard for the primary path: on a CUDA server
+        every JPEG is routed to nvJPEG, so a CPU-only fix would be a no-op for
+        real phone photos."""
+        from sglang.srt.utils import common as common_mod
+
+        for orientation in range(2, 9):
+            data = _make_jpeg_with_orientation(24, 16, orientation=orientation)
+            with patch.object(
+                common_mod, "is_jpeg_with_cuda", return_value=True
+            ), patch.object(common_mod, "decode_jpeg") as mock_decode:
+                result = common_mod._load_image(image_bytes=data, gpu_image_decode=True)
+            mock_decode.assert_not_called()
+            self.assertIsInstance(result, Image.Image)
+            ref = ImageOps.exif_transpose(Image.open(io.BytesIO(data)))
+            np.testing.assert_array_equal(
+                np.asarray(result),
+                np.asarray(ref),
+                err_msg=f"gpu-branch fallback mismatch for orientation {orientation}",
+            )
+
+    def test_gpu_branch_used_for_trivial_orientation(self):
+        """The common case (orientation 1 or absent) must still take the fast
+        nvJPEG path, so the fix costs nothing for unrotated images."""
+        import torch
+
+        from sglang.srt.utils import common as common_mod
+
+        data = _make_jpeg_with_orientation(24, 16, orientation=1)
+        sentinel = torch.zeros(3, 16, 24, dtype=torch.uint8)
+        with patch.object(
+            common_mod, "is_jpeg_with_cuda", return_value=True
+        ), patch.object(
+            common_mod, "decode_jpeg", return_value=sentinel
+        ) as mock_decode:
+            result = common_mod._load_image(image_bytes=data, gpu_image_decode=True)
+        mock_decode.assert_called_once()
+        self.assertIs(result, sentinel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #33464

## Motivation

JPEG images produced by phone cameras (iOS/Android) routinely carry an EXIF `Orientation`
tag — typically `6` (rotate 90° CW). Browsers, image viewers and OS thumbnailers apply this
tag automatically, but SGLang's image ingestion never does. The model therefore receives raw
sensor pixels while the human who uploaded the photo sees a rotated image.

The failure is silent: no error, no warning, just degraded OCR / spatial / grounding quality,
plus a human-vs-model visual mismatch.

Reproduction: a 640×480 JPEG with a red bar on the left edge and a green bar on the bottom
edge, tagged `Orientation=6`, is described by a served VLM as *"red on the left, green on the
bottom"*. A human viewing the same file sees red on **top** and green on the **left**. Baking
the rotation into the pixels makes the model answer correctly.

## What this changes

Three paths in `python/sglang/srt/utils/common.py` decode user images, and all three ignored
EXIF orientation. Fixing only one leaves a live bypass, so this PR covers all three:

**1. `_load_image()` nvJPEG branch — the primary path, and the reason a CPU-only fix is not
enough.** `is_jpeg_with_cuda()` routes *every* JPEG to `torchvision.io.decode_jpeg` on a CUDA
server and returns before `Image.open` is ever reached. nvJPEG decodes the bitstream and never
consults EXIF. Since phone photos are JPEG, this is exactly the path real rotated images take.

Fix: read the orientation from the header (`Image.open` is lazy, so this parses header + EXIF
only, no pixel decode) and, when it is non-trivial, fall through to the PIL path rather than
using nvJPEG. This keeps PIL's `exif_transpose` as the single ground-truth implementation
instead of hand-rolling tensor transposes for all 8 orientation values. Images with
orientation `1` or no EXIF — the overwhelming majority — still take the fast GPU path, so
there is no throughput regression for the common case.

**2. `_load_image()` CPU fallback.** `Image.open` does not auto-apply EXIF; `ImageOps.exif_transpose`
is the canonical normalization.

**3. `load_image()` direct-PIL branch.** `isinstance(image_file, Image.Image)` returned the
image untouched, bypassing `_load_image()` entirely.

A small helper `_get_exif_orientation()` reads the tag from raw bytes and returns `1` for
missing, malformed, or out-of-range EXIF; `_safe_exif_transpose()` wraps the transpose so that
broken metadata can never turn a decodable image into an exception, and short-circuits when no
rotation is needed so unrotated (and multi-frame) images are not eagerly copied.

## Consistency with the rest of the repo

`python/sglang/multimodal_gen/runtime/utils/vision.py` already calls
`PIL.ImageOps.exif_transpose`. The diffusion side normalizes orientation; the VLM serving path
did not. This PR removes that inconsistency.

## Prior art

vLLM shipped the equivalent fix in **#44974** ("Fix image EXIF orientation and tRNS transparency
handling") and then had to follow up a month later with **#47566** ("Normalize direct PIL image
inputs") because the direct-PIL branch was missed the first time. This PR deliberately covers
that branch in the same pass.

Scope is intentionally limited to EXIF orientation; the PNG `tRNS` transparency half of the
vLLM change is a separate concern and is not included here.

## Tests

`test/registered/unit/multimodal/test_base_processor_image_decode.py` — CPU-only, no server,
no model load:

- all 8 orientation values, asserting pixel-identical output to `PIL.ImageOps.exif_transpose`
  (a parity assertion, so no transpose/flip sign error can survive)
- nvJPEG routing, mocked so it needs no CUDA: `decode_jpeg` must **not** be called when
  orientation is non-trivial, and must **still** be called when it is trivial
- the direct-PIL branch across all 8 orientations, including the returned `image_size`
- no-EXIF, malformed bytes, corrupt EXIF inside an otherwise valid JPEG, out-of-range
  orientation values, and non-JPEG input
- `_safe_exif_transpose` returning the original image on failure, and short-circuiting
  without a copy when no rotation is required
