### PR TITLE
[PD][MTP] Fix MHA V-pointer offset when target/draft KV layer counts differ

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -84,6 +84,17 @@ class KVArgs:
     kv_buf_groups: int
     # Only used of npu, for decode total kv layers
     total_kv_layers: int
+    # Number of TARGET-model KV layers (K or V section length) BEFORE any
+    # draft-model KV pointers have been appended to kv_data_ptrs. Populated
+    # on the engine side (decode.py / prefill.py) so PD KV transfer can
+    # compute the correct V-pointer offset when the receiver has appended
+    # its NEXTN/MTP draft KV to a target-model KV pool. The transport
+    # forwards this value across the wire so the sender can override the
+    # unsafe `len(dst_kv_ptrs) // 2` assumption in
+    # CommonKVManager.get_mha_kv_ptrs_with_pp (else-branch, case 3).
+    # -1 sentinel means "not populated" -> keep the legacy `len // 2`
+    # behavior (equivalent to no MTP on decode side).
+    num_target_kv_layers: int
 
 
 class KVPoll:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -779,7 +779,10 @@ class CommonKVManager(BaseKVManager):
             return sock
 
     def get_mha_kv_ptrs_with_pp(
-        self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
+        self,
+        src_kv_ptrs: List[int],
+        dst_kv_ptrs: List[int],
+        num_dst_target_kv_layers: Optional[int] = None,
     ) -> Tuple[List[int], List[int], List[int], List[int], int]:
         start_layer = self.kv_args.prefill_start_layer
         num_kv_layers = len(src_kv_ptrs) // 2
@@ -803,10 +806,30 @@ class CommonKVManager(BaseKVManager):
                 v_ptr_offset + start_layer : v_ptr_offset + end_layer
             ]
         else:
-            # Decode pp size should be equal to prefill pp size or 1
+            # Case: PP>1 and non-equal layer counts. dst_kv_ptrs layout is
+            # [K_target..., V_target..., K_draft..., V_draft...] whenever the
+            # decode side has appended MTP/NEXTN draft KV to a target-model
+            # KV pool. `len(dst_kv_ptrs) // 2` therefore OVERCOUNTS the
+            # target section by the number of draft K layers, and every V
+            # slice below would be shifted by that amount -- corrupting
+            # target V (each layer off by draft_layers) and, on the last PP
+            # rank, overwriting draft K with the tail-end target V writes.
+            # To handle this, decode.py sends `num_target_kv_layers` (the
+            # target-only K/V section length, captured BEFORE draft ptrs
+            # were appended) over the wire; we prefer it when available and
+            # fall back to the legacy `len // 2` when the wire field is
+            # absent (older receivers, or no MTP -> the two values agree).
+            v_layer_offset = (
+                num_dst_target_kv_layers
+                if (
+                    num_dst_target_kv_layers is not None
+                    and num_dst_target_kv_layers > 0
+                )
+                else dst_num_total_layers
+            )
             dst_k_ptrs = dst_kv_ptrs[start_layer:end_layer]
             dst_v_ptrs = dst_kv_ptrs[
-                dst_num_total_layers + start_layer : dst_num_total_layers + end_layer
+                v_layer_offset + start_layer : v_layer_offset + end_layer
             ]
         layers_current_pp_stage = len(src_k_ptrs)
         return src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -456,6 +456,14 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            # Snapshot the target-model K/V layer count BEFORE appending draft
+            # pointers. Sent over the wire to prefill so that
+            # get_mha_kv_ptrs_with_pp can compute the correct V offset:
+            # without this, `len(dst_kv_ptrs) // 2` overcounts by the number
+            # of draft K layers and every V pointer is shifted, corrupting
+            # both target V (each layer off by one) and draft K (overwritten
+            # by the last target V write on the last PP rank).
+            kv_args.num_target_kv_layers = len(kv_data_ptrs) // 2
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -146,6 +146,15 @@ class KVArgsRegisterInfo:
     dcp_token_item_lens: Optional[List[int]] = None
     # Note: always put the staging field at the final (since the staging field is optional and contains multiple inputs)
     staging: Optional[StagingRegisterInfo] = None
