### PR TITLE
fix(responses): let reasoning.effort enable thinking for explicit-thinking parsers

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -668,7 +668,8 @@ class OpenAIServingResponses(OpenAIServingChat):
             if mode in ("thinking", "enable_thinking"):
                 return effort != "none"
             if mode in ("explicit_thinking", "explicit_enable_thinking"):
-                return False
+                # effort is the explicit opt-in here; chat_template_kwargs never reaches this endpoint
+                return effort is not None and effort != "none"
             return False
         if config.special_case == "always":
             return True

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -660,5 +660,40 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         self.assertIsNotNone(msg)
 
 
+class ExplicitThinkingEffortTestCase(unittest.TestCase):
+    """reasoning.effort is the only way to ask for thinking on this endpoint:
+    chat_template_kwargs is not part of the Responses request, so gating
+    explicit-thinking parsers on it left the template thinking with the
+    detector switched off, and the transcript plus the close tag reached the
+    client as the answer."""
+
+    def _enabled(self, effort, mode="explicit_thinking"):
+        serving = make_serving()
+        serving.reasoning_parser = "deepseek-v4"
+        serving.template_manager.force_reasoning = False
+        serving.template_manager.reasoning_config = None
+        serving._reasoning_detector = Mock(reasoning_default=mode)
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            reasoning={"effort": effort} if effort is not None else None,
+        )
+        return serving._is_thinking_enabled_for_request(request)
+
+    def test_effort_enables_thinking(self):
+        for effort in ("low", "medium", "high"):
+            self.assertTrue(self._enabled(effort), effort)
+
+    def test_no_effort_leaves_thinking_off(self):
+        self.assertFalse(self._enabled(None))
+
+    def test_effort_none_leaves_thinking_off(self):
+        self.assertFalse(self._enabled("none"))
+
+    def test_explicit_enable_thinking_mode_matches(self):
+        self.assertTrue(self._enabled("medium", mode="explicit_enable_thinking"))
+        self.assertFalse(self._enabled(None, mode="explicit_enable_thinking"))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

On `/v1/responses`, `_is_thinking_enabled_for_request` answers `explicit_thinking` / `explicit_enable_thinking` with a hard `return False`:

```python
if mode in ("explicit_thinking", "explicit_enable_thinking"):
    return False
```

`deepseek-v4` resolves to `_DeepSeekV3Detector`, whose `reasoning_default` is `explicit_thinking`, so the detector is never started in thinking mode on this endpoint — for any request.

`reasoning.effort` still reaches the chat template, however, and switches thinking on there. The template prefills the opening `<think>`, the model writes its transcript and a closing `</think>`, and the detector — never told it begins inside the block, and with no opening tag left in the output to latch onto — passes everything through as content. The result is no `reasoning` item at all and the raw transcript plus `</think>` delivered as the answer.

The gate is unsatisfiable as written: `chat_template_kwargs` is not part of a Responses request, so nothing can ever flip `explicit_*` to true here. `reasoning.effort` is the only way to ask for thinking on this endpoint.

## Reproduction

`DeepSeek-V4-Flash-0731`, sglang 0.5.16, 4×B300, `--reasoning-parser deepseek-v4 --tool-call-parser deepseekv4`. `/v1/responses` with tools and `reasoning: {"effort": "medium"}` leaked in 8/8 requests, in two shapes:

```
message: "I'll check whether it is t-shirt weather. Let me get the weather.</think>"
message: "</think>The weather in Budapest is currently 31°C and sunny..."
```

Output items were `['message']` — never `['reasoning', 'message']`. Chat completions were never affected, because there `chat_template_kwargs` reaches the read side and the two agree.

## Modifications

Treat `effort` as the explicit opt-in for `explicit_*` modes, matching the `mistral` branch two lines above. After the change the same 80 probes across effort levels, tools, tool-result turns, streaming and non-streaming come back clean, and `effort` finally produces a proper reasoning item:

```
items: ['reasoning', 'message']
  reasoning: 'We need answer which is larger, 9.11 or 9.9. Need be careful...'
  message:   '9.9 is larger than 9.11.\n\nBecause 9.9 = 9.90, and 9.90 > 9.11.'
```

Four cases added to `test_serving_responses.py` covering effort present, absent, `"none"`, and the `explicit_enable_thinking` alias; the file's 23 tests pass.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _(no docs affected — internal gating fix)_
- [x] Provide accuracy and speed benchmark results _(not applicable — no inference path change)_

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30897665689](https://github.com/sgl-project/sglang/actions/runs/30897665689)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30897665259](https://github.com/sgl-project/sglang/actions/runs/30897665259)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->