### PR TITLE
[CI] Free hosted-runner disk space only when it is low

### DIFF
--- a/.github/workflows/_pr-test-stage-cpu.yml
+++ b/.github/workflows/_pr-test-stage-cpu.yml
@@ -62,7 +62,12 @@ jobs:
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          # The image ships ~65G free and the suite peaks around 30G; deleting
+          # these trees is ~1M unlinks (~80s), so only pay it when actually low.
+          avail_gb=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          if [ "${avail_gb}" -lt 40 ]; then
+              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          fi
           df -h
 
       - name: Checkout code

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -245,7 +245,12 @@ jobs:
     steps:
       - name: Free disk space
         run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          # The image ships ~65G free and the suite peaks around 30G; deleting
+          # these trees is ~1M unlinks (~80s), so only pay it when actually low.
+          avail_gb=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          if [ "${avail_gb}" -lt 40 ]; then
+              sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          fi
           df -h
 
       - name: Checkout code


### PR DESCRIPTION
ubuntu-latest now ships a 145G root disk (~65G free before the sweep) while the CPU suites peak around 30G, yet every CPU job still paid ~80s deleting ~1M preinstalled files; gate the deletion on available space (<40G) so the normal path costs nothing and the fallback keeps jobs safe if the image or suite footprint changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #30975669053](https://github.com/sgl-project/sglang/actions/runs/30975669053)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30975668904](https://github.com/sgl-project/sglang/actions/runs/30975668904)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->