### PR TITLE
[CI] Replace the rust-ext-build venv instead of failing when it exists

### DIFF
--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -164,7 +164,9 @@ jobs:
           python3 -m pip install --upgrade pip
           command -v uv >/dev/null 2>&1 || pip install uv
           # build_rust needs only the build backend, not sglang's ~294 runtime deps.
-          uv venv /tmp/rust-ext-build --python python3.10 --seed
+          # `--clear`: the path is fixed and these runners are persistent, so the
+          # venv the previous job left behind must be replaced, not treated as an error.
+          uv venv --clear /tmp/rust-ext-build --python python3.10 --seed
           # shellcheck disable=SC1091
           source /tmp/rust-ext-build/bin/activate
           uv pip install "setuptools>=61.0" "setuptools-rust>=1.10" "setuptools-scm>=8.0" wheel

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -164,8 +164,6 @@ jobs:
           python3 -m pip install --upgrade pip
           command -v uv >/dev/null 2>&1 || pip install uv
           # build_rust needs only the build backend, not sglang's ~294 runtime deps.
-          # `--clear`: the path is fixed and these runners are persistent, so the
-          # venv the previous job left behind must be replaced, not treated as an error.
           uv venv --clear /tmp/rust-ext-build --python python3.10 --seed
           # shellcheck disable=SC1091
           source /tmp/rust-ext-build/bin/activate

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -164,9 +164,12 @@ jobs:
           python3 -m pip install --upgrade pip
           command -v uv >/dev/null 2>&1 || pip install uv
           # build_rust needs only the build backend, not sglang's ~294 runtime deps.
-          uv venv --clear /tmp/rust-ext-build --python python3.10 --seed
+          # Per-job path: these runners are persistent and shared, so a fixed one
+          # both inherits the previous job's venv and races a concurrent build.
+          venv="${RUNNER_TEMP:-/tmp}/sglang-ci-rust-ext-${GITHUB_RUN_ID:-norun}-$$"
+          uv venv "${venv}" --python python3.10 --seed
           # shellcheck disable=SC1091
-          source /tmp/rust-ext-build/bin/activate
+          source "${venv}/bin/activate"
           uv pip install "setuptools>=61.0" "setuptools-rust>=1.10" "setuptools-scm>=8.0" wheel
           cd python
           SGLANG_BUILD_RUST_EXTS=all python setup.py build_rust --inplace

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -167,6 +167,9 @@ jobs:
           # Per-job path: these runners are persistent and shared, so a fixed one
           # both inherits the previous job's venv and races a concurrent build.
           venv="${RUNNER_TEMP:-/tmp}/sglang-ci-rust-ext-${GITHUB_RUN_ID:-norun}-$$"
+          # Best-effort, like ci_cleanup_venv.sh: under set -e a failing EXIT trap
+          # would fail the step, and nothing here is worth keeping for a postmortem.
+          trap 'rm -rf "${venv}" || true' EXIT
           uv venv "${venv}" --python python3.10 --seed
           # shellcheck disable=SC1091
           source "${venv}/bin/activate"


### PR DESCRIPTION
## Problem

`rust-ext-build / Build Rust Ext` (added in #33460) fails in ~11s on every PR that touches `rust/`, before it compiles anything:

```
uv venv /tmp/rust-ext-build --python python3.10 --seed
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at `/tmp/rust-ext-build`. Use `--clear` to replace it
```


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30894023296](https://github.com/sgl-project/sglang/actions/runs/30894023296)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30894019241](https://github.com/sgl-project/sglang/actions/runs/30894019241)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->