### PR TITLE
Pin online NVFP4 4over6 quantization settings

### DIFF
--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -839,7 +839,13 @@ class DefaultModelLoader(BaseModelLoader):
         if is_nvfp4_online:
             # Scope exact FP4 quantization math to load-time conversion only;
             # restore the original environment before serving starts.
-            with temp_set_env(FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH="1"):
+            with temp_set_env(
+                FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH="1",
+                FLASHINFER_NVFP4_4OVER6="1",
+                FLASHINFER_NVFP4_4OVER6_E4M3_USE_256="0",
+                FLASHINFER_NVFP4_4OVER6_ERR_MODE="MSE",
+                FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH="1",
+            ):
                 model.load_weights(weights)
             if target_device.type == "cuda":
                 torch.cuda.synchronize()


### PR DESCRIPTION
## Motivation
@humansand
Online `nvfp4_online` weight conversion should use a fixed FlashInfer 4-over-6 quantization configuration so its output does not depend on user-provided values for these load-time settings.

## Modifications

- Force 4-over-6 quantization with the 448 E4M3 maximum, MSE error mode, and fast error evaluation while online NVFP4 weights are loaded.
- Keep the overrides inside the existing `temp_set_env` scope so prior user values are restored before serving begins.

## Accuracy Tests

Not run (per request).

## Speed Tests and Profiling

Not run (per request).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (No test changes requested.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Deferred.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not run per request.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #30971439581](https://github.com/sgl-project/sglang/actions/runs/30971439581)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30971440732](https://github.com/sgl-project/sglang/actions/runs/30971440732)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->