### PR TITLE
[rfork] Fix client instances not registering weight_info to EngineInfoBootstrapServer

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -62,10 +62,9 @@ class RemoteInstanceWeightTransporter:
             and get_model().remote_instance_weight_loader_backend
             != RemoteInstanceWeightLoaderBackend.MODELEXPRESS
             and self.engine is not None
-            and self.weight_info is None
         ):
-            # Register memory and upstream the transfer engine info to the bootstrap server
-            self.weight_info = register_memory_region(self.model, self.engine)
+            if self.weight_info is None:
+                self.weight_info = register_memory_region(self.model, self.engine)
             self._register_to_engine_info_bootstrap()
 
     def _register_to_engine_info_bootstrap(self: RemoteInstanceWeightTransporter):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When a new instance loads weights via rfork with the transfer_engine backend, the RemoteInstanceModelLoader calls register_memory_region during load_model() and sets weight_info on the transporter before maybe_register_and_publish_weight_info runs in initialize(). The old guard condition self.weight_info is None was at the outer if-level, causing _register_to_engine_info_bootstrap() to be skipped entirely for client instances. This leaves the EngineInfoBootstrapServer unaware of the client instance's transfer engine metadata. After this fix, client instances can also register their weight_info to the bootstrap server, enabling other new instances to discover and fork from them.

## Modifications

<!-- Detail the changes made in this pull request. -->
Moved the self.weight_info is None check from the outer if condition into an inner if block within maybe_register_and_publish_weight_info, so that memory region registration (register_memory_region) remains conditional (only when weight_info hasn't been set), while _register_to_engine_info_bootstrap() always executes regardless of whether the instance is a seed or a rfork client.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30924345840](https://github.com/sgl-project/sglang/actions/runs/30924345840)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30924346488](https://github.com/sgl-project/sglang/actions/runs/30924346488)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->