### PR TITLE
[PD] Fix spurious FINISH_LENGTH for requests aborted during KV transfer

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -868,7 +868,14 @@ class SchedulerDisaggregationPrefillMixin:
                 # todo: set Transferring correctly in backend
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
-                if not isinstance(req.finished_reason, FINISH_ABORT):
+                if req.to_finish:
+                    # The request was aborted (e.g., input exceeded
+                    # max_req_input_len) while the KV transfer was in flight.
+                    # Promote the pending abort instead of letting the success
+                    # path overwrite it with a spurious FINISH_LENGTH.
+                    req.finished_reason = req.to_finish
+                    req.to_finish = None
+                elif not isinstance(req.finished_reason, FINISH_ABORT):
                     req.finished_reason = FINISH_LENGTH(length=0)
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 # FIXME: clean up req's data in transfer engine

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -965,7 +965,14 @@ class SchedulerDisaggregationPrefillMixin:
                 # todo: set Transferring correctly in backend
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
-                if not isinstance(req.finished_reason, FINISH_ABORT):
+                if req.to_finish:
+                    # The request was aborted (e.g., input exceeded
+                    # max_req_input_len) while the KV transfer was in flight.
+                    # Promote the pending abort instead of letting the success
+                    # path overwrite it with a spurious FINISH_LENGTH.
+                    req.finished_reason = req.to_finish
+                    req.to_finish = None
+                elif not isinstance(req.finished_reason, FINISH_ABORT):
                     req.finished_reason = FINISH_LENGTH(length=0)
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 # FIXME: clean up req's data in transfer engine

