### PR TITLE
Fix ZMQ socket exhaustion in PD transfer path

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import dataclasses
+import errno
 import logging
 import threading
 import time
 from collections import OrderedDict, defaultdict
-from contextlib import nullcontext
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -46,6 +46,68 @@ from sglang.srt.utils.network import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+# A monitored PUSH endpoint consumes three sockets from the same ZMQ context:
+# the PUSH socket, libzmq's internal monitor socket, and the PAIR socket returned
+# by pyzmq's get_monitor_socket(). The manager also owns one PULL server socket.
+_ZMQ_SOCKETS_PER_MONITORED_ENDPOINT = 3
+_ZMQ_MANAGER_BASE_SOCKET_COUNT = 1
+
+# Socket destruction is asynchronous in libzmq. In particular, a newly created
+# socket can temporarily observe EMFILE while evicted sockets are still being
+# reaped. Keep retries short and bounded so endpoint churn does not kill a
+# transfer worker, while genuine configuration errors still surface promptly.
+_ZMQ_SOCKET_CREATION_MAX_ATTEMPTS = 8
+_ZMQ_SOCKET_CREATION_RETRY_BASE_DELAY = 0.001
+_TRANSIENT_ZMQ_SOCKET_ERRNOS = {errno.EADDRINUSE, errno.EMFILE, errno.ENFILE}
+
+
+def _validate_zmq_max_sockets(zmq_max_sockets: int) -> None:
+    if zmq_max_sockets <= 0:
+        raise ValueError(
+            "SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS must be greater than zero, "
+            f"got {zmq_max_sockets}."
+        )
+
+
+def _validate_zmq_socket_limits(
+    zmq_max_sockets: int, socket_cache_max_endpoints: int
+) -> None:
+    _validate_zmq_max_sockets(zmq_max_sockets)
+    if socket_cache_max_endpoints <= 0:
+        raise ValueError(
+            "SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS must be greater "
+            f"than zero, got {socket_cache_max_endpoints}."
+        )
+
+    steady_state_sockets = (
+        _ZMQ_MANAGER_BASE_SOCKET_COUNT
+        + _ZMQ_SOCKETS_PER_MONITORED_ENDPOINT * socket_cache_max_endpoints
+    )
+    if steady_state_sockets > zmq_max_sockets:
+        raise ValueError(
+            "SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS="
+            f"{socket_cache_max_endpoints} needs at least {steady_state_sockets} "
+            "ZMQ context sockets, but "
+            f"SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS={zmq_max_sockets}. "
+            "Raise the socket cap or lower the cache bound."
+        )
+
+    # A complete fleet replacement can leave one full cache awaiting libzmq's
+    # asynchronous reaper while the replacement cache is created.
+    full_replacement_sockets = (
+        _ZMQ_MANAGER_BASE_SOCKET_COUNT
+        + 2 * _ZMQ_SOCKETS_PER_MONITORED_ENDPOINT * socket_cache_max_endpoints
+    )
+    if full_replacement_sockets > zmq_max_sockets:
+        logger.warning(
+            "SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS=%s safely holds the live "
+            "socket cache but not a full cache replacement (%s sockets). "
+            "Endpoint churn may briefly rely on socket-creation retries.",
+            zmq_max_sockets,
+            full_replacement_sockets,
+        )
 
 
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
@@ -197,21 +259,14 @@ class CommonKVManager(BaseKVManager):
             or hybrid_decode_pulls_all_ranks
         )
 
-        # libzmq caps sockets per context (default 1023); the KV manager holds
-        # two sockets per decode endpoint (PUSH + PAIR monitor), so a large
-        # decode fleet exhausts the default regardless of the OS nofile limit.
+        # libzmq caps sockets per context (default 1023); each monitored decode
+        # endpoint consumes three context sockets, so a large decode fleet
+        # exhausts the default regardless of the OS nofile limit.
         zmq_max_sockets = envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
         self._socket_cache_max_endpoints = (
             envs.SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS.get()
         )
-        if 2 * self._socket_cache_max_endpoints + 1 > zmq_max_sockets:
-            logger.warning(
-                f"SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS="
-                f"{self._socket_cache_max_endpoints} needs "
-                f"{2 * self._socket_cache_max_endpoints + 1} sockets but "
-                f"SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS={zmq_max_sockets}; "
-                f"raise the socket cap or lower the cache bound."
-            )
+        _validate_zmq_socket_limits(zmq_max_sockets, self._socket_cache_max_endpoints)
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
@@ -231,6 +286,7 @@ class CommonKVManager(BaseKVManager):
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_send_locks: Dict[str, threading.Lock] = {}
         self._socket_lock = threading.Lock()
+        self._monitor_endpoint_seq = 0
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
 
@@ -763,23 +819,87 @@ class CommonKVManager(BaseKVManager):
             f"Prefill instance failed to register to bootstrap server after {max_retries} retries"
         )
 
-    def _evict_lru_endpoint_locked(self):
-        """Close and drop the least-recently-used cached endpoint.
+    @staticmethod
+    def _close_monitored_socket(
+        sock: Optional[zmq.Socket], monitor: Optional[zmq.Socket]
+    ) -> None:
+        """Best-effort, non-blocking teardown of a monitored ZMQ socket."""
+        if sock is not None:
+            try:
+                sock.disable_monitor()
+            except zmq.ZMQError:
+                pass
+        if monitor is not None:
+            try:
+                monitor.close(linger=0)
+            except zmq.ZMQError:
+                pass
+        if sock is not None:
+            try:
+                sock.close(linger=0)
+            except zmq.ZMQError:
+                pass
 
-        Caller must hold ``_socket_lock``. Takes the victim's send lock so an
-        in-flight send finishes before its socket closes; a sender that loses
-        this race gets a ``zmq.ZMQError`` and retries via
-        ``_send_multipart_locked``. Safe to acquire under ``_socket_lock``:
-        senders never wait on ``_socket_lock`` while holding a send lock.
-        """
-        victim, sock = self._socket_cache.popitem(last=False)
-        monitor = self._monitor_cache.pop(victim, None)
-        send_lock = self._socket_send_locks.pop(victim, None)
-        with send_lock if send_lock is not None else nullcontext():
-            sock.close(linger=0)
-            if monitor is not None:
-                monitor.close()
+    def _drop_endpoint_locked(self, endpoint: str) -> None:
+        """Remove and close an endpoint after any in-flight send finishes."""
+        sock = self._socket_cache.pop(endpoint, None)
+        monitor = self._monitor_cache.pop(endpoint, None)
+        send_lock = self._socket_send_locks.pop(endpoint, None)
+        if sock is None:
+            return
+        if send_lock is None:
+            self._close_monitored_socket(sock, monitor)
+            return
+        # Safe while holding _socket_lock: senders never acquire _socket_lock
+        # while holding an endpoint send lock.
+        with send_lock:
+            self._close_monitored_socket(sock, monitor)
+
+    def _evict_lru_endpoint_locked(self):
+        """Close and drop the least-recently-used cached endpoint."""
+        victim = next(iter(self._socket_cache))
+        self._drop_endpoint_locked(victim)
         logger.debug(f"Evicted LRU decode endpoint socket: {victim}")
