### PR TITLE
[CI] Make B200 base-b suites single-GPU as prep for 1-gpu B200 runners

### DIFF
--- a/test/registered/kernels/ops/kimi_k3/test_collectives.py
+++ b/test/registered/kernels/ops/kimi_k3/test_collectives.py
@@ -23,7 +23,7 @@ from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kernels.utils import multigpu_pytest_main
 
-register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=240, stage="base-c", runner_config="4-gpu-b200")
 register_cuda_ci(est_time=480, suite="nightly-8-gpu-b200", nightly=True)
 
 _HIDDEN_SIZE = 7168

--- a/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
+++ b/test/registered/spec/eagle/test_deepseek_v3_fp4_mtp_small.py
@@ -15,7 +15,7 @@ from sglang.test.test_utils import (
     write_github_step_summary,
 )
 
-register_cuda_ci(est_time=340, stage="base-b", runner_config="4-gpu-b200")
+register_cuda_ci(est_time=340, stage="base-c", runner_config="4-gpu-b200")
 
 FULL_DEEPSEEK_V3_FP4_MODEL_PATH = "nvidia/DeepSeek-V3-0324-FP4"
 SERVER_LAUNCH_TIMEOUT = 1200


### PR DESCRIPTION
Move the only two 4-GPU files out of the B200 base-b suites (`test_deepseek_v3_fp4_mtp_small.py` and `kimi_k3/test_collectives.py` -> `base-c-test-4-gpu-b200`). After this, `base-b-test-4-gpu-b200` and `base-b-kernel-unit-test-4-gpu-b200` contain single-GPU tests only, so they can later run on 1-gpu B200 runners or with in-node per-GPU parallelism.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30952156725](https://github.com/sgl-project/sglang/actions/runs/30952156725)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30952156477](https://github.com/sgl-project/sglang/actions/runs/30952156477)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->