### PR TITLE
[CI] Build the Rust extensions on the 5090 pool and seed the cache from main

### DIFF
--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -150,8 +150,18 @@ jobs:
         run: |
           set -euxo pipefail
           export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
-          # Same path ci_install_dependency.sh uses: one warm cargo cache per host.
+          # Same path ci_install_dependency.sh uses, so a runner that also runs
+          # test stages keeps one warm cargo cache. That script drops the tree
+          # under disk pressure; repeat the guard here, since nothing else prunes
+          # it on a runner that only ever builds.
           export CARGO_TARGET_DIR="${HOME}/.cache/sglang-cargo-target"
+          mkdir -p "${CARGO_TARGET_DIR}"
+          used="$(df --output=pcent "${CARGO_TARGET_DIR}" 2>/dev/null | tr -dc '0-9')"
+          if [ "${used:-0}" -ge 85 ]; then
+              echo "cargo target dir filesystem at ${used}%; dropping ${CARGO_TARGET_DIR}"
+              rm -rf "${CARGO_TARGET_DIR}"
+              mkdir -p "${CARGO_TARGET_DIR}"
+          fi
           python3 -m pip install --upgrade pip
           command -v uv >/dev/null 2>&1 || pip install uv
           # build_rust needs only the build backend, not sglang's ~294 runtime deps.

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -150,10 +150,9 @@ jobs:
         run: |
           set -euxo pipefail
           export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:${PATH}"
-          # Same path ci_install_dependency.sh uses, so a runner that also runs
-          # test stages keeps one warm cargo cache. That script drops the tree
-          # under disk pressure; repeat the guard here, since nothing else prunes
-          # it on a runner that only ever builds.
+          # Same path ci_install_dependency.sh uses, so a runner that also runs test
+          # stages keeps one warm cache. Its guard is repeated here because nothing
+          # prunes the tree on a runner that only ever builds.
           export CARGO_TARGET_DIR="${HOME}/.cache/sglang-cargo-target"
           mkdir -p "${CARGO_TARGET_DIR}"
           used="$(df --output=pcent "${CARGO_TARGET_DIR}" 2>/dev/null | tr -dc '0-9')"

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -176,6 +176,22 @@ jobs:
           MAX_GLIBC: ${{ inputs.max_glibc }}
         run: bash scripts/ci/utils/stage_rust_ext_modules.sh
 
+      # actions/cache identifies an entry by key *and* a version derived from the
+      # compression tool, so a runner without zstd saves what the hosted restore job
+      # cannot find - a silent miss every run. Warn, not fail: a cold build still works.
+      - name: Ensure zstd so the restore job can read what this job saves
+        run: |
+          set -uo pipefail
+          if ! command -v zstd >/dev/null 2>&1; then
+              if [ "$(id -u)" = "0" ]; then SUDO=""
+              elif command -v sudo >/dev/null 2>&1; then SUDO="sudo"
+              else SUDO=""; fi
+              ${SUDO} apt-get update || true
+              ${SUDO} apt-get install -y --no-install-recommends zstd || true
+          fi
+          command -v zstd >/dev/null 2>&1 \
+              || echo "::warning::zstd unavailable on ${RUNNER_NAME:-this runner}; the cache entry saved below will not be readable by the restore job"
+
       # After the verify step, so a rejected build cannot poison this key for every
       # later run.
       - name: Save built modules

--- a/.github/workflows/pr-test-extra.yml
+++ b/.github/workflows/pr-test-extra.yml
@@ -144,7 +144,7 @@ jobs:
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     uses: ./.github/workflows/_pr-test-rust-ext-build.yml
     with:
-      runs_on: x64-kernel-build-node
+      runs_on: 1-gpu-5090
       artifact_name: rust-ext-x86_64-extra
       git_ref: ${{ inputs.git_ref || '' }}
       skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -226,7 +226,7 @@ jobs:
       (needs.call-gate.result == 'success' || needs.call-gate.result == 'skipped')
     uses: ./.github/workflows/_pr-test-rust-ext-build.yml
     with:
-      runs_on: x64-kernel-build-node
+      runs_on: 1-gpu-5090
       git_ref: ${{ inputs.git_ref || '' }}
       skip_pr_test_health_check: ${{ inputs.skip_pr_test_health_check == true }}
     secrets: inherit

--- a/.github/workflows/seed-rust-ext-cache.yml
+++ b/.github/workflows/seed-rust-ext-cache.yml
@@ -1,9 +1,8 @@
 name: Seed Rust Ext Cache
 
-# A cache entry is only visible to every PR when it was written from the default
-# branch's ref, and pr-test.yml has no push trigger - so after a merge that changes
-# the key, every PR misses and compiles for itself until the next scheduled run, up
-# to 12h later. Seed it here instead, once per merge that can move the key.
+# A cache entry only reaches every PR when it was written from the default branch's
+# ref, and pr-test.yml has no push trigger - so a merge that moves the key leaves
+# every PR compiling for itself until the next scheduled run, up to 12h later.
 
 on:
   push:
@@ -18,8 +17,8 @@ concurrency:
   group: seed-rust-ext-cache
   cancel-in-progress: true
 
-# issues: read is what check-maintenance needs to reach the maintenance issue;
-# declaring permissions at all drops everything not listed here.
+# Declaring permissions at all drops everything not listed, and check-maintenance
+# needs issues: read to reach the maintenance issue.
 permissions:
   contents: read
   issues: read

