### PR TITLE
fix(hicache): support L3 storage for layer-sharded MLA

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -26,6 +26,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     STORAGE_BATCH_SIZE,
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
+    LayerShardInfo,
     PoolName,
     PoolTransfer,
 )
@@ -45,6 +46,30 @@ from sglang.srt.utils import get_device_module
 logger = logging.getLogger(__name__)
 
 device_module = get_device_module()
+
+
+def _get_layer_shard_info(mem_pool_device) -> Optional[LayerShardInfo]:
+    if not getattr(mem_pool_device, "layer_shard_enabled", False):
+        return None
+    return LayerShardInfo(
+        rank=mem_pool_device.layer_shard_rank,
+        size=mem_pool_device.layer_shard_size,
+    )
+
+
+def _is_storage_writer(
+    *,
+    is_mla_model: bool,
+    layer_shard: Optional[LayerShardInfo],
+    tp_rank: int,
+    attn_tp_rank: int,
+) -> bool:
+    if not is_mla_model:
+        return True
+    # Layer shards are distributed over CP but remain replicated over the
+    # attention-TP ranks within each shard.
+    replica_rank = attn_tp_rank if layer_shard is not None else tp_rank
+    return replica_rank == 0
 
 
 @cache
@@ -467,12 +492,7 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
-        # for MLA models, only one rank needs to backup the KV cache
-        self.backup_skip = (
-            self.storage_config.is_mla_model
-            # todo: load balancing
-            and self.storage_config.tp_rank != 0
-        )
+        self.backup_skip = not self.storage_config.is_storage_writer
 
         # Use storage backend factory for dynamic backend creation
         from sglang.srt.mem_cache.storage import StorageBackendFactory
@@ -608,11 +628,16 @@ class HiCacheController:
         # data. storage only needs rank 0 to write it back.
         from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 
-        is_mla_model = isinstance(self.mem_pool_device, MLATokenToKVPool)
-        is_compressed_mla_model = isinstance(
-            self.mem_pool_device, DeepSeekV4TokenToKVPool
+        is_mla_model = isinstance(
+            self.mem_pool_device, (MLATokenToKVPool, DeepSeekV4TokenToKVPool)
         )
-        is_rank_replicated = is_mla_model or is_compressed_mla_model
+        layer_shard = _get_layer_shard_info(self.mem_pool_device)
+        is_storage_writer = _is_storage_writer(
+            is_mla_model=is_mla_model,
+            layer_shard=layer_shard,
+            tp_rank=self.tp_rank,
+            attn_tp_rank=get_parallel().attn_tp_rank,
+        )
         # Least Common Multiple among heterogeneous tp size
         tp_lcm_size = storage_backend_extra_config.pop("tp_lcm_size", None)
         should_split_heads = False
@@ -622,7 +647,7 @@ class HiCacheController:
                 tp_lcm_size % self.tp_size == 0
             ), "tp_lcm_size must be divisible by tp_size."
             should_split_heads = (
-                not is_rank_replicated
+                not is_mla_model
                 and self.mem_pool_host.layout == "page_head"
                 and tp_lcm_size > self.tp_size
             )
@@ -636,14 +661,15 @@ class HiCacheController:
             pp_size=self.pp_size,
             attn_cp_rank=attn_cp_rank,
             attn_cp_size=attn_cp_size,
-            # TODO(hzh): Rename is_mla_model to is_rank_replicated.
-            is_mla_model=is_rank_replicated,
+            is_mla_model=is_mla_model,
             enable_storage_metrics=self.enable_storage_metrics,
             is_page_first_layout=self.mem_pool_host.layout == "page_first",
             model_name=model_name,
             tp_lcm_size=tp_lcm_size,
             should_split_heads=should_split_heads,
             extra_config=storage_backend_extra_config,
+            layer_shard=layer_shard,
+            is_storage_writer=is_storage_writer,
         )
 
     def reset(self):

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -27,6 +27,7 @@ from sglang.srt.mem_cache.hicache_storage import (
     STORAGE_BATCH_SIZE,
     HiCacheStorageConfig,
     HiCacheStorageExtraInfo,
+    LayerShardInfo,
     PoolName,
     PoolTransfer,
     count_pool_hits,
@@ -48,6 +49,30 @@ from sglang.srt.utils import get_device_module
 logger = logging.getLogger(__name__)
 
 device_module = get_device_module()
+
+
+def _get_layer_shard_info(mem_pool_device) -> Optional[LayerShardInfo]:
+    if not getattr(mem_pool_device, "layer_shard_enabled", False):
+        return None
+    return LayerShardInfo(
+        rank=mem_pool_device.layer_shard_rank,
+        size=mem_pool_device.layer_shard_size,
+    )
+
+
+def _is_storage_writer(
+    *,
+    is_mla_model: bool,
+    layer_shard: Optional[LayerShardInfo],
+    tp_rank: int,
+    attn_tp_rank: int,
+) -> bool:
+    if not is_mla_model:
+        return True
+    # Layer shards are distributed over CP but remain replicated over the
+    # attention-TP ranks within each shard.
+    replica_rank = attn_tp_rank if layer_shard is not None else tp_rank
+    return replica_rank == 0
 
 
 class LayerLoadingEvent:
@@ -550,12 +575,7 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
-        # for MLA models, only one rank needs to backup the KV cache
-        self.backup_skip = (
-            self.storage_config.is_mla_model
-            # todo: load balancing
-            and self.storage_config.tp_rank != 0
-        )
+        self.backup_skip = not self.storage_config.is_storage_writer
 
         # Use storage backend factory for dynamic backend creation
         from sglang.srt.mem_cache.storage import StorageBackendFactory
@@ -701,11 +721,16 @@ class HiCacheController:
         # data. storage only needs rank 0 to write it back.
         from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 
-        is_mla_model = isinstance(self.mem_pool_device, MLATokenToKVPool)
-        is_compressed_mla_model = isinstance(
-            self.mem_pool_device, DeepSeekV4TokenToKVPool
+        is_mla_model = isinstance(
+            self.mem_pool_device, (MLATokenToKVPool, DeepSeekV4TokenToKVPool)
         )
-        is_rank_replicated = is_mla_model or is_compressed_mla_model
+        layer_shard = _get_layer_shard_info(self.mem_pool_device)
+        is_storage_writer = _is_storage_writer(
+            is_mla_model=is_mla_model,
+            layer_shard=layer_shard,
+            tp_rank=self.tp_rank,
+            attn_tp_rank=get_parallel().attn_tp_rank,
+        )
         # Least Common Multiple among heterogeneous tp size
         tp_lcm_size = storage_backend_extra_config.pop("tp_lcm_size", None)
         should_split_heads = False
@@ -715,7 +740,7 @@ class HiCacheController:
                 "tp_lcm_size must be divisible by tp_size."
             )
             should_split_heads = (
-                not is_rank_replicated
+                not is_mla_model
                 and self.mem_pool_host.layout == "page_head"
                 and tp_lcm_size > self.tp_size
             )
@@ -729,14 +754,15 @@ class HiCacheController:
             pp_size=self.pp_size,
             attn_cp_rank=attn_cp_rank,
             attn_cp_size=attn_cp_size,
-            # TODO(hzh): Rename is_mla_model to is_rank_replicated.
-            is_mla_model=is_rank_replicated,
+            is_mla_model=is_mla_model,
             enable_storage_metrics=self.enable_storage_metrics,
             is_page_first_layout=self.mem_pool_host.layout == "page_first",
             model_name=model_name,
             tp_lcm_size=tp_lcm_size,
             should_split_heads=should_split_heads,
             extra_config=storage_backend_extra_config,
+            layer_shard=layer_shard,
+            is_storage_writer=is_storage_writer,
         )
 
     def reset(self):

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Optional, Set
 
