### PR TITLE
[CI] Collapse the EAGLE launch matrix and the scoring engine boots on the per-commit runners

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
+++ b/python/sglang/multimodal_gen/runtime/layers/quantization/mxfp4.py
@@ -16,7 +16,7 @@ from sglang.multimodal_gen.runtime.models.parameter import (
     PerTensorScaleParameter,
 )
 from sglang.srt.layers.quantization.utils import is_layer_skipped
-from sglang.srt.utils import is_hip, mxfp_supported
+from sglang.srt.utils import is_gfx95_supported, is_hip
 
 logger = logging.getLogger(__name__)
 _is_hip = is_hip()
@@ -70,7 +70,7 @@ class Mxfp4Config(QuantizationConfig):
 
     @classmethod
     def get_min_capability(cls) -> int:
-        return 95  # gfx95x, Note: mxfp_supported() is a better check
+        return 95  # gfx95x, Note: is_gfx95_supported() is a better check
 
     @classmethod
     def get_config_filenames(cls) -> list[str]:
@@ -165,7 +165,7 @@ class Mxfp4LinearMethod(LinearMethodBase):
         - Packed uint8 (2 FP4 values per byte)
         - E8M0 scales (one per 32-element block)
         """
-        if not mxfp_supported():
+        if not is_gfx95_supported():
             platform = "unknown"
             if _is_hip:
                 try:
@@ -217,7 +217,7 @@ class Mxfp4LinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
 
-        if not mxfp_supported():
+        if not is_gfx95_supported():
             raise RuntimeError(
                 "MXFP4 inference requires ROCm and MI350+ (gfx95x). "
                 "Current platform not supported."

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -58,13 +58,12 @@ from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cpu,
     is_cuda,
-    is_hip,
+    is_gfx95_supported,
     is_mps,
     is_npu,
-    mxfp_supported,
 )
 
-_is_mxfp_supported = mxfp_supported()
+_is_gfx95_supported = is_gfx95_supported()
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.topk import TopKOutput
@@ -102,7 +101,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
 }
 
 
-if is_cpu() or is_cuda() or (_is_mxfp_supported and is_hip()):
+if is_cpu() or is_cuda() or _is_gfx95_supported:
     BASE_QUANTIZATION_METHODS.update(
         {
             "mxfp4": Mxfp4Config,

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -59,7 +59,6 @@ from sglang.srt.utils import (
     is_sm100_supported,
     is_sm120_supported,
     is_triton_kernels_available,
-    mxfp_supported,
     next_power_of_2,
     round_up,
     set_weight_attrs,
@@ -256,7 +255,7 @@ class Mxfp4Config(QuantizationConfig):
         is_checkpoint_mxfp4_serialized = "mxfp4" in quant_method
 
         if _is_hip:
-            if mxfp_supported():
+            if is_gfx95_supported():
                 return cls(
                     is_checkpoint_mxfp4_serialized=is_checkpoint_mxfp4_serialized
                 )

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4.py
@@ -16,7 +16,7 @@ from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
 from sglang.srt.layers.quantization.online_quantization import CopyNumelCounter
 from sglang.srt.layers.quantization.quark.schemes import QuarkLinearScheme
 from sglang.srt.utils import is_hip
-from sglang.srt.utils.common import direct_register_custom_op, mxfp_supported
+from sglang.srt.utils.common import direct_register_custom_op, is_gfx95_supported
 
 _is_hip = is_hip()
 if _is_hip:
@@ -180,7 +180,7 @@ class QuarkW4A4MXFP4(QuarkLinearScheme):
         self.dequantization_config = dequantization_config
 
         if not self.is_checkpoint_mxfp4_serialized:
-            if not mxfp_supported():
+            if not is_gfx95_supported():
                 raise NotImplementedError(
                     "Online MXFP4 quantization requires an AMD ROCm device with "
                     "FP4 hardware support (gfx95x, e.g. MI355x)."

--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -24,7 +24,7 @@ from sglang.srt.utils import (
     is_hip,
     set_weight_attrs,
 )
-from sglang.srt.utils.common import mxfp_supported
+from sglang.srt.utils.common import is_gfx95_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -79,7 +79,7 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
         self.with_bias = False
 
         if not self.is_checkpoint_mxfp4_serialized:
-            if not mxfp_supported():
+            if not is_gfx95_supported():
                 raise NotImplementedError(
                     "Online MXFP4 quantization for MoE layers requires an AMD ROCm "
                     "device with FP4 hardware support (gfx95x, e.g. MI355x)."

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1016,22 +1016,11 @@ def set_cuda_arch():
         )
 
 
+@lru_cache(maxsize=1)
 def is_gfx95_supported():
     """Whether the device is an AMD gfx95 GPU (the MX-capable ROCm arch).
 
     False on every non-HIP build, so callers do not need their own is_hip().
-    """
-    if torch.version.hip:
-        gcn_arch = torch.cuda.get_device_properties(0).gcnArchName
-        return any(gfx in gcn_arch for gfx in ["gfx95"])
-    else:
-        return False
-
-
-@lru_cache(maxsize=1)
-def is_gfx95_supported():
-    """
-    Returns whether the current platform supports MX types.
     """
     if torch.version.hip:
         gcn_arch = torch.cuda.get_device_properties(0).gcnArchName

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1016,9 +1016,10 @@ def set_cuda_arch():
         )
 
 
-def mxfp_supported():
-    """
-    Returns whether the current platform supports MX types.
+def is_gfx95_supported():
+    """Whether the device is an AMD gfx95 GPU (the MX-capable ROCm arch).
+
+    False on every non-HIP build, so callers do not need their own is_hip().
     """
     if torch.version.hip:
         gcn_arch = torch.cuda.get_device_properties(0).gcnArchName

--- a/python/sglang/test/kits/spec_server_kits.py
+++ b/python/sglang/test/kits/spec_server_kits.py
@@ -386,8 +386,8 @@ class SpecLogprobKit:
         with ThreadPoolExecutor(8) as executor:
             list(executor.map(func, args))
 
