### PR TITLE
 [AMD] Gate DFLASH non-greedy verify on the target-only kernel being registered

### DIFF
--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -53,18 +53,7 @@ elif is_hip():
     from sglang.kernels.ops.sampling.renorm_triton import (
         top_p_renorm_probs_triton as top_p_renorm_prob,
     )
-
-    try:
-        from sgl_kernel import tree_speculative_sampling_target_only
-
-        # The ROCm sgl-kernel build omits csrc/speculative/speculative_sampling.cu
-        # while still shipping the Python wrapper, so importing the wrapper says
-        # nothing about callability; probe the registered op table instead.
-        _DFLASH_SAMPLING_VERIFY_AVAILABLE = hasattr(
-            torch.ops.sgl_kernel, "tree_speculative_sampling_target_only"
-        )
-    except Exception:
-        tree_speculative_sampling_target_only = None
+    tree_speculative_sampling_target_only = None
 else:
     top_k_renorm_prob = None
     top_p_renorm_prob = None

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -54,7 +54,17 @@ elif is_hip():
         top_p_renorm_probs_triton as top_p_renorm_prob,
     )
 
-    _DFLASH_SAMPLING_VERIFY_AVAILABLE = True
+    try:
+        from sgl_kernel import tree_speculative_sampling_target_only
+
+        # The ROCm sgl-kernel build omits csrc/speculative/speculative_sampling.cu
+        # while still shipping the Python wrapper, so importing the wrapper says
+        # nothing about callability; probe the registered op table instead.
+        _DFLASH_SAMPLING_VERIFY_AVAILABLE = hasattr(
+            torch.ops.sgl_kernel, "tree_speculative_sampling_target_only"
+        )
+    except Exception:
+        tree_speculative_sampling_target_only = None
 else:
     top_k_renorm_prob = None
     top_p_renorm_prob = None


### PR DESCRIPTION
## Motivation
`test/registered/spec/dflash/test_dflash.py` crashes the scheduler on the AMD `stage-b` runner:
```
File "python/sglang/srt/speculative/dflash_utils.py", line 749, in compute_dflash_sampling_correct_drafts_and_bonus
    tree_speculative_sampling_target_only(
NameError: name 'tree_speculative_sampling_target_only' is not defined
```
#32541 added an `elif is_hip():` branch that sets `_DFLASH_SAMPLING_VERIFY_AVAILABLE = True` but never binds `tree_speculative_sampling_target_only` in that branch. The kernel genuinely does not exist on ROCm: `csrc/speculative/speculative_sampling.cu` is listed only in the CUDA `CMakeLists.txt`, while `setup_rocm.py` compiles just `eagle_utils.cu` and `common_extension_rocm.cc` registers only `verify_tree_greedy`.
With the flag unconditionally `True`, any request with `temperature > 0` entered the non-greedy verify path and hit the unbound name. That matches the CI signal: `test_early_stop` and `test_greedy_determinism` use `temperature=0` and pass, while `test_eos_handling` uses `temperature=0.1` and kills the scheduler, turning every later request into `Connection refused`.
## Modifications
Bind the symbol in the `is_hip()` branch and derive `_DFLASH_SAMPLING_VERIFY_AVAILABLE` from whether the op is actually registered.
An `ImportError` guard would not work: `sgl_kernel/__init__.py` unconditionally re-exports the pure-Python wrapper, so the import always succeeds on ROCm and only the `torch.ops.sgl_kernel.*` dispatch inside it fails. Probing the op table is the reliable check, and `hasattr(torch.ops.<ns>, ...)` is already the idiom used in `srt/utils/custom_op.py` and `device_communicators/cpu_communicator.py`.
**Scope: the diff is confined to the `elif is_hip():` branch. The CUDA/MUSA branch and the `else` branch are byte-for-byte unchanged, so there is no path by which this can affect NVIDIA or MUSA behavior.**
On ROCm the probe returns `False`, so `dflash_worker_v2.py` takes its existing greedy-argmax fallback and emits the warning that path already logs. This restores the pre-#32541 ROCm behavior and matches `eagle_utils.py`, which puts `_is_hip` in the greedy branch for the same reason.
## Follow-up
This PR stops the crash; it does not add non-greedy verification on ROCm, where `temperature > 0` still verifies against `argmax`. Two options for a real fix, both orthogonal to this PR:
1. **Build the kernel on ROCm.** Add flashinfer to `setup_rocm.py` (`setup_musa.py` already does exactly this for the same file), then add the source and register the op. The open question is whether `flashinfer/sampling.cuh` survives hipify; encouragingly, AMD's [ROCm/flashinfer](https://github.com/ROCm/flashinfer) port already ships a HIPified `sampling.cuh`.
2. **Write a Triton target-only kernel.** `eagle_utils.py` already treats `chain_speculative_sampling_triton` and `tree_speculative_sampling_target_only` as interchangeable same-signature functions, so this needs no call-site change. DFLASH verification is a pure chain (`retrieve_next_sibling` is all `-1`), which collapses the tree walk to a linear scan. Note that `chain_speculative_sampling_triton` itself is not a drop-in substitute: it is classic rejection sampling, and with the all-zero `draft_probs` DFLASH passes, its `coin * q < p` test accepts unconditionally.
Once either lands, the op probe added here flips to `True` on its own with no further change to this file.


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31079763648](https://github.com/sgl-project/sglang/actions/runs/31079763648)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31079763058](https://github.com/sgl-project/sglang/actions/runs/31079763058)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->