+    # Trailing single-frame field (wire position 18, after staging's two
+    # frames at 14/15 and the DCP fields at 16/17). Number of TARGET-model
+    # K/V layers on the decode side, captured before any MTP/NEXTN draft KV
+    # pointers were appended to dst_kv_ptrs. Prefill uses this to compute
+    # the correct V-pointer offset instead of the unsafe
+    # `len(dst_kv_ptrs) // 2`. -1 sentinel = "not sent by receiver" (older
+    # decodes, or non-MTP layouts) -> prefill falls back to `len // 2`,
+    # which agrees with the correct value when draft KV is absent.
+    dst_num_target_kv_layers: int = -1
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]):
@@ -185,6 +194,15 @@ class KVArgsRegisterInfo:
             ),
             # Note: always put the staging field at the final
             staging=StagingRegisterInfo.from_zmq_fields(msg, 14),
+            # Optional trailing field, wire position 18 (after the two
+            # staging frames at 14/15 and the DCP fields at 16/17).
+            # Missing / empty -> -1 sentinel so older receivers stay
+            # backward-compatible.
+            dst_num_target_kv_layers=(
+                int(msg[18].decode("ascii"))
+                if len(msg) > 18 and msg[18] != b""
+                else -1
+            ),
         )
 
 
@@ -627,6 +645,7 @@ class MooncakeKVManager(CommonKVManager):
         executor: concurrent.futures.ThreadPoolExecutor,
         state_type: Optional[StateType] = None,
         force_flat: bool = False,
+        num_dst_target_kv_layers: Optional[int] = None,
         src_layer_ids: Optional[List[int]] = None,
         dst_layer_ids: Optional[List[int]] = None,
         dst_device_data_indices: Optional[npt.NDArray[np.int32]] = None,
@@ -686,7 +705,11 @@ class MooncakeKVManager(CommonKVManager):
                 ]
         else:
             src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
-                self.get_mha_kv_ptrs_with_pp(src_data_ptrs, dst_data_ptrs)
+                self.get_mha_kv_ptrs_with_pp(
+                    src_data_ptrs,
+                    dst_data_ptrs,
+                    num_dst_target_kv_layers=num_dst_target_kv_layers,
+                )
             )
             # item_lens structure: [k_layer0, k_layer1, ..., k_layerN, v_layer0, v_layer1, ..., v_layerN]
             # Use correct item lengths for K and V separately
@@ -778,6 +801,7 @@ class MooncakeKVManager(CommonKVManager):
         executor: concurrent.futures.ThreadPoolExecutor,
         dst_layer_ids: Optional[List[int]] = None,
         dst_device_kv_indices: Optional[npt.NDArray[np.int32]] = None,
+        num_dst_target_kv_layers: Optional[int] = None,
     ):
         dst_device_kv_ptrs = None
         if dst_device_kv_indices is not None:
@@ -802,6 +826,7 @@ class MooncakeKVManager(CommonKVManager):
             dst_layer_ids=dst_layer_ids,
             dst_device_data_indices=dst_device_kv_indices,
             dst_device_data_ptrs=dst_device_kv_ptrs,
