### PR TITLE
[DeepSeek-V4] Support Batched and Round-Robin CP Prefill in the Non-Paged Indexer

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1126,8 +1126,8 @@ class Envs:
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_AITER_INDEXER = EnvBool(False)
     SGLANG_OPT_DSV4_NONPAGED_INDEXER = EnvBool(True)
-    # Per-rank local query rows (after DP-attention sharding when enabled),
-    # not request ISL.
+    # Per-rank logical query rows (after DP-attention and context-parallel
+    # sharding when enabled), not request ISL or padded tensor rows.
     SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS = EnvInt(8192)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1126,8 +1126,8 @@ class Envs:
     SGLANG_OPT_USE_TILELANG_INDEXER = EnvBool(False)
     SGLANG_OPT_USE_AITER_INDEXER = EnvBool(False)
     SGLANG_OPT_DSV4_NONPAGED_INDEXER = EnvBool(True)
-    # Per-rank logical query rows (after DP-attention and context-parallel
-    # sharding when enabled), not request ISL or padded tensor rows.
+    # Per-rank padded query rows (after DP-attention and context-parallel
+    # sharding when enabled), not request ISL.
     SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS = EnvInt(8192)
     SGLANG_OPT_USE_JIT_INDEXER_METADATA = EnvBool(True)
     SGLANG_OPT_USE_ONLINE_COMPRESS = EnvBool(False)

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -666,9 +666,7 @@ class C4IndexerBackendMixin:
         seq_len_sum = sum(gather_c4_lens_cpu)
         max_seq_len = max(gather_c4_lens_cpu)
         c4_page_size = indexer_metadata.c4_page_size
-        max_seqlen_k = (
-            (max_seq_len + c4_page_size - 1) // c4_page_size * c4_page_size
-        )
+        max_seqlen_k = (max_seq_len + c4_page_size - 1) // c4_page_size * c4_page_size
         plan = NonPagedIndexerPlan(
             page_table=request_page_table,
             gather_seq_lens=gather_seq_lens,

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -19,6 +19,7 @@ import torch.nn.functional as F
 from sglang.kernels.ops.attention.dsv4 import (
     fused_q_indexer_rope_hadamard_fp4_quant,
     fused_q_indexer_rope_hadamard_quant,
+    plan_topk_v2,
     topk_transform_512,
     topk_transform_512_v2,
 )
@@ -26,7 +27,11 @@ from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.configs.deepseek_v4 import DeepSeekV4Config
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
-from sglang.srt.layers.attention.dsa.utils import aiter_can_use_preshuffle_paged_mqa
+from sglang.srt.layers.attention.dsa.utils import (
+    aiter_can_use_preshuffle_paged_mqa,
+    dsa_cp_round_robin_split_q_seqs_cpu,
+    is_dsa_prefill_cp_round_robin_split,
+)
 from sglang.srt.layers.attention.dsv4.compressor import Compressor
 from sglang.srt.layers.attention.dsv4.metadata import (
     NonPagedIndexerPlan,
@@ -495,7 +500,6 @@ class C4IndexerBackendMixin:
             forward_batch.forward_mode != ForwardMode.EXTEND
             or forward_batch._original_forward_mode is not None
             or forward_batch.tbo_parent_token_range is not None
-            or forward_batch.batch_size != 1
             or indexer_metadata.use_prefill_cuda_graph
         ):
             return False
@@ -506,9 +510,14 @@ class C4IndexerBackendMixin:
             or envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get()
         ):
             return False
+        cp_size = get_parallel().attn_cp_size
+        if cp_size > 1 and (
+            not is_dsa_prefill_cp_round_robin_split()
+            or forward_batch.attn_cp_metadata is None
+        ):
+            return False
         if (
-            get_parallel().attn_cp_size != 1
-            or self.hisparse_coordinator is not None
+            self.hisparse_coordinator is not None
             or is_in_tc_piecewise_cuda_graph()
             or is_in_breakable_cuda_graph()
         ):
@@ -558,44 +567,122 @@ class C4IndexerBackendMixin:
         if (
             extend_lens_cpu is None
             or seq_lens_cpu is None
-            or len(extend_lens_cpu) != 1
-            or len(seq_lens_cpu) != 1
-            or extend_lens_cpu[0] <= 0
+            or len(extend_lens_cpu) == 0
+            or len(extend_lens_cpu) != len(seq_lens_cpu)
+            or any(extend_len <= 0 for extend_len in extend_lens_cpu)
         ):
             return None
 
-        actual_queries = extend_lens_cpu[0]
+        cp_size = get_parallel().attn_cp_size
+        if cp_size > 1:
+            local_extend_lens_cpu, selected_request_indices = (
+                dsa_cp_round_robin_split_q_seqs_cpu(extend_lens_cpu)
+            )
+        else:
+            local_extend_lens_cpu = extend_lens_cpu
+            selected_request_indices = list(range(len(extend_lens_cpu)))
+
+        logical_query_rows = sum(local_extend_lens_cpu)
         if (
-            actual_queries != query_rows
-            or int(forward_batch.extend_num_tokens) != query_rows
-            or forward_batch.seq_lens.numel() != 1
-            or forward_batch.extend_seq_lens.numel() != 1
-            or forward_batch.extend_start_loc.numel() != 1
+            logical_query_rows
+            < envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS.get()
+        ):
+            return None
+        global_query_rows = sum(extend_lens_cpu)
+        if (
+            logical_query_rows > query_rows
+            or int(forward_batch.extend_num_tokens) != global_query_rows
+            or (cp_size == 1 and logical_query_rows != query_rows)
+        ):
+            return None
+
+        batch_size = len(extend_lens_cpu)
+        if (
+            forward_batch.seq_lens.numel() != batch_size
+            or forward_batch.extend_seq_lens.numel() != batch_size
+            or forward_batch.extend_start_loc.numel() != batch_size
             or page_table.dim() != 2
             or page_table.shape[0] < query_rows
             or c4_seq_lens.numel() < query_rows
         ):
             return None
 
