### PR TITLE
[diffusion] fix: stop silently dropping weights in update_weights_fro…

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -287,6 +287,19 @@ class LayerwiseOffloadManager:
         """Leading layers currently held across denoise steps; 0 until armed."""
         return self.resident_layers if self._residency_active else 0
 
+    @property
+    def resident_bytes(self) -> int:
+        """Total bytes held in this manager's CPU buffers.
+
+        The cost of materialising this manager's layers onto the device.
+        """
+        return sum(
+            tensor.numel() * tensor.element_size()
+            for storage in (self._consolidated_cpu_weights, self._strided_cpu_weights)
+            for per_layer in storage.values()
+            for tensor in per_layer.values()
+        )
+
     @torch.compiler.disable
     def _activate_residency(self) -> None:
         """Arm the resident set on the first denoise forward. The pinning itself is

--- a/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
@@ -48,6 +48,7 @@ from torch.distributed.tensor import DTensor, distribute_tensor
 
 from sglang.multimodal_gen.runtime.cache.teacache import TeaCacheMixin
 from sglang.multimodal_gen.runtime.loader.utils import (
+    BYTES_PER_GB,
     _list_safetensors_files,
     get_param_names_mapping,
 )
@@ -57,8 +58,10 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import (
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     is_layerwise_offloaded_module,
 )
+from sglang.multimodal_gen.runtime.models.encoders.base import TextEncoder
 from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import DiffusersPipeline
 from sglang.multimodal_gen.runtime.pipelines_core.lora_pipeline import LoRAPipeline
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.weight_sync.tensor_bucket import (
@@ -70,6 +73,11 @@ logger = init_logger(__name__)
 _DEFAULT_TENSOR_TARGET_MODULE = "transformer"
 LORA_MERGE_WEIGHT_UPDATE_MODE = "lora_merge"
 _LORA_IPC_TARGET_MODULES = frozenset({"transformer", "transformer_2"})
+# Materialising an offloaded module for a weight update makes its full weights
+# resident. Require headroom beyond the raw size: free memory is not necessarily
+# allocatable as one contiguous block. Both values are heuristics.
+_MATERIALIZE_VRAM_MARGIN = 1.2
+_MATERIALIZE_VRAM_FLOOR_GB = 1.0
 
 
 def _get_lora_layer_dict(
@@ -164,11 +172,47 @@ def _validate_weight_files(
     return weights_map, missing
 
 
-def _load_weights_into_module(module: torch.nn.Module, weights_iter) -> None:
-    """Load weights into a module, handling offload-managed parameters.
+def _load_weights_into_module(module: torch.nn.Module, weights_iter) -> set[str]:
+    """
+    Load weights into a module in place, dispatching on how that module stores them.
 
-    For offloaded modules, updates CPU buffers directly via
-    update_cpu_weights(); non-offloaded parameters use in-place copy.
+    Three paths, and the order of the checks matters: an offloaded text encoder satisfies
+    more than one condition, so the offload test must come first.
+
+    1. Offloaded modules -> write into the offload manager's consolidated CPU buffers via
+       update_cpu_weights(); anything the manager does not claim falls back to in-place copy.
+    2. TextEncoder (not offloaded, no DTensor parameters) -> delegate to the module's own
+       load_weights().
+    3. Everything else -> name mapping followed by in-place copy.
+
+    Buffers are included alongside parameters because module state such as BatchNorm running
+    statistics is stored on disk but absent from named_parameters(). For the FLUX.2 VAE the
+    BatchNorm is affine=False, so those buffers are the layer's entire state, and they set the
+    scale/shift applied to every decode.
+
+    Why TextEncoder delegates: each encoder owns quirks the generic path knows nothing about --
+    stripping a "model." prefix, per-model renames, and stacked_params_mapping fusion.  Those
+    differ per model and cannot be centralised.
+
+    Why that branch receives the RAW iterator: _iter_module_weight_updates is deliberately NOT
+    hoisted above the dispatch, even though it appears in two branches. load_weights needs the
+    original checkpoint names -- the fusion mapping is many-to-one (q_proj/k_proj/v_proj ->
+    qkv_proj), so shard_id is derived from which original name matched. Rename first and that
+    information is unrecoverable.
+
+    Why an offloaded text encoder is materialised instead: under offload the parameters are
+    torch.empty((1,)) placeholders, so load_weights has nothing real to write into, and the
+    offload path cannot fuse (it copies flattened tensors into fixed byte ranges).
+    disable_offload() restores real parameters, and enable_offload() syncs them back to the CPU
+    buffers. Same mechanism the LoRA IPC path already uses via LoRAPipeline._temporarily_disable_offload.
+
+    Why DTensor parameters are excluded: load_weights predates sharding. At startup it runs
+    before shard_model(), so it never meets a DTensor and has no branch for one; calling it on
+    an FSDP-wrapped module raises "got mixed torch.Tensor and DTensor". Those modules fall to
+    the generic path, which handles DTensor explicitly.
+
+    Note that _rollback() calls this function too, so a failure here raises again during
+    rollback -- and rollback failures propagate by design, turning a recoverable 400 into a 500.
 
     The in-place copies below (param.data.copy_, DTensor _local_tensor.copy_,
     and the offload manager's CPU-buffer copies) mutate tensors that were
@@ -181,26 +225,99 @@ def _load_weights_into_module(module: torch.nn.Module, weights_iter) -> None:
     and returns an HTTP error.
     """
     with torch.inference_mode():
