### PR TITLE
fix: synchronize DSV4 prefill plan warp init

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/c_plan.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/c_plan.cuh
@@ -154,6 +154,10 @@ __global__ __launch_bounds__(1024, 1)  //
     warp_max[tx] = 0;
     warp_min[tx] = 0xFFFFFFFFu;
   }
+  // Warp 0 initializes all warp slots while each warp later writes its own.
+  // Without this barrier, init can clobber a reduction result and make ragged
+  // extend look uniform, selecting the MTP fast path with out-of-range ragged_id.
+  __syncthreads();
 
   // === Stage B: min/max(extend_len) for MTP-uniform detection ===
   // For min, treat threads outside `batch_size` as +inf so they don't pull the min down.


### PR DESCRIPTION
## Motivation

Related to #31023.

The DeepSeek V4 compress-prefill planner initializes the shared `warp_max` / `warp_min` slots from warp 0, then each warp publishes its own reduction result to the same shared-memory arrays. Without a block-level barrier after initialization, another warp can publish its result before warp 0 finishes clearing that slot. The late initializer write can clobber the reduction result and make ragged extend lengths appear uniform, selecting the MTP fast path with invalid ragged IDs.

## Modifications

Add `__syncthreads()` after initializing `warp_max` / `warp_min` and before per-warp reductions are written. This makes the shared-memory lifetime explicit:

1. Initialize all warp slots.
2. Synchronize the block.
3. Let each warp publish its reduction result.
4. Synchronize before warp 0 aggregates the per-warp values.

## Accuracy Tests

Not run. This is a synchronization fix in a JIT CUDA planning kernel and does not intentionally change numerics.

## Speed Tests and Profiling

Not run. The added barrier is in the prefill planning kernel and is expected to have negligible performance impact compared with avoiding an unsafe shared-memory race.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

Validation performed:

- `git diff --check origin/main..HEAD`
- pre-commit hooks triggered by `git commit --amend`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30995351820](https://github.com/sgl-project/sglang/actions/runs/30995351820)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30995351501](https://github.com/sgl-project/sglang/actions/runs/30995351501)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->