### PR TITLE
[CI] Extract `download-rust-ext` and give every install step a cache fallback

### DIFF
--- a/.github/actions/download-rust-ext/action.yml
+++ b/.github/actions/download-rust-ext/action.yml
@@ -1,0 +1,78 @@
+name: 'Download prebuilt Rust extensions'
+description: >
+  Put rust-ext-build's PyO3 extension modules in the checkout and set
+  SGLANG_BUILD_RUST_EXTS=none for the rest of the job, so the install step skips
+  the cargo build. Sets nothing when neither source has them, leaving the install
+  to compile as it would have.
+
+inputs:
+  artifact_name:
+    description: >
+      Artifact published by rust-ext-build in this run. Empty goes straight to the
+      cache - the only path open to a workflow_dispatch, which has no producer job
+      of its own.
+    required: false
+    default: ''
+  cache_key_prefix:
+    description: >
+      Must match the prefix _pr-test-rust-ext-build.yml saves under, or every
+      lookup here misses.
+    required: false
+    default: rust-ext-x86_64
+
+outputs:
+  hit:
+    description: >
+      'true' when the modules are in place. Consumers that install a Rust
+      toolchain or warm a cargo cache only to build them can skip that on a hit.
+    value: ${{ steps.decide.outputs.hit }}
+
+runs:
+  using: composite
+  steps:
+    # continue-on-error: the artifact expires in a day, so a later re-run finds
+    # nothing and falls through to the cache below. download-artifact creates
+    # srt/server/, which exists only as build output.
+    - name: Download prebuilt Rust extensions
+      id: artifact
+      if: inputs.artifact_name != ''
+      continue-on-error: true
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: python/sglang/srt/
+
+    # Second, not first: the cache is evictable and this repo sits at its 10 GB
+    # limit, while the artifact is durable for the run that built it. A run reads
+    # its own branch's entries plus the default branch's, so seed-rust-ext-cache.yml
+    # and the branch's own rust-ext-build both reach here - which is what lets a
+    # workflow_dispatch and an expired-artifact re-run avoid compiling.
+    - name: Restore prebuilt Rust extensions from cache
+      id: cache
+      if: steps.artifact.outcome != 'success'
+      uses: actions/cache/restore@v4
+      with:
+        path: python/sglang/srt/*/_core*.so
+        key: ${{ inputs.cache_key_prefix }}-${{ hashFiles('rust/**', 'python/setup.py') }}
+
+    # Job-wide via GITHUB_ENV rather than per-step, so no caller repeats the
+    # condition. Only setup.py reads it, and only while building, so it is inert
+    # once install is done.
+    #
+    # Whether the modules suit this interpreter is not decided here: no crate sets
+    # abi3, so the ABI tag pins both the minor version and the arch, and a
+    # 3.12 or aarch64 pool must still compile. ci_install_dependency.sh's
+    # require_prebuilt_rust_exts checks the restored files against the local
+    # EXT_SUFFIX and clears this back to a source build on a mismatch.
+    - name: Decide whether to skip the cargo build
+      id: decide
+      shell: bash
+      run: |
+        set -uo pipefail
+        if [ "${{ steps.artifact.outcome }}" = "success" ] \
+           || [ "${{ steps.cache.outputs.cache-hit }}" = "true" ]; then
+            echo "hit=true" >> "$GITHUB_OUTPUT"
+            echo "SGLANG_BUILD_RUST_EXTS=none" >> "$GITHUB_ENV"
+        else
+            echo "hit=false" >> "$GITHUB_OUTPUT"
+        fi

--- a/.github/actions/download-rust-ext/action.yml
+++ b/.github/actions/download-rust-ext/action.yml
@@ -1,38 +1,29 @@
 name: 'Download prebuilt Rust extensions'
 description: >
   Put rust-ext-build's PyO3 extension modules in the checkout and set
-  SGLANG_BUILD_RUST_EXTS=none for the rest of the job, so the install step skips
-  the cargo build. Sets nothing when neither source has them, leaving the install
-  to compile as it would have.
+  SGLANG_BUILD_RUST_EXTS=none for the job, so install skips the cargo build.
+  Sets nothing when neither source has them, leaving install to compile.
 
 inputs:
   artifact_name:
-    description: >
-      Artifact published by rust-ext-build in this run. Empty goes straight to the
-      cache - the only path open to a workflow_dispatch, which has no producer job
-      of its own.
+    description: "rust-ext-build's artifact in this run; empty uses only the cache."
     required: false
     default: ''
   cache_key_prefix:
-    description: >
-      Must match the prefix _pr-test-rust-ext-build.yml saves under, or every
-      lookup here misses.
+    description: 'Must match what _pr-test-rust-ext-build.yml saves under.'
     required: false
     default: rust-ext-x86_64
 
 outputs:
   hit:
-    description: >
-      'true' when the modules are in place. Consumers that install a Rust
-      toolchain or warm a cargo cache only to build them can skip that on a hit.
+    description: "'true' when the modules are in place, for callers that install a Rust toolchain only to build them."
     value: ${{ steps.decide.outputs.hit }}
 
 runs:
   using: composite
   steps:
-    # continue-on-error: the artifact expires in a day, so a later re-run finds
-    # nothing and falls through to the cache below. download-artifact creates
-    # srt/server/, which exists only as build output.
+    # continue-on-error: the artifact expires in a day, so a re-run falls through
+    # to the cache below.
     - name: Download prebuilt Rust extensions
       id: artifact
       if: inputs.artifact_name != ''
@@ -43,10 +34,8 @@ runs:
         path: python/sglang/srt/
 
     # Second, not first: the cache is evictable and this repo sits at its 10 GB
-    # limit, while the artifact is durable for the run that built it. A run reads
-    # its own branch's entries plus the default branch's, so seed-rust-ext-cache.yml
-    # and the branch's own rust-ext-build both reach here - which is what lets a
-    # workflow_dispatch and an expired-artifact re-run avoid compiling.
+    # limit. A run reads its own branch's entries plus the default branch's, so
+    # seed-rust-ext-cache.yml and the branch's own rust-ext-build both land here.
     - name: Restore prebuilt Rust extensions from cache
       id: cache
       if: steps.artifact.outcome != 'success'
@@ -55,15 +44,10 @@ runs:
         path: python/sglang/srt/*/_core*.so
         key: ${{ inputs.cache_key_prefix }}-${{ hashFiles('rust/**', 'python/setup.py') }}
 