--- a/.github/workflows/seed-rust-ext-cache.yml
+++ b/.github/workflows/seed-rust-ext-cache.yml
@@ -18,9 +18,11 @@ concurrency:
   group: seed-rust-ext-cache
   cancel-in-progress: true
 
+# issues: read is what check-maintenance needs to reach the maintenance issue;
+# declaring permissions at all drops everything not listed here.
 permissions:
-  actions: write
   contents: read
+  issues: read
 
 jobs:
   seed:

--- a/.github/workflows/seed-rust-ext-cache.yml
+++ b/.github/workflows/seed-rust-ext-cache.yml
@@ -1,0 +1,30 @@
+name: Seed Rust Ext Cache
+
+# A cache entry is only visible to every PR when it was written from the default
+# branch's ref, and pr-test.yml has no push trigger - so after a merge that changes
+# the key, every PR misses and compiles for itself until the next scheduled run, up
+# to 12h later. Seed it here instead, once per merge that can move the key.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'rust/**'
+      - 'python/setup.py'
+  workflow_dispatch:
+
+# Only the newest merge needs to seed; earlier ones are already stale.
+concurrency:
+  group: seed-rust-ext-cache
+  cancel-in-progress: true
+
+permissions:
+  actions: write
+  contents: read
+
+jobs:
+  seed:
+    uses: ./.github/workflows/_pr-test-rust-ext-build.yml
+    with:
+      runs_on: 1-gpu-5090
+    secrets: inherit

--- a/rust/sglang-server/src/fsm.rs
+++ b/rust/sglang-server/src/fsm.rs
@@ -16,7 +16,6 @@ use crate::error::Error;
 
 // `Failed(Error)` carries the cause for observability even where it isn't read
 // back yet; `EncodeDone` belongs to the deferred Encoder edge.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub enum RequestState {
     Received,

--- a/rust/sglang-server/src/utils/regex.rs
+++ b/rust/sglang-server/src/utils/regex.rs
@@ -263,7 +263,6 @@ fn cache_bound(pattern: &str, max_len: usize) {
 /// can pair one pattern's bound with another's, and there is no second route to a
 /// bound that could drift from the validated one.
 pub struct RegexPattern<'a> {
-    #[allow(dead_code)]
     pattern: &'a str,
     max_len: usize,
 }
@@ -310,7 +309,6 @@ impl<'a> RegexPattern<'a> {
         Ok(Self { pattern, max_len })
     }
 
-    #[allow(dead_code)]
     /// The admitted pattern. See the field note on why this is kept.
     #[allow(dead_code)]
     pub fn pattern(&self) -> &str {

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -673,6 +673,19 @@ if spec.origin != want:
 print(f"sglang resolves to {spec.origin}")
 '
 
+    # Import, not find_spec: the finders locate an extension without dlopening it,
+    # so a .so that cannot load passes find_spec and only fails inside some suite.
+    python3 -c '
+import importlib
+for mod in ("server", "grpc", "multimodal"):
+    name = f"sglang.srt.{mod}._core"
+    try:
+        importlib.import_module(name)
+    except Exception as exc:
+        raise SystemExit(f"{name} is present but does not load: {exc!r}")
+    print(f"{name} loads")
+'
+
     mark_step_done "${FUNCNAME[0]}"
 }
 


### PR DESCRIPTION
Follows up on #33384.

```mermaid
flowchart TB
    K[("cache · rust/** hash")]
    R["restore · hosted"]
    C["compile · 5090"]
    S["16 install steps"]
    F["build during install"]

    K --> R
    R ==>|hit| S
    R -->|miss| C
    C -->|save| K
    C ==>|artifact| S
    S -.-> F
```

## Changes
- Compile on `1-gpu-5090` instead of `x64-kernel-build-node`, a single runner that also serves the sgl-kernel and docker builds. Same image as the stages it feeds, so the ABI tag matches and the modules still require only `glibc <= 2.34` - measured on this PR's run, not assumed
- Apply the same 85% disk-pressure guard to `CARGO_TARGET_DIR` that `ci_install_dependency.sh` already applies. The target dir is per runner container, and nothing prunes it on a runner that only ever builds
- Add `seed-rust-ext-cache.yml`: `push` to main filtered on `rust/**` and `python/setup.py`, the same paths the cache key hashes. A cache entry only reaches every PR when it was written from the default branch's ref, and `pr-test.yml` has no `push` trigger - so before this, a merge that moved the key left every PR compiling for itself until the next scheduled run, up to 12h later
- Drop three `#[allow(dead_code)]` that no longer suppress anything, one of them duplicated on the same function. Found by swapping every `allow` for `expect`: the remaining eight are still load-bearing, and one of those is fulfilled only in the `--lib` build, so checking `--all-targets` alone would have dropped it wrongly

## Test Plan
- Both callers are wired: `pr-test.yml` (18 consumers) and `pr-test-extra.yml` (10 consumers), each with its build job listed in its own `*-finish` needs. `artifact_name` is suffixed per caller while `cache_key_prefix` stays shared, so the two runs reuse one build but never collide on an artifact name
- The `rust/**` change above moves the cache key, so this PR's own run exercised the compile path end to end: 2s queued on the pool, 3m23s to build, cargo reporting 607 `Fresh` against 16 `Compiling`, modules requiring `glibc <= 2.34`, then cache saved and artifact uploaded

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30879730257](https://github.com/sgl-project/sglang/actions/runs/30879730257)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30879730126](https://github.com/sgl-project/sglang/actions/runs/30879730126)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

