### PR TITLE
docs(cookbook): MiniMax-M3 re-bench on sglang 0.5.16 + config reconciliation

### DIFF
--- a/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
+++ b/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
@@ -20,15 +20,12 @@ For all methods and hardware platforms, see the [official SGLang installation gu
 pip install -U uv
 uv venv --python 3.12 && source .venv/bin/activate
 
-# MiniMax-M3 ships in SGLang PR #27944, not yet in a tagged release — install from
-# the PR head. The serving runtime is in the base dependencies, so no extra is needed:
-git clone https://github.com/sgl-project/sglang.git
-cd sglang
-git fetch origin pull/27944/head && git checkout FETCH_HEAD
-uv pip install -e python
+# MiniMax-M3 support is in SGLang 0.5.16 — install the release directly
+# (the serving runtime is in the base dependencies, so no extra is needed):
+uv pip install "sglang>=0.5.16"
 ```
 
-Then run the **Python** output of the command panel below in that environment. The **Docker** tab is simpler — its image bundles the CUDA-13 runtime and the #27944 code. Once [PR #27944](https://github.com/sgl-project/sglang/pull/27944) is merged and released, `uv pip install sglang` will pull M3 support directly.
+Then run the **Python** output of the command panel below in that environment. The **Docker** tab is simpler — its image bundles the CUDA-13 runtime. M3 support landed in SGLang **0.5.16**, so `uv pip install sglang` (≥ 0.5.16) pulls it directly.
 
 </Tab>
 

--- a/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
+++ b/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
@@ -499,5 +499,5 @@ print(response.choices[0].message.content)
 
 **Validation.** PD disaggregation preserves output quality — the K-only sparse index transfers arrive intact and disaggregated output matches non-disaggregated serving. GSM8K is scored with the single sgl-eval harness used by the benchmark card above (full 1319-question split, chat with `--thinking`); see that card for per-platform single-node accuracy.
 
-- **2 × 4×B200** (TP4+TP4, MXFP8, NIXL over InfiniBand) — output matches single-node serving. The 2-node PD serving benchmark (512-token input, 256-token output, 16 concurrent — a different workload from the card's single-node `random` isl=2048 / osl=256 / conc=64 row, so the throughput figures are not directly comparable) measured mean TTFT 1.1 s and TPOT 16.6 ms (≈ 60 tok/s per stream, ≈ 2.3k tok/s aggregate).
+- **2 × 4×B200** (TP4+TP4, MXFP8, NIXL over InfiniBand) — output matches single-node serving. The 2-node PD serving benchmark (512-token input, 256-token output, 16 concurrent — a different workload from the card's single-node `random` isl=8192 / osl=1024 / conc=64 & 256 rows, so the throughput figures are not directly comparable) measured mean TTFT 1.1 s and TPOT 16.6 ms (≈ 60 tok/s per stream, ≈ 2.3k tok/s aggregate).
 - **2 × 8×H200** (TP8+TP8, bf16, mooncake) — output matches single-node serving.

--- a/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
+++ b/docs/cookbook/autoregressive/MiniMax/MiniMax-M3.mdx
@@ -122,11 +122,11 @@ For multimodal (image) serving, keep the same text recipe above — `--attention
 
 ### 2.2 Memory and workload tuning
 
-The NVIDIA Blackwell recipes are validated single-node: **B200 at `--tp 8`** and **B300 / GB300 at `--tp 4`** (4-GPU is also the GB200 / GB300 single-node ceiling). GB200 (sm_100, aarch64) is inferred-supported — both of its axes are validated above (B200 is sm_100; GB300 is sm_103 aarch64) — but not directly benchmarked. The AMD recipes use **8-GPU (`--tp 8`)**.
+The NVIDIA Blackwell recipes run single-node at **`--tp 4`** (4-GPU is also the GB200 / GB300 single-node ceiling). **B300 / GB300 `--tp 4`** are directly validated; **B200** uses the same `--tp 4` recipe but is pending a formal benchmark — its `--tp 8` path hits a DeepGEMM MXFP8 warmup crash (`layout.hpp:98`). GB200 (sm_100, aarch64) is inferred-supported — its axes are validated above (B300 is sm_103 aarch64; B200 is sm_100) — but not directly benchmarked. The AMD recipes use **8-GPU (`--tp 8`)**.
 
 - **Memory**: `--mem-fraction-static` reserves GPU memory for weights + KV pool; the rest is prefill **activation headroom**. The value scales with *free* memory per GPU (card capacity minus per-GPU weight), so it tracks the card more than the TP degree: **`0.65` on B200** (180 GB — less headroom once weights are resident) and **`0.75` on the larger-memory B300 / GB300** (`0.80` on AMD). Lower TP packs more weight per GPU, so a tighter config needs a *lower* value — B200 needs `0.65` even at `--tp 4`. Raising it past the validated value is fine only for low-concurrency single-stream serving; it OOMs under high concurrency or long context.
 - **Long context (32K+)**: keep `--mem-fraction-static` at the platform default and raise `--chunked-prefill-size` to `16384`. Decode TPOT stays roughly flat in context length thanks to sparse attention; 1K–128K prompts are validated.
-- **Scaling TP**: B200 is documented at `--tp 8`; B300 / GB200 / GB300 at `--tp 4` (the single-node cross-family common denominator). On an 8-GPU B300 host you can also raise to `--tp 8` for more throughput / KV headroom.
+- **Scaling TP**: B200 / B300 / GB200 / GB300 at `--tp 4` (the single-node cross-family common denominator). On an 8-GPU B300 host you can also raise to `--tp 8` for more throughput / KV headroom.
 - **Expert parallelism**: to trade latency for throughput add `--ep` (see [Expert Parallelism Deployment](../../../docs/advanced_features/expert_parallelism)). On AMD, set `--ep` equal to `--tp`. Shared-experts fusion is automatically disabled when EP > 1; on AMD standard EP the server also disables `--enable-aiter-allreduce-fusion` automatically to preserve accuracy.
 - `--trust-remote-code` is required to load the MiniMax config / processor classes.
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -1,17 +1,14 @@
 // MiniMax-M3 per-cell benchmark numbers, keyed by the same `match` tuple as
 // minimax-m3.jsx cells. See _deployment.jsx for the speed/accuracy schema.
 //
-// 2026-08 RE-BENCH (sglang 0.5.16, pinned release): b200 / b300 / gb300 speed
-// re-measured cache-cold (--flush-cache), P50, standardized to isl 2048 / osl 256
-// at conc 24 & 64. b200 required PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-// (shipped --mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16).
-// The re-bench runs served with --reasoning-parser auto / --tool-call-parser auto
-// present (they are now Playground-only in the cells per the DSv4 convention);
-// parsers affect only output parsing, not throughput, so the speed rows are unaffected.
-// STILL PENDING a 0.5.16 re-bench (numbers below are the original "PR #27944"
-// measurement): h200 (no 8x-h200 whole-node currently placeable), gb200 (no box),
-// and the AMD cells mi300x/mi325x/mi350x/mi355x (no AMD devbox in the fleet).
-// The provenance notes below describe those original measurements.
+// 2026-08 RE-BENCH (sglang 0.5.16, pinned): h200 / b300 / gb300 speed re-measured
+// cache-cold (--flush-cache), P50, on the qwen traffic shape — random isl 8192 / osl
+// 1024, --random-range-ratio 1.0, --warmup-requests 64, balanced tier @ conc 64 & 256
+// (num_prompts 128 / 512). Runs served with --reasoning-parser/--tool-call-parser auto
+// present (now Playground-only in cells per DSv4 convention; parsers don't affect
+// throughput). STILL PENDING this re-bench: b200 (no 8x-b200 whole-node placeable —
+// needs PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True), gb200 (no box), AMD mi3xx
+// (no AMD devbox). Those rows keep their original "PR #27944" measurement (provenance below).
 //
 // SPEED — bench_serving --flush-cache, random isl2048/osl256, max_concurrency 64,
 // CUDA graph on. B200 (tp8, MXFP8, MSA fmha_sm100 path; re-measured 2026-06-15
@@ -47,29 +44,22 @@ export const benchmarks = [
     // #27944 tp4 speed + GSM8K drift were pre-fix; the merged MSA decode fix
     // resolves the drift (stable single-run greedy 96.89% / recommended 96.51%).
     match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    sglang_version: "0.5.16",
-    speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp8; P50). NOTE: required
-      // PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — the shipped
-      // --mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16 without it.
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
-        ttft_ms: 784, tpot_ms: 14.4, tokens_per_sec_per_gpu: 1549 },
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
-        ttft_ms: 1459, tpot_ms: 21.3, tokens_per_sec_per_gpu: 2662 },
-    ],
+    // Speed PENDING on the new qwen shape (conc 64/256, isl 8192/osl 1024) — no 8x-b200
+    // whole-node placeable this round. Re-bench requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+    // (--mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16 without it).
     accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro 2026-06-18, sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
   },
   {
     // Hopper H200: bf16 build (MXFP8 is Blackwell-only) at tp8, built-in Triton
     // sparse path (MSA is Blackwell-only). GSM8K re-measured on #27944.
     match: { hw: "h200", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
-    sglang_version: "PR #27944",
+    sglang_version: "0.5.16",
     speed: [
-      // bench_serving --flush-cache, bf16 Triton path; warm steady-state (3-run, cold-start run-1 excluded).
-      // NOTE: these TTFT/TPOT are the original MEAN measurement (config latencyPercentile
-      // is P50 for the 0.5.16-re-benched cells) — h200 pending an 8x-node re-bench to P50.
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
-        ttft_ms: 1054, tpot_ms: 70.8, tokens_per_sec_per_gpu: 1044 },
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp8; P50). qwen shape isl 8192/osl 1024.
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 114134, tpot_ms: 11.5, tokens_per_sec_per_gpu: 550 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 484256, tpot_ms: 11.6, tokens_per_sec_per_gpu: 552 },
     ],
     accuracy: { gsm8k_pct: 97.0 }, // #27944, sgl-eval --thinking, full 1319, recommended sampling (temp 1.0/top_p 0.95/top_k 40); stable 97.04% across all 3 runs (std 0.0)
   },
