### PR TITLE
Use main branch in Kimi Dockerfiles

### DIFF
--- a/docker/kimi_k3/kimi_k3_cu12.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu12.Dockerfile
@@ -62,7 +62,7 @@ RUN set -eu; \
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
 RUN rm -rf /sgl-workspace/sglang && \
-    git clone --branch kimi-k3 \
+    git clone --branch main \
       https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
     cd /sgl-workspace/sglang && \
     rm -rf .git && \

--- a/docker/kimi_k3/kimi_k3_cu13.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu13.Dockerfile
@@ -53,7 +53,7 @@ ARG TORCH_CUDA_ARCH_LIST="9.0;10.0a;10.3a"
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
 RUN rm -rf /sgl-workspace/sglang && \
-    git clone --branch kimi-k3 \
+    git clone --branch main \
       https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
     cd /sgl-workspace/sglang && \
     rm -rf .git && \


### PR DESCRIPTION
## Summary

- clone SGLang from the `main` branch in the CUDA 12 Kimi-K3 Dockerfile
- clone SGLang from the `main` branch in the CUDA 13 Kimi-K3 Dockerfile

## Why

Kimi-K3 support is now available on the main branch, so the Dockerfiles no longer need to clone the dedicated `kimi-k3` branch.

## Impact

Kimi-K3 image builds will install the current SGLang code from `main` for both supported CUDA variants.

## Validation

- `git diff --check`
- verified both Kimi-K3 Dockerfiles use `git clone --branch main`
- repository pre-commit hooks passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31052945286](https://github.com/sgl-project/sglang/actions/runs/31052945286)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31052944979](https://github.com/sgl-project/sglang/actions/runs/31052944979)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->