+            num_dst_target_kv_layers=num_dst_target_kv_layers,
         )
 
     def send_kvcache_dcp(
@@ -914,6 +939,7 @@ class MooncakeKVManager(CommonKVManager):
         dst_attn_tp_size: int,
         dst_kv_item_len: int,
         executor: concurrent.futures.ThreadPoolExecutor,
+        num_dst_target_kv_layers: Optional[int] = None,
     ):
         """
         Sends KV cache slices from this Prefill rank to a target Decode rank,
@@ -967,7 +993,11 @@ class MooncakeKVManager(CommonKVManager):
             dst_head_start_offset = 0
 
         src_k_ptrs, src_v_ptrs, dst_k_ptrs, dst_v_ptrs, layers_current_pp_stage = (
-            self.get_mha_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
+            self.get_mha_kv_ptrs_with_pp(
+                self.kv_args.kv_data_ptrs,
+                dst_kv_ptrs,
+                num_dst_target_kv_layers=num_dst_target_kv_layers,
+            )
         )
 
         # Calculate precise byte offset and length for the sub-slice within the token
@@ -1679,6 +1709,7 @@ class MooncakeKVManager(CommonKVManager):
                                 executor,
                                 dst_layer_ids=target_rank_registration_info.dst_kv_layer_ids,
                                 dst_device_kv_indices=chunked_dst_device_kv_indice,
+                                num_dst_target_kv_layers=target_rank_registration_info.dst_num_target_kv_layers,
                             )
                         elif (
                             self.enable_staging
@@ -1709,6 +1740,7 @@ class MooncakeKVManager(CommonKVManager):
                                 target_rank_registration_info.dst_attn_tp_size,
                                 target_rank_registration_info.dst_kv_item_len,
                                 executor,
+                                num_dst_target_kv_layers=target_rank_registration_info.dst_num_target_kv_layers,
                             )
                         if ret != 0:
                             with self.session_lock:
@@ -2261,6 +2293,15 @@ class MooncakeKVReceiver(CommonKVReceiver):
                 packed_staging_base_ptr = b""
                 staging_total_size_str = b""
 
+            # Trailing wire frame (position 18, after staging at 14/15 and
+            # DCP at 16/17): number of target-model K/V layers captured
+            # before any MTP draft KV was appended. -1 sentinel keeps
+            # parity with older prefill instances that ignore trailing
+            # frames.
+            num_target_kv_layers_str = str(
+                getattr(self.kv_mgr.kv_args, "num_target_kv_layers", -1)
+            ).encode("ascii")
+
             sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
             try:
                 with lock:
@@ -2284,6 +2325,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             staging_total_size_str,
                             dst_dcp_size,
                             dst_dcp_rank,
+                            num_target_kv_layers_str,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -220,6 +220,11 @@ class PrefillBootstrapQueue:
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
                 self.draft_token_to_kv_pool.get_contiguous_buf_infos()
             )
+            # Symmetric snapshot with decode.py: record target-model layer
+            # count before draft pointers are appended so downstream code
+            # (either side, if ever used as sender) can compute the correct
+            # V-pointer offset instead of relying on `len // 2`.
+            kv_args.num_target_kv_layers = len(kv_data_ptrs) // 2
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens

--- a/test/srt/disaggregation/test_pp_kv_ptrs.py
+++ b/test/srt/disaggregation/test_pp_kv_ptrs.py
@@ -1,0 +1,238 @@
+"""Unit tests for CommonKVManager.get_mha_kv_ptrs_with_pp V-pointer offset.
+
+Focus of these tests: the else-branch (case 3) that fires when
+prefill's PP layout differs from decode's total KV pointer count in a
+way that ISN'T the multiplier_ratio path. This case is triggered in
+production by:
+
+  * Non-MLA / non-hybrid-MLA models (regular MHA / GQA), AND
+  * PP > 1 on the prefill side, AND
+  * Decode side has appended MTP / NEXTN draft KV pointers to a
+    target-model KV pool -> dst_kv_ptrs layout becomes
+        [K_target..., V_target..., K_draft..., V_draft...]
+    where `len(dst_kv_ptrs) // 2` OVERCOUNTS the target section by the
+    number of draft K layers.
+
+Before the fix, this branch used `dst_num_total_layers = len // 2` as
+the V-pointer base, which shifts every target-V slice by `M`
+(= number of draft layers) and, on the last PP rank, causes the tail
+of the target-V writes to overwrite the leading draft-K pointers ->
+decode reads corrupted target-V from layer 2 onwards, first token is
+still correct (aux buffer path), but every subsequent decode step
+attends to wrong V.
+
+The fix adds an optional `num_dst_target_kv_layers` parameter that
+prefill obtains from the wire-protocol frame filled in by decode BEFORE
+draft KV was concatenated. When present and > 0, we use it as
+`v_layer_offset` instead of `len // 2`.
+
+These tests exercise the pointer arithmetic in isolation by calling
+`CommonKVManager.get_mha_kv_ptrs_with_pp` unbound with a minimal fake
+`self`. That keeps the tests independent of the surrounding
+CommonKVManager __init__ (which requires ZMQ sockets, bootstrap
+server, model config etc.) while still exercising the exact production
+code path.
+"""
+
+import unittest
+from types import SimpleNamespace
+from typing import List, Tuple
+
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+
+
+def _fake_manager(prefill_start_layer: int) -> SimpleNamespace:
+    """Minimal object exposing `.kv_args.prefill_start_layer`.
+
+    `get_mha_kv_ptrs_with_pp` only reads `self.kv_args.prefill_start_layer`,
+    so a SimpleNamespace shim is sufficient and avoids the heavyweight
+    CommonKVManager constructor.
+    """
+    return SimpleNamespace(
+        kv_args=SimpleNamespace(prefill_start_layer=prefill_start_layer)
+    )
+
+
+def _call_case3(
+    src_kv_ptrs: List[int],
+    dst_kv_ptrs: List[int],
+    prefill_start_layer: int,
+    num_dst_target_kv_layers=None,
+) -> Tuple[List[int], List[int], List[int], List[int], int]:
+    return CommonKVManager.get_mha_kv_ptrs_with_pp(
+        _fake_manager(prefill_start_layer),
+        src_kv_ptrs,
+        dst_kv_ptrs,
+        num_dst_target_kv_layers=num_dst_target_kv_layers,
+    )
+
+
+class TestGetMhaKvPtrsWithPp(unittest.TestCase):
+    """Cover case 3 (PP>1 else-branch) both without and with the fix's arg."""
+
+    # Layout mimicking Qwen3.5-397B W4A8 + PP=4 prefill (15 full-attn
+    # layers split 3/4/4/4) + decode with MTP=1 draft layer:
+    #   dst_kv_ptrs layout: 15 target K + 15 target V + 1 draft K + 1 draft V
+    # We encode each ptr as an integer tag so the assertions read as
+    # "which slot did we select" instead of comparing opaque addresses.
+    N_TARGET = 15
+    N_DRAFT = 1
+
+    # Tag scheme -- makes error messages self-describing.
+    # 100..114 = target K layers 0..14
+    # 200..214 = target V layers 0..14
+    # 300      = draft K layer 0
+    # 400      = draft V layer 0
+    DST_KV_PTRS = (
+        [100 + i for i in range(N_TARGET)]  # K_t
+        + [200 + i for i in range(N_TARGET)]  # V_t
+        + [300 + i for i in range(N_DRAFT)]  # K_d
+        + [400 + i for i in range(N_DRAFT)]  # V_d
+    )
+
+    def _run_qwen35_rank(
+        self,
+        num_layers_this_rank: int,
+        prefill_start_layer: int,
+        num_dst_target_kv_layers,
+    ):
+        # Prefill side has only this rank's slice of the (K,V) pool.
+        # Values don't matter for the case-3 dst indexing test; we build
+        # a plausible K||V src list.
+        src_kv_ptrs = (
+            [500 + i for i in range(num_layers_this_rank)]  # local K
+            + [600 + i for i in range(num_layers_this_rank)]  # local V
+        )
+        return _call_case3(
+            src_kv_ptrs=src_kv_ptrs,
+            dst_kv_ptrs=list(self.DST_KV_PTRS),
+            prefill_start_layer=prefill_start_layer,
+            num_dst_target_kv_layers=num_dst_target_kv_layers,
+        )
+
+    def _expected_v_slice(self, start: int, count: int) -> List[int]:
+        return [200 + start + i for i in range(count)]
+
+    def _expected_k_slice(self, start: int, count: int) -> List[int]:
+        return [100 + start + i for i in range(count)]
+
+    # -- with the fix (num_dst_target_kv_layers=15) --------------------
+
+    def test_rank0_fixed(self):
+        _, _, dst_k, dst_v, n = self._run_qwen35_rank(
+            num_layers_this_rank=3,
+            prefill_start_layer=0,
+            num_dst_target_kv_layers=self.N_TARGET,
+        )
+        self.assertEqual(n, 3)
+        self.assertEqual(dst_k, self._expected_k_slice(0, 3))
+        self.assertEqual(dst_v, self._expected_v_slice(0, 3))
+
+    def test_rank1_fixed(self):
+        _, _, dst_k, dst_v, n = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=3,
+            num_dst_target_kv_layers=self.N_TARGET,
+        )
+        self.assertEqual(n, 4)
+        self.assertEqual(dst_k, self._expected_k_slice(3, 4))
+        self.assertEqual(dst_v, self._expected_v_slice(3, 4))
+
+    def test_rank2_fixed(self):
+        _, _, dst_k, dst_v, n = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=7,
+            num_dst_target_kv_layers=self.N_TARGET,
+        )
+        self.assertEqual(n, 4)
+        self.assertEqual(dst_k, self._expected_k_slice(7, 4))
+        self.assertEqual(dst_v, self._expected_v_slice(7, 4))
+
+    def test_rank3_fixed_does_not_touch_draft_k(self):
+        _, _, dst_k, dst_v, n = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=11,
+            num_dst_target_kv_layers=self.N_TARGET,
+        )
+        self.assertEqual(n, 4)
+        self.assertEqual(dst_k, self._expected_k_slice(11, 4))
+        self.assertEqual(dst_v, self._expected_v_slice(11, 4))
+        # Regression guard: no draft-K tag (300) may appear in dst_v.
+        self.assertNotIn(300, dst_v)
+
+    # -- without the fix (legacy sentinel) reproduces the shift --------
+
+    def test_rank3_legacy_overwrites_draft_k(self):
+        """Sanity: with sentinel -> len//2=16 -> rank3 last slot picks up
+        draft-K (tag 300). This is the pre-fix bug we're guarding
+        against. If this assertion ever fails, the fallback path has
+        drifted and the test suite is no longer catching the regression.
+        """
+        _, _, _, dst_v, _ = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=11,
+            num_dst_target_kv_layers=None,
+        )
+        # Legacy behavior: v_layer_offset = len(dst_kv_ptrs)//2 = 16.
+        # rank 3 V slice = dst_kv_ptrs[16+11 : 16+15] = tags 227..230.
+        # Tag 230 is the draft-K ptr (300 - N_TARGET*2 index = 30).
+        self.assertEqual(dst_v[-1], 300, "expected pre-fix corruption to expose draft-K in dst_v tail")
+
+    # -- backward-compat: -1 sentinel behaves like the legacy path -----
+
+    def test_sentinel_minus_one_behaves_like_legacy(self):
+        _, _, _, dst_v_a, _ = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=11,
+            num_dst_target_kv_layers=-1,
+        )
+        _, _, _, dst_v_b, _ = self._run_qwen35_rank(
+            num_layers_this_rank=4,
+            prefill_start_layer=11,
+            num_dst_target_kv_layers=None,
+        )
+        self.assertEqual(dst_v_a, dst_v_b, "-1 and None must both mean 'fall back to len//2'")
+
+    # -- no-MTP layouts: the fix is a no-op ----------------------------
+
+    def test_no_mtp_layout_unaffected(self):
+        """Decode without MTP: dst_kv_ptrs is [K..., V...] and
+        `len//2 == num_target_kv_layers`; either code path must produce
+        identical slices."""
+        n = 15
+        dst = [100 + i for i in range(n)] + [200 + i for i in range(n)]
+        src = [500 + i for i in range(4)] + [600 + i for i in range(4)]
+        legacy = _call_case3(src, dst, prefill_start_layer=3, num_dst_target_kv_layers=None)
+        fixed = _call_case3(src, dst, prefill_start_layer=3, num_dst_target_kv_layers=n)
+        self.assertEqual(legacy, fixed)
+
+    # -- case 1 / case 2 branches untouched by the new arg -------------
+
+    def test_case1_equal_layers_ignores_new_arg(self):
+        """Case 1 (num_kv == dst_num_total): new arg must not perturb."""
+        n = 15
+        src = [500 + i for i in range(n)] + [600 + i for i in range(n)]
+        dst = [100 + i for i in range(n)] + [200 + i for i in range(n)]
+        without = _call_case3(src, dst, 0, num_dst_target_kv_layers=None)
+        withit = _call_case3(src, dst, 0, num_dst_target_kv_layers=99)
+        self.assertEqual(without, withit)
+
+    def test_case2_pp1_multiplier_ignores_new_arg(self):
+        """Case 2 (PP=1, dst_num_total % num_kv != 0) uses its own
+        multiplier_ratio path; the new arg must not perturb it."""
+        # 4 local layers -> src = 4K + 4V; dst has 4 target + 1 draft
+        # per K/V section -> dst has 4+4+1+1=10 -> len//2=5, 5%4!=0
+        src = [500 + i for i in range(4)] + [600 + i for i in range(4)]
+        dst = (
+            [100 + i for i in range(4)]
+            + [200 + i for i in range(4)]
+            + [300]
+            + [400]
+        )
+        without = _call_case3(src, dst, 0, num_dst_target_kv_layers=None)
+        withit = _call_case3(src, dst, 0, num_dst_target_kv_layers=4)
+        self.assertEqual(without, withit)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Related

