### PR TITLE
[AMD] Add FlyDSL GDN linear-attention backend (--linear-attn-backend flydsl)

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -114,6 +114,18 @@ class GDNKernelDispatcher:
         self.tree_verify_kernel = triton_kernel
 
         cutedsl_kernel = None
+        flydsl_kernel = None
+
+        def _get_flydsl_kernel():
+            nonlocal flydsl_kernel
+            if flydsl_kernel is None:
+                from sglang.srt.layers.attention.linear.kernels.gdn_flydsl import (
+                    FlyDSLGDNKernel,
+                )
+
+                flydsl_kernel = FlyDSLGDNKernel()
+            return flydsl_kernel
+
         if decode_backend.is_triton():
             self.decode_kernel = triton_kernel
         elif decode_backend.is_cutedsl():
@@ -134,6 +146,19 @@ class GDNKernelDispatcher:
 
             flashinfer_kernel = FlashInferGDNKernel()
             self.decode_kernel = flashinfer_kernel
+        elif decode_backend.is_flydsl():
+            # FlyDSL recurrent decode (flydsl_gdr_decode), CUDA-graph-safe via
+            # need_shuffle_state=False + view-only reshapes + lru_cache warmup.
+            # Falls back to Triton if the aiter flydsl decode kernel is absent.
+            fk = _get_flydsl_kernel()
+            if fk.supports_flydsl_decode:
+                self.decode_kernel = fk
+            else:
+                rank0_log(
+                    "FlyDSL GDN decode kernel unavailable (aiter flydsl not "
+                    "importable). Falling back to Triton for decode."
+                )
+                self.decode_kernel = triton_kernel
         else:
             raise ValueError(f"Unsupported GDN decode backend: {decode_backend}")
 
@@ -173,6 +198,20 @@ class GDNKernelDispatcher:
 
                 flashinfer_kernel = FlashInferGDNKernel()
                 self.extend_kernel = flashinfer_kernel