-    # Job-wide via GITHUB_ENV rather than per-step, so no caller repeats the
-    # condition. Only setup.py reads it, and only while building, so it is inert
-    # once install is done.
-    #
-    # Whether the modules suit this interpreter is not decided here: no crate sets
-    # abi3, so the ABI tag pins both the minor version and the arch, and a
-    # 3.12 or aarch64 pool must still compile. ci_install_dependency.sh's
-    # require_prebuilt_rust_exts checks the restored files against the local
-    # EXT_SUFFIX and clears this back to a source build on a mismatch.
+    # Job-wide, but only setup.py reads it, and only while building.
+    # Whether the modules suit this interpreter is not decided here:
+    # require_prebuilt_rust_exts checks them against the local EXT_SUFFIX and
+    # clears this back to a source build on a mismatch.
     - name: Decide whether to skip the cargo build
       id: decide
       shell: bash

--- a/.github/actions/download-rust-ext/action.yml
+++ b/.github/actions/download-rust-ext/action.yml
@@ -33,6 +33,14 @@ runs:
         name: ${{ inputs.artifact_name }}
         path: python/sglang/srt/
 
+    # Gated with the restore below, not run unconditionally: a job whose artifact
+    # arrived never reads the cache, so it should not pay an apt-get for it. The
+    # self-hosted images ship without zstd, and the entries were saved with it.
+    - name: Ensure zstd so the cache entry is readable
+      if: steps.artifact.outcome != 'success'
+      shell: bash
+      run: bash scripts/ci/utils/ensure_zstd.sh
+
     # Second, not first: the cache is evictable and this repo sits at its 10 GB
     # limit. A run reads its own branch's entries plus the default branch's, so
     # seed-rust-ext-cache.yml and the branch's own rust-ext-build both land here.