- Issue: #27740
- Parallel PRs against the same bug: #28229 (@waynehacking8), #33457 (@yhyang201, Collaborator, Draft)

We opened this independently because we hit the bug in a slightly
different shape (MTP + non-equal PP split) and arrived at a
receiver-authoritative fix. See "Why a third PR" below for how this
one differs from the two open ones — happy to converge on whichever
approach the maintainers prefer; the unit test and repro details
should be useful in any case.

### Summary

In PD disaggregation, `CommonKVManager.get_mha_kv_ptrs_with_pp`'s
else-branch (case 3, entered when prefill is `PP > 1` with non-equal
per-rank layer counts) computes the destination V-pointer base as
`len(dst_kv_ptrs) // 2`. That formula assumes decode's KV pool is
laid out as `[K_0..K_{N-1}, V_0..V_{N-1}]`, but as soon as decode
appends its MTP/NEXTN draft KV pool, the real layout is
`[K_target..., V_target..., K_draft..., V_draft...]`. `len // 2` then
overcounts the target section by the number of draft K layers `M`,
shifting every target-V destination by `M` and, on the last PP rank,
overwriting the leading draft-K pointer with the tail of the target-V
writes.

The failure signature is very specific: the **first output token is
correct** (it comes from the aux buffer path), then every subsequent
decode step attends to a wrong V and the output drifts into garbled
text. With MTP on decode, the clobbered draft K also collapses
`spec_accept_rate` and inflates `output_len` to ~1–2k tokens per
request.

