### PR TITLE
Add zianglih as online NVFP4 and DSA Top-K code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,7 +42,7 @@
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
 /python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
-/python/sglang/srt/layers/quantization/nvfp4_online.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu @zianglih
+/python/sglang/srt/layers/quantization/nvfp4_online.py @zianglih
 /python/sglang/srt/layers/quantization/quark @HaiShaw @kkHuang-amd @yichiche @hubertlu-tw @1am9trash @BowenBao
 /python/sglang/srt/lora @Ying1123 @Fridge003 @lifuhuang @yushengsu-thu @jybsuper
 /python/sglang/srt/managers @merrymercy @Ying1123 @hnyls2002 @xiezhq-hermann
@@ -83,7 +83,7 @@
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
 /test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
-/test/registered/rl/test_update_weights_from_disk_blackwell.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
+/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96
 /python/sglang/srt/models/gemma4_*.py @kpham-sgl @pyc96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -40,6 +40,7 @@
 /python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py @yizhang2077 @hebiao064 @hanming-lu @yuan-luo
 /python/sglang/srt/layers/attention/mamba @yizhang2077 @hebiao064
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
+/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me @zianglih
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
 /python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
 /python/sglang/srt/layers/quantization/nvfp4_online.py @zianglih
@@ -82,6 +83,7 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
+/test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py @zianglih
 /test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
 /test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
 /test/srt/test_modelopt* @Edwardf0t1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,8 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
+/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @zianglih
+/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96
 /python/sglang/srt/models/gemma4_*.py @kpham-sgl @pyc96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,8 +82,8 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
-/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @zianglih
-/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
+/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
+/test/registered/rl/test_update_weights_from_disk_blackwell.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96
 /python/sglang/srt/models/gemma4_*.py @kpham-sgl @pyc96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
 /python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
+/python/sglang/srt/layers/quantization/nvfp4_online.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu @zianglih
 /python/sglang/srt/layers/quantization/quark @HaiShaw @kkHuang-amd @yichiche @hubertlu-tw @1am9trash @BowenBao
 /python/sglang/srt/lora @Ying1123 @Fridge003 @lifuhuang @yushengsu-thu @jybsuper
 /python/sglang/srt/managers @merrymercy @Ying1123 @hnyls2002 @xiezhq-hermann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,6 +92,8 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
+/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @zianglih
+/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/layers/gemma4_fused_ops.py @merrymercy @Ying1123 @Fridge003 @ispobock @HaiShaw @ch-wan @BBuf @Edwardf0t1 @kpham-sgl @pyc96
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,6 +43,7 @@
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
 /python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
+/python/sglang/srt/layers/quantization/nvfp4_online.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu @zianglih
 /python/sglang/srt/layers/quantization/quark @kkHuang-amd @yichiche @hubertlu-tw @1am9trash @BowenBao
 /python/sglang/srt/lora @Ying1123 @Fridge003 @lifuhuang @yushengsu-thu @jybsuper
 /python/sglang/srt/managers @merrymercy @Ying1123 @hnyls2002 @xiezhq-hermann

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -92,8 +92,8 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
-/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @zianglih
-/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
+/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
+/test/registered/rl/test_update_weights_from_disk_blackwell.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/layers/gemma4_fused_ops.py @merrymercy @Ying1123 @Fridge003 @ispobock @HaiShaw @ch-wan @BBuf @Edwardf0t1 @kpham-sgl @pyc96
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -83,9 +83,6 @@
 /test/registered/prefill_only @sundar24295s @chanh @fortunecookiee
 /benchmark/prefill_only/bench_score.py @sundar24295s @chanh @fortunecookiee
 /test/registered/npu @ping1jing2 @ssshinigami  @e-martirosian
-/test/registered/backends/test_flashinfer_nvfp4_online_moe_backend.py @zianglih
-/test/registered/backends/test_flashinfer_trtllm_gen_moe_backend.py @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @Alisehen @mmangkad @zianglih
-/test/registered/rl/test_update_weights_from_disk_blackwell.py @zianglih
 /test/srt/test_modelopt* @Edwardf0t1
 /python/sglang/srt/function_call/gemma4_detector.py @CatherineSue @JustinTong0323 @kpham-sgl @pyc96
 /python/sglang/srt/models/gemma4_*.py @kpham-sgl @pyc96

--- a/python/sglang/srt/layers/quantization/nvfp4_online.py
+++ b/python/sglang/srt/layers/quantization/nvfp4_online.py
@@ -1,5 +1,6 @@
-# SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Implementation details for online NVFP4 model serving from:
+# - https://humansand.ai/blog/nvfp4-rl#a-pleasant-side-effect-online-nvfp4-serving
+# - https://www.lmsys.org/blog/2026-07-29-mxfp8-nvfp4-rl#online-nvfp4-model-serving
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Motivation
@humansand
The SGLang files covered by this PR were primarily implemented and are maintained by @zianglih through the [Blackwell MXFP8 and NVFP4 RL roadmap](https://github.com/radixark/miles/issues/615) and DSA Top-K work in [#22851](https://github.com/sgl-project/sglang/pull/22851), [#32490](https://github.com/sgl-project/sglang/pull/32490), [#33006](https://github.com/sgl-project/sglang/pull/33006), and [#36313](https://github.com/sgl-project/sglang/pull/36313). 

## Modifications

- Make `@zianglih` the sole file-specific code owner for `nvfp4_online.py`.
- Add `@zianglih` alongside the existing DSA owners for `dsa_topk_backend.py`.
- Replace the stale vLLM attribution in `nvfp4_online.py` with links to the humans& and LMSYS implementation write-ups.

## Accuracy Tests

Not applicable; this PR changes only comments and ownership metadata.

## Speed Tests and Profiling

Not applicable; this PR does not change runtime behavior.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Not applicable; no runtime behavior changes.)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No external documentation changes.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34168846136](https://github.com/sgl-project/sglang/actions/runs/34168846136)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34168845725](https://github.com/sgl-project/sglang/actions/runs/34168845725)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34168846072](https://github.com/sgl-project/sglang/actions/runs/34168846072)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
