### PR TITLE
Fix DSPARK weight loading with RunAI streamer

### DIFF
--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -403,57 +403,56 @@ class DSparkDraftMixin:
         return base_logits, None
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
-        markov_weights = []
-        confidence_weights = []
-        backbone_weights = []
         params_dict = dict(self.named_parameters())
-        for name, loaded_weight in weights:
-            if any(name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES):
-                continue
-            if name.startswith("confidence_head."):
-                if self.confidence_head is None:
+        loaded_confidence_names = set()
+
+        def backbone_weights():
+            for name, loaded_weight in weights:
+                if any(name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES):
                     continue
-                confidence_weights.append((name, loaded_weight))
-            elif name.startswith("markov_head."):
-                markov_weights.append((name, loaded_weight))
-            else:
-                backbone_weights.append((name, loaded_weight))
+                if name.startswith("confidence_head."):
+                    if self.confidence_head is None:
+                        continue
+                    if name not in params_dict:
+                        raise ValueError(
+                            f"DSpark unexpected confidence weight {name!r} not "
+                            "found in model parameters."
+                        )
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                    loaded_confidence_names.add(name)
+                elif name.startswith("markov_head."):
+                    if name not in params_dict:
+                        raise ValueError(
+                            f"DSpark unexpected markov weight {name!r} not found "
+                            "in model parameters (known markov params require a "
+                            f"{type(self.markov_head).__name__} head)."
+                        )
+                    param = params_dict[name]
+                    weight_loader = getattr(
+                        param, "weight_loader", default_weight_loader
+                    )
+                    weight_loader(param, loaded_weight)
+                else:
+                    yield name, loaded_weight
 
-        super().load_weights(backbone_weights)
+        super().load_weights(backbone_weights())
 
-        for name, loaded_weight in markov_weights:
-            if name not in params_dict:
-                raise ValueError(
-                    f"DSpark unexpected markov weight {name!r} not found in model "
-                    f"parameters (known markov params require a {type(self.markov_head).__name__} head)."
-                )
-            param = params_dict[name]
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
-
-        self._load_confidence_weights(
-            confidence_weights=confidence_weights, params_dict=params_dict
+        self._assert_confidence_head_loaded(
+            loaded_names=loaded_confidence_names, params_dict=params_dict
         )
 
-    def _load_confidence_weights(
+    def _assert_confidence_head_loaded(
         self,
         *,
-        confidence_weights: list,
+        loaded_names: set,
         params_dict: dict,
     ) -> None:
         if self.confidence_head is None:
             return
-        loaded_names = set()
-        for name, loaded_weight in confidence_weights:
-            if name not in params_dict:
-                raise ValueError(
-                    f"DSpark unexpected confidence weight {name!r} not found in "
-                    "model parameters."
-                )
-            param = params_dict[name]
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
-            loaded_names.add(name)
 
         confidence_param_names = {
             name for name in params_dict if name.startswith("confidence_head.")

--- a/test/registered/spec/dspark/test_dspark_weight_loading.py
+++ b/test/registered/spec/dspark/test_dspark_weight_loading.py
@@ -1,0 +1,62 @@
+import unittest
+
+import torch
+
+from sglang.srt.model_loader.weight_utils import RUNAI_STREAMER_TENSOR_ATTR
+from sglang.srt.models.dspark import DSparkDraftMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _Backbone(torch.nn.Module):
+    def load_weights(self, weights):
+        params = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            params[name].data.copy_(loaded_weight)
+
+
+class _DraftLoadHarness(DSparkDraftMixin, _Backbone):
+    def __init__(self):
+        torch.nn.Module.__init__(self)
+        self.backbone = torch.nn.Linear(1, 1, bias=False)
+        self.markov_head = torch.nn.Linear(1, 1, bias=False)
+        self.confidence_head = torch.nn.Linear(1, 1, bias=False)
+
+
+class TestDSparkWeightLoading(CustomTestCase):
+    def test_streams_weights_before_buffer_reuse(self):
+        shared_buffer = torch.tensor([[1.0]])
+
+        def weights():
+            for name, value in (
+                ("markov_head.weight", 1.0),
+                ("backbone.weight", 2.0),
+                ("confidence_head.weight", 3.0),
+            ):
+                shared_buffer.fill_(value)
+                view = shared_buffer[:]
+                setattr(view, RUNAI_STREAMER_TENSOR_ATTR, True)
+                yield name, view
+
+        model = _DraftLoadHarness()
+        model.load_weights(weights())
+
+        self.assertEqual(model.markov_head.weight.item(), 1.0)
+        self.assertEqual(model.backbone.weight.item(), 2.0)
+        self.assertEqual(model.confidence_head.weight.item(), 3.0)
+
+    def test_missing_confidence_weight_still_errors(self):
+        model = _DraftLoadHarness()
+        weights = [
+            ("markov_head.weight", torch.tensor([[1.0]])),
+            ("backbone.weight", torch.tensor([[2.0]])),
+        ]
+
+        with self.assertRaisesRegex(ValueError, "checkpoint is missing"):
+            model.load_weights(weights)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

RunAI-streamed tensors can be zero-copy views into a reused staging buffer, so loaders must consume them before advancing the iterator. Target-only model loading already does this: target loaders copy each yielded tensor inline, `should_async_load()` forces RunAI-tagged views to be consumed synchronously, and target paths that intentionally retain paired tensors clone them first.

DSPARK was different. `DSparkDraftMixin.load_weights()` first materialized the entire iterator into `backbone_weights`, `markov_weights`, and `confidence_weights`, then loaded those lists after the iterator was exhausted. With distributed RunAI streaming, later batches reused the backing storage retained by earlier entries. The server started successfully, but the draft weights were corrupted and Kimi-K3 DSPARK acceptance length stayed at 1.00 (zero extra accepted draft tokens).

## Summary

- Consume Markov and confidence-head weights immediately while their streamed views are valid.
- Yield backbone weights directly into the existing DFlash loader so it also consumes each tensor before the iterator advances.
- Preserve unexpected-weight and missing-confidence-head validation.
- Add a regression test that reuses one backing buffer across Markov, backbone, and confidence weights.

## Details

This keeps loading streaming end to end instead of fixing correctness by cloning the full draft checkpoint. It therefore avoids adding checkpoint-sized temporary memory while retaining the existing behavior for ordinary file-backed safetensors.

The regression test demonstrates the original failure mode: before this change, the Markov parameter observes the last value written into the shared buffer (`3.0`) instead of its value at yield time (`1.0`). The new loading order preserves all three values.

## Test

- BJ SGLang container CPU regression: 2 tests passed.
- Confirmed the regression test fails against the old loader (`3.0 != 1.0`).
- Kimi-K3 TP32/EP32, 32 H200 GPUs, batch 8, 8K input / 1K output:
  - local safetensors draft: acceptance length 7.03
  - direct S3 distributed RunAI before fix: acceptance length 1.00
  - direct S3 non-distributed RunAI: acceptance length 6.98
  - direct S3 distributed RunAI after fix: acceptance length 6.98
- Black 26.1.0, isort 7.0.0, Ruff 0.15.1, registered-test registry check, and `git diff --check` passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30936901586](https://github.com/sgl-project/sglang/actions/runs/30936901586)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30936901316](https://github.com/sgl-project/sglang/actions/runs/30936901316)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->