### PR TITLE
feat(mem_cache): add KVFlow workflow-aware prefix-cache eviction

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -961,6 +961,33 @@ async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
     )
 
 
+@app.post("/v1/kvflow/update")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def kvflow_update(request: Request):
+    """Update per-agent steps_to_execution for KVFlow workflow-aware eviction.
+
+    Body: {"agent_updates": {"agent_id": steps_to_execution, ...}}
+    """
+    try:
+        body = await request.json()
+        agent_updates = body.get("agent_updates", {})
+        if not isinstance(agent_updates, dict):
+            return ORJSONResponse(
+                {"success": False, "message": "agent_updates must be a dict"},
+                status_code=HTTPStatus.BAD_REQUEST,
+            )
+    except Exception as e:
+        return ORJSONResponse(
+            {"success": False, "message": str(e)},
+            status_code=HTTPStatus.BAD_REQUEST,
+        )
+    ret = await _global_state.tokenizer_manager.kvflow_update(agent_updates)
+    return ORJSONResponse(
+        {"success": ret.success, "message": ret.message},
+        status_code=200 if ret.success else HTTPStatus.BAD_REQUEST,
+    )
+
+
 @app.post("/add_external_corpus")
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def add_external_corpus(request: Request):

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -286,6 +286,13 @@ class GenerateReqInput:
     # Extra cache key for classifying the request (e.g. cache_salt)
     extra_key: Optional[Union[List[str], str]] = None
 
+    # KVFlow workflow-aware eviction metadata (arXiv:2507.07400).
+    # kvflow_agent_id: identifies which agent this request belongs to.
+    # kvflow_fixed_prefix_len: token count of the fixed prefix (tokens 0..N
+    #   are workflow-invariant across agent invocations; tokens after N are dynamic).
+    kvflow_agent_id: Optional[str] = None
+    kvflow_fixed_prefix_len: Optional[int] = None
+
     # Whether to disallow logging for this request (e.g. due to ZDR)
     no_logs: bool = False
     # For custom metric labels
@@ -827,6 +834,8 @@ class GenerateReqInput:
             max_thinking_tokens=self.max_thinking_tokens,
             priority=self.priority,
             extra_key=self.extra_key[i] if self.extra_key is not None else None,
+            kvflow_agent_id=self.kvflow_agent_id,
+            kvflow_fixed_prefix_len=self.kvflow_fixed_prefix_len,
             no_logs=self.no_logs,
             custom_labels=self.custom_labels,
             return_bytes=self.return_bytes,
@@ -917,6 +926,10 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Extra cache key for classifying the request (e.g. cache_salt)
     extra_key: Optional[str] = None
+
+    # KVFlow workflow-aware eviction metadata
+    kvflow_agent_id: Optional[str] = None
+    kvflow_fixed_prefix_len: Optional[int] = None
 
     # Whether to disallow logging for this request (e.g. due to ZDR)
     no_logs: bool = False
@@ -1531,6 +1544,17 @@ class FlushCacheReqInput(BaseReq, kw_only=True):
 
 
 class FlushCacheReqOutput(BaseReq, kw_only=True):
+    success: bool
+    message: str = ""
+
+
+class KVFlowUpdateReqInput(BaseReq, kw_only=True):
+    """Update per-agent steps_to_execution for KVFlow eviction prioritization."""
+
+    agent_updates: Dict[str, int]  # agent_id → steps_to_execution
+
+
+class KVFlowUpdateReqOutput(BaseReq, kw_only=True):
     success: bool
     message: str = ""
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -808,6 +808,8 @@ class Req(ReqDllmMixin):
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
         extra_key: Optional[str] = None,
         routing_key: Optional[str] = None,
