### PR TITLE
[Bugfix] Scope pause/continue completion by operation

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1618,6 +1618,7 @@ class PauseGenerationReqInput(BaseReq, kw_only=True):
     """
 
     mode: Literal["abort", "retract", "in_place"] = "abort"
+    operation_id: Optional[str] = None
 
 
 class ContinueGenerationReqInput(BaseReq, kw_only=True):
@@ -1627,6 +1628,7 @@ class ContinueGenerationReqInput(BaseReq, kw_only=True):
     # inference resumes, with no race against active streams. Set to
     # False to skip the empty_cache call.
     torch_empty_cache: bool = True
+    operation_id: Optional[str] = None
 
 
 class TokenizerWorkerRegistrationReq(BaseReq, kw_only=True):
@@ -1639,6 +1641,7 @@ class PauseContinueBroadcastReq(BaseReq, kw_only=True):
     """Broadcast from router to all workers to set is_pause state."""
 
     is_pause: bool
+    operation_id: Optional[str] = None
 
 
 class UpdateWeightFromDiskReqInput(BaseReq, kw_only=True):

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -27,6 +27,7 @@ import pickle
 import signal
 import sys
 import threading
+import uuid
 import zlib
 from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
@@ -519,7 +520,9 @@ class MultiTokenizerRouter:
             ):
                 # Broadcast to ALL workers so every worker's is_pause is set
                 is_pause = isinstance(recv_obj, PauseGenerationReqInput)
-                broadcast = PauseContinueBroadcastReq(is_pause=is_pause)
+                broadcast = PauseContinueBroadcastReq(
+                    is_pause=is_pause, operation_id=recv_obj.operation_id
+                )
                 for ipc_name in self.all_worker_ipcs:
                     self.socket_mapping.send_output(ipc_name, broadcast)
                 # Forward to scheduler rank 0 (it broadcasts to all TP/PP/DP
@@ -674,8 +677,8 @@ class TokenizerWorker(TokenizerManager):
         reg = TokenizerWorkerRegistrationReq(worker_ipc_name=self.tokenizer_ipc_name)
         self._dispatch_to_scheduler(reg)
 
-        # Future for awaiting pause/continue broadcast confirmation
-        self._pause_continue_future: Optional[asyncio.Future] = None
+        # Futures for awaiting pause/continue broadcast confirmations
+        self._pause_continue_futures: Dict[str, asyncio.Future] = {}
 
         # Register PauseContinueBroadcastReq in the result dispatcher so
         # handle_loop routes it to _handle_pause_continue_broadcast
@@ -686,12 +689,7 @@ class TokenizerWorker(TokenizerManager):
         )
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
-        loop = asyncio.get_event_loop()
-        self._pause_continue_future = loop.create_future()
-        # Send to router which will broadcast to all workers
-        # (router also handles forwarding to scheduler for non-abort modes)
-        self._dispatch_to_scheduler(obj)
-        await self._pause_continue_future
+        await self._dispatch_pause_continue(obj)
 
         if obj.mode == "abort":
             # Abort polling: only the originator checks its own lock state
@@ -703,10 +701,22 @@ class TokenizerWorker(TokenizerManager):
                 await asyncio.sleep(1.0)
 
     async def continue_generation(self, obj: ContinueGenerationReqInput):
-        loop = asyncio.get_event_loop()
-        self._pause_continue_future = loop.create_future()
-        self._dispatch_to_scheduler(obj)
-        await self._pause_continue_future
+        await self._dispatch_pause_continue(obj)
+
+    async def _dispatch_pause_continue(
+        self, obj: PauseGenerationReqInput | ContinueGenerationReqInput
+    ):
+        operation_id = uuid.uuid4().hex
+        obj.operation_id = operation_id
+        future = asyncio.get_running_loop().create_future()
+        self._pause_continue_futures[operation_id] = future
+        try:
+            # Send to router which will broadcast to all workers
+            # (router also handles forwarding to scheduler for non-abort modes)
+            self._dispatch_to_scheduler(obj)
+            await future
+        finally:
+            self._pause_continue_futures.pop(operation_id, None)
 
     def _handle_pause_continue_broadcast(self, obj: PauseContinueBroadcastReq):
         """Called from handle_loop when a broadcast arrives from the router."""
@@ -722,10 +732,10 @@ class TokenizerWorker(TokenizerManager):
                 self.is_pause = False
                 self.is_pause_cond.notify_all()
 
-        # Resolve the pending future if this worker initiated the pause/continue
-        if self._pause_continue_future and not self._pause_continue_future.done():
-            self._pause_continue_future.set_result(True)
-            self._pause_continue_future = None
+        # Resolve the matching future if this worker initiated the operation.
+        future = self._pause_continue_futures.get(obj.operation_id)
+        if future is not None and not future.done():
+            future.set_result(True)
 
 
 def get_tokenizer_worker_class(server_args: ServerArgs) -> Type[TokenizerWorker]:

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -1,12 +1,20 @@
+import asyncio
 import unittest
+from unittest.mock import patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
 maybe_stub_sgl_kernel()
 
-from sglang.srt.managers.io_struct import BatchStrOutput
+from sglang.srt.managers.io_struct import (
+    BatchStrOutput,
+    ContinueGenerationReqInput,
+    PauseContinueBroadcastReq,
+    PauseGenerationReqInput,
+)
 from sglang.srt.managers.multi_tokenizer_mixin import (
+    MultiTokenizerRouter,
     TokenizerWorker,
     _handle_output_by_index,
     get_tokenizer_worker_class,
@@ -104,6 +112,178 @@ class TestMultiTokenizerMixin(unittest.TestCase):
     def test_get_tokenizer_worker_class_rejects_non_worker(self):
         with self.assertRaisesRegex(TypeError, "TokenizerWorker"):
             get_tokenizer_worker_class(InvalidServerArgs())
+
+
+class TestPauseContinueCompletion(unittest.IsolatedAsyncioTestCase):
+    def _make_worker(self):
+        worker = TokenizerWorker.__new__(TokenizerWorker)
+        worker.is_pause = False
+        worker.is_pause_cond = asyncio.Condition()
+        worker._pause_continue_futures = {}
+        dispatched = []
+        worker._dispatch_to_scheduler = dispatched.append
+        return worker, dispatched
+
+    @staticmethod
+    def _broadcast_for(request, *, is_pause):
+        # The fallback keeps this regression test on the pre-fix boolean-only
+        # protocol long enough to demonstrate the orphaned waiter.
+        kwargs = {"is_pause": is_pause}
+        operation_id = getattr(request, "operation_id", None)
+        if operation_id is not None:
+            kwargs["operation_id"] = operation_id
+        return PauseContinueBroadcastReq(**kwargs)
+
+    async def test_concurrent_operations_complete_independently_when_reordered(self):
+        worker, dispatched = self._make_worker()
+        pause_task = asyncio.create_task(
+            worker.pause_generation(PauseGenerationReqInput(mode="retract"))
+        )
+        continue_task = asyncio.create_task(
+            worker.continue_generation(
+                ContinueGenerationReqInput(torch_empty_cache=False)
+            )
+        )
+
+        try:
+            await asyncio.sleep(0)
+            self.assertEqual(len(dispatched), 2)
+            pause_request, continue_request = dispatched
+
+            await worker._apply_pause_continue_broadcast(
+                self._broadcast_for(continue_request, is_pause=False)
+            )
+            await asyncio.sleep(0)
+            self.assertTrue(continue_task.done())
+            self.assertFalse(pause_task.done())
+
+            await worker._apply_pause_continue_broadcast(
+                self._broadcast_for(pause_request, is_pause=True)
+            )
+            await asyncio.sleep(0)
+            self.assertTrue(pause_task.done())
+            await asyncio.gather(pause_task, continue_task)
+        finally:
+            for task in (pause_task, continue_task):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(pause_task, continue_task, return_exceptions=True)
+
+    async def test_cancelled_operation_is_removed_before_a_late_broadcast(self):
+        worker, dispatched = self._make_worker()
+        pause_task = asyncio.create_task(
+            worker.pause_generation(PauseGenerationReqInput(mode="retract"))
+        )
+        await asyncio.sleep(0)
+        pause_request = dispatched[0]
+        self.assertIn(pause_request.operation_id, worker._pause_continue_futures)
+
+        pause_task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await pause_task
+        self.assertEqual(worker._pause_continue_futures, {})
+
+        await worker._apply_pause_continue_broadcast(
+            self._broadcast_for(pause_request, is_pause=True)
+        )
+        self.assertTrue(worker.is_pause)
+        self.assertEqual(worker._pause_continue_futures, {})
+
+    async def test_sequential_pause_and_continue_preserve_state_transitions(self):
+        worker, dispatched = self._make_worker()
+        pause_task = asyncio.create_task(
+            worker.pause_generation(PauseGenerationReqInput(mode="retract"))
+        )
+        await asyncio.sleep(0)
+        await worker._apply_pause_continue_broadcast(
+            self._broadcast_for(dispatched[0], is_pause=True)
+        )
+        await pause_task
+        self.assertTrue(worker.is_pause)
+
+        continue_task = asyncio.create_task(
+            worker.continue_generation(
+                ContinueGenerationReqInput(torch_empty_cache=False)
+            )
+        )
+        await asyncio.sleep(0)
+        await worker._apply_pause_continue_broadcast(
+            self._broadcast_for(dispatched[1], is_pause=False)
+        )
+        await continue_task
+
+        self.assertFalse(worker.is_pause)
+        self.assertNotEqual(
+            dispatched[0].operation_id,
+            dispatched[1].operation_id,
+        )
+        self.assertEqual(worker._pause_continue_futures, {})
+
+    async def test_abort_still_polls_after_its_matching_broadcast(self):
+        class UnlockedModelUpdateLock:
+            async def is_locked(self):
+                return False
+
+        worker, dispatched = self._make_worker()
+        abort_calls = []
+        worker.abort_request = lambda *, abort_all: abort_calls.append(abort_all)
+        worker.model_update_lock = UnlockedModelUpdateLock()
+        abort_task = asyncio.create_task(
+            worker.pause_generation(PauseGenerationReqInput(mode="abort"))
+        )
+        await asyncio.sleep(0)
+
+        await worker._apply_pause_continue_broadcast(
+            self._broadcast_for(dispatched[0], is_pause=True)
+        )
+        await abort_task
+
+        self.assertEqual(abort_calls, [True])
+        self.assertTrue(worker.is_pause)
+        self.assertEqual(worker._pause_continue_futures, {})
+
+
+class TestPauseContinueRouting(unittest.IsolatedAsyncioTestCase):
+    async def test_abort_broadcast_preserves_operation_id_for_every_worker(self):
+        class RecordingSocketMapping:
+            def __init__(self):
+                self.outputs = []
+
+            def send_output(self, ipc_name, output):
+                self.outputs.append((ipc_name, output))
+
+        router = MultiTokenizerRouter.__new__(MultiTokenizerRouter)
+        router.receive_from_worker = object()
+        router.send_to_scheduler = object()
+        router.all_worker_ipcs = {"worker-0", "worker-1"}
+        router.socket_mapping = RecordingSocketMapping()
+        request = PauseGenerationReqInput(mode="abort", operation_id="pause-operation")
+        received = False
+
+        async def receive_once(_socket):
+            nonlocal received
+            if not received:
+                received = True
+                return request
+            raise asyncio.CancelledError
+
+        with patch(
+            "sglang.srt.managers.multi_tokenizer_mixin.async_sock_recv",
+            side_effect=receive_once,
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await router.router_worker_obj()
+
+        self.assertEqual(
+            {ipc_name for ipc_name, _ in router.socket_mapping.outputs},
+            router.all_worker_ipcs,
+        )
+        self.assertTrue(
+            all(
+                output.is_pause and output.operation_id == request.operation_id
+                for _, output in router.socket_mapping.outputs
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #33696.

## Motivation

PR #24462 made multi-tokenizer pause and continue operations wait for a router broadcast, but each originator worker still stores only one shared completion future. Concurrent operations on the same worker can overwrite that future and orphan one caller.

```mermaid
sequenceDiagram
    participant P as Pause caller
    participant W as TokenizerWorker
    participant C as Continue caller
    participant R as Router

    P->>W: pause(op-A)
    W->>W: futures[op-A]
    C->>W: continue(op-B)
    W->>W: futures[op-B]
    W->>R: dispatch op-A and op-B
    R-->>W: broadcast op-B
    W-->>C: resolve op-B
    R-->>W: broadcast op-A
    W-->>P: resolve op-A
```

## Modifications

- Assign each pause or continue operation a UUID at the originator worker.
- Preserve the operation ID through the router's worker broadcast.
- Store pending completions in an operation-keyed future map.
- Remove pending entries in `finally`, including cancellation and dispatch-failure paths.
- Continue applying late broadcasts to worker pause state without resolving a removed waiter.
- Preserve sequential and abort-mode behavior.

## Accuracy Tests

This change does not affect model outputs.

```text
pytest -q test/registered/unit/managers/test_multi_tokenizer_mixin.py
9 passed
```

Coverage includes concurrent reordered completion, cancellation cleanup, late broadcasts, sequential pause/continue, abort polling, and router fan-out. The concurrency test failed on the base revision because the pause task remained pending after both broadcasts.

## Speed Tests and Profiling

Pause and continue are control-plane operations. The added work is one UUID and one future-map entry per operation; inference and tokenizer data paths are unchanged.

## Checklist

- [x] Black, isort, configured Ruff checks, compilation, and `git diff --check` pass.
- [x] Focused unit tests pass.
- [x] No documentation change is needed.
- [x] Accuracy and inference benchmarks are not applicable.
- [x] The description and regression coverage include the protocol ordering and cleanup behavior.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #30997880769](https://github.com/sgl-project/sglang/actions/runs/30997880769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #30997880609](https://github.com/sgl-project/sglang/actions/runs/30997880609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->