### PR TITLE
[JIT] per_token_group_quant: fix the fp16 UE8M0 multiplier overflow, 1.23x on the fused EP-MoE path, unify the scale allocation

### DIFF
--- a/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
@@ -12,6 +12,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
 from sglang.kernels.ops.quantization.fp8_kernel import (
+    PER_TOKEN_GROUP_QUANT_EPS,
     sglang_per_token_group_quant_8bit,
 )
 from sglang.srt.utils import is_hip
@@ -136,10 +137,12 @@ def test_per_token_group_quant_with_column_major(
         x=x,
         masked_m=masked_m,
         group_size=group_size,
-        eps=1e-10,
         dst_dtype=dst_dtype,
         **{k: v for k, v in flags.items() if k not in ["masked_layout_mode"]},
     )
+    # The Triton reference still takes the absmax floor per call; the sglang entry
+    # point bakes it in (PER_TOKEN_GROUP_QUANT_EPS), so it has no eps parameter.
+    triton_kwargs = dict(execute_kwargs, eps=PER_TOKEN_GROUP_QUANT_EPS)
 
     def _postprocess(x_q, x_s):
         if masked_m is not None:
@@ -150,7 +153,7 @@ def test_per_token_group_quant_with_column_major(
         return x_q, x_s
 
     x_q_triton, x_s_triton = _postprocess(
-        *triton_per_token_group_quant_8bit(**execute_kwargs)
+        *triton_per_token_group_quant_8bit(**triton_kwargs)
     )
     x_q_sglang, x_s_sglang = _postprocess(
         *sglang_per_token_group_quant_8bit(**execute_kwargs)

--- a/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
+++ b/python/sglang/kernels/aot/tests/test_per_token_group_quant_8bit.py
@@ -9,10 +9,12 @@ from sgl_kernel.test_utils import (
 )
 
 from sglang.kernels.ops.quantization.fp8_kernel import (
+    PER_TOKEN_GROUP_QUANT_EPS,
+)
+from sglang.kernels.ops.quantization.fp8_kernel import (
     per_token_group_quant_8bit as triton_per_token_group_quant_8bit,
 )
 from sglang.kernels.ops.quantization.fp8_kernel import (
-    PER_TOKEN_GROUP_QUANT_EPS,
     sglang_per_token_group_quant_8bit,
 )
 from sglang.srt.utils import is_hip

--- a/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/per_token_group_quant.cuh
@@ -21,12 +21,18 @@ namespace {
 namespace details {
 
 SGL_DEVICE float silu(const float val) {
-  // silu(x) = x * sigmoid(x)
+  // silu(x) = x * sigmoid(x). Keep the plain divide: under --use_fast_math it is
+  // MUFU.RCP + FMUL, whereas an explicit __frcp_rn(1 + exp) is a Newton
+  // refinement (MUFU.RCP + 2 FFMA + FADD) behind a branch into an out-of-line
+  // special-value fixup. This runs per ELEMENT (not once per group like the
+  // quant multiplier), so on the fused masked path it dominated: 608 -> 384
+  // SASS instructions and 1.23x on the EP-MoE decode shapes when switched back.
+  // The divide also keeps the fused output bit-identical to the AOT v2 op.
 #if SGL_ARCH_BLACKWELL_OR_GREATER
   const float half = 0.5f * val;
   return half * (1.0f + __tanhf(half));
 #else
-  return val * __frcp_rn(1.0f + __expf(-val));
+  return val / (1.0f + __expf(-val));
 #endif
 }
 
@@ -231,6 +237,10 @@ struct QuantTrait {
   static constexpr uint32_t kBlockSize = 256;
   static constexpr uint32_t kVecSize = 32u / sizeof(InputType);
   static constexpr uint32_t kNumLanes = kGroupSize / kVecSize;
+  // Group-absmax floor, baked in here (the host rejects a caller eps != this).
+  // It bounds the quant multiplier at kMaxValue / kAmaxFloor, which is what
+  // decides whether the multiplier is representable in InputType below.
+  static constexpr float kAmaxFloor = 1e-10f;
   static_assert(sizeof(InputType) == 2, "only 16-bit inputs (bf16/fp16) are supported");
   static_assert(16 <= kGroupSize && kGroupSize <= 256, "supported group sizes are 16..256");
   static_assert(kGroupSize % kVecSize == 0 && 1 <= kNumLanes && kNumLanes <= device::kWarpThreads);
@@ -280,27 +290,43 @@ struct QuantTrait {
       local_amax2 = math::max(local_amax2, math::abs(in[i]));
     }
     const auto amax2 = cast<float2>(warp::reduce_max<kNumLanes>(local_amax2));
-    const auto amax = math::max(math::max(amax2.x, amax2.y), 1e-10f);
+    const auto amax = math::max(math::max(amax2.x, amax2.y), kAmaxFloor);
     const float raw_scale = amax * kMaxValueInv;  // the dequant scale the GEMM consumes
 
     out_vec_t out;
     details::scale_t<kUe8m0> scale_inv;
     if constexpr (kUe8m0) {
-      // ue8m0 scale: pow-2 quant multiplier is exact in float16/bfloat16 type
       static_assert(std::is_same_v<Q, fp8_e4m3_t>, "ue8m0 scales imply fp8 quantization");
       const auto exp = cast_to_ue8m0(raw_scale);
       scale_inv = static_cast<uint8_t>(exp);
       const float quant_scale = inv_scale_ue8m0(exp);
-      const auto scale2 = cast<T2>(float2{quant_scale, quant_scale});
-      // Finite scaled values already lie in +-448 (2^exp >= amax/448), so the
-      // single __hmin2 only sanitizes NaN / +inf (it returns the non-NaN
-      // operand); -inf saturates to -448 via the SATFINITE fp8 cast (see
-      // WeightTrait<fp8_e4m3_t>).
-      const auto max_clip = cast<T>(kMaxValue);
-      const auto max_clip2 = T2{max_clip, max_clip};
+      // The pow-2 multiplier is exact in the packed 16-bit domain, so scaling
+      // there costs one __hmul2 per pair and loses nothing -- but only if the
+      // multiplier itself is representable in InputType. It reaches
+      // kMaxValue / kAmaxFloor (4.5e12), which fits bfloat16 (fp32's exponent
+      // range) and NOT float16 (max 65504): an fp16 group whose absmax falls
+      // below kMaxValue / 65504 = 6.8e-3 would narrow the multiplier to inf and
+      // quantize the whole group to +-448 (0 * inf even yields NaN). Scale in
+      // fp32 there, matching the fp32-scale path below.
+      constexpr bool kScaleFitsInInput = kMaxValue / kAmaxFloor <= DTypeTrait<T>::kFloatMax;
+      if constexpr (kScaleFitsInInput) {
+        const auto scale2 = cast<T2>(float2{quant_scale, quant_scale});
+        // Finite scaled values already lie in +-448 (2^exp >= amax/448), so the
+        // single __hmin2 only sanitizes NaN / +inf (it returns the non-NaN
+        // operand); -inf saturates to -448 via the SATFINITE fp8 cast (see
+        // WeightTrait<fp8_e4m3_t>).
+        const auto max_clip = cast<T>(kMaxValue);
+        const auto max_clip2 = T2{max_clip, max_clip};
 #pragma unroll
-      for (uint32_t i = 0; i < kVecSize / 2; ++i) {
-        out[i] = static_cast<Q2>(__hmin2(__hmul2(in[i], scale2), max_clip2));
+        for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+          out[i] = static_cast<Q2>(__hmin2(__hmul2(in[i], scale2), max_clip2));
+        }
+      } else {
+        const float2 quant_scale2 = {quant_scale, quant_scale};
+#pragma unroll
+        for (uint32_t i = 0; i < kVecSize / 2; ++i) {
+          out[i] = WTrait::quant(details::mul2(cast<float2>(in[i]), quant_scale2));
+        }
       }
     } else {
       // fp32 scale: multiply in fp32 (hmul2 brings too much precision loss)

--- a/python/sglang/kernels/jit/csrc/minimax/per_token_quant_ue8m0.cuh
+++ b/python/sglang/kernels/jit/csrc/minimax/per_token_quant_ue8m0.cuh
@@ -19,81 +19,17 @@ namespace {
 using deepseek_v4::fp8::cast_to_ue8m0;
 using deepseek_v4::fp8::pack_fp8;
 
-// Per-token group quant to FP8-e4m3 with a fused UE8M0 scale. Each group of
-// kGroupSize columns gets one UE8M0 exponent byte written contiguously in
-// row-major order into ``x_sf`` (int32 [num_tokens, num_groups/4], 4 group
-// bytes per int32). This is the deep_gemm "transform_sf" pack done inline in
-// the quant, reusing the dsv4 ``cast_to_ue8m0``/``pack_fp8`` primitives -- it
-// is byte-identical to ``per_token_group_quant_fp8(scale_ue8m0=True)`` followed
-// by ``transform_sf_into_required_layout`` (both round via ceil(log2(absmax/
-// FP8_MAX))), but emits no separate transpose/pack kernel.
-struct PerTokenQuantUe8m0Params {
-  const bf16_t* __restrict__ x;  // [num_tokens, hidden]
-  fp8_e4m3_t* __restrict__ x_q;  // [num_tokens, hidden]
-  int32_t* __restrict__ x_sf;    // [num_tokens, num_groups/4]; written as bytes
-  uint32_t num_tokens;
-  uint32_t hidden;
-  uint32_t num_groups;  // hidden / kGroupSize
-};
-
-template <uint32_t kGroupSize, bool kUsePDL>
-__global__ __launch_bounds__(1024, 2) void  //
-    per_token_quant_ue8m0_kernel(const PerTokenQuantUe8m0Params __grid_constant__ params) {
-  using namespace device;
-  constexpr uint32_t kVecElems = 8;  // 8 bf16 = 16B load per thread
-  static_assert(kGroupSize % kVecElems == 0, "group_size must be a multiple of 8");
-  constexpr uint32_t kThreadsPerGroup = kGroupSize / kVecElems;
-  using InputVec = AlignedVector<bf16x2_t, kVecElems / 2>;
-  using OutputVec = AlignedVector<fp8x2_e4m3_t, kVecElems / 2>;
-
-  const uint32_t token_id = blockIdx.x;
-  const uint32_t tid = threadIdx.x;
-  PDLWaitPrimary<kUsePDL>();
-
-  const auto token_in = params.x + static_cast<uint64_t>(token_id) * params.hidden;
-  const auto token_out = params.x_q + static_cast<uint64_t>(token_id) * params.hidden;
-
-  InputVec in_vec;
-  in_vec.load(token_in, tid);
-  float local_max = 0.0f;
-  float vals[kVecElems];
-#pragma unroll
-  for (uint32_t i = 0; i < kVecElems / 2; ++i) {
-    const auto [v0, v1] = cast<fp32x2_t>(in_vec[i]);
-    vals[2 * i + 0] = v0;
-    vals[2 * i + 1] = v1;
-    local_max = fmaxf(local_max, fmaxf(fabsf(v0), fabsf(v1)));
-  }
-  // Absmax across the kThreadsPerGroup threads that cover one group.
-  local_max = warp::reduce_max<kThreadsPerGroup>(local_max);
-  const float absmax = fmaxf(local_max, 1e-10f);
-  const float raw_scale = absmax / math::FP8_E4M3_MAX;
-  const uint32_t ue8m0_exp = cast_to_ue8m0(raw_scale);
-  const float inv_scale = __uint_as_float((127u + 127u - ue8m0_exp) << 23);
-
-  OutputVec out_vec;
-#pragma unroll
-  for (uint32_t i = 0; i < kVecElems / 2; ++i) {
-    out_vec[i] = pack_fp8(vals[2 * i + 0] * inv_scale, vals[2 * i + 1] * inv_scale);
-  }
-  out_vec.store(token_out, tid);
-
-  const uint32_t group_id = tid / kThreadsPerGroup;
-  const uint32_t within_group_id = tid % kThreadsPerGroup;
-  if (within_group_id == 0 && group_id < params.num_groups) {
-    const uint32_t byte_off = token_id * params.num_groups + group_id;
-    reinterpret_cast<uint8_t*>(params.x_sf)[byte_off] = static_cast<uint8_t>(ue8m0_exp);
-  }
-  PDLTriggerSecondary<kUsePDL>();
-}
-
-// Fused quant + scatter: like per_token_quant_ue8m0_kernel, but instead of
-// writing the fp8/scale for the single source token, it scatters them straight
-// into the permuted grouped-GEMM input -- replicating each token to its ``topk``
-// destination rows -- so the separate fill_gateup_input_triton_kernel launch (and
-// the intermediate x_q/x_sf buffers) are eliminated. The fp8 value + UE8M0 scale
-// are computed exactly once per token (identical to the non-fused kernel); only
-// the stores differ.
+// Fused quant + scatter. The quant itself -- per-token group absmax, UE8M0 scale
+// via ceil(log2(absmax / FP8_MAX)), fp8-e4m3 codes -- is byte-identical to
+// per_token_group_quant(scale_ue8m0=True) with a row-major int32-packed scale;
+// what this kernel adds is the OUTPUT MAPPING. Instead of writing one row per
+// source token it scatters straight into the permuted grouped-GEMM input,
+// replicating each token to its ``topk`` destination rows, which eliminates the
+// separate fill_gateup_input_triton_kernel launch and the intermediate x_q/x_sf
+// buffers. The fp8 value + UE8M0 scale are still computed exactly once per
+// token; only the stores differ. (The non-scatter variant that used to live here
+// was a pure duplicate of the shared kernel and was removed -- if this file ever
+// needs a plain quant again, call per_token_group_quant instead of re-adding it.)
 struct PerTokenQuantUe8m0ScatterParams {
   const bf16_t* __restrict__ x;              // [num_tokens, hidden]
   fp8_e4m3_t* __restrict__ gateup_input;     // [E, m_max, hidden]
@@ -239,40 +175,6 @@ void per_token_quant_ue8m0_scatter(
   };
   if (num_tokens == 0) return;
   constexpr auto kernel = per_token_quant_ue8m0_scatter_kernel<kGroupSize, kTopK, kUsePDL>;
-  LaunchKernel(num_tokens, threads, device.unwrap())  //
-      .enable_pdl(kUsePDL)(kernel, params);
-}
-
-template <int64_t kGroupSize, bool kUsePDL>
-void per_token_quant_ue8m0(tvm::ffi::TensorView x, tvm::ffi::TensorView x_q, tvm::ffi::TensorView x_sf) {
-  using namespace host;
-  auto device = SymbolicDevice{};
-  auto M = SymbolicSize{"num_tokens"};
-  auto H = SymbolicSize{"hidden"};
-  auto G4 = SymbolicSize{"num_groups_div_4"};
-  device.set_options<kDLCUDA>();
-  TensorMatcher({M, H}).with_dtype<bf16_t>().with_device(device).verify(x);
-  TensorMatcher({M, H}).with_dtype<fp8_e4m3_t>().with_device(device).verify(x_q);
-  TensorMatcher({M, G4}).with_dtype<int32_t>().with_device(device).verify(x_sf);
-
-  const uint32_t num_tokens = static_cast<uint32_t>(M.unwrap());
-  const uint32_t hidden = static_cast<uint32_t>(H.unwrap());
-  RuntimeCheck(hidden % kGroupSize == 0, "hidden ", hidden, " not divisible by group_size ", kGroupSize);
-  const uint32_t num_groups = hidden / static_cast<uint32_t>(kGroupSize);
-  RuntimeCheck(static_cast<uint32_t>(G4.unwrap()) * 4 == num_groups);
-  const uint32_t threads = hidden / 8;  // kVecElems
-  RuntimeCheck(threads <= 1024, "hidden/8 must be <= 1024, got ", threads);
-
-  const auto params = PerTokenQuantUe8m0Params{
-      .x = static_cast<const bf16_t*>(x.data_ptr()),
-      .x_q = static_cast<fp8_e4m3_t*>(x_q.data_ptr()),
-      .x_sf = static_cast<int32_t*>(x_sf.data_ptr()),
-      .num_tokens = num_tokens,
-      .hidden = hidden,
-      .num_groups = num_groups,
-  };
-  if (num_tokens == 0) return;
-  constexpr auto kernel = per_token_quant_ue8m0_kernel<kGroupSize, kUsePDL>;
   LaunchKernel(num_tokens, threads, device.unwrap())  //
       .enable_pdl(kUsePDL)(kernel, params);
 }

--- a/python/sglang/kernels/ops/attention/dsv4/moe.py
+++ b/python/sglang/kernels/ops/attention/dsv4/moe.py
@@ -9,6 +9,7 @@ from sglang.kernels.jit.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.kernels.ops.quantization.quant_format import create_group_quant_outputs
 from sglang.srt.utils import is_xpu
 
 from .utils import make_name
@@ -216,15 +217,21 @@ def silu_and_mul_masked_post_quant(
 
 def silu_and_mul_contig_post_quant(
     input: torch.Tensor,
-    output: torch.Tensor,
-    output_scale: torch.Tensor,
     quant_group_size: int,
     scale_ue8m0: bool = False,
     transposed: bool = False,
     swiglu_limit: Optional[float] = None,
     swizzle: bool = False,
-) -> None:
+) -> Tuple[torch.Tensor, torch.Tensor]:
     apply_swiglu_limit = swiglu_limit is not None
+    output, output_scale = create_group_quant_outputs(
+        x_shape=(input.shape[0], input.shape[1] // 2),
+        device=input.device,
+        group_size=quant_group_size,
+        column_major_scales=transposed,
+        scale_tma_aligned=transposed,
+        scale_ue8m0=scale_ue8m0,
+    )
     module = _jit_silu_mul_quant_contig_module(
         quant_group_size, scale_ue8m0, swizzle, apply_swiglu_limit
     )
@@ -235,3 +242,4 @@ def silu_and_mul_contig_post_quant(
         transposed,
         float(swiglu_limit) if apply_swiglu_limit else 0.0,
     )
+    return output, output_scale

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -517,13 +517,18 @@ def create_per_token_group_quant_fp8_output_scale(
 _MUSA_KERNEL_SUPPORTED_GROUP_SIZES = (16, 32, 64, 128)
 _V3_KERNEL_SUPPORTED_GROUP_SIZES = (16, 32, 64, 128, 256)
 
+# The JIT kernel bakes the group-absmax floor in at compile time (QuantTrait::
+# kAmaxFloor in gemm/per_token_group_quant.cuh), so it is not a per-call knob and
+# the entry points below do not expose one. Named here for the MUSA AOT op, which
+# still takes it as a runtime argument.
+PER_TOKEN_GROUP_QUANT_EPS = 1e-10
+
 
 def _run_per_token_group_quant_8bit_kernel(
     x: torch.Tensor,
     x_q: torch.Tensor,
     x_s: torch.Tensor,
     group_size: int,
-    eps: float,
     fp8_min: float,
     fp8_max: float,
     *,
@@ -553,7 +558,7 @@ def _run_per_token_group_quant_8bit_kernel(
             output_q=x_q,
             output_s=x_s,
             group_size=group_size,
-            eps=eps,
+            eps=PER_TOKEN_GROUP_QUANT_EPS,
             min_8bit=fp8_min,
             max_8bit=fp8_max,
             scale_ue8m0=scale_ue8m0,
@@ -568,7 +573,7 @@ def _run_per_token_group_quant_8bit_kernel(
             x_q,
             x_s,
             group_size,
-            eps,
+            PER_TOKEN_GROUP_QUANT_EPS,
             fp8_min,
             fp8_max,
             scale_ue8m0,
@@ -578,9 +583,6 @@ def _run_per_token_group_quant_8bit_kernel(
         )
         return
 
-    assert (
-        eps == 1e-10
-    ), f"per_token_group_quant bakes the absmax floor in at 1e-10, got {eps}"
     expected_range = (-448.0, 448.0) if x_q.dtype == fp8_dtype else (-128.0, 127.0)
     assert (fp8_min, fp8_max) == expected_range, (
         f"per_token_group_quant bakes the {x_q.dtype} quant range in at {expected_range}, "
@@ -600,7 +602,6 @@ def _run_per_token_group_quant_8bit_kernel(
 def sglang_per_token_group_quant_fp8(
     x: torch.Tensor,
     group_size: int,
-    eps: float = 1e-10,
     column_major_scales: bool = False,
     scale_tma_aligned: bool = False,
     scale_ue8m0: bool = False,
@@ -641,7 +642,6 @@ def sglang_per_token_group_quant_fp8(
             x_q,
             x_s,
             group_size,
-            eps,
             fp8_min,
             fp8_max,
             scale_ue8m0=scale_ue8m0,
@@ -655,7 +655,6 @@ def sglang_per_token_group_quant_fp8(
 def sglang_per_token_group_quant_fp8_row_padded(
     x: torch.Tensor,
     group_size: int,
-    eps: float = 1e-10,
     row_alignment: int = 4,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Per-token-group quant writing into row-padded buffers (col-major scales).
@@ -682,7 +681,7 @@ def sglang_per_token_group_quant_fp8_row_padded(
     if group_size not in supported_group_sizes:
         # Keep the legacy unpadded path and let the GEMM wrapper do the padding.
         return sglang_per_token_group_quant_fp8(
-            x, group_size, eps, column_major_scales=True
+            x, group_size, column_major_scales=True
         )
 
     m, k = x.shape
@@ -699,7 +698,6 @@ def sglang_per_token_group_quant_fp8_row_padded(
             x_q[:m],
             x_s[:m],
             group_size,
-            eps,
             fp8_min,
             fp8_max,
             scale_ue8m0=False,
@@ -717,7 +715,6 @@ def sglang_per_token_group_quant_fp8_row_padded(
 def sglang_per_token_group_quant_fp8_ue8m0(
     x: torch.Tensor,
     group_size: int,
-    eps: float = 1e-10,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     assert (
         x.shape[-1] % group_size == 0
@@ -743,7 +740,6 @@ def sglang_per_token_group_quant_fp8_ue8m0(
             x_q,
             x_s,
             group_size,
-            eps,
             fp8_min,
             fp8_max,
             scale_ue8m0=True,
@@ -759,7 +755,6 @@ def sglang_per_token_group_quant_8bit(
     x: torch.Tensor,
     group_size: int,
     dst_dtype: torch.dtype,
-    eps: float = 1e-10,
     column_major_scales: bool = False,
     scale_tma_aligned: bool = False,
     scale_ue8m0: bool = False,
@@ -778,14 +773,12 @@ def sglang_per_token_group_quant_8bit(
         return sglang_per_token_group_quant_int8(
             x=x,
             group_size=group_size,
-            eps=eps,
             dtype=dst_dtype,
         )
 
     return sglang_per_token_group_quant_fp8(
         x=x,
         group_size=group_size,
-        eps=eps,
         column_major_scales=column_major_scales,
         scale_tma_aligned=scale_tma_aligned,
         scale_ue8m0=scale_ue8m0,

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -16,7 +16,6 @@ import functools
 import json
 import logging
 import os
-from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
@@ -30,6 +29,17 @@ except:
 
 from sglang.kernels.jit.utils import is_arch_support_pdl
 from sglang.kernels.ops.quantization.fp8_utils import fp8_dtype_to_triton
+
+# Re-exported: these live in a leaf module so per_token_group_quant can reach
+# them without the fp8_kernel import cycle. Kept importable from here for the
+# ~60 existing callers.
+from sglang.kernels.ops.quantization.quant_format import (  # noqa: F401
+    create_group_quant_outputs,
+    fp8_dtype,
+    fp8_max,
+    fp8_min,
+    is_fp8_fnuz,
+)
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.utils import (
     ceil_align,
@@ -107,23 +117,6 @@ if _is_musa:
 
 
 logger = logging.getLogger(__name__)
-
-
-@lru_cache()
-def is_fp8_fnuz() -> bool:
-    if _is_hip:
-        # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
-    return False
-
-
-if is_fp8_fnuz():
-    fp8_dtype = torch.float8_e4m3fnuz
-    fp8_max = 224.0
-else:
-    fp8_dtype = torch.float8_e4m3fn
-    fp8_max = torch.finfo(fp8_dtype).max
-fp8_min = -fp8_max
 
 
 @register_custom_op(mutates_args=["C"])
@@ -284,14 +277,14 @@ def _per_token_group_quant_8bit_raw(
         bit8_max = info.max
         bit8_min = info.min
 
-    x_q = torch.empty_like(x, device=x.device, dtype=dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=x.shape,
         device=x.device,
         group_size=group_size,
         column_major_scales=column_major_scales,
         scale_tma_aligned=scale_tma_aligned,
         scale_ue8m0=False,
+        out_dtype=dtype,
     )
 
     M = x.numel() // group_size
@@ -454,64 +447,6 @@ def per_token_group_quant_8bit(
         )
 
 
-def create_per_token_group_quant_fp8_output_scale(
-    x_shape,
-    device,
-    group_size,
-    column_major_scales: bool,
-    scale_tma_aligned: bool,
-    scale_ue8m0: bool,
-):
-    if scale_ue8m0:
-        if column_major_scales and scale_tma_aligned:
-            *x_batch, x_q_mn, x_q_k = x_shape
-            x_s_mn, x_s_k = x_q_mn, x_q_k // group_size
-            aligned_mn = ceil_align(x_s_mn, 4)
-            aligned_k = ceil_align(x_s_k, 4)
-            # TODO(FIXME): Fix cuda kernel and recover here to empty.
-            return torch.empty(
-                (*x_batch, aligned_k // 4, aligned_mn),
-                device=device,
-                dtype=torch.int,
-            ).transpose(-1, -2)[..., :x_s_mn, :]
-        else:
-            assert not column_major_scales, (
-                "column_major_scales requires scale_tma_aligned=True "
-                "when scale_ue8m0 is enabled"
-            )
-            # Row-major UE8M0 keeps the scale as float32 power-of-two values,
-            # matching deep_gemm.ceil_to_ue8m0 and deep_gemm.fp8_einsum.
-            return torch.empty(
-                x_shape[:-1] + (x_shape[-1] // group_size,),
-                device=device,
-                dtype=torch.float32,
-            )
-    elif column_major_scales:
-        if scale_tma_aligned:
-            # TODO extract "align" function
-            # aligned to 4 * sizeof(float)
-            aligned_size = (x_shape[-2] + 3) // 4 * 4
-            # `...` so batched (e.g. masked [E, T, H]) shapes slice the token
-            # axis, not dim 0.
-            return torch.empty(
-                x_shape[:-2] + (x_shape[-1] // group_size, aligned_size),
-                device=device,
-                dtype=torch.float32,
-            ).transpose(-1, -2)[..., : x_shape[-2], :]
-        else:
-            return torch.empty(
-                (x_shape[-1] // group_size,) + x_shape[:-1],
-                device=device,
-                dtype=torch.float32,
-            ).permute(-1, -2)
-    else:
-        return torch.empty(
-            x_shape[:-1] + (x_shape[-1] // group_size,),
-            device=device,
-            dtype=torch.float32,
-        )
-
-
 # AOT v2 (the MUSA path) runtime-switches on these; the JIT
 # per_token_group_quant kernel also templates on 256.
 _MUSA_KERNEL_SUPPORTED_GROUP_SIZES = (16, 32, 64, 128)
@@ -626,14 +561,18 @@ def sglang_per_token_group_quant_fp8(
 
     out_shape = (*x.shape[:-1], x.shape[-1] // (2 if fuse_silu_and_mul else 1))
 
-    x_q = torch.empty(out_shape, device=x.device, dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=out_shape,
         device=x.device,
         group_size=group_size,
         column_major_scales=column_major_scales,
         scale_tma_aligned=scale_tma_aligned,
         scale_ue8m0=scale_ue8m0,
+        # This entry point's UE8M0 storage has always followed its layout: packed
+        # exponent bytes when column-major, fp32 2^(e-127) (the deep_gemm
+        # ceil_to_ue8m0 form) when row-major. Stated here rather than left for
+        # the allocator to infer.
+        pack_ue8m0=column_major_scales,
     )
 
     if x.shape[0] > 0:
@@ -680,18 +619,21 @@ def sglang_per_token_group_quant_fp8_row_padded(
     )
     if group_size not in supported_group_sizes:
         # Keep the legacy unpadded path and let the GEMM wrapper do the padding.
-        return sglang_per_token_group_quant_fp8(
-            x, group_size, column_major_scales=True
-        )
+        return sglang_per_token_group_quant_fp8(x, group_size, column_major_scales=True)
 
     m, k = x.shape
     m_pad = ceil_align(m, row_alignment)
-    # mat_a buffer: (m_pad, k) row-major fp8
-    x_q = torch.empty((m_pad, k), device=x.device, dtype=fp8_dtype)
-    # scales_a buffer: column-major (stride(0) == 1), shape (m_pad, k // group)
-    x_s = torch.empty(
-        (k // group_size, m_pad), device=x.device, dtype=torch.float32
-    ).transpose(0, 1)
+    # Both buffers use the PADDED row count so the rows the GEMM reads are
+    # contiguous; the quant below writes only [:m]. scales_a is column-major
+    # (stride(0) == 1), shape (m_pad, k // group).
+    x_q, x_s = create_group_quant_outputs(
+        x_shape=(m_pad, k),
+        device=x.device,
+        group_size=group_size,
+        column_major_scales=True,
+        scale_tma_aligned=False,
+        scale_ue8m0=False,
+    )
     if m > 0:
         _run_per_token_group_quant_8bit_kernel(
             x,
@@ -709,44 +651,6 @@ def sglang_per_token_group_quant_fp8_row_padded(
         # GEMM stays bit-exact with the legacy pad_tensor path (torch.empty is garbage).
         x_q[m:].zero_()
         x_s[m:].zero_()
-    return x_q, x_s
-
-
-def sglang_per_token_group_quant_fp8_ue8m0(
-    x: torch.Tensor,
-    group_size: int,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    assert (
-        x.shape[-1] % group_size == 0
-    ), f"hidden ({x.shape[-1]}) must be divisible by group_size ({group_size})"
-    assert x.is_contiguous(), "x must be contiguous"
-
-    *x_batch, x_q_mn, x_q_k = x.shape
-    x_q = torch.empty(x.shape, device=x.device, dtype=fp8_dtype)
-
-    x_s_mn = x_q_mn
-    x_s_k = x_q_k // group_size
-    aligned_mn = ceil_align(x_s_mn, 4)
-    aligned_k = ceil_align(x_s_k, 4)
-    x_s = torch.empty(
-        (*x_batch, aligned_k // 4, aligned_mn),
-        device=x.device,
-        dtype=torch.int,
-    ).transpose(-1, -2)[..., :x_s_mn, :]
-
-    if x.shape[0] > 0:
-        _run_per_token_group_quant_8bit_kernel(
-            x,
-            x_q,
-            x_s,
-            group_size,
-            fp8_min,
-            fp8_max,
-            scale_ue8m0=True,
-            fuse_silu_and_mul=False,
-            masked_m=None,
-        )
-
     return x_q, x_s
 
 

--- a/python/sglang/kernels/ops/quantization/int8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/int8_kernel.py
@@ -194,7 +194,6 @@ def per_token_group_quant_int8(
 def sglang_per_token_group_quant_int8(
     x: torch.Tensor,
     group_size: int,
-    eps: float = 1e-10,
     dtype: torch.dtype = torch.int8,
 ):
     assert (
@@ -202,11 +201,8 @@ def sglang_per_token_group_quant_int8(
     ), "the last dimension of `x` cannot be divisible by `group_size`"
     assert x.is_contiguous(), "`x` is not contiguous"
     assert dtype == torch.int8
-    # per_token_group_quant bakes the int8 constants in ([-128, 127], eps 1e-10).
-    assert (
-        eps == 1e-10
-    ), f"per_token_group_quant bakes the absmax floor in at 1e-10, got {eps}"
-
+    # per_token_group_quant bakes the int8 constants in at compile time
+    # ([-128, 127], absmax floor 1e-10), so there is no eps knob here either.
     return per_token_group_quant(x, group_size=group_size, out_dtype=dtype)
 
 

--- a/python/sglang/kernels/ops/quantization/minimax_quant_ue8m0.py
+++ b/python/sglang/kernels/ops/quantization/minimax_quant_ue8m0.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple
+from typing import TYPE_CHECKING
 
 import torch
 
@@ -13,19 +13,6 @@ from sglang.kernels.jit.utils import (
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
-
-
-@cache_once
-def _jit_module(group_size: int) -> Module:
-    args = make_cpp_args(group_size, is_arch_support_pdl())
-    return load_jit(
-        "minimax_per_token_quant_ue8m0",
-        *args,
-        cuda_files=["minimax/per_token_quant_ue8m0.cuh"],
-        cuda_wrappers=[
-            ("per_token_quant_ue8m0", f"per_token_quant_ue8m0<{args}>"),
-        ],
-    )
 
 
 @cache_once
@@ -45,32 +32,6 @@ def _jit_scatter_module(group_size: int, topk: int) -> Module:
     )
 
 
-def per_token_quant_fp8_ue8m0(
-    x: torch.Tensor, group_size: int = 128
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Per-token group quant to FP8-e4m3 with a fused UE8M0 (int32-packed) scale.
-
-    Returns ``(x_q, x_sf)`` where ``x_q`` is fp8_e4m3 ``[num_tokens, hidden]`` and
-    ``x_sf`` is the int32-packed UE8M0 scale ``[num_tokens, hidden//group_size//4]``
-    (row-major). Byte-identical to ``per_token_group_quant_fp8(scale_ue8m0=True)``
-    followed by ``transform_sf_into_required_layout`` (both ceil-round the scale),
-    but does it in a single kernel -- no separate transpose/pack launch.
-    """
-    assert x.is_cuda and x.dtype == torch.bfloat16 and x.dim() == 2
-    assert x.is_contiguous()
-    num_tokens, hidden = x.shape
-    assert hidden % group_size == 0
-    num_groups = hidden // group_size
-    assert num_groups % 4 == 0, "num_groups must be a multiple of 4 for int32 packing"
-
-    x_q = torch.empty_like(x, dtype=torch.float8_e4m3fn)
-    x_sf = torch.empty(
-        (num_tokens, num_groups // 4), dtype=torch.int32, device=x.device
-    )
-    _jit_module(group_size).per_token_quant_ue8m0(x, x_q, x_sf)
-    return x_q, x_sf
-
-
 def per_token_quant_fp8_ue8m0_scatter(
     x: torch.Tensor,
     gateup_input: torch.Tensor,
@@ -82,7 +43,7 @@ def per_token_quant_fp8_ue8m0_scatter(
     group_size: int = 128,
 ) -> None:
     """Fused per-token FP8/UE8M0 quant **and** scatter into the permuted grouped-GEMM
-    input -- a single kernel replacing ``per_token_quant_fp8_ue8m0`` +
+    input -- a single kernel replacing ``per_token_group_quant`` +
     ``fill_gateup_input_triton_kernel``.
 
     For each source token it computes the fp8 row + int32-packed UE8M0 scale once,

--- a/python/sglang/kernels/ops/quantization/per_token_group_quant.py
+++ b/python/sglang/kernels/ops/quantization/per_token_group_quant.py
@@ -11,6 +11,7 @@ from sglang.kernels.jit.utils import (
     load_jit,
     make_cpp_args,
 )
+from sglang.kernels.ops.quantization.quant_format import create_group_quant_outputs
 from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
@@ -117,47 +118,6 @@ def _per_token_group_quant_custom_op(
         module.per_token_group_quant(input, output_q, output_s)
 
 
-def _allocate_outputs(
-    input: torch.Tensor,
-    group_size: int,
-    out_dtype: torch.dtype,
-    scale_ue8m0: bool,
-    column_major_scales: bool,
-    fuse_silu_and_mul: bool,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Allocate ``(output_q, output_s)`` in the requested major mode / scale
-    format, selected by ``(column_major_scales, scale_ue8m0)``."""
-    hidden = input.shape[-1] // (2 if fuse_silu_and_mul else 1)
-    out_shape = (*input.shape[:-1], hidden)
-    output_q = torch.empty(out_shape, device=input.device, dtype=out_dtype)
-
-    num_groups = hidden // group_size
-    if scale_ue8m0 and not column_major_scales:
-        # Row-major packed UE8M0: int32 [..., ceil(ng/4)] contiguous (an
-        # unaligned ng leaves a partially-used last int32 that the kernel zero-
-        # pads). The shared create_*_output_scale helper does not produce this
-        # layout.
-        output_s = torch.empty(
-            (*out_shape[:-1], (num_groups + 3) // 4),
-            device=input.device,
-            dtype=torch.int32,
-        )
-    else:
-        from sglang.kernels.ops.quantization.fp8_kernel import (
-            create_per_token_group_quant_fp8_output_scale,
-        )
-
-        output_s = create_per_token_group_quant_fp8_output_scale(
-            x_shape=out_shape,
-            device=input.device,
-            group_size=group_size,
-            column_major_scales=column_major_scales,
-            scale_tma_aligned=column_major_scales,
-            scale_ue8m0=scale_ue8m0,
-        )
-    return output_q, output_s
-
-
 @debug_kernel_api
 def per_token_group_quant(
     input: torch.Tensor,
@@ -199,13 +159,17 @@ def per_token_group_quant(
     """
     if output_q is None:
         assert output_s is None
-        output_q, output_s = _allocate_outputs(
-            input,
-            group_size,
-            out_dtype or torch.float8_e4m3fn,
-            scale_ue8m0,
-            column_major_scales,
-            fuse_silu_and_mul,
+        hidden = input.shape[-1] // (2 if fuse_silu_and_mul else 1)
+        out_shape = (*input.shape[:-1], hidden)
+        output_q, output_s = create_group_quant_outputs(
+            x_shape=out_shape,
+            device=input.device,
+            group_size=group_size,
+            column_major_scales=column_major_scales,
+            scale_tma_aligned=column_major_scales,
+            scale_ue8m0=scale_ue8m0,
+            pack_ue8m0=True,
+            out_dtype=out_dtype,
         )
     else:
         assert output_s is not None

--- a/python/sglang/kernels/ops/quantization/quant_format.py
+++ b/python/sglang/kernels/ops/quantization/quant_format.py
@@ -1,0 +1,185 @@
+"""What a quantized tensor looks like on the host: the FP8 format this build
+targets, and the buffers a per-token-group quant writes into.
+
+A leaf module -- ``torch`` and ``functools`` only. Everything here used to sit in
+``fp8_kernel.py``, which imports ``per_token_group_quant`` at module level, so
+``per_token_group_quant.py`` could only reach the allocation through a lazy
+import to break the cycle. Being a leaf lets both sides import it normally, which
+is also why ``is_hip()`` is inlined as ``torch.version.hip is not None`` (exactly
+what ``sglang.srt.utils.is_hip`` does) and ``ceil_align`` as two lines.
+
+The scale allocation is a single function because there used to be two that
+disagreed: ``fp8_kernel``'s produced fp32 powers of two for row-major UE8M0,
+while ``per_token_group_quant``'s ``_allocate_outputs`` produced int32-packed
+exponent bytes for the same flags. Callers had no way to say which they meant --
+hence ``pack_ue8m0``.
+
+Three things vary independently:
+
+* **rounding** -- ``scale_ue8m0`` rounds the quant multiplier to a power of two
+  (which is what makes the scale expressible as a lone 8-bit exponent).
+* **storage** -- ``pack_ue8m0`` writes that exponent byte, 4 per int32 (the
+  actual UE8M0 data type), instead of an fp32. Only meaningful under
+  ``scale_ue8m0``; without the pow-2 rounding there is no single byte to pack.
+  Unpacked UE8M0 stores ``2^(e-127)`` as fp32 -- deep_gemm's ``ceil_to_ue8m0`` /
+  ``fp8_einsum`` convention.
+* **layout** -- ``column_major_scales`` / ``scale_tma_aligned`` place the buffer
+  in memory and say nothing about what it holds.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional, Tuple
+
+import torch
+
+# --------------------------------------------------------------------------- #
+# The FP8 format this build quantizes to.
+#
+# ROCm gfx94x (MI300) implements FP8 as e4m3**fnuz**, a different bias that tops
+# out at 224 instead of 448. The device kernels already follow suit --
+# ``kFP8E4M3Max`` in ``sgl_kernel/type.cuh`` is 224 under ``HIP_FP8_TYPE_FNUZ``
+# -- so a host buffer that hardcodes e4m3fn would disagree with what the kernel
+# writes. Anything allocating an FP8 quant output has to go through these.
+#
+# Re-exported from ``fp8_kernel`` for the existing callers.
+# --------------------------------------------------------------------------- #
+
+
+@lru_cache()
+def is_fp8_fnuz() -> bool:
+    if torch.version.hip is None:
+        return False
+    # only device 0 is checked, this assumes MI300 platforms are homogeneous
+    return "gfx94" in torch.cuda.get_device_properties(0).gcnArchName
+
+
+if is_fp8_fnuz():
+    fp8_dtype = torch.float8_e4m3fnuz
+    fp8_max = 224.0
+else:
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8_dtype).max
+fp8_min = -fp8_max
+
+
+# --------------------------------------------------------------------------- #
+# Output buffers.
+# --------------------------------------------------------------------------- #
+
+
+def _ceil_align(x: int, y: int) -> int:
+    return (x + y - 1) // y * y
+
+
+def create_group_quant_scale(
+    x_shape,
+    device,
+    group_size: int,
+    column_major_scales: bool,
+    scale_tma_aligned: bool,
+    scale_ue8m0: bool,
+    pack_ue8m0: bool = True,
+) -> torch.Tensor:
+    """Allocate the scale buffer for quantizing ``x_shape`` in groups of
+    ``group_size`` along the last dim.
+
+    ``pack_ue8m0`` is read only when ``scale_ue8m0`` is set. The supported
+    combinations, where ``T`` is ``x_shape[-2]`` and ``ng`` is
+    ``x_shape[-1] // group_size``:
+
+      ue8m0  pack  col_major  tma   dtype    shape
+      -----  ----  ---------  ----  -------  --------------------------------
+      F      -     F          -     float32  [..., T, ng]        contiguous
+      F      -     T          T     float32  [..., T, ng]        TMA-aligned view
+      F      -     T          F     float32  [..., T, ng]        col-major view
+      T      T     T          T     int32    [..., T, ceil(ng,4)/4] TMA view
+      T      T     F          -     int32    [..., ceil(ng/4)]   contiguous
+      T      F     F          -     float32  [..., ng]           contiguous (2^(e-127))
+    """
+    num_groups = x_shape[-1] // group_size
+
+    if not scale_ue8m0:
+        if not column_major_scales:
+            return torch.empty(
+                x_shape[:-1] + (num_groups,), device=device, dtype=torch.float32
+            )
+        if scale_tma_aligned:
+            # aligned to 4 * sizeof(float); `...` so batched (e.g. masked
+            # [E, T, H]) shapes slice the token axis, not dim 0.
+            aligned_size = _ceil_align(x_shape[-2], 4)
+            return torch.empty(
+                x_shape[:-2] + (num_groups, aligned_size),
+                device=device,
+                dtype=torch.float32,
+            ).transpose(-1, -2)[..., : x_shape[-2], :]
+        return torch.empty(
+            (num_groups,) + x_shape[:-1], device=device, dtype=torch.float32
+        ).permute(-1, -2)
+
+    if not pack_ue8m0:
+        assert (
+            not column_major_scales
+        ), "unpacked UE8M0 (fp32 2^(e-127)) has no column-major layout"
+        return torch.empty(
+            x_shape[:-1] + (num_groups,), device=device, dtype=torch.float32
+        )
+
+    if column_major_scales:
+        assert scale_tma_aligned, (
+            "column_major_scales requires scale_tma_aligned=True "
+            "when scale_ue8m0 is enabled"
+        )
+        *x_batch, x_q_mn, _ = x_shape
+        # TODO(FIXME): Fix cuda kernel and recover here to empty.
+        return torch.empty(
+            (*x_batch, _ceil_align(num_groups, 4) // 4, _ceil_align(x_q_mn, 4)),
+            device=device,
+            dtype=torch.int32,
+        ).transpose(-1, -2)[..., :x_q_mn, :]
+
+    # Row-major packed UE8M0: an unaligned ``ng`` leaves a partially-used last
+    # int32 that the kernel zero-pads.
+    return torch.empty(
+        x_shape[:-1] + ((num_groups + 3) // 4,), device=device, dtype=torch.int32
+    )
+
+
+def create_group_quant_outputs(
+    x_shape,
+    device,
+    group_size: int,
+    column_major_scales: bool,
+    scale_tma_aligned: bool,
+    scale_ue8m0: bool,
+    pack_ue8m0: bool = True,
+    out_dtype: Optional[torch.dtype] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Allocate ``(codes, scales)`` for quantizing ``x_shape``.
+
+    ``out_dtype`` defaults to ``fp8_dtype`` above, i.e. e4m3fnuz on ROCm gfx94x
+    and e4m3fn elsewhere -- matching what the device kernels write, which follow
+    the same split via ``kFP8E4M3Max``. Pass it explicitly for int8.
+    """
+    codes = torch.empty(x_shape, device=device, dtype=out_dtype or fp8_dtype)
+    scales = create_group_quant_scale(
+        x_shape=x_shape,
+        device=device,
+        group_size=group_size,
+        column_major_scales=column_major_scales,
+        scale_tma_aligned=scale_tma_aligned,
+        scale_ue8m0=scale_ue8m0,
+        pack_ue8m0=pack_ue8m0,
+    )
+    return codes, scales
+
+
+__all__ = [
+    "is_fp8_fnuz",
+    "fp8_dtype",
+    "fp8_max",
+    "fp8_min",
+    "create_group_quant_scale",
+    "create_group_quant_outputs",
+]

--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -210,9 +210,6 @@ class DeepGemmRunnerCore(MoeRunnerCore):
     ) -> torch.Tensor:
         from sglang.kernels.ops.attention.dsv4 import silu_and_mul_contig_post_quant
         from sglang.kernels.ops.moe.ep_moe_kernels import tma_align_input_scale
-        from sglang.kernels.ops.quantization.fp8_kernel import (
-            create_per_token_group_quant_fp8_output_scale,
-        )
 
         hidden_states = runner_input.hidden_states
         hidden_states_scale = runner_input.hidden_states_scale
@@ -259,23 +256,8 @@ class DeepGemmRunnerCore(MoeRunnerCore):
         if envs.SGLANG_OPT_FIX_MEGA_MOE_MEMORY.get():
             swiglu_limit_arg: Optional[float] = self.swiglu_limit
 
-            down_input_fp8 = torch.empty(
-                (all_tokens, N // 2),
-                device=gateup_output.device,
-                dtype=torch.float8_e4m3fn,
-            )
-            down_input_scale = create_per_token_group_quant_fp8_output_scale(
-                x_shape=(all_tokens, N // 2),
-                device=gateup_output.device,
-                group_size=scale_block_size,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-            )
-            silu_and_mul_contig_post_quant(
+            down_input_fp8, down_input_scale = silu_and_mul_contig_post_quant(
                 input=gateup_output,
-                output=down_input_fp8,
-                output_scale=down_input_scale,
                 quant_group_size=scale_block_size,
                 scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
                 transposed=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -33,9 +33,6 @@ from sglang.kernels.ops.attention.dsv4 import (
     silu_and_mul_clamp,
     silu_and_mul_contig_post_quant,
 )
-from sglang.kernels.ops.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
-)
 from sglang.srt.batch_overlap.single_batch_overlap import SboFlags, compute_overlap_args
 from sglang.srt.batch_overlap.two_batch_overlap import (
     MaybeTboDeepEPDispatcher,
@@ -370,20 +367,9 @@ class DeepseekV2MLP(nn.Module):
             and hasattr(self.down_proj, "weight_scale_inv")
         ):
             M, N = gate_up.shape
-            down_input_fp8 = gate_up.new_empty((M, N // 2), dtype=torch.float8_e4m3fn)
             scale_block_size = 128
-            down_input_scale = create_per_token_group_quant_fp8_output_scale(
-                x_shape=(M, N // 2),
-                device=gate_up.device,
-                group_size=scale_block_size,
-                column_major_scales=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_tma_aligned=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-                scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
-            )
-            silu_and_mul_contig_post_quant(
+            down_input_fp8, down_input_scale = silu_and_mul_contig_post_quant(
                 input=gate_up,
-                output=down_input_fp8,
-                output_scale=down_input_scale,
                 quant_group_size=scale_block_size,
                 scale_ue8m0=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,
                 transposed=deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0,

--- a/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant.py
+++ b/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant.py
@@ -1,8 +1,6 @@
 from sglang.kernels.jit.benchmark import marker
-from sglang.kernels.jit.benchmark.utils import create_empty, create_random
+from sglang.kernels.jit.benchmark.utils import create_random
 from sglang.kernels.ops.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
-    fp8_dtype,
     fp8_max,
     fp8_min,
 )
@@ -14,6 +12,9 @@ from sglang.kernels.ops.quantization.per_token_group_quant import (
 )
 from sglang.kernels.ops.quantization.per_token_group_quant_8bit_v2 import (
     per_token_group_quant_8bit_v2,
+)
+from sglang.kernels.ops.quantization.quant_format import (
+    create_group_quant_outputs,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -56,14 +57,14 @@ FN = {"jit_v2": _jit_v2, "current": _current}
 def benchmark(group_size: int, layout: str, num_tokens: int, impl: str):
     column_major, scale_ue8m0 = LAYOUTS[layout]
     x = create_random(num_tokens, HIDDEN)
-    x_q = create_empty(num_tokens, HIDDEN, dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=(num_tokens, HIDDEN),
         device="cuda",
         group_size=group_size,
         column_major_scales=column_major,
         scale_tma_aligned=column_major,
         scale_ue8m0=scale_ue8m0,
+        pack_ue8m0=column_major,
     )
     return marker.do_bench(
         FN[impl],

--- a/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant_8bit_v2.py
+++ b/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant_8bit_v2.py
@@ -1,16 +1,16 @@
-import torch
 from sgl_kernel import sgl_per_token_group_quant_8bit
 
 from sglang.kernels.jit.benchmark import marker
 from sglang.kernels.jit.benchmark.utils import create_random
 from sglang.kernels.ops.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
-    fp8_dtype,
     fp8_max,
     fp8_min,
 )
 from sglang.kernels.ops.quantization.per_token_group_quant_8bit_v2 import (
     per_token_group_quant_8bit_v2,
+)
+from sglang.kernels.ops.quantization.quant_format import (
+    create_group_quant_outputs,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -51,14 +51,14 @@ FN = {"aot_v2": _aot_v2, "jit_v2": _jit_v2}
 @marker.benchmark("impl", ["aot_v2", "jit_v2"])
 def benchmark(num_tokens: int, impl: str):
     x = create_random(num_tokens, HIDDEN)
-    x_q = torch.empty(num_tokens, HIDDEN, device="cuda", dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=(num_tokens, HIDDEN),
         device="cuda",
         group_size=G,
         column_major_scales=True,
         scale_tma_aligned=True,
         scale_ue8m0=False,
+        pack_ue8m0=True,
     )
     return marker.do_bench(FN[impl], input_args=(x, x_q, x_s), graph_clone_args=(0,))
 

--- a/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant_masked.py
+++ b/test/registered/kernels/benchmark/quantization/bench_per_token_group_quant_masked.py
@@ -5,8 +5,6 @@ import torch
 from sglang.kernels.jit.benchmark import marker
 from sglang.kernels.jit.benchmark.utils import create_empty, create_random
 from sglang.kernels.ops.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
-    fp8_dtype,
     fp8_max,
     fp8_min,
 )
@@ -18,6 +16,9 @@ from sglang.kernels.ops.quantization.per_token_group_quant import (
 )
 from sglang.kernels.ops.quantization.per_token_group_quant_8bit_v2 import (
     per_token_group_quant_8bit_v2,
+)
+from sglang.kernels.ops.quantization.quant_format import (
+    create_group_quant_outputs,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -93,14 +94,14 @@ def benchmark(
     expected_m = math.ceil(max_tokens * topk / num_local_experts)
     in_hidden = hidden_size * (2 if fuse_silu else 1)
     x = create_random(num_local_experts, padded_tokens, in_hidden)
-    x_q = create_empty(num_local_experts, padded_tokens, hidden_size, dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=(num_local_experts, padded_tokens, hidden_size),
         device="cuda",
         group_size=group_size,
         column_major_scales=True,
         scale_tma_aligned=True,
         scale_ue8m0=True,
+        pack_ue8m0=True,
     )
     if balanced:  # simulation
         topk_ids = torch.randint(0, num_local_experts, (num_tokens * topk,))

--- a/test/registered/kernels/ops/moe/test_minimax_quant_scatter.py
+++ b/test/registered/kernels/ops/moe/test_minimax_quant_scatter.py
@@ -11,8 +11,10 @@ from sglang.kernels.ops.moe.ep_moe_kernels import (
     moe_ep_deepgemm_preprocess,
 )
 from sglang.kernels.ops.quantization.minimax_quant_ue8m0 import (
-    per_token_quant_fp8_ue8m0,
     per_token_quant_fp8_ue8m0_scatter,
+)
+from sglang.kernels.ops.quantization.per_token_group_quant import (
+    per_token_group_quant,
 )
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.deep_gemm import (
@@ -61,7 +63,9 @@ def test_quant_scatter_matches_quant_plus_fill(num_tokens, topk, hidden, group):
     tids.copy_(tids_cpu)
     s2d = torch.tensor(s2d, dtype=torch.int32, device=dev)
 
-    x_q, x_sf = per_token_quant_fp8_ue8m0(x, group)
+    x_q, x_sf = per_token_group_quant(
+        x, group_size=group, scale_ue8m0=True, column_major_scales=False
+    )
     gi_ref = torch.zeros(E, m_max, hidden, device=dev, dtype=torch.float8_e4m3fn)
     gs_ref = torch.zeros(E, G4, m_max, device=dev, dtype=torch.int32)
     fill_gateup_input_triton_kernel[(num_tokens,)](
@@ -121,7 +125,9 @@ def test_standard_deepgemm_preprocess_quantizes_with_ue8m0_scale():
         output_dtype=torch.float8_e4m3fn,
         use_mxfp8=False,
     )
-    direct_x, direct_scale = per_token_quant_fp8_ue8m0(x, group)
+    direct_x, direct_scale = per_token_group_quant(
+        x, group_size=group, scale_ue8m0=True, column_major_scales=False
+    )
 
     assert grouped_scale.dtype == torch.int32
     for token in range(num_tokens):

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
@@ -159,6 +159,43 @@ def test_ue8m0_bitexact(dtype, num_tokens, hidden):
     assert torch.equal(exp, exp_ref), "exponent bytes differ"
 
 
+# fp16 tops out at 65504, so these absmax scales need a quant multiplier
+# (448/absmax rounded up to a power of two) that fp16 cannot represent:
+# 1e-3/1e-4 sit below the 448/65504 = 6.8e-3 threshold, and the all-zero row
+# floors absmax to eps and demands the largest multiplier the kernel can make.
+SMALL_MAGNITUDE_SCALES = [1e-3, 1e-4, 0.0]
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", SMALL_MAGNITUDE_SCALES)
+def test_ue8m0_small_magnitude_bitexact(scale, dtype):
+    """UE8M0 rows whose group absmax is far below 1, bit-exact vs the torch
+    reference.
+
+    The pow-2 quant multiplier was narrowed to the input dtype to do the scaling
+    as one packed 16-bit multiply. For fp16 that overflows: a group this small
+    needs a multiplier above fp16's 65504 max, so the multiplier became ``inf``
+    and every element in the group quantized to +-448 -- an all-zero row went
+    through ``0 * inf`` to NaN, which the sanitizing clamp also turned into
+    +448. bfloat16 carries fp32's exponent range and was never affected, which
+    is why the unit-variance fp16 case in test_ue8m0_bitexact never caught it.
+    """
+    torch.manual_seed(int(dtype == torch.float16))
+    num_tokens, hidden = 8, 512
+    x32 = torch.randn(num_tokens, hidden, device="cuda", dtype=torch.float32)
+    x = (x32 * scale).to(dtype)
+    q_ref, exp_ref = ref_fp8_ue8m0(x, G)
+
+    x_q = torch.zeros_like(x, dtype=fp8_dtype)
+    x_s = _alloc_scale((num_tokens, hidden), column_major=True, scale_ue8m0=True)
+    per_token_group_quant(x, x_q, x_s, G, scale_ue8m0=True)
+    torch.cuda.synchronize()
+
+    assert torch.equal(x_q.view(torch.int8), q_ref.view(torch.int8)), "codes differ"
+    exp = _decode_packed_exp(x_s, hidden // G)
+    assert torch.equal(exp, exp_ref), "exponent bytes differ"
+
+
 @pytest.mark.parametrize("group_size", get_ci_test_range([16, 32, 64, 128], [16, 64]))
 def test_ue8m0_group_sizes(group_size):
     """Group size is a template axis (v2 dispatched a runtime switch). Each size
@@ -271,10 +308,13 @@ def test_int8_scale(column_major):
 
 
 def test_group_size_256_roundtrip():
-    """Group 256 (32 lanes on H100, 16 on Blackwell) is above v2's old cap of
-    128. Pin the derived property: the fp32 scale equals absmax/FMAX and dequant
-    round-trips. A mis-mapped wide subwarp would fold the wrong elements into
-    the group absmax and move the scale."""
+    """Group 256 is above v2's old cap of 128 and gives the kernel its widest
+    subwarp. Each lane owns a fixed 32B (16 bf16 elements) on every arch, so a
+    256-group spans 16 lanes on both Hopper and Blackwell -- only the load width
+    underneath differs (2x128-bit vs 1x256-bit). Pin the derived property: the
+    fp32 scale equals absmax/FMAX and dequant round-trips. A mis-mapped wide
+    subwarp would fold the wrong elements into the group absmax and move the
+    scale."""
     torch.manual_seed(256)
     num_tokens, hidden, gs = 9, 4096, 256
     x = torch.randn(num_tokens, hidden, device="cuda", dtype=torch.bfloat16)

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
@@ -23,12 +23,15 @@ import torch
 
 from sglang.kernels.jit.utils import get_ci_test_range
 from sglang.kernels.ops.quantization.fp8_kernel import (
-    create_per_token_group_quant_fp8_output_scale,
     fp8_dtype,
     fp8_max,
 )
 from sglang.kernels.ops.quantization.per_token_group_quant import (
     per_token_group_quant,
+)
+from sglang.kernels.ops.quantization.quant_format import (
+    create_group_quant_outputs,
+    create_group_quant_scale,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 
@@ -106,13 +109,14 @@ def _packed_exp_to_dequant_scale(x_s, ng) -> torch.Tensor:
 
 
 def _alloc_scale(x_shape, *, column_major, scale_ue8m0):
-    s = create_per_token_group_quant_fp8_output_scale(
+    s = create_group_quant_scale(
         x_shape=x_shape,
         device="cuda",
         group_size=G,
         column_major_scales=column_major,
         scale_tma_aligned=column_major,
         scale_ue8m0=scale_ue8m0,
+        pack_ue8m0=column_major,
     )
     s.zero_()
     return s
@@ -206,15 +210,16 @@ def test_ue8m0_group_sizes(group_size):
     x = torch.randn(num_tokens, hidden, device="cuda", dtype=torch.bfloat16)
     q_ref, exp_ref = ref_fp8_ue8m0(x, group_size)
 
-    x_q = torch.zeros_like(x, dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=(num_tokens, hidden),
         device="cuda",
         group_size=group_size,
         column_major_scales=True,
         scale_tma_aligned=True,
         scale_ue8m0=True,
+        pack_ue8m0=True,
     )
+    x_q.zero_()
     x_s.zero_()
     per_token_group_quant(x, x_q, x_s, group_size, scale_ue8m0=True)
     torch.cuda.synchronize()

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant_8bit_v2.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant_8bit_v2.py
@@ -7,6 +7,9 @@ from sglang.kernels.jit.utils import get_ci_test_range
 from sglang.kernels.ops.quantization.per_token_group_quant_8bit_v2 import (
     per_token_group_quant_8bit_v2,
 )
+from sglang.kernels.ops.quantization.quant_format import (
+    create_group_quant_outputs,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -22,8 +25,6 @@ if sgl_per_token_group_quant_8bit is None:
     raise ImportError("sgl_kernel AOT reference op is unavailable")
 
 from sglang.kernels.ops.quantization.fp8_kernel import (  # noqa: E402
-    create_per_token_group_quant_fp8_output_scale,
-    fp8_dtype,
     fp8_max,
     fp8_min,
 )
@@ -34,15 +35,16 @@ G = 128
 def _alloc(x_shape, scale_ue8m0):
     """Pre-allocated (zeroed) output_q + output_s for a given input/output shape.
     Zeroing makes the unwritten (padding / aligned) regions compare equal."""
-    x_q = torch.zeros(x_shape, device="cuda", dtype=fp8_dtype)
-    x_s = create_per_token_group_quant_fp8_output_scale(
+    x_q, x_s = create_group_quant_outputs(
         x_shape=x_shape,
         device="cuda",
         group_size=G,
         column_major_scales=True,
         scale_tma_aligned=True,
         scale_ue8m0=scale_ue8m0,
+        pack_ue8m0=True,
     )
+    x_q.zero_()
     x_s.zero_()
     return x_q, x_s
 


### PR DESCRIPTION
## Motivation

Two silent-correctness bugs in the trait-driven `per_token_group_quant` kernel, a
1.23x left on the table in the EP-MoE fused path, and the duplication that let all
of it hide.

Both bugs trace back to #30924. They surfaced while trying to reproduce the
GLM-5.2 H20 decode regression (#32582): #32616 reverted that PR's
`kMaxValue * __frcp_rn(amax)` back to a plain divide, noting *"the exact mechanism
is still unclear"*.

**The mechanism is fp8 round-to-nearest tie-breaking, and the reverted code was not
the accuracy problem.** Under `--use_fast_math`, `448.0f / amax` gives a multiplier
1 ULP high, so products land just above an fp8 tie (168.0000153 → rounds up to
176); `__frcp_rn` gives the correctly-rounded multiplier, so products land *on* the
tie (168.0) and round half-to-even (160). Only ~0.01% of codes on randn bf16
differ, and the mean relative dequant error is identical to six digits. So #32616
restored bit-exactness with the legacy v2 kernel, not accuracy — and it was right
to, because `__frcp_rn` is also **~5x the instruction cost**: 2 SASS instructions
(`MUFU.RCP` + `FMUL.FTZ`) versus a Newton refinement behind a branch into an
out-of-line special-value fixup. This PR does **not** re-land it.

But #32616 only fixed the quant multiplier. #30924 made the same substitution in
`details::silu`, which runs **per element** rather than once per group.

## Modifications

### 1. fp16 + UE8M0 quantized whole groups to ±448

The power-of-two quant multiplier was narrowed to the input dtype so the scaling
could be one packed `__hmul2`. That multiplier reaches `kMaxValue / eps` = 4.5e12,
which bfloat16 holds (it has fp32's exponent range) but float16 does not (max
65504). Any fp16 group whose absmax fell below 448/65504 = 6.8e-3 therefore got an
`inf` multiplier and every element in the group quantized to ±448 — an all-zero row
went through `0 * inf` to NaN, which the sanitizing clamp also turned into +448.
Measured **4095/4096 codes wrong, 100% of them ±448, silently**. The old v2 kernel
handles the same input correctly. Not covered before because the fp16 UE8M0 cases
all used unit-variance `randn`, whose absmax sits ~400x above the threshold.

The condition is now derived at compile time from `DTypeTrait<T>::kFloatMax` and a
newly-named `kAmaxFloor`, keeping the packed half multiply where it is provably
safe and scaling in fp32 otherwise. **The bf16 production path is
codegen-identical** — SASS for the bf16/ue8m0/g128 col-major flat kernel is
byte-for-byte unchanged at 200 instructions. fp16 + ue8m0 goes 128 → 160
instructions, the cost of correctness on a path no bf16 model uses.

### 2. `details::silu` used `__frcp_rn` where v2 used a plain divide — 1.23x

Because silu runs per element, this dominated the fused path. Switching it back on
the non-Blackwell branch: the bf16 fused masked kernel goes **608 → 384 SASS
instructions**, `BSSY`/`CALL` 35 → 2, worth **1.23x geomean (1.13–1.26x)** on
graph-captured EP-MoE decode shapes. It also restores bit-exactness with the AOT v2
op, which uses the same divide. Non-fused kernels are unaffected (silu is only
instantiated for `kFuseSiluAndMul`).

### 3. Dedup: one allocator, one leaf module, three fewer entry points

Four places decided what a group quant allocates, and none wrote down which scale
format they wanted — it fell out of whichever allocator you happened to call:

| | row-major UE8M0 produced |
|---|---|
| `create_per_token_group_quant_fp8_output_scale` | fp32 `2^(e-127)` |
| `per_token_group_quant._allocate_outputs` | int32 packed |
| `sglang_per_token_group_quant_fp8_ue8m0` | inlined the int32 TMA branch |
| `sglang_per_token_group_quant_fp8_row_padded` | inlined the col-major fp32 branch |

The first two **disagree for identical flags**. That is the root cause behind
several surprises here: `test_fp8_wo_a` depends on the fp32 flavor purely through a
defaulted `column_major_scales`, and the deprecated v2 fallback exists because
"layout is row-major" was being used to imply "format is fp32 pow-2".

- Collapsed into `quant_format.create_group_quant_{scale,outputs}`. Being a **leaf
  module** matters: `fp8_kernel` imports `per_token_group_quant` at module level, so
  `per_token_group_quant` could only reach the allocation through a lazy import to
  break the cycle. Both sides now import it normally.
- Unifying forces the ambiguity to be named, hence `pack_ue8m0`. Rounding, storage
  and layout are three parameters instead of two booleans plus whichever function
  you reached for. **Behaviour is unchanged**: the old contract was exactly "packed
  iff column-major", so every migrated site passes `pack_ue8m0` equal to its
  `column_major_scales` expression.
- `is_fp8_fnuz` / `fp8_dtype` / `fp8_max` / `fp8_min` moved into the same leaf and
  re-exported from `fp8_kernel`, so the ~60 existing callers are untouched. This
  also **fixes a bug the refactor would otherwise have introduced**: an earlier
  draft hardcoded `torch.float8_e4m3fn` on the theory that the dsv4 kernel is
  CUDA-only. It is not — `load_jit` strips `--use_fast_math` under
  `torch.version.hip`, `utils.cuh` maps `fp8_e4m3_t` to `uint8_t` on ROCm, and
  `type.cuh`'s `kFP8E4M3Max` is **224** under `HIP_FP8_TYPE_FNUZ`, which the kernel
  consumes via `math::FP8_E4M3_MAX`. So on gfx94x it writes fnuz codes and a
  hardcoded e4m3fn buffer would silently disagree.
- Deleted `sglang_per_token_group_quant_fp8_ue8m0` — no callers anywhere, and
  step-for-step identical to `sglang_per_token_group_quant_fp8` with
  `column_major_scales` / `scale_tma_aligned` / `scale_ue8m0` all True.
- Deleted the duplicate non-scatter `minimax/per_token_quant_ue8m0` kernel —
  measured byte-identical to the shared row-packed UE8M0 path across 8 shape ×
  group-size combinations, and used only as the scatter variant's test reference.
  That reference is now the shared kernel, which has its own bit-exact coverage.
- `silu_and_mul_contig_post_quant` allocates its own outputs, so `deep_gemm.py` and
  `deepseek_v2.py` no longer hand-roll a codes buffer plus a scale buffer each.
  **Zero production callers of the allocator now live outside
  `sglang.kernels.ops`** — scale layout is knowledge the kernel wrappers own.

### 4. Dropped the inert `eps` parameter

On CUDA it had already stopped being a knob: the kernel bakes the absmax floor in
at compile time, so the dispatcher could only assert `eps == 1e-10` or raise. An
AST sweep of all 59 call sites repo-wide (resolving positional as well as keyword
arguments) found **no caller anywhere that passes a non-default eps**. Removed from
the entry points; `PER_TOKEN_GROUP_QUANT_EPS` remains for the MUSA AOT op and the
Triton reference, whose `eps` is a live runtime argument.

## Accuracy Tests

All on H200 (sm_90a). Bit-exactness is against the pre-#30924 `per_token_group_quant_8bit_v2` kernel.

- **v2 parity matrix, 26 cells: 0 mismatches.** fp32 / ue8m0 / int8 scales ×
  row/col-major × bf16/fp16 × plain / fused-silu / masked.
- **New regression test verified to fail before the fix**: 3 fp16 cases red, 3 bf16
  green — exactly the expected signature.
- **Unified allocator reproduces both old allocators exactly** — shape / stride /
  dtype / storage_offset over 64 flag combinations including the assert cases, plus
  the int32 row-packed branch over 10 shapes.
- Auto-allocating `silu_and_mul_contig_post_quant` is **bit-identical** to the
  hand-allocated form over 5 shape/flag combinations.
- Suites: `test/registered/kernels/ops/quantization/`, `test/registered/quant/`,
  `test/registered/kernels/ops/moe/test_minimax_quant_scatter.py`,
  `test_kimi_k3_prerequisite_ops.py`, `test_fp8_wo_a.py`, and the AOT
  `test_per_token_group_quant_8bit.py` (3632 cases). Failure set is **identical to
  `main`** (24 entries, all model- or library-dependent: `auto-round` not
  installed, GGUF/AWQ/kimi/w8a8/gptqmodel need weights and a server).

## Speed Tests

Graph-captured (`torch.cuda.CUDAGraph`) EP-MoE decode shapes, bf16, group 128,
col-packed UE8M0, fused silu + masked — the `--moe-a2a-backend deepep` path.
Measuring uncaptured would have been meaningless: `per_token_group_quant` carries
~8us of Python dispatch against a 2–5us kernel.

| shape | before | after | speedup |
|---|---|---|---|
| dsv3 E=8 T=32 | 2.3187 us | 1.8400 us | **1.260x** |
| dsv3 E=8 T=128 | 3.8730 us | 3.1335 us | **1.236x** |
| dsv3 E=16 T=32 | 2.7245 us | 2.2131 us | **1.231x** |
| dsv3 E=16 T=128 | 4.9649 us | 4.3829 us | **1.133x** |
| qwen3 E=8 T=64 | 2.6925 us | 2.1359 us | **1.261x** |
| glm-ish E=8 T=64 | 2.7727 us | 2.2279 us | **1.245x** |

**geomean 1.227x.** Rep spread 0.1–0.3%. Non-fused kernels unchanged (200
instructions, byte-identical SASS).

## Blackwell verification

Two tests are gated on `get_device_sm() >= 100` and only skip on H200. **Both pass on
B200:**

- `test/registered/kernels/ops/attention/test_fp8_wo_a.py`
- `test/registered/kernels/ops/moe/test_minimax_quant_scatter.py`

The first is the one that made me leave the v2 fallback in place: its
`_flat_reference` asks for `scale_ue8m0=True` with `column_major_scales` defaulted,
which allocates fp32 and so needs the fp32-pow-2 format the shared kernel still
cannot produce. Adding that format (and retiring the fallback) is prepared but
deliberately **not** in this PR — it is a separate change with its own tradeoff.

## Checklist

- [x] Format with pre-commit (17 hooks pass)
- [x] Regression test added, verified red before the fix
- [x] Bit-exactness against the pre-#30924 kernel
- [x] SASS-level check that the production path is codegen-neutral
- [x] Blackwell run for the two SM100-gated tests (passed on B200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30904663212](https://github.com/sgl-project/sglang/actions/runs/30904663212)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30904668323](https://github.com/sgl-project/sglang/actions/runs/30904668323)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->