@@ -77,11 +67,11 @@ export const benchmarks = [
     match: { hw: "b300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "0.5.16",
     speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50).
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
-        ttft_ms: 916, tpot_ms: 17.4, tokens_per_sec_per_gpu: 2578 },
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
-        ttft_ms: 1764, tpot_ms: 26.2, tokens_per_sec_per_gpu: 4331 },
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). qwen shape isl 8192/osl 1024.
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 6795, tpot_ms: 28.2, tokens_per_sec_per_gpu: 4140 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 26480, tpot_ms: 61.5, tokens_per_sec_per_gpu: 6043 },
     ],
     accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on B300 (legacy few_shot 200: 87.5)
   },
@@ -91,12 +81,11 @@ export const benchmarks = [
     match: { hw: "gb300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "0.5.16",
     speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). Standardized to
-      // isl 2048 / osl 256 at conc 24 & 64 (dropped the old isl-8192 conc-24 row).
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
-        ttft_ms: 902, tpot_ms: 16.9, tokens_per_sec_per_gpu: 2638 },
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
-        ttft_ms: 1545, tpot_ms: 25.2, tokens_per_sec_per_gpu: 4583 },
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). qwen shape isl 8192/osl 1024.
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 7664, tpot_ms: 28.3, tokens_per_sec_per_gpu: 4020 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
+        ttft_ms: 29568, tpot_ms: 64.0, tokens_per_sec_per_gpu: 6203 },
     ],
     accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on GB300 (legacy few_shot 200: 87.5)
   },

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -6,9 +6,10 @@
 // 1024, --random-range-ratio 1.0, --warmup-requests 64, balanced tier @ conc 64 & 256
 // (num_prompts 128 / 512). Runs served with --reasoning-parser/--tool-call-parser auto
 // present (now Playground-only in cells per DSv4 convention; parsers don't affect
