### PR TITLE
[diffusion] fix: fall back to NCCL when IPC all-to-all spin times out

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py
@@ -195,7 +195,12 @@ class IpcA2AState:
 
     def exchange(self, group, send, recv_shape):
         """Symmetric exchange: write my contiguous `send` into the peer's
-        staging slot, return my staging slot viewed as `recv_shape`."""
+        staging slot, return my staging slot viewed as `recv_shape`.
+
+        Returns None if the peer never published within the spin budget: the
+        staging slot then holds incomplete data, so callers must fall back to
+        NCCL instead of consuming it.
+        """
         n_send = send.numel()
         n_recv = 1
         for v in recv_shape:
@@ -206,7 +211,9 @@ class IpcA2AState:
         local, peer = pair
         slot = self.next_slot()
         peer[slot].narrow(0, 0, n_send).copy_(send.view(-1), non_blocking=True)
-        self.signal_and_wait()
+        self.signal()
+        if self.wait_and_check():
+            return None
         return local[slot].narrow(0, 0, n_recv).view(recv_shape)
 
     def next_slot(self):
@@ -229,6 +236,25 @@ class IpcA2AState:
             self.peer_timed_out,
             self.budget_ns,
         )
+
+    def wait_and_check(self) -> bool:
+        """``wait()`` then report whether the exchange timed out.
+
+        A timed-out spin returns without the peer's half of the data, so the
+        caller must discard the staging view and fall back to NCCL. The device
+        read is skipped while a CUDA graph is being captured: there the spin
+        kernel is only recorded, never executed, so no timeout can fire.
+
+        This only reports; it does not retire the transport. Retiring must
+        happen together on every rank at a request boundary via
+        ``check_timeout`` -- a rank that flipped ``failed`` mid-step would post
+        collectives its peer (still on IPC) never posts, and the NCCL watchdog
+        would take the process down.
+        """
+        self.wait()
+        if torch.cuda.is_current_stream_capturing():
+            return False
+        return bool(self.timed_out.item())
 
     def check_timeout(self) -> None:
         """Retire the transport on every rank if any rank's spin expired.

--- a/python/sglang/multimodal_gen/runtime/layers/usp.py
+++ b/python/sglang/multimodal_gen/runtime/layers/usp.py
@@ -126,7 +126,8 @@ def _ipc_varlen_fast(x, seq_lens, head_dim, direction):
     IPC_A2A.signal()
     out = local[slot].narrow(0, 0, n_out).view(b, my_len, 2 * h_local, d)
     out[:, :, r * h_local : (r + 1) * h_local].copy_(x.narrow(1, off[r], my_len))
-    IPC_A2A.wait()
+    if IPC_A2A.wait_and_check():
+        return None
     return out
 
 
@@ -158,7 +159,9 @@ def _ipc_input_a2a_qkv(q, k, v):
         out = t.new_empty(b, 2 * s_local, half, d)
         out.narrow(1, r * s_local, s_local).copy_(t[:, :, r * half : (r + 1) * half])
         outs.append(out)
-    IPC_A2A.signal_and_wait()
+    IPC_A2A.signal()
+    if IPC_A2A.wait_and_check():
+        return None
     for i, out in enumerate(outs):
         theirs = local[slot].narrow(0, i * n, n).view(b, s_local, half, d)
         out.narrow(1, (1 - r) * s_local, s_local).copy_(theirs)
