### PR TITLE
[CI] Skip sglang-kernel and sgl-deep-gemm reinstall on version match

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -238,7 +238,9 @@ setup_pip_toolchain() {
     PIP_UNINSTALL_CMD="uv pip uninstall"
     PIP_UNINSTALL_SUFFIX=""
 
-    $PIP_UNINSTALL_CMD sgl-kernel sglang-kernel sglang sgl-fa4 flash-attn-4 $PIP_UNINSTALL_SUFFIX || true
+    # sglang-kernel stays: install_sglang_kernel reinstalls it on any version
+    # or CUDA-tag mismatch, so a matching wheel need not be cycled every job.
+    $PIP_UNINSTALL_CMD sgl-kernel sglang sgl-fa4 flash-attn-4 $PIP_UNINSTALL_SUFFIX || true
 
     mark_step_done "${FUNCNAME[0]}"
 }
@@ -451,16 +453,29 @@ install_sglang_kernel() {
     fi
 
     if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
-        # install_sglang above pulls sglang-kernel from PyPI, whose default wheel
-        # tracks one CUDA version (currently cu130). Force-reinstall from the
-        # CU_VERSION-matched sglang wheel index so runners on a different CUDA
-        # (e.g. h20 / cu129) get a wheel linked against the right libnvrtc.
-        $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        # The PyPI default wheel tracks one CUDA version (currently cu130);
+        # runners on a different CUDA need the +${CU_VERSION}-tagged wheel from
+        # the sglang index. A tag match means the right wheel is already there.
+        SGL_KERNEL_WANTED="${SGL_KERNEL_VERSION_FROM_SRT}+${CU_VERSION}"
+        SGL_KERNEL_INSTALLED=$(pip show sglang-kernel 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
+        if [ "$SGL_KERNEL_INSTALLED" = "$SGL_KERNEL_WANTED" ]; then
+            echo "sglang-kernel==${SGL_KERNEL_WANTED} already installed, keeping it"
+        else
+            $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        fi
     else
         echo "CUSTOM_BUILD_SGL_KERNEL=true: keeping freshly built sgl-kernel wheel."
     fi
     SGL_DEEP_GEMM_VERSION=$(grep -Po -m1 '(?<=sgl-deep-gemm==)[0-9A-Za-z\.\-]+' python/pyproject.toml)
     if [ "$CU_MAJOR" = "13" ]; then
+        SGL_DEEP_GEMM_WANTED="${SGL_DEEP_GEMM_VERSION}"
+    else
+        SGL_DEEP_GEMM_WANTED="${SGL_DEEP_GEMM_VERSION}+cu129"
+    fi
+    SGL_DEEP_GEMM_INSTALLED=$(pip show sgl-deep-gemm 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
+    if [ "$SGL_DEEP_GEMM_INSTALLED" = "$SGL_DEEP_GEMM_WANTED" ]; then
+        echo "sgl-deep-gemm==${SGL_DEEP_GEMM_WANTED} already installed, keeping it"
+    elif [ "$CU_MAJOR" = "13" ]; then
         $PIP_CMD install "sgl-deep-gemm==${SGL_DEEP_GEMM_VERSION}" --force-reinstall $PIP_INSTALL_SUFFIX
     else
         $PIP_CMD install "https://github.com/sgl-project/whl/releases/download/v${SGL_DEEP_GEMM_VERSION}/sgl_deep_gemm-${SGL_DEEP_GEMM_VERSION}+cu129-py3-none-manylinux2014_$(uname -m).whl" --force-reinstall $PIP_INSTALL_SUFFIX

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -238,8 +238,7 @@ setup_pip_toolchain() {
     PIP_UNINSTALL_CMD="uv pip uninstall"
     PIP_UNINSTALL_SUFFIX=""
 
-    # sglang-kernel stays: install_sglang_kernel reinstalls it on any version
-    # or CUDA-tag mismatch, so a matching wheel need not be cycled every job.
+    # sglang-kernel stays: install_sglang_kernel version-gates and reinstalls it.
     $PIP_UNINSTALL_CMD sgl-kernel sglang sgl-fa4 flash-attn-4 $PIP_UNINSTALL_SUFFIX || true
 
     mark_step_done "${FUNCNAME[0]}"
@@ -386,12 +385,11 @@ install_sglang() {
     mark_step_done "${FUNCNAME[0]}"
 }
 
-# Trust an installed wheel only if the version matches AND every RECORD file is
-# on disk - dist-info can survive a partial install (same failure mode as the
-# cusparselt guard in install_sglang). reject-local additionally refuses wheels
-# installed from a local file: a kernel-PR job installs its own build under the
-# SAME +cuXXX version string, and only file:// provenance (PEP 610
-# direct_url.json; index installs record none) tells it apart from the index wheel.
+# Trust an installed wheel only if the version matches and every RECORD file is
+# on disk (dist-info can survive a partial install - cf. the cusparselt guard).
+# reject-local refuses wheels installed from a local file: a kernel-PR job
+# installs its own build under the SAME +cuXXX version string, and only file://
+# provenance (PEP 610; index installs record none) tells them apart.
 installed_wheel_ok() {
     WHEEL_DIST="$1" WHEEL_WANTED="$2" WHEEL_REJECT_LOCAL="${3:-}" python3 - <<'EOF'
 import importlib.metadata as md
@@ -484,8 +482,7 @@ install_sglang_kernel() {
 
     if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
         # The PyPI default wheel tracks one CUDA version (currently cu130);
-        # runners on a different CUDA need the +${CU_VERSION}-tagged wheel from
-        # the sglang index. A verified match means the right wheel is in place.
+        # other runners need the +${CU_VERSION}-tagged wheel from the sglang index.
         SGL_KERNEL_WANTED="${SGL_KERNEL_VERSION_FROM_SRT}+${CU_VERSION}"
         if installed_wheel_ok sglang-kernel "${SGL_KERNEL_WANTED}" reject-local; then
             echo "sglang-kernel==${SGL_KERNEL_WANTED} already installed, keeping it"
@@ -501,8 +498,7 @@ install_sglang_kernel() {
     else
         SGL_DEEP_GEMM_WANTED="${SGL_DEEP_GEMM_VERSION}+cu129"
     fi
-    # No reject-local: nothing builds sgl-deep-gemm locally, and its cu129
-    # wheel installs from a direct URL, which legitimately records provenance.
+    # No reject-local: nothing builds sgl-deep-gemm locally.
     if installed_wheel_ok sgl-deep-gemm "${SGL_DEEP_GEMM_WANTED}"; then
         echo "sgl-deep-gemm==${SGL_DEEP_GEMM_WANTED} already installed, keeping it"
     elif [ "$CU_MAJOR" = "13" ]; then

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -396,20 +396,25 @@ import importlib.metadata as md
 import os
 import sys
 
+name = os.environ["WHEEL_DIST"]
+wanted = os.environ["WHEEL_WANTED"]
 try:
-    dist = md.distribution(os.environ["WHEEL_DIST"])
+    dist = md.distribution(name)
 except md.PackageNotFoundError:
+    print(f"{name} not installed (required: {wanted}); installing")
     sys.exit(1)
-if dist.version != os.environ["WHEEL_WANTED"]:
+if dist.version != wanted:
+    print(f"{name} mismatch (installed: {dist.version}, required: {wanted}); reinstalling")
     sys.exit(1)
 if os.environ["WHEEL_REJECT_LOCAL"] and "file://" in (dist.read_text("direct_url.json") or ""):
-    print(f"{dist.name} came from a locally built wheel; reinstalling from the index")
+    print(f"{name} came from a locally built wheel; reinstalling from the index")
     sys.exit(1)
 if dist.files is None:
+    print(f"{name} has no RECORD to verify; reinstalling")
     sys.exit(1)
 missing = [str(f) for f in dist.files if not dist.locate_file(f).exists()]
 if missing:
-    print(f"{dist.name} is missing {len(missing)} installed files (e.g. {missing[0]}); reinstalling")
+    print(f"{name} is missing {len(missing)} installed files (e.g. {missing[0]}); reinstalling")
     sys.exit(1)
 EOF
 }
@@ -481,8 +486,9 @@ install_sglang_kernel() {
     fi
 
     if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
-        # The PyPI default wheel tracks one CUDA version (currently cu130);
-        # other runners need the +${CU_VERSION}-tagged wheel from the sglang index.
+        # The PyPI default wheel tracks one CUDA version (currently cu130); other
+        # runners (e.g. h20 / cu129) need the +${CU_VERSION}-tagged wheel from the
+        # sglang index, linked against the right libnvrtc.
         SGL_KERNEL_WANTED="${SGL_KERNEL_VERSION_FROM_SRT}+${CU_VERSION}"
         if installed_wheel_ok sglang-kernel "${SGL_KERNEL_WANTED}" reject-local; then
             echo "sglang-kernel==${SGL_KERNEL_WANTED} already installed, keeping it"

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -386,6 +386,36 @@ install_sglang() {
     mark_step_done "${FUNCNAME[0]}"
 }
 
+# Trust an installed wheel only if the version matches AND every RECORD file is
+# on disk - dist-info can survive a partial install (same failure mode as the
+# cusparselt guard in install_sglang). reject-local additionally refuses wheels
+# installed from a local file: a kernel-PR job installs its own build under the
+# SAME +cuXXX version string, and only file:// provenance (PEP 610
+# direct_url.json; index installs record none) tells it apart from the index wheel.
+installed_wheel_ok() {
+    WHEEL_DIST="$1" WHEEL_WANTED="$2" WHEEL_REJECT_LOCAL="${3:-}" python3 - <<'EOF'
+import importlib.metadata as md
+import os
+import sys
+
+try:
+    dist = md.distribution(os.environ["WHEEL_DIST"])
+except md.PackageNotFoundError:
+    sys.exit(1)
+if dist.version != os.environ["WHEEL_WANTED"]:
+    sys.exit(1)
+if os.environ["WHEEL_REJECT_LOCAL"] and "file://" in (dist.read_text("direct_url.json") or ""):
+    print(f"{dist.name} came from a locally built wheel; reinstalling from the index")
+    sys.exit(1)
+if dist.files is None:
+    sys.exit(1)
+missing = [str(f) for f in dist.files if not dist.locate_file(f).exists()]
+if missing:
+    print(f"{dist.name} is missing {len(missing)} installed files (e.g. {missing[0]}); reinstalling")
+    sys.exit(1)
+EOF
+}
+
 install_sglang_kernel() {
     SGL_KERNEL_VERSION_FROM_KERNEL=$(grep -Po '(?<=^version = ")[^"]*' python/sglang/kernels/aot/pyproject.toml)
     SGL_KERNEL_VERSION_FROM_SRT=$(grep -Po -m1 '(?<=sglang-kernel==)[0-9A-Za-z\.\-]+' python/pyproject.toml)
@@ -455,10 +485,9 @@ install_sglang_kernel() {
     if [ "${CUSTOM_BUILD_SGL_KERNEL:-}" != "true" ]; then
         # The PyPI default wheel tracks one CUDA version (currently cu130);
         # runners on a different CUDA need the +${CU_VERSION}-tagged wheel from
-        # the sglang index. A tag match means the right wheel is already there.
+        # the sglang index. A verified match means the right wheel is in place.
         SGL_KERNEL_WANTED="${SGL_KERNEL_VERSION_FROM_SRT}+${CU_VERSION}"
-        SGL_KERNEL_INSTALLED=$(pip show sglang-kernel 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
-        if [ "$SGL_KERNEL_INSTALLED" = "$SGL_KERNEL_WANTED" ]; then
+        if installed_wheel_ok sglang-kernel "${SGL_KERNEL_WANTED}" reject-local; then
             echo "sglang-kernel==${SGL_KERNEL_WANTED} already installed, keeping it"
         else
             $PIP_CMD install "sglang-kernel==${SGL_KERNEL_VERSION_FROM_SRT}" --index-url "https://docs.sglang.ai/whl/${CU_VERSION}/" --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
@@ -472,8 +501,9 @@ install_sglang_kernel() {
     else
         SGL_DEEP_GEMM_WANTED="${SGL_DEEP_GEMM_VERSION}+cu129"
     fi
-    SGL_DEEP_GEMM_INSTALLED=$(pip show sgl-deep-gemm 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
-    if [ "$SGL_DEEP_GEMM_INSTALLED" = "$SGL_DEEP_GEMM_WANTED" ]; then
+    # No reject-local: nothing builds sgl-deep-gemm locally, and its cu129
+    # wheel installs from a direct URL, which legitimately records provenance.
+    if installed_wheel_ok sgl-deep-gemm "${SGL_DEEP_GEMM_WANTED}"; then
         echo "sgl-deep-gemm==${SGL_DEEP_GEMM_WANTED} already installed, keeping it"
     elif [ "$CU_MAJOR" = "13" ]; then
         $PIP_CMD install "sgl-deep-gemm==${SGL_DEEP_GEMM_VERSION}" --force-reinstall $PIP_INSTALL_SUFFIX


### PR DESCRIPTION
The install step force-reinstalled the sglang-kernel and sgl-deep-gemm wheels on every job even when the exact +cuXXX-tagged version was already installed. Keep sglang-kernel out of the blanket uninstall and reinstall both only when a check fails, following the existing flashinfer version-check pattern. Saves ~4-5s per install on warm runners.

A bare version compare is not enough to trust the installed wheel, so the gate (`installed_wheel_ok`) verifies three things via `importlib.metadata`:

- **Version + CUDA tag**: the sglang index wheels carry a `+cuXXX` local version (e.g. `0.4.5+cu130`). Per PEP 440 a local version satisfies the bare `==0.4.5` pin in pyproject, so `install_sglang` leaves a matching wheel untouched and the gate only compares the full tagged string.
- **Provenance**: jobs with `CUSTOM_BUILD_SGL_KERNEL=true` install a locally built wheel under the *same* `+cuXXX` version string. A path install records `file://` provenance in `direct_url.json` (PEP 610) while index installs record none, so the gate rejects local leftovers — without this, the next job on that runner would silently test against the previous PR's modified kernel (the old unconditional reinstall scrubbed it every job).
- **Payload**: dist-info can survive a partial install (the same failure mode the existing `nvidia-cusparselt` guard defends against), so the gate stats every RECORD entry and reinstalls when any file is missing. The old flow re-materialized the wheel every job, which self-healed such corruption; this keeps that property without paying the reinstall.

sgl-deep-gemm gets the version + payload checks but not the provenance check: nothing builds it locally, and its cu129 wheel installs from a direct URL, which legitimately records non-`file://` provenance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30982598051](https://github.com/sgl-project/sglang/actions/runs/30982598051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30982597764](https://github.com/sgl-project/sglang/actions/runs/30982597764)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->