-        final_c4_len = seq_lens_cpu[0] // 4
-        if final_c4_len <= 0:
+        gather_c4_lens_cpu = [
+            seq_lens_cpu[request_idx] // 4 for request_idx in selected_request_indices
+        ]
+        if not gather_c4_lens_cpu or any(length <= 0 for length in gather_c4_lens_cpu):
             return None
 
-        request_page_table = page_table[:1].contiguous()
-        ke = c4_seq_lens[:query_rows].reshape(-1).to(torch.int32).contiguous()
-        gather_seq_lens = ke[-1:]
-        ks = torch.zeros_like(ke)
+        local_query_starts_cpu = []
+        local_query_offset = 0
+        for local_extend_len in local_extend_lens_cpu:
+            local_query_starts_cpu.append(local_query_offset)
+            local_query_offset += local_extend_len
+
+        local_query_starts = torch.tensor(
+            local_query_starts_cpu,
+            dtype=torch.int64,
+            device=page_table.device,
+        )
+        request_page_table = page_table.index_select(0, local_query_starts).contiguous()
+
+        selected_requests = torch.tensor(
+            selected_request_indices,
+            dtype=torch.int64,
+            device=forward_batch.seq_lens.device,
+        )
+        gather_seq_lens = (
+            torch.div(
+                forward_batch.seq_lens.index_select(0, selected_requests),
+                4,
+                rounding_mode="floor",
+            )
+            .to(torch.int32)
+            .contiguous()
+        )
+
+        request_k_offsets_cpu = []
+        request_k_offset = 0
+        for gather_c4_len in gather_c4_lens_cpu:
+            request_k_offsets_cpu.append(request_k_offset)
+            request_k_offset += gather_c4_len
+        request_k_offsets = torch.tensor(
+            request_k_offsets_cpu,
+            dtype=torch.int32,
+            device=c4_seq_lens.device,
+        )
+        local_extend_lens = torch.tensor(
+            local_extend_lens_cpu,
+            dtype=torch.int64,
+            device=c4_seq_lens.device,
+        )
+        ks = torch.repeat_interleave(
+            request_k_offsets,
+            local_extend_lens,
+            output_size=logical_query_rows,
+        )
+        ks = ks.to(torch.int32).contiguous()
+
+        local_c4_seq_lens = (
+            c4_seq_lens[:logical_query_rows].reshape(-1).to(torch.int32).contiguous()
+        )
+        ke = (ks + local_c4_seq_lens).contiguous()
+
+        seq_len_sum = sum(gather_c4_lens_cpu)
+        max_seq_len = max(gather_c4_lens_cpu)
         c4_page_size = indexer_metadata.c4_page_size
-        max_seqlen_k = (final_c4_len + c4_page_size - 1) // c4_page_size * c4_page_size
+        max_seqlen_k = (
+            (max_seq_len + c4_page_size - 1) // c4_page_size * c4_page_size
+        )
         plan = NonPagedIndexerPlan(
             page_table=request_page_table,
             gather_seq_lens=gather_seq_lens,
             ks=ks,
             ke=ke,
-            seq_len_sum=final_c4_len,
-            max_seq_len=final_c4_len,
+            seq_len_sum=seq_len_sum,
+            max_seq_len=max_seq_len,
             max_seqlen_k=max_seqlen_k,
-            query_rows=query_rows,
+            query_rows=logical_query_rows,
         )
         indexer_metadata.nonpaged_plan = plan
         return plan
@@ -723,7 +810,22 @@ class C4IndexerBackendMixin:
         else:
             from deep_gemm import fp8_paged_mqa_logits as fn
 
-        query_rows = q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
+        physical_query_rows = (
+            q_indexer[0].shape[0] if use_fp4_indexer else q_indexer.shape[0]
+        )
+        nonpaged_plan = self._get_nonpaged_indexer_plan(
+            c4_indexer=c4_indexer,
+            forward_batch=forward_batch,
+            indexer_metadata=indexer_metadata,
+            page_table=indexer_metadata.page_table,
+            c4_seq_lens=indexer_metadata.c4_seq_lens,
+            query_rows=physical_query_rows,
+        )
+        query_rows = (
+            nonpaged_plan.query_rows
+            if nonpaged_plan is not None
+            else physical_query_rows
+        )
 
         def match_num_queries(tensor: torch.Tensor, value: int) -> torch.Tensor:
             if tensor.shape[0] == query_rows:
@@ -745,14 +847,6 @@ class C4IndexerBackendMixin:
         _use_aiter = envs.SGLANG_OPT_USE_AITER_INDEXER.get() and not use_fp4_indexer
         if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
             _c4sl = _c4sl.unsqueeze(-1)
-        nonpaged_plan = self._get_nonpaged_indexer_plan(
-            c4_indexer=c4_indexer,
-            forward_batch=forward_batch,
-            indexer_metadata=indexer_metadata,
-            page_table=page_table,
-            c4_seq_lens=c4_seq_lens,
-            query_rows=query_rows,
-        )
         if nonpaged_plan is not None:
             assert isinstance(q_indexer, torch.Tensor)
             logits = self._forward_nonpaged_indexer(
@@ -802,7 +896,21 @@ class C4IndexerBackendMixin:
                 : c4_sparse_page_indices.size(0)
             ]
         elif core_metadata.c4_sparse_raw_indices is not None:
-            raw_indices = core_metadata.c4_sparse_raw_indices
+            raw_indices = match_num_queries(
+                core_metadata.c4_sparse_raw_indices, value=-1
+            )
+
+        if (
+            nonpaged_plan is not None
+            and query_rows != physical_query_rows
+            and indexer_metadata.topk_metadata.shape[0] != query_rows + 1
+            and envs.SGLANG_OPT_USE_TOPK_V2.get()
+            and raw_indices is None
+            and not envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get()
+            and not self.dsa_topk_backend.is_torch()
+            and not self.dsa_topk_backend.is_flashinfer()
+        ):
+            indexer_metadata.topk_metadata = plan_topk_v2(c4_seq_lens)
 
         if (
             envs.SGLANG_TOPK_TRANSFORM_512_TORCH.get()

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -903,6 +903,8 @@ class C4IndexerBackendMixin:
         # The nonpaged CP path may trim padded query rows after metadata creation.
         # Rebuild here because top-k v2 requires a plan built from the exact
         # c4_seq_lens it sees.
+        # This can move after CP splitting during metadata initialization once
+        # nonpaged dispatch can be decided there.
         if (
             nonpaged_plan is not None
             and query_rows != physical_query_rows

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -583,11 +583,6 @@ class C4IndexerBackendMixin:
             selected_request_indices = list(range(len(extend_lens_cpu)))
 
         logical_query_rows = sum(local_extend_lens_cpu)
-        if (
-            logical_query_rows
-            < envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS.get()
-        ):
-            return None
         global_query_rows = sum(extend_lens_cpu)
         if (
             logical_query_rows > query_rows

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -900,6 +900,9 @@ class C4IndexerBackendMixin:
                 core_metadata.c4_sparse_raw_indices, value=-1
             )
 
+        # The nonpaged CP path may trim padded query rows after metadata creation.
+        # Rebuild here because top-k v2 requires a plan built from the exact
+        # c4_seq_lens it sees.
         if (
             nonpaged_plan is not None
             and query_rows != physical_query_rows

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -203,9 +203,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
                 self.assertEqual(plan.max_seq_len, expected_gather_c4_len)
                 self.assertEqual(plan.max_seqlen_k, 64)
                 torch.testing.assert_close(plan.page_table, page_table[:1])
-                torch.testing.assert_close(
-                    plan.ke, c4_seq_lens[:logical_query_rows]
-                )
+                torch.testing.assert_close(plan.ke, c4_seq_lens[:logical_query_rows])
                 torch.testing.assert_close(
                     plan.gather_seq_lens,
                     torch.tensor([expected_gather_c4_len], dtype=torch.int32),
@@ -228,9 +226,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         request_0_table = torch.tensor([[3, 1, 4]], dtype=torch.int32).repeat(4, 1)
         request_1_table = torch.tensor([[9, 7, 8]], dtype=torch.int32).repeat(3, 1)
         page_table = torch.cat((request_0_table, request_1_table), dim=0)
-        c4_seq_lens = torch.tensor(
-            [127, 128, 129, 130, 63, 64, 65], dtype=torch.int32
-        )
+        c4_seq_lens = torch.tensor([127, 128, 129, 130, 63, 64, 65], dtype=torch.int32)
 
         threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
         with (
@@ -572,9 +568,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         initial_topk_plan = torch.tensor(
             [[100, 3], [0, 9], [1, 11], [2, 0]], dtype=torch.int32
         )
-        rebuilt_topk_plan = torch.tensor(
-            [[200, 2], [0, 9], [1, 11]], dtype=torch.int32
-        )
+        rebuilt_topk_plan = torch.tensor([[200, 2], [0, 9], [1, 11]], dtype=torch.int32)
 
         nonpaged_plan = NonPagedIndexerPlan(
             page_table=page_table[:1],
@@ -586,9 +580,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
             max_seqlen_k=64,
             query_rows=logical_query_rows,
         )
-        q_indexer = torch.zeros(
-            (physical_query_rows, 2, 128), dtype=torch.float32
-        )
+        q_indexer = torch.zeros((physical_query_rows, 2, 128), dtype=torch.float32)
         weights = torch.ones((physical_query_rows, 2, 1), dtype=torch.float32)
         logits = torch.zeros((logical_query_rows, 16), dtype=torch.float32)
         c4_sparse_page_indices = torch.full(
@@ -618,9 +610,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         deep_gemm = SimpleNamespace(
             get_num_sms=MagicMock(return_value=1),
             get_paged_mqa_logits_metadata=MagicMock(
-                return_value=torch.zeros(
-                    (physical_query_rows, 2), dtype=torch.int32
-                )
+                return_value=torch.zeros((physical_query_rows, 2), dtype=torch.int32)
             ),
             fp8_paged_mqa_logits=MagicMock(),
         )

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -319,14 +319,13 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         self.assertEqual(plan.max_seq_len, 4)
         self.assertEqual(plan.max_seqlen_k, 64)
 
-    def test_round_robin_query_threshold_uses_local_rows(self):
+    def test_round_robin_query_threshold_uses_padded_rows_consistently(self):
         backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
         c4_indexer = SimpleNamespace(use_fp4_indexer=False)
         metadata = SimpleNamespace(nonpaged_plan=None, c4_page_size=64)
         cp_size = 4
-        cp_rank = 3
 
-        def build_plan(global_query_rows):
+        def build_plan(global_query_rows, cp_rank):
             padded_local_query_rows = (global_query_rows + cp_size - 1) // cp_size
             local_causal_seq_lens = torch.arange(
                 cp_rank + 1,
@@ -359,10 +358,23 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
                 query_rows=padded_local_query_rows,
             )
 
-        with get_parallel().override(attn_cp_size=cp_size, attn_cp_rank=cp_rank):
-            self.assertIsNone(build_plan(8192 * cp_size - 1))
-            self.assertIsNotNone(build_plan(8192 * cp_size))
-            self.assertIsNotNone(build_plan(8193 * cp_size))
+        for cp_rank in range(cp_size):
+            with (
+                self.subTest(cp_rank=cp_rank),
+                get_parallel().override(attn_cp_size=cp_size, attn_cp_rank=cp_rank),
+            ):
+                # All ranks have 8191 physical rows and therefore use paged.
+                self.assertIsNone(build_plan(8191 * cp_size, cp_rank))
+
+                # All ranks have 8192 padded physical rows. Rank 3 has only 8191
+                # logical rows, but every rank must still choose non-paged.
+                global_query_rows = 8192 * cp_size - 1
+                plan = build_plan(global_query_rows, cp_rank)
+                self.assertIsNotNone(plan)
+                expected_logical_rows = len(
+                    range(cp_rank + 1, global_query_rows + 1, cp_size)
+                )
+                self.assertEqual(plan.query_rows, expected_logical_rows)
 
     def test_single_request_plan_contract(self):
         backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -552,5 +552,115 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         torch.testing.assert_close(call.args[4], plan.ke)
         self.assertEqual(call.kwargs, {"clean_logits": False, "max_seqlen_k": 128})
 
+    def test_topk_v2_plan_rebuilt_once_after_cp_padding_is_trimmed(self):
+        physical_query_rows = 3
+        logical_query_rows = 2
+        page_table = torch.tensor([[3], [3], [0]], dtype=torch.int32)
+        physical_c4_seq_lens = torch.tensor([9, 11, 0], dtype=torch.int32)
+        initial_topk_plan = torch.tensor(
+            [[100, 3], [0, 9], [1, 11], [2, 0]], dtype=torch.int32
+        )
+        rebuilt_topk_plan = torch.tensor(
+            [[200, 2], [0, 9], [1, 11]], dtype=torch.int32
+        )
+
+        nonpaged_plan = NonPagedIndexerPlan(
+            page_table=page_table[:1],
+            gather_seq_lens=torch.tensor([11], dtype=torch.int32),
+            ks=torch.zeros(logical_query_rows, dtype=torch.int32),
+            ke=physical_c4_seq_lens[:logical_query_rows],
+            seq_len_sum=11,
+            max_seq_len=11,
+            max_seqlen_k=64,
+            query_rows=logical_query_rows,
+        )
+        q_indexer = torch.zeros(
+            (physical_query_rows, 2, 128), dtype=torch.float32
+        )
+        weights = torch.ones((physical_query_rows, 2, 1), dtype=torch.float32)
+        logits = torch.zeros((logical_query_rows, 16), dtype=torch.float32)
+        c4_sparse_page_indices = torch.full(
+            (physical_query_rows, 512), -1, dtype=torch.int32
+        )
+        core_metadata = SimpleNamespace(
+            positions=torch.arange(physical_query_rows),
+            page_table=page_table,
+            c4_sparse_page_indices=c4_sparse_page_indices,
+            c4_sparse_raw_indices=None,
+        )
+        backend = SimpleNamespace(
+            token_to_kv_pool=MagicMock(),
+            forward_metadata=None,
+            _forward_prepare_normal=MagicMock(return_value=(q_indexer, weights)),
+            _get_nonpaged_indexer_plan=MagicMock(return_value=nonpaged_plan),
+            _forward_nonpaged_indexer=MagicMock(return_value=logits),
+            debug_use_external_c4_sparse_indices=False,
+            hisparse_coordinator=None,
+            dsa_topk_backend=SimpleNamespace(
+                is_torch=MagicMock(return_value=False),
+                is_flashinfer=MagicMock(return_value=False),
+            ),
+        )
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False, layer_id=17)
+        forward_batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+        deep_gemm = SimpleNamespace(
+            get_num_sms=MagicMock(return_value=1),
+            get_paged_mqa_logits_metadata=MagicMock(
+                return_value=torch.zeros(
+                    (physical_query_rows, 2), dtype=torch.int32
+                )
+            ),
+            fp8_paged_mqa_logits=MagicMock(),
+        )
+
+        with (
+            patch.dict(sys.modules, {"deep_gemm": deep_gemm}),
+            envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.override(False),
+            envs.SGLANG_OPT_USE_AITER_INDEXER.override(False),
+            envs.SGLANG_OPT_USE_TILELANG_INDEXER.override(False),
+            envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.override(False),
+            envs.SGLANG_OPT_USE_TOPK_V2.override(True),
+            envs.SGLANG_TOPK_TRANSFORM_512_TORCH.override(False),
+            patch(
+                "sglang.kernels.ops.attention.dsv4.plan_topk_v2",
+                return_value=initial_topk_plan,
+            ) as initial_plan,
+            patch(f"{_INDEXER}.plan_topk_v2", return_value=rebuilt_topk_plan) as replan,
+            patch(f"{_INDEXER}.topk_transform_512_v2") as transform,
+            patch(f"{_INDEXER}.get_global_indexer_capturer", return_value=None),
+        ):
+            indexer_metadata = PagedIndexerMetadata(
+                page_size=256,
+                page_table=page_table,
+                c4_seq_lens=physical_c4_seq_lens,
+            )
+            backend.forward_metadata = SimpleNamespace(
+                indexer_metadata=indexer_metadata,
+                core_metadata=core_metadata,
+            )
+
+            for _ in range(2):
+                C4IndexerBackendMixin.forward_c4_indexer(
+                    backend,
+                    x=torch.zeros((physical_query_rows, 1)),
+                    q_lora=torch.zeros((physical_query_rows, 1)),
+                    c4_indexer=c4_indexer,
+                    forward_batch=forward_batch,
+                )
+
+        initial_plan.assert_called_once_with(physical_c4_seq_lens)
+        replan.assert_called_once()
+        torch.testing.assert_close(
+            replan.call_args.args[0], physical_c4_seq_lens[:logical_query_rows]
+        )
+        self.assertIs(indexer_metadata.topk_metadata, rebuilt_topk_plan)
+        self.assertEqual(transform.call_count, 2)
+        for call in transform.call_args_list:
+            torch.testing.assert_close(
+                call.args[1], physical_c4_seq_lens[:logical_query_rows]
+            )
+            self.assertIs(call.args[5], rebuilt_topk_plan)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
+++ b/test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
@@ -73,11 +73,17 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
     def _is_eligible(self, **overrides):
         backend = SimpleNamespace(hisparse_coordinator=None)
         c4_indexer = SimpleNamespace(use_fp4_indexer=overrides.get("fp4", False))
+        cp_size = overrides.get("cp_size", 1)
         forward_batch = SimpleNamespace(
             forward_mode=overrides.get("mode", ForwardMode.EXTEND),
             _original_forward_mode=overrides.get("original_mode"),
             tbo_parent_token_range=overrides.get("tbo"),
             batch_size=overrides.get("batch_size", 1),
+            attn_cp_metadata=(
+                SimpleNamespace()
+                if cp_size > 1 and overrides.get("has_cp_metadata", True)
+                else None
+            ),
         )
         metadata = SimpleNamespace(
             use_prefill_cuda_graph=overrides.get("prefill_graph", False)
@@ -91,7 +97,14 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
             envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.override(False),
             patch(f"{_INDEXER}.is_cuda", return_value=True),
             patch(f"{_INDEXER}.is_hip", return_value=False),
-            get_parallel().override(attn_cp_size=1),
+            get_parallel().override(
+                attn_cp_size=cp_size,
+                attn_cp_rank=overrides.get("cp_rank", 0),
+            ),
+            patch(
+                f"{_INDEXER}.is_dsa_prefill_cp_round_robin_split",
+                return_value=overrides.get("round_robin", True),
+            ),
             patch(
                 f"{_INDEXER}.is_in_tc_piecewise_cuda_graph",
                 return_value=overrides.get("piecewise_graph", False),
@@ -112,19 +125,244 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
             envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS.default, 8192
         )
         self.assertTrue(self._is_eligible())
+        self.assertTrue(self._is_eligible(batch_size=2))
+        self.assertTrue(self._is_eligible(batch_size=20_000))
+        self.assertTrue(self._is_eligible(cp_size=4, cp_rank=2))
         for case in (
             {"enabled": False},
             {"mode": ForwardMode.DECODE},
             {"original_mode": ForwardMode.DECODE},
-            {"batch_size": 2},
-            {"batch_size": 20_000},
             {"tbo": (1, 2)},
             {"prefill_graph": True},
             {"piecewise_graph": True},
             {"fp4": True},
+            {"cp_size": 4, "round_robin": False},
+            {"cp_size": 4, "has_cp_metadata": False},
         ):
             with self.subTest(case=case):
                 self.assertFalse(self._is_eligible(**case))
+
+    def test_round_robin_plan_uses_local_query_rows_and_k_prefix(self):
+        backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False)
+        cp_size = 4
+        global_query_rows = 15
+        padded_local_query_rows = 4
+        prefix_len = 6
+        final_seq_len = prefix_len + global_query_rows
+        threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
+
+        for cp_rank in range(cp_size):
+            with self.subTest(cp_rank=cp_rank):
+                local_causal_seq_lens = torch.arange(
+                    prefix_len + cp_rank + 1,
+                    final_seq_len + 1,
+                    cp_size,
+                    dtype=torch.int32,
+                )
+                logical_query_rows = local_causal_seq_lens.numel()
+                c4_seq_lens = torch.div(local_causal_seq_lens, 4, rounding_mode="floor")
+                c4_seq_lens = torch.nn.functional.pad(
+                    c4_seq_lens,
+                    (0, padded_local_query_rows - logical_query_rows),
+                )
+                page_table = torch.tensor([[3, 1]], dtype=torch.int32).repeat(
+                    padded_local_query_rows, 1
+                )
+                batch = SimpleNamespace(
+                    seq_lens=torch.tensor([final_seq_len], dtype=torch.int32),
+                    seq_lens_cpu=[final_seq_len],
+                    extend_seq_lens_cpu=[global_query_rows],
+                    extend_seq_lens=torch.tensor(
+                        [global_query_rows], dtype=torch.int32
+                    ),
+                    extend_start_loc=torch.tensor([0], dtype=torch.int32),
+                    extend_num_tokens=global_query_rows,
+                    attn_cp_metadata=SimpleNamespace(),
+                )
+                metadata = SimpleNamespace(nonpaged_plan=None, c4_page_size=64)
+
+                with (
+                    threshold.override(0),
+                    get_parallel().override(attn_cp_size=cp_size, attn_cp_rank=cp_rank),
+                ):
+                    plan = C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                        backend,
+                        c4_indexer=c4_indexer,
+                        forward_batch=batch,
+                        indexer_metadata=metadata,
+                        page_table=page_table,
+                        c4_seq_lens=c4_seq_lens,
+                        query_rows=padded_local_query_rows,
+                    )
+
+                expected_gather_c4_len = final_seq_len // 4
+                self.assertIsNotNone(plan)
+                self.assertEqual(plan.query_rows, logical_query_rows)
+                self.assertEqual(plan.seq_len_sum, expected_gather_c4_len)
+                self.assertEqual(plan.max_seq_len, expected_gather_c4_len)
+                self.assertEqual(plan.max_seqlen_k, 64)
+                torch.testing.assert_close(plan.page_table, page_table[:1])
+                torch.testing.assert_close(
+                    plan.ke, c4_seq_lens[:logical_query_rows]
+                )
+                torch.testing.assert_close(
+                    plan.gather_seq_lens,
+                    torch.tensor([expected_gather_c4_len], dtype=torch.int32),
+                )
+
+    def test_multi_request_plan_concatenates_kv_and_builds_ragged_ranges(self):
+        backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False)
+        extend_lens = [4, 3]
+        query_rows = sum(extend_lens)
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([522, 260], dtype=torch.int32),
+            seq_lens_cpu=[522, 260],
+            extend_seq_lens_cpu=extend_lens,
+            extend_seq_lens=torch.tensor(extend_lens, dtype=torch.int32),
+            extend_start_loc=torch.tensor([0, 4], dtype=torch.int32),
+            extend_num_tokens=query_rows,
+        )
+        metadata = SimpleNamespace(nonpaged_plan=None, c4_page_size=64)
+        request_0_table = torch.tensor([[3, 1, 4]], dtype=torch.int32).repeat(4, 1)
+        request_1_table = torch.tensor([[9, 7, 8]], dtype=torch.int32).repeat(3, 1)
+        page_table = torch.cat((request_0_table, request_1_table), dim=0)
+        c4_seq_lens = torch.tensor(
+            [127, 128, 129, 130, 63, 64, 65], dtype=torch.int32
+        )
+
+        threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
+        with (
+            threshold.override(query_rows),
+            get_parallel().override(attn_cp_size=1, attn_cp_rank=0),
+        ):
+            plan = C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                backend,
+                c4_indexer=c4_indexer,
+                forward_batch=batch,
+                indexer_metadata=metadata,
+                page_table=page_table,
+                c4_seq_lens=c4_seq_lens,
+                query_rows=query_rows,
+            )
+
+        self.assertIsNotNone(plan)
+        self.assertEqual(plan.query_rows, query_rows)
+        self.assertEqual(plan.seq_len_sum, 195)
+        self.assertEqual(plan.max_seq_len, 130)
+        self.assertEqual(plan.max_seqlen_k, 192)
+        torch.testing.assert_close(
+            plan.page_table,
+            torch.tensor([[3, 1, 4], [9, 7, 8]], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            plan.gather_seq_lens,
+            torch.tensor([130, 65], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            plan.ks,
+            torch.tensor([0, 0, 0, 0, 130, 130, 130], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            plan.ke,
+            torch.tensor([127, 128, 129, 130, 193, 194, 195], dtype=torch.int32),
+        )
+
+    def test_multi_request_round_robin_plan_selects_rank_local_requests(self):
+        backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False)
+        extend_lens = [3, 5, 2]
+        batch = SimpleNamespace(
+            seq_lens=torch.tensor([11, 17, 10], dtype=torch.int32),
+            seq_lens_cpu=[11, 17, 10],
+            extend_seq_lens_cpu=extend_lens,
+            extend_seq_lens=torch.tensor(extend_lens, dtype=torch.int32),
+            extend_start_loc=torch.tensor([0, 3, 8], dtype=torch.int32),
+            extend_num_tokens=sum(extend_lens),
+            attn_cp_metadata=SimpleNamespace(),
+        )
+        metadata = SimpleNamespace(nonpaged_plan=None, c4_page_size=64)
+        # Rank 2 owns flattened global query rows 2 and 6; the third row is
+        # CP/DP padding and must not be sent to DeepGEMM or ragged top-k.
+        page_table = torch.tensor([[3, 1], [9, 7], [0, 0]], dtype=torch.int32)
+        c4_seq_lens = torch.tensor([2, 4, 123], dtype=torch.int32)
+
+        threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
+        with (
+            threshold.override(0),
+            get_parallel().override(attn_cp_size=4, attn_cp_rank=2),
+        ):
+            plan = C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                backend,
+                c4_indexer=c4_indexer,
+                forward_batch=batch,
+                indexer_metadata=metadata,
+                page_table=page_table,
+                c4_seq_lens=c4_seq_lens,
+                query_rows=3,
+            )
+
+        self.assertIsNotNone(plan)
+        torch.testing.assert_close(
+            plan.page_table,
+            torch.tensor([[3, 1], [9, 7]], dtype=torch.int32),
+        )
+        torch.testing.assert_close(
+            plan.gather_seq_lens,
+            torch.tensor([2, 4], dtype=torch.int32),
+        )
+        torch.testing.assert_close(plan.ks, torch.tensor([0, 2], dtype=torch.int32))
+        torch.testing.assert_close(plan.ke, torch.tensor([2, 6], dtype=torch.int32))
+        self.assertEqual(plan.query_rows, 2)
+        self.assertEqual(plan.seq_len_sum, 6)
+        self.assertEqual(plan.max_seq_len, 4)
+        self.assertEqual(plan.max_seqlen_k, 64)
+
+    def test_round_robin_query_threshold_uses_local_rows(self):
+        backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
+        c4_indexer = SimpleNamespace(use_fp4_indexer=False)
+        metadata = SimpleNamespace(nonpaged_plan=None, c4_page_size=64)
+        cp_size = 4
+        cp_rank = 3
+
+        def build_plan(global_query_rows):
+            padded_local_query_rows = (global_query_rows + cp_size - 1) // cp_size
+            local_causal_seq_lens = torch.arange(
+                cp_rank + 1,
+                global_query_rows + 1,
+                cp_size,
+                dtype=torch.int32,
+            )
+            c4_seq_lens = torch.div(local_causal_seq_lens, 4, rounding_mode="floor")
+            c4_seq_lens = torch.nn.functional.pad(
+                c4_seq_lens,
+                (0, padded_local_query_rows - local_causal_seq_lens.numel()),
+            )
+            batch = SimpleNamespace(
+                seq_lens=torch.tensor([global_query_rows], dtype=torch.int32),
+                seq_lens_cpu=[global_query_rows],
+                extend_seq_lens_cpu=[global_query_rows],
+                extend_seq_lens=torch.tensor([global_query_rows], dtype=torch.int32),
+                extend_start_loc=torch.tensor([0], dtype=torch.int32),
+                extend_num_tokens=global_query_rows,
+                attn_cp_metadata=SimpleNamespace(),
+            )
+            metadata.nonpaged_plan = None
+            return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                backend,
+                c4_indexer=c4_indexer,
+                forward_batch=batch,
+                indexer_metadata=metadata,
+                page_table=torch.zeros((padded_local_query_rows, 1), dtype=torch.int32),
+                c4_seq_lens=c4_seq_lens,
+                query_rows=padded_local_query_rows,
+            )
+
+        with get_parallel().override(attn_cp_size=cp_size, attn_cp_rank=cp_rank):
+            self.assertIsNone(build_plan(8192 * cp_size - 1))
+            self.assertIsNotNone(build_plan(8192 * cp_size))
+            self.assertIsNotNone(build_plan(8193 * cp_size))
 
     def test_single_request_plan_contract(self):
         backend = SimpleNamespace(_can_use_nonpaged_indexer=lambda **_: True)
@@ -143,15 +381,16 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         c4_seq_lens = torch.tensor([62, 63, 64, 65], dtype=torch.int32)
 
         def build_plan():
-            return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
-                backend,
-                c4_indexer=c4_indexer,
-                forward_batch=batch,
-                indexer_metadata=metadata,
-                page_table=page_table,
-                c4_seq_lens=c4_seq_lens,
-                query_rows=query_rows,
-            )
+            with get_parallel().override(attn_cp_size=1, attn_cp_rank=0):
+                return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                    backend,
+                    c4_indexer=c4_indexer,
+                    forward_batch=batch,
+                    indexer_metadata=metadata,
+                    page_table=page_table,
+                    c4_seq_lens=c4_seq_lens,
+                    query_rows=query_rows,
+                )
 
         threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
         with threshold.override(threshold.default):
