### PR TITLE
[AMD] Bump mori to latest in sglang

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -116,7 +116,7 @@ ARG ENABLE_MORI=0
 ARG NIC_BACKEND=none
 
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
-ARG MORI_COMMIT="f7e6ac6863c53821bc7afb91a578cc6ce38fcad0"
+ARG MORI_COMMIT="12d1bc32d0c93dcd5062e74f4e0f772e36e1aac4"
 
 # NIXL (upstream ai-dynamo/nixl) — KV transfer backend for prefill/decode disaggregation.
 # Built from source for ROCm; needs UCX built --with-rocm (built here from openucx).


### PR DESCRIPTION
## Motivation

Upgrade the mori pin in the ROCm image. The current pin predates our bootstrap-timeout fix (ROCm/mori#493), which makes the MORI rendezvous timeout configurable via `MORI_BOOTSTRAP_TIMEOUT` and fixes intermittent EP16 bootstrap failures.

## Modification

Bump `MORI_COMMIT` in `docker/rocm.Dockerfile` to `12d1bc32` (includes #493).