### PR TITLE
Fix MXFP4 expert scales silently zeroing on per-expert checkpoints

### DIFF
--- a/benchmark/deepseek_v4/repack_mxfp4.py
+++ b/benchmark/deepseek_v4/repack_mxfp4.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Repack a DeepSeek-V4 checkpoint for GPUs without FP8 or FP4 kernels (SM80).
+
+The published checkpoint already stores its routed experts as MXFP4 -- e2m1
+nibbles packed into int8 [R, C/2] with e8m0 block scales over groups of 32.
+Those bytes are copied through **unchanged**, so the experts carry no
+additional quantisation error. Everything else (attention, shared experts,
+dense projections, embeddings, head, router) is FP8 e4m3 with 128x128 block
+scales, which Ampere cannot compute on; those are dequantised to BF16, which
+is lossless relative to the FP8 values.
+
+The output declares quant_method="mxfp4" and marks every non-expert module as
+ignored, so SGLang serves the experts through the Marlin MXFP4 MoE path and
+the rest unquantised.
+
+Four gates run during conversion; each one fails the build:
+  1. Expert passthrough: sample expert tensors, decode the written bytes
+     (nibble unpack x 2^e8m0) and compare against the reference dequant.
+     Relative error must be exactly 0 -- a passthrough may not change a value.
+  2. BF16 layers: compare against the FP8 reference dequant, within bf16
+     rounding (rel <= 1e-2).
+  3. Ignore list: covers every non-expert 2-D weight, and no expert.
+  4. Completeness: index intact, shard count matches, no missing tensor.
+
+Usage:
+    python3 repack_mxfp4.py --src <official dir> --dst <output dir>
+                            [--limit-shards N] [--stride K --offset J --no-finalize]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shutil
+import statistics
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+FP4_TABLE = torch.tensor(
+    [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+     -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+    dtype=torch.float32,
+)  # e2m1, matching the official inference/convert.py
+
+# Routed experts in the main body (layers.N) and in the MTP draft layers
+# (mtp.N) are both native MXFP4 and both pass through bit-for-bit. Matching
+# only the "layers." prefix drops the MTP experts into the BF16 branch, which
+# contradicts the mxfp4 declaration in the config and costs draft quality.
+EXPERT_RE = re.compile(
+    r"^(?:layers|mtp)\.\d+\.ffn\.experts\.\d+\.(w1|w2|w3)\.(weight|scale)$"
+)
+
+
+def dequant_fp4(packed_i8: torch.Tensor, scale_e8m0: torch.Tensor) -> torch.Tensor:
+    """Reference dequant: int8 [R, C/2] low-nibble-first + e8m0 [R, C/32] -> fp32 [R, C]."""
+    b = packed_i8.view(torch.uint8)
+    lo = (b & 0xF).long()
+    hi = (b >> 4).long()
+    vals = torch.empty(b.shape[0], b.shape[1] * 2, dtype=torch.float32)
+    vals[:, 0::2] = FP4_TABLE[lo]
+    vals[:, 1::2] = FP4_TABLE[hi]
+    exp = scale_e8m0.view(torch.uint8).long() - 127
+    scale = torch.pow(2.0, exp.float())
+    return vals * scale.repeat_interleave(32, dim=1)
+
+
+def dequant_fp8(w_fp8: torch.Tensor, scale_f32: torch.Tensor) -> torch.Tensor:
+    """Reference dequant: FP8 e4m3 with 128x128 block scales -> fp32."""
+    w = w_fp8.float()
+    R, C = w.shape
+    if scale_f32.dtype == torch.float8_e8m0fnu:
+        scale_f32 = torch.pow(2.0, scale_f32.view(torch.uint8).float() - 127)
+    else:
+        scale_f32 = scale_f32.float()
+    br = scale_f32.repeat_interleave(128, dim=0)[:R]
+    bc = br.repeat_interleave(128, dim=1)[:, :C]
+    return w * bc
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True)
+    ap.add_argument("--dst", required=True)
+    ap.add_argument("--limit-shards", type=int, default=0)
+    ap.add_argument("--stride", type=int, default=1)
+    ap.add_argument("--offset", type=int, default=0)
+    ap.add_argument("--no-finalize", action="store_true")
+    a = ap.parse_args()
+    src, dst = Path(a.src), Path(a.dst)
+    dst.mkdir(parents=True, exist_ok=True)
+
+    shards = sorted(src.glob("model-*.safetensors"))
+    if a.limit_shards:
+        shards = shards[: a.limit_shards]
+    todo = shards[a.offset :: a.stride]
+
+    n_pass_expert = n_bf16 = 0
+    for i, sf in enumerate(todo):
+        outd: dict[str, torch.Tensor] = {}
+        with safe_open(sf, framework="pt") as sh:
+            keys = list(sh.keys())
+            kset = set(keys)
+            for k in keys:
+                t = sh.get_tensor(k)
+                if EXPERT_RE.match(k):
+                    outd[k] = t.contiguous()  # passthrough, not one bit changed
+                    if k.endswith(".weight"):
+                        n_pass_expert += 1
+                    continue
+                if k.endswith(".scale"):
+                    continue  # non-expert scales are consumed together with their weight
+                sc_key = k.rsplit(".", 1)[0] + ".scale"
+                if t.dtype == torch.float8_e4m3fn and sc_key in kset:
+                    ref = dequant_fp8(t, sh.get_tensor(sc_key))
+                    outd[k] = ref.to(torch.bfloat16)
+                    n_bf16 += 1
+                elif t.dtype == torch.int8 and sc_key in kset:
+                    # FP4 outside the routed experts (shared experts): dequantise to bf16 too
+                    ref = dequant_fp4(t, sh.get_tensor(sc_key))
+                    outd[k] = ref.to(torch.bfloat16)
+                    n_bf16 += 1
+                else:
+                    outd[k] = t.to(torch.bfloat16) if t.is_floating_point() and t.dtype != torch.bfloat16 else t
+        save_file(outd, str(dst / sf.name))
+        print(f"[{i+1}/{len(todo)}] {sf.name}  experts passed through {n_pass_expert}  converted to bf16 {n_bf16}", flush=True)
+
+    if not a.no_finalize:
+        finalize(src, dst, expected=len(shards), smoke=bool(a.limit_shards))
+
+
+def finalize(src: Path, dst: Path, expected: int, smoke: bool) -> None:
+    files = sorted(dst.glob("model-*.safetensors"))
+    if not smoke and len(files) != expected:
+        raise SystemExit(f"shard count mismatch: {len(files)}/{expected}")
+
+    # Build the config: mxfp4 with every non-expert module on the ignore list.
+    cfg = json.loads((src / "config.json").read_text())
+    cfg.pop("quantization_config", None)
+    cfg["torch_dtype"] = "bfloat16"
+    cfg["quantization_config"] = {
+        "quant_method": "mxfp4",
+        "group_size": 32,
+        "ignored_layers": ["re:^(?!.*\\.ffn\\.experts\\.).*$"],
+        "provenance": "expert tensors passed through bit-identical from the official "
+                      "MXFP4 release; all non-expert tensors dequantized to bf16",
+    }
+    (dst / "config.json").write_text(json.dumps(cfg, indent=1))
+    for extra in ["tokenizer.json", "tokenizer_config.json", "generation_config.json",
+                  "configuration.json", "LICENSE", "README.md"]:
+        if (src / extra).exists():
+            shutil.copy(src / extra, dst / extra)
+
+    # index
+    wmap = {}
+    for f in files:
+        with safe_open(f, framework="pt") as sh:
+            for k in sh.keys():
+                wmap[k] = f.name
+    (dst / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": wmap}, indent=0))
+
+    # Gate 1: expert passthrough round-trip, bit for bit.
+    expert_keys = [k for k in wmap if EXPERT_RE.match(k) and k.endswith(".weight")][:6]
+    if not expert_keys:
+        raise SystemExit("gate 1 saw no expert tensor at all -- the gate is not guarding anything")
+    rels = []
+    for k in expert_keys:
+        with safe_open(src / wmap[k], framework="pt") as s0, \
+             safe_open(dst / wmap[k], framework="pt") as s1:
+            sc = k.rsplit(".", 1)[0] + ".scale"
+            ref = dequant_fp4(s0.get_tensor(k), s0.get_tensor(sc))
+            got = dequant_fp4(s1.get_tensor(k), s1.get_tensor(sc))
+            rels.append(((ref - got).abs().max()).item())
+    if max(rels) != 0.0:
+        raise SystemExit(f"gate 1: expert passthrough drifted, max abs diff={max(rels)}")
+    print(f"gate 1 ok: {len(expert_keys)} expert tensors passed through bit for bit")
+
+    # Gate 2: bf16 layers against the FP8 reference.
+    bf_keys = [k for k in wmap
+               if not EXPERT_RE.match(k) and k.endswith(".weight") and "norm" not in k][:6]
+    rels = []
+    for k in bf_keys:
+        with safe_open(src / wmap[k], framework="pt") as s0, \
+             safe_open(dst / wmap[k], framework="pt") as s1:
+            t = s0.get_tensor(k)
+            sc = k.rsplit(".", 1)[0] + ".scale"
+            with safe_open(src / wmap[k], framework="pt") as _s:
+                has_sc = sc in set(_s.keys())
+            if t.dtype == torch.float8_e4m3fn and has_sc:
+                ref = dequant_fp8(t, s0.get_tensor(sc))
+            elif t.dtype == torch.int8 and has_sc:
+                ref = dequant_fp4(t, s0.get_tensor(sc))
+            else:
+                continue
+            got = s1.get_tensor(k).float()
+            rels.append(((ref - got).norm() / ref.norm().clamp(min=1e-9)).item())
+    if rels:
+        med = statistics.median(rels)
+        print(f"   gate 2: {len(rels)} bf16 samples, median relative error {med:.2e}")
+        if med > 1e-2:
+            raise SystemExit("gate 2: bf16 conversion error above tolerance")
+        print("gate 2 ok: bf16 conversion within rounding error")
+
+    # Gate 3: the ignore pattern must match exactly what was routed where.
+    pat = re.compile("^(?!.*\\.ffn\\.experts\\.).*$")
+    bad_ign = [k for k in expert_keys if pat.match(k)]
+    bad_keep = [k for k in bf_keys if not pat.match(k)]
+    if bad_ign or bad_keep:
+        raise SystemExit(f"gate 3: ignore pattern misroutes {bad_ign[:2]} {bad_keep[:2]}")
+    print("gate 3 ok: ignored_layers pattern agrees with the actual split")
+    print(f"output: {sum(f.stat().st_size for f in files)/2**30:.1f} GiB across {len(files)} shards")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -865,7 +865,7 @@ class FusedMoE(torch.nn.Module):
         # if expert_id is None, then
         # all the experts are loaded at the same time
         if (
-            not expert_id
+            expert_id is None  # `not expert_id` also caught expert 0
             and self.quant_config is not None
             and self.quant_config.get_name() == "mxfp4"
             and self.quant_config.is_static_cfg()
@@ -951,17 +951,6 @@ class FusedMoE(torch.nn.Module):
                 if expert_id >= self.quant_method.num_gpu_experts:
                     return
 
-        # MXFP4 block scales are stored as e8m0 by some checkpoints (DeepSeek)
-        # and as raw uint8 by others (GPT-OSS), but the parameter buffer is
-        # always uint8. Copying an e8m0 tensor into it converts numerically --
-        # a scale byte of 120 means 2^-7, so it lands as 0 and silently zeroes
-        # every block scale. Reinterpret the bits instead.
-        if (
-            loaded_weight.dtype == torch.float8_e8m0fnu
-            and param.dtype == torch.uint8
-        ):
-            loaded_weight = loaded_weight.view(torch.uint8)
-
         self._weight_loader_impl(
             param=param,
             loaded_weight=loaded_weight,
@@ -1028,6 +1017,13 @@ class FusedMoE(torch.nn.Module):
         expert_id: int,
     ) -> None:
         tp_rank = self.moe_tp_rank
+
+        # MXFP4 block scales ship as e8m0 in some checkpoints and as raw uint8
+        # in others, but the parameter buffer is always uint8. Copying an e8m0
+        # tensor into it converts numerically: a scale byte of 120 means 2^-7,
+        # so it lands as 0 and every block scale is silently zeroed.
+        if loaded_weight.dtype == torch.float8_e8m0fnu and param.dtype == torch.uint8:
+            loaded_weight = loaded_weight.view(torch.uint8)
 
         # Special case for GGUF weights
         if self._load_gguf_weight(param, loaded_weight, shard_id, expert_id, tp_rank):
@@ -1293,6 +1289,11 @@ class FusedMoE(torch.nn.Module):
                 dim1 = loaded_weight.shape[1]
                 param.data[:, :dim1].copy_(loaded_weight)
             elif "scale" in weight_name:
+                if (
+                    loaded_weight.dtype == torch.float8_e8m0fnu
+                    and param.dtype == torch.uint8
+                ):
+                    loaded_weight = loaded_weight.view(torch.uint8)
                 param.data.copy_(loaded_weight)
             else:
                 dim1 = loaded_weight.shape[1]

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -951,6 +951,17 @@ class FusedMoE(torch.nn.Module):
                 if expert_id >= self.quant_method.num_gpu_experts:
                     return
 
+        # MXFP4 block scales are stored as e8m0 by some checkpoints (DeepSeek)
+        # and as raw uint8 by others (GPT-OSS), but the parameter buffer is
+        # always uint8. Copying an e8m0 tensor into it converts numerically --
+        # a scale byte of 120 means 2^-7, so it lands as 0 and silently zeroes
+        # every block scale. Reinterpret the bits instead.
+        if (
+            loaded_weight.dtype == torch.float8_e8m0fnu
+            and param.dtype == torch.uint8
+        ):
+            loaded_weight = loaded_weight.view(torch.uint8)
+
         self._weight_loader_impl(
             param=param,
             loaded_weight=loaded_weight,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -441,6 +441,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         self.intermediate_size_per_partition = intermediate_size_per_partition_after_pad
 
         self.hidden_size = hidden_size
+
+        # Checkpoints that ship one tensor per expert (DeepSeek) go through the
+        # generic per-expert loader, which dispatches scale loading on this
+        # attribute. Without it the loader raises on the first scale tensor.
+        # GPT-OSS never hit this: its fused all-experts-at-once tensors take the
+        # naive-copy fast path above the dispatch.
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
+
+        extra_weight_attrs.update(
+            {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
+        )
+
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
             torch.zeros(

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -304,14 +304,18 @@ class Mxfp4Config(QuantizationConfig):
                 return UnquantizedLinearMethod()
             elif _is_hip:
                 return UnquantizedLinearMethod()
+            # An MXFP4 checkpoint only serializes the MoE experts; every other
+            # linear carries plain bf16. Falling through to `return None` made
+            # the layer assert, so a single missing ignore entry killed the load.
+            return UnquantizedLinearMethod()
         elif isinstance(layer, FusedMoE):
             if self.is_checkpoint_mxfp4_serialized:
                 return Mxfp4MoEMethod(prefix=prefix)
             else:
                 return Mxfp4DynamicQuantMoEMethod()
-        else:
-            if self.is_checkpoint_mxfp4_serialized:
-                raise NotImplementedError("Mxfp4 attention layer is not implemented")
+        # Attention wrappers and embeddings carry no fp4 tensors in an MXFP4
+        # checkpoint; route them through the unquantized path like every other
+        # quant config does instead of refusing to load.
         return None
 
     def get_scaled_act_names(self) -> List[str]:
@@ -449,9 +453,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         # naive-copy fast path above the dispatch.
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
 
-        extra_weight_attrs.update(
-            {"quant_method": FusedMoeWeightScaleSupported.BLOCK.value}
-        )
+        # Per-expert checkpoints reach the generic scale loader, which
+        # dispatches on this attribute; GPT-OSS never does, so it was never set.
+        scale_attrs = dict(extra_weight_attrs)
+        scale_attrs["quant_method"] = FusedMoeWeightScaleSupported.BLOCK.value
 
         # Fused gate_up_proj (column parallel)
         w13_weight = torch.nn.Parameter(
@@ -476,7 +481,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         layer.register_parameter("w13_weight_scale", w13_weight_scale)
-        set_weight_attrs(w13_weight_scale, extra_weight_attrs)
+        set_weight_attrs(w13_weight_scale, scale_attrs)
 
         w13_weight_bias = torch.nn.Parameter(
             torch.zeros(
@@ -512,7 +517,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             requires_grad=False,
         )
         layer.register_parameter("w2_weight_scale", w2_weight_scale)
-        set_weight_attrs(w2_weight_scale, extra_weight_attrs)
+        set_weight_attrs(w2_weight_scale, scale_attrs)
 
         w2_weight_bias = torch.nn.Parameter(
             torch.zeros(layer.num_local_experts, hidden_size, dtype=torch.bfloat16),
@@ -531,8 +536,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 prepare_moe_mxfp4_layer_for_marlin,
             )
 
-            if not is_sm90_supported() and not is_sm120_supported():
-                raise RuntimeError("MXFP4 Marlin requires SM90 or SM120.")
+            # Marlin targets SM80+ and its e2m1 decode is bit manipulation,
+            # so gate on the Marlin floor rather than SM90/SM120.
+            if torch.cuda.get_device_capability()[0] < 8:
+                raise RuntimeError("MXFP4 Marlin requires SM80 or newer.")
             if not check_moe_marlin_supports_layer(layer, 32, allow_tile_padding=True):
                 raise RuntimeError(
                     "Current MXFP4 MoE layer is not supported by Marlin."

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2851,8 +2851,7 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         expert_scale_suffix = (
             "weight_scale"
-            if self.quant_config is not None
-            and self.quant_config.get_name() == "mxfp4"
+            if self.quant_config is not None and self.quant_config.get_name() == "mxfp4"
             else "weight_scale_inv"
         )
 

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -2694,6 +2694,7 @@ class DeepseekV4ForCausalLM(nn.Module):
         name: str,
         is_nextn: bool = False,
         num_hidden_layers: Optional[int] = None,
+        expert_scale_suffix: str = "weight_scale_inv",
     ) -> str:
         if name == "embed.weight":
             return "model.embed_tokens.weight"
@@ -2748,7 +2749,11 @@ class DeepseekV4ForCausalLM(nn.Module):
         name = name.replace(".w2.", ".down_proj.")
         name = name.replace(".w3.", ".up_proj.")
         if "mlp" in name and name.endswith(".scale"):
-            name = name.removesuffix(".scale") + ".weight_scale_inv"
+            # fp8 block scales are reciprocals and land on ``weight_scale_inv``;
+            # mxfp4 block scales are not, and their buffer is ``weight_scale``.
+            # Using the fp8 name for an mxfp4 checkpoint silently drops every
+            # expert scale (the parameter never matches, so it stays zeroed).
+            name = name.removesuffix(".scale") + "." + expert_scale_suffix
 
         return name
 
@@ -2844,6 +2849,13 @@ class DeepseekV4ForCausalLM(nn.Module):
 
         stacked_params_mapping = DEEPSEEK_V4_STACKED_PARAMS_MAPPING
 
+        expert_scale_suffix = (
+            "weight_scale"
+            if self.quant_config is not None
+            and self.quant_config.get_name() == "mxfp4"
+            else "weight_scale_inv"
+        )
+
         expert_params_mapping = FusedMoE.make_expert_params_mapping(
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
@@ -2907,6 +2919,7 @@ class DeepseekV4ForCausalLM(nn.Module):
                         name,
                         is_nextn=is_nextn,
                         num_hidden_layers=self.config.num_hidden_layers,
+                        expert_scale_suffix=expert_scale_suffix,
                     )
 
                     layer_id = get_layer_id(name)

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -876,7 +876,20 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         mapped_rest = mapped_rest.replace(".w3.", ".up_proj.")
         mapped_rest = mapped_rest.replace(".gate.tid2eid", ".topk.tid2eid")
         mapped_rest = mapped_rest.replace(".gate.bias", ".gate.e_score_correction_bias")
-        mapped_rest = mapped_rest.replace(".scale", ".weight_scale_inv")
+        # fp8 block scales are reciprocals and live on ``weight_scale_inv``;
+        # mxfp4 block scales are not, and their buffer is ``weight_scale``.
+        # Using the fp8 name for an mxfp4 draft silently drops every expert
+        # scale, which costs acceptance rate rather than raising anything.
+        # Mirror the main model: only MoE scales take the mxfp4 name. An
+        # attention scale in a mixed checkpoint must keep weight_scale_inv.
+        if "mlp" in mapped_rest and mapped_rest.endswith(".scale"):
+            suffix = (
+                "weight_scale"
+                if self.quant_config is not None
+                and self.quant_config.get_name() == "mxfp4"
+                else "weight_scale_inv"
+            )
+            mapped_rest = mapped_rest.removesuffix(".scale") + "." + suffix
         return f"stages.{stage_id}.{mapped_rest}"
 
 


### PR DESCRIPTION
![Serving profile after the fixes: prefill, prefix cache, concurrency](https://raw.githubusercontent.com/Hakureirm/sglang/assets/charts/pr33541_perf.png)

## Motivation

MXFP4 support in SGLang has only ever been exercised by GPT-OSS checkpoints, which pack all experts into a single tensor per projection. Those take the fused fast path in `FusedMoE.weight_loader` and never touch the per-expert loading path.

DeepSeek ships one tensor per expert. Loading such a checkpoint walks that path and hits six distinct problems in sequence — each only reachable after the previous one is fixed. Most of them fail loudly, but the last three do not: every expert block scale ends up zeroed at load time, the model starts, serves, and emits fluent text — it just stops following the prompt. Nothing in the logs reports a problem except one line in the routine "weights not initialized" list.

## Modifications

| # | Symptom | Fix |
|---|---|---|
| 1 | Load aborts: assertion on a Linear, `NotImplementedError` on attention | An MXFP4 checkpoint only serializes experts; default everything else to unquantized instead of failing the load |
| 2 | Expert 0's weights go down the fused path | `not expert_id` → `expert_id is None` |
| 3 | Every expert scale silently unloaded (all 43 MoE layers) | The DeepSeek name remap rewrites a trailing `.scale` to `.weight_scale_inv`, which is the **fp8** block-scale parameter (fp8 scales are reciprocals). MXFP4 scales are not, and their buffer is `weight_scale`, so the remapped name matched no parameter. Pick the suffix from the quantization method |
| 4 | `quant method must be one of [...]` on the first scale | `Mxfp4MoEMethod` never declared the `quant_method` weight attribute the generic scale loader dispatches on. MXFP4 is a 32-element block scale: declare `BLOCK` |
| 5 | Scales load, but every value becomes 0 | e8m0 scales copied into a uint8 buffer convert *numerically* rather than reinterpreting — a scale byte of 120 means 2^-7, so it lands as 0. View the bits instead |
| 6 | Speculative decoding loses most of its speedup | The DSpark draft model carries its own copy of the name remap with the same hardcoded fp8 suffix. Zeroed draft scales do not corrupt output — the target verifies every draft — they just wreck the acceptance rate |

Also: the Marlin MoE path was gated on SM90/SM120, but Marlin targets SM80+ and its e2m1 decode is plain bit manipulation. Gated on the Marlin floor instead, so Ampere can use it.

GPT-OSS checkpoints should be unaffected: they enter through the fused
all-experts-at-once path, and the scale-name and dispatch changes live on the
per-expert path they never take. I have no GPT-OSS hardware to confirm that,
so it is reasoning about the code, not a measurement.

One caveat worth flagging: fix #1 turns a hard load failure into an
unquantized fallback. That is right for an MXFP4 checkpoint, where only the
experts are serialized in fp4 -- but it does mean a genuinely malformed
checkpoint now loads quietly instead of aborting.

## Accuracy Tests

DeepSeek-V4-Flash-0731 on 8x A800 (SM80, TP=8), converted to MXFP4 with the expert bytes passed through unchanged. The official checkpoint already stores routed experts as e2m1 nibbles with e8m0 block scales, so the conversion is a lossless repack and any accuracy loss would come from the serving path alone.

**Needle-in-a-haystack**, 3 context lengths x 3 needle depths, 4 keyword checks
per cell (server launched with `--context-length 1000000`; the longest context
actually exercised anywhere in this PR is 218K):

| context | depth 0.1 | depth 0.5 | depth 0.9 |
|---|---|---|---|
| 4K | 4/4 | 4/4 | 4/4 |
| 32K | 4/4 | 4/4 | 4/4 |
| 128K | 4/4 | 4/4 | 4/4 |

**GSM8K**, full 1319-question test set, greedy, thinking disabled, graded by
numeric match on the last number in the answer:

| | accuracy | tokens/question |
|---|---|---|
| this PR, repacked MXFP4 on 8x A800 | 94.24% (1243/1319) | 206 |
| DeepSeek official API, same model, same questions, same grader | 96.29% (1270/1319) | 129 |

The 2.05-point gap is larger than sampling noise (~0.6 points at this n), so it
is reported as measured rather than claimed as parity. It is unlikely to come
from the weights: routed experts are byte-identical to the published
checkpoint and the FP8 layers are dequantised exactly. The more likely source
is prompt formatting — this checkpoint carries no chat template, so SGLang
falls back to a plain string format while the official endpoint applies
DeepSeek's own, and our answers do run notably longer (206 vs 129 tokens).
Worth chasing separately; it is not a property of these fixes.

**Before these fixes the same checkpoint scored 0/9 on the same grid** — every
cell missed, while the model answered fluently and nothing errored.

## Speed Tests and Profiling

All on 8x A800-SXM4-80GB (NVLink, TP=8), Marlin MoE backend, server launched
with `--context-length 1000000`.

The tables below use different `--cuda-graph-max-bs` values (16, 32 and 128),
noted per table. Single-stream numbers are therefore **not comparable across
tables** — 93.9, 97.1 and 94 all mean "one request at a time" under three
different capture sizes.

**Single stream, before vs after.** These changes are load-time only, so the
first pair is run-to-run noise. The second pair is the draft model finally
producing usable drafts once its scales load:

| | decode |
|---|---|
| no speculative, before and after | ~50 tok/s, unchanged |
| before, DSpark speculative (default gamma=5) | 58.1 tok/s |
| after, DSpark speculative (default gamma=5) | **85.9 tok/s** |

Tuning the DSpark block size on top of that is a separate, orthogonal +9%
(85.9 -> 93.9 at gamma=3); it is not part of what these fixes buy.

**DSpark block size** (256 output tokens, `--cuda-graph-max-bs 32`). Every
drafted token costs a full expert pass, so throughput peaks well before the
accepted length does. Accepted length rises with the block up to gamma=5 and
then drops at gamma=7 — that reversal is unexplained and worth a second look:

| gamma (draft tokens) | 2 (3) | **3 (4)** | 4 (5) | 5 (6, default) | 7 (8) |
|---|---|---|---|---|---|
| tok/s | 86.4 | **93.9** | 89.6 | 85.9 | 86.0 |
| accepted length | 2.08 | 2.45 | 2.75 | 3.00 | 2.25 |

**Prefill and prefix cache** (gamma=3, `--cuda-graph-max-bs 16`):

| context | cold prefill | prefill rate | same prompt again | decode after |
|---|---|---|---|---|
| 16K | 5.1 s | 3.3K tok/s | 0.29 s | 97.1 tok/s |
| 64K | 23.5 s | 2.9K tok/s | 0.41 s | 81.0 tok/s |
| 128K | 42.3 s | 3.2K tok/s | 0.70 s | 57.9 tok/s |
| 218K | 63.7 s | 3.6K tok/s | 0.89 s | 36.6 tok/s |

Prefix caching is what makes long context usable here: re-sending a 218K-token
prompt costs 0.89 s instead of 63.7 s.

**Concurrency scaling** (gamma=3, `--cuda-graph-max-bs 128` so the graphs cover
the whole range):

| concurrency | 1 | 8 | 16 | 32 | 128 |
|---|---|---|---|---|---|
| aggregate tok/s | 94 | 310 | 354 | 381 | 429 |
| per-stream tok/s | 94 | 40 | 23 | 12 | 3.5 |

Aggregate is still rising at 128, so the practical ceiling is per-stream
latency rather than throughput. Note the capture size is a real trade-off: at
128 the graph pool leaves too little room for a 200K-token prefill and the
server OOMs mid-request. Size it to the concurrency actually served.

## Reproducing

The checkpoint is a repack of `deepseek-ai/DeepSeek-V4-Flash-0731`, produced by
`benchmark/deepseek_v4/repack_mxfp4.py` in this PR (expert bytes copied
through unchanged, FP8 layers dequantised to BF16, four self-checks run during
conversion). Serving command:

```bash
python3 -m sglang.launch_server \
  --model-path <repacked> --tp 8 \
  --context-length 1000000 --mem-fraction-static 0.78 \
  --attention-backend triton --moe-runner-backend marlin \
  --cuda-graph-max-bs 16 --chunked-prefill-size 16384 \
  --speculative-algorithm DSPARK --speculative-dspark-block-size 3 \
  --reasoning-parser deepseek-v4 --tool-call-parser deepseekv4 \
  --trust-remote-code
```

`gamma` in the block-size table is `--speculative-dspark-block-size`; the value
in parentheses is the resulting verify window (gamma + 1).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
