### PR TITLE
[AMD] triton_load_watch: guard missing kernel_load_start_hook (fix fleet-wide AMD scheduler startup crash on Triton 3.4)

### DIFF
--- a/python/sglang/srt/utils/triton_load_watch.py
+++ b/python/sglang/srt/utils/triton_load_watch.py
@@ -46,9 +46,19 @@ def install() -> None:
         import triton.knobs as knobs
     except ImportError:
         return
-    _prev_compile_listener = knobs.compilation.listener
-    knobs.runtime.kernel_load_start_hook.add(_on_kernel_load)
-    knobs.compilation.listener = _on_compilation
+    # Some Triton builds shipped in the ROCm CI images (e.g. Triton 3.4.0)
+    # expose ``triton.knobs`` but not ``knobs.runtime.kernel_load_start_hook``
+    # / ``knobs.compilation.listener``. Guarding only ``ImportError`` above is
+    # insufficient: touching the missing attribute raises ``AttributeError``
+    # and crashes every scheduler at startup. Skip diagnostics on such builds.
+    runtime = getattr(knobs, "runtime", None)
+    compilation = getattr(knobs, "compilation", None)
+    hook = getattr(runtime, "kernel_load_start_hook", None)
+    if hook is None or compilation is None or not hasattr(compilation, "listener"):
+        return
+    _prev_compile_listener = compilation.listener
+    hook.add(_on_kernel_load)
+    compilation.listener = _on_compilation
     _installed = True
 
 


### PR DESCRIPTION
## Motivation

#33120 added serving-time Triton diagnostics via `triton_load_watch.install()`. On the AMD ROCm CI image (Triton **3.4.0**), this crashes **every** scheduler at startup:

```
AttributeError: 'runtime_knobs' object has no attribute 'kernel_load_start_hook'
```

`install()` only guards the `import triton.knobs` in a `try/except ImportError`. On Triton 3.4.0 the import succeeds, but `knobs.runtime.kernel_load_start_hook` (and `knobs.compilation.listener`) do not exist — so `knobs.runtime.kernel_load_start_hook.add(...)` raises an **uncaught `AttributeError`**, taking down the scheduler process before it can serve.

The AMD nightly CI monitor observed this fleet-wide: **13 of 51 `pr-test-amd` jobs** in run [31059578786](https://github.com/sgl-project/sglang/actions/runs/31059578786) crashed identically at `setUpClass` / server launch — every AMD test that launches a server. (Reference triage: bingxche/sglang-ci-bot#158, cluster R321.)

## Fix

Guard the *attribute access*, not just the import. On a Triton build that lacks the hook API, skip the diagnostics instead of crashing:

```python
    runtime = getattr(knobs, "runtime", None)
    compilation = getattr(knobs, "compilation", None)
    hook = getattr(runtime, "kernel_load_start_hook", None)
    if hook is None or compilation is None or not hasattr(compilation, "listener"):
        return
    _prev_compile_listener = compilation.listener
    hook.add(_on_kernel_load)
    compilation.listener = _on_compilation
    _installed = True
```

Behavior is unchanged on Triton builds that have the hook (>= 3.5, e.g. 3.6.0 used on NVIDIA / newer ROCm images): diagnostics install exactly as before. Only the crashing path (Triton without the hook) becomes a clean no-op.

## Validation

The exact ROCm-7.2 Triton-3.4.0 CI image was not available on my test host (all local AMD images ship Triton 3.6.0, which has the hook and does **not** crash — so a live repro requires that specific image). I validated the fix logic by simulating both `knobs` shapes:

| `knobs` shape | current `install()` | this PR |
|---|---|---|
| Triton 3.4 (no `kernel_load_start_hook`) | **AttributeError (crash)** | skipped cleanly |
| Triton 3.6 (hook present) | installed | installed |

## Checklist
- [x] Backward compatible: no behavior change where the hook exists.
- [ ] CI: please run an AMD server-launching test on the Triton-3.4 image to confirm the crash is gone.

cc @sgl-project/sgl-code-owners — Triton-3.4 API-compat guard; requesting an AMD CI run on the affected image.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31077593352](https://github.com/sgl-project/sglang/actions/runs/31077593352)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31077592999](https://github.com/sgl-project/sglang/actions/runs/31077592999)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->