### PR TITLE
Allow flush_cache while generation is paused with mode="retract"

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3990,7 +3990,7 @@ class Scheduler(
         # sleep until next event
         self.maybe_sleep_on_idle()
 
-    def is_fully_idle(self, for_health_check=False) -> bool:
+    def is_fully_idle(self, for_health_check=False, ignore_waiting_queue=False) -> bool:
         # Health check piggybacks on running requests in process_output.
         # Only running_batch + waiting_queue guarantee active GPU processing;
         # disagg queues (bootstrap/prealloc/transfer) may have items without
@@ -4007,7 +4007,10 @@ class Scheduler(
         )
 
         # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
-        idle &= len(self.waiting_queue) == 0
+        # Callers that have established the queue holds no KV skip this term
+        # (see ``flush_cache``); every other check still applies.
+        if not ignore_waiting_queue:
+            idle &= len(self.waiting_queue) == 0
 
         if (
             for_health_check
@@ -4160,7 +4163,12 @@ class Scheduler(
 
     def flush_cache(self, empty_cache: bool = True):
         """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
-        if self.is_fully_idle():
+        # A retract-pause's parked requests hold no KV and cannot re-acquire a
+        # prefix while paused, so flushing is safe; in_place keeps KV, excluded below.
+        flushable = self.is_fully_idle() or (
+            self._engine_paused and self.is_fully_idle(ignore_waiting_queue=True)
+        )
+        if flushable:
             self.cur_batch_for_debug = None
             self.last_batch = None
             self.tree_cache.reset()


### PR DESCRIPTION
Fixes #33783.

## Why this is needed

`pause_generation(mode="retract")` only partly gives back a request's KV:
`cache_finished_req(..., is_insert=False)` frees `kv_indices[cache_protected_len:]`,
while the tree-owned prefix `[0, cache_protected_len)` is merely `dec_lock_ref`'d.
So retract alone invalidates nothing, and after a weight update clearing that
prefix requires a `flush_cache`.

That path is closed: `flush_cache` needs `is_fully_idle()`, which requires an
empty `waiting_queue` — exactly what retract fills. The default
`flush_cache=True` on a weight update then trips `assert flush_cache_success`
and kills the scheduler; a standalone `GET /flush_cache` burns the caller's retry
budget and leaves the stale prefix in place.

It also contradicts the documented contract — `PauseGenerationReqInput` says of
`retract` that "The KV cache can be flushed in this mode and will be
automatically recomputed after continue_generation", in deliberate contrast to
`in_place`.

## The change

Relax exactly one term, and only while paused:

```python
def is_fully_idle(self, for_health_check=False, ignore_waiting_queue=False):
    ...
    if not ignore_waiting_queue:
        idle &= len(self.waiting_queue) == 0

def flush_cache(self, empty_cache: bool = True):
    flushable = self.is_fully_idle() or (
        self._engine_paused and self.is_fully_idle(ignore_waiting_queue=True)
    )
```

Safe because parked requests hold no KV and no cache references — `retract_all`
released the KV, `reset_for_retract` cleared `prefix_indices` / `last_node` /
`cache_protected_len`, `cache_finished_req` set `req_pool_idx = None` — and the
event loop short-circuits on `_engine_paused` before it can form a new batch, so
nothing can re-acquire a prefix before resume. `in_place` is excluded
automatically (it keeps KV and leaves `running_batch` populated).

The alternative would be to make retract release all KV including the radix-cache
entries, so it needs no flush at all. That is a larger behaviour change and
discards prefixes other live requests may still share, so this PR takes the
smaller route — happy to switch if maintainers prefer it.

## Verification

Single server, Qwen3-4B → Qwen3-4B-Instruct-2507:

| | matched prefix on the post-update request |
|---|---|
| no flush | 2306 tokens (reused its own pre-update prefix) |
| flush | 0 tokens (recomputed) |

Cache hit vs cache hit, so the only variable is which weights produced the KV:

| cached KV computed by | sum logprob (24 tokens) |
|---|---|
| old weights | -4.225184 |
| new weights | -2.906205 |

Δ = 1.319 against a 0.0 noise floor (same request under identical provenance is
bit-identical). Generated text diverges too.

End to end in a verl RL training loop (run completed, 10/10 syncs):

| | before | after |
|---|---|---|
| per-sync weight update | 26s | 2.07–2.15s |
| `Failed to flush cache` | 11 | 0 |

## Note for callers

The broken flush was burning ~24s per weight sync, which also throttled the
pipeline. Once fixed, rollout and trainer overlap far more aggressively
(concurrent sequences at the pause rose from 4 to 8), so memory budgets tuned
under the stalled behaviour may need re-tuning — in a colocated engine+trainer
deployment we lowered the engine memory fraction from 0.80 to 0.45.

Opened as a draft — happy to add a regression test, or to key the relaxation off
an explicit request flag instead of `_engine_paused`, if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