### Preconditions (all three required)

* Non-MLA / non-hybrid-MLA attention (regular MHA / GQA)
* Prefill `PP > 1` (`PP == 1` runs case 2 with a `multiplier_ratio`
  path that happens to compute the correct offset)
* Decode has MTP/NEXTN draft KV appended
  (`draft_token_to_kv_pool is not None`)

### Concrete repro

Qwen3-Next-style Qwen3.5-397B-W4A8, 60 layers with
`full_attention_interval=4` → 15 full-attn layers, split 3/4/4/4
across `PP=4`. Ranks with 4 layers see `16 % 4 == 0` and miss case 2
→ they hit the buggy case 3; NEXTN draft has `M=1` so each target V
pointer is off by one layer and rank 3's last write overwrites
`K_draft[0]`.

### Fix

Add a wire-protocol frame carrying decode's *target-model* layer
count captured **before** draft KV was concatenated, and use it as
the V offset in case 3.

* `KVArgs.num_target_kv_layers: int` — added in `base/conn.py`.
  Populated in `decode.py` and `prefill.py` immediately before
  `kv_data_ptrs += draft_kv_data_ptrs`, so it captures the true
  target section length. `-1` sentinel when there is no MTP.
* `KVArgsRegisterInfo.dst_num_target_kv_layers: int = -1` — added
  in `mooncake/conn.py`. Serialized as a single trailing ZMQ frame
  at wire position 18 (after staging at 14/15 and DCP at 16/17).
  `from_zmq` guards with `len(msg) > 18 and msg[18] != b""` so
  older senders that omit the frame still decode.
