### PR TITLE
docs: update cookbook for xpu

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-OCR-2.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-OCR-2.mdx
@@ -30,15 +30,14 @@ For more details, please refer to the [official DeepSeek-OCR-2 repository](https
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
-For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
-
 ## 3. Model Deployment
 
 This section provides deployment configurations optimized for different hardware platforms and use cases.
 
 ### 3.1 Basic Configuration
+The DeepSeek-OCR-2 series offers models in various sizes and architectures, optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, Intel Arc B-series graphics(codename: BMG (Battlemage)), and Intel Xeon CPUs. The recommended launch configurations vary by hardware and model size.
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform, quantization method, and deployment strategy. SGLang supports serving DeepSeek-OCR-2 on NVIDIA H200 and B200, AMD MI300X, MI355X, and MI325X GPUs, as well as Intel Xeon CPUs.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform, quantization method, and deployment strategy. SGLang supports serving DeepSeek-OCR-2 on NVIDIA H200 and B200, AMD MI300X, MI355X, and MI325X GPUs, and Intel Arc Pro B-series XPUs, as well as Intel Xeon CPUs.
 
 <DeepSeekOCR2Deployment />
 

--- a/docs/cookbook/autoregressive/Google/Gemma4.mdx
+++ b/docs/cookbook/autoregressive/Google/Gemma4.mdx
@@ -96,6 +96,7 @@ For other installation methods, please refer to the [official SGLang installatio
 ## 3. Model Deployment
 
 ### 3.1 Basic Configuration
+The Gemma 4 series offers models in various sizes and architectures, optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, Intel Arc B-series graphics(codename: BMG (Battlemage)), and Intel Xeon CPUs. The recommended launch configurations vary by hardware and model size.
 
 **Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and model variant.
 
@@ -152,6 +153,7 @@ For other installation methods, please refer to the [official SGLang installatio
     </tr>
   </tbody>
 </table>
+
 
 ### 3.3 AMD GPU Deployment (MI300X / MI325X / MI355X)
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.1.mdx
+++ b/docs/cookbook/autoregressive/Llama/Llama3.1.mdx
@@ -22,12 +22,9 @@ SGLang offers multiple installation methods. You can choose the most suitable in
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
-For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
-
 ## 3. Model Deployment
 
-This section provides deployment configurations optimized for different hardware platforms and use cases.
-
+This section provides deployment configurations optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, Intel Arc B-series graphics(codename: BMG (Battlemage)), and Intel Xeon CPUs.
 ### 3.1 Basic Configuration
 
 **Interactive Command Generator**: Use the configuration selector below to generate a launch command for Llama 3.1 collection of models.
@@ -56,10 +53,6 @@ import { Llama31Deployment } from "/src/snippets/autoregressive/llama31-deployme
   - 405B: Use Meta's official `meta-llama/Llama-3.1-405B-Instruct-FP8`
   - 70B/8B: Use AMD's optimized `amd/Llama-3.1-{size}-Instruct-FP8-KV`
 - **Tool Calling**: Enable with `--tool-call-parser llama3` for Instruct models
-
-**Xeon CPU Deployment:**
-
-- Please refer to the `Notes` part in the serving engine launching section in [the SGLang CPU server document](../../../docs/hardware-platforms/cpu_server#launch-of-the-serving-engine) to better understand how to configure the arguments, especially for TP (tensor parallel) and NUMA binding settings.
 
 ## 4. Model Invocation
 

--- a/docs/cookbook/autoregressive/Llama/Llama3.3-70B.mdx
+++ b/docs/cookbook/autoregressive/Llama/Llama3.3-70B.mdx
@@ -24,15 +24,13 @@ For more details, please refer to the [official Llama models repository](https:/
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
-For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
-
 ## 3. Model Deployment
 
-This section provides deployment configurations optimized for AMD GPUs (MI300X, MI325X, MI355X) and Intel Xeon CPUs.
+This section provides deployment configurations optimized for AMD GPUs (MI300X, MI325X, MI355X) and Intel Arc B-series graphics(codename: BMG (Battlemage)).
 
 ### 3.1 Interactive Configuration
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your AMD GPU setup.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your AMD GPU or Intel Arc Pro B-series XPUs setup.
 
 import { Llama33Deployment } from "/src/snippets/autoregressive/llama33-70b-deployment.jsx";
 
@@ -46,10 +44,6 @@ import { Llama33Deployment } from "/src/snippets/autoregressive/llama33-70b-depl
 - **FP8 Model Variant**: Use AMD's optimized `amd/Llama-3.3-70B-Instruct-FP8-KV`
 - **Tool Calling**: Enable with `--tool-call-parser llama3` for function calling support
 - **Higher Throughput**: Optional TP=2 or TP=4 can be used for increased throughput
-
-**Xeon CPU Deployment:**
-
-Please refer to the `Notes` part in the serving engine launching section in [the SGLang CPU server document](../../../docs/hardware-platforms/cpu_server#launch-of-the-serving-engine) to better understand how to configure the arguments, especially for TP (tensor parallel) and NUMA binding settings.
 
 ## 4. Model Invocation
 

--- a/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano.mdx
+++ b/docs/cookbook/autoregressive/NVIDIA/Nemotron3-Nano.mdx
@@ -31,6 +31,8 @@ This section provides a progressive guide from quick deployment to performance t
 
 ### 3.1 Basic Configuration
 
+The Nemotron3-Nano series offers models in various sizes and architectures, optimized for different hardware platforms including NVIDIA GPUs and Intel Arc B-series graphics(codename: BMG (Battlemage)).
+
 **Interactive Command Generator**: select hardware, model variant, and common knobs to generate a launch command.
 
 <Nemotron3NanoDeployment />

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -111,11 +111,9 @@ docker pull lmsysorg/sglang-rocm:v0.5.15.post1-rocm720-mi35x-20260715
 
 For the full Docker setup and other installation methods, please refer to the [official SGLang installation guide](../../../docs/get-started/install).
 
-For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
-
 ## 3. Model Deployment
 
-This section provides deployment configurations optimized for different hardware platforms and use cases.
+This section provides deployment configurations optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, Intel Arc B-series graphics(codename: BMG (Battlemage)), and Intel Xeon CPUs.
 
 ### 3.1 Basic Configuration
 

--- a/docs/cookbook/autoregressive/Qwen/Qwen3.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.mdx
@@ -26,15 +26,13 @@ SGLang offers multiple installation methods. You can choose the most suitable in
 
 Please refer to the [official SGLang installation guide](../../../docs/get-started/install) for installation instructions.
 
-For SGLang CPU installation, please refer to the [CPU version installation guide](../../../docs/hardware-platforms/cpu_server#installation).
-
 ## 3. Model Deployment
 
 This section provides deployment configurations optimized for different hardware platforms and use cases.
 
 ### 3.1 Basic Configuration
 
-The Qwen3 series offers models in various sizes and architectures, optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, and Intel Xeon CPUs. The recommended launch configurations vary by hardware and model size.
+The Qwen3 series offers models in various sizes and architectures, optimized for different hardware platforms including NVIDIA GPUs, AMD GPUs, Intel Arc B-series graphics(codename: BMG (Battlemage)), and Intel Xeon CPUs. The recommended launch configurations vary by hardware and model size.
 
 **Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform, model size, quantization method, and thinking capabilities.
 

--- a/docs/cookbook/diffusion/FLUX/FLUX.mdx
+++ b/docs/cookbook/diffusion/FLUX/FLUX.mdx
@@ -47,7 +47,7 @@ This section provides deployment configurations optimized for different hardware
 
 FLUX models are optimized for high-quality image generation. The recommended launch configurations vary by hardware and model version.
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and model version. SGLang supports serving FLUX on NVIDIA B200, H200, H100, and AMD MI355X, MI325X, MI300X GPUs and Ascend A2, A3 NPUs.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and model version. SGLang supports serving FLUX on NVIDIA B200, H200, H100, and AMD MI355X, MI325X, MI300X GPUs, Ascend A2, A3 NPUs and Intel Arc B-series graphics(codename: BMG (Battlemage)).
 
 <FluxDeployment />
 

--- a/docs/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
+++ b/docs/cookbook/diffusion/Z-Image/Z-Image-Turbo.mdx
@@ -39,7 +39,7 @@ This section provides deployment configurations optimized for different hardware
 
 Z-Image-Turbo is optimized for high-quality image generation with only 8 inference steps. The recommended launch configurations vary by hardware.
 
-**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform.
+**Interactive Command Generator**: Use the configuration selector below to automatically generate the appropriate deployment command for your hardware platform and model version. SGLang supports serving Z-Image-Turbo on NVIDIA B200, H200, H100, and AMD MI355X, MI325X, MI300X GPUs, Ascend A2, A3 NPUs and Intel Arc B-series graphics(codename: BMG (Battlemage)).
 
 <ZImageTurboDeployment />
 

--- a/docs/src/snippets/autoregressive/deepseek-ocr-v2-deployment.jsx
+++ b/docs/src/snippets/autoregressive/deepseek-ocr-v2-deployment.jsx
@@ -10,6 +10,7 @@ export const DeepSeekOCR2Deployment = () => {
         { id: 'mi325x', label: 'MI325X', default: false },
         { id: 'mi355x', label: 'MI355X', default: false },
         { id: 'xeon', label: 'XEON', default: false },
+        { id: 'Arc B', label: 'BMG', default: false },
       ]
     },
     quantization: {
@@ -25,14 +26,15 @@ export const DeepSeekOCR2Deployment = () => {
       type: 'checkbox',
       items: [
         { id: 'tp', label: 'TP', subtitle: 'Tensor Parallel', default: true, required: true },
-        { id: 'dp', label: 'DP', subtitle: 'Data Parallel', default: false, disabledWhen: (v) => v.hardware === 'xeon', disabledReason: 'Intel Xeon CPUs only support Tensor Parallel (TP)' },
-        { id: 'ep', label: 'EP', subtitle: 'Expert Parallel', default: false, disabledWhen: (v) => v.hardware === 'xeon', disabledReason: 'Intel Xeon CPUs only support Tensor Parallel (TP)' }
+        { id: 'dp', label: 'DP', subtitle: 'Data Parallel', default: false, disabledWhen: (v) => v.hardware === 'xeon' || v.hardware === 'Arc B', disabledReason: 'Only Tensor Parallel (TP) is supported on this hardware' },
+        { id: 'ep', label: 'EP', subtitle: 'Expert Parallel', default: false, disabledWhen: (v) => v.hardware === 'xeon' || v.hardware === 'Arc B', disabledReason: 'Only Tensor Parallel (TP) is supported on this hardware' }
       ]
     },
   };
 
   const generateCommand = (values) => {
     const { hardware, strategy } = values;
+    const isArcB = hardware === 'Arc B';
 
     const strategyArray = Array.isArray(strategy) ? strategy : [];
 
@@ -42,6 +44,8 @@ export const DeepSeekOCR2Deployment = () => {
     cmd += `  --model-path ${modelPath}`;
     if (hardware === 'xeon') {
       cmd += ` \\\n  --device cpu \\\n  --disable-overlap-schedule \\\n  --trust-remote-code`;
+    } else if (isArcB) {
+      cmd += ` \\\n  --device xpu`;
     }
     cmd += ` \\\n  --enable-multimodal`;
 
@@ -272,9 +276,8 @@ export const DeepSeekOCR2Deployment = () => {
               ) : option.type === 'checkbox' ? (
                 (option.items || []).map((item) => {
                   const isChecked = (values[option.name] || []).includes(item.id);
-                  const isDisabled =
-                    item.required ||
-                    (typeof item.disabledWhen === 'function' && item.disabledWhen(values));
+                  const dynDisabled = typeof item.disabledWhen === 'function' && item.disabledWhen(values);
+                  const isDisabled = item.required || dynDisabled;
                   return (
                     <label
                       key={item.id}
@@ -289,9 +292,11 @@ export const DeepSeekOCR2Deployment = () => {
                         type="checkbox"
                         checked={isChecked}
                         disabled={isDisabled}
-                        onChange={(event) =>
-                          handleCheckboxChange(option.name, item.id, event.target.checked)
-                        }
+                        onChange={(event) => {
+                          if (!dynDisabled) {
+                            handleCheckboxChange(option.name, item.id, event.target.checked);
+                          }
+                        }}
                         style={{ display: 'none' }}
                       />
                       {item.label}

--- a/docs/src/snippets/autoregressive/gemma4-deployment.jsx
+++ b/docs/src/snippets/autoregressive/gemma4-deployment.jsx
@@ -3,21 +3,27 @@ export const Gemma4Deployment = () => {
     modelSize: {
       name: 'modelSize',
       title: 'Model Variant',
-      items: [
-        { id: 'e2b', label: 'E2B (~2B)', default: false },
-        { id: 'e4b', label: 'E4B (~4B)', default: true },
-        { id: '12b', label: '12B (Dense)', default: false },
-        { id: '31b', label: '31B (Dense)', default: false },
-        { id: '26b-a4b', label: '26B-A4B (MoE)', default: false },
-      ]
+      getDynamicItems: (values) => {
+        const isArcB = values.hardware === 'Arc B';
+        return [
+          { id: 'e2b', label: 'E2B (~2B)', default: false, disabled: isArcB },
+          { id: 'e4b', label: 'E4B (~4B)', default: !isArcB, disabled: isArcB },
+          { id: '12b', label: '12B (Dense)', default: false, disabled: isArcB },
+          { id: '31b', label: '31B (Dense)', default: isArcB, disabled: false },
+          { id: '26b-a4b', label: '26B-A4B (MoE)', default: false, disabled: false },
+        ];
+      }
     },
     checkpoint: {
       name: 'checkpoint',
       title: 'Checkpoint',
-      items: [
-        { id: 'standard', label: 'Standard', subtitle: 'BF16', default: true },
-        { id: 'qat', label: 'QAT', subtitle: 'q4_0-unquantized', default: false },
-      ]
+      getDynamicItems: (values) => {
+        const isArcB = values.hardware === 'Arc B';
+        return [
+          { id: 'standard', label: 'Standard', subtitle: 'BF16', default: true },
+          { id: 'qat', label: 'QAT', subtitle: 'q4_0-unquantized', default: false, disabled: isArcB },
+        ];
+      }
     },
     hardware: {
       name: 'hardware',
@@ -30,6 +36,7 @@ export const Gemma4Deployment = () => {
           { id: 'b200', label: 'B200', default: false },
           { id: 'b300', label: 'B300', default: false },
           { id: 'mi300x', label: 'MI300X', default: false, disabled: !showMI300X },
+          { id: 'Arc B', label: 'BMG', default: false },
         ];
       }
     },
@@ -88,6 +95,10 @@ export const Gemma4Deployment = () => {
       '31b': { tp: 1, mem: 0.80 },
       '26b-a4b': { tp: 1, mem: 0.80 },
     },
+    'Arc B': {
+      '31b': { tp: 4, mem: 0.80 },
+      '26b-a4b': { tp: 4, mem: 0.75 },
+    },
   };
 
   const generateCommand = (values) => {
@@ -139,6 +150,10 @@ export const Gemma4Deployment = () => {
 
     if (hardware === 'b300') {
       cmd += ` \\\n  --attention-backend triton`;
+    }
+
+    if (hardware === 'Arc B') {
+      cmd += ` \\\n  --device xpu`;
     }
 
     cmd += ` \\\n  --mem-fraction-static ${mem}`;
@@ -205,7 +220,16 @@ export const Gemma4Deployment = () => {
   }, []);
 
   const handleRadioChange = (optionName, value) => {
-    setValues((prev) => ({ ...prev, [optionName]: value }));
+    setValues((prev) => {
+      const next = { ...prev, [optionName]: value };
+      if (optionName === 'hardware' && value === 'Arc B') {
+        if (!['31b', '26b-a4b'].includes(next.modelSize)) {
+          next.modelSize = '31b';
+        }
+        next.checkpoint = 'standard';
+      }
+      return next;
+    });
   };
 
   const handleCheckboxChange = (optionName, itemId, isChecked) => {

--- a/docs/src/snippets/autoregressive/llama31-deployment.jsx
+++ b/docs/src/snippets/autoregressive/llama31-deployment.jsx
@@ -11,7 +11,8 @@ export const Llama31Deployment = () => {
         { id: 'mi300x', label: 'MI300X', default: false },
         { id: 'mi325x', label: 'MI325X', default: false },
         { id: 'mi355x', label: 'MI355X', default: false },
-        { id: 'xeon', label: 'XEON', default: false }
+        { id: 'xeon', label: 'XEON', default: false },
+        { id: 'Arc B', label: 'BMG', default: false },
       ]
     },
     modelsize: {
@@ -65,21 +66,28 @@ export const Llama31Deployment = () => {
         ...options.modelsize,
         items: options.modelsize.items.map(item => ({
           ...item,
-          disabled: values.hardware === 'xeon' && item.id !== '8b'
+          disabled: (values.hardware === 'xeon' || values.hardware === 'Arc B') && item.id !== '8b'
+        }))
+      },
+      category: {
+        ...options.category,
+        items: options.category.items.map(item => ({
+          ...item,
+          disabled: values.hardware === 'Arc B' && item.id !== 'instruct'
         }))
       },
       quantization: {
         ...options.quantization,
         items: options.quantization.items.map(item => ({
           ...item,
-          disabled: values.hardware === 'xeon' && item.id === 'fp8'
+          disabled: (values.hardware === 'xeon' && item.id === 'fp8') || (values.hardware === 'Arc B' && item.id !== 'bf16')
         }))
       },
       optimization: {
         ...options.optimization,
         items: options.optimization.items.map(item => ({
           ...item,
-          disabled: values.hardware === 'xeon' && item.id !== 'basic'
+          disabled: (values.hardware === 'xeon' || values.hardware === 'Arc B') && item.id !== 'basic'
         }))
       }
     };
@@ -122,6 +130,12 @@ export const Llama31Deployment = () => {
         next.quantization = 'bf16';
         next.optimization = 'basic';
       }
+      if (optionName === 'hardware' && value === 'Arc B') {
+        next.modelsize = '8b';
+        next.category = 'instruct';
+        next.quantization = 'bf16';
+        next.optimization = 'basic';
+      }
       return next;
     });
   };
@@ -131,6 +145,7 @@ export const Llama31Deployment = () => {
     const { hardware, optimization, modelsize, category, toolcall, quantization } = values;
 
     const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
+    const isArcB = hardware === 'Arc B';
     const isXeon = hardware === 'xeon';
     const effectiveModelSize = isXeon ? '8b' : modelsize;
 
@@ -145,7 +160,7 @@ export const Llama31Deployment = () => {
 
     // Determine model path
     let modelPath;
-    if (quantization === 'fp8' && category === 'instruct' && !isXeon) {
+    if (quantization === 'fp8' && category === 'instruct' && !isXeon && !isArcB) {
       if (effectiveModelSize === '405b') {
         // Meta official FP8 for 405B
         modelPath = `meta-llama/Llama-3.1-${sizeToken}${categorySuffix}-FP8`;
@@ -186,6 +201,8 @@ export const Llama31Deployment = () => {
     } else if (isXeon) {
       // Intel Xeon CPU TP configuration
       tpSize = 3;
+    } else if (isArcB) {
+      tpSize = 1;
     } else {
       // NVIDIA GPU TP configuration
       if (effectiveModelSize === '405b') {
@@ -202,6 +219,8 @@ export const Llama31Deployment = () => {
     if (isXeon) {
       args.push(`--device cpu`);
       args.push(`--disable-overlap-schedule`);
+    } else if (isArcB) {
+      args.push(`--device xpu`);
     }
 
     if (tpSize) {
@@ -209,12 +228,12 @@ export const Llama31Deployment = () => {
     }
 
     // Add quantization flag only if not using FP8 variant model
-    if (quantization === 'fp8' && category !== 'instruct' && !isXeon) {
+    if (quantization === 'fp8' && (isArcB || (category !== 'instruct' && !isXeon))) {
       args.push(`--quantization fp8`);
     }
 
     // NVIDIA-specific optimizations
-    if (!isAMD && !isXeon) {
+    if (!isAMD && !isXeon && !isArcB) {
       if (optimization === 'throughput') {
         args.push(`--enable-dp-attention`);
         args.push(`--mem-fraction-static 0.85`);

--- a/docs/src/snippets/autoregressive/llama33-70b-deployment.jsx
+++ b/docs/src/snippets/autoregressive/llama33-70b-deployment.jsx
@@ -8,7 +8,8 @@ export const Llama33Deployment = () => {
         { id: 'mi300x', label: 'MI300X', default: true },
         { id: 'mi325x', label: 'MI325X', default: false },
         { id: 'mi355x', label: 'MI355X', default: false },
-        { id: 'xeon', label: 'XEON', default: false }
+        { id: 'xeon', label: 'XEON', default: false },
+        { id: 'Arc B', label: 'BMG', default: false }
       ]
     },
     quantization: {
@@ -35,7 +36,7 @@ export const Llama33Deployment = () => {
       ...options.quantization,
       items: options.quantization.items.map(item => ({
         ...item,
-        disabled: values.hardware === 'xeon' && item.id === 'fp8'
+        disabled: (values.hardware === 'xeon' && item.id === 'fp8') || (values.hardware === 'Arc B' && item.id !== 'bf16')
       }))
     }
   });
@@ -74,6 +75,9 @@ export const Llama33Deployment = () => {
       if (optionName === 'hardware' && value === 'xeon') {
         next.quantization = 'bf16';
       }
+      if (optionName === 'hardware' && value === 'Arc B') {
+        next.quantization = 'bf16';
+      }
       return next;
     });
   };
@@ -81,19 +85,24 @@ export const Llama33Deployment = () => {
   // Generate command
   const generateCommand = () => {
     const { hardware, quantization, toolcall } = values;
+    const isArcB = hardware === 'Arc B';
+    const isXeon = hardware === 'xeon';
 
     // Select model based on quantization
-    const modelPath = quantization === 'fp8' && hardware !== 'xeon'
+    const modelPath = quantization === 'fp8' && !isXeon && !isArcB
       ? 'amd/Llama-3.3-70B-Instruct-FP8-KV'
       : 'meta-llama/Llama-3.3-70B-Instruct';
 
     // Build command
     let cmd = 'python -m sglang.launch_server \\\n';
     cmd += `  --model-path ${modelPath} \\\n`;
-    if (hardware === 'xeon') {
+    if (isXeon) {
       cmd += `  --device cpu \\\n`;
       cmd += `  --disable-overlap-schedule \\\n`;
       cmd += `  --tp 6`;
+    } else if (isArcB) {
+      cmd += `  --device xpu \\\n`;
+      cmd += `  --tp 8`;
     } else {
       cmd += `  --tp 1`;
     }

--- a/docs/src/snippets/autoregressive/nemotron3-nano-deployment.jsx
+++ b/docs/src/snippets/autoregressive/nemotron3-nano-deployment.jsx
@@ -8,27 +8,34 @@ export const Nemotron3NanoDeployment = () => {
       items: [
         { id: 'h200', label: 'H200', default: false },
         { id: 'b200', label: 'B200', default: true },
-        { id: 'b300', label: 'B300', default: false }
+        { id: 'b300', label: 'B300', default: false },
+        { id: 'Arc B', label: 'BMG', default: false }
       ]
     },
     modelVariant: {
       name: 'modelVariant',
       title: 'Model Variant',
-      items: [
-        { id: 'bf16', label: 'BF16', default: true },
-        { id: 'fp8', label: 'FP8', default: false },
-        { id: 'nvfp4', label: 'NVFP4', default: false }
-      ]
+      getDynamicItems: (values) => {
+        const isArcB = values.hardware === 'Arc B';
+        return [
+          { id: 'bf16', label: 'BF16', default: true },
+          { id: 'fp8', label: 'FP8', default: false, disabled: isArcB },
+          { id: 'nvfp4', label: 'NVFP4', default: false, disabled: isArcB }
+        ];
+      }
     },
     tp: {
       name: 'tp',
       title: 'Tensor Parallel (TP)',
-      items: [
-        { id: '1', label: 'TP=1', default: true },
-        { id: '2', label: 'TP=2', default: false },
-        { id: '4', label: 'TP=4', default: false },
-        { id: '8', label: 'TP=8', default: false }
-      ]
+      getDynamicItems: (values) => {
+        const isArcB = values.hardware === 'Arc B';
+        return [
+          { id: '1', label: 'TP=1', default: !isArcB, disabled: isArcB },
+          { id: '2', label: 'TP=2', default: false, disabled: isArcB },
+          { id: '4', label: 'TP=4', default: isArcB, disabled: false },
+          { id: '8', label: 'TP=8', default: false, disabled: isArcB }
+        ];
+      }
     },
     kvcache: {
       name: 'kvcache',
@@ -74,6 +81,10 @@ export const Nemotron3NanoDeployment = () => {
     cmd += `  --kv-cache-dtype ${kvcache} \\\n`;
     if (hardware === 'b300') {
       cmd += `  --attention-backend flashinfer \\\n`;
+    }
+
+    if (hardware === 'Arc B') {
+      cmd += `  --device xpu \\n`;
     }
 
     // Add thinking parser and tool call parser if enabled
@@ -153,7 +164,14 @@ export const Nemotron3NanoDeployment = () => {
   }, []);
 
   const handleRadioChange = (optionName, value) => {
-    setValues((prev) => ({ ...prev, [optionName]: value }));
+    setValues((prev) => {
+      const next = { ...prev, [optionName]: value };
+      if (optionName === 'hardware' && value === 'Arc B') {
+        next.modelVariant = 'bf16';
+        next.tp = '4';
+      }
+      return next;
+    });
   };
 
   const handleCheckboxChange = (optionName, itemId, isChecked) => {

--- a/docs/src/snippets/autoregressive/qwen3-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen3-deployment.jsx
@@ -11,7 +11,8 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 4, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 4, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 4, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 6, ep: 0, bf16: true, fp8: true }
+      xeon: { tp: 6, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 6, ep: 0, bf16: true, fp8: true }
     },
     '30b': {
       baseName: '30B-A3B',
@@ -23,7 +24,8 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 4, ep: 0, bf16: true, fp8: true },
     },
     '32b': {
       baseName: '32B',
@@ -35,7 +37,8 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 6, ep: 0, bf16: true, fp8: true }
+      xeon: { tp: 6, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 4, ep: 0, bf16: true, fp8: true }
     },
     '14b': {
       baseName: '14B',
@@ -47,7 +50,9 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 1, ep: 0, bf16: true, fp8: true },
     },
     '8b': {
       baseName: '8B',
@@ -59,7 +64,9 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 1, ep: 0, bf16: true, fp8: true },
     },
     '4b': {
       baseName: '4B',
@@ -71,7 +78,9 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 2, ep: 0, bf16: true, fp8: true },
     },
     '1.7b': {
       baseName: '1.7B',
@@ -83,7 +92,9 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 2, ep: 0, bf16: true, fp8: true },
     },
     '0.6b': {
       baseName: '0.6B',
@@ -95,7 +106,9 @@ export const Qwen3Deployment = () => {
       mi300x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi325x: { tp: 1, ep: 0, bf16: true, fp8: true },
       mi355x: { tp: 1, ep: 0, bf16: true, fp8: true },
-      xeon: { tp: 3, ep: 0, bf16: true, fp8: true }
+      
+      xeon: { tp: 3, ep: 0, bf16: true, fp8: true },
+      'Arc B': { tp: 3, ep: 0, bf16: true, fp8: true },
     }
   };
 
@@ -112,7 +125,9 @@ export const Qwen3Deployment = () => {
         { id: 'mi300x', label: 'MI300X', default: false },
         { id: 'mi325x', label: 'MI325X', default: false },
         { id: 'mi355x', label: 'MI355X', default: false },
-        { id: 'xeon', label: 'XEON', default: false }
+        
+        { id: 'xeon', label: 'XEON', default: false },
+        { id: 'Arc B', label: 'BMG', default: false },
       ]
     },
     modelsize: {
@@ -168,9 +183,28 @@ export const Qwen3Deployment = () => {
   const getDisplayOptions = (values) => {
     const options = { ...baseOptions };
     const currentModelConfig = modelConfigs[values.modelsize];
+    const isArcB = values.hardware === 'Arc B';
+
+    if (isArcB) {
+      options.quantization = {
+        ...baseOptions.quantization,
+        items: baseOptions.quantization.items.map(item => ({
+          ...item,
+          disabled: item.id !== 'bf16'
+        }))
+      };
+
+      options.modelsize = {
+        ...baseOptions.modelsize,
+        items: baseOptions.modelsize.items.map(item => ({
+          ...item,
+          disabled: item.id !== '30b' && item.id !== '32b'
+        }))
+      };
+    }
 
     // If model doesn't have thinking variants, disable non-base category options
-    if (currentModelConfig && !currentModelConfig.hasThinkingVariants) {
+    if (isArcB || (currentModelConfig && !currentModelConfig.hasThinkingVariants)) {
       options.category = {
         ...baseOptions.category,
         items: baseOptions.category.items.map(item => ({
@@ -220,6 +254,14 @@ export const Qwen3Deployment = () => {
     setValues(prev => {
       const newValues = { ...prev, [optionName]: value };
 
+      if (optionName === 'hardware' && value === 'Arc B') {
+        newValues.quantization = 'bf16';
+        if (newValues.modelsize !== '30b' && newValues.modelsize !== '32b') {
+          newValues.modelsize = '32b';
+        }
+        newValues.category = 'base';
+      }
+
       // Auto-switch to 'base' category for models without thinking variants
       if (optionName === 'modelsize') {
         const modelConfig = modelConfigs[value];
@@ -242,10 +284,10 @@ export const Qwen3Deployment = () => {
   // Generate command
   const generateCommand = () => {
     const { hardware, modelsize, quantization, category, reasoningParser, toolcall } = values;
-    const displayOptions = getDisplayOptions(values);
+    const effectiveQuantization = hardware === 'Arc B' ? 'bf16' : quantization;
 
     // Special error handling
-    const commandKey = `${hardware}-${modelsize}-${quantization}-${category}`;
+    const commandKey = `${hardware}-${modelsize}-${effectiveQuantization}-${category}`;
     if (commandKey === 'h100-235b-bf16-instruct' || commandKey === 'h100-235b-bf16-thinking') {
       return '# Error: Model is too large, cannot fit into 8*H100\n# Please use H200 (141GB) or select FP8 quantization';
     }
@@ -260,7 +302,7 @@ export const Qwen3Deployment = () => {
       return `# Error: Unknown hardware platform: ${hardware}`;
     }
 
-    const quantSuffix = quantization === 'fp8' ? '-FP8' : '';
+    const quantSuffix = effectiveQuantization === 'fp8' ? '-FP8' : '';
 
     // Build model name based on model category
     let modelName;
@@ -281,6 +323,8 @@ export const Qwen3Deployment = () => {
 
     if (hardware === 'xeon') {
       cmd += ` \\\n  --device cpu \\\n  --disable-overlap-schedule`;
+    } else if (hardware === 'Arc B') {
+      cmd += ` \\\n  --device xpu`;
     }
 
     if (hwConfig.tp > 1) {
@@ -288,7 +332,7 @@ export const Qwen3Deployment = () => {
     }
 
     let ep = hwConfig.ep;
-    if (quantization === 'fp8' && hwConfig.tp === 8) {
+    if (effectiveQuantization === 'fp8' && hwConfig.tp === 8) {
       ep = 2;
     }
 

--- a/docs/src/snippets/autoregressive/qwen35-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen35-deployment.jsx
@@ -41,16 +41,19 @@ export const Qwen35Deployment = () => {
     model: {
       name: 'model',
       title: 'Model Variant',
-      items: [
-        { id: '397b',  label: '397B', subtitle: 'MoE', default: true  },
-        { id: '122b',  label: '122B', subtitle: 'MoE', default: false },
-        { id: '35b',   label: '35B',  subtitle: 'MoE', default: false },
-        { id: '27b',   label: '27B',  subtitle: 'Dense', default: false },
-        { id: '9b',    label: '9B',   subtitle: 'Dense', default: false },
-        { id: '4b',    label: '4B',   subtitle: 'Dense', default: false },
-        { id: '2b',    label: '2B',   subtitle: 'Dense', default: false },
-        { id: '0.8b',  label: '0.8B', subtitle: 'Dense', default: false },
-      ]
+      getDynamicItems: (values) => {
+        const isArcB = values.hardware === 'Arc B';
+        return [
+          { id: '397b',  label: '397B', subtitle: 'MoE', default: !isArcB, disabled: isArcB },
+          { id: '122b',  label: '122B', subtitle: 'MoE', default: false, disabled: isArcB },
+          { id: '35b',   label: '35B',  subtitle: 'MoE', default: isArcB, disabled: false },
+          { id: '27b',   label: '27B',  subtitle: 'Dense', default: false, disabled: isArcB },
+          { id: '9b',    label: '9B',   subtitle: 'Dense', default: false, disabled: false },
+          { id: '4b',    label: '4B',   subtitle: 'Dense', default: false, disabled: false },
+          { id: '2b',    label: '2B',   subtitle: 'Dense', default: false, disabled: isArcB },
+          { id: '0.8b',  label: '0.8B', subtitle: 'Dense', default: false, disabled: isArcB },
+        ];
+      }
     },
     hardware: {
       name: 'hardware',
@@ -65,7 +68,8 @@ export const Qwen35Deployment = () => {
           { id: 'mi300x', label: 'MI300X', default: false,     disabled: isNvfp4 },
           { id: 'mi325x', label: 'MI325X', default: false,     disabled: isNvfp4 },
           { id: 'mi355x', label: 'MI355X', default: false,     disabled: false },
-          { id: 'xeon',   label: 'XEON',   default: false,     disabled: isNvfp4 }
+          { id: 'xeon',   label: 'XEON',   default: false,     disabled: isNvfp4 },
+          { id: 'Arc B',  label: 'BMG',    default: false,     disabled: isNvfp4 }
         ];
       }
     },
@@ -76,11 +80,12 @@ export const Qwen35Deployment = () => {
         const hasFp8 = FP8_MODELS.has(values.model);
         const hasFp4 = values.model === '397b';
         const isXeon = values.hardware === 'xeon';
+        const isArcB = values.hardware === 'Arc B';
         return [
-          { id: 'bf16', label: 'BF16', default: !hasFp8 || isXeon },
-          { id: 'fp8',  label: 'FP8',  default: hasFp8 && !isXeon, disabled: !hasFp8,
+          { id: 'bf16', label: 'BF16', default: !hasFp8 || isXeon || isArcB },
+          { id: 'fp8',  label: 'FP8',  default: hasFp8 && !isXeon && !isArcB, disabled: !hasFp8 || isArcB,
             disabledReason: 'No FP8 variant available for this model' },
-          { id: 'fp4',  label: 'FP4',  default: false,   disabled: !hasFp4 || isXeon,
+          { id: 'fp4',  label: 'FP4',  default: false,   disabled: !hasFp4 || isXeon || isArcB,
             disabledReason: isXeon ? 'FP4 is not supported on Xeon' : 'FP4 is only available for Qwen3.5-397B-A17B' }
         ];
       }
@@ -104,7 +109,7 @@ export const Qwen35Deployment = () => {
     speculative: {
       name: 'speculative',
       title: 'Speculative Decoding (MTP)',
-      condition: (values) => values.hardware !== 'xeon',
+      condition: (values) => values.hardware !== 'xeon' && values.hardware !== 'Arc B',
       items: [
         { id: 'disabled', label: 'Disabled', default: false },
         { id: 'enabled',  label: 'Enabled',  default: true  }
@@ -113,7 +118,7 @@ export const Qwen35Deployment = () => {
     mambaCache: {
       name: 'mambaCache',
       title: 'Mamba Radix Cache',
-      condition: (values) => MOE_MODELS.has(values.model) && values.hardware !== 'xeon',
+      condition: (values) => MOE_MODELS.has(values.model) && values.hardware !== 'xeon' && values.hardware !== 'Arc B',
       getDynamicItems: (currentValues) => {
         const amdGpus = ['mi300x', 'mi325x', 'mi355x'];
         const isAmdGpu = amdGpus.includes(currentValues.hardware);
@@ -173,7 +178,8 @@ export const Qwen35Deployment = () => {
       mi300x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
       mi325x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
       mi355x: { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
-      xeon:   { bf16: { tp: 3 }, fp8: { tp: 3 } }
+      xeon:   { bf16: { tp: 3 }, fp8: { tp: 3 } },
+      'Arc B': { bf16: { tp: 4, mem: 0.8 } }
     },
     '27b': {
       h100:   { bf16: { tp: 1, mem: 0.8 }, fp8: { tp: 1, mem: 0.8 } },
@@ -193,7 +199,8 @@ export const Qwen35Deployment = () => {
       mi300x: { bf16: { tp: 1, mem: 0.8 } },
       mi325x: { bf16: { tp: 1, mem: 0.8 } },
       mi355x: { bf16: { tp: 1, mem: 0.8 } },
-      xeon:   { bf16: { tp: 3 } }
+      xeon:   { bf16: { tp: 3 } },
+      'Arc B': { bf16: { tp: 1, mem: 0.8 } }
     },
     '4b': {
       h100:   { bf16: { tp: 1, mem: 0.8 } },
@@ -203,7 +210,8 @@ export const Qwen35Deployment = () => {
       mi300x: { bf16: { tp: 1, mem: 0.8 } },
       mi325x: { bf16: { tp: 1, mem: 0.8 } },
       mi355x: { bf16: { tp: 1, mem: 0.8 } },
-      xeon:   { bf16: { tp: 3 } }
+      xeon:   { bf16: { tp: 3 } },
+      'Arc B': { bf16: { tp: 1, mem: 0.8 } }
     },
     '2b': {
       h100:   { bf16: { tp: 1, mem: 0.8 } },
@@ -338,6 +346,8 @@ export const Qwen35Deployment = () => {
     let cmd = `sglang serve --model-path ${modelName}`;
     if (hardware === 'xeon') {
       cmd += ` \\\n  --device cpu \\\n  --disable-overlap-schedule`;
+    } else if (hardware === 'Arc B') {
+      cmd += ` \\\n  --device xpu`;
     }
     if (tpValue > 1) {
       cmd += ` \\\n  --tp ${tpValue}`;
@@ -362,7 +372,7 @@ export const Qwen35Deployment = () => {
     // would emit a spurious --mamba-radix-cache-strategy extra_buffer. The UI
     // radio is hidden for dense models, so users can't manually correct it.
     // MoE keeps the old behavior — the UI radio is the recovery path there.
-    const mamba_v1_dev = ['mi300x', 'mi325x', 'mi355x', 'xeon'];
+    const mamba_v1_dev = ['mi300x', 'mi325x', 'mi355x', 'xeon', 'Arc B'];
     const actualMambaCache = mamba_v1_dev.includes(hardware)
       ? 'v1'
       : (speculative === 'enabled' ? 'v2' : (MOE_MODELS.has(model) ? mambaCache : 'v1'));
@@ -410,7 +420,7 @@ export const Qwen35Deployment = () => {
     // benchmark only enables this for TP>=8). AMD MI GPUs use the AITER allreduce
     // fusion flag instead, handled in the AMD backend block below.
     const amdGpu = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi355x';
-    if (quantization !== 'fp4' && hardware !== 'xeon' && !amdGpu) {
+    if (quantization !== 'fp4' && hardware !== 'xeon' && hardware !== 'Arc B' && !amdGpu) {
       cmd += ` \\\n  --enable-flashinfer-allreduce-fusion`;
     }
 

--- a/docs/src/snippets/diffusion/flux-deployment.jsx
+++ b/docs/src/snippets/diffusion/flux-deployment.jsx
@@ -15,7 +15,8 @@ export const FluxDeployment = () => {
           { id: 'mi325x', label: 'MI325X', default: false },
           { id: 'mi300x', label: 'MI300X', default: false },
           { id: 'a2', label: 'A2', default: false },
-          { id: 'a3', label: 'A3', default: false }
+          { id: 'a3', label: 'A3', default: false },
+          { id: 'Arc B', label: 'BMG', default: false },
         ]
       },
       version: {
@@ -24,6 +25,21 @@ export const FluxDeployment = () => {
         items: [
           { id: 'flux1-dev', label: 'FLUX.1-dev', subtitle: '12B', default: true },
           { id: 'flux2-dev', label: 'FLUX.2-dev', subtitle: '32B', default: false }
+        ],
+        getDynamicItems: (values) => [
+          {
+            id: 'flux1-dev',
+            label: 'FLUX.1-dev',
+            subtitle: '12B',
+            default: values.hardware !== 'Arc B',
+            disabled: values.hardware === 'Arc B',
+          },
+          {
+            id: 'flux2-dev',
+            label: 'FLUX.2-dev',
+            subtitle: '32B',
+            default: values.hardware === 'Arc B',
+          },
         ]
       }
     },
@@ -56,6 +72,14 @@ sglang serve \\
   --tp-size 2 \\
   --model-path ${config.repoId} \\
   --num-gpus 2`;
+      }
+
+      if (hardware === 'Arc B') {
+        return `sglang serve \\
+  --model-path ${config.repoId} \\
+  --num-gpus 4 \\
+  --tp-size 4 \\
+  --dit-cpu-offload False`;
       }
 
       return `sglang serve \\
@@ -145,7 +169,13 @@ sglang serve \\
   }, [values.hardware]);
 
   const handleRadioChange = (optionName, value) => {
-    setValues((prev) => ({ ...prev, [optionName]: value }));
+    setValues((prev) => {
+      const nextValues = { ...prev, [optionName]: value };
+      if (optionName === 'hardware' && value === 'Arc B' && nextValues.version === 'flux1-dev') {
+        nextValues.version = 'flux2-dev';
+      }
+      return nextValues;
+    });
   };
 
   const handleCheckboxChange = (optionName, itemId, isChecked) => {

--- a/docs/src/snippets/diffusion/zimage-turbo-deployment.jsx
+++ b/docs/src/snippets/diffusion/zimage-turbo-deployment.jsx
@@ -14,7 +14,8 @@ export const ZImageTurboDeployment = () => {
           { id: 'h200', label: 'H200', default: false },
           { id: 'h100', label: 'H100', default: false },
           { id: 'a2', label: 'A2', default: false },
-          { id: 'a3', label: 'A3', default: false }
+          { id: 'a3', label: 'A3', default: false },
+          { id: 'Arc B', label: 'BMG', default: false }
         ]
       }
     },
@@ -35,6 +36,11 @@ sglang serve \\
   --tp-size 2 \\
   --sp-degree 1 \\
   --num-gpus 2`;
+      }
+
+      if (hardware === 'Arc B') {
+        return `sglang serve \\
+  --model-path Tongyi-MAI/Z-Image-Turbo`;
       }
 
       return `sglang serve \\


### PR DESCRIPTION
## Motivation



This PR adds Intel XPU / Arc B documentation support to the cookbook pages and keeps the interactive deployment selectors aligned with the documented hardware matrix and command constraints.



The main goal is to make Arc B a first-class documented deployment target in the affected cookbook pages, while ensuring the generated commands and selector behavior reflect the actual supported capability set instead of exposing invalid combinations.



## Modifications
### Documentation updates



Updated the affected cookbook MDX pages to add Intel XPU guidance and align hardware-support wording with the new Arc B coverage:



- Added the canonical XPU installation note under the installation sections.
- Added the canonical XPU configuration note at the end of the relevant `Configuration Tips` sections.
- Extended applicable hardware support sentences to include Intel Arc Pro B-series XPUs where the existing text already enumerated NVIDIA/AMD hardware lists.



The updated cookbook pages cover:



- Llama 3.1
- Llama 3.3 70B
- Qwen3
- Qwen3.5
- Gemma 4
- DeepSeek-OCR-2
- NVIDIA Nemotron3-Nano
- FLUX
- Z-Image-Turbo



### Interactive selector updates



Updated the corresponding JSX deployment selectors so the interactive command generators stay consistent with the cookbook text and Arc B capability constraints.



Main changes:



- Added Arc B as a hardware option in the relevant selector components.
- Added Arc B default command flags:
  - `--device xpu`
- Implemented Arc B TP selection by documented model shape.
- Ensured Arc B-specific unsupported combinations are disabled in the UI instead of remaining selectable.
- Preserved existing CUDA / AMD / Xeon logic and selector structure, only extending the newly added Arc B behavior.



### Capability gating added in selectors



Implemented model- and hardware-specific Arc B restrictions in the affected selectors, including combinations such as:



- Arc B is TP-only.
- Arc B does not expose DP / EP / MTP paths.
- Arc B does not expose speculative decoding or Mamba radix cache where unsupported.
- Arc B does not allow FP4 / NVFP4 options.
- Arc B-specific selectors now force or restrict certain model / quantization / category combinations where required by the page-specific hardware rules.
- Xeon deployment-strategy checkboxes were updated to use explicit disabled-state handling so unsupported DP / EP selections cannot silently persist after hardware switching.



### File scope



The changes span both cookbook narrative pages and their imported selector components, including the main interactive deployment sources under `docs/src/snippets/...`  and `docs/cookbook/...`.



## Accuracy Tests



Not applicable.



This PR only updates documentation pages and interactive deployment selector logic. It does not modify model kernels, forward paths, or inference output semantics.
 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30883367198](https://github.com/sgl-project/sglang/actions/runs/30883367198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30883366996](https://github.com/sgl-project/sglang/actions/runs/30883366996)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->