### PR TITLE
[Fix] Detect generated NVVM fmax binding ABI

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_attn/cute/utils.py
+++ b/python/sglang/kernels/ops/attention/flash_attn/cute/utils.py
@@ -19,6 +19,18 @@ from cutlass.cutlass_dsl import T, dsl_user_op
 _MIXER_ATTRS = ("__vec_size__",)
 
 
+def _nvvm_fmax_requires_explicit_result_type(op=nvvm.fmax) -> bool:
+    """Detect the generated NVVM binding ABI instead of inferring it from CUDA."""
+    try:
+        first_parameter = next(iter(inspect.signature(op).parameters), None)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError("Unable to inspect the NVVM fmax binding ABI") from exc
+    return first_parameter in {"res", "result"}
+
+
+_NVVM_FMAX_REQUIRES_EXPLICIT_RESULT_TYPE = _nvvm_fmax_requires_explicit_result_type()
+
+
 class AuxData(NamedTuple):
     tensors: tuple | list | None = None
     scalars: tuple | None = None
@@ -371,10 +383,7 @@ def fmax(
     loc=None,
     ip=None,
 ) -> Float32:
-    from cutlass import CUDA_VERSION
-
-    # * NVVM call based on nvvm version
-    if CUDA_VERSION.major == 12 and CUDA_VERSION.minor == 9:
+    if _NVVM_FMAX_REQUIRES_EXPLICIT_RESULT_TYPE:
         # Old API: requires explicit result type as first positional argument
         return Float32(
             nvvm.fmax(

--- a/test/registered/kernels/ops/attention/test_cute_nvvm_compat.py
+++ b/test/registered/kernels/ops/attention/test_cute_nvvm_compat.py
@@ -1,0 +1,60 @@
+import inspect
+import sys
+
+import pytest
+from cutlass._mlir.dialects import nvvm
+
+from sglang.kernels.ops.attention.flash_attn.cute.utils import (
+    _NVVM_FMAX_REQUIRES_EXPLICIT_RESULT_TYPE,
+    _nvvm_fmax_requires_explicit_result_type,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=5, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+def _old_fmax(res, a, b, *, c=None, loc=None, ip=None):
+    return res, a, b, c, loc, ip
+
+
+def _new_fmax(a, b, *, c=None, results=None, loc=None, ip=None):
+    return a, b, c, results, loc, ip
+
+
+class _OpaqueFmax:
+    @property
+    def __signature__(self):
+        raise ValueError("signature unavailable")
+
+    def __call__(self, *args, **kwargs):
+        return args, kwargs
+
+
+def test_detects_old_and_new_nvvm_fmax_bindings():
+    assert _nvvm_fmax_requires_explicit_result_type(_old_fmax)
+    assert not _nvvm_fmax_requires_explicit_result_type(_new_fmax)
+
+
+def test_rejects_an_uninspectable_nvvm_fmax_binding():
+    with pytest.raises(RuntimeError, match="Unable to inspect"):
+        _nvvm_fmax_requires_explicit_result_type(_OpaqueFmax())
+
+
+def test_selected_call_shape_binds_to_installed_nvvm_fmax():
+    signature = inspect.signature(nvvm.fmax)
+    old_args = (object(), object(), object())
+    new_args = (object(), object())
+
+    if _NVVM_FMAX_REQUIRES_EXPLICIT_RESULT_TYPE:
+        signature.bind(*old_args, c=None)
+        with pytest.raises(TypeError):
+            signature.bind(*new_args, c=None)
+    else:
+        signature.bind(*new_args, c=None)
+        with pytest.raises(TypeError):
+            signature.bind(*old_args, c=None)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
The generated NVVM Python binding ABI can change independently of the CUDA toolkit version. The current CuTe flash-attention helper assumes every CUDA 12.9 environment uses the old `nvvm.fmax(res, a, b, ...)` form.

The official CUDA 12.9 image paired with `nvidia-cutlass-dsl==4.6.0` instead exposes:

```python
(a, b, *, c=None, ftz=None, nan=None, abs=None, results=None, loc=None, ip=None)
```

On SM100 CuTe/FA4 attention paths, SGLang therefore passes three positional arguments to a two-positional-argument binding and fails during JIT compilation with:

```text
TypeError: fmax() takes 2 positional arguments but 3 were given
```

## Modifications

- Inspect the installed `nvvm.fmax` signature once at module import instead of inferring its ABI from `CUDA_VERSION`.
- Preserve both existing call forms: use the explicit result type when the first parameter is `res` or `result`, and otherwise use the inferred-result form.
- Fail clearly if the generated binding signature cannot be inspected.
- Add registered CUDA tests for both generated binding ABIs, the fail-closed path, and the call shape selected for the binding installed in CI.

## Accuracy Tests

This does not change the `fmax` operation or attention math; it only selects the call shape accepted by the installed generated binding.

- Focused compatibility tests: `3 passed` on each node of a two-node GB200 deployment.
- End-to-end Kimi K2.6 validation: the unpatched image reproduced the exception during CuTe/FA4 graph compilation; applying only this source change allowed both server pods to become ready, complete graph capture, and pass all 10/10 output guards.
- `python3 scripts/ci/check_registered_tests.py`: passed.

## Speed Tests and Profiling

No runtime performance change is expected. Signature detection runs once during module import; the selected JIT call body is unchanged.

## Checklist

- [x] Formatted with pre-commit; all applicable hooks passed.
- [x] Added registered unit coverage for old and new NVVM binding ABIs.
- [x] No documentation update is needed because this does not change a public interface.
- [x] Provided accuracy and performance-impact results above.
- [x] Followed the existing CuTe kernel and registered-test conventions.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31046821486](https://github.com/sgl-project/sglang/actions/runs/31046821486)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31046818837](https://github.com/sgl-project/sglang/actions/runs/31046818837)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->