### PR TITLE
Let the remaining DSA config accessors accept DeepSeek-V4

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -192,13 +192,13 @@ def get_minimax_sparse_score_type(sparse_cfg: dict) -> str:
 
 
 def get_dsa_index_topk(config: PretrainedConfig) -> int:
-    assert is_deepseek_dsa(config)
+    assert is_deepseek_dsa(config) or is_deepseek_v4(config)
     return config.index_topk
 
 
 def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
     """Return whether a DSA layer reuses the previous layer's top-k indices."""
-    assert is_deepseek_dsa(config)
+    assert is_deepseek_dsa(config) or is_deepseek_v4(config)
 
     pattern = getattr(config, "index_topk_pattern", None)
     if pattern is not None:
@@ -220,7 +220,7 @@ def dsa_layer_skips_topk(config: PretrainedConfig, layer_id: int) -> bool:
 
 
 def get_dsa_index_n_heads(config: PretrainedConfig) -> int:
-    assert is_deepseek_dsa(config)
+    assert is_deepseek_dsa(config) or is_deepseek_v4(config)
     return config.index_n_heads
 
 


### PR DESCRIPTION
## Motivation

`get_dsa_seed_metadata_dim` exists to serve `index_share_for_mtp_iteration`:

```python
def get_dsa_seed_metadata_dim(hf_config) -> int:
    """Return the model-defined PD seed width, independent of local spec mode."""
    if not getattr(hf_config, "index_share_for_mtp_iteration", False):
        return 0
    return get_dsa_index_topk(hf_config)
```

`get_dsa_index_topk` asserts `is_deepseek_dsa(config)`, and `DeepseekV4ForCausalLM` is not in that architecture list — it is covered by `is_deepseek_v4` instead. So enabling `index_share_for_mtp_iteration` on DeepSeek-V4 always fails at startup, even though the config carries the field the accessor wants (`index_topk = 512` on `DeepSeek-V4-Flash-0731`).

The assertion fires after weights are loaded and CUDA graphs are captured, so it costs a full startup before it surfaces:

```
  File "sglang/srt/disaggregation/utils.py", line 73, in get_dsa_seed_metadata_dim
    return get_dsa_index_topk(hf_config)
  File "sglang/srt/configs/model_config.py", line 195, in get_dsa_index_topk
    assert is_deepseek_dsa(config)
AssertionError
[...] Received sigquit from a child process. It usually means the child failed.
```

Reproduced on 8x A800-SXM4-80GB (TP=8) with stock `deepseek-ai/DeepSeek-V4-Flash-0731`, `--speculative-algorithm DSPARK` and `--json-model-override-args '{"index_share_for_mtp_iteration": true}'`.

## Modifications

Four sibling accessors read DSA config fields. Only one of them was widened when V4 landed:

| | |
|---|---|
| `get_dsa_index_head_dim` | `is_deepseek_dsa(config) or is_deepseek_v4(config)` |
| `get_dsa_index_topk` | `is_deepseek_dsa(config)` |
| `dsa_layer_skips_topk` | `is_deepseek_dsa(config)` |
| `get_dsa_index_n_heads` | `is_deepseek_dsa(config)` |

This brings the remaining three in line.

To be precise about scope: only `get_dsa_index_topk` is reachable for a V4 config today, through `get_dsa_seed_metadata_dim` above. Its other callers are gated behind `is_deepseek_dsa` (`server_args.py`, `dsa_backend.py`) or live on the `deepseek_v2.py` path, which V4 does not take. The other two accessors are likewise unreachable for V4 right now — `resolve_pp_proxy_topk_size` short-circuits on `not is_deepseek_dsa(hf_config)` before it would call `dsa_layer_skips_topk`, and `get_dsa_index_n_heads` is reached from `deepseek_v2.py` or the LoRA shape table.

They are aligned here because the four are siblings over the same fields and the split between them is not intentional, so the next caller added on the V4 path hits the same wall. The assertion is only ever widened, never narrowed.

## Accuracy Tests

No functional change for any configuration that already loaded: every config accepted before is still accepted.
