### PR TITLE
[Bugfix][MoE] Make Marlin route alignment deterministic

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/fused_marlin_moe.py
@@ -178,7 +178,10 @@ def fused_marlin_moe(
     if global_num_experts == -1:
         global_num_experts = E
     sorted_token_ids, expert_ids, num_tokens_post_padded = moe_align_block_size(
-        topk_ids, block_size_m, global_num_experts
+        topk_ids,
+        block_size_m,
+        global_num_experts,
+        deterministic=True,
     )
 
     if workspace is None:

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/moe_align_block_size.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 import torch
 import triton
+import triton.language as tl
 
 from sglang.srt.environ import envs
 from sglang.srt.utils import is_cuda, is_hip, is_musa, is_xpu
@@ -19,11 +20,185 @@ if _is_cuda or _is_hip or _is_xpu or _is_musa:
     from sglang.kernels.ops.moe import moe_align_block_size as sgl_moe_align_block_size
 
 
+@triton.jit
+def _deterministic_align_count(
+    topk_ids_ptr,
+    chunk_counts_ptr,
+    num_entries: tl.constexpr,
+    num_buckets: tl.constexpr,
+    entries_per_chunk: tl.constexpr,
+    ignore_invalid_expert: tl.constexpr,
+):
+    chunk_id = tl.program_id(0)
+    chunk_start = chunk_id * entries_per_chunk
+    row_offset = (chunk_id + 1) * num_buckets
+
+    for bucket in range(num_buckets):
+        tl.store(chunk_counts_ptr + row_offset + bucket, 0)
+
+    for local_offset in range(entries_per_chunk):
+        route_index = chunk_start + local_offset
+        if route_index < num_entries:
+            route = tl.load(topk_ids_ptr + route_index)
+            valid = True
+            if ignore_invalid_expert:
+                valid = route >= 0
+            if valid:
+                bucket = route + 1
+                count_offset = row_offset + bucket
+                count = tl.load(chunk_counts_ptr + count_offset)
+                tl.store(chunk_counts_ptr + count_offset, count + 1)
+
+
+@triton.jit
+def _deterministic_align_chunk_prefix(
+    chunk_counts_ptr,
+    num_buckets: tl.constexpr,
+):
+    bucket = tl.program_id(0)
+    prefix = 0
+    for chunk in range(1, num_buckets + 1):
+        offset = chunk * num_buckets + bucket
+        prefix += tl.load(chunk_counts_ptr + offset)
+        tl.store(chunk_counts_ptr + offset, prefix)
+
+
+@triton.jit
+def _deterministic_align_expert_prefix(
+    chunk_counts_ptr,
+    expert_offsets_ptr,
+    num_tokens_post_pad_ptr,
+    num_buckets: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offset = 0
+    tl.store(expert_offsets_ptr, 0)
+    totals_offset = num_buckets * num_buckets
+    for bucket in range(num_buckets):
+        count = tl.load(chunk_counts_ptr + totals_offset + bucket)
+        offset += tl.cdiv(count, block_size) * block_size
+        tl.store(expert_offsets_ptr + bucket + 1, offset)
+    tl.store(num_tokens_post_pad_ptr, offset)
+
+
+@triton.jit
+def _deterministic_align_scatter(
+    topk_ids_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    chunk_counts_ptr,
+    expert_offsets_ptr,
+    num_entries: tl.constexpr,
+    num_buckets: tl.constexpr,
+    block_size: tl.constexpr,
+    entries_per_chunk: tl.constexpr,
+    ignore_invalid_expert: tl.constexpr,
+):
+    chunk_id = tl.program_id(0)
+    bucket = chunk_id
+
+    expert_start = tl.load(expert_offsets_ptr + bucket)
+    expert_end = tl.load(expert_offsets_ptr + bucket + 1)
+    for block_start in range(expert_start, expert_end, block_size):
+        tl.store(expert_ids_ptr + block_start // block_size, bucket - 1)
+
+    chunk_start = chunk_id * entries_per_chunk
+    row_offset = chunk_id * num_buckets
+    for local_offset in range(entries_per_chunk):
+        route_index = chunk_start + local_offset
+        if route_index < num_entries:
+            route = tl.load(topk_ids_ptr + route_index)
+            route_bucket = route + 1
+            valid = True
+            if ignore_invalid_expert:
+                valid = route >= 0
+            if valid:
+                count_offset = row_offset + route_bucket
+                route_rank = tl.load(chunk_counts_ptr + count_offset)
+                output_offset = route_rank + tl.load(
+                    expert_offsets_ptr + route_bucket
+                )
+                tl.store(sorted_token_ids_ptr + output_offset, route_index)
+                tl.store(chunk_counts_ptr + count_offset, route_rank + 1)
+
+
+def _moe_align_block_size_deterministic(
+    topk_ids: torch.Tensor,
+    block_size: int,
+    num_experts: int,
+    ignore_invalid_expert: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_entries = topk_ids.numel()
+    num_buckets = num_experts + 1
+    max_num_tokens_padded = num_entries + num_buckets * (block_size - 1)
+    if num_entries < num_buckets:
+        max_num_tokens_padded = num_entries * block_size
+
+    sorted_ids = torch.full(
+        (max_num_tokens_padded,),
+        num_entries,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    expert_ids = torch.full(
+        (triton.cdiv(max_num_tokens_padded, block_size),),
+        -1,
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    num_tokens_post_pad = torch.empty(
+        (1,), dtype=torch.int32, device=topk_ids.device
+    )
+    chunk_counts = torch.zeros(
+        (num_buckets + 1, num_buckets),
+        dtype=torch.int32,
+        device=topk_ids.device,
+    )
+    expert_offsets = torch.zeros(
+        (num_buckets + 1,), dtype=torch.int32, device=topk_ids.device
+    )
+    entries_per_chunk = triton.cdiv(num_entries, num_buckets)
+
+    _deterministic_align_count[(num_buckets,)](
+        topk_ids,
+        chunk_counts,
+        num_entries,
+        num_buckets,
+        entries_per_chunk,
+        ignore_invalid_expert,
+    )
+    _deterministic_align_chunk_prefix[(num_buckets,)](
+        chunk_counts,
+        num_buckets,
+    )
+    _deterministic_align_expert_prefix[(1,)](
+        chunk_counts,
+        expert_offsets,
+        num_tokens_post_pad,
+        num_buckets,
+        block_size,
+    )
+    _deterministic_align_scatter[(num_buckets,)](
+        topk_ids,
+        sorted_ids,
+        expert_ids,
+        chunk_counts,
+        expert_offsets,
+        num_entries,
+        num_buckets,
+        block_size,
+        entries_per_chunk,
+        ignore_invalid_expert,
+    )
+    return sorted_ids, expert_ids, num_tokens_post_pad
+
+
 def moe_align_block_size(
     topk_ids: torch.Tensor,
     block_size: int,
     num_experts: int,
     ignore_invalid_expert: bool = False,
+    deterministic: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Aligns the token distribution across experts to be compatible with block
@@ -34,6 +209,7 @@ def moe_align_block_size(
         top-k expert indices for each token.
     - block_size: The block size used in block matrix multiplication.
     - num_experts: The total number of experts.
+    - deterministic: Whether to preserve a stable within-expert route order.
 
     Returns:
     - sorted_token_ids: A tensor containing the sorted token indices according
@@ -62,6 +238,14 @@ def moe_align_block_size(
     - The padding ensures that the total number of tokens is now divisible
         by block_size for proper block matrix operations.
     """
+    if deterministic:
+        return _moe_align_block_size_deterministic(
+            topk_ids,
+            block_size,
+            num_experts,
+            ignore_invalid_expert,
+        )
+
     # ===== TO BE REFACTORED ====
     if _SGLANG_EXPERIMENTAL_LORA_OPTI:
         from sglang.srt.lora.trtllm_lora_temp.environ import lora_envs

--- a/test/registered/kernels/ops/moe/test_moe_align_block_size.py
+++ b/test/registered/kernels/ops/moe/test_moe_align_block_size.py
@@ -8,6 +8,9 @@ import triton.language as tl
 
 from sglang.kernels.jit.utils import get_ci_test_range
 from sglang.kernels.ops.moe.moe_align import moe_align_block_size
+from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+    moe_align_block_size as runtime_moe_align_block_size,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -357,6 +360,43 @@ def test_moe_align_block_size_v2_large_num_experts(
             f"Block {b} sorted_ids mismatch for num_experts={num_experts}, "
             f"num_tokens={num_tokens}"
         )
+
+
+@pytest.mark.parametrize(
+    "num_tokens,topk,num_experts,with_invalid_routes",
+    [
+        (128, 2, 32, False),
+        (4097, 16, 128, False),
+        (2048, 8, 128, True),
+    ],
+)
+def test_runtime_moe_align_block_size_deterministic(
+    num_tokens: int,
+    topk: int,
+    num_experts: int,
+    with_invalid_routes: bool,
+):
+    torch.manual_seed(42)
+    topk_ids = torch.topk(
+        torch.randn(num_tokens, num_experts, device="cuda"), topk, dim=-1
+    ).indices.to(torch.int32)
+    if with_invalid_routes:
+        topk_ids[:, topk // 2 :] = -1
+
+    results = [
+        runtime_moe_align_block_size(
+            topk_ids,
+            block_size=64,
+            num_experts=num_experts,
+            deterministic=True,
+        )
+        for _ in range(20)
+    ]
+    torch.cuda.synchronize()
+
+    for result in results[1:]:
+        for expected, actual in zip(results[0], result):
+            assert torch.equal(expected, actual)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The large-route path of `moe_align_block_size` assigns within-expert slots using cross-CTA `atomicAdd` operations:
（sglang/python/sglang/kernels/aot/csrc/moe/moe_align_kernel.cu:40-41）

    int32_t rank_post_pad = atomicAdd(&cumsum_buffer[expert_id], 1);
    sorted_token_ids[rank_post_pad] = i;

Although this preserves the correct set of token-expert assignments, CUDA CTA scheduling does not guarantee the order in which slots are acquired. As a result, identical `topk_ids` can produce different within-expert `sorted_token_ids` orders across repeated runs.

This matters for Marlin MoE kernels because different route packing can change GEMM tile composition and floating-point rounding. The resulting low-bit differences may be amplified by subsequent layers and cause divergent greedy generation.

The issue is only visible on the multi-CTA path. The existing small-route path is already deterministic.

Reproduction on the current `sgl_kernel`:

    tokens=4097
    topk=16
    experts=128
    block_size=64
    repeats=100

    Before:
    bitwise-identical: 1/100
    first mismatch fields: ['sorted_token_ids']

Small-route control:

    tokens=128
    topk=2
    experts=32
    block_size=64
    repeats=100

    bitwise-identical: 100/100

## Modifications

This PR adds an opt-in deterministic route-alignment path and enables it only for the main Marlin MoE path.

### Deterministic Alignment

The new path uses four Triton stages:

1. Count routes per fixed input chunk and expert.
2. Compute deterministic per-chunk prefix counts.
3. Compute padded global expert offsets.
4. Scatter routes in fixed chunk and original route order.

This preserves a stable within-expert route order without relying on cross-CTA atomic slot allocation.

### API Compatibility

A new optional argument is added:

    moe_align_block_size(
        ...,
        deterministic: bool = False,
    )

The default remains `False`, so existing callers and backends continue using the current AOT/JIT implementation without behavior or performance changes.

Only the main Marlin MoE path opts in with:

    deterministic=True

The implementation also preserves the existing `-1` sentinel and `ignore_invalid_expert` behavior used by expert-parallel routing.

### Tests

Added determinism coverage for:

- Small-route control: `128 tokens × topk 2`, 32 experts.
- Large-route regression: `4097 tokens × topk 16`, 128 experts.
- Routes containing the `-1` EP sentinel.

The tests compare all three outputs bitwise:

- `sorted_token_ids`
- `expert_ids`
- `num_tokens_post_padded`


## Accuracy Tests

### Determinism Regression

Before this change:

    tokens=4097, topk=16, experts=128, block=64, repeats=100
    FAIL: repeat=1
    fields=['sorted_token_ids']
    different sorted entries=64972/69760

After this change:

    tokens=4097, topk=16, experts=128, block=64, repeats=100
    PASS: all outputs are bitwise deterministic

### Small-Route Control

    tokens=128, topk=2, experts=32, block=64, repeats=100
    PASS: all outputs are bitwise deterministic

### Semantic Equivalence

Compared the legacy AOT path with the deterministic path for the large shape:

    num_tokens_post_padded: equal
    per-expert assignment sets: equal
    deterministic path repeated output: bitwise equal

This confirms that the deterministic path preserves the same expert assignments and padding semantics while only fixing their within-expert order.

### EP Sentinel Coverage

Tested routes containing `-1` with both:

    ignore_invalid_expert=False
    ignore_invalid_expert=True

Both modes produce bitwise-identical complete output buffers across repeated runs.

### CUDA Graph

    CUDA Graph capture: PASS
    Repeated graph replay: bitwise equal

## Speed Tests and Profiling

Microbenchmark on an NVIDIA SM120 GPU:

    tokens=4097
    topk=16
    experts=128
    block_size=64

Results:

    Legacy AOT alignment:       36.9 us
    Deterministic alignment:   158.0 us

The deterministic alignment currently adds approximately `121 us` per large Marlin MoE invocation.

This overhead only affects the Marlin path because deterministic alignment is opt-in. Other MoE backends continue using the existing implementation.

This PR prioritizes correctness and keeps the integration scope small. A future optimization could replace the large-route Triton path with a stable radix-sort implementation and persistent scratch buffers.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30891318166](https://github.com/sgl-project/sglang/actions/runs/30891318166)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30891318469](https://github.com/sgl-project/sglang/actions/runs/30891318469)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->