+        elif prefill_backend.is_flydsl():
+            # FlyDSL prefill: chunk_gated_delta_rule_fwd_h swapped for aiter's
+            # FlyDSL fwd_h (~1.8-3x faster at TP-sharded shapes, bit-identical to
+            # Triton). Reuses the decode instance if already created. Falls back
+            # to Triton internally if aiter flydsl is absent.
+            fk = _get_flydsl_kernel()
+            if fk.supports_flydsl_extend:
+                self.extend_kernel = fk
+            else:
+                rank0_log(
+                    "FlyDSL GDN prefill kernel unavailable (aiter flydsl not "
+                    "importable). Falling back to Triton for prefill."
+                )
+                self.extend_kernel = triton_kernel
         else:
             raise ValueError(f"Unsupported GDN prefill backend: {prefill_backend}")
 

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flydsl.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flydsl.py
@@ -1,0 +1,262 @@
+import inspect
+import logging
+
+import torch
+
+from sglang.kernels.ops.attention.fla.chunk_fwd import chunk_gated_delta_rule_fwd_intra
+from sglang.kernels.ops.attention.fla.chunk_o import chunk_fwd_o
+from sglang.kernels.ops.attention.fla.cumsum import chunk_local_cumsum
+from sglang.kernels.ops.attention.fla.index import prepare_chunk_indices
+from sglang.kernels.ops.attention.fla.l2norm import l2norm_fwd
+from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = 64
+
+# aiter FlyDSL GDN prefill state kernel. Guarded: if aiter (or its flydsl GDN
+# op) is unavailable, ``FlyDSLGDNKernel.extend`` transparently falls back to the
+# Triton pipeline it inherits from ``TritonGDNKernel``.
+try:
+    from aiter.ops.flydsl.linear_attention_prefill_kernels import (
+        chunk_gated_delta_rule_fwd_h_flydsl,
+    )
+
+    _FLYDSL_AVAILABLE = True
+except Exception as e:  # pragma: no cover - import-time capability probe
+    chunk_gated_delta_rule_fwd_h_flydsl = None
+    _FLYDSL_AVAILABLE = False
+    logger.warning(
+        "FlyDSL GDN kernel unavailable (%s); FlyDSLGDNKernel.extend will fall "
+        "back to the Triton chunk_gated_delta_rule path.",
+        repr(e),
+    )
+
+# aiter FlyDSL GDN decode (recurrent) kernel. Separately guarded so a build with
+# only the prefill kernel still gets the Phase-A prefill win; decode then falls
+# back to the inherited Triton packed/split decode.
+try:
+    from aiter.ops.flydsl.linear_attention_kernels import flydsl_gdr_decode
+
+    _FLYDSL_DECODE_AVAILABLE = True
+    # ``qkv_contiguous=False`` lets the kernel read the strided slices of the
+    # packed mixed_qkv projection in place instead of making three contiguous
+    # copies (ROCm/aiter#4550). Older aiter has no such argument; probe for it
+    # so this backend works on both, and picks up the zero-copy path for free
+    # once the installed aiter is new enough.
+    _FLYDSL_DECODE_STRIDED = (
+        "qkv_contiguous" in inspect.signature(flydsl_gdr_decode).parameters
+    )
+except Exception as e:  # pragma: no cover - import-time capability probe
+    flydsl_gdr_decode = None
+    _FLYDSL_DECODE_AVAILABLE = False
+    _FLYDSL_DECODE_STRIDED = False
+    logger.warning(
+        "FlyDSL GDN decode kernel unavailable (%s); FlyDSLGDNKernel.decode will "
+        "fall back to the Triton recurrent decode path.",
+        repr(e),
+    )
+
+
+class FlyDSLGDNKernel(TritonGDNKernel):
+    """GDN linear-attention kernel with the FlyDSL prefill state (``fwd_h``) core.
+
+    Only the prefill ``extend`` path is overridden: it reproduces the Triton
+    ``chunk_gated_delta_rule`` pipeline (cumsum -> intra(kkt+solve+recompute w/u)
+    -> fwd_h -> chunk_fwd_o) but swaps the ``chunk_gated_delta_rule_fwd_h`` step
+    for aiter's FlyDSL ``chunk_gated_delta_rule_fwd_h_flydsl``, which is ~1.8-3x
+    faster at the model's TP-sharded shapes and bit-identical to Triton (verified
+    across head counts, sequence lengths, and initial-state configurations).
+
+    The ``decode`` path is also overridden to use aiter's FlyDSL recurrent
+    decode (``flydsl_gdr_decode``). It is CUDA-graph-safe: ``need_shuffle_state``
+    is False (the sglang ssm pool is already ``[N, H, K, V]``, so no whole-pool
+    permute/copy), q/k/v/a/b are reshaped with pure ``view`` (no copies), and the
+    kernel is ``@lru_cache``-compiled during the graph runner's pre-capture
+    warmup forwards. ``supports_packed_decode`` is False so the backend routes to
+    this split-input decode instead of the Triton packed fast path.
+
+    ``target_verify`` is inherited unchanged from ``TritonGDNKernel``.
+    """
+
+    supports_flydsl_extend: bool = _FLYDSL_AVAILABLE
+    supports_flydsl_decode: bool = _FLYDSL_DECODE_AVAILABLE
+    # Route the GDN backend to the split-input ``decode`` path (below) rather
+    # than the Triton packed_decode fast path, so we can call flydsl_gdr_decode.
+    supports_packed_decode: bool = False
+
+    def extend(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        g: torch.Tensor,
+        beta: torch.Tensor,
+        *,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> tuple:
+        if not _FLYDSL_AVAILABLE:
+            return super().extend(
+                q,
+                k,
+                v,
+                g,
+                beta,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                **kwargs,
+            )
+
+        cu_seqlens = query_start_loc
+
+        # use_qk_l2norm_in_kernel=True in the Triton path -> l2-normalize q/k.
+        q = l2norm_fwd(q)
+        k = l2norm_fwd(k)
+
+        scale = q.shape[-1] ** -0.5
+
+        chunk_indices = (
+            prepare_chunk_indices(cu_seqlens, CHUNK_SIZE)
+            if cu_seqlens is not None
+            else None
+        )
+
+        # Cumulative log-decay per chunk (natural-log space).
+        g = chunk_local_cumsum(
+            g,
+            chunk_size=CHUNK_SIZE,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+        # fused kkt + solve_tril + recompute_w_u (Triton, unchanged).
+        w, u, A = chunk_gated_delta_rule_fwd_intra(
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+        )
+
+        # Gather per-sequence initial states from the pool. FlyDSL fwd_h takes
+        # already-gathered [N, H, K, V] states (no initial_state_indices arg)
+        # and does not update the pool in place, so we scatter the result back
+        # ourselves after the call.
+        init_state = ssm_states[cache_indices]
+
+        # FlyDSL fwd_h expects head-major (VK) layouts for w/u/g; k stays
+        # [B, T, Hg, K]. g is passed in natural-log space (use_exp2=False),
+        # matching chunk_local_cumsum output. Bit-identical to Triton fwd_h.
+        h, v_new, final_state = chunk_gated_delta_rule_fwd_h_flydsl(
+            k=k,
+            w=w.permute(0, 2, 1, 3).contiguous(),
+            u=u.permute(0, 2, 1, 3).contiguous(),
+            g=g.permute(0, 2, 1).contiguous(),
+            initial_state=init_state,
+            output_final_state=True,
+            chunk_size=CHUNK_SIZE,
+            cu_seqlens=cu_seqlens,
+            use_exp2=False,
+        )
+
+        # v_new comes back head-major [B, H, T, V] -> [B, T, H, V] for chunk_fwd_o.
+        v_new = v_new.permute(0, 2, 1, 3).contiguous()
+
+        o = chunk_fwd_o(
+            q=q,
+            k=k,
+            v=v_new,
+            h=h,
+            g=g,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # In-place state write-back: the Triton fwd_h uses INPLACE_UPDATE and the
+        # GPU caller only scatters last_recurrent_state on NPU, so mirror the
+        # in-place contract by writing the final state into the pool here.
+        ssm_states[cache_indices] = final_state.to(ssm_states.dtype, copy=False)
+
+        # Match TritonGDNKernel.extend's return contract: (o, last_state, h).
+        # last_state is None on GPU (state already written in place); h is the
+        # per-chunk state tensor consumed by mamba-state radix tracking.
+        return o.to(q.dtype), None, h
+
+    def decode(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        *,
+        A_log: torch.Tensor,
+        dt_bias: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        **kwargs,
+    ) -> torch.Tensor:
+        if not _FLYDSL_DECODE_AVAILABLE:
+            return super().decode(
+                q,
+                k,
+                v,
+                a,
+                b,
+                A_log=A_log,
+                dt_bias=dt_bias,
+                ssm_states=ssm_states,
+                cache_indices=cache_indices,
+                query_start_loc=query_start_loc,
+                **kwargs,
+            )
+
+        # sglang decode inputs: q/k [1, bs, Hk, Dk], v [1, bs, Hv, Dv],
+        # a/b [bs, Hv]. flydsl_gdr_decode wants [bs, 1, H, D] and [bs, 1, Hv].
+        # dim0 == 1, so these reshapes are pure views (no copy) -- q/k/v stay in
+        # their packed-mixed_qkv strided layout (batch stride = qkv_dim).
+        bs = q.shape[1]
+        Hk, Dk = q.shape[2], q.shape[3]
+        Hv, Dv = v.shape[2], v.shape[3]
+        query = q.reshape(bs, 1, Hk, Dk)
+        key = k.reshape(bs, 1, Hk, Dk)
+        value = v.reshape(bs, 1, Hv, Dv)
+        a_ = a.reshape(bs, 1, Hv)
+        b_ = b.reshape(bs, 1, Hv)
+
+        out = value.new_empty(bs, 1, Hv, Dv)
+
+        # flydsl_gdr_decode indexes/updates ``state`` by ``indices`` internally,
+        # so we pass the full pool + slot indices (no gather/scatter). The pool is
+        # already [N, H, K, V] (== flydsl's expected VK layout), so
+        # need_shuffle_state=False -> no whole-pool permute/copy (fast + graph
+        # safe). Where the installed aiter supports it, qkv_contiguous=False
+        # reads the strided (split-of-mixed_qkv) q/k/v directly -- this "fuses"
+        # the split (no .contiguous() copies) and is CUDA-graph safe. Older
+        # aiter copies instead; both paths are numerically identical.
+        # dt_bias must match the activation dtype (kernel assertion).
+        flydsl_gdr_decode(
+            query=query,
+            key=key,
+            value=value,
+            a=a_,
+            b=b_,
+            dt_bias=dt_bias.to(value.dtype),
+            A_log=A_log,
+            indices=cache_indices.to(torch.int32),
+            state=ssm_states,
+            out=out,
+            use_qk_l2norm=True,
+            need_shuffle_state=False,
+            **({"qkv_contiguous": False} if _FLYDSL_DECODE_STRIDED else {}),
+        )
+
+        # [bs, 1, Hv, Dv] -> [1, bs, Hv, Dv] (pure view) to match the Triton
+        # decode output layout consumed by the caller.
+        return out.reshape(1, bs, Hv, Dv)

--- a/python/sglang/srt/layers/attention/linear/utils.py
+++ b/python/sglang/srt/layers/attention/linear/utils.py
@@ -17,6 +17,7 @@ class LinearAttnKernelBackend(Enum):
     CUTEDSL = "cutedsl"
     FLASHINFER = "flashinfer"
     FLASHKDA = "flashkda"
+    FLYDSL = "flydsl"
     CUSTOM = "custom"
 
     @classmethod
@@ -34,6 +35,9 @@ class LinearAttnKernelBackend(Enum):
 
     def is_flashkda(self):
         return self == LinearAttnKernelBackend.FLASHKDA
+
+    def is_flydsl(self):
+        return self == LinearAttnKernelBackend.FLYDSL
 
     def is_custom(self):
         return self == LinearAttnKernelBackend.CUSTOM

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -348,7 +348,13 @@ MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
 
 MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
 
-LINEAR_ATTN_KERNEL_BACKEND_CHOICES = ["triton", "cutedsl", "flashinfer", "flashkda"]
+LINEAR_ATTN_KERNEL_BACKEND_CHOICES = [
+    "triton",
+    "cutedsl",
+    "flashinfer",
+    "flashkda",
+    "flydsl",
+]
 
 
 # Allow external code to add more choices

--- a/test/registered/unit/layers/attention/test_gdn_flydsl_backend_dispatch.py
+++ b/test/registered/unit/layers/attention/test_gdn_flydsl_backend_dispatch.py
@@ -1,0 +1,66 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.attention.linear.gdn_backend import GDNKernelDispatcher
+from sglang.srt.layers.attention.linear.kernels.gdn_flydsl import FlyDSLGDNKernel
+from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
+from sglang.srt.layers.attention.linear.utils import LinearAttnKernelBackend
+from sglang.srt.server_args import LINEAR_ATTN_KERNEL_BACKEND_CHOICES
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+FLYDSL = LinearAttnKernelBackend.FLYDSL
+TRITON = LinearAttnKernelBackend.TRITON
+
+
+class TestFlyDSLGDNBackendDispatch(unittest.TestCase):
+    """The flydsl GDN backend must be selectable, and must degrade to Triton
+    rather than raise when the aiter FlyDSL kernels are not importable (the
+    common case: any non-ROCm host, or a ROCm host without aiter)."""
+
+    def dispatch(self, *, extend_ok, decode_ok):
+        with (
+            patch.object(FlyDSLGDNKernel, "supports_flydsl_extend", extend_ok),
+            patch.object(FlyDSLGDNKernel, "supports_flydsl_decode", decode_ok),
+        ):
+            return GDNKernelDispatcher(decode_backend=FLYDSL, prefill_backend=FLYDSL)
+
+    def test_backend_name_is_a_server_arg_choice(self):
+        self.assertIn("flydsl", LINEAR_ATTN_KERNEL_BACKEND_CHOICES)
+        self.assertIs(LinearAttnKernelBackend("flydsl"), FLYDSL)
+        self.assertTrue(FLYDSL.is_flydsl())
+        self.assertFalse(TRITON.is_flydsl())
+
+    def test_selects_flydsl_for_both_phases_when_available(self):
+        d = self.dispatch(extend_ok=True, decode_ok=True)
+        self.assertIsInstance(d.decode_kernel, FlyDSLGDNKernel)
+        self.assertIsInstance(d.extend_kernel, FlyDSLGDNKernel)
+        # one shared instance, not two
+        self.assertIs(d.decode_kernel, d.extend_kernel)
+
+    def test_falls_back_to_triton_when_aiter_is_unavailable(self):
+        d = self.dispatch(extend_ok=False, decode_ok=False)
+        for kernel in (d.decode_kernel, d.extend_kernel):
+            self.assertIsInstance(kernel, TritonGDNKernel)
+            self.assertNotIsInstance(kernel, FlyDSLGDNKernel)
+
+    def test_falls_back_per_phase(self):
+        """A build with only the prefill kernel still gets the prefill win."""
+        d = self.dispatch(extend_ok=True, decode_ok=False)
+        self.assertIsInstance(d.extend_kernel, FlyDSLGDNKernel)
+        self.assertNotIsInstance(d.decode_kernel, FlyDSLGDNKernel)
+
+    def test_tree_verify_always_stays_on_triton(self):
+        d = self.dispatch(extend_ok=True, decode_ok=True)
+        self.assertIsInstance(d.tree_verify_kernel, TritonGDNKernel)
+        self.assertNotIsInstance(d.tree_verify_kernel, FlyDSLGDNKernel)
+
+    def test_routes_around_the_packed_decode_fast_path(self):
+        """flydsl_gdr_decode takes split q/k/v, so the packed path must be off."""
+        self.assertFalse(FlyDSLGDNKernel.supports_packed_decode)
+        self.assertTrue(TritonGDNKernel.supports_packed_decode)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On ROCm, the GDN (gated delta net) linear-attention path currently runs on the Triton
backend only. AMD's [aiter](https://github.com/ROCm/aiter) ships FlyDSL kernels for both
halves of that path — the chunked prefill state scan (`chunk_gated_delta_rule_fwd_h`) and
the recurrent decode step — which are meaningfully faster than the Triton equivalents at
the shapes GDN models actually run at.

This PR wires them up behind a new `flydsl` choice for `--linear-attn-backend`
(and the per-phase `--linear-attn-prefill-backend` / `--linear-attn-decode-backend`),
alongside the existing `triton` / `cutedsl` / `flashinfer` / `flashkda` backends.

Selecting `flydsl` is never fatal: both aiter entry points are capability-probed at
import time, and on any host where they are unavailable (every non-ROCm host, and ROCm
hosts without aiter) the kernel transparently falls back to the inherited Triton
implementation, independently per phase.

## Modifications

- **`linear/kernels/gdn_flydsl.py`** (new) — `FlyDSLGDNKernel(TritonGDNKernel)`,
  overriding two methods:
  - `extend` (prefill): reproduces the Triton `chunk_gated_delta_rule` pipeline
    (`chunk_local_cumsum` → `chunk_gated_delta_rule_fwd_intra` → `fwd_h` →
    `chunk_fwd_o`) and swaps **only** the state scan for aiter's
    `chunk_gated_delta_rule_fwd_h_flydsl`. Glue is layout-only: `w`/`u` and `g` are
    permuted to head-major for the FlyDSL call and `v_new` back; `g` stays in natural-log
    space (`use_exp2=False`); the per-sequence initial states are gathered from the pool
    and the final state scattered back in place, mirroring the Triton kernel's
    `INPLACE_UPDATE` contract.
  - `decode`: aiter's recurrent `flydsl_gdr_decode`. `supports_packed_decode = False`
    so the dispatcher routes to this split-input decode rather than the Triton packed
    fast path.

  `target_verify` / tree verify are inherited unchanged and stay on Triton.

- **`linear/gdn_backend.py`** — `is_flydsl()` branches in `GDNKernelDispatcher` for the
  decode and prefill phases. One shared `FlyDSLGDNKernel` instance is created lazily; if
  the corresponding aiter op is missing, the dispatcher logs on rank 0 and falls back to
  the Triton kernel for that phase only.

- **`linear/utils.py`**, **`server_args.py`** — `FLYDSL` enum member, `is_flydsl()`, and
  `"flydsl"` added to `LINEAR_ATTN_KERNEL_BACKEND_CHOICES`.

- **`test/registered/unit/.../test_gdn_flydsl_backend_dispatch.py`** (new) — CPU unit
  test covering backend selection, per-phase fallback when aiter is absent, tree-verify
  staying on Triton, and the packed-decode routing.

### CUDA-graph safety of the decode path

The sglang ssm pool is already `[N, H, K, V]`, which is the layout the FlyDSL kernel
wants, so `need_shuffle_state=False` — no whole-pool permute/copy. `q`/`k`/`v`/`a`/`b`
are reshaped with pure `view`s (leading dim is 1), the kernel indexes and updates the
pool by `indices` internally so there is no gather/scatter, and the `@lru_cache`-compiled
kernel is built during the graph runner's pre-capture warmup forwards. Graph capture +
replay was verified bit-exact against eager.

### aiter version compatibility

The decode path probes `inspect.signature(flydsl_gdr_decode)` for a `qkv_contiguous`
argument (ROCm/aiter#4550). When present, `qkv_contiguous=False` lets the kernel read the
strided slices of the packed `mixed_qkv` projection in place instead of making three
contiguous copies; when absent, aiter takes the copying path. The two are numerically
identical, so this PR works against released aiter today and picks up the zero-copy path
automatically once that aiter change lands.

## Accuracy Tests

**GSM8K@200, TP4, Qwen3.5-style GDN model:** `0.985` for the flydsl backend — identical
to the Triton baseline.

**Kernel parity vs the Triton backend** (MI355X, bf16), across head counts
(`Hk`∈{1,2,4}, `Hv`∈{4,8}), sequence lengths up to 1000, and batched/ragged
`cu_seqlens`:

| phase | output (max rel. err) | recurrent state (max abs. err) |
|---|---|---|
| prefill (`extend`), 6 configs | ≤ 2.0e-4 | 6.0e-8 |
| decode, 6 configs | ≤ 3.4e-3 | ≤ 3.4e-3 |

The residuals come from bf16 accumulation ordering inside the FlyDSL kernels; several
prefill configs match Triton exactly. Both the copying and the zero-copy (`qkv_contiguous`)
decode paths were run and produce the same numbers.

CPU dispatch unit test: 6/6 passing.

## Speed Tests and Profiling

Kernel level:
- prefill `fwd_h`: FlyDSL **1.8–3×** faster than Triton at TP8 shapes.
- decode step (TP4): Triton packed 36 µs → FlyDSL zero-copy strided **27 µs** (~25%).

End to end (TP4, same session, accuracy equal):
- prefill input throughput (8192 / 16384 tok): 36507 / 42353 → **37110 / 42911** tok/s.
- decode TPOT (c1 / c32 / c64): 8.20 / 12.67 / 16.56 → **8.11 / 12.67 / 16.60** ms/tok.

Prefill improves modestly; decode is at parity. The faster recurrent decode kernel does
not move end-to-end decode because GDN is only a few percent of latency-bound decode time
on these models (MoE experts and the serial layer chain dominate) — the kernel win is
real but structurally diluted.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — no user-facing doc lists the linear-attn backends; happy to add one if a maintainer points at the right page.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30903737603](https://github.com/sgl-project/sglang/actions/runs/30903737603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30903736360](https://github.com/sgl-project/sglang/actions/runs/30903736360)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->