### PR TITLE
[CI] Skip `apt-get` when the required packages are already installed

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -24,59 +24,6 @@ mark_step_done() {
 }
 
 # ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-# Check out <url> at <commit> under ~/.cache and echo the path. Kept out of the
-# workspace because actions/checkout runs `git clean -ffdx`, so an in-tree clone
-# is deleted before the next job and re-cloned every time - and an editable
-# install pointing there dangles in between. Takes a commit rather than a
-# branch or tag for two reasons: HEAD alone then tells whether the cached copy
-# is current, and a reused checkout installs exactly what a fresh clone would.
-cached_checkout() {
-    local url=$1 commit=$2 dest="${HOME}/.cache/sglang-repos/$3"
-
-    if [ "$(git -C "${dest}" rev-parse HEAD 2>/dev/null)" = "${commit}" ]; then
-        echo "${dest}"
-        return
-    fi
-
-    rm -rf "${dest}"
-    mkdir -p "$(dirname "${dest}")"
-    git init -q "${dest}"
-    # fetch the commit, not clone --branch: a shallow clone of a branch cannot
-    # reach a pinned commit once that branch moves past it.
-    git -C "${dest}" fetch -q --depth 1 "${url}" "${commit}"
-    git -C "${dest}" checkout -q FETCH_HEAD
-    echo "${dest}"
-}
-
-# ---------------------------------------------------------------------------
-# Installed-version lookup
-# ---------------------------------------------------------------------------
-
-# Print an installed distribution's version, or nothing when absent. Reads
-# metadata with the stdlib rather than `pip show`, which imports pip and its
-# vendored deps on every call (~6x slower) and needs a grep/awk pipe to parse.
-# Names are normalized per PEP 503, so any spelling of the requested name
-# matches regardless of the interpreter's importlib.metadata vintage.
-pkg_version() {
-    PKG_QUERY="$1" python3 - <<'EOF'
-import importlib.metadata as md
-import os
-import re
-
-wanted = re.sub(r"[-_.]+", "-", os.environ["PKG_QUERY"]).lower()
-for dist in md.distributions():
-    name = re.sub(r"[-_.]+", "-", dist.metadata["Name"] or "").lower()
-    if name == wanted:
-        # First match wins, as pip reports the first one on sys.path.
-        print(dist.version)
-        break
-EOF
-}
-
-# ---------------------------------------------------------------------------
 # Functions
 # ---------------------------------------------------------------------------
 
@@ -193,12 +140,12 @@ install_apt_packages() {
         ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
     )
 
-    # The images bake these in, so the common case installs nothing while still
-    # paying apt-get update's round trips to every source. Ask dpkg first - a
-    # local status read - and only reach the network for what is missing. The
-    # image, not this script, is what pins these versions: apt-get install only
-    # ever considers the packages named here, so it is not the mechanism keeping
-    # the runner current (a passing run reports 100+ other packages not upgraded).
+    # The images bake these in, so the usual run installs nothing yet still pays
+    # apt-get update's round trips to every source. Ask dpkg first - a local
+    # status read - and reach the network only for what is missing. Nothing is
+    # lost by not running apt-get install here: it only ever considers the
+    # packages named above, so it is not what keeps the runner current (a
+    # passing run reports 100+ other packages left un-upgraded). The image is.
     local pkg
     local -a MISSING_APT_PACKAGES=()
     for pkg in "${CI_APT_PACKAGES[@]}"; do