@@ -190,15 +429,16 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         )
 
         def build_plan():
-            return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
-                backend,
-                c4_indexer=c4_indexer,
-                forward_batch=batch,
-                indexer_metadata=metadata,
-                page_table=page_table,
-                c4_seq_lens=c4_seq_lens,
-                query_rows=query_rows,
-            )
+            with get_parallel().override(attn_cp_size=1, attn_cp_rank=0):
+                return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                    backend,
+                    c4_indexer=c4_indexer,
+                    forward_batch=batch,
+                    indexer_metadata=metadata,
+                    page_table=page_table,
+                    c4_seq_lens=c4_seq_lens,
+                    query_rows=query_rows,
+                )
 
         threshold = envs.SGLANG_OPT_DSV4_NONPAGED_INDEXER_MIN_QUERY_TOKENS
         with threshold.override(query_rows):
@@ -212,7 +452,7 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         batch.seq_lens_cpu = [500_000, 200]
         batch.extend_seq_lens_cpu = [2, 2]
         batch.extend_seq_lens = torch.tensor([2, 2], dtype=torch.int32)
-        batch.extend_start_loc = torch.tensor([0, 2], dtype=torch.int32)
+        batch.extend_start_loc = torch.tensor([0], dtype=torch.int32)
         with threshold.override(query_rows):
             self.assertIsNone(build_plan())
 
