### PR TITLE
[Docs] External model package example on the embedding models page

### DIFF
--- a/docs/docs/supported-models/embedding_models.mdx
+++ b/docs/docs/supported-models/embedding_models.mdx
@@ -82,6 +82,41 @@ response = requests.post(url + "/v1/embeddings", json=payload).json()
 print("Embeddings:", [x.get("embedding") for x in response.get("data", [])])
 ```
 
+## Audio Embedding via an External Model Package
+
+The [external model package hooks](./support_new_models#serving-external-models-via-the-standard-cli)
+also work for embedding models, which lets a pip package serve architectures SGLang does
+not carry in-tree. One worked example is
+[`EximiusLabs/fusion-embedding-2-2b-preview`](https://huggingface.co/EximiusLabs/fusion-embedding-2-2b-preview),
+a multimodal embedding model that places text, images, video and audio in one 2048-d
+space. Its plugin registers through an `sglang.srt.plugins` entry point, so after a pip
+install the standard launch command works with no source changes:
+
+```bash
+pip install sglang==0.5.16 'fusion-embedding[sense]'
+
+python -m sglang.launch_server \
+  --model-path EximiusLabs/fusion-embedding-2-2b-preview \
+  --is-embedding
+```
+
+Text goes through `/v1/embeddings` as usual. Audio uses the offline engine with
+`audio_data` (one clip per request):
+
+```python
+import sglang as sgl
+
+engine = sgl.Engine(model_path="EximiusLabs/fusion-embedding-2-2b-preview",
+                    is_embedding=True)
+
+out = engine.encode("<|vision_pad|><|im_end|>", audio_data=["clip.wav"])
+print(len(out[0]["embedding"]))  # 2048
+```
+
+The plugin's repository documents the prompt formats per modality and its parity
+harness against the reference implementation:
+[fusion_embedding/sglang_plugin](https://github.com/Eximius-Labs/fusion-embedding/tree/main/fusion_embedding/sglang_plugin).
+
 ## Matryoshka Embedding Example
 
 [Matryoshka Embeddings](https://sbert.net/examples/sentence_transformer/training/matryoshka/README.html#matryoshka-embeddings) or [Matryoshka Representation Learning (MRL)](https://arxiv.org/abs/2205.13147) is a technique used in training embedding models. It allows user to trade off between performance and cost.
@@ -184,6 +219,12 @@ print("Embedding:", response["data"][0]["embedding"])
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`openai/clip-vit-large-patch14-336`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>OpenAI's CLIP for image and text embeddings</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Fusion Embedding 2 (Multimodal, external package)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`EximiusLabs/fusion-embedding-2-2b-preview`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>N/A</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Text, image, video and audio in one embedding space; served through the external model package hooks via <code>pip install 'fusion-embedding[sense]'</code> (see the audio section above)</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
## Motivation

The [supported-models docs](https://docs.sglang.io/docs/supported-models/support_new_models) describe the `SGLANG_EXTERNAL_MODEL_PACKAGE` / `SGLANG_EXTERNAL_MM_MODEL_ARCH` / `SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE` hooks, but the embedding models page has no example of an external package serving an embedding model, and no audio embedding example (the `EmbeddingReqInput.audio_data` path has no in-tree embedding user yet). This adds a worked, installable example of both.

## Modifications

Docs only: one new section on `docs/docs/supported-models/embedding_models.mdx` showing an external multimodal embedding model ([EximiusLabs/fusion-embedding-2-2b-preview](https://huggingface.co/EximiusLabs/fusion-embedding-2-2b-preview), pip package `fusion-embedding`) served through the external hooks with a plain `launch_server --is-embedding` command, plus an audio request through `Engine.encode(..., audio_data=[...])`, and one row in the Supported Models table labeled as an external package. The example commands are exercised against sglang==0.5.16 (parity harness linked in the section).

Disclosure: I am the author of the external package used as the example. If maintainers prefer a neutral placeholder package instead, happy to rework the section around the hooks alone.

## Accuracy Tests

Docs only; no model or kernel code changed. The documented commands were run against sglang==0.5.16: server boots via the external hooks, `/v1/embeddings` answers, and the package's parity harness checks the served outputs against its reference implementation (text cosine 1.000000 at fp32, audio 1.000000 on 6 clips).

## Speed Tests and Profiling

Not applicable (docs only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Docs only)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Docs only)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30903533271](https://github.com/sgl-project/sglang/actions/runs/30903533271)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30903532919](https://github.com/sgl-project/sglang/actions/runs/30903532919)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->