@@ -219,7 +222,8 @@ def _ipc_input_a2a_qkv_segmented(txt_q, img_q, txt_k, img_k, txt_v, img_v, local
     # overlap with the peer's wait
     IPC_A2A.signal()
     torch._foreach_copy_(loc_dsts, loc_srcs)
-    IPC_A2A.wait()
+    if IPC_A2A.wait_and_check():
+        return None
     return tuple(outs)
 
 

--- a/test/registered/unit/multimodal_gen/test_ipc_a2a_timeout.py
+++ b/test/registered/unit/multimodal_gen/test_ipc_a2a_timeout.py
@@ -1,0 +1,96 @@
+"""Unit tests for IPC spin-timeout reporting in ipc_a2a.py.
+
+The Ulysses CUDA-IPC transport's ``spin_wait`` kernel gives up after a budget
+and flags ``timed_out`` instead of hanging the stream forever. Callers must
+then discard the (incomplete) staging data and fall back to NCCL; previously
+they consumed the staging view blindly because the flag was only read at the
+next request boundary. These tests pin ``wait_and_check`` / ``exchange`` to the
+expected behavior: report the timeout, skip the device read inside CUDA graph
+capture, and return None from ``exchange`` so callers fall back.
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.multimodal_gen.runtime.distributed.device_communicators.ipc_a2a import (
+    IpcA2AState,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestIpcA2aTimeoutReporting(CustomTestCase):
+    def _fresh_state(self):
+        state = IpcA2AState()
+        state.ops = mock.Mock()
+        return state
+
+    def test_wait_and_check_reports_no_timeout(self):
+        state = self._fresh_state()
+        state.timed_out = torch.zeros(1, dtype=torch.int32)
+        self.assertFalse(state.wait_and_check())
+        state.ops.spin_wait.assert_called_once()
+
+    def test_wait_and_check_reports_timeout(self):
+        state = self._fresh_state()
+        state.timed_out = torch.ones(1, dtype=torch.int32)
+        self.assertTrue(state.wait_and_check())
+        state.ops.spin_wait.assert_called_once()
+
+    def test_wait_and_check_skips_device_read_during_capture(self):
+        """Inside a CUDA graph capture the spin kernel is only recorded, so a
+        device read must not happen; the transport reports no timeout."""
+        state = self._fresh_state()
+        state.timed_out = torch.ones(1, dtype=torch.int32)
+        with mock.patch(
+            "torch.cuda.is_current_stream_capturing", return_value=True
+        ):
+            self.assertFalse(state.wait_and_check())
+        state.ops.spin_wait.assert_called_once()
+
+    def test_exchange_returns_none_on_timeout(self):
+        """A timed-out exchange must return None so the caller falls back to
+        NCCL instead of consuming incomplete staging data."""
+        state = self._fresh_state()
+        local = torch.zeros(2, 8, dtype=torch.float32)
+        peer = torch.zeros(2, 8, dtype=torch.float32)
+        state.get_staging = mock.Mock(return_value=(local, peer))
+        state.next_slot = mock.Mock(return_value=0)
+        state.signal = mock.Mock()
+        state.wait_and_check = mock.Mock(return_value=True)
+        send = torch.zeros(8, dtype=torch.float32)
+        self.assertIsNone(state.exchange(mock.Mock(), send, (2, 4)))
+        state.signal.assert_called_once()
+
+    def test_exchange_returns_data_on_success(self):
+        state = self._fresh_state()
+        local = torch.zeros(2, 8, dtype=torch.float32)
+        peer = torch.zeros(2, 8, dtype=torch.float32)
+        state.get_staging = mock.Mock(return_value=(local, peer))
+        state.next_slot = mock.Mock(return_value=0)
+        state.signal = mock.Mock()
+        state.wait_and_check = mock.Mock(return_value=False)
+        send = torch.zeros(8, dtype=torch.float32)
+        result = state.exchange(mock.Mock(), send, (2, 4))
+        self.assertIsNotNone(result)
+        self.assertEqual(tuple(result.shape), (2, 4))
+        state.signal.assert_called_once()
+
+    def test_check_timeout_still_retires_transport(self):
+        """check_timeout keeps raising at the request boundary so the transport
+        is retired on every rank together."""
+        state = self._fresh_state()
+        state.inited = True
+        state.failed = False
+        state.timed_out = torch.ones(1, dtype=torch.int32)
+        with self.assertRaises(RuntimeError):
+            state.check_timeout()
+        self.assertTrue(state.failed)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The CUDA-IPC transport's spin_wait kernel gives up after a budget and flags timed_out instead of hanging the stream forever, but the exchange() and IPC fast paths never checked the flag: they consumed the staging slot that holds only the local half of the data, so the step ran with silently incomplete input and the error only surfaced at the next request boundary via check_timeout.

Add IpcA2AState.wait_and_check() which reports the timeout (skipping the device read inside a CUDA graph capture, where the spin kernel is only recorded), and make exchange() and the three usp.py fast paths return None on timeout so callers fall back to NCCL. check_timeout still retires the transport on every rank at the request boundary.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->
## Motivation

The CUDA-IPC transport (`ipc_a2a.py`) synchronizes the two Ulysses ranks with a
GPU-side `spin_wait` kernel. When the peer fails to publish within the spin
budget, the kernel sets the `timed_out` flag and returns instead of hanging the
stream forever. However, **no caller checked that flag**: `exchange()` and the
IPC fast paths in `usp.py` consumed the staging slot even though it held only
the local half of the exchange. The step then ran with silently incomplete
input, and the timeout was only surfaced at the *next* request boundary by
`check_timeout()` -- after the corrupted result had already been produced.

This turns a peer stall (which the transport explicitly tries to degrade
gracefully from) into silent data corruption in the generated video/audio.

## Modifications

- `python/sglang/multimodal_gen/runtime/distributed/device_communicators/ipc_a2a.py`:
  - Add `IpcA2AState.wait_and_check()`: calls `wait()` then reports whether the
    exchange timed out, skipping the device read while a CUDA graph is being
    captured (there the spin kernel is only recorded, never executed).
  - `exchange()` now uses `signal()` + `wait_and_check()` and returns `None` on
    timeout, so callers fall back to NCCL instead of consuming incomplete data.
  - `check_timeout()` is unchanged: it still retires the transport on every
    rank at the request boundary, keeping the existing two-rank retirement
    protocol intact.
- `python/sglang/multimodal_gen/runtime/layers/usp.py`:
  - `_ipc_varlen_fast` (output path), `_ipc_input_a2a_qkv`, and
    `_ipc_input_a2a_qkv_segmented` return `None` on timeout, matching their
    existing "unavailable -> fall back to NCCL" contract.
- `test/registered/unit/multimodal_gen/test_ipc_a2a_timeout.py`:
  - New unit tests covering: no-timeout reports False, timeout reports True,
    device read is skipped during CUDA graph capture, `exchange` returns None on
    timeout / data on success, and `check_timeout` still retires the transport.

## Accuracy Tests

No model output is changed in the normal (non-timeout) path. A timeout now
correctly falls back to NCCL instead of silently producing corrupted output.
No accuracy test is required.

## Speed Tests and Profiling

No hot-path overhead in the success case: `wait_and_check` adds one device
read (an int32 `.item()`) after a successful spin, which is already the
frequency of an all-to-all per attention layer. During CUDA graph capture the
read is skipped entirely.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30910679806](https://github.com/sgl-project/sglang/actions/runs/30910679806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30910677053](https://github.com/sgl-project/sglang/actions/runs/30910677053)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->