+        kvflow_agent_id: Optional[str] = None,
+        kvflow_fixed_prefix_len: Optional[int] = None,
         dimensions: Optional[int] = None,
         http_worker_ipc: Optional[str] = None,
         time_stats: Optional[
@@ -929,6 +931,8 @@ class Req(ReqDllmMixin):
         self.eos_token_ids = eos_token_ids
         self.vocab_size = vocab_size
         self.priority = priority
+        self.kvflow_agent_id: Optional[str] = kvflow_agent_id
+        self.kvflow_fixed_prefix_len: Optional[int] = kvflow_fixed_prefix_len
 
         # For incremental decoding
         # ----- | --------- read_ids -------|

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -126,6 +126,8 @@ from sglang.srt.managers.io_struct import (
     ExpertDistributionReqType,
     FlushCacheReqInput,
     FreezeGCReq,
+    KVFlowUpdateReqInput,
+    KVFlowUpdateReqOutput,
     GetInternalStateReq,
     GetInternalStateReqOutput,
     GetWeightsByNameReqInput,
@@ -1501,6 +1503,7 @@ class Scheduler(
                 (BatchTokenizedGenerateReqInput, self.handle_batch_generate_request),
                 (BatchTokenizedEmbeddingReqInput, self.handle_batch_embedding_request),
                 (FlushCacheReqInput, self.flush_wrapper.handle),
+                (KVFlowUpdateReqInput, self._handle_kvflow_update),
                 (ClearHiCacheReqInput, self.clear_hicache_storage_wrapped),
                 (AttachHiCacheStorageReqInput, self.attach_hicache_storage_wrapped),
                 (DetachHiCacheStorageReqInput, self.detach_hicache_storage_wrapped),
@@ -2359,6 +2362,8 @@ class Scheduler(
                 ),
                 routing_key=recv_req.routing_key,
                 extra_key=recv_req.extra_key,
+                kvflow_agent_id=recv_req.kvflow_agent_id,
+                kvflow_fixed_prefix_len=recv_req.kvflow_fixed_prefix_len,
                 http_worker_ipc=recv_req.http_worker_ipc,
                 dllm_config=self.dllm_config,
                 time_stats=recv_req.time_stats,
@@ -4131,6 +4136,22 @@ class Scheduler(
             )
 
         return DetachHiCacheStorageReqOutput(success=False, message=msg)
+
+    def _handle_kvflow_update(
+        self, recv_req: KVFlowUpdateReqInput
+    ) -> KVFlowUpdateReqOutput:
+        """Update per-agent steps_to_execution for KVFlow eviction prioritization."""
+        from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+
+        if (
+            isinstance(self.tree_cache, UnifiedRadixCache)
+            and self.tree_cache.kvflow_manager is not None
+        ):
+            self.tree_cache.kvflow_manager.update(recv_req.agent_updates)
+            return KVFlowUpdateReqOutput(success=True)
+        return KVFlowUpdateReqOutput(
+            success=False, message="KVFlow eviction not enabled on this server"
+        )
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -33,6 +33,8 @@ from sglang.srt.managers.io_struct import (
     FlushCacheReqInput,
     FlushCacheReqOutput,
     GetInternalStateReq,
+    KVFlowUpdateReqInput,
+    KVFlowUpdateReqOutput,
     GetInternalStateReqOutput,
     GetWeightsByNameReqInput,
     GetWeightsByNameReqOutput,
@@ -107,6 +109,7 @@ _COMMUNICATOR_SPECS = [
     ("check_weights", CheckWeightsReqOutput),
     ("slow_down", SlowDownReqOutput),
     ("flush_cache", FlushCacheReqOutput),
+    ("kvflow_update", KVFlowUpdateReqOutput),
     ("add_external_corpus", AddExternalCorpusReqOutput),
     ("remove_external_corpus", RemoveExternalCorpusReqOutput),
     ("list_external_corpora", ListExternalCorporaReqOutput),
@@ -299,6 +302,17 @@ class TokenizerControlMixin:
         self.auto_create_handle_loop()
         return (
             await self.flush_cache_communicator(FlushCacheReqInput(timeout_s=timeout_s))
+        )[0]
+
+    async def kvflow_update(
+        self: TokenizerManager, agent_updates: Dict[str, int]
+    ) -> KVFlowUpdateReqOutput:
+        """Push per-agent steps_to_execution to the KVFlow eviction manager."""
+        self.auto_create_handle_loop()
+        return (
+            await self.kvflow_update_communicator(
+                KVFlowUpdateReqInput(agent_updates=agent_updates)
+            )
         )[0]
 
     async def clear_hicache_storage(self: TokenizerManager) -> ClearHiCacheReqOutput:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1387,6 +1387,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 routing_key=obj.routing_key,
+                kvflow_agent_id=obj.kvflow_agent_id,
+                kvflow_fixed_prefix_len=obj.kvflow_fixed_prefix_len,
                 token_type_ids=token_type_ids,
                 need_wait_for_mm_inputs=obj.need_wait_for_mm_inputs,
                 num_items_assigned=obj.num_items_assigned,

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -49,6 +49,10 @@ class CacheInitParams:
     # Time-to-live for cache entries in seconds. If None, TTL is disabled.
     cache_ttl_seconds: Optional[float] = None
 
+    # KVFlow workflow-aware eviction (arXiv:2507.07400)
+    enable_kvflow_eviction: bool = False
+    kvflow_hold_step: int = 4
+
     tree_components: Optional[tuple[ComponentType, ...]] = None
     component_registry_override: Optional[dict[ComponentType, type[TreeComponent]]] = (
         None

--- a/python/sglang/srt/mem_cache/evict_policy.py
+++ b/python/sglang/srt/mem_cache/evict_policy.py
@@ -46,6 +46,17 @@ class PriorityStrategy(EvictionStrategy):
         return (node.priority, node.last_access_time)
 
 
+class KVFlowEvictionStrategy(EvictionStrategy):
+    """Workflow-aware eviction: higher kvflow_priority nodes evicted last.
+
+    kvflow_priority is set by KVFlowAgentManager based on steps_to_execution.
+    Nodes with kvflow_priority=0 (no workflow info) are evicted LRU first.
+    """
+
+    def get_priority(self, node: TreeNode) -> Tuple[int, float]:
+        return (node.kvflow_priority, node.last_access_time)
+
+
 class SLRUStrategy(EvictionStrategy):
     def __init__(self, protected_threshold: int = 2):
         self.protected_threshold = protected_threshold

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -224,7 +224,11 @@ def build_kv_cache(
         attn_cp_cache_group=attn_cp_cpu_group,
         attn_tp_cache_group=attn_tp_cpu_group,
         pp_cache_group=pp_group.cpu_group,
-        eviction_policy=server_args.radix_eviction_policy,
+        eviction_policy=(
+            "kvflow"
+            if server_args.enable_kvflow_eviction
+            else server_args.radix_eviction_policy
+        ),
         enable_metrics=enable_metrics,
         enable_kv_cache_events=enable_kv_cache_events,
         enable_session_radix_cache=server_args.enable_session_radix_cache,
@@ -234,6 +238,8 @@ def build_kv_cache(
         pp_size=ps.pp_size,
         chunked_prefill_size=effective_chunked_prefill_size,
         sliding_window_size=sliding_window_size,
+        enable_kvflow_eviction=server_args.enable_kvflow_eviction,
+        kvflow_hold_step=server_args.kvflow_hold_step,
     )
 
     tree_cache = create_tree_cache(

--- a/python/sglang/srt/mem_cache/kvflow_agent_manager.py
+++ b/python/sglang/srt/mem_cache/kvflow_agent_manager.py
@@ -1,0 +1,106 @@
+"""KVFlow workflow-aware eviction manager for multi-agent LLM workloads.
+
+Implements the eviction half of KVFlow (arXiv:2507.07400): maintains a
+per-agent set of leaf nodes and updates ``node.kvflow_priority`` on the
+prefix path whenever the external scheduler posts new ``steps_to_execution``
+values via ``/v1/kvflow/update``.
+
+Priority scheme (higher = evicted later):
+  0  — no KVFlow protection (default, dynamic suffix, or far-future)
+  1  — far future (steps >= hold_step)
+  2  — steps = hold_step - 2
+  ...
+  hold_step — steps = 1 (next agent to run, maximum protection)
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import defaultdict
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeNode
+
+
+def _steps_to_priority(steps: int, hold_step: int) -> int:
+    """Convert steps_to_execution to a kvflow_priority value.
+
+    Steps closer to 0 (sooner to execute) get higher priority (protected longer).
+    Steps at or beyond ``hold_step`` get priority 1 (low, but not unprotected).
+    Steps=0 means currently running — caller skips those.
+    """
+    if steps >= hold_step:
+        return 1
+    return hold_step - steps + 1
+
+
+class KVFlowAgentManager:
+    """Tracks per-agent leaf nodes and refreshes their KVFlow eviction priorities.
+
+    Thread-safe: ``update`` and ``register_leaf`` may be called from different
+    threads (the scheduler event loop vs. the HTTP worker that receives /update).
+    """
+
+    def __init__(self, hold_step: int = 4) -> None:
+        self.hold_step = hold_step
+        self._agent_to_leaves: dict[str, set[UnifiedTreeNode]] = defaultdict(set)
+        self._lock = threading.Lock()
+
+    def register_leaf(self, agent_id: str, leaf: Optional[UnifiedTreeNode]) -> None:
+        """Record the deepest cached node for an agent after a request completes."""
+        if leaf is None:
+            return
+        with self._lock:
+            self._agent_to_leaves[agent_id].add(leaf)
+
+    def update(self, agent_updates: dict[str, int]) -> None:
+        """Apply a full snapshot of {agent_id: steps_to_execution} from the workflow scheduler.
+
+        Resets all previously tagged nodes to kvflow_priority=0, then re-applies
+        priorities for agents present in agent_updates with steps > 0.
+        """
+        with self._lock:
+            self._reset_all_node_priorities()
+            self._remove_stale_agents(set(agent_updates))
+            self._apply_fresh_priorities(agent_updates)
+
+    def _reset_all_node_priorities(self) -> None:
+        for leaves in self._agent_to_leaves.values():
+            for leaf in leaves:
+                self._walk_path(leaf, action=_clear_priority)
+
+    def _remove_stale_agents(self, active_agents: set[str]) -> None:
+        stale = [aid for aid in self._agent_to_leaves if aid not in active_agents]
+        for aid in stale:
+            del self._agent_to_leaves[aid]
+
+    def _apply_fresh_priorities(self, agent_updates: dict[str, int]) -> None:
+        for agent_id, steps in agent_updates.items():
+            if steps <= 0:
+                continue
+            priority = _steps_to_priority(steps, self.hold_step)
+            for leaf in self._agent_to_leaves.get(agent_id, ()):
+                self._walk_path(leaf, action=_raise_priority_to(priority))
+
+    @staticmethod
+    def _walk_path(
+        leaf: UnifiedTreeNode, action
+    ) -> None:
+        """Walk from leaf to root (exclusive), applying action to each node."""
+        cur = leaf
+        while cur is not None and cur.parent is not None:
+            action(cur)
+            cur = cur.parent
+
+
+def _clear_priority(node: UnifiedTreeNode) -> None:
+    node.kvflow_priority = 0
+
+
+def _raise_priority_to(priority: int):
+    def _apply(node: UnifiedTreeNode) -> None:
+        if node.kvflow_priority < priority:
+            node.kvflow_priority = priority
+
+    return _apply

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -114,6 +114,7 @@ class UnifiedTreeNode:
         self.hash_value = None
         self.hit_count = 0
         self.priority = priority
+        self.kvflow_priority: int = 0  # updated by KVFlowAgentManager
         self.lru_prev: list[UnifiedTreeNode | None] = [None] * (
             _NUM_COMPONENT_TYPES * 2
         )

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -212,6 +212,16 @@ class UnifiedRadixCache(BasePrefixCache):
         self.prefetch_timeout_per_page = 0.25
         self.hicache_storage_pass_prefix_keys = False
 
+        # KVFlow workflow-aware eviction (arXiv:2507.07400).
+        if params.enable_kvflow_eviction:
+            from sglang.srt.mem_cache.kvflow_agent_manager import KVFlowAgentManager
+
+            self.kvflow_manager: Optional[KVFlowAgentManager] = KVFlowAgentManager(
+                hold_step=params.kvflow_hold_step
+            )
+        else:
+            self.kvflow_manager = None
+
         self.reset()
         logger.info(f"Init Unified RadixTree with components {self.tree_components}")
 
@@ -671,6 +681,13 @@ class UnifiedRadixCache(BasePrefixCache):
 
         if is_insert and result is not None and result.last_device_node is not None:
             req.last_node = result.last_device_node
+            if (
+                self.kvflow_manager is not None
+                and req.kvflow_agent_id is not None
+            ):
+                self.kvflow_manager.register_leaf(
+                    req.kvflow_agent_id, result.last_device_node
+                )
 
         # cleanup
         for comp in self._components_tuple:

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -45,6 +45,7 @@ from sglang.srt.mem_cache.evict_policy import (
     EvictionStrategy,
     FIFOStrategy,
     FILOStrategy,
+    KVFlowEvictionStrategy,
     LFUStrategy,
     LRUStrategy,
     MRUStrategy,
@@ -60,6 +61,7 @@ _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
     "filo": FILOStrategy,
     "priority": PriorityStrategy,
     "slru": SLRUStrategy,
+    "kvflow": KVFlowEvictionStrategy,
 }
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -916,6 +916,22 @@ class ServerArgs:
         ),
         NS("memory"),
     ] = "lru"
+    enable_kvflow_eviction: A[
+        bool,
+        "Enable KVFlow workflow-aware prefix-cache eviction (arXiv:2507.07400). "
+        "Requires --radix-eviction-policy=kvflow (set automatically when enabled). "
+        "Use POST /v1/kvflow/update with {agent_updates: {agent_id: steps}} to "
+        "push workflow step counts from the external scheduler.",
+        NS("memory"),
+    ] = False
+    kvflow_hold_step: A[
+        int,
+        "Number of future agent steps for which fixed-prefix KV is protected from "
+        "eviction. Agents at steps >= kvflow_hold_step get minimal protection "
+        "(priority=1); agents at steps=1 (next to run) get maximum protection "
+        "(priority=kvflow_hold_step). Only used when --enable-kvflow-eviction.",
+        NS("memory"),
+    ] = 4
     prefill_only_disable_kv_cache: A[
         bool,
         "Skip the physical KV cache allocation for embedding-mode prefill-only workloads. Currently only valid with --is-embedding, --chunked-prefill-size=-1, --disable-radix-cache, an FA prefill backend, and non-FP4 KV cache so the fa_skip_kv_cache path is active (no layer reads or writes the cache). Other prefill-only workloads such as scoring/MIS may benefit from this later once their attention paths stop using paged KV. Scheduler admission accounting is unchanged; per-layer K/V tensors are sized to (page_size, head_num, head_dim) placeholders so GPU memory is not wasted.",

--- a/test/registered/unit/mem_cache/test_kvflow_agent_manager.py
+++ b/test/registered/unit/mem_cache/test_kvflow_agent_manager.py
@@ -1,0 +1,257 @@
+"""Unit tests for KVFlow workflow-aware eviction (arXiv:2507.07400).
+
+Tests KVFlowAgentManager priority logic, KVFlowEvictionStrategy ordering,
+and the _steps_to_priority mapping — all without GPU or SGLang runtime deps.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.mem_cache.evict_policy import KVFlowEvictionStrategy
+from sglang.srt.mem_cache.kvflow_agent_manager import (
+    KVFlowAgentManager,
+    _steps_to_priority,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+def _make_node(parent=None, kvflow_priority: int = 0, last_access_time: float = 0.0):
+    node = MagicMock()
+    node.parent = parent
+    node.kvflow_priority = kvflow_priority
+    node.last_access_time = last_access_time
+    return node
+
+
+def _make_chain(length: int):
+    """Build a root→…→leaf chain of `length` nodes; return (root, leaf)."""
+    root = _make_node(parent=None)
+    cur = root
+    for _ in range(length - 1):
+        child = _make_node(parent=cur)
+        cur = child
+    return root, cur  # (root, leaf)
+
+
+class TestStepsToPriority(CustomTestCase):
+    def test_steps_one_gets_max_protection(self):
+        # steps=1 (next agent) → hold_step, maximum priority
+        self.assertEqual(_steps_to_priority(1, hold_step=4), 4)
+
+    def test_steps_boundary_just_before_hold(self):
+        # steps=hold_step-1 gets priority 2
+        self.assertEqual(_steps_to_priority(3, hold_step=4), 2)
+
+    def test_steps_at_hold_gets_minimum_protection(self):
+        # steps=hold_step → 1, minimal but still non-zero
+        self.assertEqual(_steps_to_priority(4, hold_step=4), 1)
+
+    def test_steps_beyond_hold_also_get_minimum(self):
+        # steps > hold_step → same 1 (far future, low protection)
+        self.assertEqual(_steps_to_priority(10, hold_step=4), 1)
+
+    def test_priority_strictly_decreases_with_steps(self):
+        # Closer to execution → higher priority
+        priorities = [_steps_to_priority(s, hold_step=4) for s in [1, 2, 3, 4, 5]]
+        self.assertEqual(priorities, sorted(priorities, reverse=True))
+
+    def test_custom_hold_step(self):
+        self.assertEqual(_steps_to_priority(1, hold_step=8), 8)
+        self.assertEqual(_steps_to_priority(7, hold_step=8), 2)
+        self.assertEqual(_steps_to_priority(8, hold_step=8), 1)
+
+
+class TestKVFlowEvictionStrategy(CustomTestCase):
+    def setUp(self):
+        self.strategy = KVFlowEvictionStrategy()
+
+    def _node(self, kvflow_priority, last_access_time):
+        node = MagicMock()
+        node.kvflow_priority = kvflow_priority
+        node.last_access_time = last_access_time
+        return node
+
+    def test_returns_kvflow_priority_then_lru(self):
+        node = self._node(kvflow_priority=3, last_access_time=5.0)
+        self.assertEqual(self.strategy.get_priority(node), (3, 5.0))
+
+    def test_lower_kvflow_priority_evicted_first(self):
+        protected = self._node(kvflow_priority=4, last_access_time=1.0)
+        unprotected = self._node(kvflow_priority=0, last_access_time=10.0)
+        # unprotected (priority=0) has smaller tuple → evicted first
+        self.assertLess(
+            self.strategy.get_priority(unprotected),
+            self.strategy.get_priority(protected),
+        )
+
+    def test_same_priority_older_access_evicted_first(self):
+        old = self._node(kvflow_priority=2, last_access_time=1.0)
+        new = self._node(kvflow_priority=2, last_access_time=10.0)
+        self.assertLess(
+            self.strategy.get_priority(old),
+            self.strategy.get_priority(new),
+        )
+
+    def test_eviction_ordering_matches_expected_sequence(self):
+        nodes = [
+            self._node(kvflow_priority=0, last_access_time=5.0),  # evict 1st (low prio)
+            self._node(kvflow_priority=4, last_access_time=1.0),  # evict 4th (high prio, but old)
+            self._node(kvflow_priority=1, last_access_time=2.0),  # evict 2nd
+            self._node(kvflow_priority=4, last_access_time=8.0),  # evict 5th (high prio, new)
+            self._node(kvflow_priority=1, last_access_time=7.0),  # evict 3rd
+        ]
+        eviction_order = sorted(nodes, key=self.strategy.get_priority)
+        expected_keys = [(0, 5.0), (1, 2.0), (1, 7.0), (4, 1.0), (4, 8.0)]
+        actual_keys = [self.strategy.get_priority(n) for n in eviction_order]
+        self.assertEqual(actual_keys, expected_keys)
+
+
+class TestKVFlowAgentManagerRegisterLeaf(CustomTestCase):
+    def test_register_adds_leaf_to_agent(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        leaf = _make_node()
+        mgr.register_leaf("agent_A", leaf)
+        self.assertIn(leaf, mgr._agent_to_leaves["agent_A"])
+
+    def test_register_none_leaf_is_ignored(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        mgr.register_leaf("agent_A", None)
+        self.assertNotIn("agent_A", mgr._agent_to_leaves)
+
+    def test_register_multiple_leaves_same_agent(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        leaf1 = _make_node()
+        leaf2 = _make_node()
+        mgr.register_leaf("agent_A", leaf1)
+        mgr.register_leaf("agent_A", leaf2)
+        self.assertEqual(mgr._agent_to_leaves["agent_A"], {leaf1, leaf2})
+
+    def test_register_different_agents(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        leaf_a = _make_node()
+        leaf_b = _make_node()
+        mgr.register_leaf("agent_A", leaf_a)
+        mgr.register_leaf("agent_B", leaf_b)
+        self.assertIn(leaf_a, mgr._agent_to_leaves["agent_A"])
+        self.assertIn(leaf_b, mgr._agent_to_leaves["agent_B"])
+
+
+class TestKVFlowAgentManagerUpdate(CustomTestCase):
+    def _setup_chain(self, agent_id: str, chain_len: int, mgr: KVFlowAgentManager):
+        """Create a chain and register its leaf with mgr. Return (root, leaf)."""
+        root, leaf = _make_chain(chain_len)
+        mgr.register_leaf(agent_id, leaf)
+        return root, leaf
+
+    def test_update_sets_priority_on_path(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        root, leaf = self._setup_chain("agent_A", 4, mgr)
+
+        mgr.update({"agent_A": 1})  # steps=1 → priority=4
+
+        self.assertEqual(leaf.kvflow_priority, 4)
+        self.assertEqual(leaf.parent.kvflow_priority, 4)
+        self.assertEqual(leaf.parent.parent.kvflow_priority, 4)
+        self.assertEqual(root.kvflow_priority, 0)  # root excluded from walk
+
+    def test_steps_zero_skipped_no_protection(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+
+        mgr.update({"agent_A": 0})  # steps=0 = currently running, skip
+
+        self.assertEqual(leaf.kvflow_priority, 0)
+        self.assertEqual(leaf.parent.kvflow_priority, 0)
+
+    def test_stale_agent_removed_from_tracking(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+
+        # First update registers agent_A
+        mgr.update({"agent_A": 1})
+        self.assertIn("agent_A", mgr._agent_to_leaves)
+
+        # Second update omits agent_A → stale, should be removed
+        mgr.update({"agent_B": 2})
+        self.assertNotIn("agent_A", mgr._agent_to_leaves)
+
+    def test_stale_agent_priorities_reset(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+
+        mgr.update({"agent_A": 1})
+        self.assertEqual(leaf.kvflow_priority, 4)
+
+        # Next update drops agent_A — its nodes must be reset to 0
+        mgr.update({})
+        self.assertEqual(leaf.kvflow_priority, 0)
+        self.assertEqual(leaf.parent.kvflow_priority, 0)
+
+    def test_shared_ancestor_gets_best_priority(self):
+        """Two agents sharing a prefix node → node gets the higher priority."""
+        mgr = KVFlowAgentManager(hold_step=4)
+
+        # Build: root → shared → leaf_A
+        #                      → leaf_B
+        # shared must have a parent so _walk_path visits it (walk stops before parent=None)
+        root = _make_node(parent=None)
+        shared = _make_node(parent=root)
+        leaf_a = _make_node(parent=shared)
+        leaf_b = _make_node(parent=shared)
+
+        mgr.register_leaf("agent_A", leaf_a)
+        mgr.register_leaf("agent_B", leaf_b)
+
+        # agent_A: steps=1 (priority=4), agent_B: steps=3 (priority=2)
+        mgr.update({"agent_A": 1, "agent_B": 3})
+
+        # shared is on both paths → should get max(4, 2) = 4
+        self.assertEqual(shared.kvflow_priority, 4)
+        self.assertEqual(leaf_a.kvflow_priority, 4)
+        self.assertEqual(leaf_b.kvflow_priority, 2)
+        self.assertEqual(root.kvflow_priority, 0)  # root excluded from walk
+
+    def test_full_refresh_on_each_update(self):
+        """Priorities are fully recomputed from scratch each update call."""
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+
+        # Round 1: steps=1 → priority=4
+        mgr.update({"agent_A": 1})
+        self.assertEqual(leaf.kvflow_priority, 4)
+
+        # Round 2: steps=3 → priority=2 (not additive — should overwrite to 2)
+        mgr.update({"agent_A": 3})
+        self.assertEqual(leaf.kvflow_priority, 2)
+        self.assertEqual(leaf.parent.kvflow_priority, 2)
+
+    def test_far_future_agent_gets_minimal_protection(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+
+        mgr.update({"agent_A": 10})  # steps=10 >> hold_step=4 → priority=1
+
+        self.assertEqual(leaf.kvflow_priority, 1)
+
+    def test_empty_update_resets_all(self):
+        mgr = KVFlowAgentManager(hold_step=4)
+        _, leaf = self._setup_chain("agent_A", 3, mgr)
+        mgr.update({"agent_A": 1})
+        self.assertEqual(leaf.kvflow_priority, 4)
+
+        mgr.update({})
+        self.assertEqual(leaf.kvflow_priority, 0)
+        self.assertFalse(mgr._agent_to_leaves)
+
+    def test_unknown_agent_in_update_is_a_noop(self):
+        """agent in update but never registered has no leaves → no-op, no crash."""
+        mgr = KVFlowAgentManager(hold_step=4)
+        mgr.update({"ghost_agent": 1})  # should not raise
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION


Implements the eviction component of KVFlow: workflow-aware KV-cache priority assignment that protects an agent's prefix from eviction based on how many workflow steps away that agent is from executing.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30988626310](https://github.com/sgl-project/sglang/actions/runs/30988626310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30988626170](https://github.com/sgl-project/sglang/actions/runs/30988626170)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->