* `CommonKVManager.get_mha_kv_ptrs_with_pp` accepts a new optional
  `num_dst_target_kv_layers`. In case 3 the V base becomes
  `num_dst_target_kv_layers if > 0 else dst_num_total_layers` —
  cases 1 (equal layers) and 2 (`PP=1` multiplier_ratio) are
  untouched on purpose. Case 2 has its own arithmetic (which
  handles the `PP=1 + decode-only spec` shape correctly), and the
  launcher-side `verify_pp_epd_fixes` string check depends on the
  literal `"self.pp_size == 1"` branch remaining.
* `_send_kvcache_generic`, `send_kvcache`, and `send_kvcache_slice`
  thread the value through; the two call sites in the send loop
  pass `target_rank_registration_info.dst_num_target_kv_layers`.

### Why sender-side auto-detection isn't enough

Prefill cannot infer `num_target_kv_layers` from its own state:

* Prefill may not have loaded the NEXTN weights at all (typical PD
  deployment).
* Even when it does, `model_config.full_attention_layer_ids` is
  **overwritten in `model_runner.py` to the local PP-stage list**
  once PP init runs, so the global full-attn count can't be
  reconstructed without either walking every stage or receiving the
  value out-of-band.

Passing it in the register message is the cheapest and most robust
option.