--- a/.github/workflows/_pr-test-rust-ext-build.yml
+++ b/.github/workflows/_pr-test-rust-ext-build.yml
@@ -88,6 +88,11 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
+      # A no-op on the hosted default, which ships zstd; here for whatever
+      # restore_runs_on is pointed at, since a reader without it sees no entry.
+      - name: Ensure zstd so the saved entry is readable
+        run: bash scripts/ci/utils/ensure_zstd.sh
+
       # setup.py counts because it selects which crates get built. pyproject.toml
       # is left out - it churns on bumps that cannot affect these modules.
       - name: Restore built modules
@@ -182,21 +187,10 @@ jobs:
           MAX_GLIBC: ${{ inputs.max_glibc }}
         run: bash scripts/ci/utils/stage_rust_ext_modules.sh
 
-      # actions/cache identifies an entry by key *and* a version derived from the
-      # compression tool, so a runner without zstd saves what the hosted restore job
-      # cannot find - a silent miss every run. Warn, not fail: a cold build still works.
+      # Without it the entry saved below lands under a version no reader with zstd
+      # can find. This runner's image ships without it.
       - name: Ensure zstd so the restore job can read what this job saves
-        run: |
-          set -uo pipefail
-          if ! command -v zstd >/dev/null 2>&1; then
-              if [ "$(id -u)" = "0" ]; then SUDO=""
-              elif command -v sudo >/dev/null 2>&1; then SUDO="sudo"
-              else SUDO=""; fi
-              ${SUDO} apt-get update || true
-              ${SUDO} apt-get install -y --no-install-recommends zstd || true
-          fi
-          command -v zstd >/dev/null 2>&1 \
-              || echo "::warning::zstd unavailable on ${RUNNER_NAME:-this runner}; the cache entry saved below will not be readable by the restore job"
+        run: bash scripts/ci/utils/ensure_zstd.sh
 
       # After the verify step, so a rejected build cannot poison this key for every
       # later run.

--- a/.github/workflows/_pr-test-stage-cpu.yml
+++ b/.github/workflows/_pr-test-stage-cpu.yml
@@ -85,26 +85,23 @@ jobs:
       # This stage compiled the workspace too - 7+ minutes per partition on
       # billable hosted minutes. rust-ext-build's modules need an older glibc than
       # this runner has, which is the safe direction, and both pin Python 3.10.
-      - name: Download prebuilt Rust extensions
+      - uses: ./.github/actions/download-rust-ext
         id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       # Both only serve the fallback where this stage compiles the extensions
-      # itself, so they follow the download's outcome, not the job output: an
-      # expired artifact still needs cargo and a warm target dir here. Otherwise
-      # rust-cache restores ~1 GB per partition for nothing, on an over-quota cache.
+      # itself, so they follow whether the modules actually arrived, not the
+      # producer job's output: with the artifact expired and the cache evicted,
+      # cargo and a warm target dir are still needed here. Otherwise rust-cache
+      # restores ~1 GB per partition for nothing, on an over-quota cache.
       - name: Install protoc + Rust toolchain
-        if: ${{ steps.rust_ext.outcome != 'success' }}
+        if: ${{ steps.rust_ext.outputs.hit != 'true' }}
         timeout-minutes: 10
         run: bash scripts/ci/utils/install_rust_protoc.sh
 
       - name: Rust cache (rust/ workspace)
-        if: ${{ steps.rust_ext.outcome != 'success' }}
+        if: ${{ steps.rust_ext.outputs.hit != 'true' }}
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: rust
@@ -116,7 +113,6 @@ jobs:
         timeout-minutes: 20
         env:
           UV_SYSTEM_PYTHON: "1"
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 

--- a/.github/workflows/_pr-test-stage-cpu.yml
+++ b/.github/workflows/_pr-test-stage-cpu.yml
@@ -91,10 +91,9 @@ jobs:
           artifact_name: ${{ inputs.rust_ext_artifact }}
 
       # Both only serve the fallback where this stage compiles the extensions
