### PR TITLE
[Feature] Support logprobs in /v1/responses non-streaming path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -53,6 +53,9 @@ from sglang.srt.entrypoints.harmony_utils import (
     parse_response_input,
     render_for_completion,
 )
+from sglang.srt.entrypoints.openai.utils import (
+    to_responses_style_logprobs,
+)
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionMessageParam,
     ChatCompletionRequest,
@@ -372,6 +375,16 @@ class OpenAIServingResponses(OpenAIServingChat):
                         extra_key=self._compute_extra_key(request),
                         background=request.background,
                         require_reasoning=require_reasoning,
+                        return_logprob=bool(
+                            (request.top_logprobs and request.top_logprobs > 0)
+                            or (
+                                request.include is not None
+                                and "message.output_text.logprobs"
+                                in request.include
+                            )
+                        ),
+                        top_logprobs_num=request.top_logprobs or 0,
+                        return_text_in_logprobs=True,
                     )
 
                     generator = self._generate_with_builtin_tools(
@@ -561,16 +574,11 @@ class OpenAIServingResponses(OpenAIServingChat):
             final_res = context.last_output
             assert final_res is not None
 
-            output = self._make_response_output_items(
-                request,
-                final_res["text"],
-                tokenizer,
-                require_reasoning=require_reasoning,
-            )
-
             # Calculate usage from actual output
             num_reasoning_tokens = 0
             meta_info = None
+            output_token_logprobs = None
+            output_top_logprobs = None
             if isinstance(final_res, dict) and isinstance(
                 final_res.get("meta_info"), dict
             ):
@@ -583,6 +591,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                 num_generated_tokens = meta_info.get("completion_tokens", 0)
                 num_cached_tokens = meta_info.get("cached_tokens", 0)
                 num_reasoning_tokens = meta_info.get("reasoning_tokens", 0)
+                output_token_logprobs = meta_info.get("output_token_logprobs")
+                output_top_logprobs = meta_info.get("output_top_logprobs")
             elif isinstance(final_res, dict) and (
                 final_res.get("prompt_token_ids") is not None
                 or final_res.get("output_ids") is not None
@@ -611,6 +621,15 @@ class OpenAIServingResponses(OpenAIServingChat):
                 num_generated_tokens = 0
                 num_cached_tokens = 0
                 num_reasoning_tokens = 0
+
+            output = self._make_response_output_items(
+                request,
+                final_res["text"],
+                tokenizer,
+                require_reasoning=require_reasoning,
+                output_token_logprobs=output_token_logprobs,
+                output_top_logprobs=output_top_logprobs,
+            )
 
         usage = UsageInfo(
             prompt_tokens=num_prompt_tokens,
@@ -687,6 +706,8 @@ class OpenAIServingResponses(OpenAIServingChat):
         tokenizer: Any,
         *,
         require_reasoning: bool,
+        output_token_logprobs: Optional[list] = None,
+        output_top_logprobs: Optional[list] = None,
     ):
         if self.reasoning_parser:
             reasoning_parser = ReasoningParser(
@@ -790,11 +811,23 @@ class OpenAIServingResponses(OpenAIServingChat):
                 logger.error("Required tool JSON parse error: %s", e)
 
         if content:
+            logprobs = None
+            wants_logprobs = (
+                request.top_logprobs is not None and request.top_logprobs > 0
+            ) or (
+                request.include is not None
+                and "message.output_text.logprobs" in request.include
+            )
+            if wants_logprobs:
+                logprobs = to_responses_style_logprobs(
+                    output_token_logprobs=output_token_logprobs,
+                    output_top_logprobs=output_top_logprobs,
+                )
             output_text = ResponseOutputText(
                 text=content,
                 annotations=[],  # TODO
                 type="output_text",
-                logprobs=None,  # TODO
+                logprobs=logprobs,
             )
             message = ResponseOutputMessage(
                 id=f"msg_{random_uuid()}",

--- a/python/sglang/srt/entrypoints/openai/utils.py
+++ b/python/sglang/srt/entrypoints/openai/utils.py
@@ -11,6 +11,11 @@ from sglang.srt.entrypoints.openai.protocol import (
     StreamOptions,
 )
 
+from openai.types.responses.response_output_text import (
+    Logprob as ResponsesLogprob,
+    LogprobTopLogprob as ResponsesLogprobTopLogprob,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,6 +54,53 @@ def to_openai_style_logprobs(
         append_top_logprobs(output_top_logprobs)
 
     return ret_logprobs
+
+
+def to_responses_style_logprobs(
+    output_token_logprobs=None,
+    output_top_logprobs=None,
+) -> Optional[List[ResponsesLogprob]]:
+    """Convert internal logprob data to the OpenAI Responses API format.
+
+    Each entry in *output_token_logprobs* is a ``(logprob, token_id, token_text)``
+    tuple produced by ``TokenizerManager.detokenize_logprob_tokens``.
+    Each entry in *output_top_logprobs* is a list of the same tuples (the
+    top-k alternatives for that position) or ``None``.
+
+    Returns a list of ``ResponseOutputText.Logprob`` objects, one per output
+    token, or ``None`` when no logprob data is available.
+    """
+    if not output_token_logprobs:
+        return None
+
+    result: List[ResponsesLogprob] = []
+    for i, (logprob, _token_id, token_text) in enumerate(output_token_logprobs):
+        token_bytes = list(token_text.encode("utf-8"))
+
+        top_logprobs: List[ResponsesLogprobTopLogprob] = []
+        if output_top_logprobs is not None and i < len(output_top_logprobs):
+            inner = output_top_logprobs[i]
+            if inner is not None:
+                for tp_logprob, _tp_token_id, tp_token_text in inner:
+                    tp_str = tp_token_text
+                    top_logprobs.append(
+                        ResponsesLogprobTopLogprob(
+                            token=tp_str,
+                            bytes=list(tp_str.encode("utf-8")),
+                            logprob=tp_logprob,
+                        )
+                    )
+
+        result.append(
+            ResponsesLogprob(
+                token=token_text,
+                bytes=token_bytes,
+                logprob=logprob,
+                top_logprobs=top_logprobs,
+            )
+        )
+
+    return result
 
 
 def process_hidden_states_from_ret(

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -640,6 +640,89 @@ class OutputItemsTestCase(unittest.TestCase):
         self.assertIsInstance(output_items[0], ResponseOutputMessage)
 
 
+class LogprobsTestCase(unittest.TestCase):
+    def test_logprobs_populated_when_top_logprobs_set(self):
+        """Non-streaming: top_logprobs > 0 produces logprobs in output text."""
+        serving = make_serving()
+        request = ResponsesRequest(
+            model="x", input="hi", top_logprobs=3, store=False
+        )
+
+        token_logprobs = [
+            (-0.5, 313, "Hello"),
+            (-0.2, 1234, "world"),
+        ]
+        top_logprobs = [
+            [(-0.5, 313, "Hello"), (-1.2, 999, "Hi")],
+            [(-0.2, 1234, "world"), (-1.5, 777, "earth")],
+        ]
+
+        output_items = serving._make_response_output_items(
+            request,
+            "Hello world",
+            serving.tokenizer_manager.tokenizer,
+            require_reasoning=False,
+            output_token_logprobs=token_logprobs,
+            output_top_logprobs=top_logprobs,
+        )
+
+        msg = output_items[0]
+        self.assertIsInstance(msg, ResponseOutputMessage)
+        text_part = msg.content[0]
+        self.assertIsNotNone(text_part.logprobs)
+        self.assertEqual(len(text_part.logprobs), 2)
+        self.assertEqual(text_part.logprobs[0].token, "Hello")
+        self.assertEqual(text_part.logprobs[0].logprob, -0.5)
+        self.assertEqual(len(text_part.logprobs[0].top_logprobs), 2)
+        self.assertEqual(text_part.logprobs[1].token, "world")
+
+    def test_logprobs_populated_when_include_set(self):
+        """Non-streaming: include list triggers logprobs even with top_logprobs=0."""
+        serving = make_serving()
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            top_logprobs=0,
+            include=["message.output_text.logprobs"],
+            store=False,
+        )
+
+        token_logprobs = [(-0.1, 42, "yes")]
+
+        output_items = serving._make_response_output_items(
+            request,
+            "yes",
+            serving.tokenizer_manager.tokenizer,
+            require_reasoning=False,
+            output_token_logprobs=token_logprobs,
+            output_top_logprobs=None,
+        )
+
+        text_part = output_items[0].content[0]
+        self.assertIsNotNone(text_part.logprobs)
+        self.assertEqual(text_part.logprobs[0].token, "yes")
+        self.assertEqual(len(text_part.logprobs[0].top_logprobs), 0)
+
+    def test_logprobs_none_when_not_requested(self):
+        """Non-streaming: logprobs absent when client doesn't request them."""
+        serving = make_serving()
+        request = ResponsesRequest(
+            model="x", input="hi", store=False
+        )
+
+        output_items = serving._make_response_output_items(
+            request,
+            "hello",
+            serving.tokenizer_manager.tokenizer,
+            require_reasoning=False,
+            output_token_logprobs=[(-0.1, 1, "hello")],
+            output_top_logprobs=None,
+        )
+
+        text_part = output_items[0].content[0]
+        self.assertIsNone(text_part.logprobs)
+
+
 class HarmonyResponsesTestCase(unittest.TestCase):
     def test_developer_message_skips_unsupported_tool_types(self):
         from sglang.srt.entrypoints.harmony_utils import get_developer_message


### PR DESCRIPTION
## Motivation

The `/v1/responses` endpoint accepted `top_logprobs` and `include` parameters but silently discarded all logprob data. The engine computed logprobs (the request passed `return_logprob` through internally), yet every response construction site hardcoded `logprobs=None` or `logprobs=[]`. A client sending `top_logprobs=5` received HTTP 200 with `logprobs: null`.

This is the first PR in a stacked series covering all four code paths.

## Changes

**`utils.py`** — Added `to_responses_style_logprobs()` converter that transforms internal `(logprob, token_id, token_text)` tuples into the OpenAI Responses API format (`List[ResponseOutputText.Logprob]`), parallel to the existing `to_openai_style_logprobs()` for chat completions.

**`serving_responses.py`** — Three wiring fixes in the non-streaming non-harmony path:
1. `GenerateReqInput`: pass `return_logprob`, `top_logprobs_num`, `return_text_in_logprobs` when the client requests logprobs via `top_logprobs > 0` or `include: ["message.output_text.logprobs"]`
2. `responses_full_generator`: extract `output_token_logprobs` / `output_top_logprobs` from `meta_info` and pass to `_make_response_output_items`
3. `_make_response_output_items`: call `to_responses_style_logprobs()` and populate `ResponseOutputText.logprobs` instead of `None`

**`test_serving_responses.py`** — Added `LogprobsTestCase` with 3 tests:
- `top_logprobs > 0` produces populated logprobs with top alternatives
- `include: ["message.output_text.logprobs"]` triggers logprobs even with `top_logprobs=0`
- Default (no logprobs requested) → `logprobs=None`

## Coverage matrix

| Path | Status |
|------|--------|
| Non-streaming, non-harmony | This PR |
| Non-streaming, harmony (GPT-OSS) | Follow-up PR |
| Streaming, non-harmony | Follow-up PR |
| Streaming, harmony | Follow-up PR |

## Checklist

- [x] Code follows the existing pattern from `serving_completions.py` / `to_openai_style_logprobs()`
- [x] Unit tests added (CPU-runnable, no GPU required)
- [x] All existing tests unaffected (new params default to `None`)
- [x] No breaking changes — `logprobs` defaults to `None` when not requested (same as before)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31147448859](https://github.com/sgl-project/sglang/actions/runs/31147448859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31147448774](https://github.com/sgl-project/sglang/actions/runs/31147448774)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->