### Why a third PR

Both #28229 and #33457 target the same underlying arithmetic error
in `get_mha_kv_ptrs_with_pp` case 3. This PR keeps them cross-linked
above and tries to add value in three places:

* **MTP-specific "clobbers draft K" symptom.** With MTP/NEXTN, the
  decode KV pool is `[K_target..., V_target..., K_draft..., V_draft...]`.
  On the last PP rank the shifted V slice overruns the target-V
  section and starts overwriting the FIRST draft-K pointer, which
  collapses `spec_accept_rate` on top of the target-V corruption.
  Neither #28229 nor #33457 mentions draft-K clobber; a spec-verify
  regression would keep triggering even after either of their fixes
  covers the target-V case, if the draft-K side is not analyzed.
* **Concrete production repro.** Qwen3-Next-style Qwen3.5-397B-W4A8,
  60 layers with `full_attention_interval=4` → 15 full-attn layers,
  `PP=4` splits 3/4/4/4 across ranks. Ranks with 4 layers hit case 3
  with the bug; rank 0 with 3 layers accidentally lands in case 2
  and computes correctly. This is the exact configuration where we
  originally observed the garbled output.
* **Design trade-off.** Compared to #28229 (prefill-side
  `prefill_num_total_layers`) and #33457 (per-layer id pairing), this
  PR passes a single decode-side snapshot of the target-layer count
  in the register message. The receiver already owns the layout
  invariant (target-then-draft), so encoding the invariant at the
  receiver side keeps the change local to `common/conn.py` and stays
  orthogonal to the hybrid-linear refactor. Happy to fold this into
  either of the other PRs if the maintainers prefer their overall
  shape — the unit test and repro should still apply.

### Test

`test/srt/disaggregation/test_pp_kv_ptrs.py` exercises the case-3
arithmetic in isolation (calling `get_mha_kv_ptrs_with_pp` on a
`SimpleNamespace` shim) with the Qwen3.5 15+1 layout for all four PP
ranks. It asserts:

* Fixed code path returns the correct V slice on ranks 0–3.
* Rank 3 does NOT touch draft-K pointers (regression guard).
* Legacy code path (with `num_dst_target_kv_layers=None`) reproduces
  the pre-fix corruption — a lock so a future refactor of the
  fallback branch keeps catching this bug.
* `-1` sentinel is equivalent to `None` (backward-compat guard).
* No-MTP layouts and cases 1 / 2 are unaffected by the new arg.

### Production reproduction

Ran on the exact repro config above — Qwen3.5-397B-W4A8, PD 4p1d,
prefill PP=4 (3/4/4/4), decode PP=1 TP=8 with MTP layer.0 — with the
combined V-offset + aux-race fixes toggled by reverse-applying the
bundled patch. `aiperf` 5-min sweep, ISL=40 000, concurrency=16,
`temperature=0`, `max_new_tokens=2048`, routed via mini_lb.

| Metric                        | Fix OFF (both bugs) | Fix ON (both fixes) | Δ         |
| ----------------------------- | ------------------- | ------------------- | --------- |
| Completed requests / 5 min    | 481                 | 784                 | **+63 %** |
| System total tok/s            | 65 148              | 105 665             | **+62 %** |
| `spec_accept_rate` mean       | 0.65                | 0.80                | **+15 pp** |
| `spec_accept_len` mean (of 3) | 1.95                | 2.40                | **+23 %** |
| OSL p50                       | **33** (fake-EOS)   | 304                 | +821 %    |
| OSL p90                       | **1929** (`max`)    | 480                 | −75 %     |
| Aiperf `usage_discrepancy_count` (out of the completed request count) | 358 / 481 (74 %)    | 0 / 784 (0 %)       | reset     |

Fixed-prompt curl (`temperature=0`, single request) — the signature
matches "first token correct → attention drifts to wrong V" exactly.

**Prompt 1**: `Janet's ducks lay 16 eggs per day...` (GSM8K item, answer=18)

**Fix ON** — `finish_reason=stop`, `completion_tokens=85`, coherent CoT
terminating with the correct answer:

```
Janet starts with 16 duck eggs. She eats 3 for breakfast, leaving
16 - 3 = 13 eggs. She then bakes 4 into muffins, leaving 13 - 4 = 9
eggs to sell. She sells these 9 eggs at $2 each, so she makes
9 * $2 = $18 per day. #### 18.
```

