### PR TITLE
[Fix] Raise instead of guessing when a chat template declares no image token

### DIFF
--- a/python/sglang/lang/backend/vertexai.py
+++ b/python/sglang/lang/backend/vertexai.py
@@ -85,7 +85,7 @@ class VertexAI(BaseBackend):
     def text_to_vertexai_input(self, text, images):
         input = []
         # split with image token
-        text_segs = text.split(self.chat_template.image_token)
+        text_segs = text.split(self.chat_template.get_image_token())
         for image_path, image_base64_data in images:
             text_seg = text_segs.pop(0)
             if text_seg != "":

--- a/python/sglang/lang/backend/vertexai.py
+++ b/python/sglang/lang/backend/vertexai.py
@@ -85,7 +85,7 @@ class VertexAI(BaseBackend):
     def text_to_vertexai_input(self, text, images):
         input = []
         # split with image token
-        text_segs = text.split(self.chat_template.get_image_token())
+        text_segs = text.split(self.chat_template.image_token)
         for image_path, image_base64_data in images:
             text_seg = text_segs.pop(0)
             if text_seg != "":

--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 
 class ChatTemplateStyle(Enum):
@@ -15,9 +15,28 @@ class ChatTemplate:
     default_system_prompt: str
     role_prefix_and_suffix: Dict[str, Tuple[str, str]]
     stop_str: List[str] = ()
-    image_token: str = "<image>"
-    audio_token: str = "<audio>"
+    image_token: Optional[str] = None
+    audio_token: Optional[str] = None
     style: ChatTemplateStyle = ChatTemplateStyle.PLAIN