-    def test_logprob_spec_v2_match(self):
-        """Verify spec v2 decode logprobs match prefill scoring logprobs."""
+    def test_logprob_decode_match_prefill(self):
+        """Decode logprobs from the spec path must match prefill scoring."""
         top_k = 5
         probe_token_ids = [1, 2, 10, 100, 1000]
         prompts = [

--- a/test/registered/models_e2e/test_step3p5_flash_chain_mtp.py
+++ b/test/registered/models_e2e/test_step3p5_flash_chain_mtp.py
@@ -50,13 +50,12 @@ class TestStep3p5FlashChainMTP(GSM8KMixin, DefaultServerBase):
     gsm8k_accuracy_thres = 0.83
     gsm8k_accept_length_thres = 2.6
 
-    def test_logprob_spec_v2_match(self):
-        """Verify spec v2 decode logprobs match prefill scoring logprobs.
+    def test_logprob_decode_match_prefill(self):
+        """Decode logprobs from the spec path must match prefill scoring.
 
-        Generate tokens with chain MTP spec v2, then score the same sequence
-        via prefill-only (no speculation). The two sets of logprobs should be
-        close, validating that spec v2 + multi-layer EAGLE computes logprobs
-        correctly.
+        Generate tokens with chain MTP, then score the same sequence via
+        prefill-only (no speculation). The two sets of logprobs should be
+        close, validating that multi-layer EAGLE computes logprobs correctly.
         """
         requests.get(self.base_url + "/flush_cache")
 

--- a/test/registered/openai_server/features/test_openai_server_hidden_states.py
+++ b/test/registered/openai_server/features/test_openai_server_hidden_states.py
@@ -16,9 +16,9 @@ from sglang.test.test_utils import (
     popen_launch_server,
 )
 
-register_cuda_ci(est_time=222, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=165, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(
-    est_time=186,
+    est_time=140,
     suite="stage-b-test-1-gpu-small-amd",
     disabled="see https://github.com/sgl-project/sglang/issues/11127",
 )
@@ -298,53 +298,6 @@ class TestOpenAIServerWithEAGLEAndHiddenStatesEnabled(
         )
         cls.base_url += "/v1"
         cls.tokenizer = get_tokenizer(DEFAULT_TARGET_MODEL_EAGLE)
-        cls.return_hidden_states = [False, True]
-        cls.use_list_input = [True, False]
-        cls.parallel_sample_nums = [1]
-
-    @classmethod
-    def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
-
-
-class TestOpenAIServerWithEAGLE3AndHiddenStatesEnabled(
-    CustomTestCase, BaseTestOpenAIServerWithHiddenStates
-):
-    @classmethod
-    def setUpClass(cls):
-        cls.model = "meta-llama/Llama-3.1-8B-Instruct"
-        cls.base_url = DEFAULT_URL_FOR_TEST
-        cls.api_key = "sk-123456"
-        cls.speculative_algorithm = "EAGLE3"
-        cls.speculative_draft_model = "jamesliu1/sglang-EAGLE3-Llama-3.1-Instruct-8B"
-        cls.process = popen_launch_server(
-            cls.model,
-            cls.base_url,
-            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--speculative-algorithm",
-                cls.speculative_algorithm,
-                "--speculative-draft-model-path",
-                cls.speculative_draft_model,
-                "--speculative-num-steps",
-                5,
-                "--speculative-eagle-topk",
-                16,
-                "--speculative-num-draft-tokens",
-                64,
-                "--mem-fraction-static",
-                0.7,
-                "--chunked-prefill-size",
-                128,
-                "--max-running-requests",
-                8,
-                "--dtype",
-                "float16",
-                "--enable-return-hidden-states",
-            ],
-        )
-        cls.base_url += "/v1"
-        cls.tokenizer = get_tokenizer(cls.model)
         cls.return_hidden_states = [False, True]
         cls.use_list_input = [True, False]
         cls.parallel_sample_nums = [1]

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -16,7 +16,6 @@ bugs in tensor shape handling (e.g., 2D tensors [num_delimiters, num_label_token
 import asyncio
 import os
 import unittest
-from collections import OrderedDict
 
 import torch
 from transformers import AutoConfig, AutoTokenizer
@@ -28,7 +27,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
 )
 
-register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=175, stage="base-b", runner_config="1-gpu-small")
 
 TEST_MODEL_NAME = os.environ.get("TEST_MODEL_NAME", DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
 TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
@@ -36,36 +35,6 @@ TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
     "tomaarsen/Qwen3-Reranker-0.6B-seq-cls",
 )
 _CLS_NUM_LABELS = AutoConfig.from_pretrained(TEST_CLASSIFICATION_BASE_MODEL).num_labels
-
-# Engines are shared by config across classes and test methods: score() is
-# stateless and the radix cache is off everywhere here, so re-booting the same
-# config only cost wall time.
-#
-# The bound must stay strictly above the most engines one class holds at once
-# (two, for the MIS vs non-MIS comparisons), or eviction could shut down an
-# engine a live class still references through cls.engine.
-_MAX_LIVE_ENGINES = 3
-_ENGINE_CACHE = OrderedDict()
-
-
-def get_engine(**kwargs) -> Engine:
-    key = tuple(sorted(kwargs.items()))
-    engine = _ENGINE_CACHE.pop(key, None)
-    if engine is None:
-        while len(_ENGINE_CACHE) >= _MAX_LIVE_ENGINES:
-            _, evicted = _ENGINE_CACHE.popitem(last=False)
-            evicted.shutdown()
-            torch.cuda.empty_cache()
-        engine = Engine(**kwargs)
-    _ENGINE_CACHE[key] = engine
-    return engine
-
-
-def tearDownModule():
-    while _ENGINE_CACHE:
-        _, engine = _ENGINE_CACHE.popitem()
-        engine.shutdown()
-    torch.cuda.empty_cache()
 
 
 class TestMISServerArgsValidation(unittest.TestCase):
@@ -83,7 +52,7 @@ class TestMultiItemScoringOptimization(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = get_engine(
+        cls.engine = Engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -91,12 +60,20 @@ class TestMultiItemScoringOptimization(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-        cls.non_mis_engine = get_engine(
+        cls.non_mis_engine = Engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
             mem_fraction_static=0.15,
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.engine is not None:
+            cls.engine.shutdown()
+        if cls.non_mis_engine is not None:
+            cls.non_mis_engine.shutdown()
+        torch.cuda.empty_cache()
 
     def test_mis_basic(self):
         """Test basic MIS: correct shapes, valid probabilities."""
@@ -168,17 +145,22 @@ class TestMultiItemScoringOptimization(CustomTestCase):
 
 
 class TestMultiItemScoringClassification(CustomTestCase):
-    """Test MIS with classification models.
+    """MIS on a classification model: basics, MIS-vs-single-item parity, and
+    score distinctness / determinism / concurrency.
 
-    Uses a pre-trained Qwen3ForSequenceClassification model so that the
-    classification head weights are deterministic across Engine instances.
+    Uses a pre-trained Qwen3ForSequenceClassification model so the head
+    weights are deterministic. All three groups share one engine: the CI
+    harness requires an idle GPU at every setUpClass, so separate classes
+    would mean re-booting the same config instead of sharing it.
     """
 
     NUM_LABELS = _CLS_NUM_LABELS
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = get_engine(
+        # One engine for the whole class: score() is stateless and the radix
+        # cache is off, so the per-method boot this used to do bought nothing.
+        cls.engine = Engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -186,6 +168,12 @@ class TestMultiItemScoringClassification(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.engine is not None:
+            cls.engine.shutdown()
+            torch.cuda.empty_cache()
 
     def test_classification_mis_basic(self):
         """Classification MIS: correct shapes, valid softmax probabilities."""
@@ -222,129 +210,23 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     def test_classification_non_mis_fallback(self):
         """Classification model works correctly without --enable-mis."""
-        non_mis_engine = get_engine(
+        non_mis_engine = Engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             mem_fraction_static=0.15,
         )
-        scores = non_mis_engine.score(
-            query="Test:", items=["A", "B"], apply_softmax=True
-        ).scores
+        try:
+            scores = non_mis_engine.score(
+                query="Test:", items=["A", "B"], apply_softmax=True
+            ).scores
 
-        self.assertEqual(len(scores), 2)
-        for score_list in scores:
-            self.assertEqual(len(score_list), self.NUM_LABELS)
-            self.assertAlmostEqual(sum(score_list), 1.0, places=5)
-
-
-class TestMultiItemScoringParity(CustomTestCase):
-    """Test that MIS produces the same results as single-item scoring."""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.engine_single = get_engine(
-            model_path=TEST_MODEL_NAME,
-            disable_radix_cache=True,
-            mem_fraction_static=0.15,
-        )
-        cls.engine_mis = get_engine(
-            model_path=TEST_MODEL_NAME,
-            disable_radix_cache=True,
-            chunked_prefill_size=-1,
-            enable_mis=True,
-            attention_backend="flashinfer",
-            mem_fraction_static=0.15,
-        )
-
-    def _compare_scores(
-        self, query, items, label_token_ids=None, apply_softmax=True, test_name=""
-    ):
-        """Compare MIS vs single-item scoring results."""
-        single_scores = self.engine_single.score(
-            query=query,
-            items=items,
-            label_token_ids=label_token_ids,
-            apply_softmax=apply_softmax,
-        ).scores
-
-        mis_scores = self.engine_mis.score(
-            query=query,
-            items=items,
-            label_token_ids=label_token_ids,
-            apply_softmax=apply_softmax,
-        ).scores
-
-        self.assertEqual(
-            len(mis_scores), len(single_scores), f"{test_name}: count mismatch"
-        )
-        for i, (ms, ss) in enumerate(zip(mis_scores, single_scores)):
-            self.assertEqual(len(ms), len(ss), f"{test_name}: item {i} length mismatch")
-            for j, (m, s) in enumerate(zip(ms, ss)):
-                self.assertAlmostEqual(
-                    m,
-                    s,
-                    places=1,
-                    msg=f"{test_name}: item {i} label {j}: MIS={m} vs single={s}",
-                )
-
-    def test_parity_basic(self):
-        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
-        query = "Rate this option:"
-        items = [" Option A", " Option B", " Option C"]
-        labels = [" good", " bad"]
-        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
-        self._compare_scores(query, items, label_ids, test_name="basic")
-
-    def test_parity_tokenized_inputs(self):
-        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
-        query = "Rate this option:"
-        items = [" Option X", " Option Y"]
-        labels = [" good", " bad"]
-        query_ids = tokenizer.encode(query, add_special_tokens=False)
-        items_ids = [tokenizer.encode(i, add_special_tokens=False) for i in items]
-        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
-        self._compare_scores(query_ids, items_ids, label_ids, test_name="tokenized")
-
-    def test_parity_without_softmax(self):
-        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
-        query = "The weather today is"
-        items = [" sunny", " cloudy", " rainy"]
-        labels = [" nice", " bad"]
-        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
-        self._compare_scores(
-            query, items, label_ids, apply_softmax=False, test_name="no_softmax"
-        )
-
-    def test_parity_many_items(self):
-        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
-        query = "Rate this option from 1 to 5:"
-        items = [f" Option {i}" for i in range(10)]
-        labels = [" 1", " 2", " 3", " 4", " 5"]
-        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
-        self._compare_scores(query, items, label_ids, test_name="many_items")
-
-
-class TestMultiItemScoringClassificationParity(CustomTestCase):
-    """Test that MIS multi-item batching matches single-item MIS scoring.
-
-    Both paths use the MIS engine (with delimiter tokens in the attention
-    context).  The reference scores each item individually so each gets its
-    own forward pass; the batched path packs all items into one pass.
-    This isolates the MIS batching logic from the delimiter-presence effect.
-    """
-
-    NUM_LABELS = _CLS_NUM_LABELS
-
-    @classmethod
-    def setUpClass(cls):
-        cls.engine = get_engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            chunked_prefill_size=-1,
-            enable_mis=True,
-            attention_backend="flashinfer",
-            mem_fraction_static=0.15,
-        )
+            self.assertEqual(len(scores), 2)
+            for score_list in scores:
+                self.assertEqual(len(score_list), self.NUM_LABELS)
+                self.assertAlmostEqual(sum(score_list), 1.0, places=5)
+        finally:
+            non_mis_engine.shutdown()
+            torch.cuda.empty_cache()
 
     def _compare_scores(self, query, items, apply_softmax=True, test_name=""):
         """Compare MIS batched vs MIS single-item scoring results."""
@@ -401,75 +283,6 @@ class TestMultiItemScoringClassificationParity(CustomTestCase):
         query = "Classify this option:"
         items = [f" Option {i}" for i in range(10)]
         self._compare_scores(query, items, test_name="cls_many_items")
-
-
-class TestMultiItemScoringClassificationMISvsNonMIS(CustomTestCase):
-    """Test that MIS single-item approximates non-MIS single-item.
-
-    The MIS path inserts delimiter tokens into the attention context,
-    which slightly perturbs hidden states.  After softmax the scores
-    should still be close.  Uses places=1 (±0.05) tolerance.
-
-    Runs as a separate class so each engine is created and destroyed
-    independently to avoid GPU OOM.
-    """
-
-    def test_mis_single_vs_non_mis(self):
-        non_mis_engine = get_engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            mem_fraction_static=0.15,
-        )
-        query = "Rate this option:"
-        items = [" Option A", " Option B", " Option C"]
-        non_mis_scores = non_mis_engine.score(
-            query=query,
-            items=items,
-            apply_softmax=True,
-        ).scores
-
-        mis_engine = get_engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            chunked_prefill_size=-1,
-            enable_mis=True,
-            attention_backend="flashinfer",
-            mem_fraction_static=0.15,
-        )
-        mis_scores = mis_engine.score(
-            query=query,
-            items=items,
-            apply_softmax=True,
-        ).scores
-
-        self.assertEqual(len(mis_scores), len(non_mis_scores))
-        for i, (ms, ns) in enumerate(zip(mis_scores, non_mis_scores)):
-            self.assertEqual(len(ms), len(ns))
-            for j, (m, n) in enumerate(zip(ms, ns)):
-                self.assertAlmostEqual(
-                    m,
-                    n,
-                    places=1,
-                    msg=f"item {i} label {j}: MIS={m} vs non-MIS={n}",
-                )
-
-
-class TestMultiItemScoringClassificationAdvanced(CustomTestCase):
-    """Advanced MIS tests for classification models: score distinctness,
-    determinism, and concurrent request handling."""
-
-    NUM_LABELS = _CLS_NUM_LABELS
-
-    @classmethod
-    def setUpClass(cls):
-        cls.engine = get_engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            chunked_prefill_size=-1,
-            enable_mis=True,
-            attention_backend="flashinfer",
-            mem_fraction_static=0.15,
-        )
 
     def test_items_produce_distinct_scores(self):
         """Different items must produce different score vectors.
@@ -578,6 +391,162 @@ class TestMultiItemScoringClassificationAdvanced(CustomTestCase):
                         msg=f"Case {idx} item {i} label {j}: "
                         f"concurrent={c} vs sequential={s}",
                     )
+
+
+class TestMultiItemScoringParity(CustomTestCase):
+    """Test that MIS produces the same results as single-item scoring."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.engine_single = Engine(
+            model_path=TEST_MODEL_NAME,
+            disable_radix_cache=True,
+            log_level="error",
+            mem_fraction_static=0.15,
+        )
+        cls.engine_mis = Engine(
+            model_path=TEST_MODEL_NAME,
+            disable_radix_cache=True,
+            chunked_prefill_size=-1,
+            log_level="error",
+            enable_mis=True,
+            attention_backend="flashinfer",
+            mem_fraction_static=0.15,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        if cls.engine_single is not None:
+            cls.engine_single.shutdown()
+        if cls.engine_mis is not None:
+            cls.engine_mis.shutdown()
+        torch.cuda.empty_cache()
+
+    def _compare_scores(
+        self, query, items, label_token_ids=None, apply_softmax=True, test_name=""
+    ):
+        """Compare MIS vs single-item scoring results."""
+        single_scores = self.engine_single.score(
+            query=query,
+            items=items,
+            label_token_ids=label_token_ids,
+            apply_softmax=apply_softmax,
+        ).scores
+
+        mis_scores = self.engine_mis.score(
+            query=query,
+            items=items,
+            label_token_ids=label_token_ids,
+            apply_softmax=apply_softmax,
+        ).scores
+
+        self.assertEqual(
+            len(mis_scores), len(single_scores), f"{test_name}: count mismatch"
+        )
+        for i, (ms, ss) in enumerate(zip(mis_scores, single_scores)):
+            self.assertEqual(len(ms), len(ss), f"{test_name}: item {i} length mismatch")
+            for j, (m, s) in enumerate(zip(ms, ss)):
+                self.assertAlmostEqual(
+                    m,
+                    s,
+                    places=1,
+                    msg=f"{test_name}: item {i} label {j}: MIS={m} vs single={s}",
+                )
+
+    def test_parity_basic(self):
+        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
+        query = "Rate this option:"
+        items = [" Option A", " Option B", " Option C"]
+        labels = [" good", " bad"]
+        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
+        self._compare_scores(query, items, label_ids, test_name="basic")
+
+    def test_parity_tokenized_inputs(self):
+        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
+        query = "Rate this option:"
+        items = [" Option X", " Option Y"]
+        labels = [" good", " bad"]
+        query_ids = tokenizer.encode(query, add_special_tokens=False)
+        items_ids = [tokenizer.encode(i, add_special_tokens=False) for i in items]
+        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
+        self._compare_scores(query_ids, items_ids, label_ids, test_name="tokenized")
+
+    def test_parity_without_softmax(self):
+        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
+        query = "The weather today is"
+        items = [" sunny", " cloudy", " rainy"]
+        labels = [" nice", " bad"]
+        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
+        self._compare_scores(
+            query, items, label_ids, apply_softmax=False, test_name="no_softmax"
+        )
+
+    def test_parity_many_items(self):
+        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_NAME)
+        query = "Rate this option from 1 to 5:"
+        items = [f" Option {i}" for i in range(10)]
+        labels = [" 1", " 2", " 3", " 4", " 5"]
+        label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
+        self._compare_scores(query, items, label_ids, test_name="many_items")
+
+
+class TestMultiItemScoringClassificationMISvsNonMIS(CustomTestCase):
+    """Test that MIS single-item approximates non-MIS single-item.
+
+    The MIS path inserts delimiter tokens into the attention context,
+    which slightly perturbs hidden states.  After softmax the scores
+    should still be close.  Uses places=1 (±0.05) tolerance.
+
+    Runs as a separate class so each engine is created and destroyed
+    independently to avoid GPU OOM.
+    """
+
+    def test_mis_single_vs_non_mis(self):
+        non_mis_engine = Engine(
+            model_path=TEST_CLASSIFICATION_BASE_MODEL,
+            disable_radix_cache=True,
+            mem_fraction_static=0.15,
+        )
+        try:
+            query = "Rate this option:"
+            items = [" Option A", " Option B", " Option C"]
+            non_mis_scores = non_mis_engine.score(
+                query=query,
+                items=items,
+                apply_softmax=True,
+            ).scores
+        finally:
+            non_mis_engine.shutdown()
+            torch.cuda.empty_cache()
+
+        mis_engine = Engine(
+            model_path=TEST_CLASSIFICATION_BASE_MODEL,
+            disable_radix_cache=True,
+            chunked_prefill_size=-1,
+            enable_mis=True,
+            attention_backend="flashinfer",
+            mem_fraction_static=0.15,
+        )
+        try:
+            mis_scores = mis_engine.score(
+                query=query,
+                items=items,
+                apply_softmax=True,
+            ).scores
+        finally:
+            mis_engine.shutdown()
+            torch.cuda.empty_cache()
+
+        self.assertEqual(len(mis_scores), len(non_mis_scores))
+        for i, (ms, ns) in enumerate(zip(mis_scores, non_mis_scores)):
+            self.assertEqual(len(ms), len(ns))
+            for j, (m, n) in enumerate(zip(ms, ns)):
+                self.assertAlmostEqual(
+                    m,
+                    n,
+                    places=1,
+                    msg=f"item {i} label {j}: MIS={m} vs non-MIS={n}",
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -27,7 +27,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
 )
 
