### PR TITLE
[Bug] Accumulate sampling penalties per accepted token under speculative decoding

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -79,10 +79,7 @@ from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
 )
-from sglang.srt.mem_cache.allocation import (
-    alloc_for_decode,
-    alloc_for_extend,
-)
+from sglang.srt.mem_cache.allocation import alloc_for_decode, alloc_for_extend
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_reserve_per_decode
 from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import (
@@ -830,6 +827,11 @@ class Req(ReqDllmMixin):
         # full_untruncated_fill_ids from lengths alone, so in-place rewrites
         # that preserve length would silently corrupt fill_ids.
         self.output_ids = array("q")
+        # How many entries of output_ids have already been fed to the sampling
+        # penalizers. A decode step commits more than one token under
+        # speculative decoding, so the penalty state cannot assume 1:1 with
+        # steps and has to track its own cursor.
+        self.penalty_fed_len = 0
         # Full untruncated sequence: origin + output (+ DLLM mask block).
         # Kept in sync by _refresh_fill_ids; admission only updates
         # extend_range, never mutates this array's length.
@@ -1644,6 +1646,7 @@ class Req(ReqDllmMixin):
         # to ensure shape consistency in KV cache.
         if self.input_embeds is not None:
             self.output_ids = array("q")
+            self.penalty_fed_len = 0
 
     def offload_kv_cache(self, req_to_token_pool, token_to_kv_pool_allocator):
         token_indices = req_to_token_pool.req_to_token[
@@ -2928,22 +2931,68 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def cumulate_penalty_output_tokens(self):
         # Under overlap batch.input_ids is just a placeholder here -- the
         # real token is relayed via future_map and resolved at forward
-        # entry. So take the last output token from Req directly
+        # entry. So take the output tokens from Req directly
         # (origin_input_ids[-1] on the first decode, before any output).
-        last_tokens = [
-            req.output_ids[-1] if len(req.output_ids) else req.origin_input_ids[-1]
-            for req in self.reqs
-        ]
+        #
+        # Feed every token appended since the previous call, not just the last
+        # one: a speculative decode step commits `accept_len` tokens at once,
+        # and penalty state is per-token. Recording only the tail would leave
+        # the other accepted tokens permanently invisible to the penalizers,
+        # weakening them by a factor of the acceptance length.
+        pending = []
+        for req in self.reqs:
+            if req.penalty_fed_len > len(req.output_ids):
+                # output_ids was reset (retracted request); start over.
+                req.penalty_fed_len = 0
+            new_tokens = req.output_ids[req.penalty_fed_len :]
+            if not new_tokens and req.penalty_fed_len == 0:
+                # First decode, before any output token exists.
+                new_tokens = req.origin_input_ids[-1:]
+            else:
+                req.penalty_fed_len = len(req.output_ids)
+            pending.append(new_tokens)
+
+        max_new = max((len(tokens) for tokens in pending), default=0)
+        if max_new == 0:
+            return
+
         # Non-blocking H2D so this per-step copy doesn't sync behind the forward.
         # pin_memory (matching the prefill-path tensors) keeps the copy async;
         # is_pin_memory_available falls back to pageable on unsupported devices.
-        latest_output_ids = torch.tensor(
-            last_tokens,
+        pin_memory = is_pin_memory_available(self.device)
+        orchestrator = self.sampling_info.penalizer_orchestrator
+
+        if all(len(tokens) == 1 for tokens in pending):
+            # Non-speculative steps commit exactly one token per request; keep
+            # the original unmasked 1-D call so that path is unchanged. Rows can
+            # be empty when a request produced nothing this step, and those need
+            # the masked path below rather than an out-of-range index.
+            latest_output_ids = torch.tensor(
+                [tokens[0] for tokens in pending],
+                dtype=torch.int64,
+                pin_memory=pin_memory,
+            ).to(self.device, non_blocking=True)
+            orchestrator.cumulate_output_tokens(latest_output_ids)
+            return
+
+        # Ragged rows: pad to max_new and mark the real entries. Padding ids are
+        # never read because the mask zeroes their contribution.
+        padded_ids = torch.tensor(
+            [list(tokens) + [0] * (max_new - len(tokens)) for tokens in pending],
             dtype=torch.int64,
-            pin_memory=is_pin_memory_available(self.device),
-        ).to(self.device, non_blocking=True)
-        self.sampling_info.penalizer_orchestrator.cumulate_output_tokens(
-            latest_output_ids
+            pin_memory=pin_memory,
+        )
+        mask = torch.tensor(
+            [
+                [True] * len(tokens) + [False] * (max_new - len(tokens))
+                for tokens in pending
+            ],
+            dtype=torch.bool,
+            pin_memory=pin_memory,
+        )
+        orchestrator.cumulate_output_tokens(
+            padded_ids.to(self.device, non_blocking=True),
+            mask.to(self.device, non_blocking=True),
         )
 
     def prepare_for_decode(self):

--- a/python/sglang/srt/sampling/penaltylib/frequency_penalty.py
+++ b/python/sglang/srt/sampling/penaltylib/frequency_penalty.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
@@ -32,11 +34,17 @@ class BatchedFrequencyPenalizer(_BatchedPenalizer):
             )
         ).unsqueeze_(1)
 
-    def _cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def _cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
+        src = self.frequency_penalties
+        if mask is not None:
+            # scatter_add_ is additive, so a zero src makes padded rows a no-op.
+            src = src * mask.unsqueeze(1)
         self.cumulated_frequency_penalties.scatter_add_(
             dim=1,
             index=output_ids.unsqueeze(1),
-            src=self.frequency_penalties,
+            src=src,
         )
 
     def _apply(self, logits: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
+++ b/python/sglang/srt/sampling/penaltylib/min_new_tokens.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
@@ -67,8 +69,13 @@ class BatchedMinNewTokensPenalizer(_BatchedPenalizer):
             device=self.orchestrator.device,
         )
 
-    def _cumulate_output_tokens(self, output_ids: torch.Tensor):
-        self.len_output_tokens += 1
+    def _cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
+        if mask is None:
+            self.len_output_tokens += 1
+        else:
+            self.len_output_tokens += mask.unsqueeze(1).to(self.len_output_tokens.dtype)
 
     def _apply(self, logits: torch.Tensor):
         # Boolean-mask indexing (logits[mask]) is data-dependent and forces a

--- a/python/sglang/srt/sampling/penaltylib/orchestrator.py
+++ b/python/sglang/srt/sampling/penaltylib/orchestrator.py
@@ -42,15 +42,34 @@ class BatchedPenalizerOrchestrator:
     def reqs(self):
         return self.batch.reqs
 
-    def cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
         """
         Feed the output tokens to the penalizers.
 
         Args:
-            output_ids (torch.Tensor): The output tokens.
+            output_ids (torch.Tensor): `[batch_size]` when a step commits one
+                token per request, or `[batch_size, max_new]` when it commits
+                several (speculative decoding).
+            mask (Optional[torch.Tensor]): bool tensor shaped like `output_ids`
+                marking the real entries. Required whenever the rows are ragged,
+                since padded slots must not reach the penalty state.
         """
-        for penalizer in self.penalizers.values():
-            penalizer.cumulate_output_tokens(output_ids=output_ids)
+        if output_ids.dim() == 1:
+            for penalizer in self.penalizers.values():
+                penalizer.cumulate_output_tokens(output_ids=output_ids, mask=mask)
+            return
+
+        # Walk the accepted tokens in order. Each column is a plain 1-D update,
+        # so the penalizers only ever deal with `[batch_size]` indices and
+        # cannot hit the intra-row duplicate-index hazard of a 2-D scatter_.
+        for step in range(output_ids.shape[1]):
+            step_mask = None if mask is None else mask[:, step]
+            for penalizer in self.penalizers.values():
+                penalizer.cumulate_output_tokens(
+                    output_ids=output_ids[:, step], mask=step_mask
+                )
 
     def apply(self, logits: torch.Tensor, repeat: Optional[int] = None):
         """
@@ -209,11 +228,13 @@ class _BatchedPenalizer(abc.ABC):
         self._teardown()
         self._is_prepared = False
 
-    def cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
         if not self._is_prepared:
             return
 
-        self._cumulate_output_tokens(output_ids=output_ids)
+        self._cumulate_output_tokens(output_ids=output_ids, mask=mask)
 
     def apply(self, logits: torch.Tensor) -> torch.Tensor:
         if not self._is_prepared:
@@ -251,10 +272,16 @@ class _BatchedPenalizer(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def _cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
         """
         Cumulate the output tokens.
         Orchestrator will call this function to feed the output tokens to the penalizer.
+
+        `output_ids` is `[batch_size]`. `mask`, when given, is a `[batch_size]`
+        bool tensor; rows where it is False carry no token this step and must be
+        left untouched.
         """
         pass
 

--- a/python/sglang/srt/sampling/penaltylib/presence_penalty.py
+++ b/python/sglang/srt/sampling/penaltylib/presence_penalty.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
@@ -32,11 +34,23 @@ class BatchedPresencePenalizer(_BatchedPenalizer):
             )
         ).unsqueeze_(1)
 
-    def _cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def _cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
+        index = output_ids.unsqueeze(1)
+        src = self.presence_penalties
+        if mask is not None:
+            # scatter_ overwrites, so padded rows have to write back whatever is
+            # already stored at that index rather than the penalty value.
+            src = torch.where(
+                mask.unsqueeze(1),
+                src,
+                self.cumulated_presence_penalties.gather(1, index),
+            )
         self.cumulated_presence_penalties.scatter_(
             dim=1,
-            index=output_ids.unsqueeze(1),
-            src=self.presence_penalties,
+            index=index,
+            src=src,
         )
 
     def _apply(self, logits: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/sampling/penaltylib/repetition_penalty.py
+++ b/python/sglang/srt/sampling/penaltylib/repetition_penalty.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import torch
 
 from sglang.srt.sampling.penaltylib.orchestrator import _BatchedPenalizer
@@ -45,11 +47,23 @@ class BatchedRepetitionPenalizer(_BatchedPenalizer):
             )
         ).unsqueeze_(1)
 
-    def _cumulate_output_tokens(self, output_ids: torch.Tensor):
+    def _cumulate_output_tokens(
+        self, output_ids: torch.Tensor, mask: Optional[torch.Tensor] = None
+    ):
+        index = output_ids.unsqueeze(1)
+        src = self.repetition_penalties
+        if mask is not None:
+            # scatter_ overwrites, so padded rows have to write back whatever is
+            # already stored at that index rather than the penalty value.
+            src = torch.where(
+                mask.unsqueeze(1),
+                src,
+                self.cumulated_repetition_penalties.gather(1, index),
+            )
         self.cumulated_repetition_penalties.scatter_(
             dim=1,
-            index=output_ids.unsqueeze(1),
-            src=self.repetition_penalties,
+            index=index,
+            src=src,
         )
 
     def _apply(self, logits: torch.Tensor) -> torch.Tensor:

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -10,18 +10,11 @@ from unittest.mock import MagicMock
 
 import torch
 
-from sglang.srt.sampling.penaltylib.frequency_penalty import (
-    BatchedFrequencyPenalizer,
-)
-from sglang.srt.sampling.penaltylib.min_new_tokens import (
-    BatchedMinNewTokensPenalizer,
-)
-from sglang.srt.sampling.penaltylib.orchestrator import (
-    BatchedPenalizerOrchestrator,
-)
-from sglang.srt.sampling.penaltylib.presence_penalty import (
-    BatchedPresencePenalizer,
-)
+from sglang.srt.sampling.penaltylib.frequency_penalty import BatchedFrequencyPenalizer
+from sglang.srt.sampling.penaltylib.min_new_tokens import BatchedMinNewTokensPenalizer
+from sglang.srt.sampling.penaltylib.orchestrator import BatchedPenalizerOrchestrator
+from sglang.srt.sampling.penaltylib.presence_penalty import BatchedPresencePenalizer
+from sglang.srt.sampling.penaltylib.repetition_penalty import BatchedRepetitionPenalizer
 from sglang.test.test_utils import CustomTestCase
 
 VOCAB_SIZE = 32
@@ -29,11 +22,14 @@ DEVICE = "cpu"
 
 
 # Helpers: mock Req and ScheduleBatch
-def _make_req(freq=0.0, presence=0.0, min_tokens=0, stop_ids=None, eos_id=2):
+def _make_req(
+    freq=0.0, presence=0.0, min_tokens=0, stop_ids=None, eos_id=2, repetition=1.0
+):
     """Create a mock request with sampling params."""
     req = MagicMock()
     req.sampling_params.frequency_penalty = freq
     req.sampling_params.presence_penalty = presence
+    req.sampling_params.repetition_penalty = repetition
     req.sampling_params.min_new_tokens = min_tokens
     req.sampling_params.stop_token_ids = stop_ids
     req.tokenizer.additional_stop_token_ids = None
@@ -515,6 +511,148 @@ class TestOrchestratorMultiplePenalizers(CustomTestCase):
         self.assertTrue(orch_a.is_required)
         pen = orch_a.penalizers[BatchedFrequencyPenalizer]
         self.assertEqual(pen.frequency_penalties.shape[0], 2)
+
+
+# Multi-token accumulation (speculative decoding commits >1 token per step)
+class TestMultiTokenCumulation(CustomTestCase):
+    """A speculative decode step commits `accept_len` tokens at once. Penalty
+    state is per-token, so all of them have to be accumulated, not just the
+    last one."""
+
+    ALL_PENALIZERS = {
+        BatchedFrequencyPenalizer,
+        BatchedPresencePenalizer,
+        BatchedRepetitionPenalizer,
+        BatchedMinNewTokensPenalizer,
+    }
+
+    def _setup(self, batch_size=1, min_tokens=1):
+        # min_tokens > 0 keeps BatchedMinNewTokensPenalizer required, and so
+        # prepared, which is what makes its token counter observable.
+        reqs = [
+            _make_req(freq=0.5, presence=0.25, repetition=1.5, min_tokens=min_tokens)
+            for _ in range(batch_size)
+        ]
+        orch = BatchedPenalizerOrchestrator(
+            VOCAB_SIZE, _make_batch(reqs), self.ALL_PENALIZERS
+        )
+        return orch
+
+    @staticmethod
+    def _state(orch):
+        return {
+            "frequency": orch.penalizers[
+                BatchedFrequencyPenalizer
+            ].cumulated_frequency_penalties.clone(),
+            "presence": orch.penalizers[
+                BatchedPresencePenalizer
+            ].cumulated_presence_penalties.clone(),
+            "repetition": orch.penalizers[
+                BatchedRepetitionPenalizer
+            ].cumulated_repetition_penalties.clone(),
+            "min_new_tokens": orch.penalizers[
+                BatchedMinNewTokensPenalizer
+            ].len_output_tokens.clone(),
+        }
+
+    def test_every_accepted_token_is_counted(self):
+        """Test that a 4-token step counts all 4, not just the last one."""
+        orch = self._setup()
+        ids = torch.tensor([[3, 3, 7, 3]], dtype=torch.int64)
+        orch.cumulate_output_tokens(ids, torch.ones_like(ids, dtype=torch.bool))
+
+        freq = self._state(orch)["frequency"]
+        self.assertAlmostEqual(freq[0, 3].item(), 1.5, places=5)  # 3 x 0.5
+        self.assertAlmostEqual(freq[0, 7].item(), 0.5, places=5)  # 1 x 0.5
+
+    def test_frequency_total_matches_token_count(self):
+        """Test the accounting invariant: total penalty mass / per-token penalty
+        equals the number of tokens fed."""
+        orch = self._setup()
+        ids = torch.tensor([[3, 4, 5, 6, 7]], dtype=torch.int64)
+        orch.cumulate_output_tokens(ids, torch.ones_like(ids, dtype=torch.bool))
+
+        freq = self._state(orch)["frequency"]
+        self.assertAlmostEqual(freq.sum().item() / 0.5, 5.0, places=5)
+
+    def test_batched_step_matches_sequential_steps(self):
+        """Test that one N-token step leaves the exact state of N 1-token steps."""
+        tokens = [3, 3, 7, 3]
+
+        sequential = self._setup()
+        for token in tokens:
+            sequential.cumulate_output_tokens(torch.tensor([token], dtype=torch.int64))
+
+        batched = self._setup()
+        ids = torch.tensor([tokens], dtype=torch.int64)
+        batched.cumulate_output_tokens(ids, torch.ones_like(ids, dtype=torch.bool))
+
+        for name, expected in self._state(sequential).items():
+            self.assertTrue(
+                torch.equal(expected, self._state(batched)[name]),
+                f"{name} diverged between sequential and batched accumulation",
+            )
+
+    def test_masked_slots_are_noops(self):
+        """Test that padding in ragged rows never reaches the penalty state."""
+        orch = self._setup(batch_size=2)
+        # Row 0 accepted 3 tokens, row 1 accepted 1; the tail of row 1 is padding
+        # carrying token id 0, which must stay untouched.
+        ids = torch.tensor([[3, 4, 5], [9, 0, 0]], dtype=torch.int64)
+        mask = torch.tensor(
+            [[True, True, True], [True, False, False]], dtype=torch.bool
+        )
+        orch.cumulate_output_tokens(ids, mask)
+
+        state = self._state(orch)
+        self.assertAlmostEqual(state["frequency"][0].sum().item(), 1.5, places=5)
+        self.assertAlmostEqual(state["frequency"][1].sum().item(), 0.5, places=5)
+        # Padding id 0 must be at its untouched default for every penalizer.
+        self.assertAlmostEqual(state["frequency"][1, 0].item(), 0.0, places=5)
+        self.assertAlmostEqual(state["presence"][1, 0].item(), 0.0, places=5)
+        self.assertAlmostEqual(state["repetition"][1, 0].item(), 1.0, places=5)
+        # The one real token of row 1 still landed.
+        self.assertAlmostEqual(state["repetition"][1, 9].item(), 1.5, places=5)
+
+    def test_min_new_tokens_counts_tokens_not_steps(self):
+        """Test that min_new_tokens gates on accepted tokens, not decode steps."""
+        orch = self._setup(min_tokens=8)
+        pen = orch.penalizers[BatchedMinNewTokensPenalizer]
+        ids = torch.tensor([[1, 1, 1, 1]], dtype=torch.int64)
+        mask = torch.ones_like(ids, dtype=torch.bool)
+
+        orch.cumulate_output_tokens(ids, mask)
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertEqual(logits[0, 2].item(), float("-inf"))  # 4 tokens < 8
+
+        orch.cumulate_output_tokens(ids, mask)
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+        self.assertTrue(torch.isfinite(logits[0, 2]))  # 8 tokens, EOS unblocked
+
+    def test_ragged_min_new_tokens_is_per_request(self):
+        """Test that each request advances by its own accepted length."""
+        orch = self._setup(batch_size=2)
+        ids = torch.tensor([[3, 4, 5], [9, 0, 0]], dtype=torch.int64)
+        mask = torch.tensor(
+            [[True, True, True], [True, False, False]], dtype=torch.bool
+        )
+        orch.cumulate_output_tokens(ids, mask)
+
+        lens = self._state(orch)["min_new_tokens"]
+        self.assertEqual(int(lens[0, 0]), 3)
+        self.assertEqual(int(lens[1, 0]), 1)
+
+    def test_one_dim_path_needs_no_mask(self):
+        """Test that the non-speculative 1-D call still works without a mask."""
+        orch = self._setup(batch_size=2)
+        orch.cumulate_output_tokens(torch.tensor([3, 5], dtype=torch.int64))
+
+        state = self._state(orch)
+        self.assertAlmostEqual(state["frequency"][0, 3].item(), 0.5, places=5)
+        self.assertAlmostEqual(state["frequency"][1, 5].item(), 0.5, places=5)
+        self.assertEqual(int(state["min_new_tokens"][0, 0]), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A decode step commits `accept_len` tokens when a speculator is enabled, but `ScheduleBatch.cumulate_penalty_output_tokens` feeds only `req.output_ids[-1]` to the penalizers — one token per step. The remaining accepted tokens never enter penalty state and are never backfilled, so with a mean accepted length `L`:

* `frequency_penalty` accumulates via `scatter_add_`, so its effective strength becomes roughly `nominal / L`.
* `min_new_tokens` counts decode steps rather than tokens, so EOS stays masked to `-inf` for about `L`× longer than requested — this one is not a weakened penalty, it is an incorrect hard constraint.
* `presence_penalty` / `repetition_penalty` use an idempotent `scatter_`, so a dropped token only delays activation rather than losing it permanently. In a stable repetition loop the loop period tends to line up with the accepted length, so the same cycle position lands at the step tail every time and the other tokens in the cycle are never recorded at all.

The severity scales with acceptance length, i.e. the better the draft model, the weaker the penalties. This is invisible in the usual accuracy suites, which run without penalties and therefore leave `penalizer_orchestrator.is_required` false.

`prepare_for_decode` returns early into the spec branch, so the entry point on the speculative path is `eagle_prepare_for_decode` (`python/sglang/srt/speculative/eagle_utils.py`). That call and the non-speculative one in `prepare_for_decode` are the only two places that feed penalty state. The behavior is correct on the non-speculative path (one token per step, 1:1) and only breaks when a step commits more than one token.

The repo already has a convention for this class of problem: `update_finish_state` / `_check_str_based_finish` / `tail_str` all take `new_accepted_len` so stop-string matching covers every accepted token. The penalty path was simply not updated alongside it.

## Changes

| File | Change |
| --- | --- |
| `managers/schedule_batch.py` | `cumulate_penalty_output_tokens` feeds every token appended since the previous call, tracked by a new per-`Req` cursor `penalty_fed_len`. Ragged rows are padded to the longest accepted run and carry a validity mask. The cursor resets when `output_ids` is cleared for a retracted request. |
| `penaltylib/orchestrator.py` | `cumulate_output_tokens` accepts `[batch_size, max_new]` plus an optional mask, and walks the accepted tokens column by column so each penalizer still sees a plain 1-D index (no intra-row duplicate-index hazard in `scatter_`). |
| `penaltylib/frequency_penalty.py` | Zero the `scatter_add_` src on padded slots. |
| `penaltylib/presence_penalty.py`, `penaltylib/repetition_penalty.py` | `scatter_` overwrites, so padded slots write back the value already stored at that index. |
| `penaltylib/min_new_tokens.py` | Advance by the per-request accepted count instead of `+= 1`. |
| `test/registered/unit/sampling/test_penaltylib.py` | New `TestMultiTokenCumulation` covering the above. |

## Scope

Steps that commit exactly one token per request still take the original unmasked 1-D call, so the non-speculative path is unchanged. `mask` defaults to `None` throughout, and with no mask every penalizer executes exactly the pre-patch statements.

The fix is platform-independent — this affects CUDA as much as any other backend.

## Test plan

`test/registered/unit/sampling/test_penaltylib.py`, 47 tests (40 pre-existing + 7 new), all passing on CPU:

| Test | Asserts |
| --- | --- |
| `test_every_accepted_token_is_counted` | A 4-token step counts all 4, not just the tail. |
| `test_frequency_total_matches_token_count` | Accounting invariant: total penalty mass / per-token penalty equals the number of tokens fed. |
| `test_batched_step_matches_sequential_steps` | One N-token step leaves byte-identical state to N 1-token steps, for all four penalizers. |
| `test_masked_slots_are_noops` | Padding in ragged rows never reaches penalty state; the padding token id stays at its untouched default for each penalizer. |
| `test_min_new_tokens_counts_tokens_not_steps` | EOS is still blocked after 4 accepted tokens with `min_new_tokens=8`, and unblocked after 8. |
| `test_ragged_min_new_tokens_is_per_request` | Each request advances by its own accepted length. |
| `test_one_dim_path_needs_no_mask` | The non-speculative 1-D call still works without a mask. |

Not yet covered, and the main reason this is a draft:

* No end-to-end serving run. A useful external check is to set `min_new_tokens=100` with a speculator enabled and observe the earliest position at which EOS can be emitted — pre-patch it lands near `100 × accept_len`, post-patch near 100.
* No throughput measurement. The orchestrator now issues `max_new` small updates per step instead of one, bounded by the accepted length and only when penalties are active. If that shows up in benchmarks, `frequency_penalty` can be vectorized directly with a 2-D masked `scatter_add_`; the two overwriting penalizers are the ones that need the per-column walk.

Happy to add an integration test if reviewers prefer one before merge.

## Related

* #28180 reports the same user-visible symptom — repetition loop, `accept rate: 1.00`, request never terminates — but attributes it to `BatchedRepetitionPenalizer` not being registered. That penalizer is registered in `sampling_batch_info.py`, so that attribution no longer holds while the issue stays open. This is a plausible actual root cause.
* #29512 may be the same defect.
* Orthogonal to #32922 / #31214, which fix the ROCm verify path silently falling back to greedy. Both defects push long generations toward repetition loops and can be present at the same time.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30975433994](https://github.com/sgl-project/sglang/actions/runs/30975433994)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30975433911](https://github.com/sgl-project/sglang/actions/runs/30975433911)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->