### PR TITLE
[PP] Commit the proxy send after launching the next forward

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -130,7 +130,6 @@ class SchedulerPPMixin:
                             next_mb_id,
                         )
                     )
-                self._pp_commit_comm_work(self.send_proxy_work)
                 if cur_batch:
                     result, self.launch_event = self._pp_launch_batch(
                         mb_id,
@@ -139,6 +138,7 @@ class SchedulerPPMixin:
                         self.mb_metadata,
                         self.last_rank_comm_queue,
                     )
+                self._pp_commit_comm_work(self.send_proxy_work)
                 if get_parallel().pp_async_batch_depth == 0:
                     next_pp_outputs, next_batch_result, d2h_event = (
                         self._pp_commit_send_output_work_and_preprocess_output_tensors(
@@ -276,7 +276,6 @@ class SchedulerPPMixin:
                             next_mb_id,
                         )
                     )
-                self._pp_commit_comm_work(self.send_proxy_work)
                 if cur_batch:
                     result, self.launch_event = self._pp_launch_batch(
                         mb_id,
@@ -285,6 +284,7 @@ class SchedulerPPMixin:
                         self.mb_metadata,
                         self.last_rank_comm_queue,
                     )
+                self._pp_commit_comm_work(self.send_proxy_work)
                 if get_parallel().pp_async_batch_depth == 0:
                     next_pp_outputs, next_batch_result, d2h_event = (
                         self._pp_commit_send_output_work_and_preprocess_output_tensors(


### PR DESCRIPTION
## Modification

Move `_pp_commit_comm_work(self.send_proxy_work)` to just after `_pp_launch_batch()`
in all three PP loops (`event_loop_pp`, `event_loop_pp_disagg_prefill`,
`event_loop_pp_disagg_decode`). The forward is enqueued first; the pending send
drains concurrently with it.

No new state, no change to what is sent or received, and the in-flight depth stays
bounded at one outstanding proxy send per channel, so back-pressure is preserved.

## Evidence

Torch profiler traces, DeepSeek-V4-Pro with `--enable-prefill-cp --cp-strategy interleave`,
colocated prefill.

**Before** — the `SendRecv` kernel has to retire before the next `step[...]` begins:

<img width="1280" height="418" alt="image" src="https://github.com/user-attachments/assets/481d26f3-5fd1-4e8e-b6b6-4df121c41a0f" />

**After** — the send overlaps the following forward:

<img width="1280" height="351" alt="image" src="https://github.com/user-attachments/assets/6d30cb5b-b7bd-43d3-97b6-014f496cb7d1" />

On a 32-step capture (2×B300, pp2·tp8·cp8), 18% of total proxy-send kernel time now
overlaps the next step's compute, versus a structural 0% before, since the commit
previously serialized the two.

**Throughput and latency** (4×H100, pp4·tp8·cp8, colocated prefill):

| Input length | Baseline throughput | Patched throughput | Δ throughput | P95 TTFT (baseline → patched) | Δ P95 TTFT |
|---|---|---|---|---|---|
| 25K  | 67.19K tok/s | 69.64K tok/s | **+3.65%**  | 3,165 → 2,878 ms   | **−9.09%** |
| 131K | 65.40K tok/s | 72.30K tok/s | **+10.55%** | 16,338 → 14,910 ms | **−8.74%** |
| 262K | 61.48K tok/s | 66.48K tok/s | **+8.14%**  | 35,459 → 32,113 ms | **−9.44%** |

The direction is consistent across all three input lengths, and the P95 TTFT reduction
is stable at −8.7% to −9.4% — consistent with removing a per-step stall whose cost
scales with the number of pipeline steps rather than with token count.

Correctness is unchanged: greedy next-token probability on a fact-retrieval probe
matches baseline (99.3% vs 99.4% for the expected token).



Correctness is unchanged: greedy next-token probability on a fact-retrieval probe
matches baseline (99.3% vs 99.4% for the expected token).

**Testing coverage:** verified end-to-end on the colocated path (`event_loop_pp`).
The two disaggregated loops take the identical, mechanical change but were not
exercised on hardware — review there especially welcome.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31066507256](https://github.com/sgl-project/sglang/actions/runs/31066507256)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31066507155](https://github.com/sgl-project/sglang/actions/runs/31066507155)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->