+import msgspec
 import torch
 
 from sglang.srt.environ import envs
@@ -21,6 +22,23 @@ logger = logging.getLogger(__name__)
 
 # Max pages per batched storage IO call.
 STORAGE_BATCH_SIZE = 128
+
+
+class LayerShardInfo(msgspec.Struct, frozen=True, kw_only=True):
+    """Layer-shard identity used to isolate external-storage keys."""
+
+    rank: int
+    size: int
+
+    def __post_init__(self) -> None:
+        if self.size <= 1:
+            raise ValueError("Layer sharding requires size > 1")
+        if not 0 <= self.rank < self.size:
+            raise ValueError(f"Invalid layer shard rank {self.rank}/{self.size}")
+
+    @property
+    def key(self) -> str:
+        return f"layer{self.rank}_{self.size}"
 
 
 @dataclass
@@ -38,6 +56,14 @@ class HiCacheStorageConfig:
     tp_lcm_size: Optional[int] = None
     should_split_heads: bool = False
     extra_config: Optional[dict] = None
+    layer_shard: Optional[LayerShardInfo] = None
+    is_storage_writer: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        if self.layer_shard is not None and not self.is_mla_model:
+            raise ValueError("Layer-sharded storage currently requires MLA layout")
+        if self.is_storage_writer is None:
+            self.is_storage_writer = not self.is_mla_model or self.tp_rank == 0
 
 
 @dataclass
@@ -152,6 +178,8 @@ class HiCacheStorage(ABC):
     HiCacheStorage is a class that provides a generic key-value interface for storing and retrieving KV cache.
     It abstracts the underlying storage mechanism, allowing different implementations to be used.
     """
+
+    supports_layer_sharded_mla = False
 
     # todo, the page size of storage backend does not have to be the same as the same as host memory pool
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
@@ -360,6 +388,8 @@ class MetadataCache:
 
 class HiCacheFile(HiCacheStorage):
 
+    supports_layer_sharded_mla = True
+
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):
@@ -375,6 +405,7 @@ class HiCacheFile(HiCacheStorage):
         )
         attn_cp_rank = storage_config.attn_cp_rank
         attn_cp_size = storage_config.attn_cp_size
+        layer_shard = storage_config.layer_shard
         model_name = "-".join(model_name.split("/")) if model_name else ""
         enable_pp = pp_size > 1
         self.config_suffix = f"_{model_name}"
@@ -382,9 +413,11 @@ class HiCacheFile(HiCacheStorage):
             self.config_suffix += f"_{tp_rank}_{tp_size}"
         if enable_pp:
             self.config_suffix += f"_{pp_size}_{pp_rank}"
+        if layer_shard is not None:
+            self.config_suffix += f"_{layer_shard.key}"
         # Under NSA context parallel each CP rank holds a disjoint slice of every
         # page, so give each rank its own file key to avoid a cross-rank write race.
-        if attn_cp_size > 1:
+        elif attn_cp_size > 1:
             self.config_suffix += f"_cp{attn_cp_rank}_{attn_cp_size}"
 
         if not os.path.exists(self.file_path) and tp_rank == 0 and attn_cp_rank == 0:
@@ -425,7 +458,7 @@ class HiCacheFile(HiCacheStorage):
             self.file_path,
             self.config_suffix,
             tp_rank=tp_rank,
-            is_mla_model=is_mla_model,
+            is_storage_writer=bool(storage_config.is_storage_writer),
             extra_config=storage_config.extra_config,
             on_evict=(
                 self.metadata_cache.remove if self.metadata_cache is not None else None

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import TYPE_CHECKING, Any, List, Optional, Set
 
+import msgspec
 import torch
 
 from sglang.srt.environ import envs
@@ -21,6 +22,23 @@ logger = logging.getLogger(__name__)
 
 # Max pages per batched storage IO call.
 STORAGE_BATCH_SIZE = 128
+
+
+class LayerShardInfo(msgspec.Struct, frozen=True, kw_only=True):
+    """Layer-shard identity used to isolate external-storage keys."""
+
+    rank: int
+    size: int
+
+    def __post_init__(self) -> None:
+        if self.size <= 1:
+            raise ValueError("Layer sharding requires size > 1")
+        if not 0 <= self.rank < self.size:
+            raise ValueError(f"Invalid layer shard rank {self.rank}/{self.size}")
+
+    @property
+    def key(self) -> str:
+        return f"layer{self.rank}_{self.size}"
 
 
 @dataclass
@@ -38,6 +56,14 @@ class HiCacheStorageConfig:
     tp_lcm_size: Optional[int] = None
     should_split_heads: bool = False
     extra_config: Optional[dict] = None
+    layer_shard: Optional[LayerShardInfo] = None
+    is_storage_writer: Optional[bool] = None
+
+    def __post_init__(self) -> None:
+        if self.layer_shard is not None and not self.is_mla_model:
+            raise ValueError("Layer-sharded storage currently requires MLA layout")
+        if self.is_storage_writer is None:
+            self.is_storage_writer = not self.is_mla_model or self.tp_rank == 0
 
 
 @dataclass
@@ -164,6 +190,8 @@ class HiCacheStorage(ABC):
     HiCacheStorage is a class that provides a generic key-value interface for storing and retrieving KV cache.
     It abstracts the underlying storage mechanism, allowing different implementations to be used.
     """
+
+    supports_layer_sharded_mla = False
 
     # todo, the page size of storage backend does not have to be the same as the same as host memory pool
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
@@ -371,6 +399,8 @@ class MetadataCache:
 
 
 class HiCacheFile(HiCacheStorage):
+    supports_layer_sharded_mla = True
+
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):
@@ -386,6 +416,7 @@ class HiCacheFile(HiCacheStorage):
         )
         attn_cp_rank = storage_config.attn_cp_rank
         attn_cp_size = storage_config.attn_cp_size
+        layer_shard = storage_config.layer_shard
         model_name = "-".join(model_name.split("/")) if model_name else ""
         enable_pp = pp_size > 1
         self.config_suffix = f"_{model_name}"
@@ -393,9 +424,11 @@ class HiCacheFile(HiCacheStorage):
             self.config_suffix += f"_{tp_rank}_{tp_size}"
         if enable_pp:
             self.config_suffix += f"_{pp_size}_{pp_rank}"
+        if layer_shard is not None:
+            self.config_suffix += f"_{layer_shard.key}"
         # Under NSA context parallel each CP rank holds a disjoint slice of every
         # page, so give each rank its own file key to avoid a cross-rank write race.
