### PR TITLE
[NPU] Add test for --dllm-fdfo

### DIFF
--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
@@ -1,8 +1,8 @@
 import unittest
 
 from sglang.test.ascend.test_ascend_utils import (
-    run_bench_serving,
     LLaDA2_0_MINI_WEIGHTS_PATH,
+    run_bench_serving,
 )
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
@@ -7,7 +7,6 @@ from sglang.test.ascend.test_ascend_utils import (
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_npu_ci(est_time=400, suite="stage-b-test-2-npu-a3", nightly=False)
 register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
 
 

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
@@ -10,7 +10,7 @@ register_npu_ci(est_time=400, suite="stage-b-test-2-npu-a3", nightly=False)
 register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
 
 
-class TestNpuHierarchicalCacheTTFT(CustomTestCase):
+class TestLLaDA2MiniFDFO(CustomTestCase):
     """The test used the LLaDA2.0-mini model, with --dllm-fdfo, and throughputs improved.
 
     [Test Category] Diffusion LLM

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
@@ -1,0 +1,84 @@
+import unittest
+
+from sglang.test.ascend.test_ascend_utils import (
+    run_bench_serving,
+)
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=400, suite="stage-b-test-2-npu-a3", nightly=False)
+register_npu_ci(est_time=400, suite="nightly-2-npu-a3", nightly=True)
+
+
+class TestNpuHierarchicalCacheTTFT(CustomTestCase):
+    """The test used the LLaDA2.0-mini model, with --dllm-fdfo, and throughputs improved.
+
+    [Test Category] Diffusion LLM
+    [Test Target] --dllm-fdfo
+    """
+
+    def test_dlla_fdfo_vs_no_fdfo_performance(self):
+        TTFTS = []
+        throughputs = []
+        p99_ttfts = []
+        model = "/home/weights/LLaDA2.0-mini"
+        common_args = [
+            [
+                "--trust-remote-code",
+                "--tp-size",
+                2,
+                "--mem-fraction-static",
+                0.9,
+                "--disable-radix-cache",
+                "--max-running-requests",
+                16,
+                "--dllm-algorithm",
+                "LowConfidence",
+            ],
+            [
+                "--trust-remote-code",
+                "--tp-size",
+                2,
+                "--disable-radix-cache",
+                "--mem-fraction-static",
+                0.9,
+                "--max-running-requests",
+                16,
+                "--dllm-algorithm",
+                "LowConfidence",
+                "--no-dllm-fdfo",
+            ],
+        ]
+        for common_arg in common_args:
+            other_args = common_arg + (
+                ["--attention-backend", "ascend", "--disable-cuda-graph"]
+            )
+            res = run_bench_serving(
+                model=model,
+                num_prompts=128,
+                random_input_len=3584,
+                random_output_len=1024,
+                request_rate=float("inf"),
+                max_concurrency=16,
+                other_server_args=other_args,
+            )
+            TTFT = res["mean_ttft_ms"]
+            TTFTS.append(TTFT)
+            throughput = res["total_throughput"]
+            throughputs.append(throughput)
+            p99_ttft = res["p99_ttft_ms"]
+            p99_ttfts.append(p99_ttft)
+
+        # FDFO (First-Done-First-Out) scheduling improves performance by prioritizing
+        # requests that complete their diffusion steps earlier, reducing waiting time.
+        # With FDFO enabled:
+        # - TTFT is lower because earlier-completing requests get priority and start generating tokens sooner
+        # - Throughput is higher due to better hardware utilization from reduced blocking
+        # - P99 TTFT is lower because FDFO prevents a single slow request from blocking others
+        assert float(TTFTS[0]) < float(TTFTS[1])
+        assert float(throughputs[0]) > float(throughputs[1])
+        assert float(p99_ttfts[0]) < float(p99_ttfts[1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
+++ b/test/registered/npu/basic_function/dllm/test_npu_llada2_mini_fdfo.py
@@ -2,6 +2,7 @@ import unittest
 
 from sglang.test.ascend.test_ascend_utils import (
     run_bench_serving,
+    LLaDA2_0_MINI_WEIGHTS_PATH,
 )
 from sglang.test.ci.ci_register import register_npu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -21,7 +22,7 @@ class TestLLaDA2MiniFDFO(CustomTestCase):
         TTFTS = []
         throughputs = []
         p99_ttfts = []
-        model = "/home/weights/LLaDA2.0-mini"
+        model = LLaDA2_0_MINI_WEIGHTS_PATH
         common_args = [
             [
                 "--trust-remote-code",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation
This PR adds a test case to verify that the `--dllm-fdfo` (First-Done-First-Out) scheduling flag takes effect and improves performance for Diffusion LLM models on Ascend NPU backend. When enabled, FDFO prioritizes requests that complete their diffusion steps earlier, reducing waiting time and improving hardware utilization.

## Modifications
- Add `TestLLaDA2MiniFDFO` test class in `test_ascend_llada2.py`
- Benchmark LLaDA2.0-mini model with 128 prompts (3584 input tokens, 1024 output tokens)
- Compare performance between `--dllm-fdfo` enabled and disabled (`--no-dllm-fdfo`)
- Assert that enabling FDFO yields:
  - Lower mean TTFT (Time-To-First-Token)
  - Higher total throughput
  - Lower P99 TTFT
- Register test with NPU CI pipelines (stage-b-test-2-npu-a3 and nightly-2-npu-a3)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32802771848](https://github.com/sgl-project/sglang/actions/runs/32802771848)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32802771740](https://github.com/sgl-project/sglang/actions/runs/32802771740)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32802771784](https://github.com/sgl-project/sglang/actions/runs/32802771784)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->