### PR TITLE
Skip collective DeepEP Buffer destroy at interpreter exit (explicitly_destroy=True)

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from contextlib import nullcontext
 from dataclasses import dataclass
@@ -280,6 +281,9 @@ class DeepEPBuffer:
         is_cu12 = get_cuda_version()[0] == 12
         if not is_cu12 and use_mnnvl_fabric:
             buffer_kwargs["use_fabric"] = True
+
+        if "explicitly_destroy" in inspect.signature(Buffer.__init__).parameters:
+            buffer_kwargs["explicitly_destroy"] = True
 
         state.buffer = Buffer(group, num_nvl_bytes, num_rdma_bytes, **buffer_kwargs)
         return state.buffer


### PR DESCRIPTION
## Motivation

DeepEP's `Buffer.destroy()` is collective — it runs intranode (IPC) and internode (NVSHMEM) barriers so no rank frees buffers a peer is still using. With the default `explicitly_destroy=False`, the C++ destructor calls `destroy()` when the buffer is garbage-collected, which in practice means during interpreter finalization, since the buffer is a process-lifetime singleton held in module state.

At interpreter exit, rank teardown is unsynchronized: peer ranks may already have exited or torn down their CUDA contexts. The destructor-time collective then either hangs waiting on a dead peer or hits an illegal memory access, turning otherwise clean shutdowns into crashes — e.g. a job that finishes successfully exits nonzero and gets retried/flagged by schedulers. We hit this reproducibly on multi-node EP deployments with hybrid-ep (DeepEP 1.2.1). DeepEP's own docstring warns about the default path: "Releasing resources in the destructor may cause Python's exception handling process to hang."

## Modifications

Pass `explicitly_destroy=True` when constructing the buffer, and intentionally never call `destroy()`. The buffer already lives for the whole process, so skipping the free leaks nothing — the CUDA driver reclaims device memory and mappings at process exit. The kwarg is signature-gated with `inspect.signature`, so DeepEP builds that don't support `explicitly_destroy` are unaffected.

## Accuracy Tests

N/A — teardown-only change, no effect on the forward path.

## Speed Tests and Profiling

N/A — no effect on steady-state inference; only skips work at process exit.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D3Sfhj4kwLyrpuHkDXJ1JT

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30933346147](https://github.com/sgl-project/sglang/actions/runs/30933346147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30933342472](https://github.com/sgl-project/sglang/actions/runs/30933342472)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->