### PR TITLE
Stop testing cu129 DeepGEMM wheels

### DIFF
--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -79,57 +79,8 @@ jobs:
           name: deepgemm-wheel-cuda${{ matrix.cuda-version }}-${{ matrix.arch }}
           path: DeepGEMM/dist/*.whl
 
-  test-cu129:
-    needs: build-cu129-matrix
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch_label: sm90
-            runner: 8-gpu-h200
-            wheel_arch: x86_64
-          - arch_label: sm100
-            runner: 8-gpu-b200
-            wheel_arch: x86_64
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 120
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Checkout DeepGEMM
-        uses: actions/checkout@v4
-        with:
-          repository: sgl-project/DeepGEMM
-          ref: ${{ inputs.branch || 'dev' }}
-          path: DeepGEMM
-          submodules: recursive
-
-      - name: Download wheel
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          merge-multiple: true
-          pattern: deepgemm-wheel-cuda12.9-${{ matrix.wheel_arch }}
-
-      - name: Install wheel and deps
-        env:
-          CU_TAG: cu129
-        run: |
-          python3 -m pip install --upgrade pip
-          # deep_gemm imports torch before loading _C.so, so torch must preload the
-          # libcudart the cu129 wheel links. Pin the CUDA-matched torch (see sgl-deep-gemm.Dockerfile).
-          python3 -m pip install "torch==${TORCH_VER}" --index-url "https://download.pytorch.org/whl/${CU_TAG}" --force-reinstall
-          python3 -m pip install numpy
-          python3 -m pip install dist/*.whl
-          python3 -c "import deep_gemm; print('deep_gemm:', deep_gemm.__file__)"
-
-      - name: Run DeepGEMM test suite
-        run: |
-          chmod +x "${{ github.workspace }}/DeepGEMM/sgl_deep_gemm/run_tests.sh"
-          "${{ github.workspace }}/DeepGEMM/sgl_deep_gemm/run_tests.sh"
-
   release-cu129:
-    needs: [build-cu129-matrix, test-cu129]
+    needs: build-cu129-matrix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Align DeepGEMM with the rest of CUDA CI by testing only cu130, which should catch the same regressions

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30988979425](https://github.com/sgl-project/sglang/actions/runs/30988979425)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30988978811](https://github.com/sgl-project/sglang/actions/runs/30988978811)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->