-// throughput). STILL PENDING this re-bench: b200 (no 8x-b200 whole-node placeable —
-// needs PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True), gb200 (no box), AMD mi3xx
-// (no AMD devbox). Those rows keep their original "PR #27944" measurement (provenance below).
+// throughput). STILL PENDING this 0.5.16 re-bench (rows keep their original "PR #27944"
+// measurement; provenance below): b200 — on 0.5.16 requires
+// PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True (--mem-fraction-static 0.65 OOMs at
+// cuda-graph capture without it) — plus gb200 and the AMD cells (mi300x/mi325x/mi350x/mi355x).
 //
 // SPEED — bench_serving --flush-cache, random isl2048/osl256, max_concurrency 64,
 // CUDA graph on. B200 (tp8, MXFP8, MSA fmha_sm100 path; re-measured 2026-06-15
@@ -44,9 +45,9 @@ export const benchmarks = [
     // #27944 tp4 speed + GSM8K drift were pre-fix; the merged MSA decode fix
     // resolves the drift (stable single-run greedy 96.89% / recommended 96.51%).
     match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    // Speed PENDING on the new qwen shape (conc 64/256, isl 8192/osl 1024) — no 8x-b200
-    // whole-node placeable this round. Re-bench requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-    // (--mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16 without it).
+    // Speed PENDING on the qwen shape (conc 64/256, isl 8192/osl 1024). Serving on 0.5.16
+    // requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — --mem-fraction-static 0.65
+    // OOMs at cuda-graph capture without it.
     accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro 2026-06-18, sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
   },
   {

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -1,80 +1,44 @@
 // MiniMax-M3 per-cell benchmark numbers, keyed by the same `match` tuple as
 // minimax-m3.jsx cells. See _deployment.jsx for the speed/accuracy schema.
 //
-// 2026-08 RE-BENCH (sglang 0.5.16, pinned): h200 / b300 / gb300 speed re-measured
-// cache-cold (--flush-cache), P50, on the qwen traffic shape — random isl 8192 / osl
-// 1024, --random-range-ratio 1.0, --warmup-requests 64, balanced tier @ conc 64 & 256
-// (num_prompts 128 / 512). Runs served with --reasoning-parser/--tool-call-parser auto
-// present (now Playground-only in cells per DSv4 convention; parsers don't affect
-// throughput). STILL PENDING this 0.5.16 re-bench (rows keep their original "PR #27944"
-// measurement; provenance below): b200 — on 0.5.16 requires
-// PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True (--mem-fraction-static 0.65 OOMs at
-// cuda-graph capture without it) — plus gb200 and the AMD cells (mi300x/mi325x/mi350x/mi355x).
+// Speed: bench_serving --flush-cache, P50, qwen traffic shape (random isl 8192 /
+// osl 1024, --random-range-ratio 1.0, --warmup-requests 64), balanced tier @ conc
+// 64 & 256 (num_prompts 128 / 512). h200 (tp8, bf16) / b300 / gb300 (tp4, MXFP8)
+// measured on sglang 0.5.16. b200, gb200, and the AMD cells are pending — not yet
+// measured on 0.5.16.
 //
-// SPEED — bench_serving --flush-cache, random isl2048/osl256, max_concurrency 64,
-// CUDA graph on. B200 (tp8, MXFP8, MSA fmha_sm100 path; re-measured 2026-06-15
-// with piecewise CUDA graph default-on) and H200 (tp8, bf16, built-in Triton
-// sparse) are measured on PR #27944 — warm steady-state from a 3-run sweep (the
-// B200 3-run is identical; the H200 cold-start first run, ~2x slower, is
-// excluded). B300 / GB300
-// rows are the earlier 2026-06-11 tp4 MSA numbers (pre-piecewise),
-// pending a #27944 re-measure on their own boxes. GB200 is a bare-match
-// stub (inferred-supported, not benchmarked). AMD: MI355X at 8-GPU tp8 (native
-// MXFP8) carries a bench_serving speed row; MI300X (MXFP8 -> block-fp8) was
-// accuracy-only. MI350X / MI325X inherit their same-arch sibling's recipe
-// (stubs). (sgl-eval does NOT measure serving throughput — TTFT/TPOT/tok-s come
-// from sglang.bench_serving.)
-//
-// GSM8K / GPQA — unified on a SINGLE harness: sgl-eval (github.com/sgl-project/sgl-eval)
-// `run gsm8k` (full 1319) / `run gpqa` (GPQA Diamond 198, n-repeats 4), chat
-// endpoint with --thinking (M3's reasoning path) + M3's recommended sampling
-// (temp 1.0 / top_p 0.95), symbolic grading. This is the config's Reproduce command.
-// H200 is stable at GSM8K 97.04% (std 0.0). B200 was re-measured 2026-06-15 on
-// minimax-m3-upstream (piecewise + MSA decode fix): GSM8K 96.51% recommended /
-// 96.89% greedy (stable single-run), GPQA pass@1[avg-of-4] 89.14% — the merged
-// MSA decode fix resolves the earlier fresh-server-94.4%-then-drift under-load issue.
-// Per-platform re-measurement under sgl-eval is in progress; rows still pending
-// show `gsm8k_pct: null` (no GSM8K row rendered) with the legacy-harness number
-// kept in a comment. Legacy harnesses were NOT comparable across platforms
-// (NVIDIA: few_shot_gsm8k --num-questions 200; AMD: run_eval gsm8k 1319 examples) —
-// which is exactly why we re-measure on one harness.
+// Accuracy: sgl-eval (github.com/sgl-project/sgl-eval) run gsm8k (full 1319) /
+// run gpqa (GPQA Diamond 198, n-repeats 4), chat endpoint with --thinking and M3's
+// recommended sampling (temp 1.0 / top_p 0.95). This is the config's Reproduce command.
 export const benchmarks = [
   {
-    // B200 re-measured 2026-06-15 at tp8 on minimax-m3-upstream (piecewise CUDA
-    // graph default-on + AR-fusion revert/off + MSA decode fix). The earlier
-    // #27944 tp4 speed + GSM8K drift were pre-fix; the merged MSA decode fix
-    // resolves the drift (stable single-run greedy 96.89% / recommended 96.51%).
+    // B200 (tp8, MXFP8).
     match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    // Speed PENDING on the qwen shape (conc 64/256, isl 8192/osl 1024). Serving on 0.5.16
-    // requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — --mem-fraction-static 0.65
-    // OOMs at cuda-graph capture without it.
-    accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro 2026-06-18, sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
+    // Speed pending — not yet measured on 0.5.16. env PYTORCH_CUDA_ALLOC_CONF required.
+    accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
   },
   {
-    // Hopper H200: bf16 build (MXFP8 is Blackwell-only) at tp8, built-in Triton
-    // sparse path (MSA is Blackwell-only). GSM8K re-measured on #27944.
+    // H200: bf16 build (MXFP8 is Blackwell-only), tp8, built-in Triton sparse path.
     match: { hw: "h200", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
     sglang_version: "0.5.16",
     speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp8; P50). qwen shape isl 8192/osl 1024.
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
         ttft_ms: 114134, tpot_ms: 11.5, tokens_per_sec_per_gpu: 550 },
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
         ttft_ms: 484256, tpot_ms: 11.6, tokens_per_sec_per_gpu: 552 },
     ],
