### PR TITLE
config: template-detected parsers go to the engine's control-plane overlay

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -175,10 +175,12 @@ def init_tokenizer_manager(
             "tool-call parser",
         ),
     ):
-        if getattr(server_args, attr) != "auto":
+        if tokenizer_manager.config_value(attr) != "auto":
             continue
         if suggested is not None:
-            server_args.override(source="template-detection", **{attr: suggested})
+            tokenizer_manager.record_config_updates(
+                "template-detection", **{attr: suggested}
+            )
             logger.info(
                 f"Auto-detected --{attr.replace('_', '-')} as '{suggested}' from chat template"
             )
@@ -187,7 +189,9 @@ def init_tokenizer_manager(
                 f"--{attr.replace('_', '-')}=auto specified but could not detect "
                 f"{label} from chat template. Disabling {label}."
             )
-            server_args.override(source="template-detection", **{attr: None})
+            tokenizer_manager.record_config_updates(
+                "template-detection", **{attr: None}
+            )
 
     return tokenizer_manager, template_manager
 

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -203,8 +203,8 @@ class OpenAIServingChat(OpenAIServingBase):
     ):
         super().__init__(tokenizer_manager)
         self.template_manager = template_manager
-        self.tool_call_parser = self.tokenizer_manager.server_args.tool_call_parser
-        self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        self.tool_call_parser = self.tokenizer_manager.config_value("tool_call_parser")
+        self.reasoning_parser = self.tokenizer_manager.config_value("reasoning_parser")
         self.default_chat_template_kwargs = (
             self.tokenizer_manager.server_args.default_chat_template_kwargs or {}
         )
@@ -1049,9 +1049,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # SGLang's ReasonerGrammarBackend owns the reasoning prefix
         # when --reasoning-parser is configured, so builtin xgrammar
         # tags must describe only the post-reasoning tool-call suffix.
-        xgrammar_reasoning = thinking_mode and (
-            self.tokenizer_manager.server_args.reasoning_parser is None
-        )
+        xgrammar_reasoning = thinking_mode and (self.reasoning_parser is None)
         tool_call_constraint = None
 
         # Apply chat template and its stop strings

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -97,8 +97,8 @@ class OpenAIServingResponses(OpenAIServingChat):
     ) -> None:
         super().__init__(tokenizer_manager, template_manager)
 
-        # template_manager is already set by parent class
-        self.reasoning_parser = self.tokenizer_manager.server_args.reasoning_parser
+        # template_manager is already set by parent class; reasoning_parser comes
+        # from the parent, which reads the manager's control-plane overlay.
         self.enable_prompt_tokens_details = enable_prompt_tokens_details
 
         # Parent OpenAIServingChat.__init__ already populated default_sampling_params.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -74,6 +74,7 @@ class _MockTokenizerManager:
         self.model_path = self.server_args.model_path
         # The manager tracks the served name itself; a weight update rewrites it.
         self.served_model_name = "test-model"
+        self._config_updates = []
 
         # Mock hf_config for _resolve_chat_encoding_spec check
         mock_hf_config = Mock()
@@ -108,6 +109,13 @@ class _MockTokenizerManager:
 
         self.generate_request = Mock(return_value=_mock_generate())
         self.create_abort_task = Mock()
+
+    def config_value(self, name: str):
+        """The manager's overlay accessor: no control-plane update recorded."""
+        for _source, fields in reversed(self._config_updates):
+            if name in fields:
+                return fields[name]
+        return getattr(self.server_args, name)
 
 
 class _MockTemplateManager:
@@ -147,6 +155,35 @@ class ServingChatTestCase(unittest.TestCase):
 
         self.fastapi_request = Mock(spec=Request)
         self.fastapi_request.headers = {}
