### PR TITLE
fix(qwen3_next): don't fuse the shared expert for selectively quantiz…

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -64,6 +64,31 @@ from sglang.srt.utils import (
 
 logger = logging.getLogger(__name__)
 
+
+def _shared_expert_excluded_from_quant(quant_config) -> bool:
+    """True when the checkpoint quantizes the routed experts but keeps the
+    shared expert in higher precision (selective quantization).
+
+    In that case the shared expert must not be fused into the routed FusedMoE:
+    load_weights would remap `...shared_expert.*.weight` onto
+    `...experts.w{1,2,3}_weight`, which does not exist on a quantized
+    FusedMoE module (it holds `w{1,2,3}_weight_packed/_scale/_shape`).
+    """
+    if quant_config is None:
+        return False
+    ignore = getattr(quant_config, "ignore", None) or []
+    excluded = any("shared_expert" in str(pattern) for pattern in ignore)
+    if excluded:
+        logger.warning_once(
+            "Disabling shared-expert fusion: this checkpoint keeps shared experts "
+            "unquantized while routed experts use %s. Fusing them would remap "
+            "'...shared_expert.*.weight' onto '...experts.w{1,2,3}_weight', which "
+            "does not exist on a quantized FusedMoE module.",
+            quant_config.get_name(),
+        )
+    return excluded
+
+
 _is_cuda = is_cuda()
 _is_hip = is_hip()
 _is_npu = is_npu()
@@ -543,8 +568,12 @@ class Qwen3HybridLinearDecoderLayer(nn.Module):
                 alt_stream=alt_stream,
                 prefix=add_prefix("mlp", prefix.replace(".linear_attn", "")),
                 is_nextn=is_nextn,
-                support_shared_expert_fusion=True,
-                enable_cuda_shared_expert_fusion=True,
+                support_shared_expert_fusion=not _shared_expert_excluded_from_quant(
+                    quant_config
+                ),
+                enable_cuda_shared_expert_fusion=not _shared_expert_excluded_from_quant(
+                    quant_config
+                ),
             )
         else:
             self.mlp = Qwen2MoeMLP(
@@ -712,8 +741,12 @@ class Qwen3HybridAttentionDecoderLayer(nn.Module):
                 alt_stream=alt_stream,
                 prefix=add_prefix("mlp", prefix.replace(".self_attn", "")),
                 is_nextn=is_nextn,
-                support_shared_expert_fusion=True,
-                enable_cuda_shared_expert_fusion=True,
+                support_shared_expert_fusion=not _shared_expert_excluded_from_quant(
+                    quant_config
+                ),
+                enable_cuda_shared_expert_fusion=not _shared_expert_excluded_from_quant(
+                    quant_config
+                ),
             )
         else:
             self.mlp = Qwen2MoeMLP(
@@ -1221,6 +1254,13 @@ class Qwen3NextForCausalLM(nn.Module):
                     ) and replaced_name not in params_dict:
                         continue
                     name = replaced_name
+                    if name not in params_dict:
+                        raise KeyError(
+                            f"Checkpoint weight maps to parameter '{name}', which "
+                            f"does not exist. quantization="
+                            f"{self.quant_config.get_name() if self.quant_config else 'none'}, "
+                            f"shared_expert_fusion={self.enable_shared_expert_fusion}."
+                        )
                     param = params_dict[name]
 
                     weight_loader = getattr(param, "weight_loader")


### PR DESCRIPTION
## Motivation

Selectively quantized Qwen3-Next checkpoints fail to load:

```
File "sglang/srt/models/qwen3_next.py", line 1224, in load_weights
    param = params_dict[name]
KeyError: 'model.layers.0.mlp.experts.w2_weight'
```

Reproduced on sglang 0.5.16 and 0.5.17.dev with `bullpoint/Qwen3-Coder-Next-AWQ-4bit`, `--tp-size 2` on 2x A100-40GB. `--moe-runner-backend triton` does not help: the failure is in the weight name mapping, not in the MoE runner.

**Root cause.** The checkpoint quantizes the routed experts but keeps the shared expert in higher precision:

```
model.layers.0.mlp.experts.0.down_proj.weight_packed
model.layers.0.mlp.experts.0.down_proj.weight_scale
model.layers.0.mlp.experts.0.down_proj.weight_shape
model.layers.0.mlp.shared_expert.down_proj.weight      <-- unquantized
```

The shared expert is fused into the routed FusedMoE, so `load_weights` renames it to `mlp.experts.{num_experts}.*` and the expert params mapping maps it onto `mlp.experts.w2_weight`, which a quantized FusedMoE does not have — it holds `w{1,2,3}_weight_packed/_scale/_shape` instead.

The fix has to be applied when the modules are built. `_get_num_fused_shared_experts()` only reads back the value the MoE block already chose, so zeroing it in `Qwen3NextForCausalLM.__init__` leaves the module tree without a `shared_expert` submodule and just moves the failure to `KeyError: '...mlp.shared_expert.down_proj.weight'`.

## Modifications

- Add `_shared_expert_excluded_from_quant(quant_config)`, which detects that the quantization config excludes the shared expert, and warns once explaining why fusion is being disabled.
- Pass `support_shared_expert_fusion=False` / `enable_cuda_shared_expert_fusion=False` when building `Qwen2MoeSparseMoeBlock` in both `Qwen3HybridLinearDecoderLayer` and `Qwen3HybridAttentionDecoderLayer` for such checkpoints.
- Replace the bare `params_dict[name]` access in the expert branch of `load_weights` with an explicit `KeyError` naming the missing parameter, the active quantization scheme and the fusion state, instead of an opaque lookup failure.

## Accuracy Tests

- Before: `KeyError` during weight loading.
- With `--disable-shared-experts-fusion`: loads correctly (isolates the cause).
- With this patch, **without** any extra flag: loads correctly, emits the warning once, and generates coherent output.
- No behaviour change for unquantized checkpoints: `Qwen/Qwen3-Coder-Next` with TP8 loads as before and the warning is not emitted.

## Benchmarking and Profiling

Throughput of the now-loadable quantized checkpoint (2x A100-40GB, TP2) vs the BF16 checkpoint (8x A100-40GB, TP8), identical workload (4096 in / 512 out, 50 prompts, concurrency 8):

| | BF16, 8 GPUs | INT4, 2 GPUs |
|---|---|---|
| Output token throughput | 307 tok/s | 521 tok/s |
| Mean TPOT | 18.4 ms | 13.4 ms |
| P90 TTFT | 9876 ms | 833 ms |

## Related work

#19644 reports the same `KeyError` string on a different path: `Qwen3.5-35B-A3B-AWQ`, loaded as `Qwen3_5MoeForConditionalGeneration` with `quant=awq`, addressed by #20128 (skip quantization for FusedMoE layers listed in `modules_to_not_convert`).

This PR covers a distinct mechanism in `qwen3_next.py`: with compressed-tensors *selective* quantization the shared expert is fused into the routed FusedMoE before the quant method is consulted, so the failure happens in the weight-name remapping rather than in quant method selection. Verified on `bullpoint/Qwen3-Coder-Next-AWQ-4bit` (`Qwen3NextForCausalLM` + `quant=compressed-tensors`).