### PR TITLE
config: pass the Ray placement group as a launch argument

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -213,6 +213,10 @@ class Engine(EngineScoreMixin, EngineBase):
     run_scheduler_process_func: Callable = staticmethod(run_scheduler_process)
     run_detokenizer_process_func: Callable = staticmethod(run_detokenizer_process)
 
+    # Backend-specific launch handle: the Ray engine schedules its actors onto a
+    # placement group. Not config — a live cluster object.
+    _placement_group = None
+
     def __init__(self, **kwargs):
         """
         The arguments of this function is the same as `sglang/srt/server_args.py::ServerArgs`.
@@ -264,6 +268,7 @@ class Engine(EngineScoreMixin, EngineBase):
             init_tokenizer_manager_func=self.init_tokenizer_manager_func,
             run_scheduler_process_func=self.run_scheduler_process_func,
             run_detokenizer_process_func=self.run_detokenizer_process_func,
+            placement_group=self._placement_group,
         )
         self.tokenizer_manager = tokenizer_manager
         self.template_manager = template_manager
@@ -825,6 +830,8 @@ class Engine(EngineScoreMixin, EngineBase):
         server_args: ServerArgs,
         port_args: PortArgs,
         run_scheduler_process_func: Callable,
+        *,
+        placement_group=None,
     ) -> Tuple[SchedulerInitResult, Optional[List]]:
         """Launch scheduler processes using multiprocessing.
         Override in subclasses for different backends (e.g. Ray).
@@ -1029,6 +1036,7 @@ class Engine(EngineScoreMixin, EngineBase):
         run_scheduler_process_func: Callable,
         run_detokenizer_process_func: Callable,
         port_args: Optional[PortArgs] = None,
+        placement_group=None,
     ) -> Tuple[
         TokenizerManager,
         TemplateManager,
@@ -1089,8 +1097,13 @@ class Engine(EngineScoreMixin, EngineBase):
             weight_cache_daemon_procs = cls._launch_weight_cache_daemons(server_args)
 
         # Launch scheduler processes
+        # Passed only when there is one: this hook is an override point, and a
+        # subclass written against the three-argument signature must keep working.
+        launch_kwargs = (
+            {"placement_group": placement_group} if placement_group is not None else {}
+        )
         scheduler_init_result, scheduler_procs = cls._launch_scheduler_processes(
-            server_args, port_args, run_scheduler_process_func
+            server_args, port_args, run_scheduler_process_func, **launch_kwargs
         )
         scheduler_init_result.engine_info_bootstrap_server = (
             engine_info_bootstrap_server

--- a/python/sglang/srt/ray/data_parallel_controller.py
+++ b/python/sglang/srt/ray/data_parallel_controller.py
@@ -52,11 +52,13 @@ class RayDataParallelController(DataParallelController):
         placement_group,
         bundle_for_node: Optional[List[int]],
         rank0_node_ip: str,
+        is_custom_pg: bool = False,
     ):
         # Set Ray-specific attributes BEFORE super().__init__() because the
         # parent constructor calls launch_dp_schedulers / launch_dp_attention_schedulers
         # which we override, and those methods need these attributes.
         self.pg = placement_group
+        self.is_custom_pg = is_custom_pg
         self.bundle_for_node = bundle_for_node
         self.rank0_node_ip = rank0_node_ip
         self.scheduler_actors: List = []
@@ -137,7 +139,7 @@ class RayDataParallelController(DataParallelController):
         nnodes = server_args.nnodes
         batch_start_idx = len(self.scheduler_actors)
 
-        if self.server_args.placement_group is None:
+        if not self.is_custom_pg:
             for node_idx in range(nnodes):
                 bundle_idx = self.bundle_for_node[node_idx]
                 pp_range, tp_range, pp_per_node, tp_per_node = _calculate_rank_ranges(

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -230,12 +230,12 @@ class RayEngine(Engine):
     """Engine using Ray actors for scheduler processes."""
 
     def __init__(self, **kwargs):
-        placement_group = kwargs.pop("placement_group", None)
+        # Set before super().__init__(): it launches the subprocesses, which need
+        # the group to schedule the scheduler actors onto.
+        self._placement_group = kwargs.pop("placement_group", None)
         if "log_level" not in kwargs:
             kwargs["log_level"] = "error"
-        server_args = ServerArgs(**kwargs)
-        server_args.override("ray.placement_group", placement_group=placement_group)
-        super().__init__(server_args=server_args)
+        super().__init__(server_args=ServerArgs(**kwargs))
 
     def shutdown(self):
         """Shutdown the engine — kill Ray scheduler actors then local processes."""
@@ -252,6 +252,8 @@ class RayEngine(Engine):
         server_args: ServerArgs,
         port_args: PortArgs,
         run_scheduler_process_func: Callable,
+        *,
+        placement_group=None,
     ) -> tuple[SchedulerInitResult, None]:
         """Launch schedulers as Ray actors.
 
@@ -259,7 +261,7 @@ class RayEngine(Engine):
             Tuple of (RaySchedulerInitResult, None).
             scheduler_procs is None since Ray uses actors instead of mp.Process.
         """
-        pg = server_args.placement_group or ray.util.get_current_placement_group()
+        pg = placement_group or ray.util.get_current_placement_group()
         if pg is None:
             from ray.util.placement_group import (
                 placement_group as create_placement_group,
@@ -288,7 +290,7 @@ class RayEngine(Engine):
             )
             ray.get(pg.ready())
 
-        is_custom_pg = server_args.placement_group is not None
+        is_custom_pg = placement_group is not None
         nnodes = server_args.nnodes
         world_size = _compute_world_size(server_args)
 
@@ -424,6 +426,7 @@ class RayEngine(Engine):
                     pg,
                     bundle_for_node,
                     rank0_node_ip,
+                    is_custom_pg,
                 ),
                 None,
             )
