### PR TITLE
[Bugfix] Fix Mamba allocation crash in unified memory during radix-cache handoff

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -530,19 +530,26 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.mamba_slot_full_token_cost()
             )
 
+        # Caching an unfinished request allocates a replacement state before
+        # donating its tracking state to the radix tree. Reserve that transient
+        # handoff peak for running requests; newly admitted requests reserve it
+        # in ``_mamba_gap_budget_for_req``.
+        running_mamba_handoff_slots = 0
+        if self._mamba_slot_cost and self.is_hybrid_ssm_cache:
+            running_mamba_handoff_slots = len(running_batch.reqs)
+            running_mamba_handoff_tokens = (
+                running_mamba_handoff_slots * self._mamba_slot_cost
+            )
+            self.rem_total_token_offset += running_mamba_handoff_tokens
+            self.cur_rem_token_offset += running_mamba_handoff_tokens
+
         # `mamba_gap_reserve` is charged to `rem_total_tokens`, which INCLUDES
         # `full_evictable_size()` — but `alloc_req_slots` can only recover
         # MAMBA-recoverable bytes for a mamba slot (shared gap + peer holes +
         # mamba-evictable radix), NOT full-evictable. Gate new mamba slots on
         # that mamba-recoverable budget separately or an over-admit hits the
         # fail-loud `RuntimeError`. `None` outside the unified Mamba pool.
-        self.rem_mamba_slots = None
-        if self._mamba_slot_cost:
-            self.rem_mamba_slots = (
-                self.token_to_kv_pool_allocator.mamba_allocator.schedulable_available_size()
-            )
-            if self.is_hybrid_ssm_cache:
-                self.rem_mamba_slots += self.tree_cache.mamba_evictable_size()
+        self._rem_mamba_slot_offset = running_mamba_handoff_slots
 
         self.priority_scheduling_preemption_threshold = (
             priority_scheduling_preemption_threshold
@@ -589,6 +596,10 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()
             )
+            if self._mamba_slot_cost:
+                available_and_evictable += (
+                    self.tree_cache.mamba_evictable_size() * self._mamba_slot_cost
+                )
         else:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
@@ -603,6 +614,17 @@ class PrefillAdder:
             + self.tree_cache.swa_evictable_size()
             - self.rem_swa_token_offset
         )
+
+    @property
+    def rem_mamba_slots(self):
+        if not self._mamba_slot_cost:
+            return None
+        available_and_evictable = (
+            self.token_to_kv_pool_allocator.mamba_allocator.schedulable_available_size()
+        )
+        if self.is_hybrid_ssm_cache:
+            available_and_evictable += self.tree_cache.mamba_evictable_size()
+        return available_and_evictable - self._rem_mamba_slot_offset
 
     @property
     def cur_rem_tokens(self):
@@ -621,6 +643,10 @@ class PrefillAdder:
                 self.token_to_kv_pool_allocator.available_size()
                 + self.tree_cache.full_evictable_size()
             )
