### PR TITLE
[PD][Spec] Skip spec-only aux slots from non-last PP ranks in send_aux

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -45,6 +45,13 @@ class KVArgs:
     aux_data_ptrs: List[int]
     aux_data_lens: List[int]
     aux_item_lens: List[int]
+    # Absolute indices within aux_data_ptrs of slots holding spec-decoding-
+    # only fields (topk_p, topk_index, hidden_states). Populated on the
+    # engine side by MetadataBuffers.get_spec_only_aux_indices(). Consulted
+    # by transfer backends (see mooncake send_aux) to skip these slots on
+    # non-last PP ranks; empty list disables the skip (safe default for
+    # backends that do not populate it).
+    spec_aux_indices: List[int]
     state_types: List[StateType]
     state_data_ptrs: List[List[int]]
     state_data_lens: List[List[int]]

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -477,6 +477,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
         )
+        kv_args.spec_aux_indices = self.metadata_buffers.get_spec_only_aux_indices()
 
         setup_state_kv_args(
             kv_args,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1048,7 +1048,28 @@ class MooncakeKVManager(CommonKVManager):
         prefill_aux_ptrs = self.kv_args.aux_data_ptrs
         prefill_aux_item_lens = self.kv_args.aux_item_lens
 
+        # PP + MTP fix: on non-last PP ranks, spec-only aux slots
+        # (topk_p / topk_index / hidden_states) contain local zeros because
+        # MetadataBuffers.set_buf only fills them when
+        # ``req.hidden_states_tensor is not None`` -- true only on the last
+        # PP rank. RDMA-ing those zeros races with the last rank's valid
+        # write on the same decode aux row and can leave decode reading
+        # zeros -> constant garbage draft input -> deterministic garbled
+        # output. Skip them here so only the last PP rank writes.
+        skip_spec_aux = (
+            self.pp_size is not None
+            and self.pp_size > 1
+            and self.pp_rank != self.pp_size - 1
+        )
+        spec_aux_set = (
+            set(getattr(self.kv_args, "spec_aux_indices", ()) or ())
+            if skip_spec_aux
+            else frozenset()
+        )
+
         for i, dst_aux_ptr in enumerate(dst_aux_ptrs):
+            if i in spec_aux_set:
+                continue
             length = prefill_aux_item_lens[i]
             src_addr = prefill_aux_ptrs[i] + length * prefill_aux_index
             dst_addr = dst_aux_ptrs[i] + length * req.dst_aux_index
@@ -1065,7 +1086,22 @@ class MooncakeKVManager(CommonKVManager):
         prefill_aux_ptrs = self.kv_args.aux_data_ptrs
         prefill_aux_item_lens = self.kv_args.aux_item_lens
 
+        # See send_aux for the rationale of skipping spec-only aux slots on
+        # non-last PP ranks under PP + MTP.
+        skip_spec_aux = (
+            self.pp_size is not None
+            and self.pp_size > 1
+            and self.pp_rank != self.pp_size - 1
+        )
+        spec_aux_set = (
+            set(getattr(self.kv_args, "spec_aux_indices", ()) or ())
+            if skip_spec_aux
+            else frozenset()
+        )
+
         for i in range(len(prefill_aux_ptrs)):
+            if i in spec_aux_set:
+                continue
             length = prefill_aux_item_lens[i]
             src_addr = prefill_aux_ptrs[i] + length * prefill_aux_index
             data = AuxDataCodec.serialize_data_from_buffer(src_addr, length)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -243,6 +243,7 @@ class PrefillBootstrapQueue:
         kv_args.aux_data_ptrs, kv_args.aux_data_lens, kv_args.aux_item_lens = (
             self.metadata_buffers.get_buf_infos()
         )
+        kv_args.spec_aux_indices = self.metadata_buffers.get_spec_only_aux_indices()
         kv_args.ib_device = self.scheduler.server_args.disaggregation_ib_device
         kv_args.gpu_id = self.scheduler.ps.gpu_id
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -383,6 +383,32 @@ class MetadataBuffers:
         item_lens = [buf[0].nbytes for buf in bufs]
         return ptrs, data_lens, item_lens
 
+    def get_spec_only_aux_indices(self) -> List[int]:
+        """Return indices (within get_buf_infos() output) of aux slots that
+        hold spec-decoding-only fields (output_topk_p, output_topk_index,
+        output_hidden_states).
+
+        These fields are populated only by the last PP rank of the prefill
+        engine (see set_buf()'s ``req.hidden_states_tensor is not None``
+        gate). Transfer backends consult these indices to skip sending
+        them on non-last PP ranks; otherwise the earlier ranks' zeros
+        RDMA into the same decode aux row as the last rank's valid write
+        and can leave decode reading zeros -> garbage draft input ->
+        deterministic garbled output under PP + MTP.
+
+        The absolute positions shift with ``enable_sampling_mask``; we
+        mirror the layout in :meth:`get_buf_infos` to stay consistent.
+        """
+        # Always-present prefix: output_ids, cached_tokens, and the four
+        # logprobs tensors (2..5).
+        offset = 6
+        if self.enable_sampling_mask:
+            # Three sampling-mask tensors precede the spec-only trio.
+            offset += 3
+        # Spec-only tensors appear contiguously as topk_p, topk_index,
+        # hidden_states, in that order.
+        return [offset, offset + 1, offset + 2]
+
     def get_buf(self, idx: int):
         sampling_mask_len = None
         sampling_mask_idx = None

--- a/test/srt/disaggregation/test_metadata_buffers_spec_only.py
+++ b/test/srt/disaggregation/test_metadata_buffers_spec_only.py
@@ -1,0 +1,95 @@
+"""Unit tests for MetadataBuffers.get_spec_only_aux_indices().
+
+These tests guard the invariant that ``get_spec_only_aux_indices()``
+returns the exact positions occupied by ``output_topk_p``,
+``output_topk_index`` and ``output_hidden_states`` within the list
+returned by :meth:`MetadataBuffers.get_buf_infos`, for every combination
+of the optional aux slots (``enable_sampling_mask``, ``dsa_topk_indices``).
+
+If a future change adds or reorders aux slots without updating
+``get_spec_only_aux_indices()``, the send-side skip in
+``mooncake/conn.py::send_aux`` would target the wrong slots and re-open
+the PP + MTP garbled-output race documented in the accompanying fix.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import itertools
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.disaggregation.utils import MetadataBuffers
+
+
+# The DSA optional slot is enabled by setting output_dsa_topk_indices_dim>0.
+DSA_DIMS = (0, 8)
+SAMPLING_MASK_VALUES = (0, 32)  # 0 = disabled; >0 = enabled
+
+
+class MetadataBuffersSpecOnlyIndicesTest(unittest.TestCase):
+    def _make_buffers(
+        self, *, sampling_mask_tokens: int, dsa_dim: int
+    ) -> MetadataBuffers:
+        # MetadataBuffers touches torch.cuda.use_mem_pool via nullcontext when
+        # custom_mem_pool is None -- fine on CPU. Force CPU-side tensors by
+        # leaving custom_mem_pool=None and letting is_npu()/nvlink checks fall
+        # through to device="cpu".
+        return MetadataBuffers(
+            size=2,
+            hidden_size=16,
+            hidden_states_dtype=torch.float32,
+            max_sampling_mask_tokens=sampling_mask_tokens,
+            output_dsa_topk_indices_dim=dsa_dim,
+        )
+
+    def test_indices_match_actual_buf_positions(self):
+        for sampling_mask_tokens, dsa_dim in itertools.product(
+            SAMPLING_MASK_VALUES, DSA_DIMS
+        ):
+            with self.subTest(
+                sampling_mask_tokens=sampling_mask_tokens, dsa_dim=dsa_dim
+            ):
+                buffers = self._make_buffers(
+                    sampling_mask_tokens=sampling_mask_tokens, dsa_dim=dsa_dim
+                )
+                ptrs, _, _ = buffers.get_buf_infos()
+                indices = buffers.get_spec_only_aux_indices()
+
+                # Exactly three spec-only slots.
+                self.assertEqual(len(indices), 3)
+                # Contiguous.
+                self.assertEqual(indices, list(range(indices[0], indices[0] + 3)))
+                # All within bounds.
+                self.assertTrue(all(0 <= i < len(ptrs) for i in indices))
+                # And they must alias the three spec-only tensors exactly.
+                self.assertEqual(ptrs[indices[0]], buffers.output_topk_p.data_ptr())
+                self.assertEqual(ptrs[indices[1]], buffers.output_topk_index.data_ptr())
+                self.assertEqual(
+                    ptrs[indices[2]], buffers.output_hidden_states.data_ptr()
+                )
+
+    def test_indices_shift_with_sampling_mask(self):
+        # Baseline (no sampling_mask, no dsa): spec-only trio starts at 6.
+        buffers_off = self._make_buffers(sampling_mask_tokens=0, dsa_dim=0)
+        self.assertEqual(buffers_off.get_spec_only_aux_indices(), [6, 7, 8])
+
+        # Sampling mask on shifts spec-only trio by +3 (mask_len / mask_idx /
+        # sampling_logprobs are inserted before spec-only).
+        buffers_on = self._make_buffers(sampling_mask_tokens=32, dsa_dim=0)
+        self.assertEqual(buffers_on.get_spec_only_aux_indices(), [9, 10, 11])
+
+    def test_dsa_does_not_shift_spec_only(self):
+        # DSA slot is appended after spec-only, so it must not affect the trio.
+        buffers_no_dsa = self._make_buffers(sampling_mask_tokens=0, dsa_dim=0)
+        buffers_dsa = self._make_buffers(sampling_mask_tokens=0, dsa_dim=8)
+        self.assertEqual(
+            buffers_no_dsa.get_spec_only_aux_indices(),
+            buffers_dsa.get_spec_only_aux_indices(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Under PD disaggregation with prefill `PP > 1` and decode running
MTP/NEXTN speculative decoding, every PP rank RDMA-copied all 10
`MetadataBuffers` aux slots — including the three spec-only slots
(`output_topk_p`, `output_topk_index`, `output_hidden_states`) that
only the last PP rank ever populates. Non-last ranks send their
initial zeros to the same decode aux row that the last rank writes
to; when the zero writes land last, decode reads all zeros for
`hidden_states` and the NEXTN draft model runs on a garbage input for
the rest of the request. Symptoms are either a very low
`spec_accept_rate` with a blow-up in `output_len`, or garbled output
after the first correctly-decoded token.

### Root cause

`MetadataBuffers.set_buf()` already gates the spec-only writes behind
`if req.hidden_states_tensor is not None`, so non-last PP ranks
never *fill* those slots. But the RDMA path
(`MooncakeKVSender.send_aux` / `send_aux_tcp`) unconditionally sends
every entry of `aux_data_ptrs`, so those local zeros still race the
last rank's valid write on the shared decode aux row.

### Fix

* `MetadataBuffers.get_spec_only_aux_indices()` — a helper that
  returns the positions of the spec-only tensors within
  `get_buf_infos()`. The offset is computed from the actual layout
  (base 6, `+3` if sampling-mask slots are present) so a future
  layout change moves the returned indices with it.
* Publish these indices on `KVArgs.spec_aux_indices` so any transport
  can consume them (the field is added in `base/conn.py`; only
  mooncake reads it today).
* `send_aux` / `send_aux_tcp` skip any aux slot whose index is in
  `spec_aux_indices` **when** `pp_size > 1 and pp_rank != pp_size - 1`.

### Test

`test/srt/disaggregation/test_metadata_buffers_spec_only.py`:
* Builds a real `MetadataBuffers` for all `sampling_mask ∈ {0, 32}`
  and `dsa_dim ∈ {0, 8}` combinations.
* Verifies each returned index points at the correct tensor
  (`data_ptr()` equality).
* Regression-guards against the DSA-appended layout accidentally
  shifting the spec-only positions.

### Backward compatibility

* No wire-protocol change. `KVArgs.spec_aux_indices` is populated by
  the same engine (`decode.py`, `prefill.py`) before it's read.
* When `pp_size <= 1` or `pp_rank == pp_size - 1`, behavior is
  identical to before.
* No changes to non-mooncake transports (nixl, ascend, etc.); the
  new helper on `KVArgs` is opt-in.

### Checklist

- [x] The PR has a descriptive title
- [x] A minimal, well-scoped patch (one bug, one fix, one PR)
- [x] Added unit tests
- [x] Backward-compatible for the not-affected configurations

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30883762600](https://github.com/sgl-project/sglang/actions/runs/30883762600)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30883762430](https://github.com/sgl-project/sglang/actions/runs/30883762430)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->