### PR TITLE
[CI] Fix scheduler max new tokens test fixture

### DIFF
--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -46,6 +46,7 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
         scheduler.max_req_len = max_req_len
         scheduler.max_total_num_tokens = max_total_num_tokens
         scheduler.page_size = page_size
+        scheduler.server_args = SimpleNamespace(dcp_size=1)
         scheduler.max_new_tokens_limit = envs.SGLANG_MAX_NEW_TOKENS_LIMIT.get()
         return scheduler
 


### PR DESCRIPTION
## Summary

Fix the scheduler max-new-tokens test fixture now that #33448 reads `dcp_size` from `server_args`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30873436716](https://github.com/sgl-project/sglang/actions/runs/30873436716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30873436670](https://github.com/sgl-project/sglang/actions/runs/30873436670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->