### PR TITLE
[DCP] Fix a2a backend NCCL crash on eager decode

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1075,8 +1075,9 @@ class GroupCoordinator:
     def _all_to_all_single(self, output: torch.Tensor, input: torch.Tensor) -> None:
         # pynccl path keeps the a2a exchange CUDA-graph-capturable (DCP a2a backend).
         pynccl_comm = self.pynccl_comm
-        if pynccl_comm is not None and not pynccl_comm.disabled:
-            pynccl_comm.all_to_all_single(output, input)
+        if pynccl_comm is not None:
+            with pynccl_comm.change_state(enable=True):
+                pynccl_comm.all_to_all_single(output, input)
         else:
             torch.distributed.all_to_all_single(output, input, group=self.device_group)
 


### PR DESCRIPTION
## What does this PR do?

Fixes Bug 1 from #33577: the a2a DCP backend crashes with `NCCL Error 1: unhandled cuda error` in `pyncclGroupEnd` on eager decode batches where `B > cuda-graph-max-bs-decode`.

## Root cause

`GroupCoordinator._all_to_all_single` did not enable the pynccl comm via `change_state(enable=True)`, so on the eager decode path it silently fell back to `torch.distributed.all_to_all_single`, which crashes on NCCL 2.27.7.

## Fix

Wrap the pynccl `all_to_all_single` call in `change_state(enable=True)` so the eager path actually uses pynccl:

```python
if pynccl_comm is not None:
    with pynccl_comm.change_state(enable=True):
        pynccl_comm.all_to_all_single(output, input)
```

## Reproduction

```
--tp-size 8 --dcp-size 8 --dcp-comm-backend a2a
--attention-backend flashinfer --dtype bfloat16
--kv-cache-dtype fp8_e4m3
--cuda-graph-max-bs-decode 32 --max-running-requests 64
```

64+ concurrent requests previously crashed on the first eager decode batch (`B > 32`); with this fix the server stays up.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31254369450](https://github.com/sgl-project/sglang/actions/runs/31254369450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31254369371](https://github.com/sgl-project/sglang/actions/runs/31254369371)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->