### PR TITLE
[AMD][DI][CI] Stage the MI355X nightly on recipe-derived node counts

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -84,24 +84,36 @@ jobs:
             FILTER_ARG=(--filter "$CONFIGS_FILTER")
           fi
           MATRIX=$(python3 scripts/ci/slurm/generate_matrix.py \
-            scripts/ci/slurm/nightly-configs.yaml --runner mi355x "${FILTER_ARG[@]}")
+            scripts/ci/slurm/nightly-configs.yaml --runner mi355x --with-nodes "${FILTER_ARG[@]}")
           MATRIX="$MATRIX" python3 - <<'PY'
           import json
           import os
 
+          # Size of the amd-sglang partition. salloc takes whole nodes, so a leg
+          # can share the cluster only if two of it fit; anything larger needs
+          # all of it. Bump this if the partition grows.
+          CLUSTER_NODES = 4
+
+          # Stage on the allocation size generate_matrix.py reads out of each
+          # recipe, not on the config name. A name pattern cannot distinguish
+          # 1P1D-with-wide-decode (prefill 1 node + decode 2 nodes = 3) from
+          # plain 1P1D, so it would silently under-size that leg and let the
+          # scheduler co-schedule it -- the exact failure this staging prevents.
           matrix = json.loads(os.environ["MATRIX"])
-          groups = {
-              "matrix-2n": [entry for entry in matrix if "-1p1d" in entry["name"]],
-              "matrix-4n": [
-                  entry for entry in matrix if "-2p1d-ep16" in entry["name"]
-              ],
-          }
-          matched = {entry["name"] for entries in groups.values() for entry in entries}
-          unmatched = [entry["name"] for entry in matrix if entry["name"] not in matched]
-          if unmatched:
+          unsized = [e["name"] for e in matrix if not e.get("nodes")]
+          if unsized:
               raise SystemExit(
-                  "Unrecognized MI355X topology for config(s): " + ", ".join(unmatched)
+                  "Cannot size MI355X allocation for config(s): " + ", ".join(unsized)
               )
+
+          groups = {
+              "matrix-2n": [e for e in matrix if e["nodes"] * 2 <= CLUSTER_NODES],
+              "matrix-4n": [e for e in matrix if e["nodes"] * 2 > CLUSTER_NODES],
+          }
+          for name, entries in groups.items():
+              print(f"{name}: {len(entries)} leg(s)")
+              for entry in entries:
+                  print(f"  - {entry['name']} ({entry['nodes']} nodes)")
 
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:
               for name, entries in groups.items():
@@ -131,6 +143,10 @@ jobs:
       CONFIG_FILE: ${{ matrix.config.config_file }}
       RESULT_FILENAME: mi355x-${{ matrix.config.name }}
       MATRIX_CONFIG_NAME: ${{ matrix.config.name }}
+      # Allocation size this leg was staged for. The launcher derives its own
+      # TOTAL_NODES from the recipe and fails if the two disagree, so the
+      # staging split cannot silently drift from what actually gets allocated.
+      EXPECTED_NODES: ${{ matrix.config.nodes }}
       # NOTE: RUNNER_NAME is a built-in default env var on every runner, so the
       # launch + cleanup steps read it directly. Do NOT set it here from
       # ${{ runner.name }} -- the `runner` context is not available in job-level

--- a/scripts/ci/slurm/generate_matrix.py
+++ b/scripts/ci/slurm/generate_matrix.py
@@ -4,6 +4,13 @@ where each srt-slurm recipe runs its full concurrency sweep as a single Slurm jo
 
 conc-list in the config is documentation only and is not used to split jobs.
 
+With --with-nodes, each entry also carries `nodes`, the size of the Slurm
+allocation the leg will make. The MI355X nightly stages its matrix on that value
+so legs that fit on the cluster side by side run in parallel while legs that
+need the whole cluster run alone. The flag is opt-in so callers that do not
+stage on it (gb200) keep byte-identical output -- matrix values show up in
+GitHub job names, so an extra field would rename their jobs for no reason.
+
 Output: JSON array written to stdout, consumed by the workflow setup job as
 a dynamic matrix via fromJson(needs.setup.outputs.matrix).
 
@@ -14,6 +21,8 @@ Example:
     python3 generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner gb200
     python3 generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner gb200 \\
         --filter dsr1-fp8-1k1k-max-tpt,dsr1-fp4-1k1k-mid-curve
