### PR TITLE
[AMD][DI][CI] Gate manual MI355X dispatches and widen the queue budget

### DIFF
--- a/.github/workflows/nightly-amd-mi355x-disagg.yml
+++ b/.github/workflows/nightly-amd-mi355x-disagg.yml
@@ -27,6 +27,28 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
+  # Scheduled runs need no approval. Manual runs are gated by the mi355x-ci
+  # environment so an individual cannot queue arbitrary work onto the shared
+  # 4-node amd-sglang partition, which CI and people use at the same time.
+  # Mirrors the gb200-ci gate in nightly-72-gpu-gb200.yml.
+  #
+  # This is a separate job rather than `environment:` on the benchmark stages
+  # because gating a matrix would demand one approval per leg instead of one
+  # per run. setup stays ungated so the available config names are still listed
+  # while approval is pending.
+  #
+  # Until an admin adds required reviewers to the mi355x-ci environment this
+  # job just passes, so merging it changes nothing on its own.
+  # ---------------------------------------------------------------------------
+  gate-dispatch:
+    if: github.repository == 'sgl-project/sglang' && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: mi355x-ci
+    steps:
+      - name: Approved
+        run: echo "Manual dispatch approved for the shared amd-sglang partition."
+
+  # ---------------------------------------------------------------------------
   # Reads scripts/ci/slurm/nightly-configs.yaml and generates one matrix entry
   # per recipe YAML for runner=mi355x. To add/remove configs, edit
   # nightly-configs.yaml only.
@@ -110,10 +132,13 @@ jobs:
           PY
 
   nightly-mi355x-2n:
-    needs: setup
+    needs: [setup, gate-dispatch]
+    # gate-dispatch is skipped on schedule, so accept skipped as well as success
+    # -- otherwise the nightly would never reach the cluster.
     if: |
       always() && github.repository == 'sgl-project/sglang'
       && needs.setup.result == 'success'
+      && (needs.gate-dispatch.result == 'success' || needs.gate-dispatch.result == 'skipped')
       && needs.setup.outputs.matrix-2n != '{"include":[]}'
     runs-on: linux-sglang-mi35x-di
     strategy:
@@ -164,7 +189,16 @@ jobs:
           fi
 
       - name: Launch MI355X benchmark
-        timeout-minutes: 180
+        # Covers the salloc wait plus the recipe's TIME_LIMIT of run time, so
+        # this budget minus the leg's own runtime is how long it may sit in the
+        # Slurm queue. Staging means CI never queues behind itself; the headroom
+        # is for the people who share the partition. Measured legs run 15-90
+        # minutes, so 180 left as little as 90 minutes of headroom on the
+        # longest leg -- and when it runs out the leg reports a benchmark
+        # failure for a benchmark that never ran. A genuinely stuck leg is still
+        # bounded by TIME_LIMIT, which salloc enforces, so raising this does not
+        # let a hung benchmark run longer.
+        timeout-minutes: 300
         env:
           # Manual dispatch input wins; otherwise use the latest image resolved
           # by the setup job; otherwise the launcher falls back to the recipe default.
@@ -253,10 +287,12 @@ jobs:
   nightly-mi355x-4n:
     needs:
       - setup
+      - gate-dispatch
       - nightly-mi355x-2n
     if: |
       !cancelled() && github.repository == 'sgl-project/sglang'
       && needs.setup.result == 'success'
+      && (needs.gate-dispatch.result == 'success' || needs.gate-dispatch.result == 'skipped')
       && needs.setup.outputs.matrix-4n != '{"include":[]}'
     runs-on: linux-sglang-mi35x-di
     strategy:


### PR DESCRIPTION
> **Rebased onto `main`.** This previously stacked on #33594; #33774 has since landed the staging, so this now applies directly to `main` and is independent of #33594.

## Motivation

The `amd-sglang` partition is 4 nodes, shared between this nightly and people working interactively. #33774 bounds what *this workflow* asks of the cluster, but both problems below originate outside the workflow, so no amount of staging can address them.

**Manual dispatches stampede.** The workflow concurrency group is one static name shared by every branch. A second dispatch does not run — it sits `pending` — and by default a third dispatch [cancels and replaces that pending run](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency). The practical result is people cancelling whatever holds the slot to get the cluster: three of us contended in one afternoon and runs were cancelled twice.

**The step timeout leaves little room for that sharing.** The budget minus a leg's own runtime is how long it may sit in the Slurm queue. Measured allocations run 15–90 minutes, so `timeout-minutes: 180` left as little as 90 minutes of headroom on the longest leg (`kimik26-fp8-1k1k-1p1d` at 1h30m). When it runs out, the leg reports a benchmark failure for a benchmark that never ran — the same false signal staging exists to prevent, just sourced from outside CI.

## Modifications

**`gate-dispatch` job** — mirrors the `gb200-ci` gate in `nightly-72-gpu-gb200.yml`, whose comment states the same intent ("to prevent individuals from queuing arbitrary jobs on the shared GB200 cluster"). Scheduled runs are untouched; only `workflow_dispatch` is gated.

It is a separate job rather than `environment:` on the benchmark stages because gating a matrix job would demand one approval per leg instead of one per run. `setup` deliberately stays ungated so the available config names are still listed while approval is pending. Both stages accept `skipped` as well as `success` from the gate — without that the nightly would never reach the cluster, since the gate skips on `schedule`.

**`timeout-minutes: 180` → `300`** on the launch step. This does not let a hung benchmark run longer: a stuck leg is still bounded by `TIME_LIMIT`, which `salloc` enforces. It only stops a *queued* leg from being killed and misreported.

Everything from #33774 is preserved unchanged: `max-parallel` 2 and 1, the `needs` barrier, `!cancelled()`, and the shared `env`/`steps` anchors.

### Requires one admin action to take effect

The `mi355x-ci` environment needs **required reviewers** configured in repo settings. Until then the gate job simply passes, so merging this is a no-op on its own and cannot break the nightly.

## Accuracy Tests

N/A — CI scheduling only. No recipe, server arg, or benchmark parameter changes.

## Speed Tests and Profiling

N/A — no inference code touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

### Verification

The pre-rebase revision was dispatched against the cluster ([run 31057637515](https://github.com/sgl-project/sglang/actions/runs/31057637515), `success`). `gate-dispatch` completed in 0.1 min and `benchmark-paired` proceeded correctly behind it, confirming the load-bearing assumption: the `mi355x-ci` environment did not exist, GitHub auto-created it with no protection rules, and the gate passed rather than failing the workflow. That is what makes merging this inert.

Two things that run cannot show, stated explicitly rather than implied. The gate's *blocking* behaviour is untestable until reviewers are configured. And `timeout-minutes: 300` only manifests when a leg would otherwise be killed between 180 and 300 minutes, which needs the cluster jammed by an external job — it stays a static check.

Job graph resolves as `gate-dispatch` → `setup` → `nightly-mi355x-2n` → `nightly-mi355x-4n` → `collect-results`, with both stages depending on the gate. `actionlint` reports the same three alias-related errors as `main` unmodified and no new ones; those are pre-existing from #33774 and are false positives — the GitHub Actions parser does accept YAML anchors, which I verified on a scratch repo.