+
+    def _next_monitor_endpoint_locked(self) -> str:
+        self._monitor_endpoint_seq += 1
+        manager_id = id(self)
+        return f"inproc://sglang-kv-monitor-{manager_id}-{self._monitor_endpoint_seq}"
+
+    def _create_monitored_push_socket_locked(
+        self, endpoint: str, is_ipv6: bool
+    ) -> Tuple[zmq.Socket, zmq.Socket]:
+        """Create a PUSH socket and monitor, retrying transient reaper races."""
+        for attempt in range(_ZMQ_SOCKET_CREATION_MAX_ATTEMPTS):
+            sock = None
+            monitor = None
+            try:
+                sock = self._zmq_ctx.socket(zmq.PUSH)
+                if is_ipv6:
+                    sock.setsockopt(zmq.IPV6, 1)
+                sock.setsockopt(zmq.RECONNECT_IVL, -1)
+                sock.setsockopt(zmq.SNDTIMEO, 30000)
+                sock.setsockopt(zmq.LINGER, 0)
+                sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
+                sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
+                sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 5)
+                sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
+                sock.connect(endpoint)
+                monitor_endpoint = self._next_monitor_endpoint_locked()
+                sock.monitor(monitor_endpoint, zmq.EVENT_DISCONNECTED)
+                monitor = self._zmq_ctx.socket(zmq.PAIR)
+                monitor.connect(monitor_endpoint)
+                return sock, monitor
+            except zmq.ZMQError as error:
+                self._close_monitored_socket(sock, monitor)
+                if (
+                    error.errno not in _TRANSIENT_ZMQ_SOCKET_ERRNOS
+                    or attempt == _ZMQ_SOCKET_CREATION_MAX_ATTEMPTS - 1
+                ):
+                    raise
+                time.sleep(_ZMQ_SOCKET_CREATION_RETRY_BASE_DELAY * (2**attempt))
+
+        raise AssertionError("unreachable")
 
     def _connect(
         self, endpoint: str, is_ipv6: bool = False
@@ -800,31 +920,18 @@ class CommonKVManager(BaseKVManager):
                 if not disconnected:
                     self._socket_cache.move_to_end(endpoint)
                     return sock, self._socket_send_locks[endpoint]
-                sock.close(linger=0)
-                if monitor is not None:
-                    monitor.close()
-                self._socket_cache.pop(endpoint, None)
-                self._monitor_cache.pop(endpoint, None)
+                self._drop_endpoint_locked(endpoint)
 
             while len(self._socket_cache) >= self._socket_cache_max_endpoints:
                 self._evict_lru_endpoint_locked()
 
-            sock = self._zmq_ctx.socket(zmq.PUSH)
-            if is_ipv6:
-                sock.setsockopt(zmq.IPV6, 1)
-            sock.setsockopt(zmq.RECONNECT_IVL, -1)
-            sock.setsockopt(zmq.SNDTIMEO, 30000)
-            sock.setsockopt(zmq.LINGER, 0)
-            sock.setsockopt(zmq.TCP_KEEPALIVE, 1)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_IDLE, 30)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_INTVL, 5)
-            sock.setsockopt(zmq.TCP_KEEPALIVE_CNT, 3)
-            sock.connect(endpoint)
+            sock, monitor = self._create_monitored_push_socket_locked(endpoint, is_ipv6)
+            send_lock = threading.Lock()
+            # Publish the three cache entries only after socket and monitor
+            # creation both succeed.
             self._socket_cache[endpoint] = sock
