### PR TITLE
[Fix] Vocab out of bounds in DSpark for Inkling-Small

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -124,12 +124,18 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.draft_model = bundle.draft_model
         self._draft_sampler = None
 
+        # The mask token needs an embedding row, not a tokenizer entry, so bound it
+        # by the embedding width. A padded vocab reserves rows past the real tokens
+        # and drafts place the mask there (Inkling: 200058 real, 201024 padded).
+        target_model_config = self.target_worker.model_runner.model_config 
+        target_vocab_size = (
+            getattr(target_model_config.hf_text_config, "padded_vocab_size", None)
+            or target_model_config.vocab_size
+        )
         runtime_config = resolve_runtime_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config,
             speculative_num_draft_tokens=server_args.speculative_num_draft_tokens,
-            target_vocab_size=int(
-                self.target_worker.model_runner.model_config.vocab_size
-            ),
+            target_vocab_size=int(target_vocab_size),
         )
         self.gamma = runtime_config.gamma
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -127,7 +127,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         # The mask token needs an embedding row, not a tokenizer entry, so bound it
         # by the embedding width. A padded vocab reserves rows past the real tokens
         # and drafts place the mask there (Inkling: 200058 real, 201024 padded).
-        target_model_config = self.target_worker.model_runner.model_config 
+        target_model_config = self.target_worker.model_runner.model_config
         target_vocab_size = (
             getattr(target_model_config.hf_text_config, "padded_vocab_size", None)
             or target_model_config.vocab_size


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
When testing out https://huggingface.co/RadixArk/Inkling-Small-DSpark - we were not able to get it to work because it generated a token that was out-of-vocab. To fix this, we changed DSpark worker v2 to use the padded vocab size instead.

## Modifications

<!-- Detail the changes made in this pull request. -->
This changes the padded vocab size calculation for the DSpark worker. With this change, Inkling-Small-DSpark from RadixArk now works.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A

## Speed Tests and Profiling

We found some improvements to long-context (32k ISL, 31.5k cache, 0.5k compute / 1k OSL) interactivity and throughput using the RadixArk/Inkling-Small-DSpark speculator.

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
<img width="2391" height="898" alt="overlay_d42" src="https://github.com/user-attachments/assets/5b782143-37da-454e-961a-929ec02949ba" />


Model | Speculator | Verify | Accept len | Peak tok/s | Per GPU | Best interactivity (tok/s/user)
-- | -- | -- | -- | -- | -- | --
d42 | Inkling-Small DSpark | 6 | 3.11 | 15,420 | 3,855 | 261.3
d42 | Inkling-Small DSpark | 9 | 3.06 | 13,674 | 3,419 | 239.5

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31040593996](https://github.com/sgl-project/sglang/actions/runs/31040593996)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31040594251](https://github.com/sgl-project/sglang/actions/runs/31040594251)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->