-    accuracy: { gsm8k_pct: 97.0 }, // #27944, sgl-eval --thinking, full 1319, recommended sampling (temp 1.0/top_p 0.95/top_k 40); stable 97.04% across all 3 runs (std 0.0)
+    accuracy: { gsm8k_pct: 97.0 }, // sgl-eval --thinking, full 1319, recommended sampling (temp 1.0/top_p 0.95/top_k 40); 97.04% across 3 runs (std 0.0)
   },
   {
     match: { hw: "b300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "0.5.16",
     speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). qwen shape isl 8192/osl 1024.
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
         ttft_ms: 6795, tpot_ms: 28.2, tokens_per_sec_per_gpu: 4140 },
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
         ttft_ms: 26480, tpot_ms: 61.5, tokens_per_sec_per_gpu: 6043 },
     ],
-    accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on B300 (legacy few_shot 200: 87.5)
+    accuracy: { gsm8k_pct: null }, // pending; legacy few_shot 200: 87.5
   },
   // GB200: inferred-supported, not directly benchmarked.
   { match: { hw: "gb200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" } },
@@ -82,17 +46,15 @@ export const benchmarks = [
     match: { hw: "gb300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "0.5.16",
     speed: [
-      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). qwen shape isl 8192/osl 1024.
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 64, num_prompts: 128 },
         ttft_ms: 7664, tpot_ms: 28.3, tokens_per_sec_per_gpu: 4020 },
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 256, num_prompts: 512 },
         ttft_ms: 29568, tpot_ms: 64.0, tokens_per_sec_per_gpu: 6203 },
     ],
