### PR TITLE
Add @Jiminator as codeowner for Laguna model and config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -104,3 +104,5 @@
 /python/sglang/srt/speculative/frozen_kv_mtp_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl @pyc96
 /python/sglang/kernels/ops/speculative/ngram_*.py @hnyls2002 @Qiaolin-Yu @kpham-sgl
 /python/sglang/kernels/jit/csrc/ngram_corpus @hnyls2002 @Qiaolin-Yu @kpham-sgl
+/python/sglang/srt/models/laguna.py @Jiminator
+/python/sglang/srt/configs/laguna.py @Jiminator


### PR DESCRIPTION
## Motivation

Laguna support (`poolside/Laguna-XS.2`, `Laguna-XS-2.1`, `Laguna-S-2.1`, `Laguna-M.1`) has no `CODEOWNERS` entry today, so Laguna-touching PRs don't route a review request automatically. Adding myself for the two Laguna source files.

## Modifications

Two lines appended to `.github/CODEOWNERS`:

```
/python/sglang/srt/models/laguna.py @Jiminator
/python/sglang/srt/configs/laguna.py @Jiminator
```

This follows the existing per-model precedent in the same file — `/python/sglang/srt/models/deepseek_v2.py`, `/python/sglang/srt/models/gemma4_*.py`, `/python/sglang/srt/models/transformers.py`.

Note `/python/sglang/srt/configs/` has no owner entry currently; this adds coverage only for the Laguna config, not the directory.

## Checklist

- [x] Single-file change, no code paths touched
- [x] Paths verified to exist on `main`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30874746123](https://github.com/sgl-project/sglang/actions/runs/30874746123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30874745996](https://github.com/sgl-project/sglang/actions/runs/30874745996)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->