-        if attn_cp_size > 1:
+        elif attn_cp_size > 1:
             self.config_suffix += f"_cp{attn_cp_rank}_{attn_cp_size}"
 
         if not os.path.exists(self.file_path) and tp_rank == 0 and attn_cp_rank == 0:
@@ -436,7 +469,7 @@ class HiCacheFile(HiCacheStorage):
             self.file_path,
             self.config_suffix,
             tp_rank=tp_rank,
-            is_mla_model=is_mla_model,
+            is_storage_writer=bool(storage_config.is_storage_writer),
             extra_config=storage_config.extra_config,
             on_evict=(
                 self.metadata_cache.remove if self.metadata_cache is not None else None

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2054,6 +2054,8 @@ class DSAIndexerPoolHost(HostKVCache):
                     dst_ptrs=[self.index_k_with_scale_buffer],
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
+                    # Each indexer row stores one packed page, and indices are
+                    # already page-based.
                     page_size=1,
                 )
                 return

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -2029,8 +2029,8 @@ class DSAIndexerPoolHost(HostKVCache):
                 )
             else:
                 raise ValueError(
-                    "Layer-sharded direct DSA indexer backup only supports "
-                    f"layer_first layout, got {self.layout}"
+                    "Layer-sharded direct DSA indexer per-layer backup only "
+                    f"supports layer_first layout, got {self.layout}"
                 )
         else:
             raise ValueError(f"Unsupported IO backend: {io_backend}")
@@ -2039,7 +2039,25 @@ class DSAIndexerPoolHost(HostKVCache):
         self, device_pool, host_indices, device_indices, io_backend
     ):
         if self._is_device_layer_sharded(device_pool):
-            for layer_id in self._owned_device_layer_ids(device_pool):
+            owned_layer_ids = self._owned_device_layer_ids(device_pool)
+            if not owned_layer_ids:
+                return
+            if io_backend == "direct" and self.layout == "page_first_direct":
+                host_page_indices, device_page_indices = self._get_indexer_page_indices(
+                    host_indices, device_indices
+                )
+                transfer_kv_all_layer_direct_lf_pf(
+                    src_ptrs=[
+                        device_pool.index_k_with_scale_buffer[i]
+                        for i in owned_layer_ids
+                    ],
+                    dst_ptrs=[self.index_k_with_scale_buffer],
+                    src_indices=device_page_indices,
+                    dst_indices=host_page_indices,
+                    page_size=1,
+                )
+                return
+            for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend
                 )

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -338,24 +338,37 @@ class DSAIndexerPoolHost(HostKVCache):
     ):
         if self._is_device_layer_sharded(device_pool):
             owned_layer_ids = self._owned_device_layer_ids(device_pool)
-            if not owned_layer_ids:
-                return
             if io_backend == "direct" and self.layout == "page_first_direct":
                 host_page_indices, device_page_indices = self._get_indexer_page_indices(
                     host_indices, device_indices
                 )
-                transfer_kv_all_layer_direct_lf_pf(
-                    src_ptrs=[
-                        device_pool.index_k_with_scale_buffer[i]
-                        for i in owned_layer_ids
-                    ],
-                    dst_ptrs=[self.index_k_with_scale_buffer],
-                    src_indices=device_page_indices,
-                    dst_indices=host_page_indices,
-                    # Each indexer row stores one packed page, and indices are
-                    # already page-based.
-                    page_size=1,
-                )
+                if owned_layer_ids:
+                    transfer_kv_all_layer_direct_lf_pf(
+                        src_ptrs=[
+                            device_pool.index_k_with_scale_buffer[i]
+                            for i in owned_layer_ids
+                        ],
+                        dst_ptrs=[self.index_k_with_scale_buffer],
+                        src_indices=device_page_indices,
+                        dst_indices=host_page_indices,
+                        # Each indexer row stores one packed page, and indices are
+                        # already page-based.
+                        page_size=1,
+                    )
+                if self.mtp_draft_device_pools:
+                    # Draft layers follow the padded local target-layer region.
+                    transfer_kv_all_layer_direct_lf_pf(
+                        src_ptrs=[
+                            pool.index_k_with_scale_buffer[0]
+                            for pool in self.mtp_draft_device_pools
+                        ],
+                        dst_ptrs=[
+                            self.index_k_with_scale_buffer[:, self.target_layer_num :]
+                        ],
+                        src_indices=device_page_indices,
+                        dst_indices=host_page_indices,
+                        page_size=1,
+                    )
                 return
             for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -327,8 +327,8 @@ class DSAIndexerPoolHost(HostKVCache):
                 )
             else:
                 raise ValueError(
-                    "Layer-sharded direct DSA indexer backup only supports "
-                    f"layer_first layout, got {self.layout}"
+                    "Layer-sharded direct DSA indexer per-layer backup only "
+                    f"supports layer_first layout, got {self.layout}"
                 )
         else:
             raise ValueError(f"Unsupported IO backend: {io_backend}")
@@ -337,7 +337,25 @@ class DSAIndexerPoolHost(HostKVCache):
         self, device_pool, host_indices, device_indices, io_backend
     ):
         if self._is_device_layer_sharded(device_pool):
-            for layer_id in self._owned_device_layer_ids(device_pool):
+            owned_layer_ids = self._owned_device_layer_ids(device_pool)
+            if not owned_layer_ids:
+                return
+            if io_backend == "direct" and self.layout == "page_first_direct":
+                host_page_indices, device_page_indices = self._get_indexer_page_indices(
+                    host_indices, device_indices
+                )
+                transfer_kv_all_layer_direct_lf_pf(
+                    src_ptrs=[
+                        device_pool.index_k_with_scale_buffer[i]
+                        for i in owned_layer_ids
+                    ],
+                    dst_ptrs=[self.index_k_with_scale_buffer],
+                    src_indices=device_page_indices,
+                    dst_indices=host_page_indices,
+                    page_size=1,
+                )
+                return
+            for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend
                 )

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -352,6 +352,8 @@ class DSAIndexerPoolHost(HostKVCache):
                     dst_ptrs=[self.index_k_with_scale_buffer],
                     src_indices=device_page_indices,
                     dst_indices=host_page_indices,
+                    # Each indexer row stores one packed page, and indices are
+                    # already page-based.
                     page_size=1,
                 )
                 return

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -400,7 +400,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 )
             else:
                 raise ValueError(
-                    "Layer-sharded direct HiCache backup only supports "
+                    "Layer-sharded direct HiCache per-layer backup only supports "
                     f"layer_first layout, got {self.layout}"
                 )
         else:
@@ -419,7 +419,19 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         host_indices = self.dcp_kernel_indices(host_indices)
         device_indices = self.dcp_kernel_indices(device_indices)
         if self._is_device_layer_sharded(device_pool):