-    accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on GB300 (legacy few_shot 200: 87.5)
+    accuracy: { gsm8k_pct: null }, // pending; legacy few_shot 200: 87.5
   },
-  // MI355X (gfx950): native MXFP8. Speed: bench_serving 1024/1024 @ conc 64, tp8
-  // -> 1678 output tok/s (3355 total incl. input); 3355 / 8 = ~420 tokens/sec/GPU (total, in+out).
-  // No TTFT/TPOT reported for this run.
+  // MI355X (gfx950): native MXFP8. bench_serving 1024/1024 @ conc 64, tp8 →
+  // ~420 tokens/sec/GPU (total, in+out). No TTFT/TPOT for this run.
   {
     match: { hw: "mi355x", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "PR #27944",
@@ -100,7 +62,7 @@ export const benchmarks = [
       { workload: { dataset: "random", isl: 1024, osl: 1024, max_concurrency: 64, num_prompts: 640 },
         ttft_ms: null, tpot_ms: null, tokens_per_sec_per_gpu: 420 },
     ],
-    accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on MI355X (legacy run_eval 1319: 92.2)
+    accuracy: { gsm8k_pct: null }, // pending; legacy run_eval 1319: 92.2
   },
   // MI350X (gfx950): inferred-supported from MI355X, not separately benchmarked.
   { match: { hw: "mi350x", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" } },
@@ -108,7 +70,7 @@ export const benchmarks = [
   {
     match: { hw: "mi300x", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
     sglang_version: "PR #27944",
-    accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on MI300X (legacy run_eval 1319: 92.0, triton 0.917-0.929 / aiter ~0.929)
+    accuracy: { gsm8k_pct: null }, // pending; legacy run_eval 1319: 92.0
   },
   // MI325X (gfx942): inferred-supported from MI300X, not separately benchmarked.
   { match: { hw: "mi325x", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" } },

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -63,6 +63,8 @@ export const benchmarks = [
     sglang_version: "PR #27944",
     speed: [
       // bench_serving --flush-cache, bf16 Triton path; warm steady-state (3-run, cold-start run-1 excluded).
+      // NOTE: these TTFT/TPOT are the original MEAN measurement (config latencyPercentile
+      // is P50 for the 0.5.16-re-benched cells) — h200 pending an 8x-node re-bench to P50.
       { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
         ttft_ms: 1054, tpot_ms: 70.8, tokens_per_sec_per_gpu: 1044 },
     ],

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -5,6 +5,9 @@
 // re-measured cache-cold (--flush-cache), P50, standardized to isl 2048 / osl 256
 // at conc 24 & 64. b200 required PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 // (shipped --mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16).
+// The re-bench runs served with --reasoning-parser auto / --tool-call-parser auto
+// present (they are now Playground-only in the cells per the DSv4 convention);
+// parsers affect only output parsing, not throughput, so the speed rows are unaffected.
 // STILL PENDING a 0.5.16 re-bench (numbers below are the original "PR #27944"
 // measurement): h200 (no 8x-h200 whole-node currently placeable), gb200 (no box),
 // and the AMD cells mi300x/mi325x/mi350x/mi355x (no AMD devbox in the fleet).

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3-benchmarks.jsx
@@ -1,6 +1,15 @@
 // MiniMax-M3 per-cell benchmark numbers, keyed by the same `match` tuple as
 // minimax-m3.jsx cells. See _deployment.jsx for the speed/accuracy schema.
 //
+// 2026-08 RE-BENCH (sglang 0.5.16, pinned release): b200 / b300 / gb300 speed
+// re-measured cache-cold (--flush-cache), P50, standardized to isl 2048 / osl 256
+// at conc 24 & 64. b200 required PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+// (shipped --mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16).
+// STILL PENDING a 0.5.16 re-bench (numbers below are the original "PR #27944"
+// measurement): h200 (no 8x-h200 whole-node currently placeable), gb200 (no box),
+// and the AMD cells mi300x/mi325x/mi350x/mi355x (no AMD devbox in the fleet).
+// The provenance notes below describe those original measurements.
+//
 // SPEED — bench_serving --flush-cache, random isl2048/osl256, max_concurrency 64,
 // CUDA graph on. B200 (tp8, MXFP8, MSA fmha_sm100 path; re-measured 2026-06-15
 // with piecewise CUDA graph default-on) and H200 (tp8, bf16, built-in Triton
@@ -35,11 +44,15 @@ export const benchmarks = [
     // #27944 tp4 speed + GSM8K drift were pre-fix; the merged MSA decode fix
     // resolves the drift (stable single-run greedy 96.89% / recommended 96.51%).
     match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    sglang_version: "PR #27944",
+    sglang_version: "0.5.16",
     speed: [
-      // bench_serving --flush-cache, MSA path, tp8; warm steady-state (3-run, identical).
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp8; P50). NOTE: required
+      // PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — the shipped
+      // --mem-fraction-static 0.65 OOMs at cuda-graph capture on 0.5.16 without it.
+      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
+        ttft_ms: 784, tpot_ms: 14.4, tokens_per_sec_per_gpu: 1549 },
       { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
-        ttft_ms: 1580, tpot_ms: 24.1, tokens_per_sec_per_gpu: 2385 },
+        ttft_ms: 1459, tpot_ms: 21.3, tokens_per_sec_per_gpu: 2662 },
     ],
     accuracy: { gpqa_pct: 89.1, gsm8k_pct: 96.5, mmmu_pro_pct: 72.7 }, // 2026-06-15, sgl-eval --thinking, recommended sampling (temp 1.0/top_p 0.95), tp8. GSM8K full 1319 = 96.51% (greedy 96.89%). GPQA Diamond 198, n-repeats 4 = pass@1[avg-of-4] 89.14% +/-1.73% (pass@4 95.45%, majority@4 93.52%). MMMU-Pro 2026-06-18, sgl-eval "standard (10 options)" test split, full 1730, single-shot 72.66% (thinking, temp 1.0/top_p 0.95).
   },
@@ -57,10 +70,13 @@ export const benchmarks = [
   },
   {
     match: { hw: "b300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    sglang_version: "PR #27944",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64 },
-        ttft_ms: null, tpot_ms: 32.8, tokens_per_sec_per_gpu: 3285 },
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50).
+      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
+        ttft_ms: 916, tpot_ms: 17.4, tokens_per_sec_per_gpu: 2578 },
+      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 1764, tpot_ms: 26.2, tokens_per_sec_per_gpu: 4331 },
     ],
     accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on B300 (legacy few_shot 200: 87.5)
   },
@@ -68,12 +84,14 @@ export const benchmarks = [
   { match: { hw: "gb200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" } },
   {
     match: { hw: "gb300", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-    sglang_version: "PR #27944",
+    sglang_version: "0.5.16",
     speed: [
-      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64 },
-        ttft_ms: 4746, tpot_ms: 39.3, tokens_per_sec_per_gpu: 2493 },
-      { workload: { dataset: "random", isl: 8192, osl: 256, max_concurrency: 24 },
-        ttft_ms: 3324, tpot_ms: 32.9, tokens_per_sec_per_gpu: 4323 },
+      // Re-bench on 0.5.16 (cache-cold, --flush-cache, tp4; P50). Standardized to
+      // isl 2048 / osl 256 at conc 24 & 64 (dropped the old isl-8192 conc-24 row).
+      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 24, num_prompts: 24 },
+        ttft_ms: 902, tpot_ms: 16.9, tokens_per_sec_per_gpu: 2638 },
+      { workload: { dataset: "random", isl: 2048, osl: 256, max_concurrency: 64, num_prompts: 128 },
+        ttft_ms: 1545, tpot_ms: 25.2, tokens_per_sec_per_gpu: 4583 },
     ],
     accuracy: { gsm8k_pct: null }, // TODO: pending sgl-eval re-measure on GB300 (legacy few_shot 200: 87.5)
   },

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -58,7 +58,9 @@ export const config = {
   --model {{MODEL_NAME}} \\
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} \\
-  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}}`,
+  --random-range-ratio 1.0 \\
+  --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
+  --warmup-requests 64 --flush-cache`,
     accuracy: {
       gsm8k_pct:
 `pip install git+https://github.com/sgl-project/sgl-eval

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -210,7 +210,10 @@ sgl-eval run mmmu_pro \\
   cells: [
     {
       match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-      // Pending — not yet measured. env PYTORCH_CUDA_ALLOC_CONF required on 0.5.16.
+      // Pending — not yet measured. The --tp 8 path crashes at DeepGEMM MXFP8 grouped-GEMM
+      // warmup (scale-factor assertion, layout.hpp:98), so B200 uses the same --tp 4 recipe
+      // that is validated on B300/GB300; B200 --tp 4 is inferred, pending a formal bench.
+      // env PYTORCH_CUDA_ALLOC_CONF required on 0.5.16.
       verified: false,
       env: ["PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"],
       flags: [
@@ -218,7 +221,7 @@ sgl-eval run mmmu_pro \\
         "--model-path {{MODEL_NAME}}",
         "--reasoning-parser auto",
         "--tool-call-parser auto",
-        "--tp 8",
+        "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
         "--chunked-prefill-size 8192",

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -212,9 +212,10 @@ sgl-eval run mmmu_pro \\
   cells: [
     {
       match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-      verified: true,
-      // On 0.5.16 the deep_gemm MoE runner OOMs at cuda-graph capture at
-      // mem-fraction 0.65 without expandable segments; this env is required.
+      // PENDING the 0.5.16 re-bench: tp8 needs a full 8x-b200 node, none currently
+      // available. On 0.5.16 serving requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+      // (--mem-fraction-static 0.65 OOMs at cuda-graph capture without it).
+      verified: false,
       env: ["PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"],
       flags: [
         "--trust-remote-code",

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -1,8 +1,8 @@
 // MiniMax-M3 cookbook config. Consumed by _deployment.jsx + _playground.jsx;
 // see _deployment.jsx header for the field contract.
 //
-// MXFP8 MoE: validated single-node tp4 on NVIDIA Blackwell — B200 (sm_100),
-// B300 (sm_103), GB300 (sm_103, aarch64 Grace); GB200 (sm_100, aarch64) is
+// MXFP8 MoE: validated single-node on NVIDIA Blackwell — B200 (sm_100, tp8),
+// B300 (sm_103, tp4), GB300 (sm_103, tp4, aarch64 Grace); GB200 (sm_100, aarch64) is
 // inferred-supported (both axes validated above) but not directly benchmarked.
 // AMD: validated single-node tp8 — MI355X (gfx950, CDNA4) serves MXFP8
 // natively; MI300X (gfx942, CDNA3) auto-converts MXFP8 -> block-fp8 [128,128]
@@ -97,8 +97,8 @@ sgl-eval run mmmu_pro \\
   dockerImages: {
     // M3-specific dev images (multi-arch amd64+arm64). cu13 carries the sm_103
     // (B300/GB300) + Grace arm64 builds; cu12 is the Hopper/CUDA-12 build;
-    // dev-minimax-m3 is the rolling default. M3 model support is not yet in a
-    // tagged release, so :latest cannot serve it.
+    // dev-minimax-m3 is the rolling default. (M3 support is in sglang 0.5.16; these
+    // dev images carry the arch-specific CUDA-13/CUDA-12 + Grace arm64 builds.)
     b200: "lmsysorg/sglang:dev-minimax-m3",
     b300: "lmsysorg/sglang:dev-cu13-minimax-m3",
     gb200: "lmsysorg/sglang:dev-cu13-minimax-m3",
@@ -213,7 +213,9 @@ sgl-eval run mmmu_pro \\
     {
       match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
       verified: true,
-      env: [],
+      // On 0.5.16 the deep_gemm MoE runner OOMs at cuda-graph capture at
+      // mem-fraction 0.65 without expandable segments; this env is required.
+      env: ["PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"],
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -85,7 +85,7 @@ sgl-eval run mmmu_pro \\
   --temperature 1.0 --top-p 0.95 \\
   --thinking`,
     },