+    python3 generate_matrix.py scripts/ci/slurm/nightly-configs.yaml --runner mi355x \\
+        --with-nodes
 """
 
 import argparse
@@ -22,12 +31,49 @@ import sys
 
 import yaml
 
+# Mirrors ${GPUS_PER_NODE:-8} in launch_mi355x.sh.
+GPUS_PER_NODE = 8
+
+# Node count for a recipe that is not checked into this repo -- the gb200
+# entries point at recipes hosted in NVIDIA/srt-slurm, so their allocation size
+# cannot be read here. Consumers that stage on node count must reject this
+# rather than guess.
+NODES_UNKNOWN = 0
+
 
 def seq_len_str(isl, osl):
     def fmt(n):
         return f"{n // 1024}k" if n % 1024 == 0 else str(n)
 
     return f"{fmt(isl)}{fmt(osl)}"
+
+
+def recipe_nodes(config_file):
+    """Nodes the leg will salloc; mirrors TOTAL_NODES in launch_mi355x.sh.
+
+    An engine whose TP exceeds one node's GPU count spans ceil(TP/GPUS_PER_NODE)
+    nodes, so a role contributes workers * nodes-per-engine. Returns
+    NODES_UNKNOWN when the recipe lives outside this repo. A recipe that IS
+    present but malformed raises, because silently mis-sizing an allocation is
+    worse than a loud failure in the setup job.
+    """
+    try:
+        with open(config_file) as f:
+            recipe = yaml.safe_load(f)
+    except FileNotFoundError:
+        return NODES_UNKNOWN
+
+    resources = recipe.get("resources") or {}
+    backend = recipe["backend"]["sglang_config"]
+
+    def role_nodes(role, workers_key):
+        tp = backend[role]["tensor-parallel-size"]
+        nodes_per_engine = -(-tp // GPUS_PER_NODE)
+        return resources.get(workers_key, 1) * nodes_per_engine
+
+    return role_nodes("prefill", "prefill_workers") + role_nodes(
+        "decode", "decode_workers"
+    )
 
 
 def main():
@@ -44,6 +90,15 @@ def main():
         help=(
             "Optional comma-separated list of matrix entry names to include "
             "(e.g. 'dsr1-fp8-1k1k-max-tpt'). Names must match exactly."
+        ),
+    )
+    parser.add_argument(
+        "--with-nodes",
+        action="store_true",
+        help=(
+            "Add a `nodes` field per entry with the size of the Slurm "
+            "allocation the leg will make. Opt-in so runners that do not stage "
+            "on it keep byte-identical output."
         ),
     )
     args = parser.parse_args()
@@ -64,6 +119,7 @@ def main():
                 config_file = entry["config_file"]
                 topology = config_file.rsplit("/", 1)[-1].replace(".yaml", "")
 
+                extra = {"nodes": recipe_nodes(config_file)} if args.with_nodes else {}
                 matrix.append(
                     {
                         "name": f"{exp['model-prefix']}-{exp['precision']}-{sl}-{topology}",
@@ -75,6 +131,7 @@ def main():
                         "isl": str(isl),
                         "osl": str(osl),
                         "config_file": config_file,
+                        **extra,
                     }
                 )
 

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -1007,6 +1007,19 @@ EXCLUDE_ARG=()
 # original PW+DW (1P1D -> 2 nodes); wide EP16 1P1D gives 2+2 = 4 nodes.
 TOTAL_NODES=$(( PW * PN_PER + DW * DN_PER ))
 
+# generate_matrix.py reads the same recipe fields to size each leg, and the
+# nightly stages on that number -- legs that fit beside another run in parallel,
+# whole-cluster legs run alone. If the two ever disagreed the workflow would
+# co-schedule legs that do not fit and they would sit in salloc until the step
+# timeout, so fail here instead where the reason is obvious.
+if [[ -n "${EXPECTED_NODES:-}" && "$EXPECTED_NODES" != "$TOTAL_NODES" ]]; then
+    echo "ERROR: node count disagrees with the scheduler: workflow staged this leg" \
+         "for $EXPECTED_NODES node(s), recipe needs $TOTAL_NODES (PW=$PW PN_PER=$PN_PER" \
+         "DW=$DW DN_PER=$DN_PER). Keep generate_matrix.py's recipe_nodes() in" \
+         "sync with this formula." >&2
+    exit 1
+fi
+
 # Keep g20 out of a wide engine's root position, where its slower MORI
 # bootstrap can miss the worker-connect timeout.
 if [[ "$MATRIX_CONFIG_NAME" == *-2p1d-ep16* ]]; then


### PR DESCRIPTION
> **Rebased and reduced.** #33774 landed the 2n/4n staging while this PR was open, so everything that overlapped has been dropped. What remains is one differential change: stage on a node count read from the recipe instead of inferred from the config name, plus a guard that keeps the two node formulas from drifting.

## Motivation

#33774 stages the matrix by matching config names:

```python
"matrix-2n": [entry for entry in matrix if "-1p1d" in entry["name"]],
"matrix-4n": [entry for entry in matrix if "-2p1d-ep16" in entry["name"]],
```

That is correct for today's 28 legs. But the name is a proxy for the thing that actually determines schedulability — how many nodes the leg will `salloc` — and the proxy can be wrong in the direction that reintroduces the bug staging exists to prevent.

A 1P1D recipe with a wide decode engine (prefill TP8 on one node, decode TP16 spanning two) allocates **3 nodes**, while its name still contains `-1p1d`. It would be staged as pairable and co-scheduled onto a 4-node partition that cannot hold both legs — the second blocks in `salloc` until the step timeout and reports a benchmark failure for a benchmark that never ran.

In the other direction, a new topology such as `2p2d` matches neither pattern and hard-fails the whole nightly's `setup` job until someone edits the workflow.

## Modifications

**`generate_matrix.py`** emits a `nodes` field per entry, computed from the same recipe fields the launcher uses: `PW * ceil(PTP/8) + DW * ceil(DTP/8)`. Recipes hosted outside this repo (the gb200 entries live in NVIDIA/srt-slurm) report `0`, which the setup job rejects rather than mis-binning.

**`nightly-amd-mi355x-disagg.yml`** stages on that number against the partition size — a leg is pairable when two of it fit — and logs each leg with its node count. The 2n/4n group names, `max-parallel` 2 and 1, the `needs` barrier, and `!cancelled()` are all inherited from #33774 unchanged.

**`launch_mi355x.sh`** fails when `EXPECTED_NODES` disagrees with the `TOTAL_NODES` it derives. There are now two copies of the node formula, and without this they could drift apart silently and reintroduce the co-scheduling bug. The check is inert when the variable is unset, so running the launcher by hand is unaffected.

## Accuracy Tests

N/A — CI scheduling only. No recipe, server arg, or benchmark parameter changes.

## Speed Tests and Profiling

N/A — no inference code touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

### NVIDIA (gb200) path is untouched

`generate_matrix.py` is shared with `nightly-72-gpu-gb200.yml`, so the `nodes` field is opt-in behind `--with-nodes` and only the MI355X workflow passes it. Matrix values appear in GitHub job names, so emitting an extra field unconditionally would have renamed the NVIDIA nightly's jobs for no reason.

Verified: `--runner gb200` output is byte-identical to `main` both with and without a `--filter`, and `--runner mi355x` without the flag is byte-identical too. No NVIDIA file is modified by this PR.
### Verification

**Behaviour preserving.** The node-count classification is byte-identical to #33774's substring classification across all 28 current legs — 18 two-node, 10 four-node, an exact partition with nothing lost or duplicated. The change only alters *how* the group is decided, not which group anything lands in today.

On the hypothetical that motivates it, the two disagree as expected: a `1p1d-ep16` leg needing 3 nodes is staged `2n` by the substring match (wrong — 3 nodes cannot pair on a 4-node cluster) and `4n` by node count.

Both stages carry `EXPECTED_NODES` through the shared YAML anchor, and the shared `steps` body is unchanged. `bash -n` is clean on the launcher.

`actionlint` reports three alias-related errors (`env is alias node but mapping node is expected`, `"steps" section must be sequence node`). These are **pre-existing on `main`** — I ran actionlint against `main` unmodified and got the same three — and they are false positives: I verified on a scratch repo that the GitHub Actions parser does accept YAML anchors and aliases, with an aliased job running and resolving its aliased `env` correctly. Worth knowing if anyone wires actionlint into required CI.

The earlier revision of this PR was validated end-to-end on the cluster ([run 31057329800](https://github.com/sgl-project/sglang/actions/runs/31057329800): a 2-node leg and a 4-node leg both passing with the barrier observed). That run exercised the staging semantics now provided by #33774; this revision changes only the classification input, which is covered by the equivalence check above.