-            self._monitor_cache[endpoint] = sock.get_monitor_socket(
-                zmq.EVENT_DISCONNECTED
-            )
-            send_lock = self._socket_send_locks.setdefault(endpoint, threading.Lock())
+            self._monitor_cache[endpoint] = monitor
+            self._socket_send_locks[endpoint] = send_lock
             return sock, send_lock
 
     def _send_multipart_locked(
@@ -839,8 +946,8 @@ class CommonKVManager(BaseKVManager):
                 try:
                     sock.send_multipart(parts)
                     return
-                except zmq.ZMQError:
-                    if attempt == 1:
+                except zmq.ZMQError as error:
+                    if attempt == 1 or error.errno != errno.ENOTSOCK:
                         raise
 
     def get_mha_kv_ptrs_with_pp(
@@ -1301,7 +1408,9 @@ class CommonKVReceiver(BaseKVReceiver):
     # One PUSH socket per prefill rank endpoint (no monitor socket); raise the
     # cap so a large prefill fleet cannot exhaust the default 1023 either.
     # Read at import time: the class-level context is created once per process.
-    _ctx.set(zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get())
+    _ctx_max_sockets = envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
+    _validate_zmq_max_sockets(_ctx_max_sockets)
+    _ctx.set(zmq.MAX_SOCKETS, _ctx_max_sockets)
     _socket_cache = {}
     _socket_locks = {}
     _global_lock = threading.Lock()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -47,20 +47,6 @@ from sglang.srt.utils.network import (
 
 logger = logging.getLogger(__name__)
 
-# libzmq caps sockets per context at ZMQ_MAX_SOCKETS, default 1023. A prefill
-# rank creates two sockets per decode endpoint (PUSH + PAIR monitor), so a
-# large decode fleet (e.g. 16 replicas x 32 DP ranks = 512 endpoints -> 1025
-# sockets) exhausts the default and every further connect raises "Too many
-# open files" regardless of the OS nofile limit. Must be set on a context
-# before it creates any socket.
-ZMQ_CTX_MAX_SOCKETS = 4096
-
-# Bound for the per-endpoint PUSH-socket LRU cache. Invariant: two sockets per
-# cached endpoint plus the PULL server socket stay well under
-# ZMQ_CTX_MAX_SOCKETS (2 * 1024 + 1 = 2049 < 4096), so endpoint churn
-# (autoscaling, decode replica restarts) can no longer exhaust the context.
-SOCKET_CACHE_MAX_ENDPOINTS = 1024
-
 
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
 # so we don't open a fresh TCP connection per query (that churns short-lived
@@ -211,18 +197,34 @@ class CommonKVManager(BaseKVManager):
             or hybrid_decode_pulls_all_ranks
         )
 
+        # libzmq caps sockets per context (default 1023); the KV manager holds
+        # two sockets per decode endpoint (PUSH + PAIR monitor), so a large
+        # decode fleet exhausts the default regardless of the OS nofile limit.
+        zmq_max_sockets = envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
+        self._socket_cache_max_endpoints = (
+            envs.SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS.get()
+        )
+        if 2 * self._socket_cache_max_endpoints + 1 > zmq_max_sockets:
+            logger.warning(
+                f"SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS="
+                f"{self._socket_cache_max_endpoints} needs "
+                f"{2 * self._socket_cache_max_endpoints + 1} sockets but "
+                f"SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS={zmq_max_sockets}; "
+                f"raise the socket cap or lower the cache bound."
+            )
+
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
         # Raise the per-context socket cap before any socket exists; the
         # option does not apply retroactively.
-        self._zmq_ctx.set(zmq.MAX_SOCKETS, ZMQ_CTX_MAX_SOCKETS)
+        self._zmq_ctx.set(zmq.MAX_SOCKETS, zmq_max_sockets)
         self.rank_port, self.server_socket = get_zmq_socket_on_host(
             self._zmq_ctx, zmq.PULL, host=self.local_ip
         )
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
-        # LRU over decode endpoints, bounded by SOCKET_CACHE_MAX_ENDPOINTS;
+        # LRU over decode endpoints, bounded by _socket_cache_max_endpoints;
         # _monitor_cache and _socket_send_locks are kept in lockstep with it
         # under _socket_lock.
         self._socket_cache: OrderedDict[str, zmq.Socket] = OrderedDict()
@@ -804,7 +806,7 @@ class CommonKVManager(BaseKVManager):
                 self._socket_cache.pop(endpoint, None)
                 self._monitor_cache.pop(endpoint, None)
 
-            while len(self._socket_cache) >= SOCKET_CACHE_MAX_ENDPOINTS:
+            while len(self._socket_cache) >= self._socket_cache_max_endpoints:
                 self._evict_lru_endpoint_locked()
 
             sock = self._zmq_ctx.socket(zmq.PUSH)
@@ -1298,7 +1300,8 @@ class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
     # One PUSH socket per prefill rank endpoint (no monitor socket); raise the
     # cap so a large prefill fleet cannot exhaust the default 1023 either.
-    _ctx.set(zmq.MAX_SOCKETS, ZMQ_CTX_MAX_SOCKETS)
+    # Read at import time: the class-level context is created once per process.
+    _ctx.set(zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get())
     _socket_cache = {}
     _socket_locks = {}
     _global_lock = threading.Lock()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -6,7 +6,8 @@ import dataclasses
 import logging
 import threading
 import time
-from collections import defaultdict
+from collections import OrderedDict, defaultdict
+from contextlib import nullcontext
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -45,6 +46,20 @@ from sglang.srt.utils.network import (
 )
 
 logger = logging.getLogger(__name__)
+
+# libzmq caps sockets per context at ZMQ_MAX_SOCKETS, default 1023. A prefill
+# rank creates two sockets per decode endpoint (PUSH + PAIR monitor), so a
+# large decode fleet (e.g. 16 replicas x 32 DP ranks = 512 endpoints -> 1025
+# sockets) exhausts the default and every further connect raises "Too many
+# open files" regardless of the OS nofile limit. Must be set on a context
+# before it creates any socket.
+ZMQ_CTX_MAX_SOCKETS = 4096
+
+# Bound for the per-endpoint PUSH-socket LRU cache. Invariant: two sockets per
+# cached endpoint plus the PULL server socket stay well under
+# ZMQ_CTX_MAX_SOCKETS (2 * 1024 + 1 = 2049 < 4096), so endpoint churn
+# (autoscaling, decode replica restarts) can no longer exhaust the context.
+SOCKET_CACHE_MAX_ENDPOINTS = 1024
 
 
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
@@ -198,13 +213,19 @@ class CommonKVManager(BaseKVManager):
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
+        # Raise the per-context socket cap before any socket exists; the
+        # option does not apply retroactively.
+        self._zmq_ctx.set(zmq.MAX_SOCKETS, ZMQ_CTX_MAX_SOCKETS)
         self.rank_port, self.server_socket = get_zmq_socket_on_host(
             self._zmq_ctx, zmq.PULL, host=self.local_ip
         )
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
-        self._socket_cache: Dict[str, zmq.Socket] = {}
+        # LRU over decode endpoints, bounded by SOCKET_CACHE_MAX_ENDPOINTS;
+        # _monitor_cache and _socket_send_locks are kept in lockstep with it
+        # under _socket_lock.
+        self._socket_cache: OrderedDict[str, zmq.Socket] = OrderedDict()
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_send_locks: Dict[str, threading.Lock] = {}
         self._socket_lock = threading.Lock()
@@ -740,7 +761,27 @@ class CommonKVManager(BaseKVManager):
             f"Prefill instance failed to register to bootstrap server after {max_retries} retries"
         )
 
-    def _connect(self, endpoint: str, is_ipv6: bool = False):
+    def _evict_lru_endpoint_locked(self):
+        """Close and drop the least-recently-used cached endpoint.
+
+        Caller must hold ``_socket_lock``. Takes the victim's send lock so an
+        in-flight send finishes before its socket closes; a sender that loses
+        this race gets a ``zmq.ZMQError`` and retries via
+        ``_send_multipart_locked``. Safe to acquire under ``_socket_lock``:
+        senders never wait on ``_socket_lock`` while holding a send lock.
+        """
+        victim, sock = self._socket_cache.popitem(last=False)
+        monitor = self._monitor_cache.pop(victim, None)
+        send_lock = self._socket_send_locks.pop(victim, None)
+        with send_lock if send_lock is not None else nullcontext():
+            sock.close(linger=0)
+            if monitor is not None:
+                monitor.close()
+        logger.debug(f"Evicted LRU decode endpoint socket: {victim}")
+
+    def _connect(
+        self, endpoint: str, is_ipv6: bool = False
+    ) -> Tuple[zmq.Socket, threading.Lock]:
         with self._socket_lock:
             sock = self._socket_cache.get(endpoint)
             if sock is not None:
@@ -755,12 +796,16 @@ class CommonKVManager(BaseKVManager):
                     except zmq.ZMQError:
                         disconnected = True
                 if not disconnected:
-                    return sock
+                    self._socket_cache.move_to_end(endpoint)
+                    return sock, self._socket_send_locks[endpoint]
                 sock.close(linger=0)
                 if monitor is not None:
                     monitor.close()
                 self._socket_cache.pop(endpoint, None)
                 self._monitor_cache.pop(endpoint, None)
+
+            while len(self._socket_cache) >= SOCKET_CACHE_MAX_ENDPOINTS:
+                self._evict_lru_endpoint_locked()
 
             sock = self._zmq_ctx.socket(zmq.PUSH)
             if is_ipv6:
@@ -777,17 +822,24 @@ class CommonKVManager(BaseKVManager):
             self._monitor_cache[endpoint] = sock.get_monitor_socket(
                 zmq.EVENT_DISCONNECTED
             )
-            self._socket_send_locks.setdefault(endpoint, threading.Lock())
-            return sock
+            send_lock = self._socket_send_locks.setdefault(endpoint, threading.Lock())
+            return sock, send_lock
 
     def _send_multipart_locked(
         self, endpoint: str, parts: List[bytes], is_ipv6: bool = False
     ):
         # Cached sockets are shared across sender threads and zmq sockets are
-        # not thread-safe; serialize sends per endpoint.
-        sock = self._connect(endpoint, is_ipv6=is_ipv6)
-        with self._socket_send_locks[endpoint]:
-            sock.send_multipart(parts)
+        # not thread-safe; serialize sends per endpoint. One retry: LRU
+        # eviction may close the socket between lookup and send.
+        for attempt in range(2):
+            sock, send_lock = self._connect(endpoint, is_ipv6=is_ipv6)
+            with send_lock:
+                try:
+                    sock.send_multipart(parts)
+                    return
+                except zmq.ZMQError:
+                    if attempt == 1:
+                        raise
 
     def get_mha_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int]
@@ -1244,6 +1296,9 @@ class CommonKVSender(BaseKVSender):
 
 class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
+    # One PUSH socket per prefill rank endpoint (no monitor socket); raise the
+    # cap so a large prefill fleet cannot exhaust the default 1023 either.
+    _ctx.set(zmq.MAX_SOCKETS, ZMQ_CTX_MAX_SOCKETS)
     _socket_cache = {}
     _socket_locks = {}
     _global_lock = threading.Lock()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -62,15 +62,6 @@ _ZMQ_SOCKET_CREATION_MAX_ATTEMPTS = 8
 _ZMQ_SOCKET_CREATION_RETRY_BASE_DELAY = 0.001
 _TRANSIENT_ZMQ_SOCKET_ERRNOS = {errno.EADDRINUSE, errno.EMFILE, errno.ENFILE}
 
-# LRU eviction closes *healthy* sockets that may still hold accepted-but-
-# unflushed control messages (send_multipart returns once queued, not once
-# delivered). A bounded linger lets libzmq flush them in the background —
-# close() itself never blocks — instead of dropping them and stranding the
-# decode peer until its waiting timeout. A lingering socket keeps its context
-# slot until drained; the cap's full-replacement headroom and the transient
-# EMFILE creation retry absorb that.
-_ZMQ_EVICTED_SOCKET_LINGER_MS = 3000
-
 
 def _validate_zmq_max_sockets(zmq_max_sockets: int) -> None:
     if zmq_max_sockets <= 0:
@@ -830,9 +821,7 @@ class CommonKVManager(BaseKVManager):
 
     @staticmethod
     def _close_monitored_socket(
-        sock: Optional[zmq.Socket],
-        monitor: Optional[zmq.Socket],
-        linger_ms: int = 0,
+        sock: Optional[zmq.Socket], monitor: Optional[zmq.Socket]
     ) -> None:
         """Best-effort, non-blocking teardown of a monitored ZMQ socket."""
         if sock is not None:
@@ -847,11 +836,11 @@ class CommonKVManager(BaseKVManager):
                 pass
         if sock is not None:
             try:
-                sock.close(linger=linger_ms)
+                sock.close(linger=0)
             except zmq.ZMQError:
                 pass
 
-    def _drop_endpoint_locked(self, endpoint: str, linger_ms: int = 0) -> None:
+    def _drop_endpoint_locked(self, endpoint: str) -> None:
         """Remove and close an endpoint after any in-flight send finishes."""
         sock = self._socket_cache.pop(endpoint, None)
         monitor = self._monitor_cache.pop(endpoint, None)
@@ -859,22 +848,17 @@ class CommonKVManager(BaseKVManager):
         if sock is None:
             return
         if send_lock is None:
-            self._close_monitored_socket(sock, monitor, linger_ms=linger_ms)
+            self._close_monitored_socket(sock, monitor)
             return
         # Safe while holding _socket_lock: senders never acquire _socket_lock
         # while holding an endpoint send lock.
         with send_lock:
-            self._close_monitored_socket(sock, monitor, linger_ms=linger_ms)
+            self._close_monitored_socket(sock, monitor)
 
     def _evict_lru_endpoint_locked(self):
-        """Close and drop the least-recently-used cached endpoint.
-
-        Unlike the disconnected-peer path, the victim is a healthy socket, so
-        give queued messages a bounded background linger instead of dropping
-        them.
-        """
+        """Close and drop the least-recently-used cached endpoint."""
         victim = next(iter(self._socket_cache))
-        self._drop_endpoint_locked(victim, linger_ms=_ZMQ_EVICTED_SOCKET_LINGER_MS)
+        self._drop_endpoint_locked(victim)
         logger.debug(f"Evicted LRU decode endpoint socket: {victim}")
 
     def _next_monitor_endpoint_locked(self) -> str:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -62,6 +62,15 @@ _ZMQ_SOCKET_CREATION_MAX_ATTEMPTS = 8
 _ZMQ_SOCKET_CREATION_RETRY_BASE_DELAY = 0.001
 _TRANSIENT_ZMQ_SOCKET_ERRNOS = {errno.EADDRINUSE, errno.EMFILE, errno.ENFILE}
 
+# LRU eviction closes *healthy* sockets that may still hold accepted-but-
+# unflushed control messages (send_multipart returns once queued, not once
+# delivered). A bounded linger lets libzmq flush them in the background —
+# close() itself never blocks — instead of dropping them and stranding the
+# decode peer until its waiting timeout. A lingering socket keeps its context
+# slot until drained; the cap's full-replacement headroom and the transient
+# EMFILE creation retry absorb that.
+_ZMQ_EVICTED_SOCKET_LINGER_MS = 3000
+
 
 def _validate_zmq_max_sockets(zmq_max_sockets: int) -> None:
     if zmq_max_sockets <= 0:
@@ -821,7 +830,9 @@ class CommonKVManager(BaseKVManager):
 
     @staticmethod
     def _close_monitored_socket(
-        sock: Optional[zmq.Socket], monitor: Optional[zmq.Socket]
+        sock: Optional[zmq.Socket],
+        monitor: Optional[zmq.Socket],
+        linger_ms: int = 0,
     ) -> None:
         """Best-effort, non-blocking teardown of a monitored ZMQ socket."""
         if sock is not None:
@@ -836,11 +847,11 @@ class CommonKVManager(BaseKVManager):
                 pass
         if sock is not None:
             try:
-                sock.close(linger=0)
+                sock.close(linger=linger_ms)
             except zmq.ZMQError:
                 pass
 
-    def _drop_endpoint_locked(self, endpoint: str) -> None:
+    def _drop_endpoint_locked(self, endpoint: str, linger_ms: int = 0) -> None:
         """Remove and close an endpoint after any in-flight send finishes."""
         sock = self._socket_cache.pop(endpoint, None)
         monitor = self._monitor_cache.pop(endpoint, None)
@@ -848,17 +859,22 @@ class CommonKVManager(BaseKVManager):
         if sock is None:
             return
         if send_lock is None:
-            self._close_monitored_socket(sock, monitor)
+            self._close_monitored_socket(sock, monitor, linger_ms=linger_ms)
             return
         # Safe while holding _socket_lock: senders never acquire _socket_lock
         # while holding an endpoint send lock.
         with send_lock:
-            self._close_monitored_socket(sock, monitor)
+            self._close_monitored_socket(sock, monitor, linger_ms=linger_ms)
 
     def _evict_lru_endpoint_locked(self):
-        """Close and drop the least-recently-used cached endpoint."""
+        """Close and drop the least-recently-used cached endpoint.
+
+        Unlike the disconnected-peer path, the victim is a healthy socket, so
+        give queued messages a bounded background linger instead of dropping
+        them.
+        """
         victim = next(iter(self._socket_cache))
-        self._drop_endpoint_locked(victim)
+        self._drop_endpoint_locked(victim, linger_ms=_ZMQ_EVICTED_SOCKET_LINGER_MS)
         logger.debug(f"Evicted LRU decode endpoint socket: {victim}")
 
     def _next_monitor_endpoint_locked(self) -> str:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -425,7 +425,7 @@ class MooncakeKVManager(CommonKVManager):
                 ],
                 is_ipv6=na.is_ipv6,
             )
-        except zmq.ZMQError as error:
+        except zmq.Again as error:
             logger.warning(
                 f"Failed to send CHUNK_READY for room {req.room} to decode "
                 f"endpoint {na.to_host_port_str()} ({error}); failing the room."
@@ -1098,7 +1098,7 @@ class MooncakeKVManager(CommonKVManager):
                     aux_index=req.dst_aux_index,
                     data=data,
                 )
-            except zmq.ZMQError as error:
+            except zmq.Again as error:
                 # Report per-request failure (the caller's ret != 0 path)
                 # rather than escalating an unreachable decode endpoint into a
                 # rank-fatal transfer-worker crash.
@@ -1541,7 +1541,7 @@ class MooncakeKVManager(CommonKVManager):
                 ],
                 is_ipv6=na.is_ipv6,
             )
-        except zmq.ZMQError as error:
+        except zmq.Again as error:
             # Best-effort: the local status is already recorded and decode
             # discovers the outcome via its own waiting timeout. Raising would
             # escalate one unreachable decode endpoint into a rank-fatal
@@ -1879,9 +1879,9 @@ class MooncakeKVManager(CommonKVManager):
                 # queue). Treat it as fatal for the rank instead — signal the
                 # parent like a Scheduler crash does, so the launcher tears
                 # the rank down and the router ejects/restarts it.