+            if self._mamba_slot_cost:
+                available_and_evictable += (
+                    self.tree_cache.mamba_evictable_size() * self._mamba_slot_cost
+                )
         else:
             available_and_evictable = (
                 self.token_to_kv_pool_allocator.available_size()
@@ -705,19 +731,14 @@ class PrefillAdder:
         return cap // self.page_size * self.page_size
 
     def _mamba_gap_budget_for_req(self, req: Req) -> int:
-        """Shared-gap reservation (full-token-equivalents) for a request's new
-        mamba state. Charged only on the SHARED Mamba pool (`_mamba_slot_cost > 0`)
-        and only when the req has no state yet (`mamba_pool_idx is None`, mirroring
-        `HybridReqToTokenPool.alloc`); 0 keeps baseline / SWA / non-Mamba unchanged.
+        """Shared-gap reservation for allocations and radix handoff peak."""
+        if not self._mamba_slot_cost:
+            return 0
 
-        Conservative by design (`_mamba_slot_cost` rounds UP). Does NOT reserve
-        radix COW headroom or locked-but-evictable bytes — that residual is
-        backstopped by the fail-loud RuntimeError in `alloc_req_slots`. FIXME: if
-        over-admission crashes under pressure, make this more conservative (e.g.
-        multiply by `MAMBA_STATE_PER_REQ_PREFIX_CACHE`)."""
-        if self._mamba_slot_cost and req.mamba_pool_idx is None:
-            return self._mamba_slot_cost
-        return 0
+        slots = self.tree_cache.req_to_token_pool.mamba_slots_needed_for_req(req)
+        if self.is_hybrid_ssm_cache:
+            slots += 1
+        return self._mamba_slot_cost * slots
 
     def ceil_paged_tokens(self, tokens: int) -> int:
         return -(-tokens // self.page_size) * self.page_size
@@ -773,7 +794,7 @@ class PrefillAdder:
         # The new mamba slot also consumes one mamba-recoverable slot (gated
         # separately so full_evictable can't cover it — see __init__).
         if mamba_gap_reserve and self.rem_mamba_slots is not None:
-            self.rem_mamba_slots -= 1
+            self._rem_mamba_slot_offset += mamba_gap_reserve // self._mamba_slot_cost
         self.rem_input_tokens -= extend_input_len
 
         if self.is_hybrid_swa:

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -19,9 +19,6 @@ from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
 )
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache, EvictParams
 from sglang.srt.mem_cache.common import (
-    MAMBA_STATE_PER_REQ_NO_CACHE,
-    MAMBA_STATE_PER_REQ_PREFIX_CACHE,
-    MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY,
     available_and_evictable_str,
     evict_from_tree_cache,
 )
@@ -267,20 +264,27 @@ def alloc_req_slots(
         mamba_available_size = (
             req_to_token_pool.mamba_allocator.schedulable_available_size()
         )
-        # Eviction headroom factor: 3x (or lazy variant) for radix COW, 1x for chunk.
-        if tree_cache.supports_mamba():
-            factor = (
-                MAMBA_STATE_PER_REQ_PREFIX_CACHE_LAZY
-                if req_to_token_pool.enable_mamba_extra_buffer_lazy
-                else MAMBA_STATE_PER_REQ_PREFIX_CACHE
-            )
-        else:
-            factor = MAMBA_STATE_PER_REQ_NO_CACHE
-        mamba_state_needed = num_reqs * factor
+        mamba_state_needed = sum(
+            req_to_token_pool.mamba_slots_needed_for_req(req) for req in reqs
+        )
         if mamba_available_size < mamba_state_needed:
             if tree_cache is not None and tree_cache.supports_mamba():
-                mamba_num = max(0, mamba_state_needed - mamba_available_size)
-                tree_cache.evict(EvictParams(num_tokens=0, mamba_num=mamba_num))
+                shortfall = max(0, mamba_state_needed - mamba_available_size)
+                mamba_num = min(shortfall, tree_cache.mamba_evictable_size())
+                full_shortfall = shortfall - mamba_num
+                full_token_cost_fn = getattr(
+                    tree_cache.token_to_kv_pool_allocator,
+                    "mamba_slot_full_token_cost",
+                    None,
+                )
+                full_tokens = (
+                    full_shortfall * full_token_cost_fn()
+                    if full_shortfall and full_token_cost_fn
+                    else 0
+                )
+                tree_cache.evict(
+                    EvictParams(num_tokens=full_tokens, mamba_num=mamba_num)
+                )
     req_pool_indices = req_to_token_pool.alloc(reqs)
     if req_pool_indices is None:
         raise RuntimeError(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1289,6 +1289,20 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def register_layer_transfer_counter(self, layer_transfer_counter: LayerDoneCounter):
         self.layer_transfer_counter = layer_transfer_counter
 
+    def mamba_slots_needed_for_req(self, req: Req) -> int:
+        """Return the Mamba slots that ``alloc([req])`` will still allocate."""
+        if req.req_pool_idx is not None:
+            return 0
+
+        needed = int(req.mamba_pool_idx is None)
+        if self.enable_mamba_extra_buffer and req.mamba_ping_pong_track_buffer is None:
+            needed += (
+                1
+                if self.enable_mamba_extra_buffer_lazy
+                else self.mamba_ping_pong_track_buffer_size
+            )
+        return needed
+
     # For chunk prefill req, we do not need to allocate mamba cache,
     # We could use allocated mamba cache instead.
     def alloc(self, reqs: List[Req]) -> Optional[List[int]]:

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -474,10 +474,30 @@ class MambaComponent(TreeComponent):
         """Allocate one mamba pool slot, evicting if necessary."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
-            self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+            self.cache.evict(self._mamba_slot_eviction_params())
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
-            assert slot is not None, "Can not alloc mamba cache"
+            if slot is None:
+                allocator = self.cache.req_to_token_pool.mamba_allocator
+                raise AssertionError(
+                    "Can not alloc mamba cache after eviction fallback: "
+                    f"available={allocator.available_size()}, "
+                    f"schedulable={allocator.schedulable_available_size()}, "
+                    f"mamba_evictable={self.cache.mamba_evictable_size()}, "
+                    f"mamba_protected={self.cache.mamba_protected_size()}, "
+                    f"allocator={allocator.allocator_state_str()}, "
+                    f"cache={self.cache.available_and_evictable_str()}"
+                )
         return slot
+
+    def _mamba_slot_eviction_params(self) -> EvictParams:
+        """Evict from the side that can actually supply one shared Mamba row."""
+        allocator = self.cache.token_to_kv_pool_allocator
+        full_token_cost_fn = getattr(allocator, "mamba_slot_full_token_cost", None)
+        if full_token_cost_fn is None:
+            return EvictParams(mamba_num=1)
+        if self.cache.mamba_evictable_size() > 0:
+            return EvictParams(mamba_num=1)
+        return EvictParams(num_tokens=full_token_cost_fn())
 
     @property
     def int8_ckpt_pool(self):

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -8,6 +8,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     DecLockRefResult,
     IncLockRefResult,
 )
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils.common import Range
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -111,6 +112,50 @@ class TestPrefillAdder(CustomTestCase):
         )
         defaults.update(kwargs)
         return PrefillAdder(**defaults)
+
+    def test_unified_mamba_budget_reserves_missing_slots_and_handoff(self):
+        adder = object.__new__(PrefillAdder)
+        adder._mamba_slot_cost = 7
+        adder.is_hybrid_ssm_cache = True
+        req_pool = HybridReqToTokenPool.__new__(HybridReqToTokenPool)
+        req_pool.enable_mamba_extra_buffer = True
+        req_pool.enable_mamba_extra_buffer_lazy = False
+        req_pool.mamba_ping_pong_track_buffer_size = 2
+        adder.tree_cache = SimpleNamespace(req_to_token_pool=req_pool)
+        req = SimpleNamespace(
+            req_pool_idx=None,
+            mamba_pool_idx=None,
+            mamba_ping_pong_track_buffer=None,
+        )
+
+        # Active + two tracking states + one transient radix handoff state.
+        self.assertEqual(adder._mamba_gap_budget_for_req(req), 4 * 7)
+        req.mamba_pool_idx = object()
+        self.assertEqual(adder._mamba_gap_budget_for_req(req), 3 * 7)
+        req.mamba_ping_pong_track_buffer = object()
+        self.assertEqual(adder._mamba_gap_budget_for_req(req), 7)
+
+    def test_unified_joint_budget_credits_evictable_mamba_bytes(self):
+        adder = object.__new__(PrefillAdder)
+        adder.is_all_swa = False
+        adder.is_hybrid_swa = False
+        adder.is_hybrid_ssm_cache = True
+        adder._mamba_slot_cost = 7
+        adder.rem_total_token_offset = 4
+        adder.cur_rem_token_offset = 3
+        adder._rem_mamba_slot_offset = 1
+        adder.token_to_kv_pool_allocator = SimpleNamespace(
+            available_size=lambda: 10,
+            mamba_allocator=SimpleNamespace(schedulable_available_size=lambda: 2),
+        )
+        adder.tree_cache = SimpleNamespace(
+            full_evictable_size=lambda: 5,
+            mamba_evictable_size=lambda: 3,
+        )
+
+        self.assertEqual(adder.rem_total_tokens, 32)
+        self.assertEqual(adder.cur_rem_tokens, 33)
+        self.assertEqual(adder.rem_mamba_slots, 4)
 
     def test_preempt_success_high_priority_values_first(self):
         params = [

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -12,13 +12,16 @@ eviction -- which is why the peak, not the decode steady state, sets the floor.
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
+from sglang.srt.mem_cache.allocation import alloc_req_slots
 from sglang.srt.mem_cache.base_prefix_cache import (
     EvictParams,
     IncLockRefResult,
 )
+from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.mem_cache.unified_cache.components.mamba_component import MambaComponent
 from sglang.srt.mem_cache.unified_cache.components.tree_component import ComponentType
 from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
@@ -44,6 +47,15 @@ class _BoundedMambaAllocator:
     def free(self, value: torch.Tensor):
         self.free_ids.extend(int(v) for v in value.tolist())
 
+    def available_size(self):
+        return len(self.free_ids)
+
+    def schedulable_available_size(self):
+        return len(self.free_ids)
+
+    def allocator_state_str(self):
+        return f"free={len(self.free_ids)}"
+
 
 class _RatioCache:
     tree_components = (ComponentType.FULL, ComponentType.MAMBA)
@@ -52,9 +64,19 @@ class _RatioCache:
         self.root_node = UnifiedTreeNode(self.tree_components)
         self.allocator = _BoundedMambaAllocator(pool_size)
         self.req_to_token_pool = SimpleNamespace(mamba_allocator=self.allocator)
+        self.token_to_kv_pool_allocator = SimpleNamespace()
         self.component_evictable_size_ = {ComponentType.MAMBA: 0}
         self.component_protected_size_ = {ComponentType.MAMBA: 0}
         self.prefix_nodes = []
+
+    def mamba_evictable_size(self):
+        return self.component_evictable_size_[ComponentType.MAMBA]
+
+    def mamba_protected_size(self):
+        return self.component_protected_size_[ComponentType.MAMBA]
+
+    def available_and_evictable_str(self):
+        return "ratio-cache"
 
     def evict(self, params: EvictParams):
         # Reclaim up to mamba_num evictable (unlocked) prefix snapshots, mirroring
@@ -230,6 +252,75 @@ class TestMambaDonatedAllocRatio(unittest.TestCase):
         slot = component._alloc_mamba_slot()
         self.assertIsNotNone(slot)
         self.assertEqual(len(cache.prefix_nodes), N - 1)
+
+
+class TestUnifiedMambaAdmissionAndEviction(unittest.TestCase):
+    @staticmethod
+    def _req(*, active=False, tracking=False):
+        return SimpleNamespace(
+            req_pool_idx=None,
+            mamba_pool_idx=object() if active else None,
+            mamba_ping_pong_track_buffer=object() if tracking else None,
+        )
+
+    @staticmethod
+    def _req_pool():
+        req_pool = HybridReqToTokenPool.__new__(HybridReqToTokenPool)
+        req_pool.enable_mamba_extra_buffer = True
+        req_pool.enable_mamba_extra_buffer_lazy = False
+        req_pool.mamba_ping_pong_track_buffer_size = 2
+        req_pool.mamba_allocator = MagicMock()
+        req_pool.mamba_allocator.schedulable_available_size.return_value = 1
+        req_pool.alloc = MagicMock(return_value=[3, 4])
+        return req_pool
+
+    def test_preallocated_active_states_are_not_charged_again(self):
+        req_pool = self._req_pool()
+        tree_cache = MagicMock()
+        tree_cache.supports_mamba.return_value = True
+        tree_cache.mamba_evictable_size.return_value = 3
+
+        self.assertEqual(
+            alloc_req_slots(
+                req_pool,
+                [self._req(active=True), self._req(active=True)],
+                tree_cache,
+            ),
+            [3, 4],
+        )
+        params = tree_cache.evict.call_args.args[0]
+        self.assertEqual((params.num_tokens, params.mamba_num), (0, 3))
+
+    def test_request_slots_use_mamba_then_full_shared_bytes(self):
+        req_pool = self._req_pool()
+        tree_cache = MagicMock()
+        tree_cache.supports_mamba.return_value = True
+        tree_cache.mamba_evictable_size.return_value = 3
+        tree_cache.token_to_kv_pool_allocator.mamba_slot_full_token_cost.return_value = (
+            7
+        )
+
+        alloc_req_slots(req_pool, [self._req(), self._req()], tree_cache)
+
+        params = tree_cache.evict.call_args.args[0]
+        # Six states are missing and one fits. Three cached Mamba states cover
+        # part of the shortfall; Full KV supplies only the remaining two rows.
+        self.assertEqual((params.num_tokens, params.mamba_num), (14, 3))
+
+    def test_single_slot_eviction_uses_the_available_side(self):
+        component = object.__new__(MambaComponent)
+        component.cache = MagicMock()
+        component.cache.token_to_kv_pool_allocator.mamba_slot_full_token_cost.return_value = (
+            1590
+        )
+
+        component.cache.mamba_evictable_size.return_value = 1
+        params = component._mamba_slot_eviction_params()
+        self.assertEqual((params.num_tokens, params.mamba_num), (0, 1))
+
+        component.cache.mamba_evictable_size.return_value = 0
+        params = component._mamba_slot_eviction_params()
+        self.assertEqual((params.num_tokens, params.mamba_num), (1590, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Serving hybrid Mamba models with unified memory can crash under memory pressure with `AssertionError: Can not alloc mamba cache`. When caching an unfinished request, the radix cache must allocate a replacement Mamba slot before donating the tracked state. Admission did not reserve this checkpoint-handoff headroom, and allocation fallback tried only Mamba eviction even when full-KV cache could release shared capacity.

## Modifications

- Account for the actual Mamba slots and radix-cache handoff peak during admission.
- Reclaim from Mamba first, then full-KV cache for any remaining shortfall.
- Add allocation diagnostics and CPU-only regression tests.

## Accuracy Tests

N/A. This change does not modify model computation or outputs.

## Speed Tests and Profiling

N/A. This change adds only constant-time host-side accounting and no GPU synchronization.

## Tests

This PR adds CPU-only regression tests for Mamba admission, handoff headroom, and shared-memory eviction.

```bash
PYTHONPATH=python:test python -m pytest \
  test/registered/unit/managers/test_prefill_adder.py \
  test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py -q
```

- New regression tests: `upstream/main` **5 failed** → this PR **5 passed**
- All tests in both affected files: **30 passed**
- Pre-commit (modified files): **passed**

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no user-facing changes)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A: accounting-only fix)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31061046576](https://github.com/sgl-project/sglang/actions/runs/31061046576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31061046482](https://github.com/sgl-project/sglang/actions/runs/31061046482)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->