@@ -436,6 +439,7 @@ class RayEngine(Engine):
         pg,
         bundle_for_node: Optional[List[int]],
         rank0_node_ip: str,
+        is_custom_pg: bool = False,
     ) -> RaySchedulerInitResult:
         """Launch DP schedulers via RayDataParallelController."""
         from sglang.srt.ray.data_parallel_controller import (
@@ -461,16 +465,10 @@ class RayEngine(Engine):
             server_args,
             dist_init_addr=f"{rank0_node_ip}:{port_args.nccl_port}",
         )
-        # dataclasses.replace only copies declared fields; placement_group is
-        # a dynamic attribute that must be manually appended after the rebuild.
-        dp_server_args.override(
-            "ray.placement_group", placement_group=server_args.placement_group
-        )
-
         # Create the DP controller in-process. This blocks until all actors
         # are initialized and their event loops have started.
         controller = RayDataParallelController(
-            dp_server_args, port_args, pg, bundle_for_node, rank0_node_ip
+            dp_server_args, port_args, pg, bundle_for_node, rank0_node_ip, is_custom_pg
         )
 
         # Start the DP controller's event loop in a daemon thread.

--- a/python/sglang/srt/ray/http_server.py
+++ b/python/sglang/srt/ray/http_server.py
@@ -44,8 +44,6 @@ def launch_server(
     if execute_warmup_func is None:
         execute_warmup_func = _execute_server_warmup
 
-    server_args.override("ray.http_server.clear_placement_group", placement_group=None)
-
     (
         tokenizer_manager,
         template_manager,

--- a/test/registered/unit/test_server_args_writer_ratchet.py
+++ b/test/registered/unit/test_server_args_writer_ratchet.py
@@ -49,7 +49,7 @@ _EXCLUDED = (
     "multimodal_gen",
 )
 
-_BASELINE = 18
+_BASELINE = 15
 
 
 class TestServerArgsWriterRatchet(CustomTestCase):


### PR DESCRIPTION
**Unit 1 of 6** of the config close-out series — **base is main**, so this PR
shows exactly its own commit (`10bd50b7b0`). Whole-series diff, full CI and cross-unit
review: **#33486** (carrier, not for merge).

Merge order is 1 → 6; the base is retargeted to `main` at merge time (a chained base
puts the set into GitHub's stacked-PR mode, which blocks `--admin` merges).

## What

`RayEngine` set the caller's live `PlacementGroup` on `ServerArgs` as an
**undeclared attribute**, so `dataclasses.replace` dropped it (the DP path
re-attached it by hand), the HTTP launcher had to write `placement_group=None` to
clear it, and the DP controller asked the config whether the group was the
caller's. A live cluster handle is not config: it travels as a `placement_group`
argument on the two launch hooks, with `is_custom_pg` passed down explicitly.
`RayEngine(placement_group=pg, …)` is unchanged, as is the ambient-group fallback.

## Validation

Rebased onto main `4494fb96b2`; this unit is commit `0a1937c1b6`.

Full registered CPU battery (16 partitions) on the whole series vs its base: 5641 cases /
5146 passed / 363 bad against main's 5283 / 4784 / 371 — **no new failures** (the two
`test_model_file_verifier` "intact" cases in the raw diff fail identically on the base
commit when the file is run in isolation; they launch real servers). Attention unittests
202 passed / 571 subtests / 0 failed. Spec e2e on H200: EAGLE3 lossless parity, the fa3
suite (21), topk16 + `--speculative-token-map` (42), FROZEN_KV_MTP, dspark draft path,
dflash (3 pre-existing failures, identical on base), MiMo-V2-Flash tp4×dp2 (gsm8k 0.7953,
accept length 3.3849), EAGLE3 dp-attention, HiCache file backend, MLA split backends, Ray
custom placement group. The Blackwell-only legs (SM100 GDN prefill default, the scoped
load-format window, the fa4-draft KV dtype read on the final commit) were run separately
on 8×B300 / 4×B200 — all four items PASS.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31065691650](https://github.com/sgl-project/sglang/actions/runs/31065691650)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31065691572](https://github.com/sgl-project/sglang/actions/runs/31065691572)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->