### PR TITLE
[ROCm] Support power-of-2 scales in the row-major per-token-group quantizer

### DIFF
--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -165,6 +165,7 @@ def _per_token_group_quant_8bit(
     bit8_max,
     # Meta-parameters
     BLOCK: tl.constexpr,
+    SCALE_UE8M0: tl.constexpr,
 ):
     """A Triton-accelerated function to perform per-token-group quantization on a
     tensor.
@@ -184,6 +185,8 @@ def _per_token_group_quant_8bit(
     # Quant
     _absmax = tl.maximum(tl.max(tl.abs(y)), eps)
     y_s = _absmax / bit8_max
+    if SCALE_UE8M0:
+        y_s = tl.exp2(tl.ceil(tl.log2(tl.abs(y_s))))
     y_s_inv = 1.0 / y_s
     y_q = tl.clamp(y * y_s_inv, bit8_min, bit8_max).to(y_q_ptr.dtype.element_ty)
 
@@ -270,7 +273,7 @@ def _per_token_group_quant_8bit_raw(
     ), "the last dimension of `x` cannot be divisible by `group_size`"
     assert x.is_contiguous(), "`x` is not contiguous"
 
-    if _is_hip:
+    if is_fp8_fnuz():
         if dtype == torch.int8:
             bit8_max = 127.0
         else:
@@ -318,7 +321,6 @@ def _per_token_group_quant_8bit_raw(
             SCALE_UE8M0=scale_ue8m0,
         )
     else:
-        assert not scale_ue8m0
         _per_token_group_quant_8bit[(M,)](
             x,
             x_q,
@@ -331,9 +333,13 @@ def _per_token_group_quant_8bit_raw(
             BLOCK=BLOCK,
             num_warps=num_warps,
             num_stages=num_stages,
+            SCALE_UE8M0=scale_ue8m0,
         )
 
-    if scale_ue8m0:
+    if scale_ue8m0 and column_major_scales:
+        # Only the column-major (DeepGEMM/TMA) layout needs DeepGEMM's packing.
+        # Row-major UE8M0 scales are plain float32 powers of two and are consumed
+        # directly, so this path must stay importable on backends without DeepGEMM.
         from deep_gemm import transform_sf_into_required_layout
 
         x_s = transform_sf_into_required_layout(

--- a/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
+++ b/test/registered/kernels/ops/quantization/test_per_token_group_quant.py
@@ -247,6 +247,44 @@ def test_fp32_scale(dtype, column_major, hidden):
     assert _dequant_rel_err(x_q, x_s, x, G) < 0.05
 
 
+@pytest.mark.parametrize("hidden", [4096, 768, 128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_ue8m0_row_major_fp32_container(dtype, hidden):
+    """Row-major UE8M0: the scale is stored as an fp32 power-of-two value.
+
+    Unlike the column-major path there is no E8M0 packing here -- the allocator
+    returns an fp32 buffer and the kernel writes 2^ceil(log2(amax/FMAX)) into it
+    directly. This is the layout consumed by backends without DeepGEMM (e.g. the
+    AITER blockscale GEMMs on ROCm, which take plain fp32 block scales).
+
+    Power-of-two scales are what make the quantizer reproducible across
+    implementations: independent kernels compute amax/FMAX ~1 ULP apart, but
+    rounding the exponent up maps both to the same value."""
+    torch.manual_seed(3 + (dtype == torch.float16))
+    num_tokens = 128
+    x = torch.randn(num_tokens, hidden, device="cuda", dtype=dtype)
+
+    x_q = torch.zeros_like(x, dtype=fp8_dtype)
+    x_s = _alloc_scale((num_tokens, hidden), column_major=False, scale_ue8m0=True)
+    per_token_group_quant(x, x_q, x_s, G, scale_ue8m0=True)
+    torch.cuda.synchronize()
+
+    # fp32 container, not a packed int32 buffer
+    assert x_s.dtype == torch.float32
+    assert x_s.shape == (num_tokens, hidden // G)
+
+    # every stored scale is an exact power of two
+    finite = x_s[x_s > 0]
+    assert torch.all(torch.exp2(torch.log2(finite).round()) == finite)
+
+    # matches the ue8m0 reference decoded to fp32 (2^(e-127))
+    _, exp_ref = ref_fp8_ue8m0(x, G)
+    scale_ref = torch.exp2(exp_ref.to(torch.float32) - 127.0)
+    torch.testing.assert_close(x_s, scale_ref, rtol=0, atol=0)
+
+    assert _dequant_rel_err(x_q, x_s, x, G) < 0.05
+
+
 @pytest.mark.parametrize("column_major", [False, True])
 def test_int8_scale(column_major):
     """int8 output (row-major / col-major fp32 scale): exact stored scale