-            for layer_id in self._owned_device_layer_ids(device_pool):
+            owned_layer_ids = self._owned_device_layer_ids(device_pool)
+            if not owned_layer_ids:
+                return
+            if io_backend == "direct" and self.layout == "page_first_direct":
+                transfer_kv_all_layer_direct_lf_pf(
+                    src_ptrs=[device_pool.kv_buffer[i] for i in owned_layer_ids],
+                    dst_ptrs=[self.kv_buffer],
+                    src_indices=device_indices,
+                    dst_indices=host_indices,
+                    page_size=self.page_size,
+                )
+                return
+            for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend
                 )

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -425,16 +425,26 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         device_indices = self.maybe_dcp_kernel_indices(device_indices)
         if self._is_device_layer_sharded(device_pool):
             owned_layer_ids = self._owned_device_layer_ids(device_pool)
-            if not owned_layer_ids:
-                return
             if io_backend == "direct" and self.layout == "page_first_direct":
-                transfer_kv_all_layer_direct_lf_pf(
-                    src_ptrs=[device_pool.kv_buffer[i] for i in owned_layer_ids],
-                    dst_ptrs=[self.kv_buffer],
-                    src_indices=device_indices,
-                    dst_indices=host_indices,
-                    page_size=self.page_size,
-                )
+                if owned_layer_ids:
+                    transfer_kv_all_layer_direct_lf_pf(
+                        src_ptrs=[device_pool.kv_buffer[i] for i in owned_layer_ids],
+                        dst_ptrs=[self.kv_buffer],
+                        src_indices=device_indices,
+                        dst_indices=host_indices,
+                        page_size=self.page_size,
+                    )
+                if self.mtp_draft_device_pools:
+                    # Draft layers follow the padded local target-layer region.
+                    transfer_kv_all_layer_direct_lf_pf(
+                        src_ptrs=[
+                            pool.kv_buffer[0] for pool in self.mtp_draft_device_pools
+                        ],
+                        dst_ptrs=[self.kv_buffer[:, self.target_layer_num :]],
+                        src_indices=device_indices,
+                        dst_indices=host_indices,
+                        page_size=self.page_size,
+                    )
                 return
             for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -405,7 +405,7 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 )
             else:
                 raise ValueError(
-                    "Layer-sharded direct HiCache backup only supports "
+                    "Layer-sharded direct HiCache per-layer backup only supports "
                     f"layer_first layout, got {self.layout}"
                 )
         else:
@@ -424,7 +424,19 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         host_indices = self.maybe_dcp_kernel_indices(host_indices)
         device_indices = self.maybe_dcp_kernel_indices(device_indices)
         if self._is_device_layer_sharded(device_pool):
-            for layer_id in self._owned_device_layer_ids(device_pool):
+            owned_layer_ids = self._owned_device_layer_ids(device_pool)
+            if not owned_layer_ids:
+                return
+            if io_backend == "direct" and self.layout == "page_first_direct":
+                transfer_kv_all_layer_direct_lf_pf(
+                    src_ptrs=[device_pool.kv_buffer[i] for i in owned_layer_ids],
+                    dst_ptrs=[self.kv_buffer],
+                    src_indices=device_indices,
+                    dst_indices=host_indices,
+                    page_size=self.page_size,
+                )
+                return
+            for layer_id in owned_layer_ids:
                 self._backup_from_device_per_layer(
                     device_pool, host_indices, device_indices, layer_id, io_backend
                 )

--- a/python/sglang/srt/mem_cache/storage/backend_factory.py
+++ b/python/sglang/srt/mem_cache/storage/backend_factory.py
@@ -87,6 +87,7 @@ class StorageBackendFactory:
         if backend_name in cls._registry:
             registry_entry = cls._registry[backend_name]
             backend_class = registry_entry["loader"]()