@@ -333,15 +280,7 @@ remove_stale_cuda12_nvidia_wheels() {
     fi
 
     mapfile -t INSTALLED_NVIDIA_WHEELS < <(
-        python3 - <<'EOF'
-import importlib.metadata as md
-import re
-
-for dist in sorted(md.distributions(), key=lambda d: d.metadata["Name"] or ""):
-    name = re.sub(r"[-_.]+", "-", dist.metadata["Name"] or "").lower()
-    if name.startswith("nvidia-"):
-        print(f"{name}=={dist.version}")
-EOF
+        python3 -m pip list --format=freeze | sed -n '/^nvidia-.*==/p'
     )
     for spec in "${INSTALLED_NVIDIA_WHEELS[@]}"; do
         package_name="${spec%%==*}"
@@ -380,14 +319,9 @@ uninstall_stale_flashinfer() {
     FLASHINFER_PYTHON_REQUIRED=$(grep -Po -m1 'flashinfer_python(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
     # flashinfer-cubin is no longer a pyproject dependency (installed explicitly below), tracks the same version as flashinfer_python
     FLASHINFER_CUBIN_REQUIRED="$FLASHINFER_PYTHON_REQUIRED"
-    FLASHINFER_CUBIN_INSTALLED=$(pkg_version flashinfer-cubin)
-    FLASHINFER_JIT_RAW=$(pkg_version flashinfer-jit-cache)
-    # Split "<version>+<cu tag>"; the tag is absent on a wheel built without one.
-    FLASHINFER_JIT_INSTALLED="${FLASHINFER_JIT_RAW%%+*}"
-    case "$FLASHINFER_JIT_RAW" in
-        *+*) FLASHINFER_JIT_CU_VERSION="${FLASHINFER_JIT_RAW##*+}" ;;
-        *) FLASHINFER_JIT_CU_VERSION="" ;;
-    esac
+    FLASHINFER_CUBIN_INSTALLED=$(pip show flashinfer-cubin 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
+    FLASHINFER_JIT_INSTALLED=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//' || echo "")
+    FLASHINFER_JIT_CU_VERSION=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+//p' || echo "")
 
     UNINSTALL_CUBIN=true
     UNINSTALL_JIT_CACHE=true
@@ -467,7 +401,7 @@ install_sglang() {
     # If the file is missing, force-reinstall the wheel before downstream steps.
     SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
     if [ ! -f "$SITE_PACKAGES/nvidia/cusparselt/lib/libcusparseLt.so.0" ] \
-       && [ -n "$(pkg_version nvidia-cusparselt-cu13)" ]; then
+       && pip show nvidia-cusparselt-cu13 >/dev/null 2>&1; then
         echo "WARNING: nvidia-cusparselt-cu13 metadata present but libcusparseLt.so.0 missing — reinstalling"
         $PIP_CMD install --reinstall nvidia-cusparselt-cu13 $PIP_INSTALL_SUFFIX
     fi
@@ -550,11 +484,8 @@ install_sglang_kernel() {
         printf '%s\n' "${TORCH_IMPORT_ERROR}"
         REINSTALL_TORCH=true
     fi
-    TORCHAUDIO_RAW=$(pkg_version torchaudio)
-    TORCHVISION_RAW=$(pkg_version torchvision)
-    # Only a +cuNNN local tag counts; other local segments mean "no CUDA tag".
-    TORCHAUDIO_CUDA_VER=$(printf '%s' "$TORCHAUDIO_RAW" | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p')
-    TORCHVISION_CUDA_VER=$(printf '%s' "$TORCHVISION_RAW" | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p')
+    TORCHAUDIO_CUDA_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
+    TORCHVISION_CUDA_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
         REINSTALL_TORCH=true
     else
@@ -566,13 +497,12 @@ install_sglang_kernel() {
         done
     fi
     if [ "${REINSTALL_TORCH}" = true ]; then
-        TORCH_RAW=$(pkg_version torch)
-        TORCH_VER="${TORCH_RAW%%+*}"
-        TORCHAUDIO_VER="${TORCHAUDIO_RAW%%+*}"
-        TORCHVISION_VER="${TORCHVISION_RAW%%+*}"
+        TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
         if [ -z "${TORCH_VER}" ] || [ -z "${TORCHAUDIO_VER}" ] || [ -z "${TORCHVISION_VER}" ]; then
             echo "ERROR: could not determine installed torch package versions before reinstall."
-            echo "torch=${TORCH_RAW:-none} torchaudio=${TORCHAUDIO_RAW:-none} torchvision=${TORCHVISION_RAW:-none}"
+            pip show torch torchaudio torchvision || true
             exit 1
         fi
         echo "Reinstalling torch==${TORCH_VER} torchaudio==${TORCHAUDIO_VER} torchvision==${TORCHVISION_VER} from ${CU_VERSION} index to match torch..."
@@ -714,14 +644,14 @@ install_extra_deps() {
     # files that the live variant's RECORD still references, so we force a
     # reinstall to restore them — pip would otherwise see "already satisfied"
     # and skip.
-    if [ -n "$(pkg_version "${MOONCAKE_STALE_PKG}")" ]; then
+    if pip show ${MOONCAKE_STALE_PKG} >/dev/null 2>&1; then
         $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
         $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
-    NIXL_INSTALLED=$(pkg_version nixl)
-    NIXL_BIN_INSTALLED=$(pkg_version "${NIXL_BIN_NAME}")
+    NIXL_INSTALLED=$(pip show nixl 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
+    NIXL_BIN_INSTALLED=$(pip show "${NIXL_BIN_NAME}" 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
     if [ "$NIXL_INSTALLED" = "$NIXL_VERSION" ] && [ "$NIXL_BIN_INSTALLED" = "$NIXL_VERSION" ]; then
         echo "nixl==${NIXL_VERSION} and ${NIXL_BIN_NAME}==${NIXL_VERSION} already installed, keeping them"
     else
@@ -736,11 +666,8 @@ install_extra_deps() {
     $PIP_CMD install "sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@${SGL_EVAL_REF}" $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then
-        # v0.5
-        LMMS_EVAL_REF="8f142bc3082100dbb39aa9b15916c586f3237d09"
-        LMMS_EVAL_DIR=$(cached_checkout https://github.com/EvolvingLMMs-Lab/lmms-eval.git \
-            "${LMMS_EVAL_REF}" lmms-eval)
-        $PIP_CMD install -e "${LMMS_EVAL_DIR}" $PIP_INSTALL_SUFFIX
+        git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
+        $PIP_CMD install -e lmms-eval/ $PIP_INSTALL_SUFFIX
         # lmms-eval v0.5 pulls antlr4-python3-runtime==4.7.2, clobbering the
         # 4.9.3 that sgl-eval's latex2sympy2_extended needs (4.7.2 ImportError
         # at sgl-eval import). Pin it back so the nightly sgl-eval path works.
@@ -759,13 +686,13 @@ install_test_tools() {
     mkdir -p "${HOME}/.cache/sglang/"
     mv python/kernels.lock "${HOME}/.cache/sglang/" || true
 
-    # Install human-eval. Its setup.py needs the pinned setuptools above, hence
-    # --no-build-isolation; the ref is pinned so the cached checkout is stable.
-    HUMAN_EVAL_REF="b8ab15e93948ebb01fe7d5ba2c57ebdaefb4bfb9"
+    # Install human-eval (subshell keeps cd local)
     $PIP_CMD install "setuptools==70.0.0" $PIP_INSTALL_SUFFIX
-    HUMAN_EVAL_DIR=$(cached_checkout https://github.com/merrymercy/human-eval.git \
-        "${HUMAN_EVAL_REF}" human-eval)
-    $PIP_CMD install -e "${HUMAN_EVAL_DIR}" --no-build-isolation $PIP_INSTALL_SUFFIX
+    [ -d human-eval ] || git clone https://github.com/merrymercy/human-eval.git
+    (
+        cd human-eval
+        $PIP_CMD install -e . --no-build-isolation $PIP_INSTALL_SUFFIX
+    )
 
     mark_step_done "${FUNCNAME[0]}"
 }

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -24,6 +24,59 @@ mark_step_done() {
 }
 
 # ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Check out <url> at <commit> under ~/.cache and echo the path. Kept out of the
+# workspace because actions/checkout runs `git clean -ffdx`, so an in-tree clone
+# is deleted before the next job and re-cloned every time - and an editable
+# install pointing there dangles in between. Takes a commit rather than a
+# branch or tag for two reasons: HEAD alone then tells whether the cached copy
+# is current, and a reused checkout installs exactly what a fresh clone would.
+cached_checkout() {
+    local url=$1 commit=$2 dest="${HOME}/.cache/sglang-repos/$3"
+
+    if [ "$(git -C "${dest}" rev-parse HEAD 2>/dev/null)" = "${commit}" ]; then
+        echo "${dest}"
+        return
+    fi
+
+    rm -rf "${dest}"
+    mkdir -p "$(dirname "${dest}")"
+    git init -q "${dest}"
+    # fetch the commit, not clone --branch: a shallow clone of a branch cannot
+    # reach a pinned commit once that branch moves past it.
+    git -C "${dest}" fetch -q --depth 1 "${url}" "${commit}"
+    git -C "${dest}" checkout -q FETCH_HEAD
+    echo "${dest}"
+}
+
+# ---------------------------------------------------------------------------
+# Installed-version lookup
+# ---------------------------------------------------------------------------
+
+# Print an installed distribution's version, or nothing when absent. Reads
+# metadata with the stdlib rather than `pip show`, which imports pip and its
+# vendored deps on every call (~6x slower) and needs a grep/awk pipe to parse.
+# Names are normalized per PEP 503, so any spelling of the requested name
+# matches regardless of the interpreter's importlib.metadata vintage.
+pkg_version() {
+    PKG_QUERY="$1" python3 - <<'EOF'
+import importlib.metadata as md
+import os
+import re
+
+wanted = re.sub(r"[-_.]+", "-", os.environ["PKG_QUERY"]).lower()
+for dist in md.distributions():
+    name = re.sub(r"[-_.]+", "-", dist.metadata["Name"] or "").lower()
+    if name == wanted:
+        # First match wins, as pip reports the first one on sys.path.
+        print(dist.version)
+        break
+EOF
+}
+
+# ---------------------------------------------------------------------------
 # Functions
 # ---------------------------------------------------------------------------
 
@@ -134,22 +187,34 @@ cleanup_stale_shm() {
 }
 
 install_apt_packages() {
-    apt-get update || true
     CI_APT_PACKAGES=(
         python3 python3-pip python3-venv python3-dev git libnuma-dev libssl-dev pkg-config
         libibverbs-dev libibverbs1 ibverbs-providers ibverbs-utils
         ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
     )
-    apt-get install -y --no-install-recommends "${CI_APT_PACKAGES[@]}" || {
-        echo "Warning: apt-get install failed, checking if required packages are available..."
-        for pkg in "${CI_APT_PACKAGES[@]}"; do
-            if ! dpkg -l "$pkg" 2>/dev/null | grep -q "^ii"; then
-                echo "ERROR: Required package $pkg is not installed and apt-get failed"
-                exit 1
-            fi
-        done
-        echo "All required packages are already installed, continuing..."
-    }
+
+    # The images bake these in, so the common case installs nothing while still
+    # paying apt-get update's round trips to every source. Ask dpkg first - a
+    # local status read - and only reach the network for what is missing. The
+    # image, not this script, is what pins these versions: apt-get install only
+    # ever considers the packages named here, so it is not the mechanism keeping
+    # the runner current (a passing run reports 100+ other packages not upgraded).
+    local pkg
+    local -a MISSING_APT_PACKAGES=()
+    for pkg in "${CI_APT_PACKAGES[@]}"; do
+        dpkg -l "$pkg" 2>/dev/null | grep -q "^ii" || MISSING_APT_PACKAGES+=("$pkg")
+    done
+
+    if [ ${#MISSING_APT_PACKAGES[@]} -eq 0 ]; then
+        echo "All required apt packages are already installed, skipping apt-get"
+    else
+        echo "Installing missing apt packages: ${MISSING_APT_PACKAGES[*]}"
+        apt-get update || true
+        apt-get install -y --no-install-recommends "${MISSING_APT_PACKAGES[@]}" || {
+            echo "ERROR: apt-get failed to install: ${MISSING_APT_PACKAGES[*]}"
+            exit 1
+        }
+    fi
 
     mark_step_done "${FUNCNAME[0]}"
 }
@@ -268,7 +333,15 @@ remove_stale_cuda12_nvidia_wheels() {
     fi
 
     mapfile -t INSTALLED_NVIDIA_WHEELS < <(
-        python3 -m pip list --format=freeze | sed -n '/^nvidia-.*==/p'
+        python3 - <<'EOF'
+import importlib.metadata as md
+import re
+
+for dist in sorted(md.distributions(), key=lambda d: d.metadata["Name"] or ""):
+    name = re.sub(r"[-_.]+", "-", dist.metadata["Name"] or "").lower()
+    if name.startswith("nvidia-"):
+        print(f"{name}=={dist.version}")
+EOF
     )
     for spec in "${INSTALLED_NVIDIA_WHEELS[@]}"; do
         package_name="${spec%%==*}"
@@ -307,9 +380,14 @@ uninstall_stale_flashinfer() {
     FLASHINFER_PYTHON_REQUIRED=$(grep -Po -m1 'flashinfer_python(\[[^]]+\])?==\K[0-9A-Za-z\.\-]+' python/pyproject.toml || echo "")
     # flashinfer-cubin is no longer a pyproject dependency (installed explicitly below), tracks the same version as flashinfer_python
     FLASHINFER_CUBIN_REQUIRED="$FLASHINFER_PYTHON_REQUIRED"
-    FLASHINFER_CUBIN_INSTALLED=$(pip show flashinfer-cubin 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
-    FLASHINFER_JIT_INSTALLED=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//' || echo "")
-    FLASHINFER_JIT_CU_VERSION=$(pip show flashinfer-jit-cache 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+//p' || echo "")
+    FLASHINFER_CUBIN_INSTALLED=$(pkg_version flashinfer-cubin)
+    FLASHINFER_JIT_RAW=$(pkg_version flashinfer-jit-cache)
+    # Split "<version>+<cu tag>"; the tag is absent on a wheel built without one.
+    FLASHINFER_JIT_INSTALLED="${FLASHINFER_JIT_RAW%%+*}"
+    case "$FLASHINFER_JIT_RAW" in
+        *+*) FLASHINFER_JIT_CU_VERSION="${FLASHINFER_JIT_RAW##*+}" ;;
+        *) FLASHINFER_JIT_CU_VERSION="" ;;
+    esac
 
     UNINSTALL_CUBIN=true
     UNINSTALL_JIT_CACHE=true
@@ -389,7 +467,7 @@ install_sglang() {
     # If the file is missing, force-reinstall the wheel before downstream steps.
     SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")
     if [ ! -f "$SITE_PACKAGES/nvidia/cusparselt/lib/libcusparseLt.so.0" ] \
-       && pip show nvidia-cusparselt-cu13 >/dev/null 2>&1; then
+       && [ -n "$(pkg_version nvidia-cusparselt-cu13)" ]; then
         echo "WARNING: nvidia-cusparselt-cu13 metadata present but libcusparseLt.so.0 missing — reinstalling"
         $PIP_CMD install --reinstall nvidia-cusparselt-cu13 $PIP_INSTALL_SUFFIX
     fi
@@ -472,8 +550,11 @@ install_sglang_kernel() {
         printf '%s\n' "${TORCH_IMPORT_ERROR}"
         REINSTALL_TORCH=true
     fi
-    TORCHAUDIO_CUDA_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
-    TORCHVISION_CUDA_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p' || true)
+    TORCHAUDIO_RAW=$(pkg_version torchaudio)
+    TORCHVISION_RAW=$(pkg_version torchvision)
+    # Only a +cuNNN local tag counts; other local segments mean "no CUDA tag".
+    TORCHAUDIO_CUDA_VER=$(printf '%s' "$TORCHAUDIO_RAW" | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p')
+    TORCHVISION_CUDA_VER=$(printf '%s' "$TORCHVISION_RAW" | sed -n 's/.*+\(cu[0-9][0-9]*\)$/\1/p')
     if [ "${TORCH_CUDA_VER}" != "${CU_VERSION}" ]; then
         REINSTALL_TORCH=true
     else
@@ -485,12 +566,13 @@ install_sglang_kernel() {
         done
     fi
     if [ "${REINSTALL_TORCH}" = true ]; then
-        TORCH_VER=$(pip show torch 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        TORCHAUDIO_VER=$(pip show torchaudio 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
-        TORCHVISION_VER=$(pip show torchvision 2>/dev/null | grep "^Version:" | awk '{print $2}' | sed 's/+.*//')
+        TORCH_RAW=$(pkg_version torch)
+        TORCH_VER="${TORCH_RAW%%+*}"
+        TORCHAUDIO_VER="${TORCHAUDIO_RAW%%+*}"
+        TORCHVISION_VER="${TORCHVISION_RAW%%+*}"
         if [ -z "${TORCH_VER}" ] || [ -z "${TORCHAUDIO_VER}" ] || [ -z "${TORCHVISION_VER}" ]; then
             echo "ERROR: could not determine installed torch package versions before reinstall."
-            pip show torch torchaudio torchvision || true
+            echo "torch=${TORCH_RAW:-none} torchaudio=${TORCHAUDIO_RAW:-none} torchvision=${TORCHVISION_RAW:-none}"
             exit 1
         fi
         echo "Reinstalling torch==${TORCH_VER} torchaudio==${TORCHAUDIO_VER} torchvision==${TORCHVISION_VER} from ${CU_VERSION} index to match torch..."
@@ -632,14 +714,14 @@ install_extra_deps() {
     # files that the live variant's RECORD still references, so we force a
     # reinstall to restore them — pip would otherwise see "already satisfied"
     # and skip.
-    if pip show ${MOONCAKE_STALE_PKG} >/dev/null 2>&1; then
+    if [ -n "$(pkg_version "${MOONCAKE_STALE_PKG}")" ]; then
         $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
         $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
     $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
-    NIXL_INSTALLED=$(pip show nixl 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
-    NIXL_BIN_INSTALLED=$(pip show "${NIXL_BIN_NAME}" 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
+    NIXL_INSTALLED=$(pkg_version nixl)
+    NIXL_BIN_INSTALLED=$(pkg_version "${NIXL_BIN_NAME}")
     if [ "$NIXL_INSTALLED" = "$NIXL_VERSION" ] && [ "$NIXL_BIN_INSTALLED" = "$NIXL_VERSION" ]; then
         echo "nixl==${NIXL_VERSION} and ${NIXL_BIN_NAME}==${NIXL_VERSION} already installed, keeping them"
     else
@@ -654,8 +736,11 @@ install_extra_deps() {
     $PIP_CMD install "sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@${SGL_EVAL_REF}" $PIP_INSTALL_SUFFIX
 
     if [ "$IS_BLACKWELL" != "1" ]; then
-        git clone --branch v0.5 --depth 1 https://github.com/EvolvingLMMs-Lab/lmms-eval.git
-        $PIP_CMD install -e lmms-eval/ $PIP_INSTALL_SUFFIX
+        # v0.5
+        LMMS_EVAL_REF="8f142bc3082100dbb39aa9b15916c586f3237d09"
+        LMMS_EVAL_DIR=$(cached_checkout https://github.com/EvolvingLMMs-Lab/lmms-eval.git \
+            "${LMMS_EVAL_REF}" lmms-eval)
+        $PIP_CMD install -e "${LMMS_EVAL_DIR}" $PIP_INSTALL_SUFFIX
         # lmms-eval v0.5 pulls antlr4-python3-runtime==4.7.2, clobbering the
         # 4.9.3 that sgl-eval's latex2sympy2_extended needs (4.7.2 ImportError
         # at sgl-eval import). Pin it back so the nightly sgl-eval path works.
@@ -674,13 +759,13 @@ install_test_tools() {
     mkdir -p "${HOME}/.cache/sglang/"
     mv python/kernels.lock "${HOME}/.cache/sglang/" || true
 
-    # Install human-eval (subshell keeps cd local)
+    # Install human-eval. Its setup.py needs the pinned setuptools above, hence
+    # --no-build-isolation; the ref is pinned so the cached checkout is stable.
+    HUMAN_EVAL_REF="b8ab15e93948ebb01fe7d5ba2c57ebdaefb4bfb9"
     $PIP_CMD install "setuptools==70.0.0" $PIP_INSTALL_SUFFIX
-    [ -d human-eval ] || git clone https://github.com/merrymercy/human-eval.git
-    (
-        cd human-eval
-        $PIP_CMD install -e . --no-build-isolation $PIP_INSTALL_SUFFIX
-    )
+    HUMAN_EVAL_DIR=$(cached_checkout https://github.com/merrymercy/human-eval.git \
+        "${HUMAN_EVAL_REF}" human-eval)
+    $PIP_CMD install -e "${HUMAN_EVAL_DIR}" --no-build-isolation $PIP_INSTALL_SUFFIX
 
     mark_step_done "${FUNCNAME[0]}"
 }

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -140,12 +140,10 @@ install_apt_packages() {
         ffmpeg libavcodec-dev libavformat-dev libavutil-dev libswscale-dev
     )
 
-    # The images bake these in, so the usual run installs nothing yet still pays
-    # apt-get update's round trips to every source. Ask dpkg first - a local
-    # status read - and reach the network only for what is missing. Nothing is
-    # lost by not running apt-get install here: it only ever considers the
-    # packages named above, so it is not what keeps the runner current (a
-    # passing run reports 100+ other packages left un-upgraded). The image is.
+    # The images bake these in, so the usual run pays apt-get update's round
+    # trips to install nothing. Skipping it costs no currency either: apt-get
+    # install only ever considers the packages named above, and a passing run
+    # leaves 100+ others un-upgraded - the image is what pins these versions.
     local pkg
     local -a MISSING_APT_PACKAGES=()
     for pkg in "${CI_APT_PACKAGES[@]}"; do


### PR DESCRIPTION
- Check `dpkg -l` for the required packages first, and run `apt-get update` + `apt-get install` only for the ones actually missing (~3s per install step)
- Verified across six runner pools (h100, h200, h20, b200, b300, gb300): every job reports `0 upgraded, 0 newly installed, 0 to remove`, and `apt-get update` gets only `Hit:` responses — the step installed nothing while paying five network round trips to fetch indexes it already had
- Skipping `apt-get install` in that case costs no currency: it only ever considers the 16 packages named in the script, and those same passing runs leave 78-134 other packages un-upgraded — the image, not this script, is what pins these versions
- Self-healing: if an image ever ships without one of them, the `dpkg` check misses and the original `apt-get update` + `install` path runs for just the missing packages

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31051411890](https://github.com/sgl-project/sglang/actions/runs/31051411890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31051410895](https://github.com/sgl-project/sglang/actions/runs/31051410895)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
