### PR TITLE
Allow optimistic prefill with L2 hierarchical cache and write-back policy

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7930,8 +7930,14 @@ class ServerArgs:
             if self.pp_size > 1:
                 logger.warning("Optimistic prefill does not support pp_size > 1")
                 self.optimistic_prefill_attempts = 0
-            elif self.enable_hierarchical_cache:
-                logger.warning("Optimistic prefill does not support hierarchical cache")
+            elif self.enable_hierarchical_cache and (
+                self.hicache_storage_backend is not None
+                or self.hicache_write_policy != "write_back"
+            ):
+                logger.warning(
+                    "Optimistic prefill only supports L2 hierarchical cache "
+                    "with write-back policy"
+                )
                 self.optimistic_prefill_attempts = 0
             elif resolved_view(self).uses_mamba_radix_cache:
                 logger.warning(


### PR DESCRIPTION
## Motivation

Optimistic prefill is currently disabled whenever `--enable-hierarchical-cache`
is set. That blanket rejection is stricter than necessary. An L2 (host memory)
hierarchical cache under the `write_back` policy is compatible with optimistic
prefill, since write-back does not publish KV into a tier that a speculatively
aborted prefill attempt could leave inconsistent. The combination that is
genuinely unsafe is an L3 storage backend, or a write-through policy that
publishes eagerly.

As written, users who want both optimistic prefill and a host-memory KV tier
have to give one of them up.

## Modifications

Narrow the guard in `ServerArgs._handle_other_validations` so optimistic
prefill is only disabled when hierarchical cache is enabled **and** either:

- `hicache_storage_backend` is set (an L3 backend is configured), or
- `hicache_write_policy` is not `write_back`.

The warning message is updated to state the supported configuration rather
than a flat "does not support hierarchical cache".

This is a strict relaxation — every configuration disabled before is still
disabled except L2 + write-back. Note the default `hicache_write_policy` is
`write_through`, so simply passing `--enable-hierarchical-cache` still disables
optimistic prefill as it does today; opting in requires
`--hicache-write-policy write_back` with no storage backend.

## Original commits

- `974c18dc8`

## Test plan

Exercised `ServerArgs._handle_other_validations` directly over the gating
matrix (`disaggregation_mode="prefill"`, `optimistic_prefill_attempts=4`), all
passing:

| Configuration | `optimistic_prefill_attempts` after validation |
|---|---|
| no hierarchical cache | 4 (unchanged) |
| hicache + `write_back`, no storage backend | 4 (**newly allowed**) |
| hicache + `write_through` (default) | 0 (still disabled) |
| hicache + `write_back` + `file` storage backend | 0 (still disabled) |
| `pp_size > 1` | 0 (still disabled) |

Also ran `pre-commit run --files python/sglang/srt/server_args.py` — all hooks
pass — and `python3 -m py_compile` on the changed file.

Not run locally: end-to-end PD disaggregated serving with optimistic prefill
against a live L2 hierarchical cache, which needs a multi-node GPU setup.
That path was validated on an internal PD deployment; relying on CI here.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30946283388](https://github.com/sgl-project/sglang/actions/runs/30946283388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30946288534](https://github.com/sgl-project/sglang/actions/runs/30946288534)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->