+
+    def get_image_token(self) -> str:
+        return self._require_mm_token("image_token", self.image_token)
+
+    def get_audio_token(self) -> str:
+        return self._require_mm_token("audio_token", self.audio_token)
+
+    def _require_mm_token(self, field: str, token: Optional[str]) -> str:
+        # Guessing a placeholder is worse than failing: a template with no
+        # declared token (notably the `default` fallback) would hand back a
+        # string the server's multimodal processor does not recognize, and the
+        # request then silently degrades to a text-only prompt.
+        if token is None:
+            raise ValueError(
+                f"Chat template '{self.name}' declares no {field}. Register the "
+                f"model's chat template with an explicit {field}, or take the "
+                "placeholder from the server-side multimodal processor."
+            )
+        return token
 
     def get_prefix_and_suffix(
         self, role: str, hist_messages: List[Dict]

--- a/python/sglang/lang/chat_template.py
+++ b/python/sglang/lang/chat_template.py
@@ -1,7 +1,7 @@
 import re
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Tuple
 
 
 class ChatTemplateStyle(Enum):
@@ -15,28 +15,9 @@ class ChatTemplate:
     default_system_prompt: str
     role_prefix_and_suffix: Dict[str, Tuple[str, str]]
     stop_str: List[str] = ()
-    image_token: Optional[str] = None
-    audio_token: Optional[str] = None
+    image_token: str = "<image>"
+    audio_token: str = "<audio>"
     style: ChatTemplateStyle = ChatTemplateStyle.PLAIN
-
-    def get_image_token(self) -> str:
-        return self._require_mm_token("image_token", self.image_token)
-
-    def get_audio_token(self) -> str:
-        return self._require_mm_token("audio_token", self.audio_token)
-
-    def _require_mm_token(self, field: str, token: Optional[str]) -> str:
-        # Guessing a placeholder is worse than failing: a template with no
-        # declared token (notably the `default` fallback) would hand back a
-        # string the server's multimodal processor does not recognize, and the
-        # request then silently degrades to a text-only prompt.
-        if token is None:
-            raise ValueError(
-                f"Chat template '{self.name}' declares no {field}. Register the "
-                f"model's chat template with an explicit {field}, or take the "
-                "placeholder from the server-side multimodal processor."
-            )
-        return token
 
     def get_prefix_and_suffix(
         self, role: str, hist_messages: List[Dict]

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -528,7 +528,7 @@ class StreamExecutor:
 
         self.images_.append((path, base64_data))
         self.cur_images.append((path, base64_data))
-        self.text_ += self.chat_template.get_image_token()
+        self.text_ += self.chat_template.image_token
 
     def _execute_video(self, expr: SglVideo):
         path = expr.path
@@ -538,7 +538,7 @@ class StreamExecutor:
 
         self.images_.append((path, base64_data))
         self.cur_images.append((path, base64_data))
-        self.text_ += self.chat_template.get_image_token()
+        self.text_ += self.chat_template.image_token
 
     def _spec_gen(self, sampling_params):
         stop = sampling_params.stop

--- a/python/sglang/lang/interpreter.py
+++ b/python/sglang/lang/interpreter.py
@@ -528,7 +528,7 @@ class StreamExecutor:
 
         self.images_.append((path, base64_data))
         self.cur_images.append((path, base64_data))
-        self.text_ += self.chat_template.image_token
+        self.text_ += self.chat_template.get_image_token()
 
     def _execute_video(self, expr: SglVideo):
         path = expr.path
@@ -538,7 +538,7 @@ class StreamExecutor:
 
         self.images_.append((path, base64_data))
         self.cur_images.append((path, base64_data))
-        self.text_ += self.chat_template.image_token
+        self.text_ += self.chat_template.get_image_token()
 
     def _spec_gen(self, sampling_params):
         stop = sampling_params.stop

--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -183,6 +183,22 @@ def download_image_with_retry(image_url: str, max_retries: int = 3) -> Image.Ima
             time.sleep(2**i)
 
 
+def build_vlm_image_prompt(processor, question: str) -> str:
+    # Take the image placeholder from the model's own HF chat template: a
+    # hand-written one silently degrades to a text-only prompt on any model
+    # whose placeholder differs.
+    return processor.apply_chat_template(
+        [
+            {
+                "role": "user",
+                "content": [{"type": "image"}, {"type": "text", "text": question}],
+            }
+        ],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+
+
 def is_in_ci():
     """Return whether it is in CI runner."""
     return get_bool_env_var("SGLANG_IS_IN_CI")

--- a/test/manual/distributed/test_dp_attention_large.py
+++ b/test/manual/distributed/test_dp_attention_large.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
 from sglang.test.kits.ebnf_constrained_kit import EBNFConstrainedMixin
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
@@ -164,24 +163,38 @@ class TestDPAttentionDP2TP4VLM(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_vlm_generate(self):
-        chat_template = get_chat_template_by_model_path(self.model)
-        prompt = f"{chat_template.image_token}What is in this image?"
+        # Go through /v1/chat/completions so the server inserts the model's own
+        # image placeholder instead of the test guessing one.
         response = requests.post(
-            self.base_url + "/generate",
+            self.base_url + "/v1/chat/completions",
             json={
-                "text": prompt,
-                "image_data": [self.image_url],
-                "sampling_params": {
-                    "temperature": 0,
-                    "max_new_tokens": 16,
-                },
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": self.image_url},
+                            },
+                            {"type": "text", "text": "What is in this image?"},
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 16,
             },
         )
         response.raise_for_status()
         response_json = response.json()
         print(response_json)
-        self.assertIn("output_ids", response_json)
-        self.assertGreater(len(response_json["output_ids"]), 0)
+        self.assertTrue(response_json["choices"][0]["message"]["content"])
+
+        # image_tokens comes from the prefill's multimodal item offsets, so a
+        # non-zero count is what proves the image reached the vision tower.
+        usage_details = response_json["usage"].get("prompt_tokens_details")
+        self.assertIsNotNone(usage_details, "prompt carried no multimodal tokens")
+        self.assertGreater(usage_details.get("image_tokens", 0), 0)
 
 
 if __name__ == "__main__":

--- a/test/manual/quant/test_torchao.py
+++ b/test/manual/quant/test_torchao.py
@@ -1,9 +1,9 @@
 import unittest
 
 import requests
+from transformers import AutoProcessor
 
 from sglang import Engine
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
 from sglang.test.kits.eval_accuracy_kit import MMLUMixin
 from sglang.test.test_utils import (
@@ -13,6 +13,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    build_vlm_image_prompt,
     is_in_amd_ci,
     popen_launch_server,
 )
@@ -72,8 +73,9 @@ class TestTorchAO(CustomTestCase, MMLUMixin):
 class TestTorchAOForVLM(CustomTestCase):
     def test_vlm_generate(self):
         model_path = DEFAULT_SMALL_VLM_MODEL_NAME_FOR_TEST
-        chat_template = get_chat_template_by_model_path(model_path)
-        text = f"{chat_template.image_token}What is in this picture? Answer: "
+        text = build_vlm_image_prompt(
+            AutoProcessor.from_pretrained(model_path), "What is in this picture?"
+        )
 
         engine = Engine(
             model_path=model_path,

--- a/test/registered/cuda_graph/piecewise/test_piecewise_cuda_graph_support_1_gpu.py
+++ b/test/registered/cuda_graph/piecewise/test_piecewise_cuda_graph_support_1_gpu.py
@@ -1,9 +1,9 @@
 import unittest
 
 import torch
+from transformers import AutoProcessor
 
 from sglang import Engine
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
@@ -13,6 +13,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     SimpleNamespace,
+    build_vlm_image_prompt,
     is_in_amd_ci,
     popen_launch_server,
 )
@@ -73,8 +74,9 @@ class TestPiecewiseCudaGraphQwen25VLEmbedding(CustomTestCase):
 
     def test_embedding(self):
         model_path = "Qwen/Qwen2.5-VL-3B-Instruct"
-        chat_template = get_chat_template_by_model_path(model_path)
-        text = f"{chat_template.image_token}What is in this picture? Answer: "
+        text = build_vlm_image_prompt(
+            AutoProcessor.from_pretrained(model_path), "What is in this picture?"
+        )
         extra_args = (
             {"mem_fraction_static": AMD_MEM_FRACTION_STATIC} if is_in_amd_ci() else {}
         )

--- a/test/registered/dp_attn/test_dp_attention.py
+++ b/test/registered/dp_attn/test_dp_attention.py
@@ -2,7 +2,6 @@ import unittest
 
 import requests
 
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
@@ -204,24 +203,38 @@ class TestDPAttentionDP2TP2VLM(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_vlm_generate(self):
-        chat_template = get_chat_template_by_model_path(self.model)
-        prompt = f"{chat_template.image_token}What is in this image?"
+        # Go through /v1/chat/completions so the server inserts the model's own
+        # image placeholder instead of the test guessing one.
         response = requests.post(
-            self.base_url + "/generate",
+            self.base_url + "/v1/chat/completions",
             json={
-                "text": prompt,
-                "image_data": [self.image_url],
-                "sampling_params": {
-                    "temperature": 0,
-                    "max_new_tokens": 16,
-                },
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": self.image_url},
+                            },
+                            {"type": "text", "text": "What is in this image?"},
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 16,
             },
         )
         response.raise_for_status()
         response_json = response.json()
         print(response_json)
-        self.assertIn("output_ids", response_json)
-        self.assertGreater(len(response_json["output_ids"]), 0)
+        self.assertTrue(response_json["choices"][0]["message"]["content"])
+
+        # image_tokens comes from the prefill's multimodal item offsets, so a
+        # non-zero count is what proves the image reached the vision tower.
+        usage_details = response_json["usage"].get("prompt_tokens_details")
+        self.assertIsNotNone(usage_details, "prompt carried no multimodal tokens")
+        self.assertGreater(usage_details.get("image_tokens", 0), 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/npu/basic_function/dp_attn/test_npu_dp_attention.py
+++ b/test/registered/npu/basic_function/dp_attn/test_npu_dp_attention.py
@@ -2,7 +2,6 @@ import unittest
 
 import requests
 
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.environ import envs
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.npu_eval_accuracy_kit import NPUGSM8KMixin
@@ -175,24 +174,38 @@ class TestDPAttentionDP2TP2VLM(CustomTestCase):
         kill_process_tree(cls.process.pid)
 
     def test_vlm_generate(self):
-        chat_template = get_chat_template_by_model_path(self.model)
-        prompt = f"{chat_template.image_token}What is in this image?"
+        # Go through /v1/chat/completions so the server inserts the model's own
+        # image placeholder instead of the test guessing one.
         response = requests.post(
-            self.base_url + "/generate",
+            self.base_url + "/v1/chat/completions",
             json={
-                "text": prompt,
-                "image_data": [self.image_url],
-                "sampling_params": {
-                    "temperature": 0,
-                    "max_new_tokens": 16,
-                },
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": self.image_url},
+                            },
+                            {"type": "text", "text": "What is in this image?"},
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 16,
             },
         )
         response.raise_for_status()
         response_json = response.json()
         print(response_json)
-        self.assertIn("output_ids", response_json)
-        self.assertGreater(len(response_json["output_ids"]), 0)
+        self.assertTrue(response_json["choices"][0]["message"]["content"])
+
+        # image_tokens comes from the prefill's multimodal item offsets, so a
+        # non-zero count is what proves the image reached the vision tower.
+        usage_details = response_json["usage"].get("prompt_tokens_details")
+        self.assertIsNotNone(usage_details, "prompt carried no multimodal tokens")
+        self.assertGreater(usage_details.get("image_tokens", 0), 0)
 
 
 if __name__ == "__main__":

--- a/test/registered/tokenizer/test_skip_tokenizer_init.py
+++ b/test/registered/tokenizer/test_skip_tokenizer_init.py
@@ -9,7 +9,6 @@ import unittest
 import requests
 from transformers import AutoProcessor, AutoTokenizer
 
-from sglang.lang.chat_template import get_chat_template_by_model_path
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import (
@@ -19,6 +18,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    build_vlm_image_prompt,
     download_image_with_retry,
     popen_launch_server,
 )
@@ -234,8 +234,7 @@ class TestSkipTokenizerInitVLM(TestSkipTokenizerInit):
         cls.eos_token_id = [cls.tokenizer.eos_token_id]
 
     def get_input_ids(self, _prompt_text) -> list[int]:
-        chat_template = get_chat_template_by_model_path(self.model)
-        text = f"{chat_template.image_token}What is in this picture?"
+        text = build_vlm_image_prompt(self.processor, "What is in this picture?")
         inputs = self.processor(
             text=[text],
             images=[self.image],

--- a/test/registered/tokenizer/test_skip_tokenizer_init.py
+++ b/test/registered/tokenizer/test_skip_tokenizer_init.py
@@ -91,9 +91,13 @@ class TestSkipTokenizerInit(CustomTestCase):
                 self.assertEqual(item["meta_info"]["prompt_tokens"], len(input_ids))
 
                 if return_logprob:
-                    num_input_logprobs = len(input_ids) - request["logprob_start_len"]
-                    if num_input_logprobs > len(input_ids):
-                        num_input_logprobs -= len(input_ids)
+                    # -1 resolves to the prompt end, so no input logprob is returned.
+                    if request["logprob_start_len"] == -1:
+                        num_input_logprobs = 0
+                    else:
+                        num_input_logprobs = (
+                            len(input_ids) - request["logprob_start_len"]
+                        )
                     self.assertEqual(
                         len(item["meta_info"]["input_token_logprobs"]),
                         num_input_logprobs,


### PR DESCRIPTION
`ChatTemplate.image_token` defaulted to `<image>`, so the `default` fallback template handed back a placeholder that no multimodal processor had declared -- callers silently built a prompt the server would not recognize. Undeclared now raises with an actionable message.

Behavior change: `sgl.image()` raises for models that fall back to the `default` template instead of emitting `<image>`. Those prompts were already wrong -- the `default` template's `SYSTEM:`/`USER:` role prefixes match none of these models; only the image token happened to line up for a few processors.

Stacks on #33509.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30891697369](https://github.com/sgl-project/sglang/actions/runs/30891697369)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30891696760](https://github.com/sgl-project/sglang/actions/runs/30891696760)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->