### PR TITLE
fix(kimi-k3): hand-written section markers, and two Responses API bugs that break Codex

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -48,6 +48,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    field_serializer,
     field_validator,
     model_serializer,
     model_validator,
@@ -1713,6 +1714,23 @@ class ResponsesResponse(BaseModel):
     truncation: Optional[str] = None
     user: Optional[str] = None
     metadata: Optional[Dict[str, Any]] = None
+
+    @field_serializer("usage")
+    def _serialize_usage(self, usage: Optional[UsageInfo]) -> Optional[Dict[str, Any]]:
+        # the api specifies input_tokens/output_tokens here; UsageInfo stays
+        # chat-shaped internally so metrics and final_usage_info are unchanged
+        if usage is None:
+            return None
+        details = usage.prompt_tokens_details
+        return {
+            "input_tokens": usage.prompt_tokens,
+            "input_tokens_details": {
+                "cached_tokens": getattr(details, "cached_tokens", 0) or 0
+            },
+            "output_tokens": usage.completion_tokens or 0,
+            "output_tokens_details": {"reasoning_tokens": usage.reasoning_tokens or 0},
+            "total_tokens": usage.total_tokens,
+        }
 
     @classmethod
     def from_request(

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -79,6 +79,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# effort tiers the openai sdk's event models accept; we serve the wider api set
+_SDK_REASONING_EFFORTS = frozenset({"minimal", "low", "medium", "high"})
+
+
+def _sanitize_response_dict(d: dict) -> dict:
+    """Drop response fields the installed openai sdk's event models reject."""
+    d["tools"] = []
+    reasoning = d.get("reasoning")
+    if isinstance(reasoning, dict):
+        effort = reasoning.get("effort")
+        if effort is not None and effort not in _SDK_REASONING_EFFORTS:
+            reasoning["effort"] = "high" if effort in ("xhigh", "max") else None
+    return d
+
 
 class _MediaInputValidationError(ValueError):
     pass
@@ -1736,21 +1750,6 @@ class OpenAIServingResponses(OpenAIServingChat):
         # OpenAI SDK's Tool union may not know extended types; drop echo.
         response_dict["tools"] = []
 
-        # Convert UsageInfo to ResponseUsage format
-        if response_dict.get("usage"):
-            usage_info = response_dict["usage"]
-            response_dict["usage"] = {
-                "input_tokens": usage_info.get("prompt_tokens", 0),
-                "input_tokens_details": {
-                    "cached_tokens": usage_info.get("cached_tokens", 0)
-                },
-                "output_tokens": usage_info.get("completion_tokens", 0),
-                "output_tokens_details": {
-                    "reasoning_tokens": usage_info.get("reasoning_tokens", 0)
-                },
-                "total_tokens": usage_info.get("total_tokens", 0),
-            }
-
         yield _send_event(
             openai_responses_types.ResponseCompletedEvent(
                 type="response.completed",
@@ -1794,10 +1793,6 @@ class OpenAIServingResponses(OpenAIServingChat):
         # The streaming Response* event models echo ``tools`` through a
         # narrower OpenAI SDK Tool union; strip it to avoid pydantic
         # validation failures on extended tool types.
-        def _sanitize_response_dict(d: dict) -> dict:
-            d["tools"] = []
-            return d
-
         initial_response = _sanitize_response_dict(
             ResponsesResponse.from_request(
                 request,
@@ -2338,19 +2333,12 @@ class OpenAIServingResponses(OpenAIServingChat):
                     self.response_store[final_response.id] = final_response
 
         response_dict = _sanitize_response_dict(final_response.model_dump())
-        if response_dict.get("usage"):
-            usage_info = response_dict["usage"]
-            response_dict["usage"] = {
-                "input_tokens": usage_info.get("prompt_tokens", 0),
-                "input_tokens_details": {
-                    "cached_tokens": cached_tokens,
-                },
-                "output_tokens": usage_info.get("completion_tokens", 0),
-                "output_tokens_details": {
-                    "reasoning_tokens": reasoning_tokens_meta,
-                },
-                "total_tokens": usage_info.get("total_tokens", 0),
-            }
+        usage_dict = response_dict.get("usage")
+        if usage_dict:
+            usage_dict["input_tokens_details"]["cached_tokens"] = cached_tokens
+            usage_dict["output_tokens_details"][
+                "reasoning_tokens"
+            ] = reasoning_tokens_meta
 
         yield _send_event(
             openai_responses_types.ResponseCompletedEvent(

--- a/python/sglang/srt/function_call/kimik3_format.py
+++ b/python/sglang/srt/function_call/kimik3_format.py
@@ -1,3 +1,4 @@
+import re
 from typing import List
 
 THINK_OPEN = "<|open|>think<|sep|>"
@@ -41,6 +42,20 @@ def strip_partial_marker_suffix(text: str) -> str:
     return text
 
 
+# the model sometimes hand-writes a marker out of ordinary text tokens instead of
+# emitting the atomic special token, e.g. "<|open|>think<|sep|" with no closing ">",
+# or a truncated sep followed by a complete one; at least one sep is required so
+# prose that legitimately mentions a bare "<|open|>think" is left alone
+_HANDWRITTEN_MARKER_RE = re.compile(
+    r"<\|(?:open|close)\|>(?:think|response|message|tools)(?:<\|sep(?:\|>?)?)+"
+)
+
+
+def strip_handwritten_markers(text: str) -> str:
+    """Drop section markers the model spelled out as text rather than emitting."""
+    return _HANDWRITTEN_MARKER_RE.sub("", text)
+
+
 def strip_response_wrappers(text: str) -> str:
     open_idx = text.find(RESPONSE_OPEN)
     if open_idx != -1:
@@ -52,4 +67,4 @@ def strip_response_wrappers(text: str) -> str:
     else:
         text = text.replace(RESPONSE_CLOSE, "")
     text = text.replace(MESSAGE_CLOSE, "")
-    return strip_partial_marker_suffix(text)
+    return strip_partial_marker_suffix(strip_handwritten_markers(text))

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -219,3 +219,43 @@ def test_detector_capabilities_and_registration() -> None:
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))
+
+
+def test_handwritten_marker_before_prose() -> None:
+    # the model spells the marker out with plain text tokens instead of emitting
+    # it, so the sep is truncated: reported from two b300 deployments
+    detector = KimiK3Detector()
+    result = detector.detect_and_parse(
+        "<|open|>think<|sep|the answer is 4", [_make_tool("python")]
+    )
+    assert result.normal_text == "the answer is 4"
+
+
+def test_handwritten_marker_before_tools_channel() -> None:
+    detector = KimiK3Detector()
+    tools_channel = (
+        TOOLS_OPEN + _call_block("python", 1, {"code": ("string", "1")}) + TOOLS_CLOSE
+    )
+    result = detector.detect_and_parse(
+        "<|open|>think<|sep|" + tools_channel, [_make_tool("python")]
+    )
+    assert result.normal_text == ""
+    assert len(result.calls) == 1
+
+
+def test_repeated_seps_in_handwritten_marker() -> None:
+    # truncated sep followed by a complete one, at the tail of a text block
+    detector = KimiK3Detector()
+    result = detector.detect_and_parse(
+        "Let me try that.\n<|close|>think<|sep|<|sep|>", [_make_tool("python")]
+    )
+    assert result.normal_text == "Let me try that.\n"
+
+
+def test_prose_about_bare_marker_survives() -> None:
+    # a reply explaining the syntax must not be scrubbed; a bare marker with no
+    # sep is not a marker
+    from sglang.srt.function_call.kimik3_format import strip_handwritten_markers
+
+    prose = "you asked about <|open|>think and what it does"
+    assert strip_handwritten_markers(prose) == prose

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -660,5 +660,76 @@ class HarmonyResponsesTestCase(unittest.TestCase):
         self.assertIsNotNone(msg)
 
 
+class SdkSanitizerTestCase(unittest.TestCase):
+    """The request schema serves effort tiers above the installed SDK's set, and
+    the SDK's event models reject what they do not know, so the created event
+    raised mid-stream and the client saw the stream close before completion."""
+
+    def _effort(self, value):
+        from sglang.srt.entrypoints.openai.serving_responses import (
+            _sanitize_response_dict,
+        )
+
+        return _sanitize_response_dict(
+            {"tools": [{"type": "custom"}], "reasoning": {"effort": value}}
+        )["reasoning"]["effort"]
+
+    def test_extended_tiers_clamp_to_high(self):
+        self.assertEqual(self._effort("xhigh"), "high")
+        self.assertEqual(self._effort("max"), "high")
+
+    def test_known_tiers_pass_through(self):
+        for tier in ("minimal", "low", "medium", "high"):
+            self.assertEqual(self._effort(tier), tier)
+
+    def test_unknown_tier_drops_to_null(self):
+        self.assertIsNone(self._effort("none"))
+
+
+class ResponsesUsageShapeTestCase(unittest.TestCase):
+    """Non-streaming responses returned chat-shaped usage, so clients reading
+    input_tokens/output_tokens saw nothing and reported zero cost."""
+
+    def _dump(self, usage):
+        from sglang.srt.entrypoints.openai.protocol import ResponsesResponse
+
+        return ResponsesResponse(model="x", status="completed", usage=usage).model_dump()[
+            "usage"
+        ]
+
+    def test_serialized_usage_uses_responses_keys(self):
+        from sglang.srt.entrypoints.openai.protocol import (
+            PromptTokensDetails,
+            UsageInfo,
+        )
+
+        dumped = self._dump(
+            UsageInfo(
+                prompt_tokens=11,
+                completion_tokens=7,
+                total_tokens=18,
+                reasoning_tokens=2,
+                prompt_tokens_details=PromptTokensDetails(cached_tokens=5),
+            )
+        )
+        self.assertEqual(dumped["input_tokens"], 11)
+        self.assertEqual(dumped["output_tokens"], 7)
+        self.assertEqual(dumped["total_tokens"], 18)
+        self.assertEqual(dumped["input_tokens_details"]["cached_tokens"], 5)
+        self.assertEqual(dumped["output_tokens_details"]["reasoning_tokens"], 2)
+        self.assertNotIn("prompt_tokens", dumped)
+
+    def test_attribute_access_stays_chat_shaped(self):
+        from sglang.srt.entrypoints.openai.protocol import ResponsesResponse, UsageInfo
+
+        response = ResponsesResponse(
+            model="x", status="completed", usage=UsageInfo(prompt_tokens=3, completion_tokens=4)
+        )
+        self.assertEqual(response.usage.prompt_tokens, 3)
+
+    def test_none_usage_serializes_to_none(self):
+        self.assertIsNone(self._dump(None))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Supersedes #32567, which was opened against `kimi-k3` before the marker work landed on main. Five of the six leak shapes in that PR are fixed on main already; this is the remainder, rebuilt against current main. Field reports and repro sequences in the original thread came from @jetd1 (Baidu B300 deployment) — the double-sep tail below is theirs.

## 1. Hand-written section markers still reach the client

After a zero-length think close the model sometimes writes its next marker out of ordinary text tokens rather than emitting the atomic one, so the sep arrives truncated:

```
<|open|>think<|sep|the answer is 4          # no closing >
Let me try that.\n<|close|>think<|sep|<|sep|>   # truncated sep, then a complete one
```

Exact matching walks straight past both. On current main:

```python
KimiK3Detector().detect_and_parse("<|open|>think<|sep|the answer is 4", tools)
# normal_text == "<|open|>think<|sep|the answer is 4"
```

This compounds: once a marker lands in assistant history the model imitates it on later turns (four poisoned turns in one session, reported on #32567).

Matched tolerantly now in `strip_response_wrappers`, which both the reasoning parser's and the tool detector's content paths already share. At least one sep is required, so a reply that legitimately explains a bare `<|open|>think` in prose survives — that false positive was observed in production too, in a 4193-char answer about this very bug.

## 2. Codex cannot complete a single request

`codex-cli` 0.145 sends `reasoning.effort=xhigh`. The request schema accepts it (`ReasoningEffortTier` lists `xhigh`/`max`), but the installed OpenAI SDK's event models only know `minimal|low|medium|high`, so `ResponseCreatedEvent` raises mid-stream:

```
pydantic_core.ValidationError: 1 validation error for ResponseCreatedEvent
  Input should be 'minimal', 'low', 'medium' or 'high' [input_value='xhigh']
```

The client sees `stream disconnected before completion: stream closed before response.completed`, retries five times, and fails. `_sanitize_response_dict` already exists for exactly this class of problem with extended tool types; it now clamps unknown effort tiers as well, and moves to module scope so the harmony path shares it.

## 3. Non-streaming usage is chat-shaped

`/v1/responses` returned `{"prompt_tokens": ..., "completion_tokens": ...}` outside the streaming path, so Responses clients reading `input_tokens`/`output_tokens` got nothing and reported zero cost (LiteLLM logs `Error constructing ResponsesAPIResponse ... using model_construct` on every call). Serialized in the API shape on `ResponsesResponse` itself, which fixes the non-streaming body and stored-response retrieval and lets the two hand-rolled conversions in the streaming generators go. `UsageInfo` stays chat-shaped internally, so metrics and `final_usage_info` are unchanged.

## Tests

Four cases for the hand-written variants (including the byte-exact tails from the field reports and a guard that prose about a bare marker is preserved), three for the effort clamp, three for the usage shape. 148 pass across `test_kimik3_detector`, `test_reasoning_parser`, `test_serving_responses` and `test_serving_responses_stream`.

Verified on 8×B300 serving `moonshotai/Kimi-K3` (tp8/dcp8, DSPARK): Claude Code and Codex both run clean afterwards, and a 30-request Codex-shaped probe over `/v1/responses` reports no leaks, correct usage, and no dropped streams.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to the [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). _(no docs affected)_
- [x] Provide accuracy and speed benchmark results _(not applicable — parser and serialization only)_

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30898302132](https://github.com/sgl-project/sglang/actions/runs/30898302132)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30898299811](https://github.com/sgl-project/sglang/actions/runs/30898299811)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->