-register_cuda_ci(est_time=175, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
 
 TEST_MODEL_NAME = os.environ.get("TEST_MODEL_NAME", DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
 TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -158,8 +158,8 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        # One engine for the whole class: score() is stateless and the radix
-        # cache is off, so the per-method boot this used to do bought nothing.
+        # Two engines for the whole class: score() is stateless and the radix
+        # cache is off, so booting either config per test bought nothing.
         cls.engine = Engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
@@ -168,12 +168,18 @@ class TestMultiItemScoringClassification(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
+        cls.non_mis_engine = Engine(
+            model_path=TEST_CLASSIFICATION_BASE_MODEL,
+            disable_radix_cache=True,
+            mem_fraction_static=0.15,
+        )
 
     @classmethod
     def tearDownClass(cls):
-        if cls.engine is not None:
-            cls.engine.shutdown()
-            torch.cuda.empty_cache()
+        for engine in (cls.engine, cls.non_mis_engine):
+            if engine is not None:
+                engine.shutdown()
+        torch.cuda.empty_cache()
 
     def test_classification_mis_basic(self):
         """Classification MIS: correct shapes, valid softmax probabilities."""
@@ -210,23 +216,14 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     def test_classification_non_mis_fallback(self):
         """Classification model works correctly without --enable-mis."""
-        non_mis_engine = Engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            mem_fraction_static=0.15,
-        )
-        try:
-            scores = non_mis_engine.score(
-                query="Test:", items=["A", "B"], apply_softmax=True
-            ).scores
+        scores = self.non_mis_engine.score(
+            query="Test:", items=["A", "B"], apply_softmax=True
+        ).scores
 
-            self.assertEqual(len(scores), 2)
-            for score_list in scores:
-                self.assertEqual(len(score_list), self.NUM_LABELS)
-                self.assertAlmostEqual(sum(score_list), 1.0, places=5)
-        finally:
-            non_mis_engine.shutdown()
-            torch.cuda.empty_cache()
+        self.assertEqual(len(scores), 2)
+        for score_list in scores:
+            self.assertEqual(len(score_list), self.NUM_LABELS)
+            self.assertAlmostEqual(sum(score_list), 1.0, places=5)
 
     def _compare_scores(self, query, items, apply_softmax=True, test_name=""):
         """Compare MIS batched vs MIS single-item scoring results."""
@@ -392,6 +389,33 @@ class TestMultiItemScoringClassification(CustomTestCase):
                         f"concurrent={c} vs sequential={s}",
                     )
 
+    def test_mis_single_vs_non_mis(self):
+        """MIS single-item must approximate non-MIS single-item.
+
+        MIS inserts delimiter tokens into the attention context, which
+        perturbs hidden states; after softmax the scores should still land
+        within places=1 (+-0.05).
+        """
+        query = "Rate this option:"
+        items = [" Option A", " Option B", " Option C"]
+        non_mis_scores = self.non_mis_engine.score(
+            query=query, items=items, apply_softmax=True
+        ).scores
+        mis_scores = self.engine.score(
+            query=query, items=items, apply_softmax=True
+        ).scores
+
+        self.assertEqual(len(mis_scores), len(non_mis_scores))
+        for i, (ms, ns) in enumerate(zip(mis_scores, non_mis_scores)):
+            self.assertEqual(len(ms), len(ns))
+            for j, (m, n) in enumerate(zip(ms, ns)):
+                self.assertAlmostEqual(
+                    m,
+                    n,
+                    places=1,
+                    msg=f"item {i} label {j}: MIS={m} vs non-MIS={n}",
+                )
+
 
 class TestMultiItemScoringParity(CustomTestCase):
     """Test that MIS produces the same results as single-item scoring."""
@@ -488,65 +512,6 @@ class TestMultiItemScoringParity(CustomTestCase):
         labels = [" 1", " 2", " 3", " 4", " 5"]
         label_ids = [tokenizer.encode(lb, add_special_tokens=False)[0] for lb in labels]
         self._compare_scores(query, items, label_ids, test_name="many_items")
-
-
-class TestMultiItemScoringClassificationMISvsNonMIS(CustomTestCase):
-    """Test that MIS single-item approximates non-MIS single-item.
-
-    The MIS path inserts delimiter tokens into the attention context,
-    which slightly perturbs hidden states.  After softmax the scores
-    should still be close.  Uses places=1 (±0.05) tolerance.
-
-    Runs as a separate class so each engine is created and destroyed
-    independently to avoid GPU OOM.
-    """
-
-    def test_mis_single_vs_non_mis(self):
-        non_mis_engine = Engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            mem_fraction_static=0.15,
-        )
-        try:
-            query = "Rate this option:"
-            items = [" Option A", " Option B", " Option C"]
-            non_mis_scores = non_mis_engine.score(
-                query=query,
-                items=items,
-                apply_softmax=True,
-            ).scores
-        finally:
-            non_mis_engine.shutdown()
-            torch.cuda.empty_cache()
-
-        mis_engine = Engine(
-            model_path=TEST_CLASSIFICATION_BASE_MODEL,
-            disable_radix_cache=True,
-            chunked_prefill_size=-1,
-            enable_mis=True,
-            attention_backend="flashinfer",
-            mem_fraction_static=0.15,
-        )
-        try:
-            mis_scores = mis_engine.score(
-                query=query,
-                items=items,
-                apply_softmax=True,
-            ).scores
-        finally:
-            mis_engine.shutdown()
-            torch.cuda.empty_cache()
-
-        self.assertEqual(len(mis_scores), len(non_mis_scores))
-        for i, (ms, ns) in enumerate(zip(mis_scores, non_mis_scores)):
-            self.assertEqual(len(ms), len(ns))
-            for j, (m, n) in enumerate(zip(ms, ns)):
-                self.assertAlmostEqual(
-                    m,
-                    n,
-                    places=1,
-                    msg=f"item {i} label {j}: MIS={m} vs non-MIS={n}",
-                )
 
 
 if __name__ == "__main__":

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -37,13 +37,13 @@ TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
 )
 _CLS_NUM_LABELS = AutoConfig.from_pretrained(TEST_CLASSIFICATION_BASE_MODEL).num_labels
 
