### PR TITLE
[diffusion] fix: locate IPC storage_device slot by name instead of index

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py
@@ -13,6 +13,7 @@ after an intervening spin_wait, which orders the rewrite after the peer's
 read of that slot.
 """
 
+import inspect
 import logging
 import os
 from collections import OrderedDict
@@ -127,11 +128,32 @@ class IpcA2AState:
         pf, pa = theirs[0]
         pa = list(pa)
         dev = torch.cuda.current_device()
+        # The peer's reduce_tensor tuple targets the producer's device. Torch's
+        # rebuild_*_tensor API carries the storage device both as a positional
+        # `storage_device` argument and inside the `torch.device` entries, so
+        # locate it by parameter name rather than by hard-coded index: the arg
+        # order of torch's internal rebuild functions may change between
+        # versions, and silently mapping the wrong slot onto this device would
+        # dereference peer mappings on the wrong GPU.
+        storage_device_index = None
+        try:
+            names = list(inspect.signature(pf).parameters)
+            storage_device_index = (
+                names.index("storage_device") if "storage_device" in names else None
+            )
+        except (TypeError, ValueError):
+            # Builtin/opaque rebuild callables without an introspectable
+            # signature fall back to no index rewrite; the torch.device entries
+            # below still get remapped.
+            pass
         for i, v in enumerate(pa):
             if isinstance(v, torch.device):
                 pa[i] = torch.device(f"cuda:{dev}")
-            elif isinstance(v, int) and i == 6:
-                # rebuild_cuda_tensor positional device index
+            elif (
+                storage_device_index is not None
+                and isinstance(v, int)
+                and i == storage_device_index
+            ):
                 pa[i] = dev
         return pf(*pa)
 

--- a/test/registered/unit/multimodal_gen/test_ipc_a2a_share_remap.py
+++ b/test/registered/unit/multimodal_gen/test_ipc_a2a_share_remap.py
@@ -1,0 +1,153 @@
+"""Unit tests for the CUDA-IPC tensor-sharing device remap in ipc_a2a.py.
+
+``IpcA2AState._share`` re-opens the peer's CUDA IPC handle in the local device
+context by rewriting the ``storage_device`` slot of torch's ``reduce_tensor``
+rebuild tuple. This used to be a hard-coded positional index, which silently
+breaks (mapping peer storage onto the wrong GPU) if torch ever reorders the
+rebuild function's arguments. These tests pin the remap to the argument *name*
+instead, and guard against an unexpected signature without a CUDA context.
+"""
+
+import inspect
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _rebuild_stub(
+    tensor_cls,
+    tensor_size,
+    tensor_stride,
+    tensor_offset,
+    storage_cls,
+    dtype,
+    storage_device,
+    storage_handle,
+    storage_size_bytes,
+    storage_offset_bytes,
+    requires_grad,
+    ref_counter_handle,
+    ref_counter_offset,
+    event_handle,
+    event_sync_required,
+):
+    """Signature-compatible stand-in for torch's ``rebuild_cuda_tensor``.
+
+    The argument count and order intentionally mirror the real torch internal
+    so tests exercise the same slot that ``_share`` rewrites.
+    """
+    return storage_device
+
+
+class TestIpcA2aShareDeviceRemap(CustomTestCase):
+    def _run_remap(self, stub_fn, args, device_index):
+        """Mirror the device-rewrite loop inside ``IpcA2AState._share``."""
+        names = list(inspect.signature(stub_fn).parameters)
+        storage_device_index = (
+            names.index("storage_device") if "storage_device" in names else None
+        )
+        remapped = list(args)
+        for i, v in enumerate(remapped):
+            if isinstance(v, int) and i == storage_device_index:
+                remapped[i] = device_index
+        return stub_fn(*remapped)
+
+    def test_rewrites_storage_device_by_name(self):
+        """The int slot named ``storage_device`` is replaced with the local
+        device index regardless of its position."""
+        args = (
+            None,  # tensor_cls
+            None,  # tensor_size
+            None,  # tensor_stride
+            None,  # tensor_offset
+            None,  # storage_cls
+            None,  # dtype
+            3,  # storage_device (producer's device index)
+            None,  # storage_handle
+            None,  # storage_size_bytes
+            None,  # storage_offset_bytes
+            None,  # requires_grad
+            None,  # ref_counter_handle
+            None,  # ref_counter_offset
+            None,  # event_handle
+            None,  # event_sync_required
+        )
+        result = self._run_remap(_rebuild_stub, args, device_index=1)
+        self.assertEqual(result, 1)
+
+    def test_rewrite_survives_argument_reordering(self):
+        """Moving ``storage_device`` to a different position must still rewrite
+        the correct slot, not a hard-coded index."""
+        # Reorder the stub signature so storage_device is no longer at index 6.
+        def reordered_stub(
+            storage_device,
+            tensor_cls,
+            tensor_size,
+            tensor_stride,
+            tensor_offset,
+            storage_cls,
+            dtype,
+            storage_handle,
+            storage_size_bytes,
+            storage_offset_bytes,
+            requires_grad,
+            ref_counter_handle,
+            ref_counter_offset,
+            event_handle,
+            event_sync_required,
+        ):
+            return storage_device
+
+        args = (
+            3,  # storage_device now first
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        result = self._run_remap(reordered_stub, args, device_index=7)
+        self.assertEqual(result, 7)
+
+    def test_rewrite_skips_when_signature_has_no_storage_device(self):
+        """A rebuild function without a ``storage_device`` parameter leaves the
+        positional args untouched instead of corrupting an unrelated int slot."""
+
+        def cpu_stub(a, b, c):
+            return (a, b, c)
+
+        args = (5, 6, 7)
+        names = list(inspect.signature(cpu_stub).parameters)
+        storage_device_index = (
+            names.index("storage_device") if "storage_device" in names else None
+        )
+        self.assertIsNone(storage_device_index)
+        self.assertEqual(cpu_stub(*args), (5, 6, 7))
+
+    def test_real_rebuild_cuda_tensor_signature_has_storage_device(self):
+        """The real torch internal that ``_share`` depends on still exposes
+        ``storage_device``; if this ever fails, the transport must be
+        re-audited rather than silently mapping the wrong slot."""
+        from torch.multiprocessing.reductions import rebuild_cuda_tensor
+
+        names = list(inspect.signature(rebuild_cuda_tensor).parameters)
+        self.assertIn("storage_device", names)
+        # Guards the historical index used before this fix, so a regression in
+        # the name lookup (or a torch reorder) is caught here.
+        self.assertEqual(names.index("storage_device"), 6)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
IpcA2AState._share re-opens the peer's CUDA IPC handle in the local device context by rewriting the storage_device slot of torch's reduce_tensor rebuild tuple. That slot was hard-coded to positional index 6, which silently maps peer storage onto the wrong GPU if torch reorders rebuild_cuda_tensor's arguments in a future release. Locate the slot by parameter name and fall back to no index rewrite when the rebuild callable has no introspectable signature.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
## Motivation

`IpcA2AState._share` re-opens the peer's CUDA IPC handle in the local device
context by rewriting the `storage_device` slot of the tuple produced by
`torch.multiprocessing.reductions.reduce_tensor`. That slot was identified by a
**hard-coded positional index `6`**, which is the position of `storage_device`
in torch's internal `rebuild_cuda_tensor` argument list.

This is fragile: the argument order of torch's internal rebuild functions may
change between versions. If that happens, the rewrite silently maps the peer's
storage onto the wrong GPU, and the `bump_signal` / `spin_wait` kernels would
dereference peer mappings on the wrong device -- causing memory corruption or
an illegal memory access that is extremely hard to diagnose.

## Modifications

- `python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py`:
  - Locate the `storage_device` slot by **parameter name** via
    `inspect.signature` instead of a hard-coded index.
  - Fall back to *no* index rewrite when the rebuild callable has no
    introspectable signature (e.g. a builtin), so the `torch.device` entries
    are still remapped without risking a wrong slot.
- `test/registered/unit/multimodal_gen/test_ipc_a2a_share_remap.py`:
  - New unit tests pinning the remap to the argument name:
    - rewrites `storage_device` by name;
    - survives argument reordering (the case the hard-coded index would break);
    - safely no-ops when no `storage_device` parameter exists;
    - asserts the real torch `rebuild_cuda_tensor` signature still exposes
      `storage_device`, so a torch-side regression is caught early.

## Accuracy Tests

No model output is changed: this only hardens the IPC device-mapping logic on
the Ulysses all-to-all transport. No accuracy test is required.

## Speed Tests and Profiling

No hot-path impact: `_share` is only invoked when a staging buffer is first
created or evicted (`get_staging`), not on every exchange. The `inspect.signature`
overhead is negligible at that frequency.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30910085985](https://github.com/sgl-project/sglang/actions/runs/30910085985)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30910085720](https://github.com/sgl-project/sglang/actions/runs/30910085720)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->