### PR TITLE
Remove custom all-reduce disable from Kimi-K3 B300 recipe

### DIFF
--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -817,7 +817,6 @@ export const config = {
         "--model-path {{MODEL_NAME}}",
         "--tp-size 8",
         "--dcp-size 8",
-        "--disable-custom-all-reduce",
         "--mem-fraction-static 0.85",
         "--reasoning-parser kimi_k3",
         "--tool-call-parser kimi_k3",


### PR DESCRIPTION
## Summary

- Remove `--disable-custom-all-reduce` from the Kimi-K3 B300 Unified + Balanced recipe.
- Let the selected command, including DSPARK with HiCache off, use the default custom all-reduce path.

## Why

The B300 Balanced cell still carried an explicit custom all-reduce opt-out, so the generated deployment command disabled that path for this recipe.

## Impact

This changes only the B300 Unified + Balanced cell. Other B300 strategies and PD recipes are unchanged.

## Validation

- Targeted Node assertion for the `hw=b300`, `pdMode=unified`, `strategy=balanced`, `spec=dspark`, `hicache=off` command composition
- `mint validate`
- `mint broken-links`
- Repository pre-commit hooks

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30958544130](https://github.com/sgl-project/sglang/actions/runs/30958544130)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30958544035](https://github.com/sgl-project/sglang/actions/runs/30958544035)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->