--- a/test/registered/unit/disaggregation/test_prefill_abort_finish_reason.py
+++ b/test/registered/unit/disaggregation/test_prefill_abort_finish_reason.py
@@ -1,0 +1,145 @@
+import asyncio
+import unittest
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, FINISH_LENGTH
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_req(rid, *, to_finish=None, finished_reason=None):
+    return SimpleNamespace(
+        rid=rid,
+        pending_bootstrap=False,
+        to_finish=to_finish,
+        finished_reason=finished_reason,
+        bootstrap_host=FAKE_BOOTSTRAP_HOST,
+        return_logprob=False,
+        metadata_buffer_index=-1,
+        disagg_kv_sender=SimpleNamespace(kv_mgr=None, clear=MagicMock()),
+        time_stats=MagicMock(),
+    )
+
+
+def _make_scheduler(req):
+    scheduler = SchedulerDisaggregationPrefillMixin.__new__(
+        SchedulerDisaggregationPrefillMixin
+    )
+    scheduler.disagg_prefill_inflight_queue = [req]
+    scheduler.attn_cp_cpu_group = MagicMock()
+    scheduler.attn_tp_cpu_group = MagicMock()
+    scheduler.tree_cache = MagicMock()
+    scheduler.output_streamer = MagicMock()
+    scheduler.req_to_metadata_buffer_idx_allocator = MagicMock()
+    scheduler.metrics_reporter = SimpleNamespace(enable_metrics=False)
+    return scheduler
+
+
+class TestPrefillAbortFinishReason(CustomTestCase):
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_pending_abort_promoted_on_transfer_success(
+        self, mock_poll, mock_release
+    ):
+        # A request aborted mid-transfer (e.g., input over max_req_input_len)
+        # carries its FINISH_ABORT in to_finish. KVPoll.Success must promote it
+        # instead of overwriting it with a spurious FINISH_LENGTH.
+        req = _make_req(
+            "abort-pending",
+            to_finish=FINISH_ABORT(
+                "input too long", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+        self.assertEqual(req.finished_reason.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(req.finished_reason.err_type, "BadRequestError")
+        finish_json = req.finished_reason.to_json()
+        self.assertEqual(finish_json["type"], "abort")
+        self.assertEqual(finish_json["status_code"], HTTPStatus.BAD_REQUEST)
+
+        # The streamed request carries the abort finish_reason on the wire.
+        scheduler.output_streamer.stream_output.assert_called_once()
+        streamed_reqs = scheduler.output_streamer.stream_output.call_args.args[0]
+        self.assertIs(streamed_reqs[0], req)
+        self.assertEqual(streamed_reqs[0].finished_reason.to_json()["type"], "abort")
+        self.assertEqual(
+            streamed_reqs[0].finished_reason.to_json()["status_code"],
+            HTTPStatus.BAD_REQUEST,
+        )
+
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_normal_success_still_finish_length_zero(
+        self, mock_poll, mock_release
+    ):
+        # A transfer that completes without any pending abort keeps the legacy
+        # behavior: FINISH_LENGTH(length=0).
+        req = _make_req("normal-success")
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_reason.length, 0)
+
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_existing_finish_abort_not_overwritten(self, mock_poll, mock_release):
+        # A request that already finished with FINISH_ABORT (written directly to
+        # finished_reason) must not be replaced by FINISH_LENGTH.
+        req = _make_req(
+            "abort-existing",
+            finished_reason=FINISH_ABORT(
+                "already aborted", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+        self.assertEqual(req.finished_reason.message, "already aborted")
+        self.assertEqual(req.finished_reason.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_abort_handler_raises_value_error_for_non_stream(self):
+        # The promoted FINISH_ABORT serializes to the wire finish_reason that
+        # TokenizerManager._handle_abort_finish_reason rejects for non-streaming
+        # requests, so the caller surfaces HTTP 400 instead of HTTP 200.
+        req = _make_req(
+            "abort-wire",
+            to_finish=FINISH_ABORT(
+                "input too long", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        out = {"meta_info": {"finish_reason": req.to_finish.to_json()}}
+        tm = TokenizerManager.__new__(TokenizerManager)
+
+        with self.assertRaises(ValueError) as ctx:
+            asyncio.run(tm._handle_abort_finish_reason(out, MagicMock(), is_stream=False))
+
+        self.assertIn("input too long", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_prefill_abort_finish_reason.py
+++ b/test/registered/unit/disaggregation/test_prefill_abort_finish_reason.py
@@ -1,0 +1,144 @@
+import asyncio
+import unittest
+from http import HTTPStatus
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
+from sglang.srt.managers.schedule_batch import FINISH_ABORT, FINISH_LENGTH
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_req(rid, *, to_finish=None, finished_reason=None):
+    return SimpleNamespace(
+        rid=rid,
+        pending_bootstrap=False,
+        to_finish=to_finish,
+        finished_reason=finished_reason,
+        bootstrap_host=FAKE_BOOTSTRAP_HOST,
+        return_logprob=False,
+        metadata_buffer_index=-1,
+        disagg_kv_sender=SimpleNamespace(kv_mgr=None, clear=MagicMock()),
+        time_stats=MagicMock(),
+    )
+
+
+def _make_scheduler(req):
+    scheduler = SchedulerDisaggregationPrefillMixin.__new__(
+        SchedulerDisaggregationPrefillMixin
+    )
+    scheduler.disagg_prefill_inflight_queue = [req]
+    scheduler.attn_cp_cpu_group = MagicMock()
+    scheduler.attn_tp_cpu_group = MagicMock()
+    scheduler.tree_cache = MagicMock()
+    scheduler.output_streamer = MagicMock()
+    scheduler.req_to_metadata_buffer_idx_allocator = MagicMock()
+    scheduler.metrics_reporter = SimpleNamespace(enable_metrics=False)
+    scheduler.scheduler_stage_metrics = None
+    return scheduler
+
+
+class TestPrefillAbortFinishReason(CustomTestCase):
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_pending_abort_promoted_on_transfer_success(self, mock_poll, mock_release):
+        # A request aborted mid-transfer (e.g., input over max_req_input_len)
+        # carries its FINISH_ABORT in to_finish. KVPoll.Success must promote it
+        # instead of overwriting it with a spurious FINISH_LENGTH.
+        req = _make_req(
+            "abort-pending",
+            to_finish=FINISH_ABORT(
+                "input too long", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+        self.assertEqual(req.finished_reason.status_code, HTTPStatus.BAD_REQUEST)
+        self.assertEqual(req.finished_reason.err_type, "BadRequestError")
+        finish_json = req.finished_reason.to_json()
+        self.assertEqual(finish_json["type"], "abort")
+        self.assertEqual(finish_json["status_code"], HTTPStatus.BAD_REQUEST)
+
+        # The streamed request carries the abort finish_reason on the wire.
+        scheduler.output_streamer.stream_output.assert_called_once()
+        streamed_reqs = scheduler.output_streamer.stream_output.call_args.args[0]
+        self.assertIs(streamed_reqs[0], req)
+        self.assertEqual(streamed_reqs[0].finished_reason.to_json()["type"], "abort")
+        self.assertEqual(
+            streamed_reqs[0].finished_reason.to_json()["status_code"],
+            HTTPStatus.BAD_REQUEST,
+        )
+
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_normal_success_still_finish_length_zero(self, mock_poll, mock_release):
+        # A transfer that completes without any pending abort keeps the legacy
+        # behavior: FINISH_LENGTH(length=0).
+        req = _make_req("normal-success")
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_LENGTH)
+        self.assertEqual(req.finished_reason.length, 0)
+
+    @patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+    @patch("sglang.srt.disaggregation.prefill.poll_and_all_reduce_attn_cp_tp_group")
+    def test_existing_finish_abort_not_overwritten(self, mock_poll, mock_release):
+        # A request that already finished with FINISH_ABORT (written directly to
+        # finished_reason) must not be replaced by FINISH_LENGTH.
+        req = _make_req(
+            "abort-existing",
+            finished_reason=FINISH_ABORT(
+                "already aborted", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        scheduler = _make_scheduler(req)
+        mock_poll.return_value = [KVPoll.Success]
+
+        done = scheduler.process_disagg_prefill_inflight_queue()
+
+        self.assertEqual(done, [req])
+        self.assertIsNone(req.to_finish)
+        self.assertIsInstance(req.finished_reason, FINISH_ABORT)
+        self.assertEqual(req.finished_reason.message, "already aborted")
+        self.assertEqual(req.finished_reason.status_code, HTTPStatus.BAD_REQUEST)
+
+    def test_abort_handler_raises_value_error_for_non_stream(self):
+        # The promoted FINISH_ABORT serializes to the wire finish_reason that
+        # TokenizerManager._handle_abort_finish_reason rejects for non-streaming
+        # requests, so the caller surfaces HTTP 400 instead of HTTP 200.
+        req = _make_req(
+            "abort-wire",
+            to_finish=FINISH_ABORT(
+                "input too long", HTTPStatus.BAD_REQUEST, "BadRequestError"
+            ),
+        )
+        out = {"meta_info": {"finish_reason": req.to_finish.to_json()}}
+        tm = TokenizerManager.__new__(TokenizerManager)
+
+        with self.assertRaises(ValueError) as ctx:
+            asyncio.run(
+                tm._handle_abort_finish_reason(out, MagicMock(), is_stream=False)
+            )
+
+        self.assertIn("input too long", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

fixes #33507 

  In PD disaggregation mode, a request aborted while its KV transfer is in
  flight (e.g. input exceeding the max input length) returned to the client with
  a spurious `FINISH_LENGTH(length=0)` and HTTP 200 instead of the pending
  `FINISH_ABORT` with the correct status code. The abort stored in
  `req.to_finish` was never promoted on transfer success, so the error message
  and status were lost on the wire.

## Modifications

  - `python/sglang/srt/disaggregation/prefill.py`: in the `KVPoll.Success`
    branch of `process_disagg_prefill_inflight_queue`, promote `req.to_finish`
    to `finished_reason` when set, and only fall back to
    `FINISH_LENGTH(length=0)` when no abort is pending (keeping the existing
    guard for an already-set `FINISH_ABORT`).
  - `test/registered/unit/disaggregation/test_prefill_abort_finish_reason.py`:
    new unit tests covering (1) promotion of a pending abort on transfer
    success, (2) the legacy `FINISH_LENGTH(length=0)` fallback, (3) preservation
    of an existing `FINISH_ABORT`, and (4) the non-streaming wire behavior
    (`ValueError` -> HTTP 400).

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A — no model-output changes; finish-reason handling only.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
  N/A — adds a single branch check in the transfer-completion path.

## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and
  [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34202490614](https://github.com/sgl-project/sglang/actions/runs/34202490614)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34202490184](https://github.com/sgl-project/sglang/actions/runs/34202490184)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34202490513](https://github.com/sgl-project/sglang/actions/runs/34202490513)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->