### PR TITLE
fix(PP): size the mamba pool per pipeline stage, not per whole model

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -24,6 +24,7 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.distributed.parallel_state import get_world_group
+from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     get_kv_cache_quant_method,
@@ -1805,6 +1806,27 @@ class KVCacheConfigurator:
         server_args = self.server_args
         assert config is not None
 
+        # mamba_cache_per_req covers every mamba layer, but under PP a rank only
+        # allocates its own [start_layer, end_layer) slice. Charge the largest
+        # per-stage share so every rank derives the same pool without a collective.
+        all_mamba_layers = config.mamba2_cache_params.layers
+        if self.ps.pp_size > 1 and all_mamba_layers:
+            max_stage_mamba_layers = max(
+                sum(1 for i in all_mamba_layers if start <= i < end)
+                for start, end in (
+                    get_pp_indices(
+                        self.model_config.num_hidden_layers, rank, self.ps.pp_size
+                    )
+                    for rank in range(self.ps.pp_size)
+                )
+            )
+        else:
+            max_stage_mamba_layers = len(all_mamba_layers)
+        pp_layer_scale = max_stage_mamba_layers / max(len(all_mamba_layers), 1)
+        stage_per_req = int(
+            config.mamba2_cache_params.mamba_cache_per_req * pp_layer_scale
+        )
+
         has_spec_dec = not self.spec_algorithm.is_none()
         # ReplaySSM drops the per-step intermediate_ssm scratch, so its mamba budget
         # no longer reserves the (1 + D/ratio) intermediate factor -- the whole
@@ -1832,6 +1854,7 @@ class KVCacheConfigurator:
             )
         else:
             replayssm_ring_per_req = 0
+        replayssm_ring_per_req = int(replayssm_ring_per_req * pp_layer_scale)
         if has_spec_dec:
             assert get_spec().speculative_num_draft_tokens is not None
             assert get_schedule().max_running_requests is not None
@@ -1853,7 +1876,7 @@ class KVCacheConfigurator:
                     get_schedule().max_mamba_cache_size // ratio,
                 )
                 intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
+                    stage_per_req
                     * (capped_reqs + 1)
                     * get_spec().speculative_num_draft_tokens
                 )
@@ -1872,15 +1895,15 @@ class KVCacheConfigurator:
             # pool's padding slot). Skipped under replayssm.
             if has_spec_dec and not replayssm_active:
                 intermediate_size = (
-                    config.mamba2_cache_params.mamba_cache_per_req
+                    stage_per_req
                     * (get_schedule().max_mamba_cache_size + 1)
                     * get_spec().speculative_num_draft_tokens
                 )
                 total_rest_memory = total_rest_memory - (intermediate_size / (1 << 30))
         else:
             # Use ratio-based calculation to auto-fit available memory
-            assert config.mamba2_cache_params.mamba_cache_per_req > 0
-            per_req = config.mamba2_cache_params.mamba_cache_per_req
+            assert stage_per_req > 0
+            per_req = stage_per_req
 
             # Solve jointly for max_mamba_cache_size (K), including the pool's
             # +1 padding slot on both buffers (see memory_pool.py):
@@ -1929,7 +1952,7 @@ class KVCacheConfigurator:
                 f"Not enough GPU memory for hybrid (mamba/linear-attention) state cache. "
                 f"Computed max_mamba_cache_size={get_schedule().max_mamba_cache_size} "
                 f"(total_rest_memory={total_rest_memory:.2f} GB, "
-                f"mamba_cache_per_req={config.mamba2_cache_params.mamba_cache_per_req / (1 << 20):.2f} MB). "
+                f"mamba_cache_per_req={stage_per_req / (1 << 20):.2f} MB). "
                 f"Try: (1) reduce --max-running-requests, "
                 f"(2) increase --mem-fraction-static, "
                 f"(3) reduce --speculative-num-draft-tokens, or "