-                # Endpoint-level ZMQ send failures never reach here: the
-                # decode-notify call sites convert them to per-request
-                # failures, so this path only sees unexpected bugs.
+                # Endpoint send timeouts never reach here: decode-notify call
+                # sites convert them to per-request failures, so this path
+                # only sees unexpected bugs or process-wide resource errors.
                 logger.exception(
                     f"Transfer worker {worker_index} failed; terminating rank "
                     f"(bootstrap_port={self.bootstrap_port})."

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -403,22 +403,35 @@ class MooncakeKVManager(CommonKVManager):
 
         return PrefillStagingStrategy(self, staging_buffer)
 
-    def _send_chunk_ready(self, req, chunk_idx, kv_chunk, prefill_unique_rank):
-        """Notify decode that a non-last staging chunk RDMA is complete."""
+    def _send_chunk_ready(self, req, chunk_idx, kv_chunk, prefill_unique_rank) -> bool:
+        """Notify decode that a non-last staging chunk RDMA is complete.
+
+        Returns False when the decode endpoint is unreachable so the caller
+        can fail the room; raising would escalate one dead decode endpoint
+        into a rank-fatal transfer-worker crash.
+        """
         na = NetworkAddress(req.endpoint, req.dst_port)
-        self._send_multipart_locked(
-            na.to_tcp(),
-            [
-                b"CHUNK_READY",
-                str(req.room).encode("ascii"),
-                str(chunk_idx).encode("ascii"),
-                str(kv_chunk.index_slice.start).encode("ascii"),
-                str(len(kv_chunk.prefill_kv_indices)).encode("ascii"),
-                req.mooncake_session_id.encode("ascii"),
-                str(prefill_unique_rank).encode("ascii"),
-            ],
-            is_ipv6=na.is_ipv6,
-        )
+        try:
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [
+                    b"CHUNK_READY",
+                    str(req.room).encode("ascii"),
+                    str(chunk_idx).encode("ascii"),
+                    str(kv_chunk.index_slice.start).encode("ascii"),
+                    str(len(kv_chunk.prefill_kv_indices)).encode("ascii"),
+                    req.mooncake_session_id.encode("ascii"),
+                    str(prefill_unique_rank).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        except zmq.ZMQError as error:
+            logger.warning(
+                f"Failed to send CHUNK_READY for room {req.room} to decode "
+                f"endpoint {na.to_host_port_str()} ({error}); failing the room."
+            )
+            return False
+        return True
 
     def _do_staging_transfer(
         self,
@@ -480,7 +493,12 @@ class MooncakeKVManager(CommonKVManager):
             )
             return (-1, False)
         if ret == 0 and not kv_chunk.is_last_chunk:
-            self._send_chunk_ready(req, chunk_idx, kv_chunk, prefill_unique_rank)
+            if not self._send_chunk_ready(
+                req, chunk_idx, kv_chunk, prefill_unique_rank
+            ):
+                # Same contract as the ring-overflow -1 above: the caller's
+                # ret != 0 path fails this room.
+                return (-1, False)
         return (ret, False)
 
     def _prefetch_staging_reqs(self, room: int):
@@ -1071,14 +1089,24 @@ class MooncakeKVManager(CommonKVManager):
             src_addr = prefill_aux_ptrs[i] + length * prefill_aux_index
             data = AuxDataCodec.serialize_data_from_buffer(src_addr, length)
 
-            self.send_aux_data_to_endpoint(
-                remote=req.endpoint,
-                dst_port=req.dst_port,
-                room=req.room,
-                buffer_index=i,
-                aux_index=req.dst_aux_index,
-                data=data,
-            )
+            try:
+                self.send_aux_data_to_endpoint(
+                    remote=req.endpoint,
+                    dst_port=req.dst_port,
+                    room=req.room,
+                    buffer_index=i,
+                    aux_index=req.dst_aux_index,
+                    data=data,
+                )
+            except zmq.ZMQError as error:
+                # Report per-request failure (the caller's ret != 0 path)
+                # rather than escalating an unreachable decode endpoint into a
+                # rank-fatal transfer-worker crash.
+                logger.warning(
+                    f"Failed to send aux data for room {req.room} to decode "
+                    f"endpoint {req.endpoint}:{req.dst_port} ({error})."
+                )
+                return -1
 
         return 0
 
@@ -1503,15 +1531,26 @@ class MooncakeKVManager(CommonKVManager):
         self, remote: str, dst_port: int, room: int, status: int, prefill_rank: int
     ):
         na = NetworkAddress(remote, dst_port)
-        self._send_multipart_locked(
-            na.to_tcp(),
-            [
-                str(room).encode("ascii"),
-                str(status).encode("ascii"),
-                str(prefill_rank).encode("ascii"),
-            ],
-            is_ipv6=na.is_ipv6,
-        )
+        try:
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [
+                    str(room).encode("ascii"),
+                    str(status).encode("ascii"),
+                    str(prefill_rank).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        except zmq.ZMQError as error:
+            # Best-effort: the local status is already recorded and decode
+            # discovers the outcome via its own waiting timeout. Raising would
+            # escalate one unreachable decode endpoint into a rank-fatal
+            # transfer-worker crash and skip the remaining endpoint syncs of
+            # this request.
+            logger.warning(
+                f"Failed to sync status {status} of room {room} to decode "
+                f"endpoint {na.to_host_port_str()} ({error})."
+            )
 
     def transfer_worker(
         self,
@@ -1521,6 +1560,10 @@ class MooncakeKVManager(CommonKVManager):
         worker_index=0,
     ):
         staging_strategy = None
+        # Capture now, matching run_scheduler_process: if the launcher dies
+        # first, this thread gets reparented and a lookup at crash time would
+        # signal the adoptive parent instead.
+        parent_process = psutil.Process().parent()
         if self.enable_trace:
             trace_set_thread_info(
                 f"mooncake transfer worker {worker_index}",
@@ -1836,13 +1879,15 @@ class MooncakeKVManager(CommonKVManager):
                 # queue). Treat it as fatal for the rank instead — signal the
                 # parent like a Scheduler crash does, so the launcher tears
                 # the rank down and the router ejects/restarts it.
+                # Endpoint-level ZMQ send failures never reach here: the
+                # decode-notify call sites convert them to per-request
+                # failures, so this path only sees unexpected bugs.
                 logger.exception(
                     f"Transfer worker {worker_index} failed; terminating rank "
                     f"(bootstrap_port={self.bootstrap_port})."
                 )
-                parent = psutil.Process().parent()
-                if parent is not None:
-                    parent.send_signal(signal.SIGQUIT)
+                if parent_process is not None:
+                    parent_process.send_signal(signal.SIGQUIT)
                 else:
                     os.kill(os.getpid(), signal.SIGQUIT)
                 return

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import dataclasses
 import logging
 import os
+import signal
 import struct
 import threading
 import time
@@ -12,6 +13,7 @@ from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
+import psutil
 import zmq
 from prometheus_client import Counter
 
@@ -1827,11 +1829,23 @@ class MooncakeKVManager(CommonKVManager):
                                 self._staging_ctx.prefetch_requested.discard(key)
                         self._staging_ctx.prefetched_rooms.discard(kv_chunk.room)
 
-            except Exception as e:
-                # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
-                raise RuntimeError(
-                    f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
+            except Exception:
+                # A raise here would only kill this daemon thread: the rank's
+                # HTTP process stays "healthy" while its transfer capacity
+                # silently drains away (each dead worker orphans one transfer
+                # queue). Treat it as fatal for the rank instead — signal the
+                # parent like a Scheduler crash does, so the launcher tears
+                # the rank down and the router ejects/restarts it.
+                logger.exception(
+                    f"Transfer worker {worker_index} failed; terminating rank "
+                    f"(bootstrap_port={self.bootstrap_port})."
                 )
+                parent = psutil.Process().parent()
+                if parent is not None:
+                    parent.send_signal(signal.SIGQUIT)
+                else:
+                    os.kill(os.getpid(), signal.SIGQUIT)
+                return
 
     def start_prefill_thread(self):
         def bootstrap_thread():

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -427,6 +427,14 @@ class Envs:
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
     SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX = EnvBool(True)
+    # Per-zmq-context socket cap (libzmq default is 1023) and the bound of the
+    # per-decode-endpoint PUSH-socket LRU cache in the KV manager. Each cached
+    # endpoint holds 2 sockets (PUSH + PAIR monitor), so keep
+    # 2 * SOCKET_CACHE_MAX_ENDPOINTS + 1 < ZMQ_MAX_SOCKETS. Size the cache
+    # bound above the peak simultaneous decode-endpoint count (replicas x DP
+    # ranks); steady-state eviction means reconnect churn on most sends.
+    SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(16384)
+    SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS = EnvInt(4096)
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -429,11 +429,13 @@ class Envs:
     SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX = EnvBool(True)
     # Per-zmq-context socket cap (libzmq default is 1023) and the bound of the
     # per-decode-endpoint PUSH-socket LRU cache in the KV manager. Each cached
-    # endpoint holds 2 sockets (PUSH + PAIR monitor), so keep
-    # 2 * SOCKET_CACHE_MAX_ENDPOINTS + 1 < ZMQ_MAX_SOCKETS. Size the cache
-    # bound above the peak simultaneous decode-endpoint count (replicas x DP
-    # ranks); steady-state eviction means reconnect churn on most sends.
-    SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(16384)
+    # endpoint consumes 3 context sockets: PUSH, libzmq's internal monitor, and
+    # pyzmq's PAIR monitor receiver. The manager also owns one PULL socket.
+    # The default cap additionally leaves room for a complete cache replacement
+    # while libzmq asynchronously reaps evicted sockets
+    # (1 + 2 * 3 * 4096 = 24577 < 32768). Size the cache above the peak
+    # simultaneous endpoint count (decode replicas x DP ranks).
+    SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(32768)
     SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS = EnvInt(4096)
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)

--- a/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
+++ b/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
@@ -24,15 +24,22 @@ class TestMooncakeTransferWorkerFailure(CustomTestCase):
         return manager
 
     @patch("sglang.srt.disaggregation.mooncake.conn.psutil.Process")
-    def test_worker_failure_signals_parent(self, mock_process):
+    def test_worker_failure_signals_original_parent(self, mock_process):
         parent = MagicMock()
+        adoptive_parent = MagicMock()
         mock_process.return_value.parent.return_value = parent
         queue = MagicMock()
-        queue.get.side_effect = RuntimeError("transfer failed")
+
+        def fail_after_reparenting():
+            mock_process.return_value.parent.return_value = adoptive_parent
+            raise RuntimeError("transfer failed")
+
+        queue.get.side_effect = fail_after_reparenting
 
         self._make_manager().transfer_worker(queue, MagicMock(), worker_index=2)
 
         parent.send_signal.assert_called_once_with(signal.SIGQUIT)
+        adoptive_parent.send_signal.assert_not_called()
 
     @patch("sglang.srt.disaggregation.mooncake.conn.os.kill")
     @patch("sglang.srt.disaggregation.mooncake.conn.psutil.Process")
@@ -47,12 +54,12 @@ class TestMooncakeTransferWorkerFailure(CustomTestCase):
 
 
 class TestDecodeNotificationFailure(CustomTestCase):
-    """Decode-notification ZMQ failures must fail the request, not the rank.
+    """Decode-notification timeouts must fail the request, not the rank.
 
-    Regression guard: these notify sends used to propagate ``zmq.ZMQError``
-    (e.g. a send timeout once a dead decode endpoint's socket queue filled)
-    into ``transfer_worker``'s fatal except-block, so one unreachable decode
-    endpoint could SIGQUIT every prefill rank that kept syncing status to it.
+    Regression guard: these notify sends used to propagate ``zmq.Again`` once
+    a dead decode endpoint's socket queue filled into ``transfer_worker``'s
+    fatal except-block, so one unreachable decode endpoint could SIGQUIT every
+    prefill rank that kept syncing status to it.
     """
 
     @staticmethod
@@ -61,8 +68,8 @@ class TestDecodeNotificationFailure(CustomTestCase):
         manager._send_multipart_locked = MagicMock(side_effect=send_error)
         return manager
 
-    def test_sync_status_swallows_zmq_send_error(self):
-        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+    def test_sync_status_swallows_zmq_send_timeout(self):
+        manager = self._make_manager(zmq.Again())
 
         manager.sync_status_to_decode_endpoint(
             remote="127.0.0.1", dst_port=30000, room=7, status=2, prefill_rank=0
@@ -70,18 +77,19 @@ class TestDecodeNotificationFailure(CustomTestCase):
 
         manager._send_multipart_locked.assert_called_once()
 
-    def test_sync_status_propagates_unexpected_error(self):
-        # Only endpoint-level ZMQ failures are best-effort; genuine bugs must
-        # still reach transfer_worker's fatal handler.
-        manager = self._make_manager(RuntimeError("bug"))
+    def test_sync_status_propagates_process_wide_zmq_error(self):
+        # Resource/context failures are not evidence of a dead endpoint and
+        # must still reach transfer_worker's fatal handler.
+        manager = self._make_manager(zmq.ZMQError(errno.EMFILE))
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaises(zmq.ZMQError) as error:
             manager.sync_status_to_decode_endpoint(
                 remote="127.0.0.1", dst_port=30000, room=7, status=2, prefill_rank=0
             )
+        self.assertEqual(error.exception.errno, errno.EMFILE)
 
-    def test_chunk_ready_zmq_send_error_reports_failure(self):
-        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+    def test_chunk_ready_zmq_send_timeout_reports_failure(self):
+        manager = self._make_manager(zmq.Again())
         req = MagicMock(
             endpoint="127.0.0.1",
             dst_port=30000,
@@ -94,8 +102,8 @@ class TestDecodeNotificationFailure(CustomTestCase):
             manager._send_chunk_ready(req, 0, kv_chunk, prefill_unique_rank=0)
         )
 
-    def test_send_aux_tcp_zmq_send_error_reports_failure(self):
-        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+    def test_send_aux_tcp_zmq_send_timeout_reports_failure(self):
+        manager = self._make_manager(zmq.Again())
         manager.kv_args = MagicMock(aux_data_ptrs=[1], aux_item_lens=[8])
         req = MagicMock(endpoint="127.0.0.1", dst_port=30000, room=7, dst_aux_index=0)
 

--- a/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
+++ b/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
@@ -1,9 +1,12 @@
 """CPU unit tests for fatal Mooncake transfer-worker failures."""
 
+import errno
 import os
 import signal
 import unittest
 from unittest.mock import MagicMock, patch
+
+import zmq
 
 from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -41,6 +44,68 @@ class TestMooncakeTransferWorkerFailure(CustomTestCase):
         self._make_manager().transfer_worker(queue, MagicMock(), worker_index=1)
 
         mock_kill.assert_called_once_with(os.getpid(), signal.SIGQUIT)
+
+
+class TestDecodeNotificationFailure(CustomTestCase):
+    """Decode-notification ZMQ failures must fail the request, not the rank.
+
+    Regression guard: these notify sends used to propagate ``zmq.ZMQError``
+    (e.g. a send timeout once a dead decode endpoint's socket queue filled)
+    into ``transfer_worker``'s fatal except-block, so one unreachable decode
+    endpoint could SIGQUIT every prefill rank that kept syncing status to it.
+    """
+
+    @staticmethod
+    def _make_manager(send_error):
+        manager = object.__new__(MooncakeKVManager)
+        manager._send_multipart_locked = MagicMock(side_effect=send_error)
+        return manager
+
+    def test_sync_status_swallows_zmq_send_error(self):
+        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+
+        manager.sync_status_to_decode_endpoint(
+            remote="127.0.0.1", dst_port=30000, room=7, status=2, prefill_rank=0
+        )
+
+        manager._send_multipart_locked.assert_called_once()
+
+    def test_sync_status_propagates_unexpected_error(self):
+        # Only endpoint-level ZMQ failures are best-effort; genuine bugs must
+        # still reach transfer_worker's fatal handler.
+        manager = self._make_manager(RuntimeError("bug"))
+
+        with self.assertRaises(RuntimeError):
+            manager.sync_status_to_decode_endpoint(
+                remote="127.0.0.1", dst_port=30000, room=7, status=2, prefill_rank=0
+            )
+
+    def test_chunk_ready_zmq_send_error_reports_failure(self):
+        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+        req = MagicMock(
+            endpoint="127.0.0.1",
+            dst_port=30000,
+            room=7,
+            mooncake_session_id="session-0",
+        )
+        kv_chunk = MagicMock(index_slice=slice(0, 4), prefill_kv_indices=[0, 1, 2, 3])
+
+        self.assertFalse(
+            manager._send_chunk_ready(req, 0, kv_chunk, prefill_unique_rank=0)
+        )
+
+    def test_send_aux_tcp_zmq_send_error_reports_failure(self):
+        manager = self._make_manager(zmq.ZMQError(errno.EAGAIN))
+        manager.kv_args = MagicMock(aux_data_ptrs=[1], aux_item_lens=[8])
+        req = MagicMock(endpoint="127.0.0.1", dst_port=30000, room=7, dst_aux_index=0)
+
+        with patch(
+            "sglang.srt.disaggregation.mooncake.conn.AuxDataCodec"
+        ) as mock_codec:
+            mock_codec.serialize_data_from_buffer.return_value = b"payload"
+            self.assertEqual(
+                manager.send_aux_tcp(req, prefill_aux_index=0, dst_aux_ptrs=[1]), -1
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
+++ b/test/registered/unit/disaggregation/test_mooncake_transfer_worker_failure.py
@@ -1,0 +1,47 @@
+"""CPU unit tests for fatal Mooncake transfer-worker failures."""
+
+import os
+import signal
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMooncakeTransferWorkerFailure(CustomTestCase):
+    @staticmethod
+    def _make_manager():
+        manager = object.__new__(MooncakeKVManager)
+        manager.enable_trace = False
+        manager.bootstrap_port = 8998
+        return manager
+
+    @patch("sglang.srt.disaggregation.mooncake.conn.psutil.Process")
+    def test_worker_failure_signals_parent(self, mock_process):
+        parent = MagicMock()
+        mock_process.return_value.parent.return_value = parent
+        queue = MagicMock()
+        queue.get.side_effect = RuntimeError("transfer failed")
+
+        self._make_manager().transfer_worker(queue, MagicMock(), worker_index=2)
+
+        parent.send_signal.assert_called_once_with(signal.SIGQUIT)
+
+    @patch("sglang.srt.disaggregation.mooncake.conn.os.kill")
+    @patch("sglang.srt.disaggregation.mooncake.conn.psutil.Process")
+    def test_worker_failure_signals_self_without_parent(self, mock_process, mock_kill):
+        mock_process.return_value.parent.return_value = None
+        queue = MagicMock()
+        queue.get.side_effect = RuntimeError("transfer failed")
+
+        self._make_manager().transfer_worker(queue, MagicMock(), worker_index=1)
+
+        mock_kill.assert_called_once_with(os.getpid(), signal.SIGQUIT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_zmq_socket_cache.py
+++ b/test/registered/unit/disaggregation/test_zmq_socket_cache.py
@@ -110,13 +110,13 @@ class TestZmqSocketCache(CustomTestCase):
 
     def test_rapid_endpoint_churn_stays_bounded(self):
         # Seven is the exact steady-state requirement for a PULL socket and
-        # two monitored endpoints. This forces the retry path whenever the
-        # asynchronous reaper has not released an evicted endpoint yet.
+        # two monitored endpoints. Queue a message on every endpoint so an
+        # eviction would retain context slots if it used nonzero linger.
         manager = self._make_manager(zmq_max_sockets=7, cache_bound=2)
         endpoints = [f"tcp://127.0.0.1:{20000 + index}" for index in range(200)]
 
         for endpoint in endpoints:
-            manager._connect(endpoint)
+            manager._send_multipart_locked(endpoint, [b"payload"])
 
         self.assertEqual(list(manager._socket_cache), endpoints[-2:])
         self.assertEqual(set(manager._monitor_cache), set(endpoints[-2:]))

--- a/test/registered/unit/disaggregation/test_zmq_socket_cache.py
+++ b/test/registered/unit/disaggregation/test_zmq_socket_cache.py
@@ -1,0 +1,192 @@
+"""CPU unit tests for the disaggregation ZMQ endpoint cache."""
+
+import errno
+import threading
+import unittest
+from collections import OrderedDict
+from unittest.mock import MagicMock, patch
+
+import zmq
+
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVManager,
+    _validate_zmq_socket_limits,
+)
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestZmqSocketLimits(CustomTestCase):
+    def test_monitored_endpoint_uses_three_context_sockets(self):
+        context = zmq.Context()
+        context.set(zmq.MAX_SOCKETS, 6)
+        pull = context.socket(zmq.PULL)
+        first = context.socket(zmq.PUSH)
+        first_monitor = first.get_monitor_socket(
+            zmq.EVENT_DISCONNECTED, addr="inproc://socket-accounting-first"
+        )
+        second = context.socket(zmq.PUSH)
+
+        try:
+            # PULL + the first monitored endpoint use four sockets. The second
+            # PUSH and its internal monitor use the remaining two; creating
+            # pyzmq's PAIR monitor receiver must exceed the cap.
+            with self.assertRaises(zmq.ZMQError) as error:
+                second.get_monitor_socket(
+                    zmq.EVENT_DISCONNECTED,
+                    addr="inproc://socket-accounting-second",
+                )
+            self.assertEqual(error.exception.errno, errno.EMFILE)
+        finally:
+            CommonKVManager._close_monitored_socket(second, None)
+            CommonKVManager._close_monitored_socket(first, first_monitor)
+            pull.close(linger=0)
+            context.destroy(linger=0)
+
+    def test_rejects_nonpositive_limits(self):
+        for zmq_max_sockets, cache_bound, expected in (
+            (0, 1, "ZMQ_MAX_SOCKETS must be greater than zero"),
+            (32, 0, "SOCKET_CACHE_MAX_ENDPOINTS must be greater than zero"),
+            (32, -1, "SOCKET_CACHE_MAX_ENDPOINTS must be greater than zero"),
+        ):
+            with self.subTest(zmq_max_sockets=zmq_max_sockets, cache_bound=cache_bound):
+                with self.assertRaisesRegex(ValueError, expected):
+                    _validate_zmq_socket_limits(zmq_max_sockets, cache_bound)
+
+    def test_rejects_cap_below_actual_steady_state_requirement(self):
+        with (
+            envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.override(6),
+            envs.SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS.override(2),
+        ):
+            with self.assertRaisesRegex(ValueError, "needs at least 7"):
+                _validate_zmq_socket_limits(
+                    envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get(),
+                    envs.SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS.get(),
+                )
+
+    def test_warns_when_cap_lacks_full_replacement_headroom(self):
+        with self.assertLogs(
+            "sglang.srt.disaggregation.common.conn", level="WARNING"
+        ) as logs:
+            _validate_zmq_socket_limits(7, 2)
+        self.assertIn("full cache replacement (13 sockets)", logs.output[0])
+
+    def test_defaults_cover_full_cache_replacement(self):
+        zmq_max_sockets = envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.default
+        cache_bound = envs.SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS.default
+        self.assertEqual(zmq_max_sockets, 32768)
+        self.assertEqual(cache_bound, 4096)
+        with self.assertNoLogs(
+            "sglang.srt.disaggregation.common.conn", level="WARNING"
+        ):
+            _validate_zmq_socket_limits(zmq_max_sockets, cache_bound)
+
+
+class TestZmqSocketCache(CustomTestCase):
+    def _make_manager(self, *, zmq_max_sockets: int, cache_bound: int):
+        manager = object.__new__(CommonKVManager)
+        manager._zmq_ctx = zmq.Context()
+        manager._zmq_ctx.set(zmq.MAX_SOCKETS, zmq_max_sockets)
+        manager.server_socket = manager._zmq_ctx.socket(zmq.PULL)
+        manager._socket_cache_max_endpoints = cache_bound
+        manager._socket_cache = OrderedDict()
+        manager._monitor_cache = {}
+        manager._socket_send_locks = {}
+        manager._socket_lock = threading.Lock()
+        manager._monitor_endpoint_seq = 0
+        self.addCleanup(self._destroy_manager, manager)
+        return manager
+
+    @staticmethod
+    def _destroy_manager(manager):
+        with manager._socket_lock:
+            for endpoint in list(manager._socket_cache):
+                manager._drop_endpoint_locked(endpoint)
+        manager.server_socket.close(linger=0)
+        manager._zmq_ctx.destroy(linger=0)
+
+    def test_rapid_endpoint_churn_stays_bounded(self):
+        # Seven is the exact steady-state requirement for a PULL socket and
+        # two monitored endpoints. This forces the retry path whenever the
+        # asynchronous reaper has not released an evicted endpoint yet.
+        manager = self._make_manager(zmq_max_sockets=7, cache_bound=2)
+        endpoints = [f"tcp://127.0.0.1:{20000 + index}" for index in range(200)]
+
+        for endpoint in endpoints:
+            manager._connect(endpoint)
+
+        self.assertEqual(list(manager._socket_cache), endpoints[-2:])
+        self.assertEqual(set(manager._monitor_cache), set(endpoints[-2:]))
+        self.assertEqual(set(manager._socket_send_locks), set(endpoints[-2:]))
+        self.assertGreaterEqual(manager._monitor_endpoint_seq, len(endpoints))
+
+    @patch("sglang.srt.disaggregation.common.conn.time.sleep")
+    def test_partial_monitor_creation_is_cleaned_and_retried(self, mock_sleep):
+        manager = object.__new__(CommonKVManager)
+        manager._zmq_ctx = MagicMock()
+        manager._socket_cache_max_endpoints = 4
+        manager._socket_cache = OrderedDict()
+        manager._monitor_cache = {}
+        manager._socket_send_locks = {}
+        manager._socket_lock = threading.Lock()
+        manager._monitor_endpoint_seq = 0
+
+        failed_socket = MagicMock()
+        good_monitor = MagicMock()
+        good_socket = MagicMock()
+        manager._zmq_ctx.socket.side_effect = [
+            failed_socket,
+            zmq.ZMQError(errno.EMFILE),
+            good_socket,
+            good_monitor,
+        ]
+
+        returned_socket, _ = manager._connect("tcp://127.0.0.1:29999")
+
+        self.assertIs(returned_socket, good_socket)
+        failed_socket.disable_monitor.assert_called_once_with()
+        failed_socket.close.assert_called_once_with(linger=0)
+        mock_sleep.assert_called_once_with(0.001)
+        self.assertEqual(list(manager._socket_cache.values()), [good_socket])
+        self.assertEqual(list(manager._monitor_cache.values()), [good_monitor])
+        good_monitor.connect.assert_called_once_with(
+            good_socket.monitor.call_args.args[0]
+        )
+        first_addr = failed_socket.monitor.call_args.args[0]
+        second_addr = good_socket.monitor.call_args.args[0]
+        self.assertNotEqual(first_addr, second_addr)
+
+    def test_send_retries_only_a_socket_closed_by_eviction(self):
+        manager = object.__new__(CommonKVManager)
+        evicted_socket = MagicMock()
+        evicted_socket.send_multipart.side_effect = zmq.ZMQError(errno.ENOTSOCK)
+        replacement_socket = MagicMock()
+        manager._connect = MagicMock(
+            side_effect=[
+                (evicted_socket, threading.Lock()),
+                (replacement_socket, threading.Lock()),
+            ]
+        )
+
+        manager._send_multipart_locked("tcp://127.0.0.1:30000", [b"payload"])
+
+        self.assertEqual(manager._connect.call_count, 2)
+        replacement_socket.send_multipart.assert_called_once_with([b"payload"])
+
+    def test_send_does_not_retry_unrelated_zmq_error(self):
+        manager = object.__new__(CommonKVManager)
+        socket = MagicMock()
+        socket.send_multipart.side_effect = zmq.ZMQError(errno.EAGAIN)
+        manager._connect = MagicMock(return_value=(socket, threading.Lock()))
+
+        with self.assertRaises(zmq.ZMQError):
+            manager._send_multipart_locked("tcp://127.0.0.1:30000", [b"payload"])
+
+        manager._connect.assert_called_once_with("tcp://127.0.0.1:30000", is_ipv6=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Large PD fleets can exhaust libzmq's default per-context socket limit because the KV manager keeps a PUSH socket and monitor socket for every decode endpoint. A transfer worker failure can also leave the rank appearing healthy while transfer capacity silently drains.

This PR applies the following commits from `kimi-k3-zmq-socket-limit-fix` onto the latest `main`:

- `bb83631eeb1d6cbf52c2ef124db41a8d46cbc05b`
- `921c0a7b7a6fdbd6d0b4a3ef2b16f6a50fa87473`

## Modifications

- Raise the ZMQ per-context socket cap for PD transfer contexts.
- Bound decode endpoint sockets with an LRU cache and safely retry sends that race with eviction.
- Add `SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS` and `SGLANG_DISAGGREGATION_SOCKET_CACHE_MAX_ENDPOINTS` tuning knobs.
- Terminate the rank when a Mooncake transfer worker fails instead of only losing the daemon thread.

## Follow-up commits (beyond the original cherry-picks)

- `b7bdc905a7` Fix ZMQ socket cache lifecycle and add tests: corrected socket accounting (a monitored endpoint uses **3** context sockets: PUSH + libzmq's internal monitor + the PAIR receiver, so the default cap is now 32768 to fit a full cache replacement), hard-error validation of the two knobs, unique inproc monitor endpoints, retry of transient EMFILE/ENFILE/EADDRINUSE during socket creation (libzmq reaps closed sockets asynchronously), send-retry narrowed to ENOTSOCK, plus CPU CI unit tests.
- `62c40df920` Keep decode-endpoint failures request-scoped, not rank-fatal: decode-notify sends (status sync, CHUNK_READY, TCP aux) treat send timeouts as request failures instead of SIGQUIT-ing the rank, so one dead decode endpoint cannot cascade-kill prefill ranks; the transfer worker captures its parent process at thread start. Includes regression tests.
- `796991a051` Tighten ZMQ endpoint failure handling: retain zero-linger eviction so queued unreachable endpoints cannot consume context slots past the validated cache bound, narrow request-scoped handling to actual `zmq.Again` send timeouts so process-wide ZMQ failures still recover the rank, and strengthen the churn and parent-capture tests.

## Accuracy Tests

Not applicable; this change does not affect model outputs.

## Speed Tests and Profiling

Not run. The change targets socket resource exhaustion in large PD fleets.

## Validation

- `git diff --check origin/main...HEAD`
- `git range-diff` confirms both cherry-picked patches match the source commits.
- `python3 -m compileall -q python/sglang/srt/environ.py python/sglang/srt/disaggregation/common/conn.py python/sglang/srt/disaggregation/mooncake/conn.py`
- Focused pytest collection was unavailable in the local shell because the SGLang runtime dependencies are not installed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31065444175](https://github.com/sgl-project/sglang/actions/runs/31065444175)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31065444046](https://github.com/sgl-project/sglang/actions/runs/31065444046)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
