### PR TITLE
[Bugfix] Treat unsharded model.safetensors as HF weights in Mistral-native format detection

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7329,7 +7329,7 @@ class ServerArgs:
         """True iff the checkpoint requires load_format=mistral.
 
         Looks for consolidated*.safetensors with no competing
-        model-*.safetensors; when both weight formats ship in the
+        model*.safetensors; when both weight formats ship in the
         same checkpoint (e.g. Mistral-7B-Instruct-v0.3) the HF path is
         preferred to avoid loading Mistral-named weights into an
         HF-named architecture.
@@ -7362,7 +7362,7 @@ class ServerArgs:
                     )
                 ),
                 has_hf_weights=bool(
-                    glob.glob(os.path.join(self.model_path, "model-*.safetensors"))
+                    glob.glob(os.path.join(self.model_path, "model*.safetensors"))
                 ),
             )
 
@@ -7377,7 +7377,10 @@ class ServerArgs:
                     for f in files
                 ),
                 has_hf_weights=any(
-                    f.startswith("model-") and f.endswith(".safetensors") for f in files
+                    f.startswith("model")
+                    and f.endswith(".safetensors")
+                    and "/" not in f
+                    for f in files
                 ),
             )
         except Exception:


### PR DESCRIPTION
## Motivation

`mistralai/Shieldstral-1.0-3B` and `mistralai/Ministral-3-3B-Instruct-2512` (arch `Mistral3ForConditionalGeneration`) crash at weight load out of the box:

```
File ".../sglang/srt/models/mistral.py", line 192, in load_weights
    return self.inner.load_weights(normalize(weights))
File ".../sglang/srt/models/llava.py", line 884, in load_weights
    param = params_dict[name]
KeyError: 'layers.0.attention.wk.weight'   # Shieldstral; Ministral-3-3B: 'layers.0.attention.k_fake_quantizer.qscale_act'
```

These repos ship both weight formats: an **unsharded** HF `model.safetensors` plus Mistral-native `consolidated.safetensors` / `params.json` / `tekken.json`. `ServerArgs._is_mistral_native_format()` decides "HF weights present" by matching only the sharded pattern `model-*.safetensors`, so a single-file HF checkpoint is not seen. Detection then auto-sets `load_format=mistral`, the loader reads `consolidated.safetensors` (Mistral-native weight names), and `Mistral3ForConditionalGeneration.load_weights` — which only normalizes HF-v5 prefixes — fails with the KeyError above.

## Modifications

Match `model*.safetensors` (unsharded and sharded) in both the local-dir and HF-API branches of `_is_mistral_native_format()`, per the function's documented intent ("when both weight formats ship in the same checkpoint the HF path is preferred"). The HF-API branch additionally requires the file to be at the repo root (`"/" not in f`), keeping it consistent with the root-level glob so nested safetensors in subfolders don't count as HF weights.

With detection returning False, the AUTO load path globs both files and the existing `filter_duplicate_safetensors_files` two-file dedup already picks `model.safetensors`.

## Test

Validated on 4x H200 against latest main (1478cdec9f) + this patch, across the Mistral family. Detection flips for exactly one public repo class (consolidated + **unsharded** root `model.safetensors`), and that class was previously a guaranteed crash:

| Model | Repo weight layout | Detection (old → new) | Result |
|---|---|---|---|
| Ministral-3-3B-Instruct-2512 | consolidated + unsharded HF | mistral → auto (**changed**) | main: crash (KeyError above); patched: serves correctly |
| Shieldstral-1.0-3B | consolidated + unsharded HF | mistral → auto (**changed**) | main: crash; with HF path: serves correctly (text + Pixtral vision verified) |
| Mistral-7B-Instruct-v0.3 | consolidated + sharded HF | auto (unchanged) | serves correctly |
| Ministral-3-14B-Instruct-2512 | consolidated + sharded HF | auto (unchanged) | serves correctly |
| Mistral-Small-3.1-24B-Instruct-2503 | consolidated + sharded HF | auto (unchanged) | serves correctly |
| Mistral-Medium-3.5-128B (tp4) | consolidated + sharded HF | auto (unchanged) | serves correctly |
| Leanstral-1.5-119B-A6B (tp4) | native-only (params.json + tekken + consolidated fp8 MoE) | mistral (unchanged, name-matched) | serves correctly end-to-end (params.json config parser + mistral-common tokenizer + native weight remap) |
| Mistral-Small-4-119B-2603 (tp4) | dual-format, name-matched | mistral (unchanged, name-matched) | loads clean (0 unrecognized weights, fp8 `PixtralForConditionalGeneration`); coherent raw generation (base checkpoint, so chat template yields immediate EOS — pre-existing behavior) |

Not related to this PR (observed while testing, fails identically with and without the patch since it errors in processor init before any weight loading): `Mistral-Small-3.2-24B-Instruct-2506` ships no HF `preprocessor_config.json`/`tokenizer_config.json`, and `wrap_as_pixtral` only triggers on `model_type == "pixtral"` (its top-level type is `mistral3`), so `AutoProcessor` fails on main for that repo.

No regression surface beyond the flipped class: config parsing routes through `params.json` by model name only (`is_mistral_model()`), so flipped checkpoints always resolve an HF-named architecture, and every HF-named model class expects HF weight names. Native-format-only checkpoints, sharded dual-format checkpoints, the `mistral-large-3`/`mistral-small-4`/`leanstral` name overrides, and explicit `--load-format mistral` are all unaffected.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit or integration tests for new features or bug fixes.
- [x] Update documentation as needed, including docstrings or example tutorials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)