### PR TITLE
[Spec] Size the req_to_token row for the DFLASH decode reserve at page_size=1 (fix DSPARK KV slot leak at the context boundary)

### DIFF
--- a/python/sglang/srt/mem_cache/allocation_sizing.py
+++ b/python/sglang/srt/mem_cache/allocation_sizing.py
@@ -51,10 +51,12 @@ def get_req_to_token_extra_context_len(server_args: ServerArgs) -> int:
     """
     # FIXME(lsyin): temporary fix for the context length issue under spec decoding
     extra = 4 + (server_args.max_speculative_num_draft_tokens or 0)
-    if server_args.speculative_algorithm is not None and server_args.page_size > 1:
-        # kv_allocated_len is page-aligned (eagle_prepare_for_decode), so near
-        # the context limit the aligned reserve can overshoot by page_size - 1;
-        # without the headroom the row write silently lands in the neighbor row.
+    if server_args.speculative_algorithm is not None:
+        # Spec v2 reserves committed + 2 * draft_tokens per decode step
+        # (page-aligned when page_size > 1), so near the context limit the
+        # reserve overshoots the row; without the headroom the row write
+        # silently lands in the neighbor row and the release slice clamps,
+        # stranding the tail slots (post-eval full-pool leak).
         extra = max(
             extra,
             get_alloc_reserve_per_decode(server_args) + server_args.page_size - 1,

--- a/python/sglang/srt/speculative/dflash_info_v2.py
+++ b/python/sglang/srt/speculative/dflash_info_v2.py
@@ -144,6 +144,7 @@ class DFlashDraftInputV2(SpecInput):
         committed_seq_lens_sum = 0
         reserved_seq_lens_sum = 0
         num_needed_tokens = 0
+        max_reserved_len = 0
         max_top_k = 1
         uniform_top_k_value = None
         uniform_top_k = True
@@ -152,6 +153,8 @@ class DFlashDraftInputV2(SpecInput):
             # Read the allocation watermark from the req object like EAGLE.
             cur_alloc_len = int(req.kv.kv_allocated_len)
             reserved_len = max(cur_alloc_len, committed_len + 2 * block_size)
+            if reserved_len > max_reserved_len:
+                max_reserved_len = reserved_len
             top_k = int(req.sampling_params.top_k)
 
             batch_seq_lens_cpu_t[i] = committed_len
@@ -168,6 +171,14 @@ class DFlashDraftInputV2(SpecInput):
                 uniform_top_k_value = top_k
             elif uniform_top_k and top_k != uniform_top_k_value:
                 uniform_top_k = False
+
+        row_width = batch.req_to_token_pool.req_to_token.shape[1]
+        assert max_reserved_len <= row_width, (
+            f"DFLASH decode reserve ({max_reserved_len}) exceeds the req_to_token "
+            f"row width ({row_width}); the row write would spill into the neighbor "
+            f"row and the release slice would clamp, stranding KV slots. Widen the "
+            f"row via get_req_to_token_extra_context_len."
+        )
 
         self.max_top_k = max(max_top_k, 1)
         self.uniform_top_k_value = uniform_top_k_value if uniform_top_k else None

--- a/test/registered/unit/mem_cache/test_allocation_sizing.py
+++ b/test/registered/unit/mem_cache/test_allocation_sizing.py
@@ -1,0 +1,60 @@
+"""Unit tests for srt/mem_cache/allocation_sizing."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.mem_cache.allocation_sizing import (
+    get_alloc_reserve_per_decode,
+    get_req_to_token_extra_context_len,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _spec_args(*, page_size, num_draft_tokens, num_steps=None, topk=1):
+    return SimpleNamespace(
+        speculative_algorithm="DSPARK",
+        speculative_num_steps=num_steps,
+        speculative_eagle_topk=topk,
+        max_speculative_num_draft_tokens=num_draft_tokens,
+        page_size=page_size,
+    )
+
+
+class TestReqToTokenRowHeadroom(CustomTestCase):
+    def test_row_headroom_covers_decode_reserve_at_page_size_1(self):
+        """Spec v2 reserves committed + 2*draft_tokens per decode step, so the
+        req_to_token row must hold that watermark near the context limit.
+        Regression: the reserve-sized headroom was gated on page_size > 1, so
+        at page_size=1 a request generating to the context boundary made the
+        row write spill into the neighbor row and the release slice clamp,
+        stranding full-pool slots (post-eval leak on DSPARK, gamma=16)."""
+        args = _spec_args(page_size=1, num_draft_tokens=17)
+        self.assertGreaterEqual(
+            get_req_to_token_extra_context_len(args),
+            get_alloc_reserve_per_decode(args),
+        )
+
+    def test_row_headroom_covers_aligned_reserve_at_page_size_gt_1(self):
+        # Paged reserve overshoots by up to page_size - 1 after alignment.
+        args = _spec_args(page_size=64, num_draft_tokens=17)
+        self.assertGreaterEqual(
+            get_req_to_token_extra_context_len(args),
+            get_alloc_reserve_per_decode(args) + args.page_size - 1,
+        )
+
+    def test_non_spec_headroom_unchanged(self):
+        args = SimpleNamespace(
+            speculative_algorithm=None,
+            speculative_num_steps=None,
+            speculative_eagle_topk=None,
+            max_speculative_num_draft_tokens=None,
+            page_size=1,
+        )
+        self.assertEqual(get_req_to_token_extra_context_len(args), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #33579.

DFLASH-family spec v2 (including DSPARK) reserves `committed + 2 * num_draft_tokens` KV slots per request at every decode step (`DFlashDraftInputV2.prepare_for_decode`), but `get_req_to_token_extra_context_len` only sizes the `req_to_token` row for that reserve when `page_size > 1`. At `page_size = 1` (DSPARK's default) the row is `context_len + 4 + num_draft_tokens` wide — with gamma=16 that is headroom **21** vs reserve **34**.

When a request generates to the context boundary, the reserve exceeds the row width: the row write spills into the neighbor request's row, and the release slice `req_to_token[req_idx][start:end]` silently clamps at the row end, permanently stranding the spilled slots (11–27 per boundary-hitting request). A long run whose samples get length-truncated at the context limit then dies later on the idle self-check with `token_to_kv_pool_allocator memory leak detected!`.

The `page_size > 1` gate is wrong: the `2 * num_draft_tokens` double-buffer reserve applies at every page size; only the `page_size - 1` alignment overshoot is page>1-specific. EAGLE already has both the reserve-sized headroom and a fail-fast row-width assert (`eagle_utils.py:924`); DFLASH v2 had neither at `page_size = 1`.

## Modifications

- `allocation_sizing.get_req_to_token_extra_context_len`: drop the `page_size > 1` gate — always size the row headroom to `max(4 + num_draft_tokens, reserve + page_size - 1)` under spec decoding.
- `dflash_info_v2.DFlashDraftInputV2.prepare_for_decode`: fail-fast assert `max(reserved_len) <= row_width`, mirroring the EAGLE guard, so a future sizing regression crashes at the faulting step instead of silently corrupting the KV pool.
- New CPU CI test `test/registered/unit/mem_cache/test_allocation_sizing.py` (registered in `base-a-test-cpu`): page1 headroom covers the reserve (fails on main with `21 not greater than or equal to 34`, passes with this fix), page>1 covers the aligned reserve, non-spec headroom unchanged (4).

## Verification

- Unit: the new test is RED on current main (`95d0e57e83`) and GREEN with this PR; `pre-commit` passes on the changed files.
- Boundary repro A/B on 4x B200 (DFLASH-family target + DSPARK draft, gamma=16, `--context-length 8192`, `SGLANG_CHECK_KV_PAGE_INVARIANTS=1`, `SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY=1`, 8 concurrent requests decoding to the boundary):
  - pre-fix: all TP schedulers crash with `invariant_checker._add_owner: assert 0 <= committed <= allocated <= row_width` — the row-overflow signature;
  - post-fix: two full rounds, all requests reach the boundary (`finish_reason=length`), zero assertions, zero leak reports, inter-round idle checks green.
- Production shape (same hardware, original serve flags, `--max-total-tokens 1048576`): `sgl-eval run gsm8k` FULL 1319 at temp 1.0 / top_p 0.95 — score 96.7 (matches the pre-fix baseline 96.66), stop_rate 100%, truncated/error 0%; server healthy and leak-free after 30s+ idle, where the pre-fix build previously died on the idle self-check.

## Checklist

- [x] Format your code with `pre-commit run --all-files` on the changed files.
- [x] Add unit tests as outlined in the test registration doc.
- [x] Update documentation / docstrings as needed.
- [x] Provide throughput / accuracy verification results as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30933580337](https://github.com/sgl-project/sglang/actions/runs/30933580337)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30933743506](https://github.com/sgl-project/sglang/actions/runs/30933743506)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->