### PR TITLE
[AMD] Stop publishing the custom K3 MI35X nightly image

### DIFF
--- a/.github/workflows/release-docker-amd-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-rocm720-nightly.yml
@@ -10,7 +10,6 @@ on:
         options:
           - 'all'
           - publish
-          - publish-k3
   schedule:
     - cron: '0 12 * * *'
 
@@ -115,81 +114,6 @@ jobs:
           name: image-tag-${{ matrix.gpu_arch }}
           path: image-tag/${{ matrix.gpu_arch }}.txt
           retention-days: 1
-
-      - name: Login to Docker Hub (lmsys)
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Push to lmsysorg/sglang-rocm
-        run: |
-          docker tag rocm/sgl-dev:${{ env.IMAGE_TAG }} lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
-          docker push lmsysorg/sglang-rocm:${{ env.IMAGE_TAG }}
-
-  publish_k3_mi35x:
-    if: github.repository == 'sgl-project/sglang' && (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.job_select == 'publish-k3'))
-    runs-on: amd-docker-scale
-    environment: 'prod'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          ref: kimi-k3
-          fetch-depth: 0  # Required for git describe to find tags
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-
-      - name: "Set Date"
-        run: |
-          echo "DATE=$(date -u +%Y%m%d)" >> $GITHUB_ENV
-
-      - name: Get version from latest tag
-        id: version
-        run: |
-          # Use the shared helper so stable/post releases sort above rc tags.
-          VERSION=$(python3 python/tools/get_version_tag.py --tag-only | sed 's/^v//')
-
-          if [ -z "$VERSION" ]; then
-            echo "::error::Could not determine version from git tags"
-            exit 1
-          fi
-
-          # Get short commit hash of current HEAD
-          COMMIT_HASH=$(git rev-parse --short HEAD)
-
-          # Compose pretend version for setuptools_scm: e.g., 0.5.8.post1.dev20260211+g1a2b3c4
-          PRETEND_VERSION="${VERSION}.dev${{ env.DATE }}+g${COMMIT_HASH}"
-
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "pretend_version=${PRETEND_VERSION}" >> $GITHUB_OUTPUT
-          echo "Detected version: ${VERSION}"
-          echo "Pretend version for pip: ${PRETEND_VERSION}"
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
-
-      - name: Build and Push to rocm/sgl-dev
-        run: |
-          version=${{ steps.version.outputs.version }}
-          pretend_version=${{ steps.version.outputs.pretend_version }}
-          echo "Version: ${version}"
-          echo "Pretend version: ${pretend_version}"
-
-          tag=rocm720-mi35x-k3
-          echo "IMAGE_TAG=${tag}-${{ env.DATE }}" >> $GITHUB_ENV
-
-          # remove --build-arg NIC_BACKEND=ainic for auto detection nic support in mori
-          # UBUNTU_MIRROR forces apt over HTTPS to dodge port-80 reachability flakes
-          # to Canonical's archive.ubuntu.com mirror IPs from the amd-docker-scale runner.
-          docker build . -f docker/rocm.Dockerfile --build-arg SGL_BRANCH=kimi-k3 --build-arg BUILD_TYPE=all --build-arg GPU_ARCH=gfx950-rocm720 --build-arg ENABLE_MORI=1 --build-arg ENABLE_NIXL=1 --build-arg SETUPTOOLS_SCM_PRETEND_VERSION=${pretend_version} --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com -t rocm/sgl-dev:${tag}-${{ env.DATE }} --no-cache
-          docker push rocm/sgl-dev:${tag}-${{ env.DATE }}
 
       - name: Login to Docker Hub (lmsys)
         uses: docker/login-action@v2


### PR DESCRIPTION
## Summary
- remove the `publish_k3_mi35x` job from the ROCm 7.2 nightly Docker workflow
- remove the obsolete `publish-k3` workflow dispatch option

## Test plan
- [x] Run `git diff --check`
- [x] Verify no `publish_k3_mi35x` or `publish-k3` references remain in the workflow
- [ ] CI

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #30992087675](https://github.com/sgl-project/sglang/actions/runs/30992087675)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30992087042](https://github.com/sgl-project/sglang/actions/runs/30992087042)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->