### PR TITLE
Stop discarding an explicitly set indexer choice on SM120

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5306,9 +5306,13 @@ class ServerArgs:
                 envs.SGLANG_OPT_USE_TOPK_V2.set(False)
                 envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
-                envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
-                # Prefer TileLang over the Torch fallback.
-                envs.SGLANG_OPT_USE_TILELANG_INDEXER.set(True)
+                # Prefer TileLang over the Torch fallback, but do not override
+                # an explicit setting: a DeepGEMM build with SM120 attention
+                # support can select fp8_paged_mqa_logits instead.
+                if not envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.is_set():
+                    envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
+                if not envs.SGLANG_OPT_USE_TILELANG_INDEXER.is_set():
+                    envs.SGLANG_OPT_USE_TILELANG_INDEXER.set(True)
             elif is_hip():
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
                 envs.SGLANG_OPT_USE_FUSED_COMPRESS.set(True)


### PR DESCRIPTION
## Motivation

On SM120, `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH` and `SGLANG_OPT_USE_TILELANG_INDEXER` are set unconditionally in `_handle_model_specific_adjustments`, so an explicitly provided value is discarded.

The TileLang indexer works against stock DeepGEMM. A DeepGEMM build with SM120 attention support exposes `fp8_fp4_paged_mqa_logits` and can run the DeepGEMM indexer, but currently cannot select it.

## Modifications

`python/sglang/srt/server_args.py`: guard both assignments with `is_set()`. Defaults are unchanged.

## Accuracy Tests

Defaults are unchanged, so default model outputs are unaffected. No accuracy delta was measured for the non-default path.

## Speed Tests and Profiling

2x RTX PRO 6000 Blackwell (SM120), TP=2, DeepSeek-V4-Flash-0731, chunked prefill 8192, DSpark block size 5. Prefill issued as raw `input_ids` (excludes tokenizer and HTTP cost), warmup discarded, n=5. Decode on a fixed prompt at temperature 0, n=10, at approximately 1k context.

| cell | TileLang (default) | DeepGEMM (explicit) | delta |
|---|---:|---:|---|
| prefill 128k | 6,310 | 6,581 | +4.3% |
| prefill 64k | 7,263 | 7,316 | +0.7% (within 4.6% run-to-run spread) |
| decode C1 | 296.4 | 303.5 | +2.4% |

Torch profile of a 128k prefill attributes 13.5% of GPU kernel time to indexer kernels.

## Checklist

- [x] Format code with pre-commit — run against the changed file, passed
- [ ] Add unit tests — not added; `_handle_model_specific_adjustments` has no existing unit-test harness and the change is a two-line guard
- [ ] Update documentation — no user-facing documentation change
- [x] Provide accuracy and speed benchmark results — above
- [x] Follow the SGLang code style guidance

Prepared with AI assistance.