@@ -236,15 +476,16 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
                 4,
                 rounding_mode="floor",
             ).clamp_min_(1)
-            return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
-                backend,
-                c4_indexer=c4_indexer,
-                forward_batch=batch,
-                indexer_metadata=metadata,
-                page_table=torch.zeros((query_rows, 1), dtype=torch.int32),
-                c4_seq_lens=c4_seq_lens,
-                query_rows=query_rows,
-            )
+            with get_parallel().override(attn_cp_size=1, attn_cp_rank=0):
+                return C4IndexerBackendMixin._get_nonpaged_indexer_plan(
+                    backend,
+                    c4_indexer=c4_indexer,
+                    forward_batch=batch,
+                    indexer_metadata=metadata,
+                    page_table=torch.zeros((query_rows, 1), dtype=torch.int32),
+                    c4_seq_lens=c4_seq_lens,
+                    query_rows=query_rows,
+                )
 
         for query_rows, expected in ((8191, False), (8192, True), (8193, True)):
             with self.subTest(query_rows=query_rows):
@@ -310,7 +551,6 @@ class TestDSV4NonPagedIndexer(CustomTestCase):
         torch.testing.assert_close(call.args[3], plan.ks)
         torch.testing.assert_close(call.args[4], plan.ke)
         self.assertEqual(call.kwargs, {"clean_logits": False, "max_seqlen_k": 128})
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