+            cls._validate_layer_sharding(backend_name, backend_class, storage_config)
             logger.info(
                 f"Creating storage backend '{backend_name}' "
                 f"({registry_entry['module_path']}.{registry_entry['class_name']})"
@@ -135,6 +136,7 @@ class StorageBackendFactory:
             backend_class = cls._load_backend_class(
                 module_path, class_name, backend_name
             )
+            cls._validate_layer_sharding(backend_name, backend_class, storage_config)
 
             logger.info(
                 f"Creating dynamic storage backend '{backend_name}' "
@@ -148,6 +150,20 @@ class StorageBackendFactory:
                 f"Failed to create dynamic storage backend '{backend_name}': {e}"
             )
             raise
+
+    @staticmethod
+    def _validate_layer_sharding(
+        backend_name: str,
+        backend_class: type[HiCacheStorage],
+        storage_config: HiCacheStorageConfig,
+    ) -> None:
+        if storage_config.layer_shard is not None and not getattr(
+            backend_class, "supports_layer_sharded_mla", False
+        ):
+            raise ValueError(
+                f"Storage backend '{backend_name}' does not support "
+                "layer-sharded cache pages"
+            )
 
     @classmethod
     def _create_builtin_backend(

--- a/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
+++ b/python/sglang/srt/mem_cache/storage/file/lru_file_evictor.py
@@ -69,7 +69,7 @@ class LRUFileEvictor:
         config_suffix: str,
         *,
         tp_rank: int,
-        is_mla_model: bool,
+        is_storage_writer: bool,
         extra_config: Optional[dict] = None,
         on_evict: Optional[Callable[[str], None]] = None,
     ) -> None:
@@ -78,9 +78,7 @@ class LRUFileEvictor:
         self._tp_rank = tp_rank
         self._on_evict = on_evict
 
-        # MLA ranks share the same physical files, so centralize LRU bookkeeping
-        # on rank 0; non-MLA ranks each own their own files via the suffix.
-        self._is_storage_owner = (not is_mla_model) or (tp_rank == 0)
+        self._is_storage_owner = is_storage_writer
 
         # suffixed_key -> file size in bytes; oldest at front.
         self._lru: OrderedDict[str, int] = OrderedDict()
@@ -94,7 +92,8 @@ class LRUFileEvictor:
         self._eviction_enabled = self._eviction_configured and self._is_storage_owner
         if self._eviction_configured and not self._is_storage_owner:
             logger.info(
-                f"HiCacheFile rank {self._tp_rank} (MLA): eviction handled by rank 0; "
+                f"HiCacheFile rank {self._tp_rank}: eviction handled by the "
+                f"designated storage writer; "
                 f"this rank skips LRU bookkeeping and will not create new files."
             )
 
@@ -177,7 +176,7 @@ class LRUFileEvictor:
             return True  # unbounded storage: nothing to enforce
         if not self._is_storage_owner:
             logger.warning(
-                f"HiCacheFile rank {self._tp_rank} is not the MLA storage owner; "
+                f"HiCacheFile rank {self._tp_rank} is not the storage writer; "
                 f"not caching new key {key} because file eviction is enabled."
             )
             return False

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -330,6 +330,7 @@ class MooncakeBaseStore:
 
 
 class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
+    supports_layer_sharded_mla = True
 
     @staticmethod
     def _standalone_required_bytes(mem_pool: Any) -> int:
@@ -575,6 +576,13 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             else:
                 self.mha_suffix = f"{self.local_rank}"
                 self.mla_suffix = ""
+
+            layer_shard = storage_config.layer_shard
+            if layer_shard is not None:
+                shard_key = layer_shard.key
+                self.mla_suffix = (
+                    f"{self.mla_suffix}_{shard_key}" if self.mla_suffix else shard_key
+                )
 
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -330,6 +330,8 @@ class MooncakeBaseStore:
 
 
 class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
+    supports_layer_sharded_mla = True
+
     @staticmethod
     def _standalone_required_bytes(mem_pool: Any) -> int:
         """Compute total bytes of host buffers that must be visible to the real client.
@@ -578,6 +580,13 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             else:
                 self.mha_suffix = f"{self.local_rank}"
                 self.mla_suffix = ""
+
+            layer_shard = storage_config.layer_shard
+            if layer_shard is not None:
+                shard_key = layer_shard.key
+                self.mla_suffix = (
+                    f"{self.mla_suffix}_{shard_key}" if self.mla_suffix else shard_key
+                )
 
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads

--- a/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_lru_unit.py
@@ -29,6 +29,7 @@ from sglang.srt.environ import envs
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheFile,
     HiCacheStorageConfig,
+    LayerShardInfo,
     MetadataCache,
 )
 from sglang.srt.mem_cache.storage.file.lru_file_evictor import _parse_size_to_bytes
@@ -51,6 +52,8 @@ def _make_config(
     is_mla=False,
     model="testmodel",
     extra_config=None,
+    layer_shard=None,
+    is_storage_writer=None,
 ) -> HiCacheStorageConfig:
     return HiCacheStorageConfig(
         tp_rank=tp_rank,
@@ -64,6 +67,8 @@ def _make_config(
         is_page_first_layout=True,
         model_name=model,
         extra_config=extra_config,
+        layer_shard=layer_shard,
+        is_storage_writer=is_storage_writer,
     )
 
 
@@ -88,6 +93,8 @@ class _BackendBuilder:
         subdir=None,
         metadata_ttl=None,
         enable_metadata_cache=None,
+        layer_shard=None,
+        is_storage_writer=None,
     ) -> HiCacheFile:
         # Each backend gets its own subdir so MLA / non-MLA tests don't
         # contaminate each other's file_path.
@@ -109,6 +116,8 @@ class _BackendBuilder:
                 "metadata_ttl": metadata_ttl,
                 "enable_metadata_cache": enable_metadata_cache,
             },
+            layer_shard=layer_shard,
+            is_storage_writer=is_storage_writer,
         )
         return HiCacheFile(cfg, file_path=d)
 
@@ -295,6 +304,64 @@ class TestCPSuffix(HiCacheFileLRUTestBase):
         self.assertTrue(b0.config_suffix.endswith("_cp0_4"))
         self.assertTrue(b1.config_suffix.endswith("_cp3_4"))
         self.assertNotEqual(b0.config_suffix, b1.config_suffix)
+
+
+class TestLayerShardSuffix(HiCacheFileLRUTestBase):
+    def _layer_shard(self, rank: int) -> LayerShardInfo:
+        return LayerShardInfo(rank=rank, size=8)
+
+    def test_layer_shards_get_distinct_file_keys(self):
+        b0 = self.make_backend(
+            is_mla=True,
+            tp_rank=0,
+            tp_size=8,
+            attn_cp_rank=0,
+            attn_cp_size=8,
+            subdir="layer",
+            layer_shard=self._layer_shard(0),
+        )
+        b7 = self.make_backend(
+            is_mla=True,
+            tp_rank=7,
+            tp_size=8,
+            attn_cp_rank=7,
+            attn_cp_size=8,
+            subdir="layer",
+            layer_shard=self._layer_shard(7),
+        )
+
+        self.assertTrue(b0.config_suffix.endswith("_layer0_8"))
+        self.assertTrue(b7.config_suffix.endswith("_layer7_8"))
+        self.assertNotIn("_cp", b0.config_suffix)
+        self.assertNotEqual(b0._get_suffixed_key("k"), b7._get_suffixed_key("k"))
+
+    def test_layer_shard_writer_owns_its_files(self):
+        b = self.make_backend(
+            max_size="200",
+            is_mla=True,
+            tp_rank=7,
+            tp_size=8,
+            layer_shard=self._layer_shard(7),
+            is_storage_writer=True,
+        )
+
+        self.assertTrue(b._evictor.is_storage_owner)
+        self.assertTrue(b._evictor.enabled)
+        self.assertTrue(b.set("a", _t(50)))
+
+    def test_tp_replica_does_not_own_layer_shard_files(self):
+        b = self.make_backend(
+            max_size="200",
+            is_mla=True,
+            tp_rank=7,
+            tp_size=8,
+            layer_shard=self._layer_shard(3),
+            is_storage_writer=False,
+        )
+
+        self.assertFalse(b._evictor.is_storage_owner)
+        self.assertFalse(b._evictor.enabled)
+        self.assertFalse(b.set("a", _t(50)))
 
 
 class TestMLAOwnerGating(HiCacheFileLRUTestBase):

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -12,7 +12,11 @@ from sglang.srt.managers.cache_controller import CacheOperation as ManagerCacheO
 from sglang.srt.managers.cache_controller import (
     HiCacheController,
 )
-from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.hicache_storage import (
+    LayerShardInfo,
+    PoolName,
+    PoolTransfer,
+)
 from sglang.srt.mem_cache.hybrid_cache import hybrid_cache_controller
 from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     CacheOperation,
@@ -186,6 +190,26 @@ class TestHiCacheStagedWriteBackDispatch(unittest.TestCase):
 
     def tearDown(self):
         manager_cache_controller._timing_events_supported.cache_clear()
+
+    def test_layer_shard_selects_one_writer_per_attention_tp_group(self):
+        shard = LayerShardInfo(rank=1, size=2)
+
+        self.assertTrue(
+            manager_cache_controller._is_storage_writer(
+                is_mla_model=True,
+                layer_shard=shard,
+                tp_rank=2,
+                attn_tp_rank=0,
+            )
+        )
+        self.assertFalse(
+            manager_cache_controller._is_storage_writer(
+                is_mla_model=True,
+                layer_shard=shard,
+                tp_rank=3,
+                attn_tp_rank=1,
+            )
+        )
 
     def _patched_transfers(self, src_registry=None, module=MEMORY_POOL_HOST_MODULE):
         staged_side_effect = None

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -50,11 +50,13 @@ def _ptr_key_from_tensor(ptrs: torch.Tensor) -> tuple[int, ...]:
     return tuple(int(ptr) for ptr in ptrs.cpu().tolist())
 
 
-def _device_pool_stub(*, layer_num: int, **fields) -> SimpleNamespace:
+def _device_pool_stub(
+    *, layer_num: int, layer_shard_enabled: bool = False, **fields
+) -> SimpleNamespace:
     """Minimal device-pool stand-in with layer-split fields real pools expose."""
     return SimpleNamespace(
         layer_num=layer_num,
-        layer_shard_enabled=False,
+        layer_shard_enabled=layer_shard_enabled,
         **fields,
     )
 
@@ -136,6 +138,23 @@ def _cpu_per_layer_pf_lf_copy(
     src_indices = src_indices.to(dtype=torch.int64, device="cpu")
     dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
     dst[dst_indices] = src[src_indices, layer_id]
+
+
+def _cpu_all_layer_direct_lf_pf_copy(
+    *, src_ptrs, dst_ptrs, src_indices, dst_indices, page_size
+):
+    assert len(dst_ptrs) == 1
+    src_indices = src_indices.to(dtype=torch.int64, device="cpu")
+    dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
+    dst = dst_ptrs[0]
+    for offset in range(0, len(src_indices), page_size):
+        src_index = int(src_indices[offset])
+        dst_page = int(dst_indices[offset]) // page_size
+        for local_layer, src in enumerate(src_ptrs):
+            dst_page_layer = dst[dst_page, local_layer]
+            dst_page_layer.copy_(
+                src[src_index : src_index + page_size].reshape_as(dst_page_layer)
+            )
 
 
 class _FakeEvent:
@@ -664,6 +683,137 @@ class TestHiCacheStagedWriteBackDispatch(unittest.TestCase):
                 torch.equal(
                     host.index_k_with_scale_buffer[host_page_indices, layer_id],
                     expected[layer_id],
+                )
+            )
+
+    def test_layer_sharded_mla_direct_page_first_backup(self):
+        full_layer_num = 4
+        owned_start, owned_end = 2, 4
+        page_size = 2
+        kv_cache_dim = 5
+        host_indices = torch.tensor([0, 1, 4, 5], dtype=torch.int64)
+        device_indices = torch.tensor([2, 3, 6, 7], dtype=torch.int64)
+        device_layers = [
+            torch.empty(0, 1, kv_cache_dim, dtype=torch.uint8),
+            torch.empty(0, 1, kv_cache_dim, dtype=torch.uint8),
+            torch.arange(8 * kv_cache_dim, dtype=torch.uint8).reshape(
+                8, 1, kv_cache_dim
+            ),
+            (torch.arange(8 * kv_cache_dim, dtype=torch.uint8) + 80).reshape(
+                8, 1, kv_cache_dim
+            ),
+        ]
+        device_pool = _device_pool_stub(
+            layer_num=full_layer_num,
+            layer_shard_enabled=True,
+            layer_shard_size=2,
+            kv_buffer=device_layers,
+            _owned_local_layer_range=lambda: (owned_start, owned_end),
+        )
+
+        host = MLATokenToKVPoolHost.__new__(MLATokenToKVPoolHost)
+        host.device_pool = device_pool
+        host.layout = "page_first_direct"
+        host.page_size = page_size
+        host.layer_num = owned_end - owned_start
+        host.kv_cache_dim = kv_cache_dim
+        host.kv_buffer = torch.zeros(
+            4,
+            host.layer_num,
+            page_size,
+            1,
+            kv_cache_dim,
+            dtype=torch.uint8,
+        )
+
+        with mock.patch(
+            f"{MLA_POOL_HOST_MODULE}.transfer_kv_all_layer_direct_lf_pf",
+            side_effect=_cpu_all_layer_direct_lf_pf_copy,
+        ) as direct_copy:
+            host.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                io_backend="direct",
+            )
+
+        direct_copy.assert_called_once()
+        copied_src_ptrs = direct_copy.call_args.kwargs["src_ptrs"]
+        self.assertEqual(len(copied_src_ptrs), owned_end - owned_start)
+        for copied, device_layer in zip(
+            copied_src_ptrs, range(owned_start, owned_end), strict=True
+        ):
+            self.assertIs(copied, device_layers[device_layer])
+        for host_layer, device_layer in enumerate(range(owned_start, owned_end)):
+            expected = device_layers[device_layer][device_indices].reshape(
+                2, page_size, 1, kv_cache_dim
+            )
+            self.assertTrue(torch.equal(host.kv_buffer[[0, 2], host_layer], expected))
+
+    def test_layer_sharded_dsa_indexer_direct_page_first_backup(self):
+        full_layer_num = 4
+        owned_start, owned_end = 2, 4
+        page_size = 2
+        indexer_page_stride_size = 8
+        host_indices = torch.tensor([0, 1, 4, 5], dtype=torch.int64)
+        device_indices = torch.tensor([2, 3, 6, 7], dtype=torch.int64)
+        device_layers = [
+            torch.empty(0, 1, indexer_page_stride_size, dtype=torch.uint8),
+            torch.empty(0, 1, indexer_page_stride_size, dtype=torch.uint8),
+            torch.arange(5 * indexer_page_stride_size, dtype=torch.uint8).reshape(
+                5, 1, indexer_page_stride_size
+            ),
+            (
+                torch.arange(5 * indexer_page_stride_size, dtype=torch.uint8) + 80
+            ).reshape(5, 1, indexer_page_stride_size),
+        ]
+        device_pool = _device_pool_stub(
+            layer_num=full_layer_num,
+            layer_shard_enabled=True,
+            layer_shard_size=2,
+            index_k_with_scale_buffer=device_layers,
+            _owned_local_layer_range=lambda: (owned_start, owned_end),
+        )
+
+        host = DSAIndexerPoolHost.__new__(DSAIndexerPoolHost)
+        host.device_pool = device_pool
+        host.layout = "page_first_direct"
+        host.page_size = page_size
+        host.layer_num = owned_end - owned_start
+        host.indexer_page_stride_size = indexer_page_stride_size
+        host.index_k_with_scale_buffer = torch.zeros(
+            4,
+            host.layer_num,
+            1,
+            indexer_page_stride_size,
+            dtype=torch.uint8,
+        )
+
+        with mock.patch(
+            f"{MEMORY_POOL_HOST_MODULE}.transfer_kv_all_layer_direct_lf_pf",
+            side_effect=_cpu_all_layer_direct_lf_pf_copy,
+        ) as direct_copy:
+            host.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                io_backend="direct",
+            )
+
+        direct_copy.assert_called_once()
+        copied_src_ptrs = direct_copy.call_args.kwargs["src_ptrs"]
+        self.assertEqual(len(copied_src_ptrs), owned_end - owned_start)
+        for copied, device_layer in zip(
+            copied_src_ptrs, range(owned_start, owned_end), strict=True
+        ):
+            self.assertIs(copied, device_layers[device_layer])
+        host_page_indices = torch.tensor([0, 2], dtype=torch.int64)
+        device_page_indices = torch.tensor([1, 3], dtype=torch.int64)
+        for host_layer, device_layer in enumerate(range(owned_start, owned_end)):
+            self.assertTrue(
+                torch.equal(
+                    host.index_k_with_scale_buffer[host_page_indices, host_layer],
+                    device_layers[device_layer][device_page_indices],
                 )
             )
 

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -52,11 +52,13 @@ def _ptr_key_from_tensor(ptrs: torch.Tensor) -> tuple[int, ...]:
     return tuple(int(ptr) for ptr in ptrs.cpu().tolist())
 
 
-def _device_pool_stub(*, layer_num: int, **fields) -> SimpleNamespace:
+def _device_pool_stub(
+    *, layer_num: int, layer_shard_enabled: bool = False, **fields
+) -> SimpleNamespace:
     """Minimal device-pool stand-in with layer-split fields real pools expose."""
     return SimpleNamespace(
         layer_num=layer_num,
-        layer_shard_enabled=False,
+        layer_shard_enabled=layer_shard_enabled,
         **fields,
     )
 
@@ -165,6 +167,23 @@ def _cpu_per_layer_pf_lf_copy(
     src_indices = src_indices.to(dtype=torch.int64, device="cpu")
     dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
     dst[dst_indices] = src[src_indices, layer_id]
+
+
+def _cpu_all_layer_direct_lf_pf_copy(
+    *, src_ptrs, dst_ptrs, src_indices, dst_indices, page_size
+):
+    assert len(dst_ptrs) == 1
+    src_indices = src_indices.to(dtype=torch.int64, device="cpu")
+    dst_indices = dst_indices.to(dtype=torch.int64, device="cpu")
+    dst = dst_ptrs[0]
+    for offset in range(0, len(src_indices), page_size):
+        src_index = int(src_indices[offset])
+        dst_page = int(dst_indices[offset]) // page_size
+        for local_layer, src in enumerate(src_ptrs):
+            dst_page_layer = dst[dst_page, local_layer]
+            dst_page_layer.copy_(
+                src[src_index : src_index + page_size].reshape_as(dst_page_layer)
+            )
 
 
 class _FakeEvent:
@@ -905,6 +924,137 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
                 torch.equal(
                     host.index_k_with_scale_buffer[host_page_indices, layer_id],
                     expected[layer_id],
+                )
+            )
+
+    def test_layer_sharded_mla_direct_page_first_backup(self):
+        full_layer_num = 4
+        owned_start, owned_end = 2, 4
+        page_size = 2
+        kv_cache_dim = 5
+        host_indices = torch.tensor([0, 1, 4, 5], dtype=torch.int64)
+        device_indices = torch.tensor([2, 3, 6, 7], dtype=torch.int64)
+        device_layers = [
+            torch.empty(0, 1, kv_cache_dim, dtype=torch.uint8),
+            torch.empty(0, 1, kv_cache_dim, dtype=torch.uint8),
+            torch.arange(8 * kv_cache_dim, dtype=torch.uint8).reshape(
+                8, 1, kv_cache_dim
+            ),
+            (torch.arange(8 * kv_cache_dim, dtype=torch.uint8) + 80).reshape(
+                8, 1, kv_cache_dim
+            ),
+        ]
+        device_pool = _device_pool_stub(
+            layer_num=full_layer_num,
+            layer_shard_enabled=True,
+            layer_shard_size=2,
+            kv_buffer=device_layers,
+            _owned_local_layer_range=lambda: (owned_start, owned_end),
+        )
+
+        host = MLATokenToKVPoolHost.__new__(MLATokenToKVPoolHost)
+        host.device_pool = device_pool
+        host.layout = "page_first_direct"
+        host.page_size = page_size
+        host.layer_num = owned_end - owned_start
+        host.kv_cache_dim = kv_cache_dim
+        host.kv_buffer = torch.zeros(
+            4,
+            host.layer_num,
+            page_size,
+            1,
+            kv_cache_dim,
+            dtype=torch.uint8,
+        )
+
+        with mock.patch(
+            f"{MLA_POOL_HOST_MODULE}.transfer_kv_all_layer_direct_lf_pf",
+            side_effect=_cpu_all_layer_direct_lf_pf_copy,
+        ) as direct_copy:
+            host.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                io_backend="direct",
+            )
+
+        direct_copy.assert_called_once()
+        copied_src_ptrs = direct_copy.call_args.kwargs["src_ptrs"]
+        self.assertEqual(len(copied_src_ptrs), owned_end - owned_start)
+        for copied, device_layer in zip(
+            copied_src_ptrs, range(owned_start, owned_end), strict=True
+        ):
+            self.assertIs(copied, device_layers[device_layer])
+        for host_layer, device_layer in enumerate(range(owned_start, owned_end)):
+            expected = device_layers[device_layer][device_indices].reshape(
+                2, page_size, 1, kv_cache_dim
+            )
+            self.assertTrue(torch.equal(host.kv_buffer[[0, 2], host_layer], expected))
+
+    def test_layer_sharded_dsa_indexer_direct_page_first_backup(self):
+        full_layer_num = 4
+        owned_start, owned_end = 2, 4
+        page_size = 2
+        indexer_page_stride_size = 8
+        host_indices = torch.tensor([0, 1, 4, 5], dtype=torch.int64)
+        device_indices = torch.tensor([2, 3, 6, 7], dtype=torch.int64)
+        device_layers = [
+            torch.empty(0, 1, indexer_page_stride_size, dtype=torch.uint8),
+            torch.empty(0, 1, indexer_page_stride_size, dtype=torch.uint8),
+            torch.arange(5 * indexer_page_stride_size, dtype=torch.uint8).reshape(
+                5, 1, indexer_page_stride_size
+            ),
+            (
+                torch.arange(5 * indexer_page_stride_size, dtype=torch.uint8) + 80
+            ).reshape(5, 1, indexer_page_stride_size),
+        ]
+        device_pool = _device_pool_stub(
+            layer_num=full_layer_num,
+            layer_shard_enabled=True,
+            layer_shard_size=2,
+            index_k_with_scale_buffer=device_layers,
+            _owned_local_layer_range=lambda: (owned_start, owned_end),
+        )
+
+        host = DSAIndexerPoolHost.__new__(DSAIndexerPoolHost)
+        host.device_pool = device_pool
+        host.layout = "page_first_direct"
+        host.page_size = page_size
+        host.layer_num = owned_end - owned_start
+        host.indexer_page_stride_size = indexer_page_stride_size
+        host.index_k_with_scale_buffer = torch.zeros(
+            4,
+            host.layer_num,
+            1,
+            indexer_page_stride_size,
+            dtype=torch.uint8,
+        )
+
+        with mock.patch(
+            f"{DSA_POOL_HOST_MODULE}.transfer_kv_all_layer_direct_lf_pf",
+            side_effect=_cpu_all_layer_direct_lf_pf_copy,
+        ) as direct_copy:
+            host.backup_from_device_all_layer(
+                device_pool,
+                host_indices,
+                device_indices,
+                io_backend="direct",
+            )
+
+        direct_copy.assert_called_once()
+        copied_src_ptrs = direct_copy.call_args.kwargs["src_ptrs"]
+        self.assertEqual(len(copied_src_ptrs), owned_end - owned_start)
+        for copied, device_layer in zip(
+            copied_src_ptrs, range(owned_start, owned_end), strict=True
+        ):
+            self.assertIs(copied, device_layers[device_layer])
+        host_page_indices = torch.tensor([0, 2], dtype=torch.int64)
+        device_page_indices = torch.tensor([1, 3], dtype=torch.int64)
+        for host_layer, device_layer in enumerate(range(owned_start, owned_end)):
+            self.assertTrue(
+                torch.equal(
+                    host.index_k_with_scale_buffer[host_page_indices, host_layer],
+                    device_layers[device_layer][device_page_indices],
                 )
             )
 

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -1041,6 +1041,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         host = DSAIndexerPoolHost.__new__(DSAIndexerPoolHost)
         host.device_pool = device_pool
         host.layout = "page_first_direct"
+        host.mtp_draft_device_pools = ()
         host.page_size = page_size
         host.layer_num = owned_end - owned_start
         host.indexer_page_stride_size = indexer_page_stride_size

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -7,10 +7,12 @@ from unittest import mock
 
 import torch
 
+from sglang.srt.managers import cache_controller as manager_cache_controller
 from sglang.srt.managers.cache_controller import CacheOperation, HiCacheController
 from sglang.srt.mem_cache import l2_transfer as transfer_module
 from sglang.srt.mem_cache.buffer_mode.pipeline import BufferModePipeline
 from sglang.srt.mem_cache.hicache_storage import (
+    LayerShardInfo,
     PoolHitPolicy,
     PoolName,
     PoolTransfer,
@@ -425,6 +427,26 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         )
         self.assertIs(pool_transfers[0].host_indices, mock.sentinel.host_indices)
         self.assertIs(pool_transfers[0].device_indices, mock.sentinel.device_indices)
+
+    def test_layer_shard_selects_one_writer_per_attention_tp_group(self):
+        shard = LayerShardInfo(rank=1, size=2)
+
+        self.assertTrue(
+            manager_cache_controller._is_storage_writer(
+                is_mla_model=True,
+                layer_shard=shard,
+                tp_rank=2,
+                attn_tp_rank=0,
+            )
+        )
+        self.assertFalse(
+            manager_cache_controller._is_storage_writer(
+                is_mla_model=True,
+                layer_shard=shard,
+                tp_rank=3,
+                attn_tp_rank=1,
+            )
+        )
 
     def _patched_transfers(self, src_registry=None, module=MEMORY_POOL_HOST_MODULE):
         staged_side_effect = None

--- a/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
+++ b/test/registered/unit/mem_cache/test_mooncake_group_semantics.py
@@ -6,6 +6,7 @@ import torch
 
 from sglang.srt.mem_cache.hicache_storage import (
     HiCacheStorageConfig,
+    LayerShardInfo,
     PoolName,
     PoolTransfer,
 )
@@ -206,6 +207,8 @@ def _make_config(
     tp_rank=0,
     tp_size=1,
     tp_lcm_size=None,
+    layer_shard_rank=None,
+    layer_shard_size=None,
 ):
     extra_config = {
         "master_server_address": "127.0.0.1:50051",
@@ -215,6 +218,13 @@ def _make_config(
     }
     if extra_backend_tag is not None:
         extra_config["extra_backend_tag"] = extra_backend_tag
+
+    layer_shard = None
+    if layer_shard_rank is not None:
+        layer_shard = LayerShardInfo(
+            rank=layer_shard_rank,
+            size=layer_shard_size,
+        )
 
     return HiCacheStorageConfig(
         tp_rank=tp_rank,
@@ -230,6 +240,7 @@ def _make_config(
         tp_lcm_size=tp_lcm_size,
         should_split_heads=should_split_heads,
         extra_config=extra_config,
+        layer_shard=layer_shard,
     )
 
 
@@ -244,6 +255,8 @@ def _make_store(
     tp_rank=0,
     tp_size=1,
     tp_lcm_size=None,
+    layer_shard_rank=None,
+    layer_shard_size=None,
 ):
     fake_store_cls = _fake_store_class()
     cfg = _make_config(
@@ -255,6 +268,8 @@ def _make_store(
         tp_rank=tp_rank,
         tp_size=tp_size,
         tp_lcm_size=tp_lcm_size,
+        layer_shard_rank=layer_shard_rank,
+        layer_shard_size=layer_shard_size,
     )
 
     with patch.dict(
@@ -362,6 +377,44 @@ class TestMooncakeGroupSemantics(CustomTestCase):
         call = fake_store.batch_put_calls[0]
         self.assertEqual(call["keys"], ["page0__k"])
         self.assertEqual(call["args"][0].group_ids, ["sglang-hicache:page0"])
+
+    def test_layer_sharded_mla_uses_rank_specific_keys(self):
+        store0, fake_store0 = _make_store(
+            is_mla_model=True, layer_shard_rank=0, layer_shard_size=8
+        )
+        store7, fake_store7 = _make_store(
+            is_mla_model=True, layer_shard_rank=7, layer_shard_size=8
+        )
+        store0.register_mem_pool_host(FakeHostKVCache(objects_per_page=1))
+        store7.register_mem_pool_host(FakeHostKVCache(objects_per_page=1))
+
+        self.assertEqual(store0.batch_set_v1(["page0"], torch.tensor([0])), [True])
+        self.assertEqual(store7.batch_set_v1(["page0"], torch.tensor([0])), [True])
+
+        self.assertEqual(fake_store0.batch_put_calls[0]["keys"], ["page0_layer0_8_k"])
+        self.assertEqual(fake_store7.batch_put_calls[0]["keys"], ["page0_layer7_8_k"])
+
+    def test_layer_shard_suffix_applies_to_sidecar_pool(self):
+        store, fake_store = _make_store(
+            is_mla_model=True, layer_shard_rank=3, layer_shard_size=8
+        )
+        indexer_pool = FakeIndexerPool()
+        store.register_mem_host_pool_v2(indexer_pool, PoolName.INDEXER)
+
+        result = store.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.INDEXER,
+                    keys=["page0"],
+                    host_indices=torch.tensor([0]),
+                )
+            ]
+        )
+
+        self.assertEqual(result[PoolName.INDEXER], [True])
+        self.assertEqual(
+            fake_store.batch_put_calls[0]["keys"], ["page0_layer3_8_indexer"]
+        )
 
     def test_split_heads_group_ids(self):
         store, fake_store = _make_store(


### PR DESCRIPTION
## Motivation

Layer-sharded MLA cache store a different subset of model layers on each CP rank. HiCache did not support this topology correctly:

- `page_first_direct` did not support per-layer backup;
- different layer shards used the same external-storage keys;
- only the global MLA rank 0 wrote to storage, while every layer shard requires
  a writer for its owned layers.

This prevented GLM with CP cache LayerSplit from using L3 storage.

Related: #38324 fixes MTP layer addressing under CP layer split. This PR adds the page_first_direct backup path, including packed MTP KV and DSA indexer buffers. Correct MTP cache save/restore with this configuration requires both changes.

## Modifications

- Add `page_first_direct` backup for layer-sharded MLA pools.
- Propagate layer-shard identity to the storage backends.
- Use shard-specific keys for File and Mooncake storage.
- Select one writer per attention-TP replica group for every layer shard.
- Reject storage backends that do not support layer-sharded MLA.
- Add unit tests for File ownership and key isolation, Mooncake keys, and TP writer selection.

## Accuracy

GSM8K Platinum with Mooncake L3, 8-shot prompting, 1,209 samples:

- Cold: 0.964
- Warm after `flush_cache`: 0.963


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34122579506](https://github.com/sgl-project/sglang/actions/runs/34122579506)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34128520498](https://github.com/sgl-project/sglang/actions/runs/34128520498)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34122579473](https://github.com/sgl-project/sglang/actions/runs/34122579473)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->