### PR TITLE
[Bugfix] Support deterministic min-p sampling with a seed

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -583,10 +583,6 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     probs_sort[(probs_sum - probs_sort) > top_ps.view(-1, 1)] = 0.0
 
     if need_min_p_sampling:
-        # TODO: probs_sort should be re-normalized for the use of multinomial_with_seed
-        assert (
-            sampling_seed is None
-        ), "With sampling seed, multinomial_with_seed will provide wrong results"
         min_p_thresholds = probs_sort[:, 0] * min_ps
         probs_sort[probs_sort < min_p_thresholds.view(-1, 1)] = 0.0
 

--- a/test/registered/unit/layers/test_sampler.py
+++ b/test/registered/unit/layers/test_sampler.py
@@ -1,0 +1,43 @@
+"""Unit tests for deterministic sampling behavior in srt/layers/sampler.py."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.sampler import (
+    top_k_top_p_min_p_sampling_from_probs_torch,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestSeededMinPSampling(CustomTestCase):
+    def test_seeded_min_p_sampling_is_reproducible_and_filtered(self):
+        batch_size = 128
+        device = "cuda"
+        probs = torch.tensor([[0.05, 0.55, 0.10, 0.30]], device=device).repeat(
+            batch_size, 1
+        )
+        kwargs = dict(
+            probs=probs,
+            top_ks=torch.full((batch_size,), 4, dtype=torch.int32, device=device),
+            top_ps=torch.ones(batch_size, device=device),
+            min_ps=torch.full((batch_size,), 0.5, device=device),
+            need_min_p_sampling=True,
+            sampling_seed=torch.arange(batch_size, dtype=torch.int64, device=device),
+            positions=torch.full((batch_size,), 17, dtype=torch.int64, device=device),
+        )
+
+        first = top_k_top_p_min_p_sampling_from_probs_torch(**kwargs)
+        second = top_k_top_p_min_p_sampling_from_probs_torch(**kwargs)
+
+        self.assertTrue(torch.equal(first, second))
+        # min_p=0.5 retains only probabilities >= 0.5 * max_prob. The
+        # surviving original token IDs are 1 and 3, despite sorting internally.
+        self.assertEqual(set(first.tolist()), {1, 3})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #33695.

## Motivation

The PyTorch sampling path rejects requests that combine `min_p` with a deterministic sampling seed, even though both parameters are accepted by the sampling API.

The deterministic sampler uses Gumbel-max after filtering. Renormalizing the retained probabilities would add the same row-wide constant to every retained log-weight, so normalization cannot change the sampled `argmax`.

## Modifications

- Remove the assertion that rejects seeded `min_p` sampling.
- Keep using the existing deterministic Gumbel-max path after top-k, top-p, and min-p filtering.
- Add a CUDA unit test that verifies:
  - repeated calls with identical seeds and positions produce identical tokens;
  - tokens removed by `min_p` are never selected;
  - sorted sampling indices map back to the original token IDs.

## Accuracy Tests

```text
pytest -q test/registered/unit/layers/test_sampler.py::TestSeededMinPSampling::test_seeded_min_p_sampling_is_reproducible_and_filtered
1 passed
```

The test failed on the base revision at the existing assertion. No model-forward code or logits are changed; the new behavior applies only to the previously rejected parameter combination.

## Speed Tests and Profiling

No additional operations are added to the sampling path. The change removes an assertion and leaves the existing filtering and Gumbel-max kernels unchanged.

## Checklist

- [x] Format and configured pre-commit checks pass.
- [x] A focused unit regression test covers the fix.
- [x] No documentation change is needed; the API already accepts both parameters.
- [x] No inference benchmark is needed because the patch adds no runtime work.
- [x] The change follows the existing sampler implementation and test layout.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30997878753](https://github.com/sgl-project/sglang/actions/runs/30997878753)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30997878491](https://github.com/sgl-project/sglang/actions/runs/30997878491)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->