### PR TITLE
[Bugfix] Serialize disk weight-update completion state

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2007,33 +2007,47 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        async with self.model_update_operation_lock:
-            # Immediately update the weights if the engine is in paused state
-            async with self.is_pause_cond:
-                is_paused = self.is_pause
-
-            lock_context = (
-                self.model_update_lock.writer_lock if not is_paused else nullcontext()
-            )
-            async with lock_context:
+        async def run_update():
+            async with self.model_update_operation_lock:
                 update_task = asyncio.create_task(
                     self._wait_for_model_update_from_disk(obj)
                 )
+                cancelled_error = None
                 try:
                     success, message, num_paused_requests = await asyncio.shield(
                         update_task
                     )
-                except asyncio.CancelledError:
+                except asyncio.CancelledError as exc:
                     # Scheduler responses have no operation id. Keep ownership of
                     # the shared completion state until this response is drained.
-                    await asyncio.shield(update_task)
-                    raise
+                    while not update_task.done():
+                        try:
+                            await asyncio.shield(update_task)
+                        except asyncio.CancelledError:
+                            continue
+                    success, message, num_paused_requests = update_task.result()
+                    cancelled_error = exc
 
-        if success and obj.weight_version is not None:
-            self._update_weight_version_if_provided(obj.weight_version)
-            message += f" Weight version updated to {obj.weight_version}."
+                if success and obj.weight_version is not None:
+                    self._update_weight_version_if_provided(obj.weight_version)
+                    message += f" Weight version updated to {obj.weight_version}."
 