[PR #29619](https://github.com/sgl-project/sglang/pull/29619) introduced the non-paged DeepSeek-V4 C4 indexer for long-context prefill, and [PR #30140](https://github.com/sgl-project/sglang/pull/30140) enabled it by default when the local query length is at least 8,192 tokens per rank. The benchmarks in those PRs showed that, once the fixed KV-gather cost is amortized at this scale, gathering the indexer KV cache into contiguous storage and using the non-paged DeepGEMM kernel can improve prefill throughput.

However, the existing fast path is restricted to `CP=1` and `batch_size=1`, which excludes two important serving scenarios:

1. Prefill workers in prefill/decode-disaggregated deployments commonly use context parallelism for long-context requests. CP distributes the prefill workload across ranks and limits per-rank activation memory, but the existing restriction forces these requests back to the paged indexer even when the per-rank query length reaches the profitable non-paged region.
2. With chunked prefill, the scheduler can co-schedule multiple requests as long as their combined prefill tokens fit within `--chunked-prefill-size`. Such `batch_size>1` batches should also benefit from the non-paged path when their aggregate local query length reaches the threshold.

This PR extends the non-paged indexer to batched prefill and round-robin context-parallel prefill while preserving the existing query-length threshold and fail-closed fallbacks for unsupported configurations.

## Modifications

- Extend the non-paged indexer from single-request prefill to batched prefill.
- Support CP prefill only with the `interleave` (round-robin) strategy. Other CP strategies, such as `zigzag`, explicitly fall back to the paged indexer; support for additional CP layouts is left to follow-up work.
- Build rank-local gather plans that concatenate the selected requests' C4 KV sequences and provide request-aware ragged `[ks, ke)` ranges to DeepGEMM.
- Trim CP/DP padding before DeepGEMM and top-k, keep dispatch consistent across CP ranks, and rebuild the top-k v2 plan when the logical query shape changes. 
- Add unit tests for the new batched and round-robin CP paths and their fallback boundaries.

## Accuracy Tests

### Test design

- **Hardware:** 4x HZZ2
- **Workload:** GSM8K, repeated three times per configuration
- **Paged baseline:** `SGLANG_OPT_DSV4_NONPAGED_INDEXER=0`
- **Optimized path:** `SGLANG_OPT_DSV4_NONPAGED_INDEXER=1`

The two configurations used the same model, server arguments, dataset, and evaluation parameters. The environment variable above was the only difference between them.

### Reproduction commands

Run the server once for each configuration, changing only `SGLANG_OPT_DSV4_NONPAGED_INDEXER`:

```bash
# Use 0 for the paged baseline and 1 for the optimized non-paged run.
export SGLANG_OPT_DSV4_NONPAGED_INDEXER=0

python3 -m sglang.launch_server \
  --model-path <model-path> \
  --tp-size 4 \
  --ep-size 4 \
  --moe-runner-backend flashinfer_mxfp4 \
  --enable-prefill-cp \
  --cp-strategy interleave \
  --max-prefill-tokens 40960 \
  --chunked-prefill-size 40960 \
  --disable-radix-cache
```

Run the same evaluation against each server:

```bash
python3 -m sglang.test.run_eval \
  --base-url http://127.0.0.1:30000 \
  --model <served-model-name> \
  --eval-name gsm8k \
  --api completion \
  --gsm8k-data-path <gsm8k-data-path> \
  --num-threads 128 \
  --repeat 3 \
  --temperature 0 \
  --top-p 1
```

### Runtime (NONPAGED=1)
<img width="2188" height="712" alt="微信图片_20260804233831_7_4" src="https://github.com/user-attachments/assets/60f55712-6a48-4bf5-ad2c-e40e77d02e64" />
A runtime log screenshot confirms that the local sequence length exceeded 8,192 tokens per rank, verifying that the non-paged indexer threshold was met and that the optimized code path was exercised during the accuracy evaluation.

### Results

| Configuration | Run 1 | Run 2 | Run 3 | Mean |
| --- | ---: | ---: | ---: | ---: |
| Paged baseline (`NONPAGED=0`) | 0.952 | 0.950 | 0.956 | 0.9527 |
| Non-paged (`NONPAGED=1`) | 0.951 | 0.954 | 0.956 | 0.9537 |
| Delta (non-paged - baseline) | -0.001 | +0.004 | 0.000 | +0.0010 |

The paged and non-paged configurations achieved comparable GSM8K scores. The optimized run's mean score was `+0.0010` (`+0.10` percentage points) above the baseline, which is within the observed run-to-run variation. No accuracy regression was observed.

## Checklist

- [x] Format the code with pre-commit.
- [x] Add or update unit tests.
- [ ] Update documentation where needed.
- [ ] Provide relevant accuracy and performance results.
- [x] Follow the SGLang code-style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->