### PR TITLE
Fix TopK output contracts under torch.compile

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_native.py
+++ b/python/sglang/srt/layers/moe/fused_moe_native.py
@@ -15,7 +15,7 @@ from sglang.srt.layers.moe.token_dispatcher import (
     StandardCombineInput,
     StandardDispatchOutput,
 )
-from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.srt.layers.moe.topk import StandardTopKOutput, TopKOutputChecker
 
 
 def fused_moe_forward_native(
@@ -26,6 +26,10 @@ def fused_moe_forward_native(
     x = dispatch_output.hidden_states
     topk_output = dispatch_output.topk_output
     moe_runner_config = layer.moe_runner_config
+
+    if TopKOutputChecker.format_is_bypassed(topk_output):
+        topk_output = topk_output.to_standard(layer_id=layer.layer_id)
+    assert TopKOutputChecker.format_is_standard(topk_output)
 
     if moe_runner_config.apply_router_weight_on_input:
         raise NotImplementedError()

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -472,6 +472,29 @@ class TopK(MultiPlatformOp):
         assert TopKOutputChecker.format_is_standard(topk_output)
         return self.waterfill_balancer.expand_topk(topk_output, num_tokens)
 
+    def _get_output_format(self) -> TopKOutputFormat:
+        if self.topk_config.output_format is not None:
+            return self.topk_config.output_format
+        if get_moe_runner_backend().is_triton_kernels():
+            return TopKOutputFormat.TRITON_KERNEL
+        # ===== TO BE REFACTORED ====
+        if get_moe_runner_backend().is_experimental_sgl_trtllm():
+            try:
+                use_standard_for_lora = bool(get_lora().enable_lora)
+            except ValueError:
+                use_standard_for_lora = False
+            return (
+                TopKOutputFormat.STANDARD
+                if use_standard_for_lora
+                else TopKOutputFormat.BYPASSED
+            )
+        # ===== END TO BE REFACTORED ====
+        if get_moe_runner_backend().is_flashinfer_trtllm() or (
+            get_moe_runner_backend().is_flashinfer_mxfp4() and not self.is_fp4_experts
+        ):
+            return TopKOutputFormat.BYPASSED
+        return TopKOutputFormat.STANDARD
+
     def forward_native(
         self,
         hidden_states: torch.Tensor,
@@ -507,29 +530,6 @@ class TopK(MultiPlatformOp):
             expert_location_dispatch_info=expert_location_dispatch_info,
         )
         return self._apply_waterfill(topk_output, hidden_states.shape[0])
-
-    def _get_output_format(self) -> TopKOutputFormat:
-        if self.topk_config.output_format is not None:
-            return self.topk_config.output_format
-        if get_moe_runner_backend().is_triton_kernels():
-            return TopKOutputFormat.TRITON_KERNEL
-        # ===== TO BE REFACTORED ====
-        if get_moe_runner_backend().is_experimental_sgl_trtllm():
-            try:
-                use_standard_for_lora = bool(get_lora().enable_lora)
-            except ValueError:
-                use_standard_for_lora = False
-            return (
-                TopKOutputFormat.STANDARD
-                if use_standard_for_lora
-                else TopKOutputFormat.BYPASSED
-            )
-        # ===== END TO BE REFACTORED ====
-        if get_moe_runner_backend().is_flashinfer_trtllm() or (
-            get_moe_runner_backend().is_flashinfer_mxfp4() and not self.is_fp4_experts
-        ):
-            return TopKOutputFormat.BYPASSED
-        return TopKOutputFormat.STANDARD
 
     def forward_cuda(
         self,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -503,15 +503,10 @@ class TopK(MultiPlatformOp):
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
+        self.topk_config.torch_native = True
         output_format = self._get_output_format()
-        if output_format == TopKOutputFormat.TRITON_KERNEL:
-            # renormalize=True is equivalent to sm_first=False
-            routing_data, gather_idx, scatter_idx = routing(
-                router_logits,
-                self.topk_config.top_k,
-                sm_first=not self.topk_config.renormalize,
-            )
-            return TritonKernelTopKOutput(routing_data, gather_idx, scatter_idx)
+        # Quantized runners consume the bypass carrier directly; the native
+        # unquantized fallback materializes it before using routing tensors.
         if output_format == TopKOutputFormat.BYPASSED:
             return BypassedTopKOutput(
                 hidden_states=hidden_states,
@@ -520,7 +515,6 @@ class TopK(MultiPlatformOp):
                 num_token_non_padded=num_token_non_padded,
                 expert_location_dispatch_info=expert_location_dispatch_info,
             )
-        self.topk_config.torch_native = True
         topk_output = select_experts(
             hidden_states=hidden_states,
             layer_id=self.layer_id,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -480,6 +480,23 @@ class TopK(MultiPlatformOp):
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
+        output_format = self._get_output_format()
+        if output_format == TopKOutputFormat.TRITON_KERNEL:
+            # renormalize=True is equivalent to sm_first=False
+            routing_data, gather_idx, scatter_idx = routing(
+                router_logits,
+                self.topk_config.top_k,
+                sm_first=not self.topk_config.renormalize,
+            )
+            return TritonKernelTopKOutput(routing_data, gather_idx, scatter_idx)
+        if output_format == TopKOutputFormat.BYPASSED:
+            return BypassedTopKOutput(
+                hidden_states=hidden_states,
+                router_logits=router_logits,
+                topk_config=self.topk_config,
+                num_token_non_padded=num_token_non_padded,
+                expert_location_dispatch_info=expert_location_dispatch_info,
+            )
         self.topk_config.torch_native = True
         topk_output = select_experts(
             hidden_states=hidden_states,
@@ -491,6 +508,29 @@ class TopK(MultiPlatformOp):
         )
         return self._apply_waterfill(topk_output, hidden_states.shape[0])
 
+    def _get_output_format(self) -> TopKOutputFormat:
+        if self.topk_config.output_format is not None:
+            return self.topk_config.output_format
+        if get_moe_runner_backend().is_triton_kernels():
+            return TopKOutputFormat.TRITON_KERNEL
+        # ===== TO BE REFACTORED ====
+        if get_moe_runner_backend().is_experimental_sgl_trtllm():
+            try:
+                use_standard_for_lora = bool(get_lora().enable_lora)
+            except ValueError:
+                use_standard_for_lora = False
+            return (
+                TopKOutputFormat.STANDARD
+                if use_standard_for_lora
+                else TopKOutputFormat.BYPASSED
+            )
+        # ===== END TO BE REFACTORED ====
+        if get_moe_runner_backend().is_flashinfer_trtllm() or (
+            get_moe_runner_backend().is_flashinfer_mxfp4() and not self.is_fp4_experts
+        ):
+            return TopKOutputFormat.BYPASSED
+        return TopKOutputFormat.STANDARD
+
     def forward_cuda(
         self,
         hidden_states: torch.Tensor,
@@ -499,29 +539,7 @@ class TopK(MultiPlatformOp):
         num_token_non_padded: Optional[torch.Tensor] = None,
         expert_location_dispatch_info: Optional[ExpertLocationDispatchInfo] = None,
     ) -> TopKOutput:
-        if self.topk_config.output_format is not None:
-            output_format = self.topk_config.output_format
-        elif get_moe_runner_backend().is_triton_kernels():
-            output_format = TopKOutputFormat.TRITON_KERNEL
-        # ===== TO BE REFACTORED ====
-        elif get_moe_runner_backend().is_experimental_sgl_trtllm():
-            try:
-
-                use_standard_for_lora = bool(get_lora().enable_lora)
-            except ValueError:
-                use_standard_for_lora = False
-            output_format = (
-                TopKOutputFormat.STANDARD
-                if use_standard_for_lora
-                else TopKOutputFormat.BYPASSED
-            )
-        # ===== END TO BE REFACTORED ====
-        elif get_moe_runner_backend().is_flashinfer_trtllm() or (
-            get_moe_runner_backend().is_flashinfer_mxfp4() and not self.is_fp4_experts
-        ):
-            output_format = TopKOutputFormat.BYPASSED
-        else:
-            output_format = TopKOutputFormat.STANDARD
+        output_format = self._get_output_format()
 
         if output_format == TopKOutputFormat.TRITON_KERNEL:
             # renormalize=True is equivalent to sm_first=False

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -3,20 +3,16 @@ from unittest.mock import patch
 
 import torch
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
-from sglang.srt.layers.moe import MoeRunnerBackend
-from sglang.srt.layers.moe.topk import (
-    BypassedTopKOutput,
-    StandardTopKOutput,
-    TopK,
-    TopKOutputFormat,
-    TritonKernelTopKOutput,
-)
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput
+from sglang.srt.layers.moe.topk import BypassedTopKOutput, TopK
 from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
 from sglang.srt.layers.moe.topk import biased_topk_impl as native_biased_topk
 from sglang.srt.layers.moe.topk import fused_topk_torch_native as native_fused_topk
 from sglang.srt.layers.moe.topk import grouped_topk_gpu as native_grouped_topk
+from sglang.srt.layers.quantization.unquant import UnquantizedFusedMoEMethod
 from sglang.srt.models.llama4 import Llama4MoE
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -180,63 +176,64 @@ class TestBiasedTopK(CustomTestCase):
 
 
 class TestTopK(CustomTestCase):
-    def test_native_forward_preserves_standard_format(self):
-        topk = TopK(top_k=2)
-        hidden_states = torch.randn(1, 4)
-        router_logits = torch.randn(1, 8)
-        expected = StandardTopKOutput(
-            torch.randn(1, 2), torch.zeros(1, 2, dtype=torch.int64), router_logits
-        )
+    def test_compile_mode_bypassed_topk_is_consumed_by_native_moe(self):
+        """A bypass-routing backend must interoperate with native compiled MoE."""
 
-        with patch("sglang.srt.layers.moe.topk.select_experts", return_value=expected):
-            output = topk.forward_native(hidden_states, router_logits)
+        class CompileMoe(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.topk = TopK(top_k=2)
+                self.method = UnquantizedFusedMoEMethod()
+                self.layer_id = 3
+                self.moe_runner_config = MoeRunnerConfig(activation="silu")
+                self.w13_weight = torch.nn.Parameter(
+                    torch.tensor(
+                        [
+                            [[1.0, 0.0], [0.0, 1.0]],
+                            [[0.0, 1.0], [1.0, 0.0]],
+                        ]
+                    ),
+                    requires_grad=False,
+                )
+                self.w2_weight = torch.nn.Parameter(
+                    torch.tensor(
+                        [
+                            [[1.0], [0.0]],
+                            [[0.0], [1.0]],
+                        ]
+                    ),
+                    requires_grad=False,
+                )
+                self.topk.enter_torch_compile(num_tokens=1)
+                self.method.enter_torch_compile(num_tokens=1)
 
-        self.assertIs(output, expected)
-        self.assertTrue(topk.topk_config.torch_native)
+            def forward(self, hidden_states, router_logits):
+                topk_output = self.topk(hidden_states, router_logits)
+                dispatch_output = StandardDispatchOutput(
+                    hidden_states, None, topk_output
+                )
+                return self.method.apply(self, dispatch_output).hidden_states
 
-    def test_native_forward_preserves_bypassed_format(self):
-        topk = TopK(top_k=2, output_format=TopKOutputFormat.BYPASSED)
-        hidden_states = torch.randn(1, 4)
-        router_logits = torch.randn(1, 8)
-
-        output = topk.forward_native(hidden_states, router_logits)
-
-        self.assertIsInstance(output, BypassedTopKOutput)
-        self.assertIs(output.hidden_states, hidden_states)
-        self.assertIs(output.router_logits, router_logits)
-
-    def test_native_forward_preserves_backend_bypassed_format(self):
-        topk = TopK(top_k=2)
-        hidden_states = torch.randn(1, 4)
-        router_logits = torch.randn(1, 8)
+        hidden_states = torch.tensor([[1.0, 2.0]])
+        router_logits = torch.tensor([[0.25, 0.75]])
+        torch._dynamo.reset()
+        model = CompileMoe()
+        self.addCleanup(model.topk.leave_torch_compile)
+        self.addCleanup(model.method.leave_torch_compile)
+        self.addCleanup(torch._dynamo.reset)
 
         with patch(
             "sglang.srt.layers.moe.topk.get_moe_runner_backend",
-            return_value=MoeRunnerBackend.FLASHINFER_TRTLLM,
+            new=lambda: MoeRunnerBackend.FLASHINFER_TRTLLM,
         ):
-            output = topk.forward_native(hidden_states, router_logits)
+            topk_output = model.topk(hidden_states, router_logits)
+            expected = model(hidden_states, router_logits)
+            compiled = torch.compile(model, backend="eager", fullgraph=True)
+            actual = compiled(hidden_states, router_logits)
 
-        self.assertIsInstance(output, BypassedTopKOutput)
-        self.assertIs(output.hidden_states, hidden_states)
-        self.assertIs(output.router_logits, router_logits)
-
-    def test_native_forward_preserves_triton_format(self):
-        topk = TopK(top_k=2, output_format=TopKOutputFormat.TRITON_KERNEL)
-        hidden_states = torch.randn(1, 4)
-        router_logits = torch.randn(1, 8)
-        routing_data, gather_idx, scatter_idx = object(), object(), object()
-
-        with patch(
-            "sglang.srt.layers.moe.topk.routing",
-            return_value=(routing_data, gather_idx, scatter_idx),
-            create=True,
-        ):
-            output = topk.forward_native(hidden_states, router_logits)
-
-        self.assertIsInstance(output, TritonKernelTopKOutput)
-        self.assertIs(output.routing_data, routing_data)
-        self.assertIs(output.gather_indx, gather_idx)
-        self.assertIs(output.scatter_indx, scatter_idx)
+        self.assertIsInstance(topk_output, BypassedTopKOutput)
+        self.assertTrue(topk_output.topk_config.torch_native)
+        torch.testing.assert_close(actual, expected)
 
     def _run_single_test(self, M, E, topk, renormalize, dtype):
         torch.manual_seed(1998)

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 import torch
+
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
 from sglang.srt.layers.moe.token_dispatcher import StandardDispatchOutput

--- a/test/registered/cpu/test_topk.py
+++ b/test/registered/cpu/test_topk.py
@@ -1,8 +1,16 @@
 import unittest
+from unittest.mock import patch
 
 import torch
-
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+from sglang.srt.layers.moe import MoeRunnerBackend
+from sglang.srt.layers.moe.topk import (
+    BypassedTopKOutput,
+    StandardTopKOutput,
+    TopK,
+    TopKOutputFormat,
+    TritonKernelTopKOutput,
+)
 from sglang.srt.layers.moe.topk import (
     biased_grouped_topk_impl as native_biased_grouped_topk,
 )
@@ -172,6 +180,64 @@ class TestBiasedTopK(CustomTestCase):
 
 
 class TestTopK(CustomTestCase):
+    def test_native_forward_preserves_standard_format(self):
+        topk = TopK(top_k=2)
+        hidden_states = torch.randn(1, 4)
+        router_logits = torch.randn(1, 8)
+        expected = StandardTopKOutput(
+            torch.randn(1, 2), torch.zeros(1, 2, dtype=torch.int64), router_logits
+        )
+
+        with patch("sglang.srt.layers.moe.topk.select_experts", return_value=expected):
+            output = topk.forward_native(hidden_states, router_logits)
+
+        self.assertIs(output, expected)
+        self.assertTrue(topk.topk_config.torch_native)
+
+    def test_native_forward_preserves_bypassed_format(self):
+        topk = TopK(top_k=2, output_format=TopKOutputFormat.BYPASSED)
+        hidden_states = torch.randn(1, 4)
+        router_logits = torch.randn(1, 8)
+
+        output = topk.forward_native(hidden_states, router_logits)
+
+        self.assertIsInstance(output, BypassedTopKOutput)
+        self.assertIs(output.hidden_states, hidden_states)
+        self.assertIs(output.router_logits, router_logits)
+
+    def test_native_forward_preserves_backend_bypassed_format(self):
+        topk = TopK(top_k=2)
+        hidden_states = torch.randn(1, 4)
+        router_logits = torch.randn(1, 8)
+
+        with patch(
+            "sglang.srt.layers.moe.topk.get_moe_runner_backend",
+            return_value=MoeRunnerBackend.FLASHINFER_TRTLLM,
+        ):
+            output = topk.forward_native(hidden_states, router_logits)
+
+        self.assertIsInstance(output, BypassedTopKOutput)
+        self.assertIs(output.hidden_states, hidden_states)
+        self.assertIs(output.router_logits, router_logits)
+
+    def test_native_forward_preserves_triton_format(self):
+        topk = TopK(top_k=2, output_format=TopKOutputFormat.TRITON_KERNEL)
+        hidden_states = torch.randn(1, 4)
+        router_logits = torch.randn(1, 8)
+        routing_data, gather_idx, scatter_idx = object(), object(), object()
+
+        with patch(
+            "sglang.srt.layers.moe.topk.routing",
+            return_value=(routing_data, gather_idx, scatter_idx),
+            create=True,
+        ):
+            output = topk.forward_native(hidden_states, router_logits)
+
+        self.assertIsInstance(output, TritonKernelTopKOutput)
+        self.assertIs(output.routing_data, routing_data)
+        self.assertIs(output.gather_indx, gather_idx)
+        self.assertIs(output.scatter_indx, scatter_idx)
+
     def _run_single_test(self, M, E, topk, renormalize, dtype):
         torch.manual_seed(1998)
 


### PR DESCRIPTION
Fixes part of #26324.

When single-token execution enters `torch.compile` mode, `TopK` switches from its CUDA implementation to `forward_native`. That path always materialized `StandardTopKOutput`, even when the selected MoE runner requires a deferred `BypassedTopKOutput` carrier. The mismatch reaches the runner as an output format assertion failure.

The native unquantized MoE fallback has the opposite consumer contract: it needs materialized routing tensors. Returning the bypass carrier without adapting this consumer causes a tuple-unpack failure instead.

## Change

- Preserve `BypassedTopKOutput` during compiled TopK execution when the selected backend requires it.
- Materialize bypassed routing only at the native unquantized MoE consumer boundary.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30976888468](https://github.com/sgl-project/sglang/actions/runs/30976888468)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30976888371](https://github.com/sgl-project/sglang/actions/runs/30976888371)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->