@@ -1941,7 +1964,7 @@ class KVCacheConfigurator:
         # the ring is not allocated).
         mamba_state_memory = (
             (get_schedule().max_mamba_cache_size + 1)
-            * (config.mamba2_cache_params.mamba_cache_per_req + replayssm_ring_per_req)
+            * (stage_per_req + replayssm_ring_per_req)
             / (1 << 30)
         )
         return total_rest_memory - mamba_state_memory

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -232,5 +232,84 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
         self.assertEqual(len(cache.prefix_nodes), N - 1)
 
 
+class TestPPMambaPoolSizing(unittest.TestCase):
+    """A PP rank only allocates mamba state for its own [start_layer, end_layer)
+    slice, so charging it for the whole model's layers starves the pool. Sizing
+    uses the largest per-stage share, which also keeps every rank on the same
+    pool size (and hence the same max_running_requests / pp_max_micro_batch_size)
+    without a collective."""
+
+    # Kimi-K3 shaped: 93 layers, linear attention everywhere except every 4th and
+    # the last, so the 69 mamba layers split unevenly over 8 stages (9 or 8 each).
+    TOTAL_LAYERS = 93
+    MAMBA_LAYERS = [i for i in range(93) if (i + 1) % 4 != 0 and i <= 90]
+    BUDGET_GB = 8.0
+
+    @classmethod
+    def _pool_size(cls, pp_rank, pp_size):
+        from sglang.srt import runtime_context as rc
+        from sglang.srt.configs.mamba_utils import (
+            Mamba2CacheParams,
+            Mamba2StateDType,
+            Mamba2StateShape,
+        )
+        from sglang.srt.distributed.utils import get_pp_indices
+        from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+        from sglang.srt.runtime_context import get_schedule
+
+        shape = Mamba2StateShape(
+            conv=[(4096, 3)],
+            temporal=(64, 128, 128),
+            intermediate_size=0,
+            conv_dim=0,
+            ssm_state_size=0,
+            num_heads=0,
+            head_dim=0,
+            state_size=0,
+            conv_kernel=0,
+            num_k_heads_per_tp=8,
+        )
+        params = Mamba2CacheParams(
+            shape=shape,
+            dtype=Mamba2StateDType(conv=torch.bfloat16, temporal=torch.float32),
+            layers=list(cls.MAMBA_LAYERS),
+        )
+        start, end = get_pp_indices(cls.TOTAL_LAYERS, pp_rank, pp_size)
+        fake = SimpleNamespace(
+            mambaish_config=SimpleNamespace(mamba2_cache_params=params),
+            server_args=SimpleNamespace(),
+            spec_algorithm=SimpleNamespace(is_none=lambda: True),
+            layer_info=SimpleNamespace(start_layer=start, end_layer=end),
+            ps=SimpleNamespace(attn_dp_size=1, pp_size=pp_size),
+            hybrid_gdn_config=None,
+            model_config=SimpleNamespace(
+                hf_config=SimpleNamespace(), num_hidden_layers=cls.TOTAL_LAYERS
+            ),
+        )
+        with rc.get_context().override_server_args(
+            disable_radix_cache=False,
+            max_mamba_cache_size=None,
+            max_running_requests=None,
+            mamba_full_memory_ratio=0.5,
+            enable_linear_replayssm_spec=False,
+        ):
+            KVCacheConfigurator._handle_max_mamba_cache(fake, cls.BUDGET_GB)
+            return get_schedule().max_mamba_cache_size
+
+    def test_stage_is_not_charged_for_the_whole_model(self):
+        solo = self._pool_size(0, 1)
+        staged = self._pool_size(0, 8)
+        # The busiest stage holds 9 of the 69 mamba layers, so it should fit
+        # roughly 69/9 more slots than a rank holding all of them. pp_size=1 is
+        # unchanged: that rank does hold every layer.
+        self.assertGreater(staged, solo * 5)
+
+    def test_every_stage_agrees_on_the_pool_size(self):
+        sizes = {self._pool_size(r, 8) for r in range(8)}
+        self.assertEqual(
+            len(sizes), 1, f"per-rank pool sizes diverged: {sorted(sizes)}"
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

`KVCacheConfigurator._handle_max_mamba_cache` sizes the mamba state pool from `config.mamba2_cache_params.mamba_cache_per_req`, which is computed over the whole model's mamba layer list:

```python
) * len(self.layers)      # configs/mamba_utils.py
```

Under pipeline parallelism each rank only allocates state for the layers in its own `[start_layer, end_layer)` slice — the allocation paths in this same file already filter on that range. Charging the whole model against a single stage over-estimates the per-slot cost by roughly `pp_size`, so the pool is sized for a fraction of the requests that actually fit.

On Kimi-K3 (93 layers, 69 linear-attention layers) at `pp_size=8` this resolves to a 26-slot pool, which clamps `max_running_requests` to 6. That propagates: `resolve_max_num_reqs` clamps `max_running_requests` to `max_mamba_cache_size // ratio`, which in turn sets `pp_max_micro_batch_size`.

## Modifications

Scale the per-request cost (and the ReplaySSM ring, which is sized the same way) by the stage's share of the mamba layers.

The scale is taken from the stage holding the **most** mamba layers, not from this rank's own count. Both give the same system-wide capacity — the system is limited by the heaviest stage either way — but the maximum is identical on every rank, so `max_mamba_cache_size`, `max_running_requests` and `pp_max_micro_batch_size` stay uniform across stages without a collective. Scaling by each rank's own share instead makes those values diverge whenever the mamba layers do not split evenly, which is the common case: at `pp_size=8` a 93-layer model distributes its 69 mamba layers as `[9, 8, 8, 9, 9, 9, 9, 8]`.

Sweeping 145 mamba budgets from 4 to 40 GiB on that layout:

| scaling | budgets where `pp_max_micro_batch_size` diverges across stages |
|---|---|
| this rank's own share | 95/145 (65.5%) |
| largest stage's share (this PR) | 0/145 |

`pp_max_micro_batch_size` has to agree on every stage: it decides how a batch is split into microbatches, so a stage that picks a different split disagrees with its neighbours about which sequences are in flight.

Every rank computes the layer distribution locally from `get_pp_indices`, so nothing is communicated. At `pp_size=1` the rank holds every mamba layer and the scale is exactly 1.

## Accuracy Tests

End to end on Kimi-K3 with real weights, `pp_size=8` `tp_size=1`, 2 nodes, `--attention-backend flashinfer`, GSM8K 200 questions:

| | `max_mamba_cache_size` | `max_running_requests` | GSM8K |
|---|---:|---:|---:|
| before, `--chunked-prefill-size 16384` | 26 | 6 | 0.985 |
| after, `--chunked-prefill-size 16384` | **210** | **52** | 0.990 |
| before, `--chunked-prefill-size 65536` | 26 | 6 | 0.985 |
| after, `--chunked-prefill-size 65536` | **210** | **52** | 0.985 |

The pool grows 8.1x and the concurrency ceiling 8.7x, while the score stays in the same band (the 0.985/0.990 spread is one question out of 200). The change only lifts a capacity limit; it does not touch any compute path.

What that "before" column looks like in the startup log: the unpatched tree allocates a per-stage pool but charges the whole model against it, so every stage lands on the same starved cap.

```
PP0  max_mamba_cache_size: 26   conv_state 0.05GB   ssm_state 1.42GB
PP1  max_mamba_cache_size: 26   conv_state 0.04GB   ssm_state 1.27GB
PP2  max_mamba_cache_size: 26   conv_state 0.04GB   ssm_state 1.27GB
PP3  max_mamba_cache_size: 26   conv_state 0.05GB   ssm_state 1.42GB
PP4  max_mamba_cache_size: 26   conv_state 0.05GB   ssm_state 1.42GB
PP5  max_mamba_cache_size: 26   conv_state 0.05GB   ssm_state 1.42GB
PP6  max_mamba_cache_size: 26   conv_state 0.05GB   ssm_state 1.42GB
PP7  max_mamba_cache_size: 26   conv_state 0.04GB   ssm_state 1.27GB

all stages: max_running_requests is capped to 6 by the mamba state cache
            (max_mamba_cache_size=26, 4 state slots per request)
```

The allocated `ssm_state` already varies with what each stage holds — 1.42 GB on the stages with 9 mamba layers, 1.27 GB on those with 8 (the layers distribute as `[9, 8, 8, 9, 9, 9, 9, 8]`). The pool size does not: all eight stages are sized as if they held all 69.

The same over-charge also applies when the pool size is given explicitly. `--max-mamba-cache-size` skips the auto solve, so the pool itself comes out right, but the memory the solver then books for it still uses the whole-model per-request cost — leaving too little for the KV pool. Same layout, 70 GiB handed to the solver:

| `--max-mamba-cache-size` | KV budget left, before | after |
|---:|---:|---:|
| 112 | 39.36 GiB | 66.00 GiB |
| 144 | 30.69 GiB | 64.87 GiB |
| 210 | 12.80 GiB | 62.54 GiB |
| 328 | **-19.20 GiB** | 58.37 GiB |

At 328 the budget goes negative and there is no KV pool left to build, which is what an operator sees as "raising `--max-mamba-cache-size` makes startup fail".

Driving `_handle_max_mamba_cache` once per rank on the same layer layout with an 8 GiB budget isolates the same effect:

| | before | after |
|---|---|---|
| `pp_size=1` pool | 8 | 8 (unchanged) |
| `pp_size=8` pool, per rank | 8, 8, 8, 8, 8, 8, 8, 8 | 74, 74, 74, 74, 74, 74, 74, 74 |

`TestPPMambaPoolSizing` in `test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py` adds two CPU-only tests. `test_stage_is_not_charged_for_the_whole_model` fails on the unpatched tree and passes with this change; running that file goes from `1 failed, 7 passed` to `8 passed`.

## Speed Tests and Profiling

The pool size this PR unlocks is what an agentic serving configuration actually wants. On a 1P1D deployment (8 GPUs running PP8 prefill, 8 running TP8 decode) with a trace-replay workload of 98,827 requests — mean input 219k tokens, p90 549k, ~98% theoretical prefix reuse — a 144-slot mamba pool with a 14.5M-token KV pool sustains:

| client concurrency | effective total | per GPU | TTFT p50 | prompt cache read |
|---:|---:|---:|---:|---:|
| 16 | 70,756 tok/s | 4,422 | — | 94.7% |
| 24 | 78,437 tok/s | 4,902 | 7.05 s | 93.6% |
| 32 | 26,184 tok/s | 1,637 | 85.10 s | 92.8% |
| 32, decode `--decode-context-parallel-size 8` | 82,977 tok/s | 5,186 | 6.8 s | 71.2% |

"Effective total" counts prompt tokens including cache hits, which is what the client sees; at 93.6% reuse the recomputed share is far smaller. The per-GPU column divides by all 16 GPUs in the deployment. The last row is the mean of two runs; the drop at concurrency 32 is a decode-side KV limit, not a mamba one, and decode context parallelism removes it.

That operating point is not reachable without this change: the auto solve gives roughly `1/pp_size` of it, and setting `--max-mamba-cache-size` by hand instead runs into the accounting problem above. The numbers are a capability statement, not a before/after delta — there is no matched "before" run at this pool size because the configuration does not come up.

Per-token cost is unchanged; this PR only lifts a capacity limit.

### Note for existing deployments

Correcting the over-charge frees real memory, so at an unchanged `--mem-fraction-static` the solver hands the KV pool what the mamba pool was previously over-booking. On a Kimi-K3 PP8 prefill instance that moved `max_total_tokens` from 2,123,072 to 21,287,872 at the same flag value, and the instance then failed to start. The old over-charge was acting as unintended headroom. Deployments tuned against the previous accounting may need to lower `--mem-fraction-static` or pin `--max-total-tokens` after this change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

### Merge order

This PR raises the concurrency ceiling, which makes packed prefill batches larger. On the same hardware that turns out to be what makes the int32 overflow in #33665 reachable in practice: before this change `max_running_requests` is clamped to 6 and a batch never gets near the 2^31 threshold, after it the ceiling is 52. Worth landing that one first.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30984169609](https://github.com/sgl-project/sglang/actions/runs/30984169609)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31123531254](https://github.com/sgl-project/sglang/actions/runs/31123531254)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->