### PR TITLE
fix(rust-server): Drain recv_from_rpc in rust-server mode

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1796,14 +1796,24 @@ class Scheduler(
 
             output = self._request_dispatcher(recv_req)
             if output is not None:
-                if self.rust_server is not None:
-                    # Embedded Rust server: every control-request response goes
-                    # back through the egress ring (the zmq tokenizer socket is
-                    # not consumed); the Rust api_server shapes it per-endpoint.
-                    self.rust_server.push_control_output(recv_req, output)
-                elif isinstance(output, RpcReqOutput):
+                if isinstance(output, RpcReqOutput):
+                    # The rpc channel is a bidirectional zmq DEALER pair with
+                    # the offline `Engine`, and it exists in rust-server mode
+                    # too: the reply goes back down that socket, never through
+                    # the Rust egress ring (which routes by a rust-minted rid
+                    # that an rpc request does not carry). Checked before the
+                    # rust branch for exactly that reason.
+                    #
+                    # Only rank 0 holds the socket, so the None check is what
+                    # keeps the other ranks from answering -- every rank runs
+                    # `handle_rpc_request`, but one reply is owed.
                     if self.ipc_channels.recv_from_rpc is not None:
                         sock_send(self.ipc_channels.recv_from_rpc, output)
+                elif self.rust_server is not None:
+                    # Embedded Rust server: every other control-request response
+                    # goes back through the egress ring (the zmq tokenizer socket
+                    # is not consumed); the Rust api_server shapes it per-endpoint.
+                    self.rust_server.push_control_output(recv_req, output)
                 else:
                     self.ipc_channels.send_to_tokenizer.send_output(output, recv_req)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1797,16 +1797,10 @@ class Scheduler(
             output = self._request_dispatcher(recv_req)
             if output is not None:
                 if isinstance(output, RpcReqOutput):
-                    # The rpc channel is a bidirectional zmq DEALER pair with
-                    # the offline `Engine`, and it exists in rust-server mode
-                    # too: the reply goes back down that socket, never through
-                    # the Rust egress ring (which routes by a rust-minted rid
-                    # that an rpc request does not carry). Checked before the
-                    # rust branch for exactly that reason.
-                    #
-                    # Only rank 0 holds the socket, so the None check is what
-                    # keeps the other ranks from answering -- every rank runs
-                    # `handle_rpc_request`, but one reply is owed.
+                    # This must precede the rust branch: the egress ring routes by
+                    # a rust-minted rid, which an rpc request does not carry. Only
+                    # rank 0 holds the socket, so the None check keeps the other
+                    # ranks from replying as well.
                     if self.ipc_channels.recv_from_rpc is not None:
                         sock_send(self.ipc_channels.recv_from_rpc, output)
                 elif self.rust_server is not None:

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -108,9 +108,7 @@ class SchedulerRequestReceiver:
 
                 # Rust ringbuffer backend: drain the in-process ring fed by the
                 # embedded Rust TokenizerManager instead of the zmq *tokenizer*
-                # socket. Same non-blocking, msgpack-decoded contract as the zmq
-                # branch below. The rpc socket is a separate channel and is
-                # drained either way -- see its own loop.
+                # socket. Same non-blocking, msgpack-decoded contract.
                 if envs.SGLANG_RUST_SERVER.get():
                     recv_reqs.extend(
                         self.recv_from_tokenizer.drain(self.max_recv_per_poll)
@@ -125,24 +123,11 @@ class SchedulerRequestReceiver:
                             break
                         recv_reqs.append(recv_req)
 
-                # The rpc channel is a bidirectional zmq DEALER pair with the
-                # offline `Engine` (`collective_rpc`). The Rust server replaces
-                # the tokenizer channel only -- it has no rpc equivalent -- so
-                # this drain runs in both modes.
-                #
-                # In rust-server mode the idle loop parks on the ingress ring
-                # alone (`RustServerIdleSleeper`), and an rpc frame cannot wake
-                # that park: `flume` exposes no fd, so nothing can wait on the
-                # ring and a zmq socket at once. An rpc request that arrives
-                # while the scheduler is idle therefore sits in the socket until
-                # the park times out (1s) and the next poll reaches this loop.
-                #
-                # That wait is deliberate, not an oversight: it is capped at one
-                # park timeout, and `collective_rpc`'s only in-tree callers
-                # (`save_remote_model` / `save_sharded_model`) go on to spend
-                # seconds to minutes writing checkpoint weights, so up to a
-                # second spent getting noticed does not register against the
-                # work it precedes.
+                # The peer here is the offline `Engine` (`collective_rpc`). The
+                # Rust server replaces the tokenizer channel only, so this loop
+                # runs in both modes. In rust mode `RustServerIdleSleeper` parks
+                # on the ring alone, so a frame arriving at an idle scheduler
+                # waits out that park before this loop sees it.
                 while True:
                     try:
                         if self.recv_limit_reached(len(recv_reqs)):

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -107,23 +107,42 @@ class SchedulerRequestReceiver:
                 recv_reqs = []
 
                 # Rust ringbuffer backend: drain the in-process ring fed by the
-                # embedded Rust TokenizerManager instead of a zmq socket. Same
-                # non-blocking, msgpack-decoded contract as the zmq path below.
+                # embedded Rust TokenizerManager instead of the zmq *tokenizer*
+                # socket. Same non-blocking, msgpack-decoded contract as the zmq
+                # branch below. The rpc socket is a separate channel and is
+                # drained either way -- see its own loop.
                 if envs.SGLANG_RUST_SERVER.get():
                     recv_reqs.extend(
                         self.recv_from_tokenizer.drain(self.max_recv_per_poll)
                     )
-                    return recv_reqs
-
-                while True:
-                    try:
-                        if self.recv_limit_reached(len(recv_reqs)):
+                else:
+                    while True:
+                        try:
+                            if self.recv_limit_reached(len(recv_reqs)):
+                                break
+                            recv_req = sock_recv(self.recv_from_tokenizer, zmq.NOBLOCK)
+                        except zmq.ZMQError:
                             break
-                        recv_req = sock_recv(self.recv_from_tokenizer, zmq.NOBLOCK)
-                    except zmq.ZMQError:
-                        break
-                    recv_reqs.append(recv_req)
+                        recv_reqs.append(recv_req)
 
+                # The rpc channel is a bidirectional zmq DEALER pair with the
+                # offline `Engine` (`collective_rpc`). The Rust server replaces
+                # the tokenizer channel only -- it has no rpc equivalent -- so
+                # this drain runs in both modes.
+                #
+                # In rust-server mode the idle loop parks on the ingress ring
+                # alone (`RustServerIdleSleeper`), and an rpc frame cannot wake
+                # that park: `flume` exposes no fd, so nothing can wait on the
+                # ring and a zmq socket at once. An rpc request that arrives
+                # while the scheduler is idle therefore sits in the socket until
+                # the park times out (1s) and the next poll reaches this loop.
+                #
+                # That wait is deliberate, not an oversight: it is capped at one
+                # park timeout, and `collective_rpc`'s only in-tree callers
+                # (`save_remote_model` / `save_sharded_model`) go on to spend
+                # seconds to minutes writing checkpoint weights, so up to a
+                # second spent getting noticed does not register against the
+                # work it precedes.
                 while True:
                     try:
                         if self.recv_limit_reached(len(recv_reqs)):

--- a/test/registered/unit/managers/test_request_receiver_rpc_drain.py
+++ b/test/registered/unit/managers/test_request_receiver_rpc_drain.py
@@ -1,11 +1,11 @@
-"""The scheduler's rpc channel must survive rust-server mode.
+"""Regression tests for the scheduler's rpc channel under rust-server mode.
 
-Rank 0 has two input channels: the tokenizer channel (which the embedded Rust
-server replaces with an in-process ring) and the rpc channel (a zmq DEALER pair
-with the offline ``Engine``, which Rust has no equivalent for). A regression
-made ``_pull_raw_reqs`` return as soon as it had drained the ring, so the rpc
-socket was created and wired up but never read, and the matching reply branch in
-``process_input_requests`` was shadowed by the rust branch.
+Rank 0 has two input channels. The embedded Rust server replaces the tokenizer
+channel with an in-process ring, but it has no equivalent for the rpc channel, a
+zmq DEALER pair with the offline ``Engine``. ``_pull_raw_reqs`` used to return as
+soon as it had drained the ring, so the rpc socket was created and wired up but
+never read, and the rust branch in ``process_input_requests`` shadowed the reply
+that should have gone back over zmq.
 """
 
 import unittest
@@ -34,16 +34,11 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class _FakeSocket:
-    """A zmq socket holding a fixed queue, then empty.
+    """A zmq socket yielding a fixed queue, then raising ``zmq.Again``.
 
-    Yields each queued object once and then raises ``zmq.Again``, which is what a
-    real socket does under ``zmq.NOBLOCK`` with nothing queued. Both receive
-    methods are implemented so the test holds under either IPC encoding
-    (``sock_recv`` picks between them on ``SGLANG_USE_PICKLE_IPC``).
-
-    A fake rather than a real socket pair on purpose: a freshly connected
-    ``inproc://`` / ``ipc://`` pair races an immediate non-blocking ``recv``, so
-    a real pair would make this test flaky.
+    This is a fake rather than a real socket pair because a freshly connected
+    pair races an immediate non-blocking ``recv``. Both receive methods exist
+    because ``sock_recv`` picks between them on ``SGLANG_USE_PICKLE_IPC``.
     """
 
     def __init__(self, objs=()):
@@ -62,10 +57,10 @@ class _FakeSocket:
 
 
 class _FakeRing:
-    """Stand-in for ``RustServer`` as the receiver's ingress source.
+    """Stand-in for ``RustServer`` as the ingress source.
 
-    ``RustServer.drain`` returns already-decoded request objects, so what they
-    are is the ring's business, not the receiver's — hence plain sentinels.
+    ``drain`` returns objects that are already decoded, so their contents are the
+    ring's concern rather than the receiver's. Plain sentinels are enough here.
     """
 
     def __init__(self, objs=()):
@@ -87,7 +82,7 @@ def _make_receiver(*, recv_from_tokenizer, recv_from_rpc) -> SchedulerRequestRec
         input_blocker=None,
         mm_receiver=None,
         # All-defaults: pp_rank / attn_tp_rank / attn_cp_rank are 0, which is the
-        # rank-zero branch of _pull_raw_reqs — the only one that owns sockets.
+        # rank-zero branch of _pull_raw_reqs, the only one that owns sockets.
         ps=ParallelState.trivial(),
         tp_group=group,
         tp_cpu_group=group,
@@ -109,9 +104,9 @@ def _make_receiver(*, recv_from_tokenizer, recv_from_rpc) -> SchedulerRequestRec
 
 class TestRequestReceiverRpcDrain(unittest.TestCase):
     def test_rust_mode_drains_rpc_socket(self):
-        """Rust mode must read the rpc socket, not just the ingress ring.
+        """Rust mode reads the rpc socket as well as the ingress ring.
 
-        Draining only the ring leaves rpc requests queued forever, and
+        If it drains only the ring, rpc requests stay queued and
         ``collective_rpc`` blocks on a reply that is never sent.
         """
         ring_req = object()
@@ -133,11 +128,10 @@ class TestRequestReceiverRpcDrain(unittest.TestCase):
         self.assertEqual(recv_reqs[1], rpc_req)
 
     def test_rust_mode_does_not_read_the_zmq_tokenizer_socket(self):
-        """The ring replaces the tokenizer socket; both must not be drained.
+        """The ring replaces the tokenizer socket instead of adding to it.
 
-        Guards the branch that makes the ring an *alternative* to the tokenizer
-        socket rather than an addition — reading both would double-admit work in
-        any deployment that still has a producer on the zmq side.
+        Reading both would double-admit work in any deployment that still has a
+        producer on the zmq side.
         """
         ring = _FakeRing([object()])
         receiver = _make_receiver(recv_from_tokenizer=ring, recv_from_rpc=_FakeSocket())
@@ -153,10 +147,10 @@ class TestRequestReceiverRpcDrain(unittest.TestCase):
         self.assertEqual(ring.drain_calls, [-1])
 
     def test_zmq_mode_still_drains_both_sockets(self):
-        """The non-rust path keeps draining tokenizer *and* rpc into one list.
+        """The non-rust path drains the tokenizer socket and then the rpc socket.
 
-        The rust branch sits directly above these two loops, so restructuring it
-        can silently drop either one.
+        The rust branch sits directly above both loops, so restructuring it can
+        silently drop either one.
         """
         tokenizer_req = RpcReqInput(method="tokenizer_channel_sentinel")
         rpc_req = RpcReqInput(
@@ -192,11 +186,11 @@ class TestRpcReplyRouting(unittest.TestCase):
         return scheduler
 
     def test_rust_mode_replies_to_rpc_over_zmq(self):
-        """An RpcReqOutput must go back down the DEALER pair, not the egress ring.
+        """An RpcReqOutput goes back down the DEALER pair, not the egress ring.
 
         The Rust egress routes by a rust-minted rid, which an rpc request that
-        arrived over zmq does not carry — so pushing the reply there asserts and
-        takes the scheduler down.
+        arrived over zmq does not carry, so pushing the reply there trips an
+        assert and takes the scheduler down.
         """
         rpc_req = RpcReqInput(method="save_remote_model", parameters={"url": "s3://x"})
         rpc_out = RpcReqOutput(success=True, message="")
@@ -213,8 +207,8 @@ class TestRpcReplyRouting(unittest.TestCase):
     def test_rust_mode_still_routes_other_control_output_to_the_ring(self):
         """Only RpcReqOutput is special-cased; the rust branch keeps the rest.
 
-        Without this, hoisting the RpcReqOutput check could just as easily have
-        been written to swallow every control response.
+        A hoisted RpcReqOutput check could have been written to swallow every
+        control response instead of only that one type.
         """
         recv_req = SimpleNamespace(rid="abc", http_worker_ipc=None)
         output = SimpleNamespace()

--- a/test/registered/unit/managers/test_request_receiver_rpc_drain.py
+++ b/test/registered/unit/managers/test_request_receiver_rpc_drain.py
@@ -1,0 +1,233 @@
+"""The scheduler's rpc channel must survive rust-server mode.
+
+Rank 0 has two input channels: the tokenizer channel (which the embedded Rust
+server replaces with an in-process ring) and the rpc channel (a zmq DEALER pair
+with the offline ``Engine``, which Rust has no equivalent for). A regression
+made ``_pull_raw_reqs`` return as soon as it had drained the ring, so the rpc
+socket was created and wired up but never read, and the matching reply branch in
+``process_input_requests`` was shadowed by the rust branch.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import zmq
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState  # noqa: E402
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    RpcReqInput,
+    RpcReqOutput,
+    msgpack_encode,
+)
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+from sglang.srt.managers.scheduler_components.request_receiver import (  # noqa: E402
+    SchedulerRequestReceiver,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeSocket:
+    """A zmq socket holding a fixed queue, then empty.
+
+    Yields each queued object once and then raises ``zmq.Again``, which is what a
+    real socket does under ``zmq.NOBLOCK`` with nothing queued. Both receive
+    methods are implemented so the test holds under either IPC encoding
+    (``sock_recv`` picks between them on ``SGLANG_USE_PICKLE_IPC``).
+
+    A fake rather than a real socket pair on purpose: a freshly connected
+    ``inproc://`` / ``ipc://`` pair races an immediate non-blocking ``recv``, so
+    a real pair would make this test flaky.
+    """
+
+    def __init__(self, objs=()):
+        self.objs = list(objs)
+
+    def _pop(self):
+        if not self.objs:
+            raise zmq.Again()
+        return self.objs.pop(0)
+
+    def recv_pyobj(self, flags=0):
+        return self._pop()
+
+    def recv(self, flags=0):
+        return msgpack_encode(self._pop())
+
+
+class _FakeRing:
+    """Stand-in for ``RustServer`` as the receiver's ingress source.
+
+    ``RustServer.drain`` returns already-decoded request objects, so what they
+    are is the ring's business, not the receiver's — hence plain sentinels.
+    """
+
+    def __init__(self, objs=()):
+        self.objs = list(objs)
+        self.drain_calls = []
+
+    def drain(self, max_recv):
+        self.drain_calls.append(max_recv)
+        drained, self.objs = self.objs, []
+        return drained
+
+
+def _make_receiver(*, recv_from_tokenizer, recv_from_rpc) -> SchedulerRequestReceiver:
+    group = SimpleNamespace(rank=0, ranks=[0], cpu_group=object())
+    return SchedulerRequestReceiver(
+        recv_from_tokenizer=recv_from_tokenizer,
+        recv_from_rpc=recv_from_rpc,
+        recv_skipper=None,
+        input_blocker=None,
+        mm_receiver=None,
+        # All-defaults: pp_rank / attn_tp_rank / attn_cp_rank are 0, which is the
+        # rank-zero branch of _pull_raw_reqs — the only one that owns sockets.
+        ps=ParallelState.trivial(),
+        tp_group=group,
+        tp_cpu_group=group,
+        attn_tp_group=group,
+        attn_tp_cpu_group=group,
+        attn_cp_group=group,
+        attn_cp_cpu_group=group,
+        world_group=group,
+        server_args=SimpleNamespace(
+            enable_dp_attention=False,
+            enable_dp_attention_local_control_broadcast=False,
+        ),
+        model_config=SimpleNamespace(is_multimodal=False),
+        max_recv_per_poll=-1,
+        stream_output=lambda *args, **kwargs: None,
+        get_last_batch=lambda: None,
+    )
+
+
+class TestRequestReceiverRpcDrain(unittest.TestCase):
+    def test_rust_mode_drains_rpc_socket(self):
+        """Rust mode must read the rpc socket, not just the ingress ring.
+
+        Draining only the ring leaves rpc requests queued forever, and
+        ``collective_rpc`` blocks on a reply that is never sent.
+        """
+        ring_req = object()
+        rpc_req = RpcReqInput(method="save_remote_model", parameters={"url": "s3://x"})
+        receiver = _make_receiver(
+            recv_from_tokenizer=_FakeRing([ring_req]),
+            recv_from_rpc=_FakeSocket([rpc_req]),
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.request_receiver."
+            "envs.SGLANG_RUST_SERVER.get",
+            return_value=True,
+        ):
+            recv_reqs = receiver._pull_raw_reqs()
+
+        self.assertEqual(len(recv_reqs), 2)
+        self.assertIs(recv_reqs[0], ring_req)
+        self.assertEqual(recv_reqs[1], rpc_req)
+
+    def test_rust_mode_does_not_read_the_zmq_tokenizer_socket(self):
+        """The ring replaces the tokenizer socket; both must not be drained.
+
+        Guards the branch that makes the ring an *alternative* to the tokenizer
+        socket rather than an addition — reading both would double-admit work in
+        any deployment that still has a producer on the zmq side.
+        """
+        ring = _FakeRing([object()])
+        receiver = _make_receiver(recv_from_tokenizer=ring, recv_from_rpc=_FakeSocket())
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.request_receiver."
+            "envs.SGLANG_RUST_SERVER.get",
+            return_value=True,
+        ):
+            receiver._pull_raw_reqs()
+
+        # -1 (unlimited) is forwarded verbatim; RustServer.drain owns the fallback.
+        self.assertEqual(ring.drain_calls, [-1])
+
+    def test_zmq_mode_still_drains_both_sockets(self):
+        """The non-rust path keeps draining tokenizer *and* rpc into one list.
+
+        The rust branch sits directly above these two loops, so restructuring it
+        can silently drop either one.
+        """
+        tokenizer_req = RpcReqInput(method="tokenizer_channel_sentinel")
+        rpc_req = RpcReqInput(
+            method="save_sharded_model", parameters={"path": "/tmp/x"}
+        )
+        receiver = _make_receiver(
+            recv_from_tokenizer=_FakeSocket([tokenizer_req]),
+            recv_from_rpc=_FakeSocket([rpc_req]),
+        )
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.request_receiver."
+            "envs.SGLANG_RUST_SERVER.get",
+            return_value=False,
+        ):
+            recv_reqs = receiver._pull_raw_reqs()
+
+        self.assertEqual(recv_reqs, [tokenizer_req, rpc_req])
+
+
+class TestRpcReplyRouting(unittest.TestCase):
+    def _make_scheduler(self, *, rust_server) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.session_controller = MagicMock()
+        scheduler.return_health_check_ipcs = []
+        scheduler.rust_server = rust_server
+        scheduler.ipc_channels = SimpleNamespace(
+            recv_from_rpc=object(),
+            send_to_tokenizer=MagicMock(),
+        )
+        scheduler.flush_wrapper = MagicMock()
+        scheduler.external_corpus_manager = None
+        return scheduler
+
+    def test_rust_mode_replies_to_rpc_over_zmq(self):
+        """An RpcReqOutput must go back down the DEALER pair, not the egress ring.
+
+        The Rust egress routes by a rust-minted rid, which an rpc request that
+        arrived over zmq does not carry — so pushing the reply there asserts and
+        takes the scheduler down.
+        """
+        rpc_req = RpcReqInput(method="save_remote_model", parameters={"url": "s3://x"})
+        rpc_out = RpcReqOutput(success=True, message="")
+        rust_server = MagicMock()
+        scheduler = self._make_scheduler(rust_server=rust_server)
+        scheduler._request_dispatcher = MagicMock(return_value=rpc_out)
+
+        with patch("sglang.srt.managers.scheduler.sock_send") as sock_send:
+            scheduler.process_input_requests([rpc_req])
+
+        sock_send.assert_called_once_with(scheduler.ipc_channels.recv_from_rpc, rpc_out)
+        rust_server.push_control_output.assert_not_called()
+
+    def test_rust_mode_still_routes_other_control_output_to_the_ring(self):
+        """Only RpcReqOutput is special-cased; the rust branch keeps the rest.
+
+        Without this, hoisting the RpcReqOutput check could just as easily have
+        been written to swallow every control response.
+        """
+        recv_req = SimpleNamespace(rid="abc", http_worker_ipc=None)
+        output = SimpleNamespace()
+        rust_server = MagicMock()
+        scheduler = self._make_scheduler(rust_server=rust_server)
+        scheduler._request_dispatcher = MagicMock(return_value=output)
+
+        with patch("sglang.srt.managers.scheduler.sock_send") as sock_send:
+            scheduler.process_input_requests([recv_req])
+
+        rust_server.push_control_output.assert_called_once_with(recv_req, output)
+        sock_send.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes the "recv_from_rpc is never drained in rust-server mode" TODO item from #29799.

Rank 0's scheduler drains two input channels per event-loop iteration: the tokenizer channel (zmq PULL, `scheduler_input_ipc_name`) and the rpc channel (zmq DEALER, `rpc_ipc_name`, used only by the offline `sgl.Engine`'s `collective_rpc`). `SGLANG_RUST_SERVER` replaces the first with an in-process ring and has no rpc equivalent, so the second has to keep working in both modes.

The rust branch was added at the top of `_pull_raw_reqs` and ends in `return`, which exits the whole function: it bypasses the tokenizer drain (intended) and the rpc drain below it (not intended). The socket is still created and wired into the receiver, but nothing reads it. The reply direction has the mirror problem: `process_input_requests` tested `self.rust_server is not None` before `isinstance(output, RpcReqOutput)`, so the zmq reply branch was unreachable, and the Rust egress path it took instead asserts on a rust-minted rid that an rpc request arriving over zmq does not carry.

## Modifications

In `scheduler_components/request_receiver.py`, the early `return` becomes an `if/else`, so rust mode bypasses only the tokenizer drain. The rpc loop body is unchanged.

In `scheduler.py`, `process_input_requests` now tests `isinstance(output, RpcReqOutput)` before the `rust_server` branch, so an rpc reply goes back down the DEALER pair instead of into the Rust egress ring. This is behaviour-preserving in zmq mode: there `rust_server` is `None`, so that branch was already reached.

The two are one fix: draining without the reorder would make the first rpc request in rust mode hit the rid assert and take the scheduler down, turning a silent hang into a crash.

### Deliberately not changed

- Idle wake-up. In rust mode the idle loop parks on the ring alone, so an rpc frame arriving at an idle scheduler waits out the 1s park timeout. No unified wait exists, since `flume` exposes no fd and `zmq.Poller` cannot watch the ring. The delay is bounded and documented in a comment at the drain, and it is negligible for the checkpoint exports that are its only in-tree callers.

## Accuracy Tests

N/A

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30952583076](https://github.com/sgl-project/sglang/actions/runs/30952583076)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30952582600](https://github.com/sgl-project/sglang/actions/runs/30952582600)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->