**Fix OFF** — `finish_reason=length`, `completion_tokens=2048`,
`reasoning_tokens=2047`, `content=null` (never emits `</think>`).
Verbatim first ~400 chars of `reasoning_content`:

```
Here1 spte sp:  そも )
  1
   sp:  1  1  1
   1  1   1  1 
  
  1  1  sp:  1  1 
   1  
  
 
  1  1  1  1  1  1  
  1  1 
  1 
  1 
 
  1  1  1   sp:  1  1  1  
  1  1 
  
  1  1 Золо
  1  1  1  1  1  
   1  1 
```

Last ~200 chars of the same 2048-token generation:

```
 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
 1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1  1
```

The whole 2048-token budget degenerates into whitespace-separated `1`s.


**Prompt 2**: `用中文解释 CAP 定理...`

**Fix ON** — `finish_reason=stop`, `completion_tokens=157`,
three well-formed Chinese paragraphs:

```
**一致性（Consistency）** 指的是在分布式系统中，所有节点在同一时刻看到的
数据是完全相同的。也就是说，一旦某个节点完成了数据更新，其他节点必须能立
即读取到最新的数据，否则就违背了一致性。

**可用性（Availability）** 意味着系统在任何时刻都能对请求做出响应，保证
服务不中断。即使部分节点发生故障，只要还有节点存活，系统就必须能正常处理
读写请求，不能让用户等到超时或报错。

**分区容错（Partition Tolerance）** 是指当网络出现故障，导致节点之间无法
通信（即发生网络分区）时，系统仍然能够继续运行。CAP 定理的核心结论是：在
网络分区不可避免的前提下，系统只能在一致性和可用性之间二选一，无法同时满
足三者。
```

- **Fix OFF** → `finish_reason=length`, `completion_tokens=2048`,
  `reasoning_tokens=2047`, `content=null`. Verbatim first 400 chars of
  `reasoning_content`:

  ```
  Thinking
  1ERERm is  1  2
   1  2   3  
   1 ists  2 
   1  2   3  4  5   6 
   1  2  3  
   1  2   3  sp  4  5  6  7  sp  8   sp  9  10  1
   1  2  3  4   5   6   7  8   9  10  11  12  13   14  15  16  1  17   sp  18  19  20  2
   1  2  3  4  5  6  
   1  2  3  4   5  6  7 
   1  2  3 
   1  sp  2  3  4  5   6  7  8   9  10  11
  ```

  The model emits `Thinking` (the reasoning-mode prefix — token 0 is
  correct, consistent with "first token from aux buffer path is fine"),
  then attention drifts to a wrong V slot and the rest of the generation
  collapses into `1 2 3 sp 4 5 6 …` number sequences that never form a
  sentence.

Note the `Fix OFF` column combines this V-offset bug with the aux-race
bug (#33496) that shipped in the same internal commit; both fire
together in NEXTN M=1 PD. The `test_pp_kv_ptrs.py` unit test above
isolates this PR's arithmetic contribution.
### Backward compatibility

* **Old decode + new prefill**: decode omits the trailing frame →
  prefill sees `len(msg) <= 18` at position 18 → falls back to the
  `-1` sentinel → legacy `len // 2` behavior. Only breaks in the same
  configurations that were already broken (old decode running MTP
  under `PP > 1`), so this is not a new regression.
* **New decode + old prefill**: prefill's `recv_multipart` accepts
  arbitrary trailing frames; the field is not read → no crash.
* **Both new**: fix is active.
* **No MTP either side**: `num_target_kv_layers` stays `-1` →
  fall back to `len // 2` → identical to old behavior.

### Checklist

- [x] The PR has a descriptive title
- [x] A minimal, well-scoped patch (one bug, one fix, one PR)
- [x] Added unit tests
- [x] Backward-compatible wire protocol via trailing-frame + sentinel
      (position 18, after staging 14/15 and DCP 16/17)
- [x] Non-mooncake transports are not affected (the new `KVArgs`
      field is opt-in and defaults to `-1`)



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30916973572](https://github.com/sgl-project/sglang/actions/runs/30916973572)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30916972809](https://github.com/sgl-project/sglang/actions/runs/30916972809)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->