-        model_params = dict(module.named_parameters())
-        weights_iter = _iter_module_weight_updates(module, weights_iter, model_params)
-
-        offload_managers: list = []
-        if is_layerwise_offloaded_module(module):
-            offload_managers = [
-                m for m in module.layerwise_offload_managers if m.enabled
-            ]
-
-        if offload_managers:
-            weight_dict = dict(weights_iter)
-            offloaded_names: set[str] = set()
-            for manager in offload_managers:
-                offloaded_names.update(manager.update_cpu_weights(weight_dict))
-            remaining = (
-                (n, w) for n, w in weight_dict.items() if n not in offloaded_names
+        should_disable_offload = (
+            is_layerwise_offloaded_module(module)
+            and isinstance(module, TextEncoder)
+            and _can_materialize_module(module)
+        )
+        updated_weights: set[str] = set()
+        if should_disable_offload:
+            module.disable_offload()
+        try:
+            model_params = dict(module.named_parameters())
+            named_buffers = dict(module.named_buffers())
+            target_tensors = model_params | named_buffers
+            offload_managers: list = []
+            has_distributed_params = any(
+                isinstance(p, DTensor) for p in model_params.values()
             )
-            load_weights_into_model(remaining, model_params)
-        else:
-            load_weights_into_model(weights_iter, model_params)
+            if is_layerwise_offloaded_module(module):
+                offload_managers = [
+                    m for m in module.layerwise_offload_managers if m.enabled
+                ]
+            if offload_managers:
+                # Not hoisted above the dispatch on purpose: the TextEncoder branch
+                # below needs the unmapped checkpoint names.
+                weights_iter = _iter_module_weight_updates(
+                    module, weights_iter, target_tensors
+                )
+                weight_dict = dict(weights_iter)
+                offloaded_names: set[str] = set()
+                for manager in offload_managers:
+                    offloaded_names.update(manager.update_cpu_weights(weight_dict))
+                remaining = (
+                    (n, w) for n, w in weight_dict.items() if n not in offloaded_names
+                )
+                updated_weights.update(offloaded_names)
+                updated_weights.update(
+                    load_weights_into_model(remaining, target_tensors)
+                )
+            # TODO(firefly-silvers): FSDP-wrapped text encoders are excluded here and fall
+            # through to the generic path, which cannot strip the "model." prefix or fuse
+            # q/k/v. So their weights are NOT updated (silently, until the completeness
+            # check lands). load_weights() runs before shard_model() at startup, so it has
+            # no DTensor branch and raises "got mixed torch.Tensor and DTensor" if called.
+            # A fix needs either DTensor handling inside the per-model load_weights(), or
+            # the fsdp_load.py pattern: run the weight loader into a plain temp tensor,
+            # then distribute_tensor() the result. An offloaded and sharded encoder is
+            # materialised above and then lands here too, doing no useful work. See #31924.
+            elif isinstance(module, TextEncoder) and not has_distributed_params:
+                updated_weights.update(module.load_weights(weights_iter))
+            else:
+                # See the note above: kept per-branch so the TextEncoder path stays raw.
+                weights_iter = _iter_module_weight_updates(
+                    module, weights_iter, target_tensors
+                )
+                updated_weights.update(
+                    load_weights_into_model(weights_iter, target_tensors)
+                )
+        finally:
+            # enable_offload() syncs GPU state back into the CPU buffers before
+            # re-placeholdering. Without it the update above is silently discarded.
+            if should_disable_offload:
+                module.enable_offload()
+        return updated_weights
+
+
+def _offloaded_weight_bytes(module: torch.nn.Module) -> int:
+    return sum(
+        manager.resident_bytes
+        for manager in module.layerwise_offload_managers
+        if manager.enabled
+    )
+
+
+def _can_materialize_module(module: torch.nn.Module) -> bool:
+    """Whether this module's offloaded weights fit in free VRAM with headroom."""
+    required_gb = _offloaded_weight_bytes(module) / BYTES_PER_GB
+    needed_gb = max(
+        required_gb * _MATERIALIZE_VRAM_MARGIN,
+        required_gb + _MATERIALIZE_VRAM_FLOOR_GB,
+    )
+    available_gb = current_platform.get_available_gpu_memory()
+    if available_gb < needed_gb:
+        logger.warning(
+            "Not materialising %s for weight update: needs %.2f GB (%.2f GB weights "
+            "plus headroom), only %.2f GB free. Falling back to the offload path, "
+            "which cannot strip prefixes or fuse names -- this module's weights will "
+            "be skipped.",
+            type(module).__name__,
+            needed_gb,
+            required_gb,
+            available_gb,
+        )
+        return False
+    return True
 
 
 def _build_module_weight_name_mapper(module: torch.nn.Module):
@@ -258,18 +375,18 @@ def _resolve_lora_ipc_layer_dict_key(
 def _iter_module_weight_updates(
     module: torch.nn.Module,
     weights_iter,
-    model_params: dict,
+    target_tensors: dict,
 ):
     map_name = _build_module_weight_name_mapper(module)
     module_name = type(module).__name__
 
     for name, loaded_weight in weights_iter:
-        if name in model_params:
+        if name in target_tensors:
             yield name, loaded_weight
             continue
 
         mapped_name = map_name(name) if map_name is not None else name
-        if mapped_name in model_params:
+        if mapped_name in target_tensors:
             yield mapped_name, loaded_weight
             continue
 
@@ -282,17 +399,19 @@ def _iter_module_weight_updates(
 
 
 def load_weights_into_model(
-    weights_iter, model_params: dict, module_name: str | None = None
-) -> None:
-    """Copy weights from weights_iter into model_params in-place."""
+    weights_iter, target_tensors: dict, module_name: str | None = None
+) -> set[str]:
+    """Copy weights from weights_iter into target_tensors in-place."""
+    updated_weights: set[str] = set()
     for name, loaded_weight in weights_iter:
-        if name not in model_params:
+        if name not in target_tensors:
             logger.warning("Skipping weight update: parameter %r not found", name)
             continue
-        param = model_params[name]
+        param = target_tensors[name]
         weight_loader = getattr(param, "weight_loader", None)
         if callable(weight_loader):
             weight_loader(param, loaded_weight.to(param.dtype))
+            updated_weights.add(name)
         else:
             dtensor_param = param if isinstance(param, DTensor) else None
             if dtensor_param is None and isinstance(
@@ -315,6 +434,8 @@ def load_weights_into_model(
                         f"model={param.shape}, loaded={loaded_weight.shape}"
                     )
                 param.data.copy_(loaded_weight.to(param.dtype))
+            updated_weights.add(name)
+    return updated_weights
 
 
 class WeightsUpdater:
@@ -426,15 +547,17 @@ class WeightsUpdater:
         weights_map: dict[str, str],
     ) -> tuple[bool, str]:
         """Load weights into each module; rollback on first failure."""
-        updated_modules: list[str] = []
+        updated_modules: dict[str, int] = {}
 
         for module_name, module in modules_to_update:
             try:
                 weights_iter = _get_weights_iter(weights_map[module_name])
-                _load_weights_into_module(module, weights_iter)
-                updated_modules.append(module_name)
+                loaded_weights = _load_weights_into_module(module, weights_iter)
+                if len(loaded_weights) == 0:
+                    logger.warning(f"0 weights loaded for module {module_name}")
+                updated_modules[module_name] = len(loaded_weights)
             except Exception as e:
-                rollback_list = updated_modules + [module_name]
+                rollback_list = list(updated_modules) + [module_name]
                 logger.error(
                     f"Weight update failed for module '{module_name}': {e}. "
                     f"Rolling back {len(rollback_list)} module(s) "
@@ -448,8 +571,10 @@ class WeightsUpdater:
                     f"All modules rolled back to original weights."
                 )
 
-        names = ", ".join(updated_modules)
-        return True, f"Updated {len(updated_modules)} modules ({names})."
+        updated_module_name = ", ".join(
+            f"{key}: {value}" for key, value in updated_modules.items()
+        )
+        return True, f"Updated {len(updated_modules)} modules ({updated_module_name})."
 
     def _rollback(self, updated_modules: list[str]) -> None:
         """Restore updated_modules to original weights.

--- a/python/sglang/multimodal_gen/test/unit/test_weights_updater.py
+++ b/python/sglang/multimodal_gen/test/unit/test_weights_updater.py
@@ -1,0 +1,125 @@
+"""Unit tests for the diffusion weight-reload path (issue #31924).
+
+Exercises WeightsUpdater.update_weights_from_disk end to end against fake modules:
+  - buffers (BatchNorm running stats) are loaded alongside parameters
+  - TextEncoder modules are routed to their own load_weights() with UNMAPPED names
+
+The DTensor guard is not covered here: constructing a real DTensor needs a device
+mesh and distributed init. It is covered by the GPU offload test.
+
+CPU-only; no model loading, no distributed init.
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.multimodal_gen.configs.models.encoders.base import TextEncoderConfig
+from sglang.multimodal_gen.runtime.models.encoders.base import TextEncoder
+from sglang.multimodal_gen.runtime.post_training.weights_updater import WeightsUpdater
+
+
+def _write_module_weights(root: Path, module_name: str, tensors: dict) -> None:
+    """Lay out <root>/<module_name>/model.safetensors, as update_weights_from_disk expects."""
+    module_dir = root / module_name
+    module_dir.mkdir(parents=True, exist_ok=True)
+    save_file(tensors, str(module_dir / "model.safetensors"))
+
+
+class FakePipeline:
+    """Minimal stand-in: WeightsUpdater only needs .modules, .model_path, get_module()."""
+
+    def __init__(self, modules: dict):
+        self.modules = modules
+        self.model_path = "unused"
+
+    def get_module(self, name):
+        return self.modules.get(name)
+
+
+class BufferModule(torch.nn.Module):
+    """Plain nn.Module -> takes the generic path. affine=False mirrors the FLUX.2 VAE,
+    so the BatchNorm contributes 3 buffers and 0 parameters."""
+
+    def __init__(self):
+        super().__init__()
+        self.fc = torch.nn.Linear(4, 2)
+        self.bn = torch.nn.BatchNorm1d(2, affine=False, track_running_stats=True)
+
+
+class FakeTextEncoder(TextEncoder):
+    """Records the names it is handed, then loads them the way a real encoder does."""
+
+    def __init__(self):
+        super().__init__(TextEncoderConfig())
+        self.fc = torch.nn.Linear(4, 2)
+        self.received_names: list[str] = []
+
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def load_weights(self, weights):
+        params = dict(self.named_parameters())
+        loaded = set()
+        for name, tensor in weights:
+            self.received_names.append(name)
+            if name.startswith("model."):
+                name = name[len("model.") :]
+            if name in params:
+                params[name].data.copy_(tensor)
+                loaded.add(name)
+        return loaded
+
+
+class TestUpdateWeightsFromDisk(unittest.TestCase):
+    def test_buffers_are_loaded_alongside_parameters(self):
+        module = BufferModule()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_module_weights(
+                root,
+                "vae",
+                {
+                    "fc.weight": torch.ones(2, 4),
+                    "fc.bias": torch.full((2,), 0.5),
+                    "bn.running_mean": torch.tensor([1.0, 2.0]),
+                    "bn.running_var": torch.tensor([0.5, 0.5]),
+                    "bn.num_batches_tracked": torch.tensor(7),
+                },
+            )
+            updater = WeightsUpdater(FakePipeline({"vae": module}))
+            success, message = updater.update_weights_from_disk(str(root))
+
+        self.assertTrue(success)
+        self.assertIn("vae: 5", message)
+        torch.testing.assert_close(module.bn.running_mean, torch.tensor([1.0, 2.0]))
+        self.assertEqual(module.bn.num_batches_tracked, 7)
+
+    def test_text_encoder_receives_unmapped_names(self):
+        module = FakeTextEncoder()
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_module_weights(
+                root,
+                "text_encoder",
+                {
+                    "model.fc.weight": torch.ones(2, 4),  # "model." prefix, as on disk
+                    "model.fc.bias": torch.full((2,), 0.5),
+                },
+            )
+            updater = WeightsUpdater(FakePipeline({"text_encoder": module}))
+            success, message = updater.update_weights_from_disk(str(root))
+        self.assertTrue(success)
+        self.assertIn("text_encoder: 2", message)
+        torch.testing.assert_close(module.fc.bias, torch.full((2,), 0.5))
+        torch.testing.assert_close(module.fc.weight, torch.ones(2, 4))
+        self.assertEqual(
+            sorted(module.received_names), ["model.fc.bias", "model.fc.weight"]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…m_disk

update_weights_from_disk reported success while discarding weights:

  - VAE BatchNorm buffers were never loaded (named_parameters() excludes buffers), leaving stale latent-normalisation statistics that scale every decode
  - text encoders were routed through the generic name-mapping path, which cannot strip their "model." prefix or fuse q/k/v, so no weight loaded
  - the API counted a module as updated if nothing raised, so all of this was invisible

Changes:
  - include named_buffers() alongside named_parameters()
  - route TextEncoder modules to their own load_weights(), materialising layerwise-offloaded encoders first (same mechanism the LoRA IPC path already uses)
  - report per-module loaded counts in the response, and warn on zero

Known limitation: FSDP-sharded text encoders are still skipped -- load_weights runs before shard_model() at startup so it has no DTensor branch. Marked with a TODO; now visible as "text_encoder: 0" instead of silent.

Verified on 1x NVIDIA L4 with FLUX.2-klein-base-4B: silently dropped weights across the 5 tests in test_update_weights_from_disk.py went 2409 -> 398, all tests passing. Two CPU regression tests added, each verified to fail when its fix is reverted.

Partially addresses #31924.

## Motivation

`update_weights_from_disk` returned `success: true` while silently discarding weights. On a single-GPU FLUX.2-klein-base-4B run, the 5 tests in `test_update_weights_from_disk.py` dropped **2409 tensors** and every request still reported success.

This matters because the API exists for RL refit: a training loop can swap in new weights, get a 200 back, and keep serving the old ones. Three independent causes:
1. **VAE buffers were never loaded.** The reload path built its lookup from `named_parameters()`, which excludes buffers. For the FLUX.2 VAE the BatchNorm is `affine=False` (`autoencoder_kl_flux2.py:109`), so `running_mean` / `running_var` are the layer's *entire* state — and they set the scale and shift applied to every decode (`configs/pipeline_configs/flux.py:703-717`). A reloaded VAE kept stale normalisation statistics.

2. **Text encoders loaded nothing at all.** They were routed through the generic name-mapping path, which cannot strip their `model.` prefix or apply `stacked_params_mapping` fusion. Startup does both inside the encoder's own `load_weights` (`encoders/qwen3.py:431,467`); the reload path never called it, so all 398 tensors missed.

3. **Nothing counted what landed.** `_apply_weights` marked a module updated if no exception was raised, so 1 and 2 were invisible. Startup already rejects this — it compares `weights_to_load - loaded_weights` and refuses to continue with uninitialised weights (`text_encoder_loader.py:460-467`). Reload never got the same treatment.

Partially addresses #31924. See the note at the bottom on that issue's headline symptom.

## Modifications

- **Include buffers.** `_load_weights_into_module` now builds its lookup from `named_parameters()` **and** `named_buffers()`.

- **Dispatch text encoders to their own loader.** Three-way branch, offload checked first (an offloaded text encoder satisfies more than one condition). Layerwise-offloaded encoders are materialised via `disable_offload()` / `enable_offload()` first, since `load_weights` cannot write into `torch.empty((1,))` placeholders. That is the same mechanism the LoRA IPC path already uses (`weights_updater.py:631` → `lora_pipeline.py:208-219`), applied to a ~1 GB encoder rather than the 7.8 GB DiT.

- **Guard the materialisation on free VRAM.** Materialising is not free: measured at **7.32 GB** for the FLUX.2-klein text encoder, against **8.27 GB** free at that point on a 24 GB L4 (the DiT and VAE are already resident). Without a guard this could OOM on a tighter card or a larger encoder. `_can_materialize_module` compares the module's offloaded byte total against available memory and, if it will not fit, **falls back to the existing offload path** — the module is skipped exactly as it is today, and reports `0` so the skip stays visible. Never worse than current behaviour.

- **`LayerwiseOffloadManager.resident_bytes` property** (`layerwise_offload.py`). Sums both CPU storages — the consolidated per-dtype buffers and the strided tensors used for layout-sensitive (quantized) weights. No behaviour change; added so the size calculation lives with the storage it describes rather than reaching into the manager's internals from `weights_updater`. Summing over `named_parameters()` would report almost nothing, since those are `(1,)` placeholders under offload.

- **Report what landed.** `_load_weights_into_module` and `load_weights_into_model` return the names they applied; the response message now carries per-module counts, and a zero count logs a warning:
  ```
  Updated 3 modules (text_encoder: 290, transformer: 169, vae: 251).
  ```
**Blast radius.** The transformer path is unchanged — it is the one path that already worked. `update_weights_from_tensor` (the RL tensor-IPC entry point, which defaults to `transformer` only) is untouched. The two modules this changes were 100% broken before, so there is nothing to regress.

**On the guard's constants.** `_MATERIALIZE_VRAM_MARGIN = 1.2` and a 1 GB floor are heuristics. They are grounded in one measurement: `resident_bytes` reports 6.77 GB while the observed VRAM delta was 7.32 GB — an ~8% underestimate, presumably allocator block rounding — so a margin is needed, and 1.2× covers it with ~0.8 GB to spare. Happy to take different values, or a different signal entirely, if there is an established convention here I have missed.

**Known limitation.** FSDP-sharded text encoders are still skipped. `load_weights` runs before `shard_model()` at startup, so it has no DTensor branch and raises `aten.copy_.default got mixed torch.Tensor and DTensor` if called on one. Those modules are excluded by an explicit guard and fall back to the generic path. Marked with a `TODO` and left for a follow-up - closing it needs either DTensor handling inside each model's `load_weights`, or the `fsdp_load.py` pattern (weight loader into a plain temp tensor, then `distribute_tensor`), and no `unshard`/`reshard` precedent exists in `multimodal_gen` today. Thanks to the per-module counts it is no longer silent — it surfaces as `text_encoder: 0`.

## Accuracy Tests

`test_update_weights_from_disk.py`, 1×NVIDIA L4, `FLUX.2-klein-base-4B`, all 5 tests passing before and after (the tests never caught this — they only assert the transformer checksum).

Silently dropped weights across the suite:

| module | before | after |
|---|---|---|
| `Qwen3ForCausalLM` (text encoder) | 1990 | **0** |
| `AutoencoderKLFlux2` (vae) | 21 | **0** |
| `Flux2Transformer2DModel` | 0 | 0 |
| `FSDPQwen3ForCausalLM` | 398 | 398 (known limitation) |
| **total** | **2409** | **398** |

Per-module counts now reported, cross-checked against the checkpoints: transformer 169 = the checkpoint's 169 tensors; vae 251 = 248 parameters + 3 BatchNorm buffers; text_encoder 290 = its parameter count after q/k/v and gate/up fusion.

Two CPU unit tests added (`test/unit/test_weights_updater.py`), exercising `update_weights_from_disk` end to end against fake modules. **Each was verified to fail when its own fix is reverted, and only its own** — reverting the buffer union fails the buffer test alone (`vae: 2`, not 5); reverting the text-encoder branch fails that test alone (`text_encoder: 0`, not 2), which is the same signature as the production bug.

Verified at single-GPU only. Tensor-parallel and multi-GPU FSDP sharding of the text encoder are not exercised by this setup.

## Speed Tests and Profiling

No inference-path change; the modified code runs only during `update_weights_from_disk`, which is serialised by the scheduler and never concurrent with generation.

Two reload-path costs, both bounded:

1. **Materialising an offloaded text encoder** temporarily makes its weights GPU-resident - measured at **7.32 GB** for FLUX.2-klein — for the duration of the update, then re-offloads in a `finally`. This is now guarded on free VRAM (see Modifications); if it will not fit, the update falls back rather than risking an OOM. For reference, the existing LoRA IPC path performs the same materialisation on the 7.8 GB DiT without a guard.

2. **The free-memory query calls `torch.cuda.empty_cache()`** (the default for `current_platform.get_available_gpu_memory`). That releases cached blocks back to the driver, so the subsequent materialisation allocates through `cudaMalloc` rather than reusing the caching allocator. It runs once per offloaded-text-encoder update - roughly 6–7 times across the test suite. I kept it because passing `empty_cache=False` underreports free memory (cached blocks look occupied), and the guard already approves with only ~0.15 GB of slack on this setup; a pessimistic reading would make it reject when it should not. Open to the opposite trade-off if reviewers prefer it.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- no user-facing docs cover this API's response format -->
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---

**On #31924's headline symptom.** That issue reports a shape-mismatch 400 on the *transformer*. I could not reproduce it: all 5 tests pass on NVIDIA L4 at commit `b61cb5f9de`, on a `weights_updater.py` unchanged since #31263 — i.e. the same code that failed on AMD. The transformer had zero skips, because that checkpoint's 169 tensors already use sglang's parameter names, so `param_names_mapping` never runs. Details posted to the issue. This PR therefore fixes the secondary defect and does **not** unblock re-enabling the ROCm skip from #31925.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31022203118](https://github.com/sgl-project/sglang/actions/runs/31022203118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31022203914](https://github.com/sgl-project/sglang/actions/runs/31022203914)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->