### PR DESCRIPTION
## Motivation

`_per_token_group_quant_8bit_raw` asserts `not scale_ue8m0` on the row-major path, so
UE8M0 (power-of-two) activation scales are only reachable via the column-major layout,
which packs scales into int32 and calls `deep_gemm.transform_sf_into_required_layout`.
DeepGEMM isn't available on ROCm, and on non-CUDA backends
`per_token_group_quant_fp8` *is* `_per_token_group_quant_8bit_raw`, so AMD has no way to
get UE8M0 activation scales at all.

The scale allocator already handles the row-major case ("Row-major UE8M0 keeps the scale
as float32 power-of-two values"); only the kernel was missing.

This matters for RL training: TE's blockwise recipe can emit power-of-two scales
(`force_pow_2_scales=True`), but the rollout side on ROCm could only emit continuous fp32,
so the two sides quantized the same tensors differently.

## Modifications

- Add `SCALE_UE8M0` to `_per_token_group_quant_8bit`, using the same
  `exp2(ceil(log2(...)))` rounding as the colmajor kernel. It has to be applied before
  `y_s_inv`, since this kernel scales by reciprocal-multiply rather than division.
- Drop `assert not scale_ue8m0` and forward the flag.
- Gate `transform_sf_into_required_layout` on `column_major_scales`, so the row-major path
  doesn't need DeepGEMM.
- Use `is_fp8_fnuz()` instead of `_is_hip` for the `224.0` cap. 224 is the `e4m3fnuz` max
  and applies to gfx94x; gfx950 uses `e4m3fn` (max 448). Module-level `fp8_max` already
  keys on `is_fp8_fnuz()`. This is a consistency fix, not a precision one — measured
  round-trip error is identical either way.

CUDA path untouched.

## Why gating the transform is safe

The combination it gates out was previously unreachable: `scale_ue8m0=True` with
`column_major_scales=False` hit `assert not scale_ue8m0` and never got to the transform.
So the transform only ever ran with `column_major_scales=True`, and the added condition is
equivalent for all existing inputs. Consistently, every caller that reaches this function
passes either `scale_ue8m0=False` or `DEEPGEMM_SCALE_UE8M0` for both flags
(`fp8_utils.py:537,539` and `:933,935`, `deepseek_v2.py:379,381,388`, `deepep.py:513,518`,
`moe_runner/deep_gemm.py:271,273,313,315`).

## Verification

On MI355X (gfx950, ROCm 7.2): row-major `scale_ue8m0=True` now runs, all scales are exact
powers of two, and `scale_ue8m0=False` output is unchanged. Byte-compared against TE's
`Float8BlockQuantizer(block_scaling_dim=1, force_pow_2_scales=True)` on a 512x4096 bf16
input: 0/2097152 values and 0/16384 scales differ. (TE and Triton land ~1 ULP apart on
`amax / 448`, but rounding the exponent up maps both to the same power of two.)

Adds `test_ue8m0_row_major_fp32_container` over `{bf16, fp16} x {4096, 768, 128}`. The
existing `test_ue8m0_*` cases all hardcode `column_major=True` and the layout-varying ones
pass `scale_ue8m0=False`, so this combination was uncovered. The test also fails without
the `is_fp8_fnuz()` fix (224 vs 448 — an exact factor of 2).

## Checklist

- [x] Verified on AMD gfx950 (MI355X), ROCm 7.2
- [x] CUDA/DeepGEMM path unchanged
- [x] Unit test added