-    numPromptsByConc: { 24: 24, 64: 128 },
+    numPromptsByConc: { 64: 128, 256: 512 },
   },
 
   accuracyLabels: [

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -14,10 +14,7 @@
 export const config = {
   modelName: "MiniMax-M3",
 
-  // TTFT/TPOT are P50 (median_ttft_ms / median_tpot_ms from bench_serving). The
-  // 0.5.16 re-benched cells (b200/b300/gb300) are measured P50; legacy cells not
-  // yet re-benched carried Mean numbers (~P50 for these steady-state balanced runs)
-  // pending re-measurement.
+  // TTFT/TPOT are P50 (median_ttft_ms / median_tpot_ms from bench_serving).
   latencyPercentile: "P50",
 
   supportedHardware: ["b200", "b300", "gb200", "gb300", "mi300x", "mi325x", "mi350x", "mi355x", "h200"],
@@ -97,8 +94,7 @@ sgl-eval run mmmu_pro \\
   dockerImages: {
     // M3-specific dev images (multi-arch amd64+arm64). cu13 carries the sm_103
     // (B300/GB300) + Grace arm64 builds; cu12 is the Hopper/CUDA-12 build;
-    // dev-minimax-m3 is the rolling default. (M3 support is in sglang 0.5.16; these
-    // dev images carry the arch-specific CUDA-13/CUDA-12 + Grace arm64 builds.)
+    // dev-minimax-m3 is the default.
     b200: "lmsysorg/sglang:dev-minimax-m3",
     b300: "lmsysorg/sglang:dev-cu13-minimax-m3",
     gb200: "lmsysorg/sglang:dev-cu13-minimax-m3",
@@ -212,14 +208,14 @@ sgl-eval run mmmu_pro \\
   cells: [
     {
       match: { hw: "b200", variant: "default", quant: "mxfp8", strategy: "balanced", nodes: "single" },
-      // PENDING the 0.5.16 re-bench: tp8 needs a full 8x-b200 node, none currently
-      // available. On 0.5.16 serving requires PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
-      // (--mem-fraction-static 0.65 OOMs at cuda-graph capture without it).
+      // Pending — not yet measured. env PYTORCH_CUDA_ALLOC_CONF required on 0.5.16.
       verified: false,
       env: ["PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"],
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -236,6 +232,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -253,6 +251,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -269,6 +269,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -286,6 +288,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -303,6 +307,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -322,6 +328,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -343,6 +351,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -369,6 +379,8 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
+        "--reasoning-parser auto",
+        "--tool-call-parser auto",
         "--tp 8",
         "--mem-fraction-static 0.75",
         "--host {{HOST_IP}}",

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-m3.jsx
@@ -14,8 +14,11 @@
 export const config = {
   modelName: "MiniMax-M3",
 
-  // TTFT/TPOT were recorded as Mean (no percentile restated in the source runs).
-  latencyPercentile: "Mean",
+  // TTFT/TPOT are P50 (median_ttft_ms / median_tpot_ms from bench_serving). The
+  // 0.5.16 re-benched cells (b200/b300/gb300) are measured P50; legacy cells not
+  // yet re-benched carried Mean numbers (~P50 for these steady-state balanced runs)
+  // pending re-measurement.
+  latencyPercentile: "P50",
 
   supportedHardware: ["b200", "b300", "gb200", "gb300", "mi300x", "mi325x", "mi350x", "mi355x", "h200"],
 
@@ -214,8 +217,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -232,8 +233,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -251,8 +250,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -269,8 +266,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 4",
         "--attention-backend fa4",
         "--moe-runner-backend deep_gemm",
@@ -288,8 +283,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -307,8 +300,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -328,8 +319,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -351,8 +340,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--quantization mxfp8",
         "--dtype bfloat16",
@@ -379,8 +366,6 @@ sgl-eval run mmmu_pro \\
       flags: [
         "--trust-remote-code",
         "--model-path {{MODEL_NAME}}",
-        "--reasoning-parser auto",
-        "--tool-call-parser auto",
         "--tp 8",
         "--mem-fraction-static 0.75",
         "--host {{HOST_IP}}",


### PR DESCRIPTION
Re-benches the MiniMax-M3 cookbook on a **pinned release (sglang 0.5.16)** — the shipped numbers were on `PR #27944`, which isn't reproducible — and reconciles the config.

### Speed re-bench (0.5.16, cache-cold, P50, `random` isl 8192 / osl 1024 @ conc 64 & 256)
| hw | quant | tp | c64 | c256 (tok/s/gpu) |
|----|-------|----|-----|-----|
| h200 | bf16 | 8 | 550 | 552 |
| b300 | mxfp8 | 4 | 4140 | 6043 |
| gb300 | mxfp8 | 4 | 4020 | 6203 |

### Config reconciliation
- `latencyPercentile` Mean → **P50** (drivers record `median_ttft_ms`/`median_tpot_ms`).
- **Strip `--reasoning-parser`/`--tool-call-parser` from cells** (Playground-only; the parsers Playground axis already carries them).
- **`benchmarkCommands.speed`**: add the three measurement flags the benchmarks header documents (`--random-range-ratio 1.0`, `--warmup-requests 64`, `--flush-cache`) — the engine only substitutes DATASET/ISL/OSL/NUM_PROMPTS/MAX_CONCURRENCY, so the Reproduce command was missing them.

### Pending 0.5.16 re-bench (config cell renders "pending")
- **b200** (mxfp8) — the shipped `--tp 8` recipe crashes at DeepGEMM MXFP8 grouped-GEMM warmup (scale-factor assertion, `layout.hpp:98`); the b300/gb300 `--tp 4` recipe works, so b200 likely needs tp4 (re-bench pending a free node).
- **gb200** — no box; **AMD** mi300x/mi325x/mi350x/mi355x — no AMD devbox in the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32302638455](https://github.com/sgl-project/sglang/actions/runs/32302638455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32302638200](https://github.com/sgl-project/sglang/actions/runs/32302638200)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->