-      # itself, so they follow whether the modules actually arrived, not the
-      # producer job's output: with the artifact expired and the cache evicted,
-      # cargo and a warm target dir are still needed here. Otherwise rust-cache
-      # restores ~1 GB per partition for nothing, on an over-quota cache.
+      # itself, so they follow whether the modules arrived, not the producer job's
+      # output. Otherwise rust-cache restores ~1 GB per partition for nothing, on
+      # an over-quota cache.
       - name: Install protoc + Rust toolchain
         if: ${{ steps.rust_ext.outputs.hit != 'true' }}
         timeout-minutes: 10

--- a/.github/workflows/_pr-test-stage-cpu.yml
+++ b/.github/workflows/_pr-test-stage-cpu.yml
@@ -29,7 +29,7 @@ on:
         type: string
         required: true
       rust_ext_artifact:
-        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, means this stage compiles them during install.'
+        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, falls back to the cache; a miss there compiles during install.'
         type: string
         default: ''
 

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -124,23 +124,14 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      # continue-on-error: the artifact expires in a day, so a later re-run just
-      # compiles during install. download-artifact creates srt/server/, which
-      # exists only as build output.
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(steps.rc.outputs.install_timeout) }}
         env:
           GRACE_BLACKWELL: ${{ steps.rc.outputs.grace_blackwell || '0' }}
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ fromJson(inputs.check_changes).sgl_kernel }} bash ${{ steps.rc.outputs.install }}
 

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -124,7 +124,11 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
+      # Skipped whole, not just the artifact half: an empty name is how base-c-gb300
+      # opts out of prebuilt modules entirely to keep covering the source build, and
+      # the cache key is arch-blind - it would hand that aarch64 stage x86_64 ones.
       - uses: ./.github/actions/download-rust-ext
+        if: ${{ inputs.rust_ext_artifact != '' }}
         with:
           artifact_name: ${{ inputs.rust_ext_artifact }}
 

--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -55,9 +55,13 @@ on:
         type: string
         default: ''
       rust_ext_artifact:
-        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, means this stage compiles them during install.'
+        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, falls back to the cache; a miss there compiles during install.'
         type: string
         default: ''
+      skip_prebuilt_rust_ext:
+        description: 'Take neither the artifact nor the cache, and compile during install. For a stage no prebuild targets: the cache key is arch-blind, so an aarch64 stage would be handed x86_64 modules.'
+        type: boolean
+        default: false
 
 # Mirror pr-test.yml top-level env. Reusable workflows do NOT inherit caller's
 # workflow-level env across the workflow_call boundary, so anything pr-test.yml
@@ -124,11 +128,8 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      # Skipped whole, not just the artifact half: an empty name is how base-c-gb300
-      # opts out of prebuilt modules entirely to keep covering the source build, and
-      # the cache key is arch-blind - it would hand that aarch64 stage x86_64 ones.
       - uses: ./.github/actions/download-rust-ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
+        if: ${{ !inputs.skip_prebuilt_rust_ext }}
         with:
           artifact_name: ${{ inputs.rust_ext_artifact }}
 

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -71,19 +71,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda13.0
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -120,19 +113,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda13.0
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -171,19 +157,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda13.0
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -222,19 +201,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda13.0
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ inputs.sgl_kernel }} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 

--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       rust_ext_artifact:
-        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, means this job compiles them during install.'
+        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, falls back to the cache; a miss there compiles during install.'
         type: string
         default: ''
       runner_config:

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -106,19 +106,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
       - name: Run diffusion server tests
@@ -183,19 +176,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -257,19 +243,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -330,19 +309,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -410,19 +382,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -466,20 +431,14 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
         env:
           SGLANG_CI_EARLY_LD_LIBRARY_PATH: "1"
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -530,19 +489,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 

--- a/.github/workflows/pr-test-multimodal-gen.yml
+++ b/.github/workflows/pr-test-multimodal-gen.yml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       rust_ext_artifact:
-        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, means this job compiles them during install.'
+        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, falls back to the cache; a miss there compiles during install.'
         type: string
         default: ''
       runner_config:

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       rust_ext_artifact:
-        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, means this job compiles them during install.'
+        description: 'Artifact of prebuilt Rust extension modules, from rust-ext-build. Empty, or a download that fails, falls back to the cache; a miss there compiles during install.'
         type: string
         default: ''
       runner_config:

--- a/.github/workflows/pr-test-sgl-kernel.yml
+++ b/.github/workflows/pr-test-sgl-kernel.yml
@@ -58,19 +58,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
@@ -104,19 +97,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh
 
@@ -162,19 +148,12 @@ jobs:
           merge-multiple: true
           pattern: wheel-python3.10-cuda*
 
-      - name: Download prebuilt Rust extensions
-        id: rust_ext
-        if: ${{ inputs.rust_ext_artifact != '' }}
-        continue-on-error: true
-        uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download-rust-ext
         with:
-          name: ${{ inputs.rust_ext_artifact }}
-          path: python/sglang/srt/
+          artifact_name: ${{ inputs.rust_ext_artifact }}
 
       - name: Install dependencies
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outcome == 'success' && 'none' || '' }}
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{inputs.sgl_kernel}} bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -511,7 +511,7 @@ jobs:
       timeout_per_file: '1800'
       # aarch64 has no prebuild, so this stage compiles during install - which also
       # makes it the only stage still covering that path. Keep it that way.
-      rust_ext_artifact: ''
+      skip_prebuilt_rust_ext: true
     secrets: inherit
 
   # List every build and test job: `skipped` passes here, so an omission turns that

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -104,8 +104,7 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
-      # No artifact_name: a workflow_dispatch has no rust-ext-build job of its own,
-      # so the cache is the only source here.
+      # No artifact_name: a workflow_dispatch has no rust-ext-build job of its own.
       - uses: ./.github/actions/download-rust-ext
 
       - name: Install dependencies
@@ -276,15 +275,14 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      # Worth the most here of the three jobs: this runner is hosted, so it has no
-      # persistent cargo target dir to fall back on and every dispatch compiled
-      # cold. Its setup-python pins the same 3.10 the modules were built against.
+      # Worth the most of the three jobs: this runner is hosted, so it has no
+      # persistent cargo target dir and every dispatch compiled cold. Its
+      # setup-python pins the same 3.10 the modules were built against.
       - uses: ./.github/actions/download-rust-ext
         id: rust_ext
 
       # Needed by setuptools-rust to build the bundled native gRPC extension
-      # (rust/sglang-grpc) when installing the main `sglang` wheel from source, so
-      # nothing needs it once the prebuilt modules are in place.
+      # (rust/sglang-grpc) when installing the main `sglang` wheel from source.
       - name: Install protoc + Rust toolchain
         if: ${{ steps.rust_ext.outputs.hit != 'true' }}
         timeout-minutes: 10

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -104,29 +104,14 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
-      # The stages get these as an artifact from rust-ext-build, which a
-      # workflow_dispatch cannot reach - artifacts are per-run. The cache behind it
-      # is not: a run reads its own branch's entries plus the default branch's, so
-      # both seed-rust-ext-cache.yml (main) and this PR's own rust-ext-build hit
-      # here. Key must match _pr-test-rust-ext-build.yml's default cache_key_prefix.
-      - name: Restore prebuilt Rust extensions
-        id: rust_ext
-        continue-on-error: true
-        uses: actions/cache/restore@v4
-        with:
-          path: python/sglang/srt/*/_core*.so
-          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
+      # No artifact_name: a workflow_dispatch has no rust-ext-build job of its own,
+      # so the cache is the only source here.
+      - uses: ./.github/actions/download-rust-ext
 
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(inputs.install_timeout) }}
         env:
           GRACE_BLACKWELL: ${{ inputs.grace_blackwell }}
-          # require_prebuilt_rust_exts re-checks the modules against this
-          # interpreter's EXT_SUFFIX, which carries both the minor version and the
-          # arch, and clears this back to a source build on any mismatch. So an
-          # aarch64 or 3.12 pool restoring these x86_64/3.10 modules falls back
-          # rather than importing nothing.
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outputs.cache-hit == 'true' && 'none' || '' }}
         run: |
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
@@ -214,18 +199,10 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
-      - name: Restore prebuilt Rust extensions
-        id: rust_ext
-        continue-on-error: true
-        uses: actions/cache/restore@v4
-        with:
-          path: python/sglang/srt/*/_core*.so
-          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
+      - uses: ./.github/actions/download-rust-ext
 
       - name: Install dependencies (diffusion)
         timeout-minutes: 20
