### PR TITLE
feat: Add DeepEP custom wheel build workflow (#32607)

### DIFF
--- a/.github/workflows/release-whl-deepep.yml
+++ b/.github/workflows/release-whl-deepep.yml
@@ -1,0 +1,183 @@
+name: Release sgl-deepep
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Wheel version (e.g. 0.1.0, 0.1.1rc0)"
+        type: string
+        required: true
+      target:
+        type: choice
+        description: "Build target (default: all)"
+        required: false
+        default: 'all'
+        options:
+          - 'all'
+          - 'cu129'
+          - 'cu130'
+
+concurrency:
+  group: release-sgl-deepep-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TORCH_VER: "2.11.0"
+
+jobs:
+  build-cu129-matrix:
+    if: |
+      github.repository == 'sgl-project/sglang' &&
+      (github.event.inputs.target == 'all' || github.event.inputs.target == 'cu129')
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        cuda-version: ["12.9"]
+        arch: [x86_64, aarch64]
+        include:
+          - arch: x86_64
+            runner: x64-kernel-build-node
+          - arch: aarch64
+            runner: arm-kernel-build-node
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Clean workspace
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
+      - uses: actions/checkout@v4
+
+      - name: Create DeepEP Workspace
+        run: mkdir -p ${{ github.workspace }}/deepep-workspace
+
+      - name: Build wheel
+        run: |
+          chmod +x ./scripts/build_sgl_deepep.sh ./scripts/rename_sgl_deepep_whl.sh ./scripts/apply_deepep_k3_patch.sh
+          ./scripts/build_sgl_deepep.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}" "${{ github.workspace }}/deepep-workspace" "${{ matrix.arch }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepep-wheel-cuda${{ matrix.cuda-version }}-${{ matrix.arch }}
+          path: deepep-workspace/dist/*.whl
+
+  release-cu129:
+    needs: [build-cu129-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+          pattern: deepep-wheel-cuda12.9-*
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          repository: sgl-project/whl
+          token: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+          files: |
+            dist/*
+
+      - name: Clone wheel index
+        run: git clone https://oauth2:${WHL_TOKEN}@github.com/sgl-project/whl.git sgl-whl
+        env:
+          WHL_TOKEN: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+
+      - name: Update wheel index
+        run: python3 scripts/update_deepep_whl_index.py --cuda 129 --wheel-dir dist
+
+      - name: Push wheel index
+        run: |
+          cd sgl-whl
+          git config --local user.name "sglang-bot"
+          git config --local user.email "sglangbot@gmail.com"
+          git add -A
+          git commit -m "update deep-ep-cpp whl index for v${{ inputs.version }}"
+          git push
+
+  build-cu130-matrix:
+    if: |
+      github.repository == 'sgl-project/sglang' &&
+      (github.event.inputs.target == 'all' || github.event.inputs.target == 'cu130')
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+        cuda-version: ["13.0"]
+        arch: [x86_64, aarch64]
+        include:
+          - arch: x86_64
+            runner: x64-kernel-build-node
+          - arch: aarch64
+            runner: arm-kernel-build-node
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Clean workspace
+        run: |
+          docker run --rm -v "${{ github.workspace }}:/workspace" alpine:3 \
+            sh -c 'rm -rf /workspace/..?* /workspace/.[!.]* /workspace/*' || true
+
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create DeepEP Workspace
+        run: mkdir -p ${{ github.workspace }}/deepep-workspace
+
+      - name: Build wheel
+        run: |
+          chmod +x ./scripts/build_sgl_deepep.sh ./scripts/rename_sgl_deepep_whl.sh ./scripts/apply_deepep_k3_patch.sh
+          ./scripts/build_sgl_deepep.sh "${{ matrix.python-version }}" "${{ matrix.cuda-version }}" "${{ github.workspace }}/deepep-workspace" "${{ matrix.arch }}"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: deepep-wheel-cuda${{ matrix.cuda-version }}-${{ matrix.arch }}
+          path: deepep-workspace/dist/*.whl
+
+  release-cu130:
+    needs: [build-cu130-matrix]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+          pattern: deepep-wheel-cuda13.0-*
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ inputs.version }}
+          repository: sgl-project/whl
+          token: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+          files: |
+            dist/*
+
+      - name: Clone wheel index
+        run: git clone https://oauth2:${WHL_TOKEN}@github.com/sgl-project/whl.git sgl-whl
+        env:
+          WHL_TOKEN: ${{ secrets.GH_PAT_FOR_WHL_RELEASE }}
+
+      - name: Update wheel index
+        run: python3 scripts/update_deepep_whl_index.py --cuda 130 --wheel-dir dist
+
+      - name: Push wheel index
+        run: |
+          cd sgl-whl
+          git config --local user.name "sglang-bot"
+          git config --local user.email "sglangbot@gmail.com"
+          git add -A
+          git commit -m "update deep-ep-cpp whl index for v${{ inputs.version }}"
+          git push

--- a/docker/sgl-deepep.Dockerfile
+++ b/docker/sgl-deepep.Dockerfile
@@ -1,0 +1,35 @@
+ARG BASE_IMG=pytorch/manylinux2_28-builder
+ARG CUDA_VERSION=13.0
+
+FROM ${BASE_IMG}:cuda${CUDA_VERSION}
+
+ARG ARCH=x86_64
+ARG CUDA_VERSION=13.0
+ARG PYTHON_VERSION=3.12
+ARG PYTHON_TAG=cp312-cp312
+ARG TORCH_VER=2.11.0
+ARG TVM_FFI_VER=0.1.11
+ARG PIP_DEFAULT_INDEX=https://pypi.python.org/simple
+ARG PYTORCH_MIRROR=download.pytorch.org
+
+ENV PYTHON_ROOT_PATH=/opt/python/${PYTHON_TAG}
+ENV PATH=${PYTHON_ROOT_PATH}/bin:${PATH}
+
+RUN yum install -y --nogpgcheck git wget tar gcc gcc-c++ make \
+ && yum clean all && rm -rf /var/cache/yum
+
+RUN set -eux; \
+    if [ "${ARCH}" = "aarch64" ]; then _LIB=sbsa; else _LIB="${ARCH}"; fi; \
+    mkdir -p /usr/lib/${ARCH}-linux-gnu/; \
+    ln -sf /usr/local/cuda-${CUDA_VERSION}/targets/${_LIB}-linux/lib/stubs/libcuda.so /usr/lib/${ARCH}-linux-gnu/libcuda.so
+
+RUN --mount=type=cache,id=sgl-deepep-pip,target=/root/.cache/pip \
+    set -eux; \
+    case "${CUDA_VERSION}" in \
+      13.0) CU_TAG=cu130 ;; \
+      12.9) CU_TAG=cu129 ;; \
+      *)    CU_TAG=cu130 ;; \
+    esac; \
+    ${PYTHON_ROOT_PATH}/bin/pip install torch==${TORCH_VER} --index-url https://${PYTORCH_MIRROR}/whl/${CU_TAG}; \
+    ${PYTHON_ROOT_PATH}/bin/pip install --index-url ${PIP_DEFAULT_INDEX} \
+        ninja setuptools wheel build numpy apache-tvm-ffi==${TVM_FFI_VER}

--- a/scripts/apply_deepep_k3_patch.sh
+++ b/scripts/apply_deepep_k3_patch.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Kimi-K3 DeepEP patch + rebuild -- IMAGE-BUILD variant of the runtime patcher.
+#
+# Stock DeepEP (deepseek-ai@d28bd67, shipped in the base image at
+# /sgl-workspace/DeepEP) does not serve Kimi-K3:
+#   - LL topk capped at 11; K3 routes top-16  -> assert at internode_ll.cu
+#   - SWITCH_HIDDEN lacks 3584 (K3 latent-MoE dispatch dim)
+#   - normal-internode issues an unaligned 64-bit SourceMeta access for packed
+#     K3 FP8 scales when dispatch crosses the 8-rank NVL domain (EP > 8)
+#   - CUDA 13 relocated the cccl headers -> the stock build cannot find them
+#
+# Differences vs the devbox runtime script (why a separate copy):
+#   1. arch comes from $TORCH_CUDA_ARCH_LIST (no GPU at image-build time; the
+#      runtime script probes torch.cuda.get_device_capability which needs a GPU)
+#   2. adds the setup.py cccl include-dir fix (required to COMPILE on CUDA 13;
+#      the devbox had it applied manually)
+#   3. adds the configs.cuh CPU/cycle timeout bump (cross-node init headroom)
+#
+# Idempotent (grep/count-guarded). The default wheel contains native cubins for
+# Hopper sm_90, B200 sm_100a, and GB300 sm_103a.
+set -euo pipefail
+: "${TORCH_CUDA_ARCH_LIST:=9.0;10.0a;10.3a}"
+DEEPEP_DIR="${DEEPEP_DIR:-/sgl-workspace/DeepEP}"
+DEEPEP_COMMIT="${DEEPEP_COMMIT:-d28bd676c2120573c9f1425f0c16c39faa4117e6}"
+
+# PyTorch accepts CUDA architecture lists separated by spaces or semicolons.
+read -r -a CUDA_ARCHES <<< "${TORCH_CUDA_ARCH_LIST//;/ }"
+[ "${#CUDA_ARCHES[@]}" -gt 0 ] || { echo "ERROR: TORCH_CUDA_ARCH_LIST is empty"; exit 1; }
+for CUDA_ARCH in "${CUDA_ARCHES[@]}"; do
+  [[ "$CUDA_ARCH" =~ ^[0-9]+\.[0-9]+a?$ ]] || {
+    echo "ERROR: unsupported CUDA architecture '$CUDA_ARCH' in TORCH_CUDA_ARCH_LIST='$TORCH_CUDA_ARCH_LIST'"
+    exit 1
+  }
+done
+
+# The base image is expected to ship the DeepEP source here; clone-pin if not.
+if [ ! -d "$DEEPEP_DIR/csrc" ]; then
+  echo "== $DEEPEP_DIR missing — cloning deepseek-ai/DeepEP @ $DEEPEP_COMMIT"
+  git clone --recursive https://github.com/deepseek-ai/DeepEP.git "$DEEPEP_DIR"
+  git -C "$DEEPEP_DIR" checkout "$DEEPEP_COMMIT"
+  git -C "$DEEPEP_DIR" submodule update --init --recursive
+fi
+cd "$DEEPEP_DIR"
+
+echo "== [1/6] internode_ll.cu: LL topk caps 9/11 -> 16"
+TOPK_CAPS_EXPECTED=$(grep -Eci "kNumMaxTop[Kk] = (9|11|16)" csrc/kernels/internode_ll.cu || true)
+[ "$TOPK_CAPS_EXPECTED" -ge 2 ] || {
+  echo "ERROR: expected >=2 recognized topk caps, found $TOPK_CAPS_EXPECTED"
+  exit 1
+}
+sed -i 's/constexpr int kNumMaxTopK = 11;/constexpr int kNumMaxTopK = 16;/' csrc/kernels/internode_ll.cu
+sed -i 's/constexpr int kNumMaxTopK = 9;/constexpr int kNumMaxTopK = 16;/'  csrc/kernels/internode_ll.cu
+sed -i 's/constexpr int kNumMaxTopk = 9;/constexpr int kNumMaxTopk = 16;/'  csrc/kernels/internode_ll.cu
+sed -i 's/constexpr int kNumMaxTopk = 11;/constexpr int kNumMaxTopk = 16;/' csrc/kernels/internode_ll.cu
+TOPK_CAPS_PATCHED=$(grep -ci "kNumMaxTop[Kk] = 16" csrc/kernels/internode_ll.cu || true)
+TOPK_CAPS_UNPATCHED=$(grep -Eci "kNumMaxTop[Kk] = (9|11)" csrc/kernels/internode_ll.cu || true)
+if [ "$TOPK_CAPS_PATCHED" -ne "$TOPK_CAPS_EXPECTED" ] || [ "$TOPK_CAPS_UNPATCHED" -ne 0 ]; then
+  echo "ERROR: expected $TOPK_CAPS_EXPECTED topk caps patched, found $TOPK_CAPS_PATCHED patched and $TOPK_CAPS_UNPATCHED unpatched"
+  exit 1
+fi
+
+echo "== [2/6] launch.cuh: SWITCH_HIDDEN += case 3584 (K3 latent MoE)"
+grep -q "case_macro(3584)" csrc/kernels/launch.cuh || \
+  sed -i 's/case 4096: case_macro(4096);/case 3584: case_macro(3584); case 4096: case_macro(4096);/' csrc/kernels/launch.cuh
+grep -q "case_macro(3584)" csrc/kernels/launch.cuh || { echo "ERROR: hidden 3584 case not applied"; exit 1; }
+
+echo "== [3/6] configs.cuh: raise CPU/cycle timeouts 100s -> 1000s (cross-node init headroom)"
+# '@' delimiter (pattern contains '#'); '$' anchor avoids the ENABLE_FAST_DEBUG '...10' line.
+sed -i 's@^#define NUM_CPU_TIMEOUT_SECS 100$@#define NUM_CPU_TIMEOUT_SECS 1000@' csrc/kernels/configs.cuh
+sed -i 's@^#define NUM_TIMEOUT_CYCLES 200000000000ull@#define NUM_TIMEOUT_CYCLES 2000000000000ull@' csrc/kernels/configs.cuh
+grep -q "NUM_CPU_TIMEOUT_SECS 1000$" csrc/kernels/configs.cuh || echo "   WARN: CPU timeout not raised (layout changed?) — non-fatal"
+
+echo "== [4/6] tests/test_low_latency.py: nvfp4 tolerance 0.007 -> 0.008 (topk16 noise)"
+python3 - <<'EOF'
+p = "tests/test_low_latency.py"
+s = open(p).read()
+old = "elif dispatch_use_nvfp4:\n                                    diff_threshold = 0.007"
+new = "elif dispatch_use_nvfp4:\n                                    diff_threshold = 0.008"
+if old in s:
+    open(p, "w").write(s.replace(old, new)); print("   patched")
+else:
+    print("   already patched or layout changed (skipped)")
+EOF
+
+echo "== [5/6] internode.cu: 4-byte-aligned SourceMeta scalar access (EP>8 normal internode)"
+python3 - <<'EOF'
+from pathlib import Path
+path = Path("csrc/kernels/internode.cu")
+source = path.read_text()
+changed = False
+abi_old = 'EP_STATIC_ASSERT(sizeof(SourceMeta) % sizeof(int) == 0, "Invalid size of `SourceMeta`");'
+abi_new = 'EP_STATIC_ASSERT(sizeof(SourceMeta) == 2 * sizeof(int), "SourceMeta scalar access requires exactly two int fields");'
+if source.count(abi_old) == 2 and source.count(abi_new) == 0:
+    source = source.replace(abi_old, abi_new); changed = True; print("   tightened both SourceMeta ABI assertions")
+elif source.count(abi_old) == 0 and source.count(abi_new) == 2:
+    print("   ABI assertions already tightened")
+else:
+    raise SystemExit(f"ERROR: unexpected SourceMeta ABI layout: old={source.count(abi_old)}, new={source.count(abi_new)}")
+replacements = (
+    ("sender store",
+     """            // Copy source metadata into symmetric send buffer
+            if (lane_id < num_topk_ranks)
+                st_na_global(reinterpret_cast<SourceMeta*>(dst_send_buffers[lane_id]), src_meta);
+""",
+     """            // SourceMeta may be only 4-byte aligned after packed scales.
+            // Store its two int fields separately to avoid an unaligned 64-bit store.
+            if (lane_id < num_topk_ranks) {
+                auto meta_values = reinterpret_cast<int*>(dst_send_buffers[lane_id]);
+                st_na_global(meta_values, src_meta.src_rdma_rank);
+                st_na_global(meta_values + 1, src_meta.is_token_in_nvl_rank_bits);
+            }
+"""),
+    ("forwarder load",
+     """                auto src_meta = ld_nc_global(reinterpret_cast<SourceMeta*>(shifted + hidden_bytes + scale_bytes));
+""",
+     """                auto src_meta_values = reinterpret_cast<const int*>(shifted + hidden_bytes + scale_bytes);
+                SourceMeta src_meta;
+                src_meta.src_rdma_rank = ld_nc_global(src_meta_values);
+                src_meta.is_token_in_nvl_rank_bits = ld_nc_global(src_meta_values + 1);
+"""),
+    ("receiver load",
+     """                auto meta = ld_nc_global(reinterpret_cast<SourceMeta*>(shifted + hidden_bytes + scale_bytes));
+""",
+     """                auto meta_values = reinterpret_cast<const int*>(shifted + hidden_bytes + scale_bytes);
+                SourceMeta meta;
+                meta.src_rdma_rank = ld_nc_global(meta_values);
+                meta.is_token_in_nvl_rank_bits = ld_nc_global(meta_values + 1);
+"""),
+)
+for label, old, new in replacements:
+    oc, nc = source.count(old), source.count(new)
+    if oc == 1 and nc == 0:
+        source = source.replace(old, new); changed = True; print(f"   patched {label}")
+    elif oc == 0 and nc == 1:
+        print(f"   {label} already patched")
+    else:
+        raise SystemExit(f"ERROR: unexpected {label} layout: old={oc}, new={nc}")
+for unsafe in ("st_na_global(reinterpret_cast<SourceMeta*>", "ld_nc_global(reinterpret_cast<SourceMeta*>"):
+    if unsafe in source:
+        raise SystemExit(f"ERROR: unsafe SourceMeta access remains: {unsafe}")
+if changed:
+    path.write_text(source)
+EOF
+
+echo "== [5b] setup.py: add CUDA 13 cccl include dir (compile fix)"
+grep -q "/usr/local/cuda/include/cccl" setup.py || \
+  sed -i "s#\(    include_dirs = \['csrc/'\]\)#\1\n    include_dirs.append('/usr/local/cuda/include/cccl')#" setup.py
+grep -q "/usr/local/cuda/include/cccl" setup.py || { echo "ERROR: cccl include not added to setup.py"; exit 1; }
+
+echo "== [6/6] rebuild + reinstall for TORCH_CUDA_ARCH_LIST=$TORCH_CUDA_ARCH_LIST (no GPU needed)"
+rm -rf build dist
+TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" python3 setup.py bdist_wheel
+pip install dist/*.whl --force-reinstall --no-deps
+
+echo "== verify installed cubin arches"
+SO=$(find /usr/ /opt/ -name "deep_ep_cpp*.so" | head -1)
+[ -n "$SO" ] || { echo "ERROR: installed deep_ep_cpp shared object not found"; exit 1; }
+CUBIN_LIST=$(cuobjdump --list-elf "$SO")
+VERIFIED_SMS=()
+for CUDA_ARCH in "${CUDA_ARCHES[@]}"; do
+  SM="sm_${CUDA_ARCH/./}"
+  grep -Eq "(^|[^[:alnum:]_])${SM}([^[:alnum:]_]|$)" <<< "$CUBIN_LIST" || {
+    echo "ERROR: cubin arch $SM not found in $SO"
+    printf '%s\n' "$CUBIN_LIST" | head
+    exit 1
+  }
+  VERIFIED_SMS+=("$SM")
+done
+echo "== OK: DeepEP rebuilt (topk16 + hidden3584 + SourceMeta align + cccl) for ${VERIFIED_SMS[*]}"

--- a/scripts/build_sgl_deepep.sh
+++ b/scripts/build_sgl_deepep.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# Build sgl-deepep wheel inside a CUDA-versioned container.
+#
+# Usage: build_sgl_deepep.sh <PYTHON_VERSION> <CUDA_VERSION> <DEEPEP_WORKSPACE> [ARCH]
+set -ex
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <PYTHON_VERSION> <CUDA_VERSION> <DEEPEP_WORKSPACE> [ARCH]"
+  exit 1
+fi
+
+PYTHON_VERSION="$1"
+CUDA_VERSION="$2"
+DEEPEP_WORKSPACE="$(cd "$3" && pwd)"
+ARCH="${4:-$(uname -i)}"
+
+case "${CUDA_VERSION}" in
+  13.0) CU_TAG=cu130 ;;
+  12.9) CU_TAG=cu129 ;;
+  *)
+    echo "Unsupported CUDA_VERSION: ${CUDA_VERSION}" >&2
+    exit 1
+    ;;
+esac
+
+if [ "${ARCH}" = "aarch64" ]; then
+  BASE_IMG="pytorch/manylinuxaarch64-builder"
+else
+  BASE_IMG="pytorch/manylinux2_28-builder"
+fi
+
+PY_TAG="cp${PYTHON_VERSION//.}-cp${PYTHON_VERSION//.}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+DOCKERFILE="${REPO_ROOT}/docker/sgl-deepep.Dockerfile"
+RENAME_SCRIPT="${SCRIPT_DIR}/rename_sgl_deepep_whl.sh"
+PATCH_SCRIPT="${SCRIPT_DIR}/apply_deepep_k3_patch.sh"
+
+DEPS_TAG="sgl-deepep-deps:cuda${CUDA_VERSION}-${PY_TAG}-${ARCH}"
+
+echo "----------------------------------------"
+echo "PYTHON_VERSION: ${PYTHON_VERSION}"
+echo "CUDA_VERSION:   ${CUDA_VERSION}"
+echo "CU_TAG:         ${CU_TAG}"
+echo "ARCH:           ${ARCH}"
+echo "BASE_IMG:       ${BASE_IMG}"
+echo "DEEPEP_WORKSPACE: ${DEEPEP_WORKSPACE}"
+echo "DEPS_TAG:       ${DEPS_TAG}"
+echo "----------------------------------------"
+
+docker build \
+  -f "${DOCKERFILE}" "$(dirname "${DOCKERFILE}")" \
+  --build-arg BASE_IMG="${BASE_IMG}" \
+  --build-arg CUDA_VERSION="${CUDA_VERSION}" \
+  --build-arg ARCH="${ARCH}" \
+  --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+  --build-arg PYTHON_TAG="${PY_TAG}" \
+  -t "${DEPS_TAG}" \
+  --network=host
+
+mkdir -p "${DEEPEP_WORKSPACE}/dist"
+
+# 1) Build the wheel inside the deps container.
+docker run --rm \
+  --network=host \
+  -v "${DEEPEP_WORKSPACE}:/sgl-workspace/DeepEP" \
+  -v "${PATCH_SCRIPT}:/apply_deepep_k3_patch.sh:ro" \
+  -w /sgl-workspace/DeepEP \
+  -e DEEPEP_DIR=/sgl-workspace/DeepEP \
+  "${DEPS_TAG}" \
+  bash /apply_deepep_k3_patch.sh
+
+# 2) Rename inside the same image so we have a working pip / wheel CLI and can
+#    rewrite the root-owned wheel files written by the build container above.
+docker run --rm \
+  -v "${DEEPEP_WORKSPACE}:/sgl-workspace/DeepEP" \
+  -v "${RENAME_SCRIPT}:/rename_sgl_deepep_whl.sh:ro" \
+  -w /sgl-workspace/DeepEP \
+  "${DEPS_TAG}" \
+  bash /rename_sgl_deepep_whl.sh dist "${CU_TAG}" "${ARCH}"
+
+# 3) cu130 only: produce a sibling dist-pypi/ with the +cu130 local-version
+#    stripped (PyPI rejects local versions).
+if [ "${CU_TAG}" = "cu130" ]; then
+  docker run --rm \
+    -v "${DEEPEP_WORKSPACE}:/sgl-workspace/DeepEP" \
+    -w /sgl-workspace/DeepEP \
+    "${DEPS_TAG}" \
+    bash -c '
+set -eux
+mkdir -p dist-pypi
+for w in dist/*.whl; do
+  tmp=$(mktemp -d)
+  python3 -m wheel unpack "$w" --dest "$tmp"
+  unpacked=$(find "$tmp" -mindepth 1 -maxdepth 1 -type d | head -1)
+  info=$(find "$unpacked" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+  meta="$info/METADATA"
+  orig=$(grep "^Version:" "$meta" | head -1 | sed "s/^Version:[[:space:]]*//")
+  new=$(echo "$orig" | sed "s/+cu[0-9]\+$//")
+  if [ "$orig" != "$new" ]; then
+    sed -i "s/^Version:.*/Version: ${new}/" "$meta"
+    old_base=$(basename "$info")
+    new_base="${old_base/${orig}/${new}}"
+    mv "$info" "$(dirname "$info")/${new_base}"
+  fi
+  python3 -m wheel pack "$unpacked" --dest-dir dist-pypi
+  rm -rf "$tmp"
+done
+ls -lh dist-pypi/
+'
+fi
+
+echo "Wheels in ${DEEPEP_WORKSPACE}/dist:"
+ls -lh "${DEEPEP_WORKSPACE}/dist"/*.whl 2>/dev/null || true
+if [ "${CU_TAG}" = "cu130" ]; then
+  echo "PyPI-ready wheels in ${DEEPEP_WORKSPACE}/dist-pypi:"
+  ls -lh "${DEEPEP_WORKSPACE}/dist-pypi"/*.whl 2>/dev/null || true
+fi

--- a/scripts/rename_sgl_deepep_whl.sh
+++ b/scripts/rename_sgl_deepep_whl.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Rename a freshly-built sgl-deepep wheel so its filename, METADATA Version,
+# and WHEEL platform tag carry the +cuXXX local version and manylinux2014_<arch>
+# tag expected by the sgl-whl index and PyPI upload step.
+#
+# Input:  dist/deep_ep_cpp-<VERSION>-py3-none-any.whl (or similar)
+# Output: dist/deep_ep_cpp-<VERSION>+<CU_TAG>-py3-none-manylinux2014_<ARCH>.whl
+#
+# Usage: rename_sgl_deepep_whl.sh <WHEEL_DIR> <CU_TAG> <ARCH>
+#   WHEEL_DIR: directory containing the *.whl file (e.g. DeepEP/dist)
+#   CU_TAG:    cu129 | cu130
+#   ARCH:      x86_64 | aarch64
+set -ex
+
+if [ $# -lt 3 ]; then
+  echo "Usage: $0 <WHEEL_DIR> <CU_TAG> <ARCH>"
+  exit 1
+fi
+
+WHEEL_DIR="$1"
+CU_TAG="$2"
+ARCH="$3"
+PLAT_TAG="manylinux2014_${ARCH}"
+
+PYTHON="${PYTHON:-python3}"
+"${PYTHON}" -m pip install --quiet wheel
+
+shopt -s nullglob
+wheel_files=("${WHEEL_DIR}"/deep_ep_cpp-*.whl)
+if [ ${#wheel_files[@]} -eq 0 ]; then
+  echo "No deep_ep_cpp wheel found under ${WHEEL_DIR}" >&2
+  exit 1
+fi
+
+for wheel in "${wheel_files[@]}"; do
+  TMPDIR=$(mktemp -d)
+  trap 'rm -rf -- "$TMPDIR"' ERR
+
+  "${PYTHON}" -m wheel unpack "$wheel" --dest "$TMPDIR"
+  UNPACKED=$(find "$TMPDIR" -mindepth 1 -maxdepth 1 -type d | head -1)
+  DIST_INFO=$(find "$UNPACKED" -maxdepth 1 -type d -name "*.dist-info" | head -1)
+  WHEEL_META="${DIST_INFO}/WHEEL"
+  METADATA_FILE="${DIST_INFO}/METADATA"
+
+  # Replace the py3-none-any tag with a platform-specific one.
+  sed -i "s/^Tag: py3-none-any$/Tag: py3-none-${PLAT_TAG}/" "$WHEEL_META"
+
+  ORIG_VERSION=$(grep '^Version:' "$METADATA_FILE" | head -1 | sed 's/^Version:[[:space:]]*//')
+  if [[ "$ORIG_VERSION" == *"+${CU_TAG}"* ]]; then
+    NEW_VERSION="$ORIG_VERSION"
+  else
+    NEW_VERSION="${ORIG_VERSION}+${CU_TAG}"
+    sed -i "s/^Version:.*/Version: ${NEW_VERSION}/" "$METADATA_FILE"
+    OLD_BASE=$(basename "$DIST_INFO")
+    NEW_BASE="${OLD_BASE/${ORIG_VERSION}/${NEW_VERSION}}"
+    mv "$DIST_INFO" "${UNPACKED}/${NEW_BASE}"
+  fi
+
+  rm -f "$wheel"
+  "${PYTHON}" -m wheel pack "$UNPACKED" --dest-dir "$WHEEL_DIR"
+  rm -rf "$TMPDIR"
+  trap - ERR
+done
+
+echo "Renamed wheels in ${WHEEL_DIR}:"
+ls -lh "${WHEEL_DIR}"/*.whl

--- a/scripts/update_deepep_whl_index.py
+++ b/scripts/update_deepep_whl_index.py
@@ -1,0 +1,40 @@
+import argparse
+import hashlib
+import pathlib
+import re
+
+SUPPORTED_CUDA_VERSIONS = ["129", "130"]
+
+
+def update_wheel_index(cuda_version, wheel_dir):
+    index_dir = pathlib.Path(f"sgl-whl/cu{cuda_version}/deep-ep-cpp")
+    index_dir.mkdir(exist_ok=True, parents=True)
+    base_url = "https://github.com/sgl-project/whl/releases/download"
+
+    suffix = f"+cu{cuda_version}"
+    for path in sorted(pathlib.Path(wheel_dir).glob("*.whl")):
+        if suffix not in path.name:
+            continue
+        with open(path, "rb") as f:
+            sha256 = hashlib.sha256(f.read()).hexdigest()
+        match = re.match(r"deep_ep_cpp-([0-9][^-+]*)(?:\+cu[0-9]+)?-", path.name)
+        if not match:
+            continue
+        ver = match.group(1)
+        full_url = f"{base_url}/v{ver}/{path.name}#sha256={sha256}"
+        with (index_dir / "index.html").open("a") as f:
+            f.write(f'<a href="{full_url}">{path.name}</a><br>\n')
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--cuda", type=str, required=True, choices=SUPPORTED_CUDA_VERSIONS
+    )
+    parser.add_argument("--wheel-dir", type=str, default="dist")
+    args = parser.parse_args()
+    update_wheel_index(args.cuda, args.wheel_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

This PR fulfills a checklist item in the Kimi K3 Roadmap (#32607) to automate the building of a patched `DeepEP` custom wheel.

### Changes
- **Extracted `apply_deepep_k3_patch.sh`**: Lifted the K3 patching script (from day0 commit `bd51cab`) into `scripts/` so it is version controlled and accessible by the CI workflow.
- **Automated Workflow**: Added `.github/workflows/release-whl-deepep.yml`, heavily modeled after the existing DeepGEMM release workflow. It sets up `manylinux` Docker builders, patches the `deepseek-ai/DeepEP` source via `apply_deepep_k3_patch.sh`, and compiles the C++ extensions for `cu129` and `cu130`.
- **Docker & Build Scripts**: Added `docker/sgl-deepep.Dockerfile` and `scripts/build_sgl_deepep.sh` which encapsulate the compilation environment to guarantee reproducible builds without local CUDA installation.
- **Wheel Indexing**: Added `scripts/update_deepep_whl_index.py` to seamlessly append the generated wheels to `sgl-project/whl`.

Fixes part of #32607.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30962887783](https://github.com/sgl-project/sglang/actions/runs/30962887783)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30962887800](https://github.com/sgl-project/sglang/actions/runs/30962887800)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->