### PR TITLE
fix(multimodal): use a per-user lock file for cuda_ipc feature transport

### DIFF
--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -1,5 +1,7 @@
 import fcntl
 import logging
+import os
+import tempfile
 import threading
 import time
 from multiprocessing import shared_memory
@@ -20,7 +22,14 @@ MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL = (
     envs.SGLANG_MM_ITEM_MEM_POOL_RECYCLE_INTERVAL_SEC.get()
 )
 
-SHM_LOCK_FILE = "/tmp/shm_wr_lock.lock"
+# Per-user lock path. The old hardcoded /tmp/shm_wr_lock.lock is created by
+# whichever user starts a server first; under a typical umask its mode (0644)
+# then denies every other user's scheduler the write needed to take the flock
+# (PermissionError), breaking cuda_ipc feature transport on shared hosts.
+# Scoping to the current uid also removes false cross-server lock contention.
+SHM_LOCK_FILE = os.path.join(
+    tempfile.gettempdir(), f"sgl_shm_wr_lock_{os.getuid()}.lock"
+)
 
 # Processors set this marker only when their encoder consumes each IPC feature
 # on a single TP rank.  The scheduler then keeps the feature lazy until the

--- a/test/registered/unit/multimodal/test_mm_ipc_lock_path.py
+++ b/test/registered/unit/multimodal/test_mm_ipc_lock_path.py
@@ -1,0 +1,27 @@
+import os
+import tempfile
+
+from sglang.srt.utils.cuda_ipc_transport_utils import SHM_LOCK_FILE
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMmIpcLockPathPerUser(CustomTestCase):
+    def test_lock_path_is_per_user_and_writable(self):
+        # Regression for the shared-host PermissionError: the lock file must not
+        # be a single hardcoded path that the first user's umask can lock every
+        # other user out of.
+        self.assertNotEqual(SHM_LOCK_FILE, "/tmp/shm_wr_lock.lock")
+        self.assertTrue(SHM_LOCK_FILE.startswith(tempfile.gettempdir()))
+        self.assertIn(str(os.getuid()), SHM_LOCK_FILE)
+        # The current user can take the lock (append open is what the code does).
+        with open(SHM_LOCK_FILE, "a"):
+            pass
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #33687.

The multimodal `cuda_ipc` feature transport — the auto-selected default for
single-node CUDA serving, introduced in #11464 — serializes its
consumption-counter update with an `flock` on a hardcoded, world-shared lock
file:

```python
# python/sglang/srt/utils/cuda_ipc_transport_utils.py
SHM_LOCK_FILE = "/tmp/shm_wr_lock.lock"
```

On a multi-tenant host this file is created by whichever user starts a server
first. Under a typical umask (022 → `0644`, 002 → `0664`) every *other* user
then has only read access, so their scheduler raises `PermissionError:
[Errno 13]` the first time it reconstructs a multimodal feature (in
`_acknowledge_consumption`), and the whole TP group goes down. This is **not**
root-specific — any first-creating user with a non-writable-to-others umask
locks everyone else out. The sticky bit on `/tmp` does not help, since it only
guards unlink/rename, not writing to an existing file.

The only current workaround is `--mm-feature-transport cpu`, which disables the
GPU-side IPC fast path.

Minimal, deterministic reproduction (no GPU, no model):

```bash
# Simulate a foreign-owned / restrictive lock file left by an earlier server
touch /tmp/shm_wr_lock.lock && chmod 0444 /tmp/shm_wr_lock.lock

python3 -c 'open("/tmp/shm_wr_lock.lock", "a").close()'
# PermissionError: [Errno 13] Permission denied: '/tmp/shm_wr_lock.lock'
```

## Modifications

- `python/sglang/srt/utils/cuda_ipc_transport_utils.py`: scope the lock file to
  the current user —
  `os.path.join(tempfile.gettempdir(), f"sgl_shm_wr_lock_{os.getuid()}.lock")`.
  Besides fixing the permission error on shared hosts, this also removes false
  cross-server lock contention, since each server owns its own pool and sync
  buffers.
- `test/registered/unit/multimodal/test_mm_ipc_lock_path.py`: CPU-only
  regression test asserting the lock path is no longer the shared hardcoded
  `/tmp` path, lives under the temp dir, is scoped to the current uid, and is
  writable by the current user. Registered via `register_cpu_ci`.

## Accuracy Tests

Not applicable. This change only affects the inter-process lock-file path used
by multimodal feature transport. It does not touch model weights, kernels, or
the forward path, so model outputs are unchanged.

## Speed Tests and Profiling

Not applicable. There is no change to any compute/inference path. The lock
scope only changes which file `flock` operates on; per-server contention is
reduced, never increased.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A (no user-facing flag or behavior change)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A (lock-path-only change; no model-output or perf impact)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30994706005](https://github.com/sgl-project/sglang/actions/runs/30994706005)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30994705734](https://github.com/sgl-project/sglang/actions/runs/30994705734)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->