-        return success, message, num_paused_requests
+                if cancelled_error is not None:
+                    raise cancelled_error
+
+                return success, message, num_paused_requests
+
+        # Keep the pause state stable through a paused update so generation
+        # cannot resume while the update bypasses the inference writer lock.
+        async with self.is_pause_cond:
+            if self.is_pause:
+                return await run_update()
+
+        # Queue unpaused operations as writers before serializing access to the
+        # scheduler's untagged completion state. This preserves the RWLock's
+        # writer preference for every update already requested.
+        async with self.model_update_lock.writer_lock:
+            return await run_update()
 
     def record_config_updates(self, source: str, **fields) -> None:
         """Record a control-plane config change for this engine.

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -606,6 +606,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Weight updates
         # The event to notify the weight sync is finished.
         self.model_update_lock = RWLock()
+        self.model_update_operation_lock = asyncio.Lock()
         self.model_update_result: Optional[Awaitable[UpdateWeightFromDiskReqOutput]] = (
             None
         )
@@ -2006,17 +2007,27 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if obj.abort_all_requests:
             self.abort_request(abort_all=True)
 
-        # Immediately update the weights if the engine is in paused state
-        async with self.is_pause_cond:
-            is_paused = self.is_pause
+        async with self.model_update_operation_lock:
+            # Immediately update the weights if the engine is in paused state
+            async with self.is_pause_cond:
+                is_paused = self.is_pause
 
-        lock_context = (
-            self.model_update_lock.writer_lock if not is_paused else nullcontext()
-        )
-        async with lock_context:
-            success, message, num_paused_requests = (
-                await self._wait_for_model_update_from_disk(obj)
+            lock_context = (
+                self.model_update_lock.writer_lock if not is_paused else nullcontext()
             )
+            async with lock_context:
+                update_task = asyncio.create_task(
+                    self._wait_for_model_update_from_disk(obj)
+                )
+                try:
+                    success, message, num_paused_requests = await asyncio.shield(
+                        update_task
+                    )
+                except asyncio.CancelledError:
+                    # Scheduler responses have no operation id. Keep ownership of
+                    # the shared completion state until this response is drained.
+                    await asyncio.shield(update_task)
+                    raise
 
         if success and obj.weight_version is not None:
             self._update_weight_version_if_provided(obj.weight_version)

--- a/test/registered/unit/managers/test_tokenizer_manager_weight_updates.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_weight_updates.py
@@ -55,6 +55,104 @@ def _paused_manager() -> tuple[TokenizerManager, _SchedulerBoundary]:
 
 
 class TestTokenizerManagerWeightUpdates(unittest.IsolatedAsyncioTestCase):
+    async def test_paused_update_blocks_resume_until_completion(self):
+        manager, scheduler = _paused_manager()
+        await manager.model_update_operation_lock.acquire()
+
+        update = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="first", load_format="dummy")
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        async def resume_generation():
+            async with manager.is_pause_cond:
+                manager.is_pause = False
+                manager.is_pause_cond.notify_all()
+
+        resume = asyncio.create_task(resume_generation())
+        await asyncio.sleep(0)
+        resumed_before_update_owned_completion = resume.done()
+
+        manager.model_update_operation_lock.release()
+        await scheduler.wait_for_requests(1)
+        scheduler.complete("first complete")
+        self.assertEqual(
+            await asyncio.wait_for(update, timeout=1),
+            (True, "first complete", 0),
+        )
+        await asyncio.wait_for(resume, timeout=1)
+
+        self.assertFalse(
+            resumed_before_update_owned_completion,
+            "generation resumed while a paused update was waiting to dispatch",
+        )
+
+    async def test_unpaused_updates_preserve_writer_preference(self):
+        manager, scheduler = _paused_manager()
+        manager.is_pause = False
+        await manager.model_update_lock.acquire_reader()
+
+        first = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="first", load_format="dummy")
+            )
+        )
+        while manager.model_update_lock._waiting_writers < 1:
+            await asyncio.sleep(0)
+
+        second = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="second", load_format="dummy")
+            )
+        )
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+        late_reader_acquired = asyncio.Event()
+        release_late_reader = asyncio.Event()
+
+        async def run_late_reader():
+            async with manager.model_update_lock.reader_lock:
+                late_reader_acquired.set()
+                await release_late_reader.wait()
+
+        late_reader = asyncio.create_task(run_late_reader())
+        await manager.model_update_lock.release_reader()
+
+        await scheduler.wait_for_requests(1)
+        scheduler.complete("first complete")
+
+        second_dispatched = asyncio.create_task(scheduler.wait_for_requests(2))
+        late_reader_arrived = asyncio.create_task(late_reader_acquired.wait())
+        done, pending = await asyncio.wait(
+            {second_dispatched, late_reader_arrived},
+            return_when=asyncio.FIRST_COMPLETED,
+            timeout=1,
+        )
+        second_kept_priority = second_dispatched in done
+
+        if second_kept_priority:
+            scheduler.complete("second complete")
+        else:
+            release_late_reader.set()
+            await scheduler.wait_for_requests(2)
+            scheduler.complete("second complete")
+
+        await asyncio.wait_for(asyncio.gather(first, second), timeout=1)
+        release_late_reader.set()
+        await asyncio.wait_for(late_reader, timeout=1)
+        for task in pending:
+            task.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+
+        self.assertTrue(
+            second_kept_priority,
+            "a generation reader overtook an update that was already queued",
+        )
+
     async def test_paused_concurrent_updates_each_receive_own_completion(self):
         manager, scheduler = _paused_manager()
         first = asyncio.create_task(
@@ -131,6 +229,55 @@ class TestTokenizerManagerWeightUpdates(unittest.IsolatedAsyncioTestCase):
                 if not task.done():
                     task.cancel()
             await asyncio.gather(first, second, return_exceptions=True)
+
+    async def test_cancelled_successful_update_still_publishes_weight_version(self):
+        manager, scheduler = _paused_manager()
+        update = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(
+                    model_path="first",
+                    load_format="dummy",
+                    weight_version="version-1",
+                )
+            )
+        )
+        await scheduler.wait_for_requests(1)
+
+        update.cancel()
+        await asyncio.sleep(0)
+        scheduler.complete("first complete")
+
+        with self.assertRaises(asyncio.CancelledError):
+            await update
+        self.assertEqual(
+            manager.config_value("weight_version"),
+            "version-1",
+            "a completed update must publish metadata even if its caller cancels",
+        )
+
+    async def test_repeated_cancellation_cannot_interrupt_response_drain(self):
+        manager, scheduler = _paused_manager()
+        update = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="first", load_format="dummy")
+            )
+        )
+        await scheduler.wait_for_requests(1)
+
+        update.cancel()
+        await asyncio.sleep(0)
+        update.cancel()
+        await asyncio.sleep(0)
+        released_before_response = update.done()
+
+        scheduler.complete("first complete")
+        with self.assertRaises(asyncio.CancelledError):
+            await update
+
+        self.assertFalse(
+            released_before_response,
+            "repeated cancellation released response ownership before completion",
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_tokenizer_manager_weight_updates.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_weight_updates.py
@@ -1,0 +1,137 @@
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (
+    UpdateWeightFromDiskReqInput,
+    UpdateWeightFromDiskReqOutput,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SchedulerBoundary:
+    def __init__(self, manager: TokenizerManager):
+        self.manager = manager
+        self.requests = []
+
+    def dispatch(self, request: UpdateWeightFromDiskReqInput):
+        self.requests.append(request)
+
+    async def wait_for_requests(self, count: int):
+        async def wait():
+            while len(self.requests) < count:
+                await asyncio.sleep(0)
+
+        await asyncio.wait_for(wait(), timeout=1)
+
+    def complete(self, message: str):
+        self.manager._handle_update_weights_from_disk_req_output(
+            UpdateWeightFromDiskReqOutput(success=True, message=message)
+        )
+
+
+def _paused_manager() -> tuple[TokenizerManager, _SchedulerBoundary]:
+    manager = TokenizerManager.__new__(TokenizerManager)
+    manager.server_args = SimpleNamespace(
+        checkpoint_engine_wait_weights_before_ready=False,
+    )
+    manager.elastic_worker_count = 1
+    manager._config_updates = []
+    manager.event_loop = asyncio.get_running_loop()
+    manager.asyncio_tasks = set()
+    manager.init_weight_update()
+    manager.is_pause = True
+
+    scheduler = _SchedulerBoundary(manager)
+    manager._dispatch_to_scheduler = scheduler.dispatch
+    return manager, scheduler
+
+
+class TestTokenizerManagerWeightUpdates(unittest.IsolatedAsyncioTestCase):
+    async def test_paused_concurrent_updates_each_receive_own_completion(self):
+        manager, scheduler = _paused_manager()
+        first = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="first", load_format="dummy")
+            )
+        )
+        second = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="second", load_format="dummy")
+            )
+        )
+
+        try:
+            await scheduler.wait_for_requests(1)
+            scheduler.complete("first complete")
+
+            done, _ = await asyncio.wait({first}, timeout=1)
+            self.assertIn(first, done, "the first update lost its completion")
+            self.assertEqual(
+                first.result(),
+                (True, "first complete", 0),
+            )
+
+            await scheduler.wait_for_requests(2)
+            scheduler.complete("second complete")
+            self.assertEqual(
+                await asyncio.wait_for(second, timeout=1),
+                (True, "second complete", 0),
+            )
+        finally:
+            for task in (first, second):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(first, second, return_exceptions=True)
+
+    async def test_cancellation_keeps_completion_ownership_until_response(self):
+        manager, scheduler = _paused_manager()
+        first = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="first", load_format="dummy")
+            )
+        )
+        await scheduler.wait_for_requests(1)
+
+        first.cancel()
+        await asyncio.sleep(0)
+        second = asyncio.create_task(
+            manager.update_weights_from_disk(
+                UpdateWeightFromDiskReqInput(model_path="second", load_format="dummy")
+            )
+        )
+
+        try:
+            await asyncio.sleep(0)
+            self.assertEqual(
+                len(scheduler.requests),
+                1,
+                "a canceled update released ownership before its response arrived",
+            )
+
+            scheduler.complete("first complete")
+            with self.assertRaises(asyncio.CancelledError):
+                await first
+
+            await scheduler.wait_for_requests(2)
+            scheduler.complete("second complete")
+            self.assertEqual(
+                await asyncio.wait_for(second, timeout=1),
+                (True, "second complete", 0),
+            )
+        finally:
+            for task in (first, second):
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(first, second, return_exceptions=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #33698.

## Motivation

Paused disk weight updates bypass `model_update_lock.writer_lock`. Two concurrent callers can therefore overwrite the shared future and aggregation fields used to receive scheduler responses, leaving one caller pending.

The scheduler response currently has no operation identifier, so only one operation can safely own that shared state at a time.

```mermaid
sequenceDiagram
    participant A as Caller A
    participant T as TokenizerManager
    participant B as Caller B
    participant S as Scheduler

    A->>T: update weights
    T->>T: acquire operation lock
    T->>S: dispatch update A
    B->>T: update weights
    Note over B,T: waits for operation lock
    S-->>T: result A
    T-->>A: complete A
    T->>T: release operation lock
    T->>S: dispatch update B
    S-->>T: result B
    T-->>B: complete B
```

## Modifications

- Add a dedicated operation lock around disk weight-update dispatch and completion.
- Preserve the existing writer-lock behavior for unpaused updates.
- Shield the in-flight scheduler task from caller cancellation.
- If a caller is cancelled, drain its untagged scheduler response before releasing ownership, then propagate cancellation.
- Add scheduler-boundary tests for concurrent paused updates and cancellation ordering.

This does not add a response timeout or change scheduler message formats.

## Accuracy Tests

This change does not affect model outputs.

```text
pytest -q test/registered/unit/managers/test_tokenizer_manager_weight_updates.py
2 passed

pytest -q   test/registered/unit/managers/test_tokenizer_manager_weight_updates.py   test/registered/unit/managers/test_tokenizer_config_updates.py
14 passed
```

The concurrency regression failed on the base revision because the first caller lost its completion.

## Speed Tests and Profiling

This is a control-plane path. Sequential updates are unchanged. Overlapping updates are intentionally serialized because their scheduler responses cannot currently be correlated by operation.

## Checklist

- [x] Black, isort, scoped Ruff checks, compilation, and `git diff --check` pass.
- [x] Focused and adjacent unit tests pass.
- [x] No documentation change is needed.
- [x] Accuracy and speed benchmarks are not applicable to this control-plane fix.
- [x] Cancellation ownership is covered by regression tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31002721211](https://github.com/sgl-project/sglang/actions/runs/31002721211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31002720946](https://github.com/sgl-project/sglang/actions/runs/31002720946)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->