### PR TITLE
[AMD] [CI] Track the MI355X disagg nightly in the AMD CI job monitor

### DIFF
--- a/.github/workflows/amd-ci-job-monitor.yml
+++ b/.github/workflows/amd-ci-job-monitor.yml
@@ -55,7 +55,7 @@ jobs:
           if [[ -n "${{ inputs.job_filter }}" ]]; then
             echo "workflows=pr-test-amd.yml" >> "$GITHUB_OUTPUT"
           else
-            echo "workflows=pr-test-amd.yml,nightly-test-amd.yml,pr-test-amd-rocm720.yml,nightly-test-amd-rocm720.yml" >> "$GITHUB_OUTPUT"
+            echo "workflows=pr-test-amd.yml,nightly-test-amd.yml,pr-test-amd-rocm720.yml,nightly-test-amd-rocm720.yml,nightly-amd-mi355x-disagg.yml" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fetch Actions data snapshot
@@ -121,6 +121,7 @@ jobs:
       nightly_jobs: ${{ steps.parse.outputs.nightly_jobs }}
       pr_rocm720_jobs: ${{ steps.parse.outputs.pr_rocm720_jobs }}
       nightly_rocm720_jobs: ${{ steps.parse.outputs.nightly_rocm720_jobs }}
+      disagg_jobs: ${{ steps.parse.outputs.disagg_jobs }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -159,6 +160,15 @@ jobs:
             jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "nightly_rocm720_jobs=$nightly_rocm720_jobs" >> $GITHUB_OUTPUT
           echo "Nightly ROCm 7.2 jobs: $nightly_rocm720_jobs"
+
+          # Parse nightly-amd-mi355x-disagg.yml (exclude utility jobs)
+          # Excluded: setup, collect-results -- both run on ubuntu-latest and the
+          # snapshot only keeps self-hosted jobs, so they would report as empty.
+          disagg_jobs=$(yq -r '.jobs | keys | .[]' .github/workflows/nightly-amd-mi355x-disagg.yml | \
+            grep -v -E '^(setup|collect-results)$' | \
+            jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "disagg_jobs=$disagg_jobs" >> $GITHUB_OUTPUT
+          echo "MI355X disagg jobs: $disagg_jobs"
 
   # PR CI reports using dynamic matrix
   pr-ci-reports:
@@ -316,6 +326,45 @@ jobs:
             --input-data-file ci-data/actions-job-snapshot.json \
             --summary
 
+  # MI355X 2N 1P1D disagg nightly reports using dynamic matrix
+  nightly-disagg-reports:
+    name: Nightly MI355X Disagg - ${{ matrix.job_name }}
+    needs: [parse-workflows, fetch-actions-data]
+    if: ${{ !inputs.job_filter }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        job_name: ${{ fromJson(needs.parse-workflows.outputs.disagg_jobs) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install dependencies
+        run: pip install tabulate
+
+      - name: Download Actions data snapshot
+        uses: actions/download-artifact@v4
+        with:
+          name: actions-job-snapshot
+          path: ci-data
+
+      - name: Generate MI355X Disagg Report
+        timeout-minutes: 15
+        run: |
+          python scripts/ci/utils/query_job_status.py \
+            --repo ${{ github.repository }} \
+            --job "${{ matrix.job_name }}" \
+            --workflow "nightly-amd-mi355x-disagg.yml" \
+            --hours ${{ inputs.hours || '24' }} \
+            --input-data-file ci-data/actions-job-snapshot.json \
+            --summary
+
   # Runner fleet report - cross-workflow runner analytics in a single pass
   runner-fleet-report:
     name: Runner Fleet Report
@@ -346,7 +395,7 @@ jobs:
           python scripts/ci/utils/query_job_status.py \
             --repo ${{ github.repository }} \
             --runner-report \
-            --workflow "pr-test-amd.yml,nightly-test-amd.yml,pr-test-amd-rocm720.yml,nightly-test-amd-rocm720.yml" \
+            --workflow "pr-test-amd.yml,nightly-test-amd.yml,pr-test-amd-rocm720.yml,nightly-test-amd-rocm720.yml,nightly-amd-mi355x-disagg.yml" \
             --hours ${{ inputs.hours || '24' }} \
             --input-data-file ci-data/actions-job-snapshot.json \
             --summary


### PR DESCRIPTION
## Motivation

The AMD CI job monitor takes a daily snapshot of GitHub Actions data and turns it into per-job status reports plus a runner fleet report, but it only fetches four workflows: `pr-test-amd.yml`, `nightly-test-amd.yml`, `pr-test-amd-rocm720.yml` and `nightly-test-amd-rocm720.yml`. [`nightly-amd-mi355x-disagg.yml`](https://github.com/sgl-project/sglang/actions/workflows/nightly-amd-mi355x-disagg.yml) is not in that list, so neither its legs nor its `linux-sglang-mi35x-di` runner show up anywhere in the report.

The gap matters more for this workflow than for the others. The disagg nightly `salloc`s nodes out of the shared 4-node `amd-sglang` partition, which CI and people use at the same time. GitHub hands a leg to any idle runner carrying the label without knowing the cluster is busy, so a leg dispatched while its nodes are held just blocks in `salloc` until the 180-minute step timeout fires and reports a benchmark failure that never actually ran. Queue time and duration per leg are what distinguish that from a real regression, and they are already computed for every other AMD workflow.

## Modifications

`.github/workflows/amd-ci-job-monitor.yml` only:

- Add `nightly-amd-mi355x-disagg.yml` to the workflow list that `fetch-actions-data` snapshots, so its runs land in the shared `actions-job-snapshot.json` artifact every report job reads.
- Add it to the `--workflow` list of `runner-fleet-report`, which is what brings `linux-sglang-mi35x-di` into the concurrency, busy-period, 15-minute utilization and queue-time-distribution tables.
- Add a `nightly-disagg-reports` matrix job emitting one per-job status report, built the same way as the four existing report groups.
- Extend `parse-workflows` with a `disagg_jobs` output that reads the job keys out of the workflow file rather than hardcoding them, matching how the other four groups are built.

`setup` and `collect-results` are excluded from that parse: both run on `ubuntu-latest`, and `fetch_all_jobs_snapshot()` drops jobs whose only label is `ubuntu-latest`, so they would render as empty "no jobs found" reports.

Scope is the whole workflow, not one topology. Tracking keys on the workflow file and the `linux-sglang-mi35x-di` runner, so every leg is covered regardless of node footprint — the 2-node 1P1D recipes and the 4-node 2P1D wide-EP16 recipes alike. (The workflow's display name still says "2N 1P1D", which predates the EP16 recipes in `nightly-configs.yaml`.)

No change to `scripts/ci/utils/query_job_status.py` — the disagg workflow's one self-hosted job already flows through the existing code paths. `_get_runner_label()` falls back to `labels[0]` for `linux-sglang-mi35x-di` (it does not hit the `linux-mi*` fast path), and `_job_name_matches_filter()` accepts the `job-id (matrix values)` form GitHub renders for matrix legs.

API cost is negligible: the disagg nightly runs once a day, so this adds a couple of runs to a snapshot that already covers the per-commit AMD workflows.

## Result

Dispatched on this branch with a 24-hour window to produce a real report: [run 31045950484](https://github.com/sgl-project/sglang/actions/runs/31045950484). Same shape as a scheduled run, now with the disagg runner present.

[Runner Fleet Report](https://github.com/sgl-project/sglang/actions/runs/31045950484/job/92444113665), last row is new:

| Runner Label | Peak Concurrent | Avg Concurrent | Total Jobs | Avg Queue | P50 Queue | P99 Queue | Avg Duration |
|-------------|----------------|---------------|-----------|-----------|-----------|-----------|-------------|
| `linux-mi35x-gpu-1` | **3** | 2.1 | 124 | 16m35s | 3m50s | 2h4m | 19m11s |
| `linux-mi35x-gpu-2` | **2** | 1.5 | 10 | 12m28s | 0m18s | 51m46s | 27m57s |
| `linux-mi35x-gpu-8` | **5** | 3.0 | 297 | 4h25m | 3h21m | 9h49m | 33m45s |
| `linux-mi35x-gpu-8.fabric` | **1** | 1.0 | 120 | 9h48m | 10h23m | 19h13m | 19m11s |
| `linux-sglang-mi35x-di` | **1** | 1.0 | 32 | 6h4m | 5h2m | 15h32m | 33m35s |

The utilization and queue-distribution sections pick it up too, and they show the serialization this was meant to expose. One runner, 28 legs dispatched at once by the 04:22 UTC nightly:

| Time (UTC) | Running | Queued |
|-----------|---------|--------|
| 08-05 04:30 | **1** | 27 |

`linux-sglang-mi35x-di` queue distribution: 32 samples, P50 5h2m, P90 13h29m, P99 15h32m, with 78.1% of legs waiting over an hour. The [per-job report](https://github.com/sgl-project/sglang/actions/runs/31045950484/job/92444113559) puts numbers on individual legs — the worst one waited 15h32m to start and then ran for 29m36s.

## Verification

Beyond the dispatched run above, the workflow's own `pull_request` trigger smoke-tested this PR at [run 31044418489](https://github.com/sgl-project/sglang/actions/runs/31044418489): `Parse Workflow Jobs`, `Fetch Actions Snapshot`, `Runner Fleet Report` and `Nightly MI355X Disagg - nightly-mi355x-benchmark` all green, with the parse step logging `MI355X disagg jobs: ["nightly-mi355x-benchmark"]`.

Checked locally before pushing: the snapshot workflow list and the fleet-report workflow list are identical, every `--workflow` a report job queries is present in the snapshot, and `fromJson()` on the parse output yields a non-empty array so the matrix cannot expand to zero legs.

## Known limitation

The per-job report keys on the workflow's job *id*, which only matches what the API reports for a plain matrix job. If the legs are ever moved into a reusable workflow, GitHub renames them to `<caller job> / <inner job>` and the prefix filter stops matching, so `nightly-disagg-reports` would need updating at the same time. The fleet report is unaffected either way, since it keys on the runner label rather than the job name.

## Accuracy Tests

N/A — CI reporting only, no runtime, kernel or model code touched.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
