### PR TITLE
[Model] Qwen2-MoE: overlap shared-expert compute with DeepEP communication on CUDA

### DIFF
--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -351,6 +351,15 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 config.num_experts + get_exec().moe.ep_num_redundant_experts
             )
             self.top_k = config.num_experts_per_tok
+        # Overlap shared_expert with DeepEP dispatch/combine on CUDA. Cached at
+        # init time per the general code style rule on init-static extraction;
+        # ``_forward_deepep`` reads this instead of re-deriving every layer.
+        self._enable_deepep_cuda_shared_overlap = (
+            _is_cuda
+            and self.alt_stream is not None
+            and self.shared_expert is not None
+            and get_moe_a2a_backend().is_deepep()
+        )
         self.is_nextn = is_nextn
 
     def get_moe_weights(self):
@@ -464,7 +473,11 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
             and envs.SGLANG_NPU_USE_MULTI_STREAM.get()
             and forward_batch.forward_mode.is_cuda_graph()
         )
+        enable_cuda_alt_stream = (
+            self._enable_deepep_cuda_shared_overlap and not enable_dual_stream
+        )
         shared_output = None
+        shared_event = None
         if hidden_states.shape[0] > 0:
             # router_logits: (num_tokens, n_experts)
             router_logits, _ = self.gate(hidden_states)
@@ -472,6 +485,14 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
                 shared_output = shared_expert_on_independent_stream(
                     hidden_states.clone(), self._forward_shared_experts
                 )
+            elif enable_cuda_alt_stream:
+                current_stream = torch.cuda.current_stream()
+                self.alt_stream.wait_stream(current_stream)
+                with torch.cuda.stream(self.alt_stream):
+                    shared_output = self._forward_shared_experts(hidden_states)
+                    if shared_output is not None:
+                        shared_output.record_stream(self.alt_stream)
+                        shared_event = self.alt_stream.record_event()
             else:
                 shared_output = self._forward_shared_experts(hidden_states)
             topk_output = self.topk(
@@ -494,6 +515,8 @@ class Qwen2MoeSparseMoeBlock(nn.Module):
         )
         if enable_dual_stream:
             wait_share_stream()
+        if shared_event is not None:
+            torch.cuda.current_stream().wait_event(shared_event)
 
         if shared_output is not None:
             final_hidden_states.add_(shared_output)