-        env:
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outputs.cache-hit == 'true' && 'none' || '' }}
         run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
@@ -299,45 +276,17 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
-      # Worth more here than on the GPU jobs: this runner is hosted, so it has no
-      # persistent CARGO_TARGET_DIR to fall back on and every run compiles cold.
-      # Its setup-python pins the same 3.10 the modules were built against.
-      - name: Restore prebuilt Rust extensions
+      # Worth the most here of the three jobs: this runner is hosted, so it has no
+      # persistent cargo target dir to fall back on and every dispatch compiled
+      # cold. Its setup-python pins the same 3.10 the modules were built against.
+      - uses: ./.github/actions/download-rust-ext
         id: rust_ext
-        continue-on-error: true
-        uses: actions/cache/restore@v4
-        with:
-          path: python/sglang/srt/*/_core*.so
-          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
-
-      # This job installs with plain uv rather than ci_install_dependency.sh, so
-      # require_prebuilt_rust_exts never runs; do its check here. A partial entry
-      # must not reach SGLANG_BUILD_RUST_EXTS=none - that would install with a
-      # module missing and silently skip the tests needing it. Exact EXT_SUFFIX,
-      # not a _core*.so glob: the import system ignores a module built for another
-      # version or arch, which the glob would still count as present.
-      - name: Decide whether the restored modules are usable
-        id: prebuilt
-        run: |
-          set -uo pipefail
-          suffix=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
-          missing=()
-          for pkg in server grpc multimodal; do
-              [ -f "python/sglang/srt/${pkg}/_core${suffix}" ] || missing+=("${pkg}")
-          done
-          if [ ${#missing[@]} -gt 0 ]; then
-              echo "::notice::no prebuilt _core${suffix} for: ${missing[*]}; building from source"
-              echo "usable=false" >> "$GITHUB_OUTPUT"
-          else
-              echo "Using prebuilt Rust extension modules; skipping the cargo build."
-              echo "usable=true" >> "$GITHUB_OUTPUT"
-          fi
 
       # Needed by setuptools-rust to build the bundled native gRPC extension
-      # (rust/sglang-grpc) when installing the main `sglang` wheel from source.
-      # Skipped when the prebuilt modules cover it, since then nothing compiles.
+      # (rust/sglang-grpc) when installing the main `sglang` wheel from source, so
+      # nothing needs it once the prebuilt modules are in place.
       - name: Install protoc + Rust toolchain
-        if: steps.prebuilt.outputs.usable != 'true'
+        if: ${{ steps.rust_ext.outputs.hit != 'true' }}
         timeout-minutes: 10
         run: bash scripts/ci/utils/install_rust_protoc.sh
 
@@ -345,7 +294,6 @@ jobs:
         timeout-minutes: 20
         env:
           UV_SYSTEM_PYTHON: "1"
-          SGLANG_BUILD_RUST_EXTS: ${{ steps.prebuilt.outputs.usable == 'true' && 'none' || '' }}
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -104,10 +104,29 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
+      # The stages get these as an artifact from rust-ext-build, which a
+      # workflow_dispatch cannot reach - artifacts are per-run. The cache behind it
+      # is not: a run reads its own branch's entries plus the default branch's, so
+      # both seed-rust-ext-cache.yml (main) and this PR's own rust-ext-build hit
+      # here. Key must match _pr-test-rust-ext-build.yml's default cache_key_prefix.
+      - name: Restore prebuilt Rust extensions
+        id: rust_ext
+        continue-on-error: true
+        uses: actions/cache/restore@v4
+        with:
+          path: python/sglang/srt/*/_core*.so
+          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
+
       - name: Install dependencies
         timeout-minutes: ${{ fromJson(inputs.install_timeout) }}
         env:
           GRACE_BLACKWELL: ${{ inputs.grace_blackwell }}