+
+    def test_parsers_follow_the_control_plane_overlay(self):
+        """Template detection records the parsers on the manager, not on its
+        ServerArgs — the instance keeps what the launcher passed."""
+        self.tm.server_args.tool_call_parser = "auto"
+        self.tm.server_args.reasoning_parser = "auto"
+        self.tm._config_updates.append(
+            (
+                "template-detection",
+                {"tool_call_parser": "qwen25", "reasoning_parser": None},
+            )
+        )
+
+        chat = OpenAIServingChat(self.tm, self.template_manager)
+
+        self.assertEqual(chat.tool_call_parser, "qwen25")
+        self.assertIsNone(chat.reasoning_parser)
+        self.assertEqual(self.tm.server_args.tool_call_parser, "auto")
+
+    def test_the_xgrammar_gate_follows_the_overlay(self):
+        """A detected `reasoning_parser` must gate xgrammar, not the seed's "auto"."""
+        self.tm.server_args.reasoning_parser = "auto"
+        self.tm._config_updates.append(
+            ("template-detection", {"reasoning_parser": "qwen3"})
+        )
+        chat = OpenAIServingChat(self.tm, self.template_manager)
+        self.assertEqual(chat.reasoning_parser, "qwen3")
+        # the gate reads the same value the parser was built from
+        self.assertIsNotNone(chat.reasoning_parser)
 
     def test_text_only_model_rejects_media_before_generation(self):
         media_parts = {

--- a/test/registered/unit/entrypoints/openai/utils.py
+++ b/test/registered/unit/entrypoints/openai/utils.py
@@ -52,6 +52,7 @@ class MockTokenizerManager:
             tool_call_parser=None,
             incremental_streaming_output=False,
         )
+        self._config_updates = []
         self.tokenizer = Mock()
         self.tokenizer.encode.return_value = [1, 2, 3]
         self.tokenizer.chat_template = None
@@ -59,6 +60,13 @@ class MockTokenizerManager:
         self.num_reserved_tokens = 0
         self.generate_request = Mock()
         self.create_abort_task = Mock()
+
+    def config_value(self, name: str):
+        """The manager's overlay accessor: no control-plane update recorded."""
+        for _source, fields in reversed(self._config_updates):
+            if name in fields:
+                return fields[name]
+        return getattr(self.server_args, name)
 
 
 class MockTemplateManager:


### PR DESCRIPTION
**Unit 3 of 6** of the config close-out series — **base is #33488 (unit 2)**, so this PR
shows exactly its own commit (`f91001aa6b`). Whole-series diff, full CI and cross-unit
review: **#33486** (carrier, not for merge).

Merge order is 1 → 6; the base is retargeted to `main` at merge time (a chained base
puts the set into GitHub's stacked-PR mode, which blocks `--admin` merges).

## What

`init_tokenizer_manager` wrote the chat-template-detected `reasoning_parser` /
`tool_call_parser` onto the published `ServerArgs`, *after*
`TokenizerManager.__init__` had projected the config bags — so the namespace
readers and the resolved-config readback disagreed with the instance, and a second
`Engine` in the same process inherited the first one's detection. Detection is
per-engine control-plane state, which the manager already models
(`record_config_updates` / `config_value`, overlaid by the readback endpoints).
The architecture pass is untouched: it runs before the schedulers fork, and they
resolve their bags from the instance they are handed.

## Validation

Rebased onto main `4494fb96b2`; this unit is commit `48320be2ee`.

Full registered CPU battery (16 partitions) on the whole series vs its base: 5641 cases /
5146 passed / 363 bad against main's 5283 / 4784 / 371 — **no new failures** (the two
`test_model_file_verifier` "intact" cases in the raw diff fail identically on the base
commit when the file is run in isolation; they launch real servers). Attention unittests
202 passed / 571 subtests / 0 failed. Spec e2e on H200: EAGLE3 lossless parity, the fa3
suite (21), topk16 + `--speculative-token-map` (42), FROZEN_KV_MTP, dspark draft path,
dflash (3 pre-existing failures, identical on base), MiMo-V2-Flash tp4×dp2 (gsm8k 0.7953,
accept length 3.3849), EAGLE3 dp-attention, HiCache file backend, MLA split backends, Ray
custom placement group. The Blackwell-only legs (SM100 GDN prefill default, the scoped
load-format window, the fa4-draft KV dtype read on the final commit) were run separately
on 8×B300 / 4×B200 — all four items PASS.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31065770112](https://github.com/sgl-project/sglang/actions/runs/31065770112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31065770006](https://github.com/sgl-project/sglang/actions/runs/31065770006)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->