### PR TITLE
feat(grpc): expose multi-choice generation streams

### DIFF
--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -133,8 +133,9 @@ message GenerateRequest {
 }
 
 message GenerateResponse {
-  // Legacy cumulative response fields. New clients should use the request,
-  // choice, delta, and terminal fields below for multi-choice generation.
+  // Legacy response fields. output_ids preserves the configured server streaming
+  // mode: cumulative by default, or disjoint segments with incremental streaming.
+  // New clients should use the request, choice, delta, and terminal fields below.
   repeated int32 output_ids = 1;
   map<string, string> meta_info = 2;
   bool finished = 3;

--- a/proto/sglang/runtime/v1/sglang.proto
+++ b/proto/sglang/runtime/v1/sglang.proto
@@ -133,9 +133,52 @@ message GenerateRequest {
 }
 
 message GenerateResponse {
+  // Legacy cumulative response fields. New clients should use the request,
+  // choice, delta, and terminal fields below for multi-choice generation.
   repeated int32 output_ids = 1;
   map<string, string> meta_info = 2;
   bool finished = 3;
+  string request_id = 4;
+  int32 choice_index = 5;
+  repeated int32 delta_output_ids = 6;
+  oneof terminal {
+    GenerationFinish finish = 10;
+    GenerationError error = 11;
+  }
+}
+
+enum FinishReason {
+  FINISH_REASON_UNSPECIFIED = 0;
+  FINISH_REASON_STOP = 1;
+  FINISH_REASON_LENGTH = 2;
+  FINISH_REASON_CANCELLED = 3;
+}
+
+message StopReason {
+  oneof reason {
+    string matched_string = 1;
+    int32 matched_token_id = 2;
+  }
+}
+
+message GenerationFinish {
+  FinishReason reason = 1;
+  optional StopReason stop_reason = 2;
+}
+
+enum GenerationErrorCode {
+  GENERATION_ERROR_CODE_UNSPECIFIED = 0;
+  GENERATION_ERROR_CODE_INVALID_ARGUMENT = 1;
+  GENERATION_ERROR_CODE_CANCELLED = 2;
+  GENERATION_ERROR_CODE_UNAVAILABLE = 3;
+  GENERATION_ERROR_CODE_INTERNAL = 4;
+  GENERATION_ERROR_CODE_DEADLINE_EXCEEDED = 5;
+}
+
+message GenerationError {
+  GenerationErrorCode code = 1;
+  string message = 2;
+  bool retryable = 3;
 }
 
 // ---- Text-based embed (text in, embedding out) ----

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,46 +10,16 @@ import asyncio
 import dataclasses
 import json
 import logging
-import threading
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
 from pydantic import ValidationError
 
 from sglang.srt.configs.embedding_model_spec import resolved_embedding_plan
+from sglang.srt.entrypoints.grpc_native_generation import NativeGenerationAdapter
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class _ChoiceOutputState:
-    """Per-choice state used to normalize both SGLang streaming modes."""
-
-    cumulative_output_ids: List[int] = dataclasses.field(default_factory=list)
-
-
-def _normalize_choice_output(
-    chunk: dict,
-    state: _ChoiceOutputState,
-    *,
-    incremental: bool,
-) -> dict:
-    """Return legacy cumulative IDs and new delta IDs for one choice."""
-    normalized = dict(chunk)
-    current_output_ids = list(chunk.get("output_ids") or [])
-    if incremental:
-        delta_output_ids = current_output_ids
-        state.cumulative_output_ids.extend(current_output_ids)
-    else:
-        previous_count = len(state.cumulative_output_ids)
-        delta_start = previous_count if previous_count <= len(current_output_ids) else 0
-        delta_output_ids = current_output_ids[delta_start:]
-        state.cumulative_output_ids = current_output_ids
-
-    normalized["output_ids"] = list(state.cumulative_output_ids)
-    normalized["delta_output_ids"] = delta_output_ids
-    return normalized
 
 
 class _BadOpenAIRequest(ValueError):
@@ -84,7 +54,7 @@ class _GrpcRequest:
         return bool(self._is_disconnected_fn())
 
 
-class RuntimeHandle:
+class RuntimeHandle(NativeGenerationAdapter):
     """Thin Python handle that the Rust gRPC server calls into.
 
     Provides synchronous ``submit_*``, ``abort``, and info methods.
@@ -106,9 +76,6 @@ class RuntimeHandle:
         self.scheduler_info = scheduler_info or {}
 
         self._openai_serving_classes = None
-        self._active_generation_futures = {}
-        self._generation_futures_lock = threading.Lock()
-
         self.tokenizer_manager.auto_create_handle_loop()
         self._event_loop = self.tokenizer_manager.event_loop
 
@@ -139,12 +106,18 @@ class RuntimeHandle:
     def _is_closed_status(status) -> bool:
         return status is not None and status == type(status).Closed
 
-    def _abort_request_id(self, rid) -> None:
+    def _abort_request_id(self, rid, lifecycle_id=None) -> None:
         if isinstance(rid, list):
             for single_rid in rid:
-                self.tokenizer_manager.abort_request(rid=single_rid)
+                self.tokenizer_manager.abort_request(
+                    rid=single_rid,
+                    lifecycle_id=lifecycle_id,
+                )
         else:
-            self.tokenizer_manager.abort_request(rid=rid)
+            self.tokenizer_manager.abort_request(
+                rid=rid,
+                lifecycle_id=lifecycle_id,
+            )
 
     async def _send_with_backpressure(
         self,
@@ -153,6 +126,7 @@ class RuntimeHandle:
         payload,
         *,
         timeout_abort_rid=None,
+        timeout_abort_lifecycle_id=None,
         **kwargs,
     ) -> bool:
         status = self._safe_callback(chunk_callback, payload, **kwargs)
@@ -172,7 +146,10 @@ class RuntimeHandle:
             )
         except asyncio.TimeoutError:
             if timeout_abort_rid is not None:
-                self._abort_request_id(timeout_abort_rid)
+                self._abort_request_id(
+                    timeout_abort_rid,
+                    timeout_abort_lifecycle_id,
+                )
                 logger.warning(
                     "gRPC chunk backpressure wait timed out after %ss; aborted request",
                     self._BACKPRESSURE_TIMEOUT_S,
@@ -217,27 +194,6 @@ class RuntimeHandle:
         future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
         future.add_done_callback(self._log_unhandled_future_exception)
         return future
-
-    def _track_generation_future(self, rid: str, future) -> None:
-        with self._generation_futures_lock:
-            self._active_generation_futures[rid] = future
-
-        def _remove_finished(completed) -> None:
-            with self._generation_futures_lock:
-                if self._active_generation_futures.get(rid) is completed:
-                    self._active_generation_futures.pop(rid, None)
-
-        future.add_done_callback(_remove_finished)
-
-    def _cancel_generation_futures(self, rid: str, abort_all: bool) -> None:
-        with self._generation_futures_lock:
-            if abort_all:
-                futures = list(self._active_generation_futures.values())
-            else:
-                future = self._active_generation_futures.get(rid)
-                futures = [] if future is None else [future]
-        for future in futures:
-            future.cancel()
 
     @staticmethod
     def _log_unhandled_future_exception(future) -> None:
@@ -324,6 +280,7 @@ class RuntimeHandle:
         req_dict: dict,
         chunk_callback,
         choice_aware: bool = False,
+        lifecycle_id=None,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         mock_request = (
@@ -336,267 +293,45 @@ class RuntimeHandle:
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            future = self._submit_on_tm_loop(
+            self._submit_on_tm_loop(
                 self._run_generate(
                     obj,
                     chunk_callback,
                     stream,
                     mock_request,
                     choice_aware=choice_aware,
+                    lifecycle_id=lifecycle_id,
                 )
             )
-            rid = req_dict.get("rid")
-            if isinstance(rid, str):
-                self._track_generation_future(rid, future)
         elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
             obj = EmbeddingReqInput(**req_dict)
-            self._submit_on_tm_loop(self._run_embed(obj, chunk_callback, mock_request))
+            self._submit_on_tm_loop(
+                self._run_embed(
+                    obj,
+                    chunk_callback,
+                    mock_request,
+                    lifecycle_id=lifecycle_id,
+                )
+            )
         else:
             raise ValueError(
                 f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
             )
 
-    @staticmethod
-    def _generation_error_meta(error: Exception) -> dict:
-        status_code = getattr(error, "status_code", None)
-        if status_code is None:
-            status_code = (
-                400 if isinstance(error, (ValidationError, ValueError)) else 500
-            )
-        detail = getattr(error, "detail", None)
-        return {
-            "finish_reason": {
-                "type": "error",
-                "status_code": int(status_code),
-                "message": str(detail if detail is not None else error),
-            }
-        }
-
-    async def _send_generation_errors(
-        self,
-        chunk_callback,
-        ready_event: Optional[asyncio.Event],
-        *,
-        error: Exception,
-        expected_choices: int,
-        terminal_choices: set,
-        timeout_abort_rid,
-    ) -> None:
-        unfinished = [
-            index for index in range(expected_choices) if index not in terminal_choices
-        ]
-        for position, index in enumerate(unfinished):
-            keep_going = await self._send_with_backpressure(
-                chunk_callback,
-                ready_event,
-                {
-                    "index": index,
-                    "output_ids": [],
-                    "delta_output_ids": [],
-                    "meta_info": self._generation_error_meta(error),
-                },
-                finished=position == len(unfinished) - 1,
-                timeout_abort_rid=timeout_abort_rid,
-            )
-            if not keep_going:
-                self._abort_request_id(timeout_abort_rid)
-                return
-
-    async def _run_generate(
-        self,
-        obj,
-        chunk_callback,
-        stream: bool,
-        request,
-        *,
-        choice_aware: bool = False,
-    ):
-        ready_event = None
-        gen = None
-        sampling_params = getattr(obj, "sampling_params", None)
-        if isinstance(sampling_params, dict):
-            parallel_sample_num = sampling_params.get("n", 1)
-        elif isinstance(sampling_params, list) and sampling_params:
-            parallel_sample_num = sampling_params[0].get("n", 1)
-        else:
-            parallel_sample_num = getattr(obj, "parallel_sample_num", 1)
-        expected_choices = max(1, int(parallel_sample_num))
-        terminal_choices = set()
-        try:
-            ready_event = self._install_on_ready(chunk_callback)
-            generate_kwargs = {"request": request}
-            if choice_aware:
-                generate_kwargs["yield_scheduler_errors"] = True
-            gen = self.tokenizer_manager.generate_request(obj, **generate_kwargs)
-            if stream:
-                incremental = bool(
-                    getattr(
-                        getattr(self.tokenizer_manager, "server_args", None),
-                        "incremental_streaming_output",
-                        False,
-                    )
-                )
-                output_states = {
-                    index: _ChoiceOutputState() for index in range(expected_choices)
-                }
-                async for chunk in gen:
-                    choice_index = int(chunk.get("index") or 0)
-                    if not 0 <= choice_index < expected_choices:
-                        self._abort_request_id(obj.rid)
-                        self._send_native_error(
-                            chunk_callback,
-                            f"choice index {choice_index} is outside 0..{expected_choices}",
-                        )
-                        return
-                    if choice_index in terminal_choices:
-                        self._abort_request_id(obj.rid)
-                        self._send_native_error(
-                            chunk_callback,
-                            f"data after terminal for choice {choice_index}",
-                        )
-                        return
-                    choice_finished = (
-                        chunk.get("meta_info", {}).get("finish_reason") is not None
-                    )
-                    if choice_finished:
-                        terminal_choices.add(choice_index)
-                    finished = len(terminal_choices) == expected_choices
-                    callback_chunk = (
-                        _normalize_choice_output(
-                            chunk,
-                            output_states[choice_index],
-                            incremental=incremental,
-                        )
-                        if choice_aware
-                        else chunk
-                    )
-                    keep_going = await self._send_with_backpressure(
-                        chunk_callback,
-                        ready_event,
-                        callback_chunk,
-                        finished=finished,
-                        timeout_abort_rid=obj.rid,
-                    )
-                    if finished or not keep_going:
-                        return
-                # Defensive: generator exited without a finish_reason chunk.
-                missing = sorted(set(range(expected_choices)) - terminal_choices)
-                error = RuntimeError(
-                    f"SGLang stream ended without terminal choices: {missing}"
-                )
-                if choice_aware:
-                    await self._send_generation_errors(
-                        chunk_callback,
-                        ready_event,
-                        error=error,
-                        expected_choices=expected_choices,
-                        terminal_choices=terminal_choices,
-                        timeout_abort_rid=obj.rid,
-                    )
-                else:
-                    self._send_native_error(chunk_callback, str(error))
-            else:
-                result = await gen.__anext__()
-                chunks = result if isinstance(result, list) else [result]
-                if len(chunks) != expected_choices:
-                    error = RuntimeError(
-                        f"SGLang returned {len(chunks)} choices; expected {expected_choices}"
-                    )
-                    if choice_aware:
-                        await self._send_generation_errors(
-                            chunk_callback,
-                            ready_event,
-                            error=error,
-                            expected_choices=expected_choices,
-                            terminal_choices=terminal_choices,
-                            timeout_abort_rid=obj.rid,
-                        )
-                    else:
-                        self._send_native_error(chunk_callback, str(error))
-                    return
-                for index, chunk in enumerate(chunks):
-                    callback_chunk = dict(chunk)
-                    callback_chunk.setdefault("index", index)
-                    if choice_aware:
-                        output_ids = list(chunk.get("output_ids") or [])
-                        callback_chunk["output_ids"] = output_ids
-                        callback_chunk["delta_output_ids"] = output_ids
-                    terminal_choices.add(index)
-                    keep_going = await self._send_with_backpressure(
-                        chunk_callback,
-                        ready_event,
-                        callback_chunk,
-                        finished=index == len(chunks) - 1,
-                        timeout_abort_rid=obj.rid,
-                    )
-                    if not keep_going:
-                        return
-        except StopAsyncIteration:
-            error = RuntimeError("SGLang returned no generation result")
-            if choice_aware:
-                await self._send_generation_errors(
-                    chunk_callback,
-                    ready_event,
-                    error=error,
-                    expected_choices=expected_choices,
-                    terminal_choices=terminal_choices,
-                    timeout_abort_rid=obj.rid,
-                )
-            else:
-                self._send_native_error(chunk_callback, str(error))
-        except asyncio.CancelledError:
-            if not choice_aware:
-                raise
-            error = RuntimeError(f"Request aborted: {obj.rid}")
-            error.status_code = 499
-            await self._send_generation_errors(
-                chunk_callback,
-                ready_event,
-                error=error,
-                expected_choices=expected_choices,
-                terminal_choices=terminal_choices,
-                timeout_abort_rid=obj.rid,
-            )
-        except Exception as e:
-            logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            if choice_aware:
-                await self._send_generation_errors(
-                    chunk_callback,
-                    ready_event,
-                    error=e,
-                    expected_choices=expected_choices,
-                    terminal_choices=terminal_choices,
-                    timeout_abort_rid=obj.rid,
-                )
-            else:
-                self._send_native_error(chunk_callback, str(e))
-        finally:
-            if gen is not None:
-                await gen.aclose()
-            self._uninstall_on_ready(chunk_callback)
-
-    async def _run_embed(self, obj, chunk_callback, request):
-        try:
-            gen = self.tokenizer_manager.generate_request(obj, request=request)
-            result = await gen.__anext__()
-            self._safe_callback(chunk_callback, result, finished=True)
-        except StopAsyncIteration:
-            self._safe_callback(chunk_callback, {}, finished=True)
-        except Exception as e:
-            logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
-            self._send_native_error(chunk_callback, str(e))
-
     # Bounded so a stuck TM loop can't deadlock the gRPC handler thread that
-    # called abort. abort_request only enqueues a message on the ZMQ socket,
-    # so a few seconds is generous; if we time out, log and drop — the client
-    # will retry or give up.
+    # called abort. A timeout is propagated so the gRPC Abort RPC cannot report
+    # success without knowing whether the scheduler saw the request.
     _ABORT_TIMEOUT_S = 5.0
 
-    def abort(self, rid: str = "", abort_all: bool = False):
+    def abort(
+        self,
+        rid: str = "",
+        lifecycle_id=None,
+        abort_all: bool = False,
+    ):
         """Abort a request by request ID or abort all active requests."""
-        self._cancel_generation_futures(rid, abort_all)
         loop = self._tm_loop
 
         try:
@@ -605,17 +340,19 @@ class RuntimeHandle:
             running_loop = None
 
         if running_loop is loop:
-            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
-            return
+            return self.tokenizer_manager.abort_request(
+                rid=rid,
+                abort_all=abort_all,
+                lifecycle_id=lifecycle_id,
+            )
 
         future = asyncio.run_coroutine_threadsafe(
-            self._abort_async(rid, abort_all),
+            self._abort_async(rid, lifecycle_id, abort_all),
             loop,
         )
         try:
-            future.result(timeout=self._ABORT_TIMEOUT_S)
+            return future.result(timeout=self._ABORT_TIMEOUT_S)
         except TimeoutError:
-            future.cancel()
             logger.error(
                 "gRPC abort timed out after %ss (rid=%r, abort_all=%s); "
                 "tokenizer_manager loop appears stuck",
@@ -623,9 +360,14 @@ class RuntimeHandle:
                 rid,
                 abort_all,
             )
+            raise
 
-    async def _abort_async(self, rid: str, abort_all: bool) -> None:
-        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+    async def _abort_async(self, rid: str, lifecycle_id, abort_all: bool) -> bool:
+        return self.tokenizer_manager.abort_request(
+            rid=rid,
+            abort_all=abort_all,
+            lifecycle_id=lifecycle_id,
+        )
 
     def get_model_info(self) -> str:
         model_config = self.tokenizer_manager.model_config
@@ -769,9 +511,11 @@ class RuntimeHandle:
             obj = UpdateWeightFromDiskReqInput(
                 model_path=model_path, load_format=load_format
             )
-            success, message, num_paused = (
-                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
-            )
+            (
+                success,
+                message,
+                num_paused,
+            ) = await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
             return {
                 "success": success,
                 "message": message,

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -10,6 +10,7 @@ import asyncio
 import dataclasses
 import json
 import logging
+import threading
 from types import SimpleNamespace
 from typing import Any, Awaitable, Callable, Dict, List, Optional
 
@@ -75,6 +76,8 @@ class RuntimeHandle:
         self.scheduler_info = scheduler_info or {}
 
         self._openai_serving_classes = None
+        self._active_generation_futures = {}
+        self._generation_futures_lock = threading.Lock()
 
         self.tokenizer_manager.auto_create_handle_loop()
         self._event_loop = self.tokenizer_manager.event_loop
@@ -180,12 +183,36 @@ class RuntimeHandle:
         except Exception as e:
             logger.warning("gRPC clear_on_ready failed: %s", e)
 
-    def _submit_on_tm_loop(self, coro: Awaitable) -> None:
+    def _submit_on_tm_loop(self, coro: Awaitable):
         future = asyncio.run_coroutine_threadsafe(coro, self._tm_loop)
         future.add_done_callback(self._log_unhandled_future_exception)
+        return future
+
+    def _track_generation_future(self, rid: str, future) -> None:
+        with self._generation_futures_lock:
+            self._active_generation_futures[rid] = future
+
+        def _remove_finished(completed) -> None:
+            with self._generation_futures_lock:
+                if self._active_generation_futures.get(rid) is completed:
+                    self._active_generation_futures.pop(rid, None)
+
+        future.add_done_callback(_remove_finished)
+
+    def _cancel_generation_futures(self, rid: str, abort_all: bool) -> None:
+        with self._generation_futures_lock:
+            if abort_all:
+                futures = list(self._active_generation_futures.values())
+            else:
+                future = self._active_generation_futures.get(rid)
+                futures = [] if future is None else [future]
+        for future in futures:
+            future.cancel()
 
     @staticmethod
     def _log_unhandled_future_exception(future) -> None:
+        if future.cancelled():
+            return
         try:
             future.result()
         except Exception as e:
@@ -278,9 +305,12 @@ class RuntimeHandle:
 
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
-            self._submit_on_tm_loop(
+            future = self._submit_on_tm_loop(
                 self._run_generate(obj, chunk_callback, stream, mock_request)
             )
+            rid = req_dict.get("rid")
+            if isinstance(rid, str):
+                self._track_generation_future(rid, future)
         elif req_type == "embed":
             from sglang.srt.managers.io_struct import EmbeddingReqInput
 
@@ -363,6 +393,7 @@ class RuntimeHandle:
 
     def abort(self, rid: str = "", abort_all: bool = False):
         """Abort a request by request ID or abort all active requests."""
+        self._cancel_generation_futures(rid, abort_all)
         loop = self._tm_loop
 
         try:

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -22,6 +22,36 @@ from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 logger = logging.getLogger(__name__)
 
 
+@dataclasses.dataclass
+class _ChoiceOutputState:
+    """Per-choice state used to normalize both SGLang streaming modes."""
+
+    cumulative_output_ids: List[int] = dataclasses.field(default_factory=list)
+
+
+def _normalize_choice_output(
+    chunk: dict,
+    state: _ChoiceOutputState,
+    *,
+    incremental: bool,
+) -> dict:
+    """Return legacy cumulative IDs and new delta IDs for one choice."""
+    normalized = dict(chunk)
+    current_output_ids = list(chunk.get("output_ids") or [])
+    if incremental:
+        delta_output_ids = current_output_ids
+        state.cumulative_output_ids.extend(current_output_ids)
+    else:
+        previous_count = len(state.cumulative_output_ids)
+        delta_start = previous_count if previous_count <= len(current_output_ids) else 0
+        delta_output_ids = current_output_ids[delta_start:]
+        state.cumulative_output_ids = current_output_ids
+
+    normalized["output_ids"] = list(state.cumulative_output_ids)
+    normalized["delta_output_ids"] = delta_output_ids
+    return normalized
+
+
 class _BadOpenAIRequest(ValueError):
     pass
 
@@ -293,6 +323,7 @@ class RuntimeHandle:
         req_type: str,
         req_dict: dict,
         chunk_callback,
+        choice_aware: bool = False,
         is_disconnected_fn: Optional[Callable[[], bool]] = None,
     ):
         mock_request = (
@@ -306,7 +337,13 @@ class RuntimeHandle:
             obj = GenerateReqInput(**req_dict)
             stream = req_dict.get("stream", False)
             future = self._submit_on_tm_loop(
-                self._run_generate(obj, chunk_callback, stream, mock_request)
+                self._run_generate(
+                    obj,
+                    chunk_callback,
+                    stream,
+                    mock_request,
+                    choice_aware=choice_aware,
+                )
             )
             rid = req_dict.get("rid")
             if isinstance(rid, str):
@@ -321,54 +358,220 @@ class RuntimeHandle:
                 f"Unknown req_type: {req_type!r} (expected 'generate' or 'embed')"
             )
 
-    async def _run_generate(self, obj, chunk_callback, stream: bool, request):
+    @staticmethod
+    def _generation_error_meta(error: Exception) -> dict:
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            status_code = (
+                400 if isinstance(error, (ValidationError, ValueError)) else 500
+            )
+        detail = getattr(error, "detail", None)
+        return {
+            "finish_reason": {
+                "type": "error",
+                "status_code": int(status_code),
+                "message": str(detail if detail is not None else error),
+            }
+        }
+
+    async def _send_generation_errors(
+        self,
+        chunk_callback,
+        ready_event: Optional[asyncio.Event],
+        *,
+        error: Exception,
+        expected_choices: int,
+        terminal_choices: set,
+        timeout_abort_rid,
+    ) -> None:
+        unfinished = [
+            index for index in range(expected_choices) if index not in terminal_choices
+        ]
+        for position, index in enumerate(unfinished):
+            keep_going = await self._send_with_backpressure(
+                chunk_callback,
+                ready_event,
+                {
+                    "index": index,
+                    "output_ids": [],
+                    "delta_output_ids": [],
+                    "meta_info": self._generation_error_meta(error),
+                },
+                finished=position == len(unfinished) - 1,
+                timeout_abort_rid=timeout_abort_rid,
+            )
+            if not keep_going:
+                self._abort_request_id(timeout_abort_rid)
+                return
+
+    async def _run_generate(
+        self,
+        obj,
+        chunk_callback,
+        stream: bool,
+        request,
+        *,
+        choice_aware: bool = False,
+    ):
         ready_event = None
         gen = None
+        sampling_params = getattr(obj, "sampling_params", None)
+        if isinstance(sampling_params, dict):
+            parallel_sample_num = sampling_params.get("n", 1)
+        elif isinstance(sampling_params, list) and sampling_params:
+            parallel_sample_num = sampling_params[0].get("n", 1)
+        else:
+            parallel_sample_num = getattr(obj, "parallel_sample_num", 1)
+        expected_choices = max(1, int(parallel_sample_num))
+        terminal_choices = set()
         try:
             ready_event = self._install_on_ready(chunk_callback)
-            gen = self.tokenizer_manager.generate_request(obj, request=request)
+            generate_kwargs = {"request": request}
+            if choice_aware:
+                generate_kwargs["yield_scheduler_errors"] = True
+            gen = self.tokenizer_manager.generate_request(obj, **generate_kwargs)
             if stream:
-                completed_choices = set()
-                expected_choices = obj.batch_size * obj.parallel_sample_num
+                incremental = bool(
+                    getattr(
+                        getattr(self.tokenizer_manager, "server_args", None),
+                        "incremental_streaming_output",
+                        False,
+                    )
+                )
+                output_states = {
+                    index: _ChoiceOutputState() for index in range(expected_choices)
+                }
                 async for chunk in gen:
+                    choice_index = int(chunk.get("index") or 0)
+                    if not 0 <= choice_index < expected_choices:
+                        self._abort_request_id(obj.rid)
+                        self._send_native_error(
+                            chunk_callback,
+                            f"choice index {choice_index} is outside 0..{expected_choices}",
+                        )
+                        return
+                    if choice_index in terminal_choices:
+                        self._abort_request_id(obj.rid)
+                        self._send_native_error(
+                            chunk_callback,
+                            f"data after terminal for choice {choice_index}",
+                        )
+                        return
                     choice_finished = (
                         chunk.get("meta_info", {}).get("finish_reason") is not None
                     )
                     if choice_finished:
-                        choice_id = chunk.get(
-                            "index", chunk.get("meta_info", {}).get("id")
+                        terminal_choices.add(choice_index)
+                    finished = len(terminal_choices) == expected_choices
+                    callback_chunk = (
+                        _normalize_choice_output(
+                            chunk,
+                            output_states[choice_index],
+                            incremental=incremental,
                         )
-                        completed_choices.add(choice_id)
-                    finished = len(completed_choices) >= expected_choices
+                        if choice_aware
+                        else chunk
+                    )
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
-                        chunk,
+                        callback_chunk,
                         finished=finished,
                         timeout_abort_rid=obj.rid,
                     )
                     if finished or not keep_going:
                         return
                 # Defensive: generator exited without a finish_reason chunk.
-                self._safe_callback(chunk_callback, {}, finished=True)
+                missing = sorted(set(range(expected_choices)) - terminal_choices)
+                error = RuntimeError(
+                    f"SGLang stream ended without terminal choices: {missing}"
+                )
+                if choice_aware:
+                    await self._send_generation_errors(
+                        chunk_callback,
+                        ready_event,
+                        error=error,
+                        expected_choices=expected_choices,
+                        terminal_choices=terminal_choices,
+                        timeout_abort_rid=obj.rid,
+                    )
+                else:
+                    self._send_native_error(chunk_callback, str(error))
             else:
                 result = await gen.__anext__()
                 chunks = result if isinstance(result, list) else [result]
+                if len(chunks) != expected_choices:
+                    error = RuntimeError(
+                        f"SGLang returned {len(chunks)} choices; expected {expected_choices}"
+                    )
+                    if choice_aware:
+                        await self._send_generation_errors(
+                            chunk_callback,
+                            ready_event,
+                            error=error,
+                            expected_choices=expected_choices,
+                            terminal_choices=terminal_choices,
+                            timeout_abort_rid=obj.rid,
+                        )
+                    else:
+                        self._send_native_error(chunk_callback, str(error))
+                    return
                 for index, chunk in enumerate(chunks):
+                    callback_chunk = dict(chunk)
+                    callback_chunk.setdefault("index", index)
+                    if choice_aware:
+                        output_ids = list(chunk.get("output_ids") or [])
+                        callback_chunk["output_ids"] = output_ids
+                        callback_chunk["delta_output_ids"] = output_ids
+                    terminal_choices.add(index)
                     keep_going = await self._send_with_backpressure(
                         chunk_callback,
                         ready_event,
-                        chunk,
+                        callback_chunk,
                         finished=index == len(chunks) - 1,
                         timeout_abort_rid=obj.rid,
                     )
                     if not keep_going:
                         return
         except StopAsyncIteration:
-            self._safe_callback(chunk_callback, {}, finished=True)
+            error = RuntimeError("SGLang returned no generation result")
+            if choice_aware:
+                await self._send_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=error,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    timeout_abort_rid=obj.rid,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(error))
+        except asyncio.CancelledError:
+            if not choice_aware:
+                raise
+            error = RuntimeError(f"Request aborted: {obj.rid}")
+            error.status_code = 499
+            await self._send_generation_errors(
+                chunk_callback,
+                ready_event,
+                error=error,
+                expected_choices=expected_choices,
+                terminal_choices=terminal_choices,
+                timeout_abort_rid=obj.rid,
+            )
         except Exception as e:
             logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
-            self._send_native_error(chunk_callback, str(e))
+            if choice_aware:
+                await self._send_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=e,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    timeout_abort_rid=obj.rid,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(e))
         finally:
             if gen is not None:
                 await gen.aclose()

--- a/python/sglang/srt/entrypoints/grpc_native_generation.py
+++ b/python/sglang/srt/entrypoints/grpc_native_generation.py
@@ -1,0 +1,260 @@
+"""Native generate/embed request adapter for the Rust gRPC bridge."""
+
+import asyncio
+import logging
+from typing import Optional
+
+from pydantic import ValidationError
+
+logger = logging.getLogger(__name__)
+
+
+class NativeGenerationAdapter:
+    """Generation-specific RuntimeHandle behavior kept out of the control adapter."""
+
+    @staticmethod
+    def _generation_error_meta(error: Exception) -> dict:
+        status_code = getattr(error, "status_code", None)
+        if status_code is None:
+            status_code = (
+                400 if isinstance(error, (ValidationError, ValueError)) else 500
+            )
+        detail = getattr(error, "detail", None)
+        return {
+            "finish_reason": {
+                "type": "error",
+                "status_code": int(status_code),
+                "message": str(detail if detail is not None else error),
+            }
+        }
+
+    async def _send_generation_errors(
+        self,
+        chunk_callback,
+        ready_event: Optional[asyncio.Event],
+        *,
+        error: Exception,
+        expected_choices: int,
+        terminal_choices: set,
+        error_outputs: dict,
+        timeout_abort_rid,
+        timeout_abort_lifecycle_id,
+    ) -> None:
+        unfinished = [
+            index for index in range(expected_choices) if index not in terminal_choices
+        ]
+        for position, index in enumerate(unfinished):
+            keep_going = await self._send_with_backpressure(
+                chunk_callback,
+                ready_event,
+                {
+                    "index": index,
+                    "output_ids": error_outputs.get(index, []),
+                    "delta_output_ids": [],
+                    "meta_info": self._generation_error_meta(error),
+                },
+                finished=position == len(unfinished) - 1,
+                timeout_abort_rid=timeout_abort_rid,
+                timeout_abort_lifecycle_id=timeout_abort_lifecycle_id,
+            )
+            if not keep_going:
+                self._abort_request_id(
+                    timeout_abort_rid,
+                    timeout_abort_lifecycle_id,
+                )
+                return
+
+    async def _run_generate(
+        self,
+        obj,
+        chunk_callback,
+        stream: bool,
+        request,
+        *,
+        choice_aware: bool = False,
+        lifecycle_id=None,
+    ):
+        ready_event = None
+        gen = None
+        sampling_params = getattr(obj, "sampling_params", None)
+        if isinstance(sampling_params, dict):
+            parallel_sample_num = sampling_params.get("n", 1)
+        elif isinstance(sampling_params, list) and sampling_params:
+            parallel_sample_num = sampling_params[0].get("n", 1)
+        else:
+            parallel_sample_num = getattr(obj, "parallel_sample_num", 1)
+        expected_choices = max(1, int(parallel_sample_num))
+        terminal_choices = set()
+        error_outputs = {}
+        try:
+            ready_event = self._install_on_ready(chunk_callback)
+            generate_kwargs = {
+                "request": request,
+                "request_lifecycle_id": lifecycle_id,
+            }
+            if choice_aware:
+                generate_kwargs["yield_scheduler_errors"] = True
+            gen = self.tokenizer_manager.generate_request(obj, **generate_kwargs)
+            if stream:
+                incremental = bool(
+                    getattr(
+                        getattr(self.tokenizer_manager, "server_args", None),
+                        "incremental_streaming_output",
+                        False,
+                    )
+                )
+                output_counts = {index: 0 for index in range(expected_choices)}
+                async for chunk in gen:
+                    choice_index = int(chunk.get("index") or 0)
+                    if not 0 <= choice_index < expected_choices:
+                        self._abort_request_id(obj.rid, lifecycle_id)
+                        self._send_native_error(
+                            chunk_callback,
+                            f"choice index {choice_index} is outside 0..{expected_choices}",
+                        )
+                        return
+                    if choice_index in terminal_choices:
+                        self._abort_request_id(obj.rid, lifecycle_id)
+                        self._send_native_error(
+                            chunk_callback,
+                            f"data after terminal for choice {choice_index}",
+                        )
+                        return
+                    choice_finished = (
+                        chunk.get("meta_info", {}).get("finish_reason") is not None
+                    )
+                    if choice_finished:
+                        terminal_choices.add(choice_index)
+                    finished = len(terminal_choices) == expected_choices
+                    callback_chunk = dict(chunk)
+                    output_ids = chunk.get("output_ids") or []
+                    if incremental:
+                        callback_chunk["delta_output_ids"] = output_ids
+                        error_outputs[choice_index] = []
+                    else:
+                        previous_count = output_counts[choice_index]
+                        delta_start = (
+                            previous_count if previous_count <= len(output_ids) else 0
+                        )
+                        callback_chunk["delta_output_ids"] = output_ids[delta_start:]
+                        output_counts[choice_index] = len(output_ids)
+                        error_outputs[choice_index] = output_ids
+                    if choice_finished:
+                        error_outputs.pop(choice_index, None)
+                    keep_going = await self._send_with_backpressure(
+                        chunk_callback,
+                        ready_event,
+                        callback_chunk,
+                        finished=finished,
+                        timeout_abort_rid=obj.rid,
+                        timeout_abort_lifecycle_id=lifecycle_id,
+                    )
+                    if finished or not keep_going:
+                        return
+                # Defensive: generator exited without a finish_reason chunk.
+                missing = sorted(set(range(expected_choices)) - terminal_choices)
+                error = RuntimeError(
+                    f"SGLang stream ended without terminal choices: {missing}"
+                )
+                if choice_aware:
+                    await self._send_generation_errors(
+                        chunk_callback,
+                        ready_event,
+                        error=error,
+                        expected_choices=expected_choices,
+                        terminal_choices=terminal_choices,
+                        error_outputs=error_outputs,
+                        timeout_abort_rid=obj.rid,
+                        timeout_abort_lifecycle_id=lifecycle_id,
+                    )
+                else:
+                    self._send_native_error(chunk_callback, str(error))
+            else:
+                result = await gen.__anext__()
+                chunks = result if isinstance(result, list) else [result]
+                if len(chunks) != expected_choices:
+                    error = RuntimeError(
+                        f"SGLang returned {len(chunks)} choices; expected {expected_choices}"
+                    )
+                    if choice_aware:
+                        await self._send_generation_errors(
+                            chunk_callback,
+                            ready_event,
+                            error=error,
+                            expected_choices=expected_choices,
+                            terminal_choices=terminal_choices,
+                            error_outputs=error_outputs,
+                            timeout_abort_rid=obj.rid,
+                            timeout_abort_lifecycle_id=lifecycle_id,
+                        )
+                    else:
+                        self._send_native_error(chunk_callback, str(error))
+                    return
+                for index, chunk in enumerate(chunks):
+                    callback_chunk = dict(chunk)
+                    callback_chunk.setdefault("index", index)
+                    output_ids = list(chunk.get("output_ids") or [])
+                    callback_chunk["output_ids"] = output_ids
+                    callback_chunk["delta_output_ids"] = output_ids
+                    terminal_choices.add(index)
+                    keep_going = await self._send_with_backpressure(
+                        chunk_callback,
+                        ready_event,
+                        callback_chunk,
+                        finished=index == len(chunks) - 1,
+                        timeout_abort_rid=obj.rid,
+                        timeout_abort_lifecycle_id=lifecycle_id,
+                    )
+                    if not keep_going:
+                        return
+        except StopAsyncIteration:
+            error = RuntimeError("SGLang returned no generation result")
+            if choice_aware:
+                await self._send_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=error,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    error_outputs=error_outputs,
+                    timeout_abort_rid=obj.rid,
+                    timeout_abort_lifecycle_id=lifecycle_id,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(error))
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("gRPC generate error for rid=%s: %s", obj.rid, e)
+            if choice_aware:
+                await self._send_generation_errors(
+                    chunk_callback,
+                    ready_event,
+                    error=e,
+                    expected_choices=expected_choices,
+                    terminal_choices=terminal_choices,
+                    error_outputs=error_outputs,
+                    timeout_abort_rid=obj.rid,
+                    timeout_abort_lifecycle_id=lifecycle_id,
+                )
+            else:
+                self._send_native_error(chunk_callback, str(e))
+        finally:
+            if gen is not None:
+                await gen.aclose()
+            self._uninstall_on_ready(chunk_callback)
+
+    async def _run_embed(self, obj, chunk_callback, request, *, lifecycle_id=None):
+        try:
+            gen = self.tokenizer_manager.generate_request(
+                obj,
+                request=request,
+                request_lifecycle_id=lifecycle_id,
+            )
+            result = await gen.__anext__()
+            self._safe_callback(chunk_callback, result, finished=True)
+        except StopAsyncIteration:
+            self._safe_callback(chunk_callback, {}, finished=True)
+        except Exception as e:
+            logger.error("gRPC embed error for rid=%s: %s", obj.rid, e)
+            self._send_native_error(chunk_callback, str(e))

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -585,7 +586,11 @@ class SchedulerBatchResultProcessor:
                 logger.error(
                     f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
                 )
-                req.to_finish = FINISH_ABORT()
+                req.to_finish = FINISH_ABORT(
+                    message=f"Grammar accept_token failed: {e}",
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    err_type="GrammarError",
+                )
         req.grammar.finished = req.finished()
 
     def _apply_chunked_prefill_logprobs(
@@ -726,7 +731,11 @@ class SchedulerBatchResultProcessor:
                 f"Grammar accept_token failed for req {req.rid} with token "
                 f"{tokens}: {e}"
             )
-            req.to_finish = FINISH_ABORT()
+            req.to_finish = FINISH_ABORT(
+                message=f"Grammar accept_token failed: {e}",
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                err_type="GrammarError",
+            )
         return retained
 
     def advance_grammar_fsm(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -745,6 +745,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         self.auto_create_handle_loop()
 
@@ -796,10 +797,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     if obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_obj.input_ids)
                     self._send_one_request(tokenized_obj)
-                    async for response in self._wait_one_response(obj, request):
+                    async for response in self._wait_one_response(
+                        obj,
+                        request,
+                        yield_scheduler_errors=yield_scheduler_errors,
+                    ):
                         yield response
                 else:
-                    async for response in self._handle_batch_request(obj, request):
+                    async for response in self._handle_batch_request(
+                        obj,
+                        request,
+                        yield_scheduler_errors=yield_scheduler_errors,
+                    ):
                         yield response
         except BaseException:
             # _init_req_state created a rid_to_state entry per (sub-)request up
@@ -1620,6 +1629,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         out: dict,
         state: ReqState,
         is_stream: bool,
+        yield_scheduler_errors: bool = False,
     ) -> Optional[dict]:
         """Handle abort/error finish reasons from the scheduler.
 
@@ -1628,17 +1638,19 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         """
         finish_reason = out["meta_info"]["finish_reason"]
 
+        status_code = finish_reason.get("status_code")
+
         if (
             finish_reason.get("type") == "abort"
-            and finish_reason.get("status_code") == HTTPStatus.BAD_REQUEST
+            and status_code == HTTPStatus.BAD_REQUEST
         ):
             if not is_stream:
+                if yield_scheduler_errors:
+                    return out
                 raise ValueError(finish_reason["message"])
             return out
 
-        if finish_reason.get("type") == "abort" and finish_reason.get(
-            "status_code"
-        ) in (
+        if finish_reason.get("type") == "abort" and status_code in (
             HTTPStatus.SERVICE_UNAVAILABLE,
             HTTPStatus.INTERNAL_SERVER_ERROR,
         ):
@@ -1651,8 +1663,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             if self.enable_lora and state.obj.lora_path:
                 await self.lora_registry.release(state.obj.lora_id)
             if not is_stream:
+                if yield_scheduler_errors:
+                    return out
                 raise fastapi.HTTPException(
-                    status_code=finish_reason["status_code"],
+                    status_code=status_code,
                     detail=finish_reason["message"],
                 )
             return out
@@ -1663,6 +1677,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         """Wait for the response of one request."""
         state = self.rid_to_state[obj.rid]
@@ -1737,7 +1752,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Check if this was an abort/error created by scheduler
                 if isinstance(out["meta_info"].get("finish_reason"), dict):
                     abort_out = await self._handle_abort_finish_reason(
-                        out, state, is_stream
+                        out,
+                        state,
+                        is_stream,
+                        yield_scheduler_errors=yield_scheduler_errors,
                     )
                     if abort_out is not None:
                         yield abort_out
@@ -1771,6 +1789,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
+        yield_scheduler_errors: bool = False,
     ):
         batch_size = obj.batch_size
 
@@ -1788,7 +1807,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     state = self.rid_to_state[tmp_obj.rid]
                     if tmp_obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_objs[i].input_ids)
-                    generators.append(self._wait_one_response(tmp_obj, request))
+                    generators.append(
+                        self._wait_one_response(
+                            tmp_obj,
+                            request,
+                            yield_scheduler_errors=yield_scheduler_errors,
+                        )
+                    )
                     rids.append(tmp_obj.rid)
             else:
                 # Sequential tokenization and processing
@@ -1807,7 +1832,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         if tmp_obj.return_prompt_token_ids:
                             state.prompt_token_ids = list(tokenized_obj.input_ids)
                         self._send_one_request(tokenized_obj)
-                        generators.append(self._wait_one_response(tmp_obj, request))
+                        generators.append(
+                            self._wait_one_response(
+                                tmp_obj,
+                                request,
+                                yield_scheduler_errors=yield_scheduler_errors,
+                            )
+                        )
                         rids.append(tmp_obj.rid)
         else:
             # FIXME: When using batch and parallel_sample_num together, the perf is not optimal.
@@ -1866,7 +1897,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     if tmp_obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_objs[i].input_ids)
                     self._send_one_request(tokenized_obj)
-                    generators.append(self._wait_one_response(tmp_obj, request))
+                    generators.append(
+                        self._wait_one_response(
+                            tmp_obj,
+                            request,
+                            yield_scheduler_errors=yield_scheduler_errors,
+                        )
+                    )
                     rids.append(tmp_obj.rid)
 
                 parent_state = self.rid_to_state.get(logical_rid)

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -746,6 +746,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
         yield_scheduler_errors: bool = False,
+        request_lifecycle_id: Optional[object] = None,
     ):
         self.auto_create_handle_loop()
 
@@ -773,7 +774,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"routed_dp_rank={obj.routed_dp_rank} out of range [0, {dp_size})"
                 )
 
-        request_lifecycles = self._init_req_state(obj, request)
+        request_lifecycles = self._init_req_state(
+            obj,
+            request,
+            lifecycle_id=request_lifecycle_id,
+        )
         try:
             if self.server_args.language_only:
                 self._handle_epd_disaggregation_encode_request(obj)
@@ -1735,9 +1740,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we log finished results and metrics.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"][
-                        "response_sent_to_client_ts"
-                    ] = state.time_stats.get_response_sent_to_client_realtime()
+                    out["meta_info"]["response_sent_to_client_ts"] = (
+                        state.time_stats.get_response_sent_to_client_realtime()
+                    )
                 self.request_logger.log_finished_request(
                     obj,
                     out,
@@ -1768,9 +1773,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Record response sent time right before we send response.
                 if not state.time_stats.response_sent_to_client_time:
                     state.time_stats.set_response_sent_to_client_time()
-                    out["meta_info"][
-                        "response_sent_to_client_ts"
-                    ] = state.time_stats.get_response_sent_to_client_realtime()
+                    out["meta_info"]["response_sent_to_client_ts"] = (
+                        state.time_stats.get_response_sent_to_client_realtime()
+                    )
                 yield out
             else:
                 if (
@@ -1964,11 +1969,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 return_exceptions=True,
             )
 
-    def abort_request(self, rid: str = "", abort_all: bool = False):
+    def abort_request(
+        self,
+        rid: str = "",
+        abort_all: bool = False,
+        lifecycle_id: Optional[object] = None,
+    ) -> bool:
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
-            return
+            return False
         if abort_all:
             for state_rid, state in self.rid_to_state.items():
                 if state_rid not in self.child_rid_to_logical_rid:
@@ -1976,9 +1986,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             target_rids = (rid,)
         elif rid in self.child_rid_to_logical_rid:
             # Preserve direct child aborts for internal callers.
+            state = self.rid_to_state.get(rid)
+            if state is None or (
+                lifecycle_id is not None and state.lifecycle_id != lifecycle_id
+            ):
+                return False
             target_rids = (rid,)
         elif rid in self.rid_to_state:
             state = self.rid_to_state[rid]
+            if lifecycle_id is not None and state.lifecycle_id != lifecycle_id:
+                return False
             state.abort_requested = True
             parallel_sample_num = getattr(state.obj, "parallel_sample_num", None)
             if parallel_sample_num is None:
@@ -1990,13 +2007,35 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 )
             if parallel_sample_num > 1:
                 # Snapshot because scheduler abort echoes remove child ownership.
-                target_rids = tuple(sorted(self.logical_rid_to_child_rids.get(rid, ())))
+                target_rids = tuple(
+                    sorted(
+                        child_rid
+                        for child_rid in self.logical_rid_to_child_rids.get(rid, ())
+                        if lifecycle_id is None
+                        or self.rid_to_state.get(child_rid) is not None
+                        and self.rid_to_state[child_rid].lifecycle_id == lifecycle_id
+                    )
+                )
             else:
                 target_rids = (rid,)
         elif child_rids := self.logical_rid_to_child_rids.get(rid):
-            target_rids = tuple(sorted(child_rids))
+            target_rids = tuple(
+                sorted(
+                    child_rid
+                    for child_rid in child_rids
+                    if lifecycle_id is None
+                    or self.rid_to_state.get(child_rid) is not None
+                    and self.rid_to_state[child_rid].lifecycle_id == lifecycle_id
+                )
+            )
+            if lifecycle_id is not None and not target_rids:
+                return False
+        elif lifecycle_id is not None:
+            # Exact-lifecycle aborts must never fall through to the scheduler's
+            # prefix-based RID matching after that lifecycle has completed.
+            return False
         elif self.server_args.tokenizer_worker_num == 1:
-            return
+            return False
         else:
             target_rids = (rid,)
 
@@ -2007,6 +2046,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.metrics_collector.observe_one_aborted_request(
                 self.metrics_collector.labels
             )
+        return bool(target_rids)
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
         async with self.is_pause_cond:
@@ -2051,9 +2091,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.model_update_lock.writer_lock if not is_paused else nullcontext()
         )
         async with lock_context:
-            success, message, num_paused_requests = (
-                await self._wait_for_model_update_from_disk(obj)
-            )
+            (
+                success,
+                message,
+                num_paused_requests,
+            ) = await self._wait_for_model_update_from_disk(obj)
 
         if success and obj.weight_version is not None:
             self._update_weight_version_if_provided(obj.weight_version)
@@ -2586,8 +2628,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         # shared batch-output loop; degrade to nested instead.
                         state.input_top_logprobs_flat_fields = None
                         logger.error(
-                            "Falling back to nested input top logprobs for "
-                            "rid=%s: %s",
+                            "Falling back to nested input top logprobs for rid=%s: %s",
                             meta_info.get("id"),
                             e,
                         )
@@ -3061,7 +3102,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 filename = os.path.join(
                     self.crash_dump_folder,
                     hostname,
-                    f'crash_dump_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}.pkl',
+                    f"crash_dump_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.pkl",
                 )
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
 
@@ -3272,9 +3313,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 scale_phase=self.elastic_scale_phase,
             )
         self.auto_create_handle_loop()
-        responses: List[ScaleElasticEPReqOutput] = (
-            await self.scale_elastic_ep_communicator(obj)
-        )
+        responses: List[
+            ScaleElasticEPReqOutput
+        ] = await self.scale_elastic_ep_communicator(obj)
         for res in responses:
             if not res.success:
                 self.elastic_scale_phase = res.scale_phase
@@ -3426,7 +3467,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         """Remove a request state and its parallel-sampling ownership."""
         state = self.rid_to_state.get(rid)
         if state is None or (
-            lifecycle_id is not None and state.lifecycle_id is not lifecycle_id
+            lifecycle_id is not None and state.lifecycle_id != lifecycle_id
         ):
             return None
         self.rid_to_state.pop(rid)
@@ -3437,6 +3478,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 children.discard(rid)
                 if not children:
                     self.logical_rid_to_child_rids.pop(logical_rid, None)
+                    logical_state = self.rid_to_state.get(logical_rid)
+                    if logical_state is not None and logical_state.abort_requested:
+                        self.rid_to_state.pop(logical_rid)
         return state
 
     def _raise_if_logical_rid_aborted(self, logical_rid: str) -> None:
@@ -3543,12 +3587,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 for child_rid in self.logical_rid_to_child_rids.get(logical_rid, ())
                 if (
                     (state := self.rid_to_state.get(child_rid)) is not None
-                    and state.lifecycle_id is lifecycle_id
+                    and state.lifecycle_id == lifecycle_id
                 )
             )
             logical_state = self.rid_to_state.get(logical_rid)
             owns_logical_state = (
-                logical_state is not None and logical_state.lifecycle_id is lifecycle_id
+                logical_state is not None and logical_state.lifecycle_id == lifecycle_id
             )
             target_rids = tuple(
                 rid for rid in child_rids if self.rid_to_state[rid].dispatched
@@ -3565,9 +3609,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         "Failed to abort request rid=%s",
                         target_rid,
                     )
+            # Dispatched requests remain registered until the scheduler returns
+            # their terminal output or AbortReq echo. This is the acknowledgement
+            # barrier that prevents a reused RID from receiving stale output.
             for child_rid in child_rids:
-                self._remove_req_state(child_rid, lifecycle_id)
-            self._remove_req_state(logical_rid, lifecycle_id)
+                if child_rid not in target_rids:
+                    self._remove_req_state(child_rid, lifecycle_id)
+            if owns_logical_state:
+                if target_rids:
+                    logical_state.abort_requested = True
+                elif not logical_state.dispatched:
+                    self._remove_req_state(logical_rid, lifecycle_id)
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -28,7 +28,9 @@ impl ResponseChunk {
 pub struct ResponseData {
     pub text: Option<String>,
     pub output_ids: Option<Vec<i32>>,
+    pub delta_output_ids: Option<Vec<i32>>,
     pub embedding: Option<Vec<f32>>,
+    pub choice_index: i32,
     pub json_bytes: Option<Vec<u8>>,
     pub meta_info: HashMap<String, String>,
 }
@@ -67,6 +69,7 @@ struct BridgeState {
 struct ActiveChannel {
     incarnation: u64,
     sender: Sender<ResponseChunk>,
+    preserve_on_explicit_abort: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -156,7 +159,11 @@ impl PyBridge {
     // Channel + callback helpers
     // ------------------------------------------------------------------
 
-    fn create_channel(&self, rid: &str) -> PyResult<SubmittedRequest> {
+    fn create_channel(
+        &self,
+        rid: &str,
+        preserve_on_explicit_abort: bool,
+    ) -> PyResult<SubmittedRequest> {
         let (sender, receiver) = mpsc::channel(self.response_channel_capacity);
         let mut state = lock_or_recover(self.state.as_ref(), "state");
         if state.abort_all_in_progress {
@@ -179,6 +186,7 @@ impl PyBridge {
             ActiveChannel {
                 incarnation: key.incarnation,
                 sender,
+                preserve_on_explicit_abort,
             },
         );
         Ok(SubmittedRequest { key, receiver })
@@ -219,8 +227,9 @@ impl PyBridge {
         rid: &str,
         req_type: &str,
         req_dict: HashMap<String, serde_json::Value>,
+        choice_aware: bool,
     ) -> PyResult<SubmittedRequest> {
-        let submitted = self.create_channel(rid)?;
+        let submitted = self.create_channel(rid, choice_aware)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let py_req_dict = json_map_to_pydict(py, &req_dict)?;
@@ -230,6 +239,7 @@ impl PyBridge {
             kwargs.set_item("req_type", req_type)?;
             kwargs.set_item("req_dict", py_req_dict)?;
             kwargs.set_item("chunk_callback", callback)?;
+            kwargs.set_item("choice_aware", choice_aware)?;
 
             self.runtime_handle
                 .call_method(py, "submit_request", (), Some(&kwargs))?;
@@ -290,14 +300,7 @@ impl PyBridge {
 
         let mut state = lock_or_recover(self.state.as_ref(), "state");
         for key in &keys {
-            if remove_channel_refs_locked(&mut state, key) {
-                state.terminal_errors.insert(
-                    key.clone(),
-                    TerminalError::Aborted {
-                        rid: key.rid.clone(),
-                    },
-                );
-            }
+            finalize_explicit_abort_locked(&mut state, key);
         }
         if abort_all {
             state.abort_all_in_progress = false;
@@ -397,7 +400,7 @@ impl PyBridge {
         F: for<'py> FnOnce(Python<'py>, &Py<PyAny>, Py<PyAny>) -> PyResult<()>,
     {
         // Closure args are: current Python token, RuntimeHandle, and the JSON chunk callback.
-        let submitted = self.create_channel(rid)?;
+        let submitted = self.create_channel(rid, false)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let callback = self.make_json_callback(py, submitted.key.clone())?;
@@ -558,6 +561,23 @@ fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool
     }
     remove_auxiliary_refs_locked(state, key);
     is_active
+}
+
+fn finalize_explicit_abort_locked(state: &mut BridgeState, key: &RequestKey) {
+    let preserves_choice_terminals = state.channels.get(key.rid()).is_some_and(|channel| {
+        channel.incarnation == key.incarnation && channel.preserve_on_explicit_abort
+    });
+    if preserves_choice_terminals {
+        return;
+    }
+    if remove_channel_refs_locked(state, key) {
+        state.terminal_errors.insert(
+            key.clone(),
+            TerminalError::Aborted {
+                rid: key.rid.clone(),
+            },
+        );
+    }
 }
 
 fn remove_channel_refs(key: &RequestKey, state: &BridgeStateRef) {
@@ -766,16 +786,27 @@ impl ChunkCallback {
             .get_item("output_ids")?
             .and_then(|v| v.extract::<Vec<i32>>().ok());
 
+        let delta_output_ids: Option<Vec<i32>> = chunk
+            .get_item("delta_output_ids")?
+            .and_then(|v| v.extract::<Vec<i32>>().ok());
+
         let embedding: Option<Vec<f32>> = chunk
             .get_item("embedding")?
             .and_then(|v| v.extract::<Vec<f32>>().ok());
+
+        let choice_index = chunk
+            .get_item("index")?
+            .and_then(|v| v.extract::<i32>().ok())
+            .unwrap_or(0);
 
         let meta_info = extract_meta_info(chunk);
 
         let data = ResponseData {
             text,
             output_ids,
+            delta_output_ids,
             embedding,
+            choice_index,
             json_bytes: None,
             meta_info,
         };
@@ -864,7 +895,9 @@ impl JsonChunkCallback {
         let data = ResponseData {
             text: None,
             output_ids: None,
+            delta_output_ids: None,
             embedding: None,
+            choice_index: 0,
             json_bytes: Some(bytes_data),
             meta_info,
         };

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -2,6 +2,7 @@ use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict};
 use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
 use tokio::runtime::Handle;
 use tokio::sync::mpsc::error::TrySendError;
@@ -32,17 +33,40 @@ pub struct ResponseData {
     pub meta_info: HashMap<String, String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RequestKey {
+    rid: String,
+    incarnation: u64,
+}
+
+impl RequestKey {
+    pub fn rid(&self) -> &str {
+        &self.rid
+    }
+}
+
+pub struct SubmittedRequest {
+    pub key: RequestKey,
+    pub receiver: Receiver<ResponseChunk>,
+}
+
 pub const DEFAULT_RESPONSE_CHANNEL_CAPACITY: usize = 64;
 
 type BridgeStateRef = Arc<Mutex<BridgeState>>;
 
 #[derive(Default)]
 struct BridgeState {
-    channels: HashMap<String, Sender<ResponseChunk>>,
-    pending_sends: HashSet<String>,
-    ready_callbacks: HashMap<String, Py<PyAny>>,
-    ready_signals: HashSet<String>,
-    terminal_errors: HashMap<String, TerminalError>,
+    channels: HashMap<String, ActiveChannel>,
+    abort_all_in_progress: bool,
+    pending_sends: HashSet<RequestKey>,
+    ready_callbacks: HashMap<RequestKey, Py<PyAny>>,
+    ready_signals: HashSet<RequestKey>,
+    terminal_errors: HashMap<RequestKey, TerminalError>,
+}
+
+struct ActiveChannel {
+    incarnation: u64,
+    sender: Sender<ResponseChunk>,
 }
 
 #[derive(Debug, Clone)]
@@ -92,6 +116,7 @@ pub struct PyBridge {
     context_len: i32,
     response_channel_capacity: usize,
     tokio_handle: Handle,
+    next_incarnation: AtomicU64,
 }
 
 impl PyBridge {
@@ -113,6 +138,7 @@ impl PyBridge {
             context_len,
             response_channel_capacity,
             tokio_handle,
+            next_incarnation: AtomicU64::new(1),
         }
     }
 
@@ -130,26 +156,37 @@ impl PyBridge {
     // Channel + callback helpers
     // ------------------------------------------------------------------
 
-    fn create_channel(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    fn create_channel(&self, rid: &str) -> PyResult<SubmittedRequest> {
         let (sender, receiver) = mpsc::channel(self.response_channel_capacity);
         let mut state = lock_or_recover(self.state.as_ref(), "state");
+        if state.abort_all_in_progress {
+            return Err(PyRuntimeError::new_err(
+                "Cannot submit a gRPC request while abort_all is in progress",
+            ));
+        }
         if state.channels.contains_key(rid) {
             return Err(PyRuntimeError::new_err(format!(
                 "Duplicate active gRPC request id: {}",
                 rid
             )));
         }
-        state.channels.insert(rid.to_string(), sender);
-        state.terminal_errors.remove(rid);
-        state.ready_callbacks.remove(rid);
-        state.ready_signals.remove(rid);
-        state.pending_sends.remove(rid);
-        Ok(receiver)
+        let key = RequestKey {
+            rid: rid.to_string(),
+            incarnation: self.next_incarnation.fetch_add(1, Ordering::Relaxed),
+        };
+        state.channels.insert(
+            rid.to_string(),
+            ActiveChannel {
+                incarnation: key.incarnation,
+                sender,
+            },
+        );
+        Ok(SubmittedRequest { key, receiver })
     }
 
-    fn make_chunk_callback(&self, py: Python<'_>, rid: String) -> PyResult<Py<PyAny>> {
+    fn make_chunk_callback(&self, py: Python<'_>, key: RequestKey) -> PyResult<Py<PyAny>> {
         let callback = ChunkCallback {
-            rid,
+            key,
             state: self.state.clone(),
             runtime_handle: self.runtime_handle.clone_ref(py),
             tokio_handle: self.tokio_handle.clone(),
@@ -158,9 +195,9 @@ impl PyBridge {
         Ok(py_callback.into_any())
     }
 
-    fn make_json_callback(&self, py: Python<'_>, rid: String) -> PyResult<Py<PyAny>> {
+    fn make_json_callback(&self, py: Python<'_>, key: RequestKey) -> PyResult<Py<PyAny>> {
         let callback = JsonChunkCallback {
-            rid,
+            key,
             state: self.state.clone(),
             runtime_handle: self.runtime_handle.clone_ref(py),
             tokio_handle: self.tokio_handle.clone(),
@@ -182,13 +219,12 @@ impl PyBridge {
         rid: &str,
         req_type: &str,
         req_dict: HashMap<String, serde_json::Value>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
-        let receiver = self.create_channel(rid)?;
-        let rid_owned = rid.to_string();
+    ) -> PyResult<SubmittedRequest> {
+        let submitted = self.create_channel(rid)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let py_req_dict = json_map_to_pydict(py, &req_dict)?;
-            let callback = self.make_chunk_callback(py, rid_owned)?;
+            let callback = self.make_chunk_callback(py, submitted.key.clone())?;
 
             let kwargs = PyDict::new(py);
             kwargs.set_item("req_type", req_type)?;
@@ -201,9 +237,9 @@ impl PyBridge {
         });
 
         match result {
-            Ok(()) => Ok(receiver),
+            Ok(()) => Ok(submitted),
             Err(err) => {
-                self.remove_channel(rid);
+                self.remove_channel(&submitted.key);
                 Err(err)
             }
         }
@@ -220,47 +256,88 @@ impl PyBridge {
             ));
         }
 
-        let should_call_python = if abort_all {
+        let keys = if abort_all {
             let mut state = lock_or_recover(self.state.as_ref(), "state");
-            let rids = state
+            state.abort_all_in_progress = true;
+            state
                 .channels
-                .drain()
-                .map(|(rid, _)| rid)
-                .collect::<Vec<_>>();
-            let affected = rids.len();
-            state.pending_sends.clear();
-            state.ready_callbacks.clear();
-            state.ready_signals.clear();
-            for channel_rid in rids {
-                state.terminal_errors.insert(
-                    channel_rid.clone(),
-                    TerminalError::Aborted { rid: channel_rid },
-                );
-            }
-            tracing::debug!(affected, "gRPC abort_all cleared active response channels");
-            true
+                .iter()
+                .map(|(rid, channel)| RequestKey {
+                    rid: rid.clone(),
+                    incarnation: channel.incarnation,
+                })
+                .collect::<Vec<_>>()
         } else {
-            let mut state = lock_or_recover(self.state.as_ref(), "state");
-            let was_active = remove_channel_refs_locked(&mut state, rid);
-            if was_active {
-                state
-                    .terminal_errors
-                    .insert(rid.to_string(), TerminalError::Aborted { rid: rid.into() });
-            } else {
-                tracing::debug!(rid, "Ignoring abort for inactive gRPC request id");
-            }
-            was_active
+            let state = lock_or_recover(self.state.as_ref(), "state");
+            state.channels.get(rid).map_or_else(Vec::new, |channel| {
+                vec![RequestKey {
+                    rid: rid.to_string(),
+                    incarnation: channel.incarnation,
+                }]
+            })
         };
 
-        if !should_call_python {
+        if !abort_all && keys.is_empty() {
+            tracing::debug!(rid, "Ignoring abort for inactive gRPC request id");
             return Ok(());
         }
 
-        Python::attach(|py| {
+        let call_result = Python::attach(|py| {
             self.runtime_handle
                 .call_method1(py, "abort", (rid, abort_all))?;
             Ok(())
-        })
+        });
+
+        let mut state = lock_or_recover(self.state.as_ref(), "state");
+        for key in &keys {
+            if remove_channel_refs_locked(&mut state, key) {
+                state.terminal_errors.insert(
+                    key.clone(),
+                    TerminalError::Aborted {
+                        rid: key.rid.clone(),
+                    },
+                );
+            }
+        }
+        if abort_all {
+            state.abort_all_in_progress = false;
+            tracing::debug!(
+                affected = keys.len(),
+                "gRPC abort_all cleared active response channels"
+            );
+        }
+        call_result
+    }
+
+    pub fn abort_request(&self, key: &RequestKey) -> PyResult<()> {
+        let is_active = {
+            let state = lock_or_recover(self.state.as_ref(), "state");
+            state
+                .channels
+                .get(key.rid())
+                .is_some_and(|channel| channel.incarnation == key.incarnation)
+        };
+        if !is_active {
+            let mut state = lock_or_recover(self.state.as_ref(), "state");
+            remove_auxiliary_refs_locked(&mut state, key);
+            return Ok(());
+        }
+
+        let call_result = Python::attach(|py| {
+            self.runtime_handle
+                .call_method1(py, "abort", (key.rid(), false))?;
+            Ok(())
+        });
+        let mut state = lock_or_recover(self.state.as_ref(), "state");
+        if remove_channel_refs_locked(&mut state, key) {
+            state.terminal_errors.insert(
+                key.clone(),
+                TerminalError::Aborted {
+                    rid: key.rid.clone(),
+                },
+            );
+        }
+        call_result
     }
 
     // ------------------------------------------------------------------
@@ -315,58 +392,49 @@ impl PyBridge {
         })
     }
 
-    fn submit_json<F>(&self, rid: &str, call: F) -> PyResult<Receiver<ResponseChunk>>
+    fn submit_json<F>(&self, rid: &str, call: F) -> PyResult<SubmittedRequest>
     where
         F: for<'py> FnOnce(Python<'py>, &Py<PyAny>, Py<PyAny>) -> PyResult<()>,
     {
         // Closure args are: current Python token, RuntimeHandle, and the JSON chunk callback.
-        let receiver = self.create_channel(rid)?;
-        let rid_owned = rid.to_string();
+        let submitted = self.create_channel(rid)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
-            let callback = self.make_json_callback(py, rid_owned)?;
+            let callback = self.make_json_callback(py, submitted.key.clone())?;
             call(py, &self.runtime_handle, callback)
         });
 
         match result {
-            Ok(()) => Ok(receiver),
+            Ok(()) => Ok(submitted),
             Err(err) => {
-                self.remove_channel(rid);
+                self.remove_channel(&submitted.key);
                 Err(err)
             }
         }
     }
 
-    pub fn submit_get_load(
-        &self,
-        rid: &str,
-        dp_rank: Option<i32>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_get_load(&self, rid: &str, dp_rank: Option<i32>) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "get_load", (callback, dp_rank))?;
             Ok(())
         })
     }
 
-    pub fn submit_flush_cache(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_flush_cache(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "flush_cache", (callback,))?;
             Ok(())
         })
     }
 
-    pub fn submit_pause_generation(
-        &self,
-        rid: &str,
-        mode: &str,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_pause_generation(&self, rid: &str, mode: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "pause_generation", (mode, callback))?;
             Ok(())
         })
     }
 
-    pub fn submit_continue_generation(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_continue_generation(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "continue_generation", (callback,))?;
             Ok(())
@@ -377,14 +445,14 @@ impl PyBridge {
         &self,
         rid: &str,
         output_dir: Option<&str>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "start_profile", (output_dir, callback))?;
             Ok(())
         })
     }
 
-    pub fn submit_stop_profile(&self, rid: &str) -> PyResult<Receiver<ResponseChunk>> {
+    pub fn submit_stop_profile(&self, rid: &str) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, |py, runtime_handle, callback| {
             runtime_handle.call_method1(py, "stop_profile", (callback,))?;
             Ok(())
@@ -396,7 +464,7 @@ impl PyBridge {
         rid: &str,
         model_path: &str,
         load_format: Option<&str>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             runtime_handle.call_method1(
                 py,
@@ -417,7 +485,7 @@ impl PyBridge {
         method_name: &str,
         json_body: &[u8],
         trace_headers: &HashMap<String, String>,
-    ) -> PyResult<Receiver<ResponseChunk>> {
+    ) -> PyResult<SubmittedRequest> {
         self.submit_json(rid, move |py, runtime_handle, callback| {
             let kwargs = PyDict::new(py);
             let py_bytes = PyBytes::new(py, json_body);
@@ -437,57 +505,78 @@ impl PyBridge {
         })
     }
 
-    pub fn remove_channel(&self, rid: &str) {
+    pub fn remove_channel(&self, key: &RequestKey) {
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        remove_channel_refs_locked(&mut state, rid);
-        state.terminal_errors.remove(rid);
+        remove_channel_refs_locked(&mut state, key);
+        state.terminal_errors.remove(key);
     }
 
-    pub fn take_terminal_error(&self, rid: &str) -> Option<TerminalError> {
+    pub fn take_terminal_error(&self, key: &RequestKey) -> Option<TerminalError> {
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        state.terminal_errors.remove(rid)
+        state.terminal_errors.remove(key)
     }
 }
 
 fn close_channel_with_error(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     runtime_handle: &Py<PyAny>,
     error: TerminalError,
 ) {
+    let is_active = {
+        let state = lock_or_recover(state.as_ref(), "state");
+        state
+            .channels
+            .get(key.rid())
+            .is_some_and(|channel| channel.incarnation == key.incarnation)
+    };
+    if !is_active {
+        return;
+    }
+    let _ = runtime_handle.call_method1(py, "abort", (key.rid(), false));
     let mut state = lock_or_recover(state.as_ref(), "state");
-    remove_channel_refs_locked(&mut state, rid);
-    state.terminal_errors.insert(rid.to_string(), error);
-    drop(state);
-    let _ = runtime_handle.call_method1(py, "abort", (rid, false));
+    if remove_channel_refs_locked(&mut state, key) {
+        state.terminal_errors.insert(key.clone(), error);
+    }
 }
 
-fn remove_channel_refs_locked(state: &mut BridgeState, rid: &str) -> bool {
-    let had_channel = state.channels.remove(rid).is_some();
-    let had_pending = state.pending_sends.remove(rid);
-    let had_callback = state.ready_callbacks.remove(rid).is_some();
-    let had_signal = state.ready_signals.remove(rid);
-    had_channel || had_pending || had_callback || had_signal
+fn remove_auxiliary_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool {
+    let had_pending = state.pending_sends.remove(key);
+    let had_callback = state.ready_callbacks.remove(key).is_some();
+    let had_signal = state.ready_signals.remove(key);
+    had_pending || had_callback || had_signal
 }
 
-fn remove_channel_refs(rid: &str, state: &BridgeStateRef) {
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    remove_channel_refs_locked(&mut state, rid);
+fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool {
+    let is_active = state
+        .channels
+        .get(key.rid())
+        .is_some_and(|channel| channel.incarnation == key.incarnation);
+    if is_active {
+        state.channels.remove(key.rid());
+    }
+    remove_auxiliary_refs_locked(state, key);
+    is_active
 }
 
-fn register_pending_send(rid: &str, state: &BridgeStateRef) -> bool {
+fn remove_channel_refs(key: &RequestKey, state: &BridgeStateRef) {
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.insert(rid.to_string())
+    remove_channel_refs_locked(&mut state, key);
 }
 
-fn mark_send_ready(py: Python<'_>, rid: &str, state: &BridgeStateRef) -> Option<Py<PyAny>> {
+fn register_pending_send(key: &RequestKey, state: &BridgeStateRef) -> bool {
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.remove(rid);
-    if let Some(callback) = state.ready_callbacks.get(rid) {
+    state.pending_sends.insert(key.clone())
+}
+
+fn mark_send_ready(py: Python<'_>, key: &RequestKey, state: &BridgeStateRef) -> Option<Py<PyAny>> {
+    let mut state = lock_or_recover(state.as_ref(), "state");
+    state.pending_sends.remove(key);
+    if let Some(callback) = state.ready_callbacks.get(key) {
         Some(callback.clone_ref(py))
     } else {
-        state.ready_signals.insert(rid.to_string());
+        state.ready_signals.insert(key.clone());
         None
     }
 }
@@ -500,16 +589,23 @@ fn notify_ready(py: Python<'_>, rid: &str, callback: Py<PyAny>) {
 
 fn set_on_ready_for_rid(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     on_ready: Py<PyAny>,
 ) -> PyResult<()> {
     let should_notify = {
         let mut state = lock_or_recover(state.as_ref(), "state");
+        if state
+            .channels
+            .get(key.rid())
+            .is_none_or(|channel| channel.incarnation != key.incarnation)
+        {
+            return Ok(());
+        }
         state
             .ready_callbacks
-            .insert(rid.to_string(), on_ready.clone_ref(py));
-        state.ready_signals.remove(rid)
+            .insert(key.clone(), on_ready.clone_ref(py));
+        state.ready_signals.remove(key)
     };
     if should_notify {
         on_ready.call0(py)?;
@@ -517,16 +613,16 @@ fn set_on_ready_for_rid(
     Ok(())
 }
 
-fn clear_on_ready_for_rid(rid: &str, state: &BridgeStateRef) {
+fn clear_on_ready_for_rid(key: &RequestKey, state: &BridgeStateRef) {
     // End notifications for this rid. Do not call set_on_ready again for the same rid.
     let mut state = lock_or_recover(state.as_ref(), "state");
-    state.ready_callbacks.remove(rid);
-    state.ready_signals.remove(rid);
+    state.ready_callbacks.remove(key);
+    state.ready_signals.remove(key);
 }
 
 fn try_send_chunk(
     py: Python<'_>,
-    rid: &str,
+    key: &RequestKey,
     state: &BridgeStateRef,
     runtime_handle: &Py<PyAny>,
     tokio_handle: &Handle,
@@ -537,27 +633,29 @@ fn try_send_chunk(
     match sender.try_send(msg) {
         Ok(()) => {
             if terminal {
-                remove_channel_refs(rid, state);
+                remove_channel_refs(key, state);
             }
             Ok(ChunkSendStatus::Ready)
         }
         Err(TrySendError::Full(msg)) => {
-            if !register_pending_send(rid, state) {
+            if !register_pending_send(key, state) {
                 tracing::warn!(
-                    rid,
+                    rid = key.rid(),
                     "gRPC bridge received another chunk before the parked chunk drained; closing stream"
                 );
                 close_channel_with_error(
                     py,
-                    rid,
+                    key,
                     state,
                     runtime_handle,
-                    TerminalError::ChannelFull { rid: rid.into() },
+                    TerminalError::ChannelFull {
+                        rid: key.rid.clone(),
+                    },
                 );
                 return Ok(ChunkSendStatus::Closed);
             }
 
-            let rid_owned = rid.to_string();
+            let key_owned = key.clone();
             let state = state.clone();
             let runtime_handle = runtime_handle.clone_ref(py);
             let sender = sender.clone();
@@ -568,13 +666,13 @@ fn try_send_chunk(
                         if terminal {
                             // Terminal chunks end the producer contract; no further on_ready
                             // signal is fired after a parked Finished/Error drains.
-                            remove_channel_refs(&rid_owned, &state);
+                            remove_channel_refs(&key_owned, &state);
                             return;
                         }
 
                         Python::attach(|py| {
-                            if let Some(callback) = mark_send_ready(py, &rid_owned, &state) {
-                                notify_ready(py, &rid_owned, callback);
+                            if let Some(callback) = mark_send_ready(py, &key_owned, &state) {
+                                notify_ready(py, key_owned.rid(), callback);
                             }
                         });
                     }
@@ -582,11 +680,11 @@ fn try_send_chunk(
                         Python::attach(|py| {
                             close_channel_with_error(
                                 py,
-                                &rid_owned,
+                                &key_owned,
                                 &state,
                                 &runtime_handle,
                                 TerminalError::ClientDisconnected {
-                                    rid: rid_owned.clone(),
+                                    rid: key_owned.rid.clone(),
                                 },
                             );
                         });
@@ -599,10 +697,12 @@ fn try_send_chunk(
         Err(TrySendError::Closed(_)) => {
             close_channel_with_error(
                 py,
-                rid,
+                key,
                 state,
                 runtime_handle,
-                TerminalError::ClientDisconnected { rid: rid.into() },
+                TerminalError::ClientDisconnected {
+                    rid: key.rid.clone(),
+                },
             );
             Ok(ChunkSendStatus::Closed)
         }
@@ -612,7 +712,7 @@ fn try_send_chunk(
 // Typed chunk callback for SGLang-native RPCs (dict-based chunks).
 #[pyclass]
 struct ChunkCallback {
-    rid: String,
+    key: RequestKey,
     state: BridgeStateRef,
     runtime_handle: Py<PyAny>,
     tokio_handle: Handle,
@@ -623,11 +723,11 @@ impl ChunkCallback {
     /// Register before producing chunks. If a parked chunk drained before registration,
     /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
     fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.rid, &self.state, on_ready)
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
     }
 
     fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.rid, &self.state);
+        clear_on_ready_for_rid(&self.key, &self.state);
     }
 
     #[pyo3(signature = (chunk, finished=false, error=None))]
@@ -639,16 +739,17 @@ impl ChunkCallback {
     ) -> PyResult<ChunkSendStatus> {
         let py = chunk.py();
         let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(&self.rid) {
-            Some(s) => s.clone(),
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
             None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
         };
         drop(state);
 
         if let Some(err_msg) = error {
             return try_send_chunk(
                 py,
-                &self.rid,
+                &self.key,
                 &self.state,
                 &self.runtime_handle,
                 &self.tokio_handle,
@@ -687,7 +788,7 @@ impl ChunkCallback {
 
         try_send_chunk(
             py,
-            &self.rid,
+            &self.key,
             &self.state,
             &self.runtime_handle,
             &self.tokio_handle,
@@ -700,7 +801,7 @@ impl ChunkCallback {
 // JSON chunk callback for OpenAI pass-through RPCs (raw bytes).
 #[pyclass]
 struct JsonChunkCallback {
-    rid: String,
+    key: RequestKey,
     state: BridgeStateRef,
     runtime_handle: Py<PyAny>,
     tokio_handle: Handle,
@@ -711,11 +812,11 @@ impl JsonChunkCallback {
     /// Register before producing chunks. If a parked chunk drained before registration,
     /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
     fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.rid, &self.state, on_ready)
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
     }
 
     fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.rid, &self.state);
+        clear_on_ready_for_rid(&self.key, &self.state);
     }
 
     #[pyo3(signature = (chunk_bytes, finished=false, error=None, status_code=None))]
@@ -728,16 +829,17 @@ impl JsonChunkCallback {
     ) -> PyResult<ChunkSendStatus> {
         let py = chunk_bytes.py();
         let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(&self.rid) {
-            Some(s) => s.clone(),
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
             None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
         };
         drop(state);
 
         if let Some(err_msg) = error {
             return try_send_chunk(
                 py,
-                &self.rid,
+                &self.key,
                 &self.state,
                 &self.runtime_handle,
                 &self.tokio_handle,
@@ -775,7 +877,7 @@ impl JsonChunkCallback {
 
         try_send_chunk(
             py,
-            &self.rid,
+            &self.key,
             &self.state,
             &self.runtime_handle,
             &self.tokio_handle,

--- a/rust/sglang-grpc/src/bridge.rs
+++ b/rust/sglang-grpc/src/bridge.rs
@@ -11,6 +11,9 @@ use tokio::sync::mpsc::{self, Receiver, Sender};
 use crate::tokenizers::RustTokenizer;
 use crate::utils::{json_map_to_pydict, py_value_to_json_string};
 
+mod callbacks;
+use callbacks::{ChunkCallback, JsonChunkCallback};
+
 #[derive(Debug, Clone)]
 pub enum ResponseChunk {
     Data(ResponseData),
@@ -45,6 +48,10 @@ impl RequestKey {
     pub fn rid(&self) -> &str {
         &self.rid
     }
+
+    fn incarnation(&self) -> u64 {
+        self.incarnation
+    }
 }
 
 pub struct SubmittedRequest {
@@ -59,7 +66,7 @@ type BridgeStateRef = Arc<Mutex<BridgeState>>;
 #[derive(Default)]
 struct BridgeState {
     channels: HashMap<String, ActiveChannel>,
-    abort_all_in_progress: bool,
+    abort_all_in_progress: usize,
     pending_sends: HashSet<RequestKey>,
     ready_callbacks: HashMap<RequestKey, Py<PyAny>>,
     ready_signals: HashSet<RequestKey>,
@@ -68,8 +75,11 @@ struct BridgeState {
 
 struct ActiveChannel {
     incarnation: u64,
-    sender: Sender<ResponseChunk>,
+    sender: Option<Sender<ResponseChunk>>,
     preserve_on_explicit_abort: bool,
+    scheduler_backed: bool,
+    submitting: bool,
+    abort_requested: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -163,10 +173,11 @@ impl PyBridge {
         &self,
         rid: &str,
         preserve_on_explicit_abort: bool,
+        scheduler_backed: bool,
     ) -> PyResult<SubmittedRequest> {
         let (sender, receiver) = mpsc::channel(self.response_channel_capacity);
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        if state.abort_all_in_progress {
+        if state.abort_all_in_progress > 0 {
             return Err(PyRuntimeError::new_err(
                 "Cannot submit a gRPC request while abort_all is in progress",
             ));
@@ -185,8 +196,11 @@ impl PyBridge {
             rid.to_string(),
             ActiveChannel {
                 incarnation: key.incarnation,
-                sender,
+                sender: Some(sender),
                 preserve_on_explicit_abort,
+                scheduler_backed,
+                submitting: scheduler_backed,
+                abort_requested: false,
             },
         );
         Ok(SubmittedRequest { key, receiver })
@@ -229,7 +243,7 @@ impl PyBridge {
         req_dict: HashMap<String, serde_json::Value>,
         choice_aware: bool,
     ) -> PyResult<SubmittedRequest> {
-        let submitted = self.create_channel(rid, choice_aware)?;
+        let submitted = self.create_channel(rid, choice_aware, true)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let py_req_dict = json_map_to_pydict(py, &req_dict)?;
@@ -240,6 +254,7 @@ impl PyBridge {
             kwargs.set_item("req_dict", py_req_dict)?;
             kwargs.set_item("chunk_callback", callback)?;
             kwargs.set_item("choice_aware", choice_aware)?;
+            kwargs.set_item("lifecycle_id", submitted.key.incarnation())?;
 
             self.runtime_handle
                 .call_method(py, "submit_request", (), Some(&kwargs))?;
@@ -247,7 +262,33 @@ impl PyBridge {
         });
 
         match result {
-            Ok(()) => Ok(submitted),
+            Ok(()) => {
+                let abort_requested = {
+                    let mut state = lock_or_recover(self.state.as_ref(), "state");
+                    state
+                        .channels
+                        .get_mut(submitted.key.rid())
+                        .filter(|channel| channel.incarnation == submitted.key.incarnation)
+                        .is_some_and(|channel| {
+                            channel.submitting = false;
+                            channel.abort_requested
+                        })
+                };
+                if abort_requested {
+                    if let Err(err) = self.abort_runtime_request(&submitted.key) {
+                        let mut state = lock_or_recover(self.state.as_ref(), "state");
+                        if let Some(channel) = state
+                            .channels
+                            .get_mut(submitted.key.rid())
+                            .filter(|channel| channel.incarnation == submitted.key.incarnation)
+                        {
+                            channel.abort_requested = false;
+                        }
+                        return Err(err);
+                    }
+                }
+                Ok(submitted)
+            }
             Err(err) => {
                 self.remove_channel(&submitted.key);
                 Err(err)
@@ -259,6 +300,17 @@ impl PyBridge {
     // Abort
     // ------------------------------------------------------------------
 
+    fn abort_runtime_request(&self, key: &RequestKey) -> PyResult<()> {
+        Python::attach(|py| {
+            self.runtime_handle.call_method1(
+                py,
+                "abort",
+                (key.rid(), Some(key.incarnation()), false),
+            )?;
+            Ok(())
+        })
+    }
+
     pub fn abort(&self, rid: &str, abort_all: bool) -> PyResult<()> {
         if !abort_all && rid.trim().is_empty() {
             return Err(PyValueError::new_err(
@@ -266,25 +318,37 @@ impl PyBridge {
             ));
         }
 
-        let keys = if abort_all {
+        let (keys, call_runtime) = if abort_all {
             let mut state = lock_or_recover(self.state.as_ref(), "state");
-            state.abort_all_in_progress = true;
-            state
+            state.abort_all_in_progress += 1;
+            let keys = state
                 .channels
-                .iter()
-                .map(|(rid, channel)| RequestKey {
-                    rid: rid.clone(),
-                    incarnation: channel.incarnation,
+                .iter_mut()
+                .map(|(rid, channel)| {
+                    channel.abort_requested = true;
+                    RequestKey {
+                        rid: rid.clone(),
+                        incarnation: channel.incarnation,
+                    }
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            (keys, true)
         } else {
-            let state = lock_or_recover(self.state.as_ref(), "state");
-            state.channels.get(rid).map_or_else(Vec::new, |channel| {
-                vec![RequestKey {
-                    rid: rid.to_string(),
-                    incarnation: channel.incarnation,
-                }]
-            })
+            let mut state = lock_or_recover(self.state.as_ref(), "state");
+            state.channels.get_mut(rid).map_or_else(
+                || (Vec::new(), false),
+                |channel| {
+                    channel.abort_requested = true;
+                    let should_call = channel.scheduler_backed && !channel.submitting;
+                    (
+                        vec![RequestKey {
+                            rid: rid.to_string(),
+                            incarnation: channel.incarnation,
+                        }],
+                        should_call,
+                    )
+                },
+            )
         };
 
         if !abort_all && keys.is_empty() {
@@ -292,18 +356,36 @@ impl PyBridge {
             return Ok(());
         }
 
-        let call_result = Python::attach(|py| {
-            self.runtime_handle
-                .call_method1(py, "abort", (rid, abort_all))?;
+        let call_result = if abort_all {
+            Python::attach(|py| {
+                self.runtime_handle
+                    .call_method1(py, "abort", (rid, Option::<u64>::None, true))?;
+                Ok(())
+            })
+        } else if call_runtime {
+            self.abort_runtime_request(&keys[0])
+        } else {
             Ok(())
-        });
+        };
 
         let mut state = lock_or_recover(self.state.as_ref(), "state");
-        for key in &keys {
-            finalize_explicit_abort_locked(&mut state, key);
+        if call_result.is_ok() {
+            for key in &keys {
+                finalize_explicit_abort_locked(&mut state, key);
+            }
+        } else {
+            for key in &keys {
+                if let Some(channel) = state
+                    .channels
+                    .get_mut(key.rid())
+                    .filter(|channel| channel.incarnation == key.incarnation)
+                {
+                    channel.abort_requested = false;
+                }
+            }
         }
         if abort_all {
-            state.abort_all_in_progress = false;
+            state.abort_all_in_progress = state.abort_all_in_progress.saturating_sub(1);
             tracing::debug!(
                 affected = keys.len(),
                 "gRPC abort_all cleared active response channels"
@@ -313,34 +395,33 @@ impl PyBridge {
     }
 
     pub fn abort_request(&self, key: &RequestKey) -> PyResult<()> {
-        let is_active = {
-            let state = lock_or_recover(self.state.as_ref(), "state");
-            state
-                .channels
-                .get(key.rid())
-                .is_some_and(|channel| channel.incarnation == key.incarnation)
-        };
-        if !is_active {
+        let (scheduler_backed, submitting) = {
             let mut state = lock_or_recover(self.state.as_ref(), "state");
+            let Some(channel) = state
+                .channels
+                .get_mut(key.rid())
+                .filter(|channel| channel.incarnation == key.incarnation)
+            else {
+                remove_auxiliary_refs_locked(&mut state, key);
+                state.terminal_errors.remove(key);
+                return Ok(());
+            };
+            channel.abort_requested = true;
+            channel.sender.take();
+            let scheduler_backed = channel.scheduler_backed;
+            let submitting = channel.submitting;
             remove_auxiliary_refs_locked(&mut state, key);
-            return Ok(());
-        }
+            state.terminal_errors.remove(key);
+            if !scheduler_backed {
+                state.channels.remove(key.rid());
+            }
+            (scheduler_backed, submitting)
+        };
 
-        let call_result = Python::attach(|py| {
-            self.runtime_handle
-                .call_method1(py, "abort", (key.rid(), false))?;
-            Ok(())
-        });
-        let mut state = lock_or_recover(self.state.as_ref(), "state");
-        if remove_channel_refs_locked(&mut state, key) {
-            state.terminal_errors.insert(
-                key.clone(),
-                TerminalError::Aborted {
-                    rid: key.rid.clone(),
-                },
-            );
+        if scheduler_backed && !submitting {
+            self.abort_runtime_request(key)?;
         }
-        call_result
+        Ok(())
     }
 
     // ------------------------------------------------------------------
@@ -400,7 +481,7 @@ impl PyBridge {
         F: for<'py> FnOnce(Python<'py>, &Py<PyAny>, Py<PyAny>) -> PyResult<()>,
     {
         // Closure args are: current Python token, RuntimeHandle, and the JSON chunk callback.
-        let submitted = self.create_channel(rid, false)?;
+        let submitted = self.create_channel(rid, false, false)?;
 
         let result = Python::attach(|py| -> PyResult<()> {
             let callback = self.make_json_callback(py, submitted.key.clone())?;
@@ -527,20 +608,52 @@ fn close_channel_with_error(
     runtime_handle: &Py<PyAny>,
     error: TerminalError,
 ) {
-    let is_active = {
-        let state = lock_or_recover(state.as_ref(), "state");
-        state
+    let (should_abort, had_consumer, scheduler_backed) = {
+        let mut state = lock_or_recover(state.as_ref(), "state");
+        let Some(channel) = state
             .channels
-            .get(key.rid())
-            .is_some_and(|channel| channel.incarnation == key.incarnation)
+            .get_mut(key.rid())
+            .filter(|channel| channel.incarnation == key.incarnation)
+        else {
+            return;
+        };
+        let sender = channel.sender.take();
+        let had_consumer = sender.as_ref().is_some_and(|sender| !sender.is_closed());
+        let should_abort =
+            channel.scheduler_backed && !channel.submitting && !channel.abort_requested;
+        channel.abort_requested = true;
+        let scheduler_backed = channel.scheduler_backed;
+        remove_auxiliary_refs_locked(&mut state, key);
+        if had_consumer {
+            state.terminal_errors.insert(key.clone(), error);
+        }
+        if !scheduler_backed {
+            state.channels.remove(key.rid());
+        }
+        (should_abort, had_consumer, scheduler_backed)
     };
-    if !is_active {
-        return;
+    if should_abort
+        && let Err(err) =
+            runtime_handle.call_method1(py, "abort", (key.rid(), Some(key.incarnation()), false))
+    {
+        let mut state = lock_or_recover(state.as_ref(), "state");
+        if let Some(channel) = state
+            .channels
+            .get_mut(key.rid())
+            .filter(|channel| channel.incarnation == key.incarnation)
+        {
+            channel.abort_requested = false;
+        }
+        tracing::warn!(
+            rid = key.rid(),
+            "Failed to abort closed gRPC request: {err}"
+        );
     }
-    let _ = runtime_handle.call_method1(py, "abort", (key.rid(), false));
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    if remove_channel_refs_locked(&mut state, key) {
-        state.terminal_errors.insert(key.clone(), error);
+    if !had_consumer && scheduler_backed {
+        tracing::debug!(
+            rid = key.rid(),
+            "Retaining request tombstone until scheduler terminal"
+        );
     }
 }
 
@@ -564,13 +677,20 @@ fn remove_channel_refs_locked(state: &mut BridgeState, key: &RequestKey) -> bool
 }
 
 fn finalize_explicit_abort_locked(state: &mut BridgeState, key: &RequestKey) {
-    let preserves_choice_terminals = state.channels.get(key.rid()).is_some_and(|channel| {
-        channel.incarnation == key.incarnation && channel.preserve_on_explicit_abort
-    });
-    if preserves_choice_terminals {
+    let Some(channel) = state
+        .channels
+        .get_mut(key.rid())
+        .filter(|channel| channel.incarnation == key.incarnation)
+    else {
+        return;
+    };
+    if channel.preserve_on_explicit_abort {
         return;
     }
-    if remove_channel_refs_locked(state, key) {
+    let had_consumer = channel.sender.take().is_some();
+    let scheduler_backed = channel.scheduler_backed;
+    remove_auxiliary_refs_locked(state, key);
+    if had_consumer {
         state.terminal_errors.insert(
             key.clone(),
             TerminalError::Aborted {
@@ -578,364 +698,14 @@ fn finalize_explicit_abort_locked(state: &mut BridgeState, key: &RequestKey) {
             },
         );
     }
+    if !scheduler_backed {
+        state.channels.remove(key.rid());
+    }
 }
 
 fn remove_channel_refs(key: &RequestKey, state: &BridgeStateRef) {
     let mut state = lock_or_recover(state.as_ref(), "state");
     remove_channel_refs_locked(&mut state, key);
-}
-
-fn register_pending_send(key: &RequestKey, state: &BridgeStateRef) -> bool {
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.insert(key.clone())
-}
-
-fn mark_send_ready(py: Python<'_>, key: &RequestKey, state: &BridgeStateRef) -> Option<Py<PyAny>> {
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    state.pending_sends.remove(key);
-    if let Some(callback) = state.ready_callbacks.get(key) {
-        Some(callback.clone_ref(py))
-    } else {
-        state.ready_signals.insert(key.clone());
-        None
-    }
-}
-
-fn notify_ready(py: Python<'_>, rid: &str, callback: Py<PyAny>) {
-    if let Err(err) = callback.call0(py) {
-        tracing::warn!(rid, "gRPC on_ready callback failed: {}", err);
-    }
-}
-
-fn set_on_ready_for_rid(
-    py: Python<'_>,
-    key: &RequestKey,
-    state: &BridgeStateRef,
-    on_ready: Py<PyAny>,
-) -> PyResult<()> {
-    let should_notify = {
-        let mut state = lock_or_recover(state.as_ref(), "state");
-        if state
-            .channels
-            .get(key.rid())
-            .is_none_or(|channel| channel.incarnation != key.incarnation)
-        {
-            return Ok(());
-        }
-        state
-            .ready_callbacks
-            .insert(key.clone(), on_ready.clone_ref(py));
-        state.ready_signals.remove(key)
-    };
-    if should_notify {
-        on_ready.call0(py)?;
-    }
-    Ok(())
-}
-
-fn clear_on_ready_for_rid(key: &RequestKey, state: &BridgeStateRef) {
-    // End notifications for this rid. Do not call set_on_ready again for the same rid.
-    let mut state = lock_or_recover(state.as_ref(), "state");
-    state.ready_callbacks.remove(key);
-    state.ready_signals.remove(key);
-}
-
-fn try_send_chunk(
-    py: Python<'_>,
-    key: &RequestKey,
-    state: &BridgeStateRef,
-    runtime_handle: &Py<PyAny>,
-    tokio_handle: &Handle,
-    sender: &Sender<ResponseChunk>,
-    msg: ResponseChunk,
-) -> PyResult<ChunkSendStatus> {
-    let terminal = msg.is_terminal();
-    match sender.try_send(msg) {
-        Ok(()) => {
-            if terminal {
-                remove_channel_refs(key, state);
-            }
-            Ok(ChunkSendStatus::Ready)
-        }
-        Err(TrySendError::Full(msg)) => {
-            if !register_pending_send(key, state) {
-                tracing::warn!(
-                    rid = key.rid(),
-                    "gRPC bridge received another chunk before the parked chunk drained; closing stream"
-                );
-                close_channel_with_error(
-                    py,
-                    key,
-                    state,
-                    runtime_handle,
-                    TerminalError::ChannelFull {
-                        rid: key.rid.clone(),
-                    },
-                );
-                return Ok(ChunkSendStatus::Closed);
-            }
-
-            let key_owned = key.clone();
-            let state = state.clone();
-            let runtime_handle = runtime_handle.clone_ref(py);
-            let sender = sender.clone();
-
-            tokio_handle.spawn(async move {
-                match sender.send(msg).await {
-                    Ok(()) => {
-                        if terminal {
-                            // Terminal chunks end the producer contract; no further on_ready
-                            // signal is fired after a parked Finished/Error drains.
-                            remove_channel_refs(&key_owned, &state);
-                            return;
-                        }
-
-                        Python::attach(|py| {
-                            if let Some(callback) = mark_send_ready(py, &key_owned, &state) {
-                                notify_ready(py, key_owned.rid(), callback);
-                            }
-                        });
-                    }
-                    Err(_) => {
-                        Python::attach(|py| {
-                            close_channel_with_error(
-                                py,
-                                &key_owned,
-                                &state,
-                                &runtime_handle,
-                                TerminalError::ClientDisconnected {
-                                    rid: key_owned.rid.clone(),
-                                },
-                            );
-                        });
-                    }
-                }
-            });
-
-            Ok(ChunkSendStatus::Pending)
-        }
-        Err(TrySendError::Closed(_)) => {
-            close_channel_with_error(
-                py,
-                key,
-                state,
-                runtime_handle,
-                TerminalError::ClientDisconnected {
-                    rid: key.rid.clone(),
-                },
-            );
-            Ok(ChunkSendStatus::Closed)
-        }
-    }
-}
-
-// Typed chunk callback for SGLang-native RPCs (dict-based chunks).
-#[pyclass]
-struct ChunkCallback {
-    key: RequestKey,
-    state: BridgeStateRef,
-    runtime_handle: Py<PyAny>,
-    tokio_handle: Handle,
-}
-
-#[pymethods]
-impl ChunkCallback {
-    /// Register before producing chunks. If a parked chunk drained before registration,
-    /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
-    fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
-    }
-
-    fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.key, &self.state);
-    }
-
-    #[pyo3(signature = (chunk, finished=false, error=None))]
-    fn __call__(
-        &self,
-        chunk: &Bound<'_, PyDict>,
-        finished: bool,
-        error: Option<String>,
-    ) -> PyResult<ChunkSendStatus> {
-        let py = chunk.py();
-        let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(self.key.rid()) {
-            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
-            None => return Ok(ChunkSendStatus::Closed),
-            Some(_) => return Ok(ChunkSendStatus::Closed),
-        };
-        drop(state);
-
-        if let Some(err_msg) = error {
-            return try_send_chunk(
-                py,
-                &self.key,
-                &self.state,
-                &self.runtime_handle,
-                &self.tokio_handle,
-                &sender,
-                ResponseChunk::Error(err_msg),
-            );
-        }
-
-        let text: Option<String> = chunk
-            .get_item("text")?
-            .and_then(|v| v.extract::<String>().ok());
-
-        let output_ids: Option<Vec<i32>> = chunk
-            .get_item("output_ids")?
-            .and_then(|v| v.extract::<Vec<i32>>().ok());
-
-        let delta_output_ids: Option<Vec<i32>> = chunk
-            .get_item("delta_output_ids")?
-            .and_then(|v| v.extract::<Vec<i32>>().ok());
-
-        let embedding: Option<Vec<f32>> = chunk
-            .get_item("embedding")?
-            .and_then(|v| v.extract::<Vec<f32>>().ok());
-
-        let choice_index = chunk
-            .get_item("index")?
-            .and_then(|v| v.extract::<i32>().ok())
-            .unwrap_or(0);
-
-        let meta_info = extract_meta_info(chunk);
-
-        let data = ResponseData {
-            text,
-            output_ids,
-            delta_output_ids,
-            embedding,
-            choice_index,
-            json_bytes: None,
-            meta_info,
-        };
-
-        let msg = if finished {
-            ResponseChunk::Finished(data)
-        } else {
-            ResponseChunk::Data(data)
-        };
-
-        try_send_chunk(
-            py,
-            &self.key,
-            &self.state,
-            &self.runtime_handle,
-            &self.tokio_handle,
-            &sender,
-            msg,
-        )
-    }
-}
-
-// JSON chunk callback for OpenAI pass-through RPCs (raw bytes).
-#[pyclass]
-struct JsonChunkCallback {
-    key: RequestKey,
-    state: BridgeStateRef,
-    runtime_handle: Py<PyAny>,
-    tokio_handle: Handle,
-}
-
-#[pymethods]
-impl JsonChunkCallback {
-    /// Register before producing chunks. If a parked chunk drained before registration,
-    /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
-    fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
-        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
-    }
-
-    fn clear_on_ready(&self) {
-        clear_on_ready_for_rid(&self.key, &self.state);
-    }
-
-    #[pyo3(signature = (chunk_bytes, finished=false, error=None, status_code=None))]
-    fn __call__(
-        &self,
-        chunk_bytes: &Bound<'_, pyo3::PyAny>,
-        finished: bool,
-        error: Option<String>,
-        status_code: Option<i32>,
-    ) -> PyResult<ChunkSendStatus> {
-        let py = chunk_bytes.py();
-        let state = lock_or_recover(self.state.as_ref(), "state");
-        let sender = match state.channels.get(self.key.rid()) {
-            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
-            None => return Ok(ChunkSendStatus::Closed),
-            Some(_) => return Ok(ChunkSendStatus::Closed),
-        };
-        drop(state);
-
-        if let Some(err_msg) = error {
-            return try_send_chunk(
-                py,
-                &self.key,
-                &self.state,
-                &self.runtime_handle,
-                &self.tokio_handle,
-                &sender,
-                ResponseChunk::Error(err_msg),
-            );
-        }
-
-        let bytes_data: Vec<u8> = if let Ok(b) = chunk_bytes.extract::<Vec<u8>>() {
-            b
-        } else if let Ok(s) = chunk_bytes.extract::<String>() {
-            s.into_bytes()
-        } else {
-            vec![]
-        };
-
-        let mut meta_info = HashMap::new();
-        if let Some(code) = status_code {
-            meta_info.insert("status_code".to_string(), code.to_string());
-        }
-
-        let data = ResponseData {
-            text: None,
-            output_ids: None,
-            delta_output_ids: None,
-            embedding: None,
-            choice_index: 0,
-            json_bytes: Some(bytes_data),
-            meta_info,
-        };
-
-        let msg = if finished {
-            ResponseChunk::Finished(data)
-        } else {
-            ResponseChunk::Data(data)
-        };
-
-        try_send_chunk(
-            py,
-            &self.key,
-            &self.state,
-            &self.runtime_handle,
-            &self.tokio_handle,
-            &sender,
-            msg,
-        )
-    }
-}
-
-fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
-    let mut meta = HashMap::new();
-    if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
-        && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
-    {
-        for (k, v) in meta_dict.iter() {
-            // The proto schema is map<string, string>; encode each Python value as JSON
-            // so clients can recover numbers, booleans, arrays, and objects losslessly.
-            if let Ok(key) = k.extract::<String>()
-                && let Ok(val) = py_value_to_json_string(&v)
-            {
-                meta.insert(key, val);
-            }
-        }
-    }
-    meta
 }
 
 #[cfg(test)]

--- a/rust/sglang-grpc/src/bridge/callbacks.rs
+++ b/rust/sglang-grpc/src/bridge/callbacks.rs
@@ -1,0 +1,389 @@
+use super::*;
+
+fn register_pending_send(key: &RequestKey, state: &BridgeStateRef) -> bool {
+    let mut state = lock_or_recover(state.as_ref(), "state");
+    if state
+        .channels
+        .get(key.rid())
+        .is_none_or(|channel| channel.incarnation != key.incarnation || channel.sender.is_none())
+    {
+        return false;
+    }
+    state.pending_sends.insert(key.clone())
+}
+
+fn mark_send_ready(py: Python<'_>, key: &RequestKey, state: &BridgeStateRef) -> Option<Py<PyAny>> {
+    let mut state = lock_or_recover(state.as_ref(), "state");
+    state.pending_sends.remove(key);
+    if state
+        .channels
+        .get(key.rid())
+        .is_none_or(|channel| channel.incarnation != key.incarnation || channel.sender.is_none())
+    {
+        return None;
+    }
+    if let Some(callback) = state.ready_callbacks.get(key) {
+        Some(callback.clone_ref(py))
+    } else {
+        state.ready_signals.insert(key.clone());
+        None
+    }
+}
+
+fn notify_ready(py: Python<'_>, rid: &str, callback: Py<PyAny>) {
+    if let Err(err) = callback.call0(py) {
+        tracing::warn!(rid, "gRPC on_ready callback failed: {}", err);
+    }
+}
+
+fn set_on_ready_for_rid(
+    py: Python<'_>,
+    key: &RequestKey,
+    state: &BridgeStateRef,
+    on_ready: Py<PyAny>,
+) -> PyResult<()> {
+    let should_notify = {
+        let mut state = lock_or_recover(state.as_ref(), "state");
+        if state.channels.get(key.rid()).is_none_or(|channel| {
+            channel.incarnation != key.incarnation || channel.sender.is_none()
+        }) {
+            return Ok(());
+        }
+        state
+            .ready_callbacks
+            .insert(key.clone(), on_ready.clone_ref(py));
+        state.ready_signals.remove(key)
+    };
+    if should_notify {
+        on_ready.call0(py)?;
+    }
+    Ok(())
+}
+
+fn clear_on_ready_for_rid(key: &RequestKey, state: &BridgeStateRef) {
+    // End notifications for this rid. Do not call set_on_ready again for the same rid.
+    let mut state = lock_or_recover(state.as_ref(), "state");
+    state.ready_callbacks.remove(key);
+    state.ready_signals.remove(key);
+}
+
+fn try_send_chunk(
+    py: Python<'_>,
+    key: &RequestKey,
+    state: &BridgeStateRef,
+    runtime_handle: &Py<PyAny>,
+    tokio_handle: &Handle,
+    sender: &Sender<ResponseChunk>,
+    msg: ResponseChunk,
+) -> PyResult<ChunkSendStatus> {
+    let terminal = msg.is_terminal();
+    match sender.try_send(msg) {
+        Ok(()) => {
+            if terminal {
+                remove_channel_refs(key, state);
+            }
+            Ok(ChunkSendStatus::Ready)
+        }
+        Err(TrySendError::Full(msg)) => {
+            if !register_pending_send(key, state) {
+                tracing::warn!(
+                    rid = key.rid(),
+                    "gRPC bridge received another chunk before the parked chunk drained; closing stream"
+                );
+                close_channel_with_error(
+                    py,
+                    key,
+                    state,
+                    runtime_handle,
+                    TerminalError::ChannelFull {
+                        rid: key.rid.clone(),
+                    },
+                );
+                return Ok(ChunkSendStatus::Closed);
+            }
+
+            let key_owned = key.clone();
+            let state = state.clone();
+            let runtime_handle = runtime_handle.clone_ref(py);
+            let sender = sender.clone();
+
+            tokio_handle.spawn(async move {
+                match sender.send(msg).await {
+                    Ok(()) => {
+                        if terminal {
+                            // Terminal chunks end the producer contract; no further on_ready
+                            // signal is fired after a parked Finished/Error drains.
+                            remove_channel_refs(&key_owned, &state);
+                            return;
+                        }
+
+                        Python::attach(|py| {
+                            if let Some(callback) = mark_send_ready(py, &key_owned, &state) {
+                                notify_ready(py, key_owned.rid(), callback);
+                            }
+                        });
+                    }
+                    Err(_) if terminal => {
+                        // The scheduler terminal reached the bridge even though the
+                        // consumer disappeared before the parked send drained.
+                        remove_channel_refs(&key_owned, &state);
+                    }
+                    Err(_) => {
+                        Python::attach(|py| {
+                            close_channel_with_error(
+                                py,
+                                &key_owned,
+                                &state,
+                                &runtime_handle,
+                                TerminalError::ClientDisconnected {
+                                    rid: key_owned.rid.clone(),
+                                },
+                            );
+                        });
+                    }
+                }
+            });
+
+            Ok(ChunkSendStatus::Pending)
+        }
+        Err(TrySendError::Closed(_)) => {
+            if terminal {
+                remove_channel_refs(key, state);
+                return Ok(ChunkSendStatus::Closed);
+            }
+            close_channel_with_error(
+                py,
+                key,
+                state,
+                runtime_handle,
+                TerminalError::ClientDisconnected {
+                    rid: key.rid.clone(),
+                },
+            );
+            Ok(ChunkSendStatus::Closed)
+        }
+    }
+}
+
+// Typed chunk callback for SGLang-native RPCs (dict-based chunks).
+#[pyclass]
+pub(super) struct ChunkCallback {
+    pub(super) key: RequestKey,
+    pub(super) state: BridgeStateRef,
+    pub(super) runtime_handle: Py<PyAny>,
+    pub(super) tokio_handle: Handle,
+}
+
+#[pymethods]
+impl ChunkCallback {
+    /// Register before producing chunks. If a parked chunk drained before registration,
+    /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
+    fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
+    }
+
+    fn clear_on_ready(&self) {
+        clear_on_ready_for_rid(&self.key, &self.state);
+    }
+
+    #[pyo3(signature = (chunk, finished=false, error=None))]
+    fn __call__(
+        &self,
+        chunk: &Bound<'_, PyDict>,
+        finished: bool,
+        error: Option<String>,
+    ) -> PyResult<ChunkSendStatus> {
+        let py = chunk.py();
+        let state = lock_or_recover(self.state.as_ref(), "state");
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
+            None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
+        };
+        drop(state);
+
+        let Some(sender) = sender else {
+            if finished || error.is_some() {
+                remove_channel_refs(&self.key, &self.state);
+            }
+            return Ok(ChunkSendStatus::Closed);
+        };
+
+        if let Some(err_msg) = error {
+            return try_send_chunk(
+                py,
+                &self.key,
+                &self.state,
+                &self.runtime_handle,
+                &self.tokio_handle,
+                &sender,
+                ResponseChunk::Error(err_msg),
+            );
+        }
+
+        let text: Option<String> = chunk
+            .get_item("text")?
+            .and_then(|v| v.extract::<String>().ok());
+
+        let output_ids: Option<Vec<i32>> = chunk
+            .get_item("output_ids")?
+            .and_then(|v| v.extract::<Vec<i32>>().ok());
+
+        let delta_output_ids: Option<Vec<i32>> = chunk
+            .get_item("delta_output_ids")?
+            .and_then(|v| v.extract::<Vec<i32>>().ok());
+
+        let embedding: Option<Vec<f32>> = chunk
+            .get_item("embedding")?
+            .and_then(|v| v.extract::<Vec<f32>>().ok());
+
+        let choice_index = chunk
+            .get_item("index")?
+            .and_then(|v| v.extract::<i32>().ok())
+            .unwrap_or(0);
+
+        let meta_info = extract_meta_info(chunk);
+
+        let data = ResponseData {
+            text,
+            output_ids,
+            delta_output_ids,
+            embedding,
+            choice_index,
+            json_bytes: None,
+            meta_info,
+        };
+
+        let msg = if finished {
+            ResponseChunk::Finished(data)
+        } else {
+            ResponseChunk::Data(data)
+        };
+
+        try_send_chunk(
+            py,
+            &self.key,
+            &self.state,
+            &self.runtime_handle,
+            &self.tokio_handle,
+            &sender,
+            msg,
+        )
+    }
+}
+
+// JSON chunk callback for OpenAI pass-through RPCs (raw bytes).
+#[pyclass]
+pub(super) struct JsonChunkCallback {
+    pub(super) key: RequestKey,
+    pub(super) state: BridgeStateRef,
+    pub(super) runtime_handle: Py<PyAny>,
+    pub(super) tokio_handle: Handle,
+}
+
+#[pymethods]
+impl JsonChunkCallback {
+    /// Register before producing chunks. If a parked chunk drained before registration,
+    /// Rust fires `on_ready` immediately so late registration cannot miss the edge.
+    fn set_on_ready(&self, py: Python<'_>, on_ready: Py<PyAny>) -> PyResult<()> {
+        set_on_ready_for_rid(py, &self.key, &self.state, on_ready)
+    }
+
+    fn clear_on_ready(&self) {
+        clear_on_ready_for_rid(&self.key, &self.state);
+    }
+
+    #[pyo3(signature = (chunk_bytes, finished=false, error=None, status_code=None))]
+    fn __call__(
+        &self,
+        chunk_bytes: &Bound<'_, pyo3::PyAny>,
+        finished: bool,
+        error: Option<String>,
+        status_code: Option<i32>,
+    ) -> PyResult<ChunkSendStatus> {
+        let py = chunk_bytes.py();
+        let state = lock_or_recover(self.state.as_ref(), "state");
+        let sender = match state.channels.get(self.key.rid()) {
+            Some(channel) if channel.incarnation == self.key.incarnation => channel.sender.clone(),
+            None => return Ok(ChunkSendStatus::Closed),
+            Some(_) => return Ok(ChunkSendStatus::Closed),
+        };
+        drop(state);
+
+        let Some(sender) = sender else {
+            if finished || error.is_some() {
+                remove_channel_refs(&self.key, &self.state);
+            }
+            return Ok(ChunkSendStatus::Closed);
+        };
+
+        if let Some(err_msg) = error {
+            return try_send_chunk(
+                py,
+                &self.key,
+                &self.state,
+                &self.runtime_handle,
+                &self.tokio_handle,
+                &sender,
+                ResponseChunk::Error(err_msg),
+            );
+        }
+
+        let bytes_data: Vec<u8> = if let Ok(b) = chunk_bytes.extract::<Vec<u8>>() {
+            b
+        } else if let Ok(s) = chunk_bytes.extract::<String>() {
+            s.into_bytes()
+        } else {
+            vec![]
+        };
+
+        let mut meta_info = HashMap::new();
+        if let Some(code) = status_code {
+            meta_info.insert("status_code".to_string(), code.to_string());
+        }
+
+        let data = ResponseData {
+            text: None,
+            output_ids: None,
+            delta_output_ids: None,
+            embedding: None,
+            choice_index: 0,
+            json_bytes: Some(bytes_data),
+            meta_info,
+        };
+
+        let msg = if finished {
+            ResponseChunk::Finished(data)
+        } else {
+            ResponseChunk::Data(data)
+        };
+
+        try_send_chunk(
+            py,
+            &self.key,
+            &self.state,
+            &self.runtime_handle,
+            &self.tokio_handle,
+            &sender,
+            msg,
+        )
+    }
+}
+
+fn extract_meta_info(chunk: &Bound<'_, PyDict>) -> HashMap<String, String> {
+    let mut meta = HashMap::new();
+    if let Ok(Some(meta_obj)) = chunk.get_item("meta_info")
+        && let Ok(meta_dict) = meta_obj.cast::<PyDict>()
+    {
+        for (k, v) in meta_dict.iter() {
+            // The proto schema is map<string, string>; encode each Python value as JSON
+            // so clients can recover numbers, booleans, arrays, and objects losslessly.
+            if let Ok(key) = k.extract::<String>()
+                && let Ok(val) = py_value_to_json_string(&v)
+            {
+                meta.insert(key, val);
+            }
+        }
+    }
+    meta
+}

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -34,8 +34,11 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
             current_key.rid.clone(),
             ActiveChannel {
                 incarnation: current_key.incarnation,
-                sender,
+                sender: Some(sender),
                 preserve_on_explicit_abort: false,
+                scheduler_backed: true,
+                submitting: false,
+                abort_requested: false,
             },
         );
         state.pending_sends.insert(old_key.clone());
@@ -65,8 +68,11 @@ fn explicit_abort_keeps_choice_aware_channel_for_terminal_errors() {
         key.rid.clone(),
         ActiveChannel {
             incarnation: key.incarnation,
-            sender,
+            sender: Some(sender),
             preserve_on_explicit_abort: true,
+            scheduler_backed: true,
+            submitting: false,
+            abort_requested: true,
         },
     );
 
@@ -74,4 +80,31 @@ fn explicit_abort_keeps_choice_aware_channel_for_terminal_errors() {
 
     assert!(state.channels.contains_key(key.rid()));
     assert!(!state.terminal_errors.contains_key(&key));
+}
+
+#[test]
+fn explicit_abort_closes_legacy_consumer_but_reserves_request_id() {
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let key = RequestKey {
+        rid: "legacy".to_string(),
+        incarnation: 1,
+    };
+    let mut state = BridgeState::default();
+    state.channels.insert(
+        key.rid.clone(),
+        ActiveChannel {
+            incarnation: key.incarnation,
+            sender: Some(sender),
+            preserve_on_explicit_abort: false,
+            scheduler_backed: true,
+            submitting: false,
+            abort_requested: true,
+        },
+    );
+
+    finalize_explicit_abort_locked(&mut state, &key);
+
+    let channel = state.channels.get(key.rid()).unwrap();
+    assert!(channel.sender.is_none());
+    assert!(state.terminal_errors.contains_key(&key));
 }

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -35,6 +35,7 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
             ActiveChannel {
                 incarnation: current_key.incarnation,
                 sender,
+                preserve_on_explicit_abort: false,
             },
         );
         state.pending_sends.insert(old_key.clone());
@@ -50,4 +51,27 @@ async fn stale_request_key_cannot_abort_reused_request_id() {
         current_key.incarnation
     );
     assert!(!state.pending_sends.contains(&old_key));
+}
+
+#[test]
+fn explicit_abort_keeps_choice_aware_channel_for_terminal_errors() {
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let key = RequestKey {
+        rid: "multi-choice".to_string(),
+        incarnation: 1,
+    };
+    let mut state = BridgeState::default();
+    state.channels.insert(
+        key.rid.clone(),
+        ActiveChannel {
+            incarnation: key.incarnation,
+            sender,
+            preserve_on_explicit_abort: true,
+        },
+    );
+
+    finalize_explicit_abort_locked(&mut state, &key);
+
+    assert!(state.channels.contains_key(key.rid()));
+    assert!(!state.terminal_errors.contains_key(&key));
 }

--- a/rust/sglang-grpc/src/bridge/tests.rs
+++ b/rust/sglang-grpc/src/bridge/tests.rs
@@ -7,3 +7,47 @@ fn terminal_error_messages_include_request_id() {
     };
     assert!(error.message().contains("rid"));
 }
+
+#[tokio::test]
+async fn stale_request_key_cannot_abort_reused_request_id() {
+    Python::initialize();
+    let runtime_handle = Python::attach(|py| PyDict::new(py).clone().unbind().into_any());
+    let bridge = PyBridge::new(
+        runtime_handle,
+        None,
+        1,
+        1,
+        tokio::runtime::Handle::current(),
+    );
+    let (sender, _receiver) = tokio::sync::mpsc::channel(1);
+    let old_key = RequestKey {
+        rid: "reused".to_string(),
+        incarnation: 1,
+    };
+    let current_key = RequestKey {
+        rid: "reused".to_string(),
+        incarnation: 2,
+    };
+    {
+        let mut state = lock_or_recover(bridge.state.as_ref(), "state");
+        state.channels.insert(
+            current_key.rid.clone(),
+            ActiveChannel {
+                incarnation: current_key.incarnation,
+                sender,
+            },
+        );
+        state.pending_sends.insert(old_key.clone());
+    }
+
+    // The dict has no `abort` method, so this also proves the stale path never
+    // invokes the Python abort callback for the new incarnation.
+    bridge.abort_request(&old_key).unwrap();
+
+    let state = lock_or_recover(bridge.state.as_ref(), "state");
+    assert_eq!(
+        state.channels.get(current_key.rid()).unwrap().incarnation,
+        current_key.incarnation
+    );
+    assert!(!state.pending_sends.contains(&old_key));
+}

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -11,7 +11,7 @@ use tokio_stream::Stream;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Request, Response, Status};
 
-use crate::bridge::{PyBridge, ResponseChunk, TerminalError};
+use crate::bridge::{PyBridge, RequestKey, ResponseChunk, SubmittedRequest, TerminalError};
 use crate::proto;
 use crate::utils::{
     build_classify_dict, build_embed_dict, build_generate_dict, build_text_embed_dict,
@@ -87,15 +87,15 @@ async fn recv_chunk_with_timeout(
 
 struct RequestAbortGuard {
     bridge: Arc<PyBridge>,
-    rid: String,
+    key: RequestKey,
     armed: bool,
 }
 
 impl RequestAbortGuard {
-    fn new(bridge: Arc<PyBridge>, rid: impl Into<String>) -> Self {
+    fn new(bridge: Arc<PyBridge>, key: RequestKey) -> Self {
         Self {
             bridge,
-            rid: rid.into(),
+            key,
             armed: true,
         }
     }
@@ -107,7 +107,7 @@ impl RequestAbortGuard {
     fn abort_now(&mut self) {
         if self.armed {
             self.armed = false;
-            spawn_abort(self.bridge.clone(), self.rid.clone());
+            spawn_abort(self.bridge.clone(), self.key.clone());
         }
     }
 }
@@ -117,22 +117,22 @@ impl Drop for RequestAbortGuard {
         if self.armed {
             // Dropping a response stream means the client stopped consuming; propagate
             // cancellation to Python without blocking the Tokio worker.
-            spawn_abort(self.bridge.clone(), self.rid.clone());
+            spawn_abort(self.bridge.clone(), self.key.clone());
         }
     }
 }
 
-fn spawn_abort(bridge: Arc<PyBridge>, rid: String) {
+fn spawn_abort(bridge: Arc<PyBridge>, key: RequestKey) {
     match tokio::runtime::Handle::try_current() {
         Ok(handle) => {
             // Fire-and-forget: dropping the JoinHandle detaches the task.
             drop(handle.spawn_blocking(move || {
-                let _ = bridge.abort(&rid, false);
+                let _ = bridge.abort_request(&key);
             }));
         }
         Err(_) => {
             tracing::warn!(
-                rid,
+                rid = key.rid(),
                 "Skipping gRPC request abort because no Tokio runtime is available"
             );
         }
@@ -141,11 +141,11 @@ fn spawn_abort(bridge: Arc<PyBridge>, rid: String) {
 
 async fn recv_terminal_chunk_for_request(
     bridge: &Arc<PyBridge>,
-    rid: &str,
+    key: &RequestKey,
     receiver: &mut Receiver<ResponseChunk>,
     response_timeout: Duration,
 ) -> Result<ResponseChunk, Status> {
-    let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid.to_string());
+    let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
 
     match recv_chunk_with_timeout(receiver, response_timeout, || {
         format!("Request timed out after {}s", response_timeout.as_secs())
@@ -154,7 +154,7 @@ async fn recv_terminal_chunk_for_request(
     {
         Ok(Some(ResponseChunk::Data(_))) => {
             tracing::warn!(
-                rid,
+                rid = key.rid(),
                 "Unary gRPC response received non-terminal Data chunk; expected Finished"
             );
             abort_guard.abort_now();
@@ -167,7 +167,7 @@ async fn recv_terminal_chunk_for_request(
             Ok(chunk)
         }
         Ok(None) => {
-            let (status, should_abort) = closed_stream_status(bridge, rid);
+            let (status, should_abort) = closed_stream_status(bridge, key);
             if should_abort {
                 abort_guard.abort_now();
             } else {
@@ -186,8 +186,8 @@ async fn recv_terminal_chunk_for_request(
     }
 }
 
-fn closed_stream_status(bridge: &Arc<PyBridge>, rid: &str) -> (Status, bool) {
-    if let Some(error) = bridge.take_terminal_error(rid) {
+fn closed_stream_status(bridge: &Arc<PyBridge>, key: &RequestKey) -> (Status, bool) {
+    if let Some(error) = bridge.take_terminal_error(key) {
         (terminal_error_status(error), false)
     } else {
         (
@@ -231,17 +231,16 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_text_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_request(&rid, "generate", req_dict)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
-        let rid_clone = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
                     Ok(Some(ResponseChunk::Data(data))) => {
@@ -266,7 +265,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -300,17 +299,16 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_request(&rid, "generate", req_dict)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
-        let rid_clone = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
                     Ok(Some(ResponseChunk::Data(data))) => {
@@ -335,7 +333,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -369,14 +367,14 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_text_embed_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_request(&rid, "embed", req_dict)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -404,14 +402,14 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_embed_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_request(&rid, "embed", req_dict)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -446,14 +444,14 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_classify_dict(&rid, &req);
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_request(&rid, "embed", req_dict)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -642,13 +640,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::GetLoadResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_get_load(&rid, req.dp_rank)
             .map_err(|e| pyerr_to_status(e, "Failed to get load"))?;
 
-        let json_info =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_info = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         Ok(Response::new(proto::GetLoadResponse { json_info }))
     }
 
@@ -679,13 +676,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::FlushCacheRequest>,
     ) -> Result<Response<proto::FlushCacheResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_flush_cache(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to flush cache"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::FlushCacheResponse {
@@ -700,13 +696,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::PauseGenerationResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_pause_generation(&rid, &req.mode)
             .map_err(|e| pyerr_to_status(e, "Failed to pause generation"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::PauseGenerationResponse {
@@ -719,13 +714,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::ContinueGenerationRequest>,
     ) -> Result<Response<proto::ContinueGenerationResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_continue_generation(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to continue generation"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::ContinueGenerationResponse {
@@ -792,13 +786,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::StartProfileResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_start_profile(&rid, req.output_dir.as_deref())
             .map_err(|e| pyerr_to_status(e, "Failed to start profile"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::StartProfileResponse {
@@ -811,13 +804,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
         _request: Request<proto::StopProfileRequest>,
     ) -> Result<Response<proto::StopProfileResponse>, Status> {
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_stop_profile(&rid)
             .map_err(|e| pyerr_to_status(e, "Failed to stop profile"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::StopProfileResponse {
@@ -831,13 +823,12 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     ) -> Result<Response<proto::UpdateWeightsResponse>, Status> {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
-        let receiver = self
+        let submitted = self
             .bridge
             .submit_update_weights(&rid, &req.model_path, req.load_format.as_deref())
             .map_err(|e| pyerr_to_status(e, "Failed to update weights"))?;
 
-        let json_str =
-            recv_json_response(&self.bridge, &rid, receiver, self.response_timeout).await?;
+        let json_str = recv_json_response(&self.bridge, submitted, self.response_timeout).await?;
         let v: serde_json::Value = serde_json::from_str(&json_str)
             .map_err(|e| Status::internal(format!("Failed to parse JSON response: {}", e)))?;
         Ok(Response::new(proto::UpdateWeightsResponse {
@@ -857,17 +848,16 @@ impl SglangServiceImpl {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
-        let rid_clone = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
-            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), rid_clone.clone());
+            let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
                     Ok(Some(ResponseChunk::Data(data))) => {
@@ -891,7 +881,7 @@ impl SglangServiceImpl {
                         break;
                     }
                     Ok(None) => {
-                        let (status, should_abort) = closed_stream_status(&bridge, &rid_clone);
+                        let (status, should_abort) = closed_stream_status(&bridge, &key);
                         if should_abort {
                             abort_guard.abort_now();
                         } else {
@@ -920,14 +910,14 @@ impl SglangServiceImpl {
         let req = request.into_inner();
         let rid = uuid::Uuid::new_v4().to_string();
 
-        let mut receiver = self
+        let SubmittedRequest { key, mut receiver } = self
             .bridge
             .submit_openai(&rid, method_name, &req.json_body, &req.trace_headers)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
             &self.bridge,
-            &rid,
+            &key,
             &mut receiver,
             self.response_timeout,
         )
@@ -954,12 +944,12 @@ impl SglangServiceImpl {
 /// Receive a single JSON response from the bridge channel.
 async fn recv_json_response(
     bridge: &Arc<PyBridge>,
-    rid: &str,
-    mut receiver: Receiver<ResponseChunk>,
+    submitted: SubmittedRequest,
     response_timeout: Duration,
 ) -> Result<String, Status> {
+    let SubmittedRequest { key, mut receiver } = submitted;
     let chunk =
-        recv_terminal_chunk_for_request(bridge, rid, &mut receiver, response_timeout).await?;
+        recv_terminal_chunk_for_request(bridge, &key, &mut receiver, response_timeout).await?;
 
     match chunk {
         ResponseChunk::Data(data) | ResponseChunk::Finished(data) => {

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -438,7 +438,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "generate", req_dict, true)
+            .submit_request(&rid, "generate", req_dict, expected_choices > 1)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();

--- a/rust/sglang-grpc/src/server.rs
+++ b/rust/sglang-grpc/src/server.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -214,6 +214,142 @@ fn openai_status_code(meta_info: &HashMap<String, String>, default: i32) -> i32 
         .unwrap_or(default)
 }
 
+const MAX_GENERATION_CHOICES: i32 = 1024;
+
+fn expected_generation_choices(request: &proto::GenerateRequest) -> Result<usize, Box<Status>> {
+    let choices = request
+        .sampling_params
+        .as_ref()
+        .and_then(|params| params.n)
+        .unwrap_or(1);
+    if !(1..=MAX_GENERATION_CHOICES).contains(&choices) {
+        return Err(Box::new(Status::invalid_argument(format!(
+            "sampling_params.n must be between 1 and {MAX_GENERATION_CHOICES}, got {choices}"
+        ))));
+    }
+    Ok(choices as usize)
+}
+
+fn finish_reason_value(
+    meta_info: &HashMap<String, String>,
+) -> Result<Option<serde_json::Value>, String> {
+    let Some(encoded) = meta_info.get("finish_reason") else {
+        return Ok(None);
+    };
+    let value: serde_json::Value = serde_json::from_str(encoded)
+        .map_err(|error| format!("SGLang returned malformed finish_reason: {error}"))?;
+    Ok((!value.is_null()).then_some(value))
+}
+
+struct ChoiceTracker {
+    expected: usize,
+    terminal: HashSet<i32>,
+}
+
+impl ChoiceTracker {
+    fn new(expected: usize) -> Self {
+        Self {
+            expected,
+            terminal: HashSet::new(),
+        }
+    }
+
+    fn observe(
+        &mut self,
+        choice_index: i32,
+        choice_terminal: bool,
+        request_finished: bool,
+    ) -> Result<bool, String> {
+        if choice_index < 0 || choice_index as usize >= self.expected {
+            return Err(format!(
+                "SGLang returned choice index {choice_index} outside 0..{}",
+                self.expected
+            ));
+        }
+        if self.terminal.contains(&choice_index) {
+            return Err(format!(
+                "SGLang returned data after terminal for choice {choice_index}"
+            ));
+        }
+        if choice_terminal {
+            self.terminal.insert(choice_index);
+        }
+        if request_finished && self.terminal.len() != self.expected {
+            return Err(format!(
+                "SGLang closed Generate after {}/{} terminal choices",
+                self.terminal.len(),
+                self.expected
+            ));
+        }
+        Ok(self.terminal.len() == self.expected)
+    }
+}
+
+enum GenerationTerminal {
+    Finish(proto::GenerationFinish),
+    Error(proto::GenerationError),
+}
+
+fn generation_terminal(finish_reason: Option<&serde_json::Value>) -> GenerationTerminal {
+    let Some(value) = finish_reason else {
+        return GenerationTerminal::Error(proto::GenerationError {
+            code: proto::GenerationErrorCode::Internal as i32,
+            message: "SGLang stream ended without finish_reason".into(),
+            retryable: false,
+        });
+    };
+    let finish_type = value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .or_else(|| value.as_str())
+        .unwrap_or("error");
+    if matches!(finish_type, "abort" | "error") {
+        let status_code = value.get("status_code").and_then(serde_json::Value::as_i64);
+        let (code, retryable) = match status_code {
+            Some(408 | 504) => (proto::GenerationErrorCode::DeadlineExceeded, true),
+            Some(499) => (proto::GenerationErrorCode::Cancelled, false),
+            Some(400..=499) => (proto::GenerationErrorCode::InvalidArgument, false),
+            Some(503) => (proto::GenerationErrorCode::Unavailable, true),
+            None if finish_type == "abort" => (proto::GenerationErrorCode::Cancelled, false),
+            _ => (proto::GenerationErrorCode::Internal, false),
+        };
+        return GenerationTerminal::Error(proto::GenerationError {
+            code: code as i32,
+            message: value
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("SGLang generation failed")
+                .to_string(),
+            retryable,
+        });
+    }
+
+    let reason = match finish_type {
+        "stop" => proto::FinishReason::Stop,
+        "length" => proto::FinishReason::Length,
+        "cancelled" => proto::FinishReason::Cancelled,
+        _ => proto::FinishReason::Unspecified,
+    };
+    let stop_reason = value.get("matched").and_then(|matched| {
+        use proto::stop_reason::Reason;
+        let reason = if let Some(value) = matched.as_str() {
+            Some(Reason::MatchedString(value.to_string()))
+        } else {
+            matched
+                .as_i64()
+                .and_then(|value| i32::try_from(value).ok())
+                .map(Reason::MatchedTokenId)
+        }?;
+        Some(proto::StopReason {
+            reason: Some(reason),
+        })
+    });
+    GenerationTerminal::Finish(proto::GenerationFinish {
+        reason: reason as i32,
+        stop_reason,
+    })
+}
+
 #[tonic::async_trait]
 impl proto::sglang_service_server::SglangService for SglangServiceImpl {
     // --- SGLang-native RPCs: TextGenerate / Generate ---
@@ -233,7 +369,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "generate", req_dict)
+            .submit_request(&rid, "generate", req_dict, false)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
@@ -298,34 +434,75 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
             .clone()
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         let req_dict = build_generate_dict(&rid, &req).map_err(Status::invalid_argument)?;
+        let expected_choices = expected_generation_choices(&req).map_err(|status| *status)?;
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "generate", req_dict)
+            .submit_request(&rid, "generate", req_dict, true)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let bridge = self.bridge.clone();
+        let public_rid = rid.clone();
         let response_timeout = self.response_timeout;
 
         let stream = async_stream::stream! {
             let mut abort_guard = RequestAbortGuard::new(bridge.clone(), key.clone());
+            let mut choices = ChoiceTracker::new(expected_choices);
             loop {
                 match recv_chunk_with_timeout(&mut receiver, response_timeout, || "Stream chunk timed out".to_string()).await {
-                    Ok(Some(ResponseChunk::Data(data))) => {
-                        yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
-                            meta_info: data.meta_info,
-                            finished: false,
+                    Ok(Some(chunk @ (ResponseChunk::Data(_) | ResponseChunk::Finished(_)))) => {
+                        let request_finished = matches!(&chunk, ResponseChunk::Finished(_));
+                        let data = match chunk {
+                            ResponseChunk::Data(data) | ResponseChunk::Finished(data) => data,
+                            ResponseChunk::Error(_) => unreachable!(),
+                        };
+                        let finish_reason = match finish_reason_value(&data.meta_info) {
+                            Ok(value) => value,
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        let choice_terminal = request_finished || finish_reason.is_some();
+                        let all_terminal = match choices.observe(
+                            data.choice_index,
+                            choice_terminal,
+                            request_finished,
+                        ) {
+                            Ok(all_terminal) => all_terminal,
+                            Err(error) => {
+                                abort_guard.abort_now();
+                                yield Err(Status::internal(error));
+                                break;
+                            }
+                        };
+                        let output_ids = data.output_ids.unwrap_or_default();
+                        let terminal = choice_terminal.then(|| match generation_terminal(finish_reason.as_ref()) {
+                            GenerationTerminal::Finish(finish) => {
+                                proto::generate_response::Terminal::Finish(finish)
+                            }
+                            GenerationTerminal::Error(error) => {
+                                proto::generate_response::Terminal::Error(error)
+                            }
                         });
-                    }
-                    Ok(Some(ResponseChunk::Finished(data))) => {
-                        abort_guard.disarm();
+                        if all_terminal {
+                            abort_guard.disarm();
+                        }
                         yield Ok(proto::GenerateResponse {
-                            output_ids: data.output_ids.unwrap_or_default(),
+                            delta_output_ids: data
+                                .delta_output_ids
+                                .unwrap_or_else(|| output_ids.clone()),
+                            output_ids,
                             meta_info: data.meta_info,
-                            finished: true,
+                            finished: request_finished,
+                            request_id: public_rid.clone(),
+                            choice_index: data.choice_index,
+                            terminal,
                         });
-                        break;
+                        if all_terminal {
+                            break;
+                        }
                     }
                     Ok(Some(ResponseChunk::Error(msg))) => {
                         abort_guard.disarm();
@@ -369,7 +546,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(&rid, "embed", req_dict, false)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
@@ -404,7 +581,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(&rid, "embed", req_dict, false)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(
@@ -446,7 +623,7 @@ impl proto::sglang_service_server::SglangService for SglangServiceImpl {
 
         let SubmittedRequest { key, mut receiver } = self
             .bridge
-            .submit_request(&rid, "embed", req_dict)
+            .submit_request(&rid, "embed", req_dict, false)
             .map_err(|e| pyerr_to_status(e, "Failed to submit request"))?;
 
         let chunk = recv_terminal_chunk_for_request(

--- a/rust/sglang-grpc/src/server/tests.rs
+++ b/rust/sglang-grpc/src/server/tests.rs
@@ -1,8 +1,9 @@
 use super::{
-    DEFAULT_GRPC_MAX_MESSAGE_SIZE, openai_status_code, resolve_max_message_size,
-    terminal_error_status,
+    ChoiceTracker, DEFAULT_GRPC_MAX_MESSAGE_SIZE, GenerationTerminal, generation_terminal,
+    openai_status_code, resolve_max_message_size, terminal_error_status,
 };
 use crate::bridge::TerminalError;
+use crate::proto;
 use std::collections::HashMap;
 use tonic::Code;
 
@@ -36,6 +37,47 @@ fn terminal_error_status_maps_abort_to_cancelled() {
     });
 
     assert_eq!(status.code(), Code::Cancelled);
+}
+
+#[test]
+fn choice_tracker_requires_one_terminal_per_choice() {
+    let mut tracker = ChoiceTracker::new(2);
+
+    assert!(!tracker.observe(0, false, false).unwrap());
+    assert!(!tracker.observe(0, true, false).unwrap());
+    assert!(tracker.observe(1, true, true).unwrap());
+    assert!(tracker.observe(1, false, false).is_err());
+    assert!(ChoiceTracker::new(2).observe(2, false, false).is_err());
+    assert!(ChoiceTracker::new(2).observe(0, true, true).is_err());
+}
+
+#[test]
+fn generation_terminal_maps_stop_and_scheduler_error() {
+    let stop = serde_json::json!({"type": "stop", "matched": "END"});
+    match generation_terminal(Some(&stop)) {
+        GenerationTerminal::Finish(finish) => {
+            assert_eq!(finish.reason, proto::FinishReason::Stop as i32);
+            assert!(matches!(
+                finish.stop_reason.and_then(|reason| reason.reason),
+                Some(proto::stop_reason::Reason::MatchedString(value)) if value == "END"
+            ));
+        }
+        GenerationTerminal::Error(_) => panic!("expected a finish terminal"),
+    }
+
+    let error = serde_json::json!({
+        "type": "error",
+        "status_code": 503,
+        "message": "busy"
+    });
+    match generation_terminal(Some(&error)) {
+        GenerationTerminal::Error(error) => {
+            assert_eq!(error.code, proto::GenerationErrorCode::Unavailable as i32);
+            assert!(error.retryable);
+            assert_eq!(error.message, "busy");
+        }
+        GenerationTerminal::Finish(_) => panic!("expected an error terminal"),
+    }
 }
 
 // SAFETY: env vars are process-global; bundle all SGLANG_TONIC_PAYLOAD cases into one

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,6 +1,8 @@
 import asyncio
 import enum
+import threading
 import unittest
+from concurrent.futures import Future
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
@@ -109,6 +111,23 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             [[1], [2], [3]],
         )
         self.assertEqual([call[1] for call in callback.calls], [False, False, True])
+
+
+class TestNativeGrpcRequestLifecycle(CustomTestCase):
+    def test_reused_request_id_keeps_current_generation_future(self):
+        handle = RuntimeHandle.__new__(RuntimeHandle)
+        handle._active_generation_futures = {}
+        handle._generation_futures_lock = threading.Lock()
+        old_future = Future()
+        current_future = Future()
+
+        handle._track_generation_future("reused", old_future)
+        handle._track_generation_future("reused", current_future)
+        old_future.set_result(None)
+
+        self.assertIs(handle._active_generation_futures["reused"], current_future)
+        handle._cancel_generation_futures("reused", abort_all=False)
+        self.assertTrue(current_future.cancelled())
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -28,20 +28,23 @@ class _RecordingCallback:
 
 
 class _FakeTokenizerManager:
-    def __init__(self, responses):
+    def __init__(self, responses, *, incremental=False):
         self.responses = responses
+        self.server_args = SimpleNamespace(incremental_streaming_output=incremental)
 
-    def generate_request(self, obj, request=None):
+    def generate_request(self, obj, request=None, **kwargs):
         async def generate():
             for response in self.responses:
+                if isinstance(response, BaseException):
+                    raise response
                 yield response
 
         return generate()
 
 
-def _make_runtime_handle(responses):
+def _make_runtime_handle(responses, *, incremental=False):
     handle = RuntimeHandle.__new__(RuntimeHandle)
-    handle.tokenizer_manager = _FakeTokenizerManager(responses)
+    handle.tokenizer_manager = _FakeTokenizerManager(responses, incremental=incremental)
     return handle
 
 
@@ -50,8 +53,20 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
         callback = _RecordingCallback()
         responses = [
             [
-                {"output_ids": [1], "meta_info": {"id": "choice-0"}},
-                {"output_ids": [2], "meta_info": {"id": "choice-1"}},
+                {
+                    "output_ids": [1],
+                    "meta_info": {
+                        "id": "choice-0",
+                        "finish_reason": {"type": "stop"},
+                    },
+                },
+                {
+                    "output_ids": [2],
+                    "meta_info": {
+                        "id": "choice-1",
+                        "finish_reason": {"type": "length"},
+                    },
+                },
             ]
         ]
         handle = _make_runtime_handle(responses)
@@ -63,13 +78,18 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
                 callback,
                 stream=False,
                 request=None,
+                choice_aware=True,
             )
         )
 
         self.assertEqual([call[0]["output_ids"] for call in callback.calls], [[1], [2]])
+        self.assertEqual(
+            [call[0]["delta_output_ids"] for call in callback.calls], [[1], [2]]
+        )
+        self.assertEqual([call[0]["index"] for call in callback.calls], [0, 1])
         self.assertEqual([call[1] for call in callback.calls], [False, True])
 
-    def test_streaming_first_finished_choice_is_not_batch_terminal(self):
+    def test_streaming_preserves_interleaved_choice_identity_and_deltas(self):
         callback = _RecordingCallback()
         responses = [
             {
@@ -78,8 +98,13 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
                 "meta_info": {"id": "choice-0", "finish_reason": None},
             },
             {
+                "index": 1,
+                "output_ids": [3],
+                "meta_info": {"id": "choice-1", "finish_reason": None},
+            },
+            {
                 "index": 0,
-                "output_ids": [2],
+                "output_ids": [1, 2],
                 "meta_info": {
                     "id": "choice-0",
                     "finish_reason": {"type": "stop"},
@@ -87,10 +112,10 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             },
             {
                 "index": 1,
-                "output_ids": [3],
+                "output_ids": [3, 4],
                 "meta_info": {
                     "id": "choice-1",
-                    "finish_reason": {"type": "stop"},
+                    "finish_reason": {"type": "length"},
                 },
             },
         ]
@@ -103,14 +128,88 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
                 callback,
                 stream=True,
                 request=None,
+                choice_aware=True,
+            )
+        )
+
+        self.assertEqual([call[0]["index"] for call in callback.calls], [0, 1, 0, 1])
+        self.assertEqual(
+            [call[0]["output_ids"] for call in callback.calls],
+            [[1], [3], [1, 2], [3, 4]],
+        )
+        self.assertEqual(
+            [call[0]["delta_output_ids"] for call in callback.calls],
+            [[1], [3], [2], [4]],
+        )
+        self.assertEqual(
+            [call[1] for call in callback.calls], [False, False, False, True]
+        )
+
+    def test_generation_error_terminates_each_unfinished_choice(self):
+        callback = _RecordingCallback()
+        responses = [
+            {
+                "index": 0,
+                "output_ids": [1],
+                "meta_info": {
+                    "id": "choice-0",
+                    "finish_reason": {"type": "stop"},
+                },
+            },
+            RuntimeError("scheduler failed"),
+        ]
+        handle = _make_runtime_handle(responses)
+        obj = SimpleNamespace(rid="logical", batch_size=1, parallel_sample_num=2)
+
+        asyncio.run(
+            handle._run_generate(
+                obj,
+                callback,
+                stream=True,
+                request=None,
+                choice_aware=True,
+            )
+        )
+
+        self.assertEqual([call[0]["index"] for call in callback.calls], [0, 1])
+        self.assertEqual(
+            callback.calls[1][0]["meta_info"]["finish_reason"]["type"], "error"
+        )
+        self.assertEqual([call[1] for call in callback.calls], [False, True])
+
+    def test_incremental_streaming_retains_legacy_cumulative_output(self):
+        callback = _RecordingCallback()
+        responses = [
+            {
+                "index": 0,
+                "output_ids": [1],
+                "meta_info": {"finish_reason": None},
+            },
+            {
+                "index": 0,
+                "output_ids": [2],
+                "meta_info": {"finish_reason": {"type": "stop"}},
+            },
+        ]
+        handle = _make_runtime_handle(responses, incremental=True)
+        obj = SimpleNamespace(rid="logical", batch_size=1, parallel_sample_num=1)
+
+        asyncio.run(
+            handle._run_generate(
+                obj,
+                callback,
+                stream=True,
+                request=None,
+                choice_aware=True,
             )
         )
 
         self.assertEqual(
-            [call[0]["output_ids"] for call in callback.calls],
-            [[1], [2], [3]],
+            [call[0]["output_ids"] for call in callback.calls], [[1], [1, 2]]
         )
-        self.assertEqual([call[1] for call in callback.calls], [False, False, True])
+        self.assertEqual(
+            [call[0]["delta_output_ids"] for call in callback.calls], [[1], [2]]
+        )
 
 
 class TestNativeGrpcRequestLifecycle(CustomTestCase):

--- a/test/registered/unit/entrypoints/test_grpc_bridge.py
+++ b/test/registered/unit/entrypoints/test_grpc_bridge.py
@@ -1,11 +1,10 @@
 import asyncio
 import enum
-import threading
 import unittest
-from concurrent.futures import Future
 from types import SimpleNamespace
 
 from sglang.srt.entrypoints.grpc_bridge import RuntimeHandle
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -156,6 +155,11 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
                     "finish_reason": {"type": "stop"},
                 },
             },
+            {
+                "index": 1,
+                "output_ids": [7],
+                "meta_info": {"id": "choice-1", "finish_reason": None},
+            },
             RuntimeError("scheduler failed"),
         ]
         handle = _make_runtime_handle(responses)
@@ -171,13 +175,14 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             )
         )
 
-        self.assertEqual([call[0]["index"] for call in callback.calls], [0, 1])
+        self.assertEqual([call[0]["index"] for call in callback.calls], [0, 1, 1])
         self.assertEqual(
-            callback.calls[1][0]["meta_info"]["finish_reason"]["type"], "error"
+            callback.calls[2][0]["meta_info"]["finish_reason"]["type"], "error"
         )
-        self.assertEqual([call[1] for call in callback.calls], [False, True])
+        self.assertEqual(callback.calls[2][0]["output_ids"], [7])
+        self.assertEqual([call[1] for call in callback.calls], [False, False, True])
 
-    def test_incremental_streaming_retains_legacy_cumulative_output(self):
+    def test_incremental_streaming_preserves_legacy_segments(self):
         callback = _RecordingCallback()
         responses = [
             {
@@ -204,29 +209,25 @@ class TestNativeGrpcParallelResponses(CustomTestCase):
             )
         )
 
-        self.assertEqual(
-            [call[0]["output_ids"] for call in callback.calls], [[1], [1, 2]]
-        )
+        self.assertEqual([call[0]["output_ids"] for call in callback.calls], [[1], [2]])
         self.assertEqual(
             [call[0]["delta_output_ids"] for call in callback.calls], [[1], [2]]
         )
 
 
 class TestNativeGrpcRequestLifecycle(CustomTestCase):
-    def test_reused_request_id_keeps_current_generation_future(self):
-        handle = RuntimeHandle.__new__(RuntimeHandle)
-        handle._active_generation_futures = {}
-        handle._generation_futures_lock = threading.Lock()
-        old_future = Future()
-        current_future = Future()
+    def test_stale_lifecycle_cannot_abort_reused_request_id(self):
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.rid_to_state = {
+            "reused": SimpleNamespace(lifecycle_id=2, abort_requested=False)
+        }
+        manager.child_rid_to_logical_rid = {}
+        manager.logical_rid_to_child_rids = {}
 
-        handle._track_generation_future("reused", old_future)
-        handle._track_generation_future("reused", current_future)
-        old_future.set_result(None)
+        aborted = manager.abort_request("reused", lifecycle_id=1)
 
-        self.assertIs(handle._active_generation_futures["reused"], current_future)
-        handle._cancel_generation_futures("reused", abort_all=False)
-        self.assertTrue(current_future.cancelled())
+        self.assertFalse(aborted)
+        self.assertFalse(manager.rid_to_state["reused"].abort_requested)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

This is horizontal slice 2 of the typed-generation prototype in #32121, following the request-semantics slice merged in #32588.

SGLang already produces a top-level choice index for parallel generation, but the Rust callback discards it and the `GenerateResponse` schema cannot carry it. As a result, an external client cannot attribute interleaved `n > 1` chunks or terminals to a choice. The bridge also keys lifecycle state only by the public request ID, so stale callbacks and abort guards can interfere with a newer request that reuses the same ID.

## Modifications

- Extend `GenerateResponse` additively with the stable public `request_id`, `choice_index`, per-choice `delta_output_ids`, and a typed finish/error terminal.
- Preserve the legacy cumulative `output_ids`, `meta_info`, and stream-level `finished` fields for existing clients.
- Normalize cumulative and `--incremental-streaming-output` modes into per-choice deltas while retaining cumulative legacy output.
- Keep the response stream open until every choice emits exactly one terminal; reject out-of-range choices, data after a terminal, and premature stream completion.
- Surface attributable scheduler failures and cancellation as per-choice generation errors.
- Add an internal request key composed of the public request ID and a monotonically increasing incarnation.
- Key active channels, parked sends, readiness callbacks, readiness signals, terminal errors, and server abort guards by the exact request incarnation.
- Preserve choice-aware channels during explicit abort so unfinished choices can emit cancellation terminals.
- Track Python generation futures by request ID with identity-checked cleanup so an old future cannot erase a newer one.

Usage, logprobs, and generic engine metadata remain in the reference PR and are intentionally left for slice 3.

## Accuracy Tests

Not applicable. This changes transport response attribution and lifecycle ownership without changing model execution or sampling.

## Speed Tests and Profiling

Not applicable. Delta normalization tracks one output offset per choice and processes each newly generated token once. Legacy cumulative response fields remain available for compatibility.

## Validation

- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path rust/Cargo.toml -p sglang-grpc --all-targets -- -D warnings`
- `cargo check --manifest-path rust/Cargo.toml -p sglang-grpc`
- `cargo test --manifest-path rust/Cargo.toml -p sglang-grpc` (17 passed; linked against system Python 3.10 for the PyO3 test binary)
- Focused Python bridge tests (5 passed): interleaved cumulative choices, incremental streaming, non-streaming choices, partial-choice errors, and request-ID reuse
- `python scripts/ci/check_registered_tests.py`
- Ruff lint, Python syntax compilation, and `git diff --check`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (The proto comments document legacy and multi-choice response semantics.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to transport-only response attribution.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31046647612](https://github.com/sgl-project/sglang/actions/runs/31046647612)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31046647893](https://github.com/sgl-project/sglang/actions/runs/31046647893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->