### PR TITLE
Strip --speculative-draft-model-path when switching Playground speculative presets

### DIFF
--- a/docs/src/snippets/_playground.jsx
+++ b/docs/src/snippets/_playground.jsx
@@ -813,6 +813,7 @@ export const Playground = ({ config }) => {
         const baseSpec = flags.filter((f) => {
           const head = f.split(/[\s=]/)[0];
           return head === "--speculative-algorithm"
+              || head === "--speculative-draft-model-path"
               || head === "--speculative-num-steps"
               || head === "--speculative-eagle-topk"
               || head === "--speculative-num-draft-tokens"
@@ -840,7 +841,8 @@ export const Playground = ({ config }) => {
           return { flags, env };
         }
         flags = h.stripFlagsByFirstToken(flags, [
-          "--speculative-algorithm", "--speculative-num-steps",
+          "--speculative-algorithm", "--speculative-draft-model-path",
+          "--speculative-num-steps",
           "--speculative-eagle-topk", "--speculative-num-draft-tokens",
           "--speculative-dspark-block-size",
           "--speculative-ngram-max-bfs-breadth",


### PR DESCRIPTION
## Motivation

The Playground's **Speculative Decoding** axis strips the `--speculative-*` flag family from the base cell before splicing in the picked preset's flags, but `--speculative-draft-model-path` is missing from both the strip list and the derive filter. On a base cell whose recipe carries an external draft checkpoint (DSpark / DFlash), switching the preset leaves the stale draft path in the emitted command: picking **Off (greedy)** emits an orphan `--speculative-draft-model-path`, and picking another algorithm (e.g. EAGLE/MTP on a DSpark cell) pairs the new algorithm with the old algorithm's draft checkpoint.

## Modifications

Add `--speculative-draft-model-path` to the speculative handler's two flag-family lists in `docs/src/snippets/_playground.jsx` (the `deriveFromBase` filter and the `apply` strip list).

Behavior on existing configs:

- Cells without a draft path (the vast majority): unchanged.
- `thinkingmachines/inkling` (DSpark preview cell): derive still resolves to "Inherited from base"; switching to Off / EAGLE now cleanly drops the DSpark draft path instead of leaking it into the EAGLE command.
- `poolside/laguna-*`: declare no speculative axis, so the handler never runs — unaffected.
- Presets that carry their own `--speculative-draft-model-path` (e.g. a DSPARK preset) now round-trip: derive highlights the matching preset on a base cell that bakes the same pair, and switching away strips both flags together.

Validated with `node docs/scripts/check_cookbook_configs.mjs` and `mint validate`.

## Accuracy Tests

N/A (docs widget only).

## Speed Tests and Profiling

N/A (docs widget only).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #35703222323](https://github.com/sgl-project/sglang/actions/runs/35703222323)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35703222067](https://github.com/sgl-project/sglang/actions/runs/35703222067)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->