### PR TITLE
fix: support batched OpenAI cache keys

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -148,18 +148,40 @@ class OpenAIServingBase(ABC):
 
         return f"{self._request_id_prefix()}{uuid.uuid4().hex}"
 
-    def _compute_extra_key(self, request: OpenAIServingRequest) -> Optional[str]:
-        """Compute the final extra_key by concatenating cache_salt and extra_key if both are provided."""
-        parts = []
-        for key in ["cache_salt", "extra_key"]:
+    def _compute_extra_key(
+        self, request: OpenAIServingRequest
+    ) -> Optional[Union[List[str], str]]:
+        """Combine cache_salt and extra_key for scalar and batched requests."""
+
+        def validate_key(key: str) -> Optional[Union[List[str], str]]:
             value = getattr(request, key, None)
-            if value:
-                if not isinstance(value, str):
-                    raise TypeError(
-                        f"Value of {key} must be a string, but got {type(value).__name__}"
-                    )
-                parts.append(value)
-        return "".join(parts) if parts else None
+            if value is None or value == "":
+                return None
+            if isinstance(value, str) or (
+                isinstance(value, list) and all(isinstance(item, str) for item in value)
+            ):
+                return value
+            raise TypeError(
+                f"Value of {key} must be a string or a list of strings, "
+                f"but got {type(value).__name__}"
+            )
+
+        cache_salt = validate_key("cache_salt")
+        extra_key = validate_key("extra_key")
+
+        if cache_salt is None:
+            return extra_key
+        if extra_key is None:
+            return cache_salt
+        if isinstance(cache_salt, str) and isinstance(extra_key, str):
+            return cache_salt + extra_key
+        if isinstance(cache_salt, str):
+            return [cache_salt + value for value in extra_key]
+        if isinstance(extra_key, str):
+            return [value + extra_key for value in cache_salt]
+        if len(cache_salt) != len(extra_key):
+            raise ValueError("cache_salt and extra_key lists must have the same length")
+        return [salt + key for salt, key in zip(cache_salt, extra_key)]
 
     @abstractmethod
     def _convert_to_internal_request(

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -65,6 +65,63 @@ class ServingCompletionTestCase(unittest.TestCase):
         internal, _ = self.sc._convert_to_internal_request(req)
         self.assertEqual(internal.input_ids, [1, 2, 3, 4])
 
+    def test_batched_cache_key_lists(self):
+        for field in ("extra_key", "cache_salt"):
+            with self.subTest(field=field):
+                req = CompletionRequest(
+                    model="x",
+                    prompt=["A", "B"],
+                    **{field: ["tenant-a", "tenant-b"]},
+                )
+
+                internal, _ = self.sc._convert_to_internal_request(req)
+
+                self.assertEqual(internal.extra_key, ["tenant-a", "tenant-b"])
+
+    def test_batched_cache_salt_and_extra_key(self):
+        test_cases = [
+            ("salt-", "tenant", "salt-tenant"),
+            (
+                "salt-",
+                ["tenant-a", "tenant-b"],
+                ["salt-tenant-a", "salt-tenant-b"],
+            ),
+            (
+                ["salt-a-", "salt-b-"],
+                "tenant",
+                ["salt-a-tenant", "salt-b-tenant"],
+            ),
+            (
+                ["salt-a-", "salt-b-"],
+                ["tenant-a", "tenant-b"],
+                ["salt-a-tenant-a", "salt-b-tenant-b"],
+            ),
+        ]
+
+        for cache_salt, extra_key, expected_extra_key in test_cases:
+            with self.subTest(cache_salt=cache_salt, extra_key=extra_key):
+                req = CompletionRequest(
+                    model="x",
+                    prompt=["A", "B"],
+                    cache_salt=cache_salt,
+                    extra_key=extra_key,
+                )
+
+                internal, _ = self.sc._convert_to_internal_request(req)
+
+                self.assertEqual(internal.extra_key, expected_extra_key)
+
+    def test_batched_cache_key_length_mismatch(self):
+        req = CompletionRequest(
+            model="x",
+            prompt=["A", "B"],
+            cache_salt=["salt-a", "salt-b"],
+            extra_key=["tenant-a"],
+        )
+
+        with self.assertRaisesRegex(ValueError, "must have the same length"):
+            self.sc._convert_to_internal_request(req)
+
     # ---------- echo-handling ----------
     def test_echo_with_list_of_strings_streaming(self):
         req = CompletionRequest(


### PR DESCRIPTION
## Motivation

Fixes #33563.

`CompletionRequest` accepts batched prompts and declares `extra_key` and
`cache_salt` as either scalar strings or per-prompt string lists. However, the
OpenAI request adapter only accepted scalar values, so schema-valid batched
requests raised `TypeError` before reaching `GenerateReqInput` normalization and
could be returned as HTTP 500 responses.

## Modifications

- Accept scalar strings and per-prompt string lists in `_compute_extra_key`.
- Preserve the existing scalar concatenation behavior.
- Broadcast a scalar key when it is combined with a per-prompt list and combine
  two lists elementwise.
- Reject two key lists with different lengths using a clear `ValueError`.
- Add CPU unit coverage for list-only values, scalar/list combinations,
  elementwise list composition, legacy scalar behavior, and length mismatches.

## Validation

- Source-level CPU harness using the repository's `CompletionRequest` model and
  `_compute_extra_key` implementation: 7 scalar/batch cases and 1 mismatch case
  passed.
- `uvx ruff check --select=F401,F821` on the changed files: passed.
- `black --check` on the changed files: passed.
- `python -m py_compile` on the changed files: passed.
- `git diff --check`: passed.
- The registered completion-serving test file could not be collected locally
  because Triton is unavailable on macOS; the new tests are registered in the
  existing CPU CI suite.

## Accuracy Tests

Not applicable. This change only normalizes request metadata and does not alter
model execution or generated outputs.

## Speed Tests and Profiling

Not applicable. The change performs at most one small per-request list
comprehension during OpenAI request adaptation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed for this bug fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable; see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30928809587](https://github.com/sgl-project/sglang/actions/runs/30928809587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30928810406](https://github.com/sgl-project/sglang/actions/runs/30928810406)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->