--- a/test/registered/unit/models/test_qwen2_moe_deepep_cuda_overlap.py
+++ b/test/registered/unit/models/test_qwen2_moe_deepep_cuda_overlap.py
@@ -1,0 +1,120 @@
+"""Unit tests for Qwen2MoeSparseMoeBlock._forward_deepep CUDA/DeepEP overlap.
+
+Exercises the ``self._enable_deepep_cuda_shared_overlap`` init-static gate and
+the fork/join scheduling contract added to ``_forward_deepep``:
+
+- When the gate is True and the NPU ``enable_dual_stream`` branch is not taken,
+  ``shared_expert`` forks onto ``self.alt_stream`` and joins via a CUDA event
+  before the final ``add_``.
+- When the gate is False the code path is bit-identical to the serial baseline
+  (no ``wait_stream``, no event record/wait), and the numerical result
+  ``experts + shared`` is unchanged.
+
+Pure Python — no GPU, no model weights, no server. Mocks ``torch.cuda`` stream
+APIs and ``torch.Tensor.record_stream`` so the scheduling contract is exercised
+on any host.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.models.qwen2_moe import Qwen2MoeSparseMoeBlock
+from sglang.test.test_utils import CustomTestCase
+
+
+class _StubTopKOutput:
+    """Identity placeholder for StandardTopKOutput; not inspected downstream."""
+
+
+def _build_block(*, gate_enabled: bool):
+    """Bare stub exposing exactly the attributes _forward_deepep reads."""
+    stub = SimpleNamespace()
+    stub._enable_deepep_cuda_shared_overlap = gate_enabled
+    stub.alt_stream = mock.MagicMock(name="alt_stream")
+    stub.alt_stream.record_event = mock.MagicMock(return_value=mock.sentinel.event)
+    stub.shared_expert = object()  # non-None marker; not called directly
+    stub.is_nextn = True  # skip ExpertLocationDispatchInfo.init_new branch
+    stub.layer_id = 0
+
+    router_logits = torch.zeros(1, 8)
+    stub.gate = mock.MagicMock(return_value=(router_logits, None))
+    stub.topk = mock.MagicMock(return_value=_StubTopKOutput())
+    stub.topk.empty_topk_output = mock.MagicMock(return_value=_StubTopKOutput())
+
+    shared_tensor = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    stub._forward_shared_experts = mock.MagicMock(return_value=shared_tensor)
+
+    experts_tensor = torch.tensor([[10.0, 20.0, 30.0, 40.0]])
+    stub.experts = mock.MagicMock(return_value=experts_tensor)
+
+    return stub
+
+
+def _call(stub, hidden_states):
+    forward_batch = SimpleNamespace(
+        forward_mode=SimpleNamespace(is_cuda_graph=lambda: False),
+        num_token_non_padded=None,
+    )
+    return Qwen2MoeSparseMoeBlock._forward_deepep(stub, hidden_states, forward_batch)
+
+
+class TestQwen2MoeDeepepCudaOverlap(CustomTestCase):
+    def _run(self, *, gate_enabled):
+        stub = _build_block(gate_enabled=gate_enabled)
+        hidden = torch.ones(1, 4)
+
+        current_stream = mock.MagicMock(name="current_stream")
+        alt_ctx = mock.MagicMock()
+        alt_ctx.__enter__ = mock.MagicMock(return_value=None)
+        alt_ctx.__exit__ = mock.MagicMock(return_value=False)
+
+        with mock.patch(
+            "sglang.srt.models.qwen2_moe.torch.cuda.current_stream",
+            return_value=current_stream,
+        ), mock.patch(
+            "sglang.srt.models.qwen2_moe.torch.cuda.stream",
+            return_value=alt_ctx,
+        ), mock.patch.object(
+            torch.Tensor, "record_stream", new=lambda self, s: None
+        ):
+            result = _call(stub, hidden)
+
+        return result, stub, current_stream
+
+    def test_gate_true_forks_and_joins_via_event(self):
+        result, stub, current_stream = self._run(gate_enabled=True)
+
+        stub.alt_stream.wait_stream.assert_called_once_with(current_stream)
+        stub.alt_stream.record_event.assert_called_once_with()
+        current_stream.wait_event.assert_called_once_with(mock.sentinel.event)
+
+        self.assertTrue(
+            torch.equal(result, torch.tensor([[11.0, 22.0, 33.0, 44.0]])),
+            f"unexpected result: {result}",
+        )
+
+    def test_gate_false_stays_serial(self):
+        result, stub, current_stream = self._run(gate_enabled=False)
+
+        stub.alt_stream.wait_stream.assert_not_called()
+        stub.alt_stream.record_event.assert_not_called()
+        current_stream.wait_event.assert_not_called()
+
+        self.assertTrue(
+            torch.equal(result, torch.tensor([[11.0, 22.0, 33.0, 44.0]])),
+            f"unexpected result: {result}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`Qwen2MoeSparseMoeBlock._forward_deepep` currently executes shared-expert compute before top-k routing and the routed experts:

```text
gate -> shared_expert -> topk -> DeepEP dispatch -> routed experts -> DeepEP combine -> add
```

The block already has a dual-stream path, but it is restricted to NPU by `is_npu()` and `SGLANG_NPU_USE_MULTI_STREAM`. CUDA therefore stays on the serial path, even when DeepEP is the MoE all-to-all backend.

This leaves an overlap opportunity in DeepEP low-latency decode. DeepEP dispatch/combine uses a limited number of SMs while waiting on communication, while small-batch shared-expert GEMMs are memory-bound and use only a fraction of the GPU. The shared-expert result is independent of top-k routing and routed-expert execution until the final accumulation.

With this change:

```text
default stream: gate -> topk -> DeepEP dispatch -> routed experts -> DeepEP combine -> wait -> add
alt stream:           \-> shared_expert --------------------------------------> event
```

## Modifications

- Add a CUDA auxiliary-stream path to `_forward_deepep` when all of the following hold:
  - the current device is CUDA;
  - `self.alt_stream` and `self.shared_expert` are available;
  - the MoE all-to-all backend is DeepEP; and
  - the existing NPU dual-stream path is not active.
- Reuse `self.alt_stream`, which is already passed into `Qwen2MoeSparseMoeBlock` and used by `forward_normal_dual_stream`.
- Make the auxiliary stream wait for the current stream before reading `hidden_states`.
- Run `shared_expert` on the auxiliary stream, protect the output with `record_stream`, and record a CUDA event for this fork.
- Wait for that event immediately before the final in-place `add_`.
- Preserve the existing NPU branch unchanged and give it precedence over the CUDA branch.
- Preserve the existing serial path for non-CUDA devices, non-DeepEP backends, or when the auxiliary stream/shared expert is unavailable.
- Cache the CUDA + DeepEP overlap eligibility in `__init__` so the invariant backend/device checks are not repeated in every layer.
- Add CPU-only unit coverage for the auxiliary-stream fork/join contract and the serial fallback.

Because `Qwen2MoeSparseMoeBlock` is shared, the change is inherited by `qwen2_moe`, `qwen3_5`, and `qwen3_5_mtp`.

## Accuracy Tests

This is a scheduling-only change: it runs the same operators and preserves the synchronization point before the final accumulation. Configurations outside the CUDA + DeepEP gate continue to use the existing serial path.

CPU-only unit tests with mocked CUDA stream APIs cover both scheduling branches:

- overlap enabled: the shared expert forks to `alt_stream`, records an event, and the default stream waits before `add_`;
- overlap disabled: no auxiliary-stream or event operations are issued and the serial fallback is preserved; and
- both branches produce the same expected `experts + shared_expert` result.

These tests validate the scheduling contract without requiring a GPU, model weights, or a DeepEP deployment. In the live A/B deployment, speculative-decoding acceptance length was also unchanged: `1.97` with overlap disabled and `1.97` with overlap enabled.

## Speed Tests and Profiling

### Setup

- Model: Qwen3-family MoE
- Quantization: W4A8
- Decoding: speculative decoding
- Hardware: 8× H800 SXM on the decode side
- MoE backend: `--moe-a2a-backend deepep --deepep-mode low_latency`
- aiperf workload: Poisson arrivals, `--request-rate 5`, ISL = 41,000, OSL = 250, five runs per variant

### Nsight Systems timeline

The traces below use the same decode workload and timeline scale.

| Baseline | This PR |
| --- | --- |
| <img width="480" alt="Before: serialized shared expert" src="https://github.com/user-attachments/assets/58fff82b-3ec4-4cb2-afea-ac0678d0b2f5" /> | <img width="480" alt="After: shared expert overlaps with DeepEP" src="https://github.com/user-attachments/assets/44fc55d1-8bd4-45ec-a3c7-7689ff040db3" /> |

Before this PR, `shared_expert` is serialized before DeepEP dispatch/combine. With this PR, it runs on `alt_stream` and overlaps with DeepEP communication; the default stream waits only before the final `add_`.

### aiperf

| Variant | Mean TPOT | Delta |
| --- | ---: | ---: |
| Baseline | 10.44 ms | — |
| This PR | 9.41 ms | -1.03 ms (-9.81%) |

Welch's t-test: `t = +6.81`, `p < 1e-4`.

### Live traffic

A 4P1D deployment collected about 34,000 decode-batch samples over 77 minutes. Within matched `rr` buckets, p50 latency improved monotonically from 2.4% at `rr=2` to 8.0% at `rr=4`.

The expected benefit is largest for DeepEP low-latency, small-batch, long-context decode. Large-batch and prefill workloads are expected to benefit less because shared-expert compute consumes more GPU resources and leaves less communication slack to overlap.

## Checklist

- [x] Format the code according to [SGLang's pre-commit guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add CPU-only unit tests for the overlap and serial fallback paths.
- [x] Documentation is not required: this is an internal scheduling optimization with no user-facing API or configuration changes.
- [x] Provide scheduling/output checks, profiling traces, and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance), including caching the init-static overlap gate.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30916730632](https://github.com/sgl-project/sglang/actions/runs/30916730632)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30916739775](https://github.com/sgl-project/sglang/actions/runs/30916739775)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->