### PR TITLE
fix(openai): wrap non-streaming error responses in the OpenAI error envelope

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -222,7 +222,12 @@ class OpenAIServingBase(ABC):
             param=param,
             code=status_code,
         )
-        return ORJSONResponse(content=error.model_dump(), status_code=status_code)
+        # Wrap in an "error" envelope to match the OpenAI error schema, the
+        # streaming path below, and the Rust router. Clients built on the
+        # official OpenAI SDK read the message out of response["error"].
+        return ORJSONResponse(
+            content={"error": error.model_dump()}, status_code=status_code
+        )
 
     def create_streaming_error_response(
         self,

--- a/test/registered/unit/entrypoints/openai/test_serving_base.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_base.py
@@ -1,0 +1,80 @@
+"""
+Unit-tests for OpenAIServingBase error-response shaping.
+Run with either:
+    python test/registered/unit/entrypoints/openai/test_serving_base.py -v
+or
+    pytest test/registered/unit/entrypoints/openai/test_serving_base.py -v
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import json
+import unittest
+from unittest.mock import Mock
+
+import orjson
+
+from sglang.srt.entrypoints.openai.serving_base import OpenAIServingBase
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StubServing(OpenAIServingBase):
+    """Minimal concrete subclass -- both error helpers live on the base class."""
+
+    def _request_id_prefix(self) -> str:
+        return "stub-"
+
+    def _convert_to_internal_request(self, request, raw_request=None):
+        raise NotImplementedError
+
+
+class TestCreateErrorResponse(unittest.TestCase):
+    def setUp(self):
+        tokenizer_manager = Mock()
+        tokenizer_manager.server_args = Mock(
+            tokenizer_metrics_allowed_custom_labels=None
+        )
+        self.serving = _StubServing(tokenizer_manager)
+
+    @staticmethod
+    def _body(response):
+        return orjson.loads(response.body)
+
+    def test_error_response_is_wrapped_in_error_envelope(self):
+        response = self.serving.create_error_response(
+            "max_tokens=999999 cannot be greater than the model context length",
+            err_type="BadRequestError",
+            status_code=400,
+            param="max_tokens",
+        )
+        self.assertEqual(response.status_code, 400)
+
+        body = self._body(response)
+        # Clients built on the official OpenAI SDK read the failure out of
+        # body["error"]; a flat body makes them report an empty error.
+        self.assertIn("error", body)
+        self.assertNotIn("message", body)
+
+        error = body["error"]
+        self.assertEqual(error["type"], "BadRequestError")
+        self.assertEqual(error["param"], "max_tokens")
+        self.assertEqual(error["code"], 400)
+        self.assertIn("cannot be greater than", error["message"])
+
+    def test_streaming_and_non_streaming_agree_on_shape(self):
+        kwargs = dict(message="boom", err_type="BadRequestError", status_code=400)
+        non_streaming = self._body(self.serving.create_error_response(**kwargs))
+        streaming = json.loads(self.serving.create_streaming_error_response(**kwargs))
+
+        self.assertEqual(non_streaming.keys(), streaming.keys())
+        self.assertEqual(
+            non_streaming["error"]["message"], streaming["error"]["message"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Problem

`OpenAIServingBase.create_error_response` returned `ErrorResponse.model_dump()` directly as the response body, so a non-streaming 400 came back flat:

```json
{"object":"error","message":"max_tokens=999999 cannot be greater than...","type":"BadRequestError","param":"max_tokens","code":400}
```

The OpenAI error schema puts the failure under an `"error"` key:

```json
{"error":{"message":"...","type":"BadRequestError","param":"max_tokens","code":400}}
```

Clients built on the official OpenAI SDK look under `error`, find nothing, and surface an empty or unparseable error instead of the real message — so a perfectly clear server-side validation failure reaches the user as `no body`.

## Why this is the inconsistent one

sglang already emits the enveloped form on every other error path:

- `create_streaming_error_response` (`serving_base.py:241`) returns `json.dumps({"error": error.model_dump()})`
- the Rust router serialises through `ErrorEnvelope { error: ErrorBody }` (`experimental/sgl-router/src/server/error.rs:155-166`)

Only the Python non-streaming path was flat, so the same logical failure had two different shapes depending on whether the caller set `stream=true`.

## Change

One-line fix in `create_error_response` to wrap in the `"error"` envelope.

## Compatibility

This changes the non-streaming error body, which is a visible surface. Worth being explicit about it:

- Clients matching the OpenAI schema are **fixed** by this (they are broken today).
- Clients reading the flat sglang-specific keys would need to read `body["error"]["message"]` instead of `body["message"]`. Given the streaming path and the router already use the envelope, the flat shape looks like the outlier rather than an intentional contract.
- HTTP status codes are unchanged.

I checked the existing suites: `test_request_length_validation.py` asserts with `assertIn(...)` against `response.text` and `str(cm.exception)`, so it is shape-agnostic and stays green.

If you would rather preserve the flat keys alongside the envelope, say the word and I will make it additive instead.

## Test

Adds `test/registered/unit/entrypoints/openai/test_serving_base.py` (mirrors the source tree per `test/registered/unit/README.md`, registered via `register_cpu_ci`), covering the envelope shape and that the streaming and non-streaming paths agree.

I verified the test discriminates rather than just passing: run against the unwrapped implementation both tests fail (`dict_keys(['object','message','type','param','code']) != dict_keys(['error'])`), and against the fix both pass.

`black` 26.1.0 and `isort` 7.0.0 (with the repo's `.isort.cfg`) are clean on both files.

Fixes #33504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30900633548](https://github.com/sgl-project/sglang/actions/runs/30900633548)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30900630965](https://github.com/sgl-project/sglang/actions/runs/30900630965)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->