+          # require_prebuilt_rust_exts re-checks the modules against this
+          # interpreter's EXT_SUFFIX, which carries both the minor version and the
+          # arch, and clears this back to a source build on any mismatch. So an
+          # aarch64 or 3.12 pool restoring these x86_64/3.10 modules falls back
+          # rather than importing nothing.
+          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outputs.cache-hit == 'true' && 'none' || '' }}
         run: |
           if [[ "${{ inputs.runs_on }}" == "1-gpu-5090" ]]; then
             source /etc/profile.d/sglang-ci.sh
@@ -195,8 +214,18 @@ jobs:
 
       - uses: ./.github/actions/check-maintenance
 
+      - name: Restore prebuilt Rust extensions
+        id: rust_ext
+        continue-on-error: true
+        uses: actions/cache/restore@v4
+        with:
+          path: python/sglang/srt/*/_core*.so
+          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
+
       - name: Install dependencies (diffusion)
         timeout-minutes: 20
+        env:
+          SGLANG_BUILD_RUST_EXTS: ${{ steps.rust_ext.outputs.cache-hit == 'true' && 'none' || '' }}
         run: bash scripts/ci/cuda/ci_install_dependency.sh diffusion
 
       - name: Run test
@@ -270,9 +299,45 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
 
+      # Worth more here than on the GPU jobs: this runner is hosted, so it has no
+      # persistent CARGO_TARGET_DIR to fall back on and every run compiles cold.
+      # Its setup-python pins the same 3.10 the modules were built against.
+      - name: Restore prebuilt Rust extensions
+        id: rust_ext
+        continue-on-error: true
+        uses: actions/cache/restore@v4
+        with:
+          path: python/sglang/srt/*/_core*.so
+          key: rust-ext-x86_64-${{ hashFiles('rust/**', 'python/setup.py') }}
+
+      # This job installs with plain uv rather than ci_install_dependency.sh, so
+      # require_prebuilt_rust_exts never runs; do its check here. A partial entry
+      # must not reach SGLANG_BUILD_RUST_EXTS=none - that would install with a
+      # module missing and silently skip the tests needing it. Exact EXT_SUFFIX,
+      # not a _core*.so glob: the import system ignores a module built for another
+      # version or arch, which the glob would still count as present.
+      - name: Decide whether the restored modules are usable
+        id: prebuilt
+        run: |
+          set -uo pipefail
+          suffix=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')
+          missing=()
+          for pkg in server grpc multimodal; do
+              [ -f "python/sglang/srt/${pkg}/_core${suffix}" ] || missing+=("${pkg}")
+          done
+          if [ ${#missing[@]} -gt 0 ]; then
+              echo "::notice::no prebuilt _core${suffix} for: ${missing[*]}; building from source"
+              echo "usable=false" >> "$GITHUB_OUTPUT"
+          else
+              echo "Using prebuilt Rust extension modules; skipping the cargo build."
+              echo "usable=true" >> "$GITHUB_OUTPUT"
+          fi
+
       # Needed by setuptools-rust to build the bundled native gRPC extension
       # (rust/sglang-grpc) when installing the main `sglang` wheel from source.
+      # Skipped when the prebuilt modules cover it, since then nothing compiles.
       - name: Install protoc + Rust toolchain
+        if: steps.prebuilt.outputs.usable != 'true'
         timeout-minutes: 10
         run: bash scripts/ci/utils/install_rust_protoc.sh
 
@@ -280,6 +345,7 @@ jobs:
         timeout-minutes: 20
         env:
           UV_SYSTEM_PYTHON: "1"
+          SGLANG_BUILD_RUST_EXTS: ${{ steps.prebuilt.outputs.usable == 'true' && 'none' || '' }}
         run: |
           uv pip install -e "python[dev]" --index-strategy unsafe-best-match --prerelease allow
 

--- a/scripts/ci/utils/ensure_zstd.sh
+++ b/scripts/ci/utils/ensure_zstd.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install zstd when missing, for any job that reads or writes an actions/cache entry.
+# actions/cache identifies an entry by key *and* a version derived from the
+# compression tool, so a runner without zstd cannot see what one with it saved -
+# a silent miss every run. Warn, not fail: both sides work without the cache.
+set -uo pipefail
+if ! command -v zstd >/dev/null 2>&1; then
+    if [ "$(id -u)" = "0" ]; then SUDO=""
+    elif command -v sudo >/dev/null 2>&1; then SUDO="sudo"
+    else SUDO=""; fi
+    ${SUDO} apt-get update || true
+    ${SUDO} apt-get install -y --no-install-recommends zstd || true
+fi
+command -v zstd >/dev/null 2>&1 \
+    || echo "::warning::zstd unavailable on ${RUNNER_NAME:-this runner}; actions/cache entries here will not match the ones saved with it"


### PR DESCRIPTION
## Summary
- Extract the inline "Download prebuilt Rust extensions" step into `.github/actions/download-rust-ext`, shared by all 19 call sites
- Fall back to the `rust-ext-x86_64-*` cache when the artifact is unavailable, so an expired artifact no longer means a cold cargo build
- Reach it from `rerun-test.yml`, which compiled all three PyO3 modules from source on every dispatch

## Background
- `_pr-test-rust-ext-build.yml` publishes the modules two ways: a cache entry keyed by `hashFiles('rust/**', 'python/setup.py')`, and a per-run artifact
- Consumers only read the artifact, which carries `retention-days: 1` — any re-run past that day recompiles during install
- `rerun-test.yml` is a `workflow_dispatch` with no `rust-ext-build` job in its own run, so it could not read the artifact at all

## Changes
**New action**
- Tries `download-artifact` first (durable for the run that built it), then `cache/restore` (evictable, and this repo sits at its 10 GB limit)
- Exports `SGLANG_BUILD_RUST_EXTS=none` through `GITHUB_ENV` on a hit, so no caller repeats the conditional
- Exposes `hit` for callers that install a Rust toolchain only to build these modules

**Call sites**
- 16 existing sites across `_pr-test-stage.yml`, `_pr-test-stage-cpu.yml`, `pr-test-jit-kernel.yml`, `pr-test-multimodal-gen.yml` and `pr-test-sgl-kernel.yml` collapse to 2-4 lines each (13 of them were byte-identical)
- `_pr-test-stage-cpu.yml` gates `install_rust_protoc.sh` and `Swatinem/rust-cache` on `outputs.hit` rather than the download's `outcome`, so a cache hit skips them too
- `rerun-test.yml`: all three modes (`cuda` / `multimodal_gen` / `cpu`) now reach the cache; the `cpu` job also skips the toolchain install, which matters most there since `ubuntu-latest` has no persistent cargo target dir and always compiled cold

## Behavior
- Artifact hit: unchanged — `SGLANG_BUILD_RUST_EXTS=none`, no cargo build
- Artifact missing or expired: now tries the cache instead of going straight to a source build
- Miss on both: the variable goes unset rather than empty, which `setup.py` treats identically (both build every declared extension)
- The variable moves from step-level `env` to `GITHUB_ENV`; no job builds sglang a second time after install, so the only reader is the same install step as before
- `base-c-test-4-gpu-gb300` stays the one stage that compiles during install, now via an explicit `skip_prebuilt_rust_ext: true` rather than an empty artifact name — the cache key is arch-blind, so that aarch64 stage would otherwise be handed x86_64 modules. Separating the two also means an empty artifact name (a skipped or failed `rust-ext-build`) still reaches the cache everywhere else

## Notes
- A cache lookup only matches an entry saved with the same compression tool, so a runner without `zstd` misses silently and compiles as before — no worse than today
- `require_prebuilt_rust_exts` still checks the restored files against the local `EXT_SUFFIX`, which pins both the minor version and the arch, so a 3.12 or aarch64 pool falls back to a source build instead of importing nothing

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30955907205](https://github.com/sgl-project/sglang/actions/runs/30955907205)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30955907005](https://github.com/sgl-project/sglang/actions/runs/30955907005)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->