-# Engines are shared across classes by config: score() is stateless and the
-# radix cache is off everywhere here, so booting the same config once per class
-# only cost wall time.
+# Engines are shared by config across classes and test methods: score() is
+# stateless and the radix cache is off everywhere here, so re-booting the same
+# config only cost wall time.
 #
-# The bound must stay strictly above the most engines any single class holds at
-# once (two, for the MIS vs non-MIS comparisons) -- otherwise eviction could
-# shut down an engine a live class still references through cls.engine.
+# The bound must stay strictly above the most engines one class holds at once
+# (two, for the MIS vs non-MIS comparisons), or eviction could shut down an
+# engine a live class still references through cls.engine.
 _MAX_LIVE_ENGINES = 3
 _ENGINE_CACHE = OrderedDict()
 
@@ -178,8 +178,6 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        # One engine for the whole class: score() is stateless and the radix
-        # cache is off, so the per-method boot this used to do bought nothing.
         cls.engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -16,6 +16,7 @@ bugs in tensor shape handling (e.g., 2D tensors [num_delimiters, num_label_token
 import asyncio
 import os
 import unittest
+from collections import OrderedDict
 
 import torch
 from transformers import AutoConfig, AutoTokenizer
@@ -27,7 +28,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
 )
 
-register_cuda_ci(est_time=175, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=120, stage="base-b", runner_config="1-gpu-small")
 
 TEST_MODEL_NAME = os.environ.get("TEST_MODEL_NAME", DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
 TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
@@ -35,6 +36,36 @@ TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
     "tomaarsen/Qwen3-Reranker-0.6B-seq-cls",
 )
 _CLS_NUM_LABELS = AutoConfig.from_pretrained(TEST_CLASSIFICATION_BASE_MODEL).num_labels
+
+# Engines are shared across classes by config: score() is stateless and the
+# radix cache is off everywhere here, so booting the same config once per class
+# only cost wall time.
+#
+# The bound must stay strictly above the most engines any single class holds at
+# once (two, for the MIS vs non-MIS comparisons) -- otherwise eviction could
+# shut down an engine a live class still references through cls.engine.
+_MAX_LIVE_ENGINES = 3
+_ENGINE_CACHE = OrderedDict()
+
+
+def get_engine(**kwargs) -> Engine:
+    key = tuple(sorted(kwargs.items()))
+    engine = _ENGINE_CACHE.pop(key, None)
+    if engine is None:
+        while len(_ENGINE_CACHE) >= _MAX_LIVE_ENGINES:
+            _, evicted = _ENGINE_CACHE.popitem(last=False)
+            evicted.shutdown()
+            torch.cuda.empty_cache()
+        engine = Engine(**kwargs)
+    _ENGINE_CACHE[key] = engine
+    return engine
+
+
+def tearDownModule():
+    while _ENGINE_CACHE:
+        _, engine = _ENGINE_CACHE.popitem()
+        engine.shutdown()
+    torch.cuda.empty_cache()
 
 
 class TestMISServerArgsValidation(unittest.TestCase):
@@ -52,7 +83,7 @@ class TestMultiItemScoringOptimization(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = Engine(
+        cls.engine = get_engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -60,20 +91,12 @@ class TestMultiItemScoringOptimization(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-        cls.non_mis_engine = Engine(
+        cls.non_mis_engine = get_engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
             mem_fraction_static=0.15,
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.engine is not None:
-            cls.engine.shutdown()
-        if cls.non_mis_engine is not None:
-            cls.non_mis_engine.shutdown()
-        torch.cuda.empty_cache()
 
     def test_mis_basic(self):
         """Test basic MIS: correct shapes, valid probabilities."""
@@ -157,7 +180,7 @@ class TestMultiItemScoringClassification(CustomTestCase):
     def setUpClass(cls):
         # One engine for the whole class: score() is stateless and the radix
         # cache is off, so the per-method boot this used to do bought nothing.
-        cls.engine = Engine(
+        cls.engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -165,12 +188,6 @@ class TestMultiItemScoringClassification(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.engine is not None:
-            cls.engine.shutdown()
-            torch.cuda.empty_cache()
 
     def test_classification_mis_basic(self):
         """Classification MIS: correct shapes, valid softmax probabilities."""
@@ -207,23 +224,19 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     def test_classification_non_mis_fallback(self):
         """Classification model works correctly without --enable-mis."""
-        non_mis_engine = Engine(
+        non_mis_engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             mem_fraction_static=0.15,
         )
-        try:
-            scores = non_mis_engine.score(
-                query="Test:", items=["A", "B"], apply_softmax=True
-            ).scores
+        scores = non_mis_engine.score(
+            query="Test:", items=["A", "B"], apply_softmax=True
+        ).scores
 
-            self.assertEqual(len(scores), 2)
-            for score_list in scores:
-                self.assertEqual(len(score_list), self.NUM_LABELS)
-                self.assertAlmostEqual(sum(score_list), 1.0, places=5)
-        finally:
-            non_mis_engine.shutdown()
-            torch.cuda.empty_cache()
+        self.assertEqual(len(scores), 2)
+        for score_list in scores:
+            self.assertEqual(len(score_list), self.NUM_LABELS)
+            self.assertAlmostEqual(sum(score_list), 1.0, places=5)
 
 
 class TestMultiItemScoringParity(CustomTestCase):
@@ -231,29 +244,19 @@ class TestMultiItemScoringParity(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine_single = Engine(
+        cls.engine_single = get_engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
-            log_level="error",
             mem_fraction_static=0.15,
         )
-        cls.engine_mis = Engine(
+        cls.engine_mis = get_engine(
             model_path=TEST_MODEL_NAME,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
-            log_level="error",
             enable_mis=True,
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.engine_single is not None:
-            cls.engine_single.shutdown()
-        if cls.engine_mis is not None:
-            cls.engine_mis.shutdown()
-        torch.cuda.empty_cache()
 
     def _compare_scores(
         self, query, items, label_token_ids=None, apply_softmax=True, test_name=""
@@ -336,7 +339,7 @@ class TestMultiItemScoringClassificationParity(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = Engine(
+        cls.engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -344,12 +347,6 @@ class TestMultiItemScoringClassificationParity(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.engine is not None:
-            cls.engine.shutdown()
-        torch.cuda.empty_cache()
 
     def _compare_scores(self, query, items, apply_softmax=True, test_name=""):
         """Compare MIS batched vs MIS single-item scoring results."""
@@ -420,24 +417,20 @@ class TestMultiItemScoringClassificationMISvsNonMIS(CustomTestCase):
     """
 
     def test_mis_single_vs_non_mis(self):
-        non_mis_engine = Engine(
+        non_mis_engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             mem_fraction_static=0.15,
         )
-        try:
-            query = "Rate this option:"
-            items = [" Option A", " Option B", " Option C"]
-            non_mis_scores = non_mis_engine.score(
-                query=query,
-                items=items,
-                apply_softmax=True,
-            ).scores
-        finally:
-            non_mis_engine.shutdown()
-            torch.cuda.empty_cache()
+        query = "Rate this option:"
+        items = [" Option A", " Option B", " Option C"]
+        non_mis_scores = non_mis_engine.score(
+            query=query,
+            items=items,
+            apply_softmax=True,
+        ).scores
 
-        mis_engine = Engine(
+        mis_engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -445,15 +438,11 @@ class TestMultiItemScoringClassificationMISvsNonMIS(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-        try:
-            mis_scores = mis_engine.score(
-                query=query,
-                items=items,
-                apply_softmax=True,
-            ).scores
-        finally:
-            mis_engine.shutdown()
-            torch.cuda.empty_cache()
+        mis_scores = mis_engine.score(
+            query=query,
+            items=items,
+            apply_softmax=True,
+        ).scores
 
         self.assertEqual(len(mis_scores), len(non_mis_scores))
         for i, (ms, ns) in enumerate(zip(mis_scores, non_mis_scores)):
@@ -475,7 +464,7 @@ class TestMultiItemScoringClassificationAdvanced(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.engine = Engine(
+        cls.engine = get_engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -483,12 +472,6 @@ class TestMultiItemScoringClassificationAdvanced(CustomTestCase):
             attention_backend="flashinfer",
             mem_fraction_static=0.15,
         )
-
-    @classmethod
-    def tearDownClass(cls):
-        if cls.engine is not None:
-            cls.engine.shutdown()
-        torch.cuda.empty_cache()
 
     def test_items_produce_distinct_scores(self):
         """Different items must produce different score vectors.

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -27,7 +27,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
 )
 
-register_cuda_ci(est_time=211, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=175, stage="base-b", runner_config="1-gpu-small")
 
 TEST_MODEL_NAME = os.environ.get("TEST_MODEL_NAME", DEFAULT_SMALL_MODEL_NAME_FOR_TEST)
 TEST_CLASSIFICATION_BASE_MODEL = os.environ.get(
@@ -153,8 +153,11 @@ class TestMultiItemScoringClassification(CustomTestCase):
 
     NUM_LABELS = _CLS_NUM_LABELS
 
-    def setUp(self):
-        self.engine = Engine(
+    @classmethod
+    def setUpClass(cls):
+        # One engine for the whole class: score() is stateless and the radix
+        # cache is off, so the per-method boot this used to do bought nothing.
+        cls.engine = Engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,
             chunked_prefill_size=-1,
@@ -163,9 +166,10 @@ class TestMultiItemScoringClassification(CustomTestCase):
             mem_fraction_static=0.15,
         )
 
-    def tearDown(self):
-        if self.engine is not None:
-            self.engine.shutdown()
+    @classmethod
+    def tearDownClass(cls):
+        if cls.engine is not None:
+            cls.engine.shutdown()
             torch.cuda.empty_cache()
 
     def test_classification_mis_basic(self):

--- a/test/registered/prefill_only/test_multi_item_scoring.py
+++ b/test/registered/prefill_only/test_multi_item_scoring.py
@@ -145,21 +145,20 @@ class TestMultiItemScoringOptimization(CustomTestCase):
 
 
 class TestMultiItemScoringClassification(CustomTestCase):
-    """MIS on a classification model: basics, MIS-vs-single-item parity, and
-    score distinctness / determinism / concurrency.
+    """MIS on a classification model: basics, MIS-vs-single-item parity, score
+    distinctness / determinism / concurrency.
 
-    Uses a pre-trained Qwen3ForSequenceClassification model so the head
-    weights are deterministic. All three groups share one engine: the CI
-    harness requires an idle GPU at every setUpClass, so separate classes
-    would mean re-booting the same config instead of sharing it.
+    Pre-trained Qwen3ForSequenceClassification, so the head weights are
+    deterministic. One class rather than four because the CI harness demands an
+    idle GPU at every setUpClass -- splitting these means re-booting the same
+    two engines instead of sharing them. score() is stateless and the radix
+    cache is off, so sharing is safe.
     """
 
     NUM_LABELS = _CLS_NUM_LABELS
 
     @classmethod
     def setUpClass(cls):
-        # Two engines for the whole class: score() is stateless and the radix
-        # cache is off, so booting either config per test bought nothing.
         cls.engine = Engine(
             model_path=TEST_CLASSIFICATION_BASE_MODEL,
             disable_radix_cache=True,

--- a/test/registered/quant/test_quark_mxfp4.py
+++ b/test/registered/quant/test_quark_mxfp4.py
@@ -3,9 +3,8 @@ import os
 import re
 import unittest
 
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci
 
-register_cuda_ci(est_time=103, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=106, suite="stage-b-test-1-gpu-small-amd-mi35x")
 import time
 from types import SimpleNamespace

--- a/test/registered/quant/test_quark_mxfp4.py
+++ b/test/registered/quant/test_quark_mxfp4.py
@@ -13,7 +13,7 @@ import requests
 import torch
 
 from sglang.srt.utils import kill_process_tree
-from sglang.srt.utils.common import is_cuda_alike, mxfp_supported
+from sglang.srt.utils.common import is_cuda_alike, is_gfx95_supported
 from sglang.test.few_shot_gsm8k import run_eval
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
@@ -35,7 +35,7 @@ class TestOnlineQuantizationMemoryLoad(CustomTestCase):
                 f"test requires {cls.tp} devices, only {torch.cuda.device_count()} are available."
             )
 
-        if not mxfp_supported():
+        if not is_gfx95_supported():
             raise unittest.SkipTest(
                 "online MXFP4 quantization requires an AMD ROCm device with "
                 "FP4 hardware support (gfx95x, e.g. MI355x)"

--- a/test/registered/spec/dflash/test_dflash.py
+++ b/test/registered/spec/dflash/test_dflash.py
@@ -161,7 +161,7 @@ class TestDFlashServerNoCudaGraph(TestDFlashServerBase):
     other_launch_args = ["--disable-cuda-graph"]
 
 
-class TestDFlashServerSpecV2(TestDFlashServerBase):
+class TestDFlashServerOverlap(TestDFlashServerBase):
     disable_overlap = False
 
     def test_radix_attention(self):
@@ -169,7 +169,7 @@ class TestDFlashServerSpecV2(TestDFlashServerBase):
         assert self.process.poll() is None
 
 
-class TestDFlashServerSpecV2PlanStream(TestDFlashServerSpecV2):
+class TestDFlashServerOverlapPlanStream(TestDFlashServerOverlap):
     overlap_plan_stream = True
 
 

--- a/test/registered/spec/eagle/test_spec_eagle.py
+++ b/test/registered/spec/eagle/test_spec_eagle.py
@@ -1,5 +1,7 @@
-"""EAGLE3 spec-decoding core: overlap (spec v2) x no-overlap (spec v1) matrix,
-same standard config (topk=1, page_size=1), only ``disable_overlap`` differs.
+"""EAGLE3 spec-decoding core: overlap x no-overlap matrix at the standard
+config (topk=1, page_size=1); only ``disable_overlap`` differs. Both run the
+same EAGLEWorkerV2 -- the scheduler just drives it synchronously when overlap
+is off.
 flashinfer is pinned (the 5090 default) so a default-selection change can't
 silently alter what this exercises.
 """
@@ -35,13 +37,13 @@ class _Core(Eagle3Base):
 
 
 class TestEagle3Overlap(_Core, *_KITS):
-    """Spec v2 (overlap scheduler on)."""
+    """Overlap scheduler on."""
 
     disable_overlap = False
 
 
 class TestEagle3NoOverlap(_Core, *_KITS):
-    """Spec v1 (overlap scheduler off)."""
+    """Overlap scheduler off (synchronous)."""
 
     disable_overlap = True
 

--- a/test/registered/spec/eagle/test_spec_eagle_fa3.py
+++ b/test/registered/spec/eagle/test_spec_eagle_fa3.py
@@ -17,7 +17,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=540, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=250, stage="base-b", runner_config="1-gpu-large")
 
 
 class TestEagle3Fa3(Eagle3Base, SpecAccuracyKit, SpecLogprobKit):

--- a/test/registered/spec/eagle/test_spec_eagle_fa3.py
+++ b/test/registered/spec/eagle/test_spec_eagle_fa3.py
@@ -10,7 +10,6 @@ from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
-    SpecCorrectnessKit,
     SpecFeatureKit,
     SpecLogprobKit,
     SpecPenaltyKit,
@@ -18,11 +17,17 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=600, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=540, stage="base-b", runner_config="1-gpu-large")
 
 
-class TestEagle3Fa3(Eagle3Base, SpecCorrectnessKit, SpecAccuracyKit, SpecLogprobKit):
-    """EAGLE3 topk=1 on fa3 (the H200 default backend), overlap on."""
+class TestEagle3Fa3(Eagle3Base, SpecAccuracyKit, SpecLogprobKit):
+    """EAGLE3 topk=1 on fa3 (the H200 default backend), overlap on.
+
+    The accept-length / eos / batch-generation / first-token-finish checks are
+    scheduler and sampling behaviours, so the flashinfer and triton runs on the
+    5090 pool cover them. Logprob losslessness stays: it reads through the
+    verify output, which the attention unit cases do not reach.
+    """
 
     attention_backend = "fa3"
     disable_overlap = False

--- a/test/registered/spec/eagle/test_spec_eagle_fa3.py
+++ b/test/registered/spec/eagle/test_spec_eagle_fa3.py
@@ -22,7 +22,7 @@ register_cuda_ci(est_time=600, stage="base-b", runner_config="1-gpu-large")
 
 
 class TestEagle3Fa3(Eagle3Base, SpecCorrectnessKit, SpecAccuracyKit, SpecLogprobKit):
-    """EAGLE3 spec v2 topk=1 on fa3 (the H200 default backend)."""
+    """EAGLE3 topk=1 on fa3 (the H200 default backend), overlap on."""
 
     attention_backend = "fa3"
     disable_overlap = False
@@ -37,7 +37,7 @@ class TestEagleLlama2Fa3Page256(
     SpecPerfKit,
     SpecFeatureKit,
 ):
-    """EAGLE/Llama-2 topk=5 tree on fa3 + page_size=256 (spec v1)."""
+    """EAGLE/Llama-2 topk=5 tree on fa3 + page_size=256, overlap off."""
 
     spec_topk = 5
     spec_steps = 8

--- a/test/registered/spec/eagle/test_spec_eagle_fa3.py
+++ b/test/registered/spec/eagle/test_spec_eagle_fa3.py
@@ -23,10 +23,9 @@ register_cuda_ci(est_time=540, stage="base-b", runner_config="1-gpu-large")
 class TestEagle3Fa3(Eagle3Base, SpecAccuracyKit, SpecLogprobKit):
     """EAGLE3 topk=1 on fa3 (the H200 default backend), overlap on.
 
-    The accept-length / eos / batch-generation / first-token-finish checks are
-    scheduler and sampling behaviours, so the flashinfer and triton runs on the
-    5090 pool cover them. Logprob losslessness stays: it reads through the
-    verify output, which the attention unit cases do not reach.
+    No SpecCorrectnessKit: those checks are scheduler/sampling behaviour, which
+    the 5090 runs already cover. Logprob losslessness stays -- it reads through
+    the verify output, which the attention unit cases do not reach.
     """
 
     attention_backend = "fa3"

--- a/test/registered/spec/eagle/test_spec_eagle_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_page.py
@@ -1,7 +1,7 @@
-"""page_size > 1 variants at topk=1 (flashinfer).
+"""EAGLE3 chain drafting (topk=1) at page_size > 1, flashinfer.
 
-EAGLE3 page64 (spec v2) + EAGLE/Llama-2 page4 (spec v1). topk>1 page variants
-live in test_spec_eagle_topk.py. Runs on the cheap (5090) runner.
+topk=1 takes its own fast path in the draft worker, so this cell is not
+covered by the tree variants in test_spec_eagle_topk_page.py.
 """
 
 import unittest
@@ -13,25 +13,16 @@ from sglang.test.kits.spec_server_kits import (
     SpecFeatureKit,
     SpecLogprobKit,
 )
-from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
+from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=360, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=215, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Page64(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeatureKit):
-    """EAGLE3 spec v2, page_size=64 (flashinfer): + logprob losslessness."""
+    """Overlap scheduler, page_size=64: + logprob losslessness."""
 
     page_size = 64
     disable_overlap = False
-    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
-
-
-class TestEagleLlama2Page4Topk1(EagleLlama2Base, SpecAccuracyKit, SpecFeatureKit):
-    """Llama-2 topk=1 + page_size=4."""
-
-    spec_topk = 1
-    spec_tokens = 6
-    page_size = 4
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/spec/eagle/test_spec_eagle_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_page.py
@@ -16,7 +16,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=250, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=230, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Page64(

--- a/test/registered/spec/eagle/test_spec_eagle_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_page.py
@@ -10,15 +10,22 @@ from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
+    SpecCorrectnessKit,
     SpecFeatureKit,
     SpecLogprobKit,
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=215, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=250, stage="base-b", runner_config="1-gpu-small")
 
 
-class TestEagle3Page64(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeatureKit):
+class TestEagle3Page64(
+    Eagle3Base,
+    SpecCorrectnessKit,
+    SpecAccuracyKit,
+    SpecLogprobKit,
+    SpecFeatureKit,
+):
     """Overlap scheduler, page_size=64: + logprob losslessness."""
 
     page_size = 64

--- a/test/registered/spec/eagle/test_spec_eagle_parity.py
+++ b/test/registered/spec/eagle/test_spec_eagle_parity.py
@@ -27,7 +27,7 @@ class _Eagle3ParityBase(Eagle3Base):
 
 @unittest.skipIf(_is_xpu, "CUDA runner only")
 class TestEagle3ParityCUDA(SpecParityKit, _Eagle3ParityBase):
-    """EAGLE3 spec v2 (flashinfer, overlap) greedy output == non-spec reference.
+    """EAGLE3 (flashinfer, overlap) greedy output == non-spec reference.
 
     SpecParityKit is first so its setUpClass runs the reference server (and tears
     it down) before the fixture launches the spec server -- sequential, one model

--- a/test/registered/spec/eagle/test_spec_eagle_stress.py
+++ b/test/registered/spec/eagle/test_spec_eagle_stress.py
@@ -1,18 +1,15 @@
-"""Perf + stress: throughput, retract-under-pressure, abort storms, timeouts.
+"""Perf + stress: throughput and retract-under-pressure.
 
-These need memory headroom / measure load behavior, so they run on the large
-(Hopper) runner.
+These need memory headroom / measure load behaviour, so they run on the large
+(Hopper) runner. The scheduler timeout paths carry no spec-specific state, so
+they live in unit/managers/test_scheduler_timeouts.py plus the cheap e2e in
+scheduler/test_scheduler_control.py.
 """
 
 import unittest
 
 from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
-from sglang.test.kits.abort_timeout_kit import (
-    AbortAllMixin,
-    RunningTimeoutTwoWaveMixin,
-    WaitingTimeoutMixin,
-)
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
     SpecFeatureKit,
@@ -20,7 +17,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=780, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=440, stage="base-b", runner_config="1-gpu-large")
 
 
 class TestEagle3Perf(Eagle3Base, SpecPerfKit):
@@ -54,28 +51,6 @@ class TestEagle3Topk16V2Retract(Eagle3Base, SpecAccuracyKit, SpecFeatureKit):
     extra_args = ("--max-total-tokens", 4500)  # small KV to trigger retract
     env_overrides = (
         (envs.SGLANG_TEST_RETRACT, True),
-        (envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),
-    )
-
-
-class TestEagleLlama2AbortAll(EagleLlama2Base, AbortAllMixin):
-    abort_all_max_new_tokens = 4000
-    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
-
-
-class TestEagleLlama2WaitingTimeout(EagleLlama2Base, WaitingTimeoutMixin):
-    max_running_requests = 1
-    env_overrides = (
-        (envs.SGLANG_REQ_WAITING_TIMEOUT, 0.001),
-        (envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),
-    )
-
-
-class TestEagleLlama2RunningTimeout(EagleLlama2Base, RunningTimeoutTwoWaveMixin):
-    # Regression: https://github.com/sgl-project/sglang/pull/18760
-    max_running_requests = 16
-    env_overrides = (
-        (envs.SGLANG_REQ_RUNNING_TIMEOUT, 3),
         (envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),
     )
 

--- a/test/registered/spec/eagle/test_spec_eagle_stress.py
+++ b/test/registered/spec/eagle/test_spec_eagle_stress.py
@@ -24,7 +24,7 @@ register_cuda_ci(est_time=780, stage="base-b", runner_config="1-gpu-large")
 
 
 class TestEagle3Perf(Eagle3Base, SpecPerfKit):
-    """Decode throughput (max_new_tokens=1) on EAGLE3 spec v2."""
+    """Decode throughput (max_new_tokens=1) on EAGLE3."""
 
     disable_overlap = False
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
@@ -42,7 +42,7 @@ class TestEagleLlama2Retract(EagleLlama2Base, SpecAccuracyKit, SpecFeatureKit):
 
 
 class TestEagle3Topk16V2Retract(Eagle3Base, SpecAccuracyKit, SpecFeatureKit):
-    """EAGLE3 topk=16 tree on spec v2 under retract; must not leak KV. Stresses
+    """EAGLE3 topk=16 tree under retract; must not leak KV. Stresses
     the accepted-path KV move (move_accept_tokens_to_target_kvcache)."""
 
     spec_topk = 16

--- a/test/registered/spec/eagle/test_spec_eagle_topk.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk.py
@@ -31,10 +31,9 @@ class TestEagle3Topk16(
     SpecFeatureKit,
     SpecHiddenStatesKit,
 ):
-    """EAGLE3 topk=16 tree with the overlap scheduler: guards the accepted-path
-    compaction (validated by logprob_decode_match_prefill) and, via
-    SpecHiddenStatesKit, the per-request hidden-state stride slicing that the
-    same tree compaction feeds.
+    """EAGLE3 topk=16 tree, overlap scheduler: guards the accepted-path
+    compaction (via logprob_decode_match_prefill) and the per-request
+    hidden-state stride slicing that the same compaction feeds.
     """
 
     spec_topk = 16

--- a/test/registered/spec/eagle/test_spec_eagle_topk.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk.py
@@ -9,6 +9,7 @@ import unittest
 
 from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.abort_timeout_kit import AbortAllMixin
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
     SpecCorrectnessKit,
@@ -19,7 +20,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=830, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=870, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Topk16(
@@ -54,9 +55,16 @@ class TestEagleLlama2Suite(
     SpecLogprobKit,
     SpecPenaltyKit,
     SpecFeatureKit,
+    AbortAllMixin,
 ):
-    """EAGLE/Llama-2 topk=8 full coverage (kits listed in bases)."""
+    """EAGLE/Llama-2 topk=8 full coverage (kits listed in bases).
 
+    Hosts AbortAllMixin: aborting mid-decode has to release the tree draft
+    state, and the strict mem check below turns a leak into a failure. It needs
+    no server flags of its own, so it rides this launch.
+    """
+
+    abort_all_max_new_tokens = 4000
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/spec/eagle/test_spec_eagle_topk.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk.py
@@ -1,8 +1,7 @@
-"""topk > 1 tree drafting (EAGLE3 topk16 + EAGLE/Llama-2 topk8).
+"""topk > 1 tree drafting at page_size=1 (EAGLE3 topk16 + EAGLE/Llama-2 topk8).
 
-topk > 1 routes to spec v1, except page_size==1 which can also stay on spec v2
-(overlap). flashinfer is pinned because this runs on the cheap (5090) runner,
-where fa3 (Hopper-only) isn't available -- functional sanity only, no perf/stress.
+flashinfer is pinned because this runs on the cheap (5090) runner, where fa3
+(Hopper-only) isn't available -- functional sanity only, no perf/stress.
 (topk > 1 on fa3 is covered on the Hopper runner in test_spec_eagle_fa3.py.)
 """
 
@@ -14,32 +13,38 @@ from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
     SpecCorrectnessKit,
     SpecFeatureKit,
+    SpecHiddenStatesKit,
     SpecLogprobKit,
     SpecPenaltyKit,
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
 
-register_cuda_ci(est_time=1180, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=830, stage="base-b", runner_config="1-gpu-small")
 
 
-class TestEagle3Topk16(Eagle3Base, SpecCorrectnessKit, SpecAccuracyKit, SpecLogprobKit):
-    """EAGLE3 topk=16 tree (spec v1): correctness + gsm8k + logprob losslessness."""
+class TestEagle3Topk16(
+    Eagle3Base,
+    SpecCorrectnessKit,
+    SpecAccuracyKit,
+    SpecLogprobKit,
+    SpecFeatureKit,
+    SpecHiddenStatesKit,
+):
+    """EAGLE3 topk=16 tree with the overlap scheduler: guards the accepted-path
+    compaction (validated by logprob_decode_match_prefill) and, via
+    SpecHiddenStatesKit, the per-request hidden-state stride slicing that the
+    same tree compaction feeds.
+    """
 
     spec_topk = 16
     spec_tokens = 64
-    disable_overlap = True  # synchronous baseline; SpecV2 subclass flips overlap on
+    disable_overlap = False
+    enable_return_hidden_states = True
     cuda_graph_max_bs_decode = 5
     acc_length_thres = 3.1
     batch_accept_len_thres = 1.75
     gsm8k_accept_len_thres = 2.4  # EAGLE3 topk16 gsm8k accept ~2.48
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
-
-
-class TestEagle3Topk16SpecV2(TestEagle3Topk16, SpecFeatureKit):
-    """EAGLE3 topk=16 tree on spec v2 (overlap, page1): guards the v2 tree path's
-    accepted-path compaction, validated by logprob_spec_v2_match."""
-
-    disable_overlap = False
 
 
 class TestEagleLlama2Suite(

--- a/test/registered/spec/eagle/test_spec_eagle_topk_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk_page.py
@@ -18,7 +18,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=330, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=365, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Page4Topk8(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeatureKit):
@@ -28,7 +28,8 @@ class TestEagle3Page4Topk8(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeat
     spec_topk = 8
     spec_tokens = 32
     disable_overlap = False
-    # Tuned for the topk=8 tree; the preset value is a topk=1 number.
+    # The preset accept-length numbers are topk=1 values, so they are loose
+    # for a topk=8 tree; tighten once CI reports the actuals.
     gsm8k_accept_len_thres = 2.0
     cuda_graph_max_bs_decode = 5
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)

--- a/test/registered/spec/eagle/test_spec_eagle_topk_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk_page.py
@@ -1,10 +1,10 @@
-"""EAGLE3 tree drafting (topk > 1) at page_size > 1, flashinfer.
+"""EAGLE3 tree drafting (topk > 1) at page_size > 1, flashinfer (fa3 is
+Hopper-only).
 
-page_size=4 with 32 draft tokens puts the draft window across several pages,
-the layout the unit fixture refuses to build (it pins tree draft to
-page_size=1, see speculative_draft_runner.py). The window-inside-one-page
+page_size=4 with 32 draft tokens spreads the draft window over several pages --
+the layout the unit fixture refuses to build (tree draft is pinned to
+page_size=1 there, see speculative_draft_runner.py). The window-inside-one-page
 regime is covered by test_spec_eagle_fa3.py page256 on the Hopper runner.
-flashinfer is pinned since fa3 is Hopper-only.
 """
 
 import unittest
@@ -28,8 +28,8 @@ class TestEagle3Page4Topk8(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeat
     spec_topk = 8
     spec_tokens = 32
     disable_overlap = False
-    # The preset accept-length numbers are topk=1 values, so they are loose
-    # for a topk=8 tree; tighten once CI reports the actuals.
+    # Preset accept-length values are topk=1 numbers -- loose for a topk=8
+    # tree; tighten once CI reports the actuals.
     gsm8k_accept_len_thres = 2.0
     cuda_graph_max_bs_decode = 5
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)

--- a/test/registered/spec/eagle/test_spec_eagle_topk_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk_page.py
@@ -1,9 +1,10 @@
-"""topk > 1 tree drafting at page_size > 1 (EAGLE3 topk8 + EAGLE/Llama-2 topk8).
+"""EAGLE3 tree drafting (topk > 1) at page_size > 1, flashinfer.
 
-page64 stays on spec v2 (overlap), page4 runs on spec v1 (no overlap). flashinfer is
-pinned because this runs on the cheap (5090) runner, where fa3 (Hopper-only) isn't
-available -- functional sanity only, no perf/stress. (page>1 topk>1 on fa3 is covered
-on the Hopper runner in test_spec_eagle_fa3.py.)
+page_size=4 with 32 draft tokens puts the draft window across several pages,
+the layout the unit fixture refuses to build (it pins tree draft to
+page_size=1, see speculative_draft_runner.py). The window-inside-one-page
+regime is covered by test_spec_eagle_fa3.py page256 on the Hopper runner.
+flashinfer is pinned since fa3 is Hopper-only.
 """
 
 import unittest
@@ -13,27 +14,23 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
     SpecFeatureKit,
+    SpecLogprobKit,
 )
-from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
+from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=720, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=330, stage="base-b", runner_config="1-gpu-small")
 
 
-class TestEagle3Page64Topk8(Eagle3Base, SpecAccuracyKit, SpecFeatureKit):
-    """EAGLE3 topk=8 tree + page_size=64 (spec v2)."""
+class TestEagle3Page4Topk8(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeatureKit):
+    """Overlap scheduler, topk=8 tree, page_size=4."""
 
-    page_size = 64
+    page_size = 4
     spec_topk = 8
     spec_tokens = 32
     disable_overlap = False
+    # Tuned for the topk=8 tree; the preset value is a topk=1 number.
+    gsm8k_accept_len_thres = 2.0
     cuda_graph_max_bs_decode = 5
-    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
-
-
-class TestEagleLlama2Page4Topk8(EagleLlama2Base, SpecAccuracyKit, SpecFeatureKit):
-    """Llama-2 topk>1 tree + page_size=4 (spec v1)."""
-
-    page_size = 4
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/spec/eagle/test_spec_eagle_topk_page.py
+++ b/test/registered/spec/eagle/test_spec_eagle_topk_page.py
@@ -18,7 +18,7 @@ from sglang.test.kits.spec_server_kits import (
 )
 from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=365, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=345, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Page4Topk8(Eagle3Base, SpecAccuracyKit, SpecLogprobKit, SpecFeatureKit):

--- a/test/registered/spec/eagle/test_spec_eagle_triton.py
+++ b/test/registered/spec/eagle/test_spec_eagle_triton.py
@@ -1,6 +1,8 @@
-"""triton attention backend (EAGLE3 topk=1 chain + EAGLE/Llama-2 topk=8 tree).
+"""triton attention backend, EAGLE3 chain drafting.
 
-triton runs everywhere, so this stays on the cheap (5090) runner.
+triton runs everywhere, so this stays on the cheap (5090) runner. triton tree
+verify is covered by attention/unittests/dense/test_triton.py, and the tree
+accept-path compaction e2e lives in test_spec_eagle_topk.py.
 """
 
 import unittest
@@ -11,13 +13,12 @@ from sglang.test.kits.matched_stop_kit import MatchedStopMixin
 from sglang.test.kits.spec_server_kits import (
     SpecAccuracyKit,
     SpecFeatureKit,
-    SpecHiddenStatesKit,
     SpecLogprobKit,
     SpecPenaltyKit,
 )
-from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base, EagleLlama2Base
+from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
 
-register_cuda_ci(est_time=350, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=230, stage="base-b", runner_config="1-gpu-small")
 
 
 class TestEagle3Triton(
@@ -28,27 +29,13 @@ class TestEagle3Triton(
     SpecPenaltyKit,
     SpecFeatureKit,
 ):
-    """EAGLE3 spec v2 on triton (kits listed in bases)."""
+    """Overlap scheduler on triton (kits listed in bases)."""
 
     attention_backend = "triton"
     max_running_requests = 64
     cuda_graph_max_bs_decode = 64
     gsm8k_num_examples = 200
     gsm8k_check_accept_len = False
-    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
-
-
-class TestEagleLlama2Triton(
-    EagleLlama2Base, SpecAccuracyKit, SpecFeatureKit, SpecHiddenStatesKit
-):
-    """EAGLE/Llama-2 topk=8 tree on triton.
-
-    Hosts SpecHiddenStatesKit: topk>1 exercises the tree accept-path
-    compaction that the per-req hidden-state stride slicing depends on.
-    """
-
-    attention_backend = "triton"
-    enable_return_hidden_states = True
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/spec/test_spec_standalone.py
+++ b/test/registered/spec/test_spec_standalone.py
@@ -4,24 +4,30 @@ from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.json_constrained_kit import JSONConstrainedMixin
 from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.server_fixtures.standalone_fixture import StandaloneServerBase
-from sglang.test.test_utils import CustomTestCase
+from sglang.test.test_utils import CustomTestCase, is_in_ci
 
-# V2 standalone speculative decoding tests (FA3, Triton, FlashInfer backends).
+# V2 standalone speculative decoding. CI runs only fa3, the backend this
+# algorithm is actually deployed on; the triton / flashinfer variants stay
+# runnable locally. Per-backend spec verify numerics are covered by
+# attention/unittests/dense/test_{triton,flashinfer}.py.
 # Non-V2 backends moved to test_spec_standalone_extra.py.
-register_cuda_ci(est_time=450, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=170, stage="base-b", runner_config="1-gpu-large")
 
 
-class TestStandaloneV2SpeculativeDecodingBase(StandaloneServerBase, CustomTestCase):
+class TestStandaloneV2SpeculativeDecodingBase(
+    StandaloneServerBase, CustomTestCase, RegexConstrainedMixin, JSONConstrainedMixin
+):
+    # Hosts the constrained mixins: overlap is on, so they exercise the
+    # grammar barrier path.
     attention_backend = "fa3"
 
 
-class TestStandaloneV2SpeculativeDecodingTriton(
-    StandaloneServerBase, CustomTestCase, RegexConstrainedMixin, JSONConstrainedMixin
-):
-    # Constrained mixins reuse this server; overlap on -> grammar barrier path.
+@unittest.skipIf(is_in_ci(), "CI covers fa3 only; run locally for triton.")
+class TestStandaloneV2SpeculativeDecodingTriton(StandaloneServerBase, CustomTestCase):
     attention_backend = "triton"
 
 
+@unittest.skipIf(is_in_ci(), "CI covers fa3 only; run locally for flashinfer.")
 class TestStandaloneV2SpeculativeDecodingFlashinfer(
     StandaloneServerBase, CustomTestCase
 ):

--- a/test/registered/spec/test_spec_standalone.py
+++ b/test/registered/spec/test_spec_standalone.py
@@ -6,10 +6,9 @@ from sglang.test.kits.regex_constrained_kit import RegexConstrainedMixin
 from sglang.test.server_fixtures.standalone_fixture import StandaloneServerBase
 from sglang.test.test_utils import CustomTestCase, is_in_ci
 
-# V2 standalone speculative decoding. CI runs only fa3, the backend this
-# algorithm is actually deployed on; the triton / flashinfer variants stay
-# runnable locally. Per-backend spec verify numerics are covered by
-# attention/unittests/dense/test_{triton,flashinfer}.py.
+# V2 standalone speculative decoding. CI runs only fa3 (the backend this is
+# deployed on); triton / flashinfer stay runnable locally, and their spec verify
+# numerics live in attention/unittests/dense/test_{triton,flashinfer}.py.
 # Non-V2 backends moved to test_spec_standalone_extra.py.
 register_cuda_ci(est_time=170, stage="base-b", runner_config="1-gpu-large")
 

--- a/test/registered/unit/managers/test_scheduler_timeouts.py
+++ b/test/registered/unit/managers/test_scheduler_timeouts.py
@@ -1,0 +1,122 @@
+"""Boundary tests for the scheduler's waiting / running request timeouts.
+
+Both paths are pure bookkeeping over timestamps -- no model, no GPU, no draft
+worker -- so they are driven here directly instead of through a server. The
+e2e side (503 reaching the client, server stays up) is covered by
+scheduler/test_scheduler_control.py.
+"""
+
+import time
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class _FakeReq:
+    """Minimal stand-in; must stay hashable because the waiting-timeout path
+    collects dropped requests in a set."""
+
+    def __init__(self, rid, wait_entry=0.0, forward_entry=0.0, is_finished=False):
+        self.rid = rid
+        self.to_finish = None
+        self._finished = is_finished
+        self.time_stats = SimpleNamespace(
+            wait_queue_entry_time=wait_entry,
+            forward_entry_time=forward_entry,
+            trace_ctx=MagicMock(),
+        )
+
+    def finished(self):
+        return self._finished
+
+
+def _req(
+    rid: str, *, wait_entry: float = 0.0, forward_entry: float = 0.0, finished=False
+):
+    return _FakeReq(rid, wait_entry, forward_entry, finished)
+
+
+def _scheduler(waiting_queue):
+    s = Scheduler.__new__(Scheduler)
+    s.waiting_queue = waiting_queue
+    s.enable_hicache_storage = False
+    s.ipc_channels = SimpleNamespace(send_to_tokenizer=MagicMock())
+    return s
+
+
+class TestWaitingTimeout(CustomTestCase):
+    def test_drops_only_reqs_past_the_deadline(self):
+        now = time.perf_counter()
+        stale = _req("stale", wait_entry=now - 10)
+        fresh = _req("fresh", wait_entry=now)
+        s = _scheduler([stale, fresh])
+
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1.0):
+            s._abort_on_waiting_timeout()
+
+        self.assertEqual([r.rid for r in s.waiting_queue], ["fresh"])
+        self.assertEqual(s.ipc_channels.send_to_tokenizer.send_output.call_count, 1)
+
+    def test_unset_entry_time_is_never_dropped(self):
+        # 0 is the "not yet stamped" sentinel; the guard is `0 < entry_time`.
+        s = _scheduler([_req("unstamped", wait_entry=0.0)])
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(1e-9):
+            s._abort_on_waiting_timeout()
+        self.assertEqual(len(s.waiting_queue), 1)
+        s.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_disabled_timeout_is_a_no_op(self):
+        s = _scheduler([_req("stale", wait_entry=time.perf_counter() - 100)])
+        with envs.SGLANG_REQ_WAITING_TIMEOUT.override(0):
+            s._abort_on_waiting_timeout()
+        self.assertEqual(len(s.waiting_queue), 1)
+
+
+class TestRunningTimeout(CustomTestCase):
+    @staticmethod
+    def _batch(reqs):
+        return SimpleNamespace(reqs=reqs, is_empty=lambda: not reqs)
+
+    def test_marks_only_stale_unfinished_reqs(self):
+        now = time.perf_counter()
+        stale = _req("stale", forward_entry=now - 10)
+        fresh = _req("fresh", forward_entry=now)
+        done = _req("done", forward_entry=now - 10, finished=True)
+        s = _scheduler([])
+
+        with envs.SGLANG_REQ_RUNNING_TIMEOUT.override(1.0):
+            s._abort_on_running_timeout(self._batch([stale, fresh, done]))
+
+        self.assertIsNotNone(stale.to_finish)
+        self.assertIsNone(fresh.to_finish)
+        self.assertIsNone(done.to_finish, "a finished req must not be aborted")
+
+    def test_unset_forward_entry_time_is_never_marked(self):
+        s = _scheduler([])
+        req = _req("unstamped", forward_entry=0.0)
+        with envs.SGLANG_REQ_RUNNING_TIMEOUT.override(1e-9):
+            s._abort_on_running_timeout(self._batch([req]))
+        self.assertIsNone(req.to_finish)
+
+    def test_empty_batch_and_disabled_timeout_are_no_ops(self):
+        s = _scheduler([])
+        with envs.SGLANG_REQ_RUNNING_TIMEOUT.override(1.0):
+            s._abort_on_running_timeout(self._batch([]))
+        req = _req("stale", forward_entry=time.perf_counter() - 100)
+        with envs.SGLANG_REQ_RUNNING_TIMEOUT.override(0):
+            s._abort_on_running_timeout(self._batch([req]))
+        self.assertIsNone(req.to_finish)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_timeouts.py
+++ b/test/registered/unit/managers/test_scheduler_timeouts.py
@@ -23,8 +23,7 @@ register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 
 class _FakeReq:
-    """Minimal stand-in; must stay hashable because the waiting-timeout path
-    collects dropped requests in a set."""
+    """Must stay hashable: the waiting-timeout path collects drops in a set."""
 
     def __init__(self, rid, wait_entry=0.0, forward_entry=0.0, is_finished=False):
         self.rid = rid


### PR DESCRIPTION
Trims the per-commit speculative-decoding and scoring test matrices, plus two cleanups around the AMD MXFP4 gate. No coverage axis is dropped without naming where it still lives.

## Wall time

Per-file numbers are the p90 measured in `sglang-ci-stats` before this stack; the "after" column is the new `est_time` (the partitioner prefers live data, so these become real once the weekly refresh runs).

**base-b / 1-gpu-5090** — 10116s -> 9187s, and the stage drops from 9 to 8 shards (load factor 8.06 -> 7.32):

| file | measured | after |
|---|---|---|
| `spec/eagle/test_spec_eagle_topk.py` | 1022 | 870 |
| `spec/eagle/test_spec_eagle_topk_page.py` | 554 | 345 |
| `spec/eagle/test_spec_eagle_triton.py` | 462 | 230 |
| `spec/eagle/test_spec_eagle_page.py` | 400 | 230 |
| `openai_server/features/test_openai_server_hidden_states.py` | 251 | 165 |
| `prefill_only/test_multi_item_scoring.py` | 246 | 120 |
| `quant/test_quark_mxfp4.py` | 9 | dropped |

**base-b / 1-gpu-h100** — 9746s -> 9256s (load factor 7.60 -> 7.22):

| file | measured | after |
|---|---|---|
| `spec/eagle/test_spec_eagle_stress.py` | 824 | 440 |
| `spec/eagle/test_spec_eagle_fa3.py` | 294 | 250 |
| `spec/test_spec_standalone.py` | 248 | 170 |

## EAGLE launch matrix

The `spec v1 / spec v2` wording in these files described routing that no longer exists — `spec_info.py` returns `EAGLEWorkerV2` for every EAGLE config, overlap on or off — so what read as two axes was one. Collapsing to the real axes leaves one launch per `(topk, page_size)` cell plus one per axis that cannot fold into a cell (overlap, drafter arch, backend, chunked-prefill, token map), and 13 launches become 9:

- Drop `TestEagle3Topk16` (overlap off) and merge its kit set into the overlap-on class: tree x overlap-off is already covered by `TestEagleLlama2Suite`, and that class now also hosts `SpecHiddenStatesKit`, whose stated dependency is the tree accept-path compaction rather than the triton backend it used to ride on.
- Drop `TestEagleLlama2Triton` (its only unique axis was hidden states, now hosted above) and `TestEagleLlama2Page4Topk8` / `TestEagleLlama2Page4Topk1` (same `(topk, page)` cells as the EAGLE3 classes, differing only by model).
- Move the surviving tree x page>1 launch to `page_size=4`, where 32 draft tokens span several pages. That is the layout the unit fixture refuses to build (`speculative_draft_runner.py` pins tree draft to `page_size=1`), so it needs an e2e; the window-inside-one-page regime stays covered by `test_spec_eagle_fa3.py` page256.
- Add `SpecCorrectnessKit` to both `page_size > 1` cells, which had accuracy and feature coverage but never checked accept length / eos / batch generation at `page_size > 1`. Cheap: those servers already run gsm8k.

## Scheduler timeouts and abort under spec

`_abort_on_waiting_timeout` and `_abort_on_running_timeout` are timestamp bookkeeping over `waiting_queue` / `running_batch.reqs` with no draft-worker state involved, so the two 7B spec launches that covered them are replaced by `unit/managers/test_scheduler_timeouts.py`, which also pins the branches an e2e cannot reach: the `0 < entry_time` sentinel, finished requests not being aborted, and the disabled-timeout no-op. The 503-reaches-the-client half stays in `scheduler/test_scheduler_control.py`. `AbortAllMixin` needs no server flags, so it moves onto the existing 5090 Llama-2 tree launch instead of holding its own.

## Runner-appropriate coverage

- `test_spec_standalone.py`: CI runs fa3 only (the backend this algorithm is deployed on) and the triton / flashinfer variants are `skipIf(is_in_ci())` — per-backend spec verify numerics live in `attention/unittests/dense/`. The constrained mixins move onto the fa3 class so the grammar barrier path is unaffected.
- `test_spec_eagle_fa3.py`: drop `SpecCorrectnessKit` from the chain class. Accept length / eos / batch generation are scheduler and sampling behaviour, already covered on the cheap runner; logprob losslessness stays because it reads through the verify output, which the attention unit cases do not.
- `test_spec_eagle_stress.py`: keep the three genuinely load-bearing classes (throughput, two retract variants) and drop the timeout pair covered above.
- `test_openai_server_hidden_states.py`: drop the EAGLE3 twin of the EAGLE spec class. Both ran the identical matrix over the OpenAI endpoint; the worker-side risk (tree compaction x per-request hidden-state stride) is now covered at `/generate` by the EAGLE3 tree launch on the 5090.

## Scoring engines

`test_multi_item_scoring.py` booted 12 engines per run for 5 distinct configs, including one boot per test method in the classification class. Because `CustomTestCase` waits for an idle GPU before every `setUpClass`, engines cannot be shared across classes — so the four classification classes that used byte-identical configs are merged into one class holding two engines, and the boot count drops to 6 with every test method preserved.

## MXFP4 gate cleanups

- `test/registered/quant/test_quark_mxfp4.py` exercises `--quantization quark_mxfp4`, AMD Quark's online MXFP4 quantization, which requires a ROCm gfx95 device; on the 5090 every class raises `unittest.SkipTest` in `setUpClass`. Only the CUDA registration is dropped — the `stage-b-test-1-gpu-small-amd-mi35x` one, which can actually run, stays. NVIDIA MXFP4 coverage is unaffected (`unit/layers/quantization/test_mxfp4_sm120_cutlass.py`, `models_e2e/test_gpt_oss_4gpu_mxfp4.py`, `models_e2e/test_gpt_oss_sm120.py`).
- `mxfp_supported()` in `srt/utils/common.py` was a byte-for-byte duplicate of the `is_gfx95_supported()` defined a few lines below it, except the latter is `@lru_cache`d and already used by four kernel modules. The duplicate is deleted and its five call sites now use `is_gfx95_supported()`. The old name read like a format-capability check when it answers "is this an AMD gfx95 GPU"; two call sites had bolted on their own `is_hip()` next to it, and the redundant one in `layers/quantization/__init__.py` goes away. The `if _is_hip:` in `mxfp4.py` stays — its else-branch raises with `gcnArchName`, so it is load-bearing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31055241727](https://github.com/sgl-project/sglang/actions/runs/31055241727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31055241524](https://github.com/sgl-project/sglang/actions/runs/31055241524)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
