### PR TITLE
docker: pin nightly image source to workflow commit

### DIFF
--- a/.github/workflows/release-docker-dev.yml
+++ b/.github/workflows/release-docker-dev.yml
@@ -68,7 +68,7 @@ jobs:
 
           # Determine extra build args
           if [ "${{ github.event_name }}" = "schedule" ]; then
-            echo "extra_build_args=--build-arg USE_LATEST_SGLANG=1 --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
+            echo "extra_build_args=--build-arg BRANCH_TYPE=local --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
           else
             echo "extra_build_args=--build-arg BRANCH_TYPE=local --build-arg CMAKE_BUILD_PARALLEL_LEVEL=\$(nproc)" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Scheduled nightlies now source SGLang from the workflow checkout instead of cloning moving main. This keeps the installed revision equal to the dated tag and image provenance labels.

### How This Was Implemented
- Replaced the scheduled-only `USE_LATEST_SGLANG=1` build argument with `BRANCH_TYPE=local`.
- Reused the Dockerfile’s existing local-source branch, which copies the workflow checkout into the image.
- Left manual and PR build configuration unchanged.

<details>
<summary>Walkthrough</summary>

The reusable workflow checks out the revision used for the nightly tag and provenance labels. Passing `BRANCH_TYPE=local` makes the Dockerfile install that checkout, eliminating the second fetch of moving `main` during the build.

</details>

### Validation
- `git diff --check`
- Targeted assertion that scheduled builds contain `BRANCH_TYPE=local` and not `USE_LATEST_SGLANG=1`.
<!-- codex-pr-description:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31034913174](https://github.com/sgl-project/sglang/actions/runs/31034913174)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31034913189](https://github.com/sgl-project/sglang/actions/runs/31034913189)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->