### PR TITLE
[model-gateway] Preserve explicit zero refill rate for concurrency limiting

### DIFF
--- a/sgl-model-gateway/src/app_context.rs
+++ b/sgl-model-gateway/src/app_context.rs
@@ -376,10 +376,7 @@ impl AppContextBuilder {
         self.rate_limiter = match config.max_concurrent_requests {
             n if n <= 0 => None,
             n => {
-                let rate_limit_tokens = config
-                    .rate_limit_tokens_per_second
-                    .filter(|&t| t > 0)
-                    .unwrap_or(n);
+                let rate_limit_tokens = config.rate_limit_tokens_per_second.unwrap_or(n);
                 Some(Arc::new(TokenBucket::new(
                     n as usize,
                     rate_limit_tokens as usize,

--- a/sgl-model-gateway/tests/common/mod.rs
+++ b/sgl-model-gateway/tests/common/mod.rs
@@ -295,10 +295,7 @@ pub async fn create_test_context(config: RouterConfig) -> Arc<AppContext> {
     let rate_limiter = match config.max_concurrent_requests {
         n if n <= 0 => None,
         n => {
-            let rate_limit_tokens = config
-                .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
-                .unwrap_or(n);
+            let rate_limit_tokens = config.rate_limit_tokens_per_second.unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,
@@ -414,10 +411,7 @@ pub async fn create_test_context_with_parsers(config: RouterConfig) -> Arc<AppCo
     let rate_limiter = match config.max_concurrent_requests {
         n if n <= 0 => None,
         n => {
-            let rate_limit_tokens = config
-                .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
-                .unwrap_or(n);
+            let rate_limit_tokens = config.rate_limit_tokens_per_second.unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,
@@ -543,10 +537,7 @@ pub async fn create_test_context_with_mcp_config(
     let rate_limiter = match config.max_concurrent_requests {
         n if n <= 0 => None,
         n => {
-            let rate_limit_tokens = config
-                .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
-                .unwrap_or(n);
+            let rate_limit_tokens = config.rate_limit_tokens_per_second.unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,

--- a/sgl-model-gateway/tests/common/test_app.rs
+++ b/sgl-model-gateway/tests/common/test_app.rs
@@ -1,4 +1,7 @@
-use std::sync::{Arc, OnceLock};
+use std::{
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
 
 use axum::Router;
 use data_connector::{
@@ -11,13 +14,31 @@ use smg::{
     core::{
         BasicWorkerBuilder, LoadMonitor, ModelCard, RuntimeType, Worker, WorkerRegistry, WorkerType,
     },
-    middleware::{AuthConfig, TokenBucket},
+    middleware::{AuthConfig, ConcurrencyLimiter, QueuedRequest, TokenBucket},
     policies::PolicyRegistry,
     routers::RouterTrait,
     server::{build_app, AppState},
     tokenizer::registry::TokenizerRegistry,
 };
 use smg_mcp::{McpConfig, McpManager};
+
+fn init_concurrency_queue(
+    rate_limiter: Option<Arc<TokenBucket>>,
+    queue_size: usize,
+    queue_timeout_secs: u64,
+) -> Option<tokio::sync::mpsc::Sender<QueuedRequest>> {
+    let (limiter, processor) = ConcurrencyLimiter::new(
+        rate_limiter,
+        queue_size,
+        Duration::from_secs(queue_timeout_secs),
+    );
+
+    if let Some(processor) = processor {
+        tokio::spawn(processor.run());
+    }
+
+    limiter.queue_tx
+}
 
 /// Create a test Axum application using the actual server's build_app function
 #[allow(dead_code)]
@@ -30,16 +51,19 @@ pub fn create_test_app(
     let rate_limiter = match router_config.max_concurrent_requests {
         n if n <= 0 => None,
         n => {
-            let rate_limit_tokens = router_config
-                .rate_limit_tokens_per_second
-                .filter(|&t| t > 0)
-                .unwrap_or(n);
+            let rate_limit_tokens = router_config.rate_limit_tokens_per_second.unwrap_or(n);
             Some(Arc::new(TokenBucket::new(
                 n as usize,
                 rate_limit_tokens as usize,
             )))
         }
     };
+
+    let concurrency_queue_tx = init_concurrency_queue(
+        rate_limiter.clone(),
+        router_config.queue_size,
+        router_config.queue_timeout_secs,
+    );
 
     // Initialize registries
     let worker_registry = Arc::new(WorkerRegistry::new());
@@ -87,7 +111,7 @@ pub fn create_test_app(
     let app_state = Arc::new(AppState {
         router,
         context: app_context,
-        concurrency_queue_tx: None,
+        concurrency_queue_tx,
         router_manager: None,
         mesh_handler: None,
         mesh_sync_manager: None,
@@ -125,18 +149,22 @@ pub fn create_test_app_with_context(
     router: Arc<dyn RouterTrait>,
     app_context: Arc<AppContext>,
 ) -> Router {
+    let router_config = &app_context.router_config;
+    let concurrency_queue_tx = init_concurrency_queue(
+        app_context.rate_limiter.clone(),
+        router_config.queue_size,
+        router_config.queue_timeout_secs,
+    );
+
     // Create AppState with the test router and context
     let app_state = Arc::new(AppState {
         router,
         context: app_context.clone(),
-        concurrency_queue_tx: None,
+        concurrency_queue_tx,
         router_manager: None,
         mesh_handler: None,
         mesh_sync_manager: None,
     });
-
-    // Get config from the context
-    let router_config = &app_context.router_config;
 
     // Configure request ID headers (use defaults if not specified)
     let request_id_headers = router_config.request_id_headers.clone().unwrap_or_else(|| {

--- a/sgl-model-gateway/tests/reliability/rate_limiting_test.rs
+++ b/sgl-model-gateway/tests/reliability/rate_limiting_test.rs
@@ -130,6 +130,66 @@ mod rate_limiting_tests {
         ctx.shutdown().await;
     }
 
+    /// Test that explicit zero refill rate is preserved as strict concurrency limiting.
+    #[tokio::test]
+    async fn test_rate_limit_zero_does_not_fall_back_to_refill() {
+        let config = RouterConfig::builder()
+            .regular_mode(vec![])
+            .random_policy()
+            .host("127.0.0.1")
+            .port(3404)
+            .max_payload_size(256 * 1024 * 1024)
+            .request_timeout_secs(600)
+            .worker_startup_timeout_secs(5)
+            .worker_startup_check_interval_secs(1)
+            .max_concurrent_requests(1)
+            .rate_limit_tokens_per_second(0)
+            .queue_size(10)
+            .queue_timeout_secs(2)
+            .build_unchecked();
+
+        let ctx =
+            AppTestContext::new_with_config(config, vec![TestWorkerConfig::slow(19304, 3000)])
+                .await;
+
+        let app = ctx.create_app().await;
+
+        let mut handles = Vec::new();
+        for i in 0..2 {
+            let app_clone = app.clone();
+            let handle = tokio::spawn(async move {
+                let payload = json!({
+                    "text": format!("Zero refill request {}", i),
+                    "stream": false
+                });
+
+                let req = Request::builder()
+                    .method("POST")
+                    .uri("/generate")
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from(serde_json::to_string(&payload).unwrap()))
+                    .unwrap();
+
+                app_clone.oneshot(req).await.unwrap().status()
+            });
+            handles.push(handle);
+        }
+
+        let mut statuses = Vec::new();
+        for handle in handles {
+            statuses.push(handle.await.unwrap());
+        }
+
+        statuses.sort();
+        assert_eq!(
+            statuses,
+            vec![StatusCode::OK, StatusCode::REQUEST_TIMEOUT],
+            "explicit zero refill rate should not fall back to refill behavior"
+        );
+
+        ctx.shutdown().await;
+    }
+
     /// Test unlimited concurrent requests when set to 0
     #[tokio::test]
     async fn test_unlimited_concurrent_requests() {


### PR DESCRIPTION
## Motivation

`TokenBucket` supports `refill_rate = 0` as strict concurrency limiting: tokens are only returned when requests complete, so the bucket behaves like a semaphore.

However, the gateway context currently drops an explicit `rate_limit_tokens_per_second = 0` before constructing the bucket:

```rust
config
    .rate_limit_tokens_per_second
    .filter(|&t| t > 0)
    .unwrap_or(n)
```

As a result, users cannot explicitly configure zero-refill behavior through `rate_limit_tokens_per_second = 0`; the value is treated the same as unset and falls back to `max_concurrent_requests`.

This PR is a minimal fix that preserves the existing default behavior for unset `rate_limit_tokens_per_second`, while allowing an explicit `0` to reach `TokenBucket`.

Related prior work:
- #21683 also targets support for `rate_limit_tokens_per_second = 0`.
- #21362 changes the default behavior for unset `rate_limit_tokens_per_second`.
- #31907 addresses a broader set of concurrency limiter issues.

This PR intentionally keeps the scope narrow: preserve explicit zero refill, align test helpers with production behavior, and add a regression test for the queue path.

## Modifications

- Preserve explicit `rate_limit_tokens_per_second = 0` when constructing the gateway `TokenBucket`.
  - `None` still defaults to `max_concurrent_requests`.
  - `0` now remains `0`.
  - Negative values are still rejected by config validation on normal startup paths.
- Apply the same construction behavior to model-gateway test helpers.
- Initialize the test app's `ConcurrencyLimiter` queue processor so tests exercise the same queue path as the production server.
- Add a regression test covering explicit zero-refill behavior with queued requests:
  - `max_concurrent_requests = 1`
  - `rate_limit_tokens_per_second = 0`
  - one request succeeds;
  - one queued request times out instead of being admitted by automatic refill.

This PR intentionally does not change:
- the default refill behavior when `rate_limit_tokens_per_second` is unset;
- token return / lease semantics;
- the queue scheduling model;
- CLI or user-facing documentation.

## Accuracy Tests

Not applicable. This change only affects gateway request admission behavior and does not affect model outputs.

## Speed Tests and Profiling

No dedicated performance benchmark was run.

The change does not add new work to the request hot path. It only changes how an already-supported `TokenBucket` refill value is derived from config and makes tests exercise the production queue path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is required; this preserves an already validated config value.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable for this gateway admission-control fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30900701569](https://github.com/sgl-project/sglang/actions/runs/30900701569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30900701427](https://github.com/sgl-project/sglang/actions/runs/30900701427)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->