### PR TITLE
Fix MXFP4 scale placeholder initialization

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -70,6 +70,10 @@ from sglang.srt.utils.custom_op import register_custom_op
 
 has_triton_kernels = is_triton_kernels_available()
 
+# Serialized MXFP4 scales use raw UE8M0 bytes. Keep fresh parameters valid for
+# post-load transforms and dummy initialization; 127 is the neutral scale (1.0).
+_UE8M0_ONE = 127
+
 
 if is_flashinfer_available():
     from flashinfer import (
@@ -473,10 +477,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w13_weight_scale = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                2 * intermediate_size_per_partition_after_pad,
-                hidden_size // mxfp4_block,
+            torch.full(
+                (
+                    layer.num_local_experts,
+                    2 * intermediate_size_per_partition_after_pad,
+                    hidden_size // mxfp4_block,
+                ),
+                fill_value=_UE8M0_ONE,
                 dtype=scale_dtype,
             ),
             requires_grad=False,
@@ -512,10 +519,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         w2_weight_scale = torch.nn.Parameter(
-            torch.zeros(
-                layer.num_local_experts,
-                hidden_size,
-                intermediate_size_per_partition_after_pad // mxfp4_block,
+            torch.full(
+                (
+                    layer.num_local_experts,
+                    hidden_size,
+                    intermediate_size_per_partition_after_pad // mxfp4_block,
+                ),
+                fill_value=_UE8M0_ONE,
                 dtype=scale_dtype,
             ),
             requires_grad=False,


### PR DESCRIPTION
## Summary

- Initialize serialized MXFP4 MoE scale placeholders with the raw UE8M0 encoding of 1.0 instead of zero.
- Keep packed weight placeholders zero-filled; real checkpoint loading still overwrites the scale placeholders.

## Failure

A real-weight Kimi K3 presharded reload with the MegaMoE/DeepGEMM path failed while rebuilding the post-processed parameter layout. Reload invokes process_weights_after_loading on a fresh model skeleton before copying the cached tensors, and the fresh MXFP4 scale placeholders reached DeepGEMM first.

The workers aborted in deep_gemm/include/deep_gemm/impls/smxx_layout.cuh:131, surfaced as CUDA error 719 from transform_sf_into_required_layout. This happened before the cached scales could be restored.

## Root cause

Serialized MXFP4 scales are stored as raw uint8 UE8M0 bytes. Fresh modules previously zero-filled these tensors. UE8M0 byte 0 represents 2^-127; converting it to FP32 produces a subnormal value instead of the normalized power-of-two representation required by the DeepGEMM layout transform.

Dummy initialization only randomizes floating-point tensors, so the uint8 scale tensors also retained their zero placeholders.

## Fix

Initialize the two serialized MXFP4 MoE scale tensors with byte 127, the UE8M0 representation of 1.0. This provides a neutral normalized placeholder for post-load processing and dummy execution while preserving normal checkpoint-loading behavior.

## Validation

The behavior was validated with actual Kimi K3 weights by seeding the same scale placeholders to byte 127 immediately before post-processing, which is equivalent to the initialization performed by this change. A TP8 disaggregated deployment with one prefill worker and eight decode workers completed all 144 target/draft rank reloads without the DeepGEMM assertion. An 8K-input/1K-output benchmark then completed 1280/1280 requests.

The full pre-commit suite also passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30978432947](https://github.com/sgl-project/sglang/actions/runs/30978432947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30978432790](https://github.com/sgl-project/sglang/actions/runs/30978432790)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->