### PR TITLE
[docs] Document the gateway /engine_metrics aggregation endpoint

### DIFF
--- a/docs/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs/docs/advanced_features/sgl_model_gateway.mdx
@@ -799,7 +799,7 @@ Response:
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`GET`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`/engine_metrics`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Engine-level metrics from workers</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Aggregated engine metrics from all workers, labeled by `worker_addr` (workers need `--enable-metrics`)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`GET`</td>
@@ -2098,6 +2098,26 @@ Enable with `--prometheus-host`/`--prometheus-port` (defaults to `0.0.0.0:29000`
 #### Duration Buckets
 
 1ms, 5ms, 10ms, 25ms, 50ms, 100ms, 250ms, 500ms, 1s, 2.5s, 5s, 10s, 15s, 30s, 45s, 60s, 90s, 120s, 180s, 240s
+
+#### Aggregated Worker Engine Metrics (`/engine_metrics`)
+
+The `smg_*` metrics above describe the gateway itself (routing, workers' health, circuit breakers). Engine-level metrics (`sglang:*` — cache hit rate, generation throughput, queue depth, TTFT histograms) are produced by each SGLang worker and exposed on the worker's own `/metrics` endpoint.
+
+Instead of scraping every worker individually, you can query `GET /engine_metrics` on the gateway's main port. The gateway fans out to the `/metrics` endpoint of every registered worker, merges the responses, and labels each series with `worker_addr` so per-worker values remain distinguishable:
+
+```bash
+curl http://localhost:30080/engine_metrics
+```
+
+```text
+sglang:gen_throughput{model_name="...",worker_addr="http://127.0.0.1:30001"} 512.3
+sglang:gen_throughput{model_name="...",worker_addr="http://127.0.0.1:30002"} 498.7
+```
+
+Requirements and failure modes:
+
+- Workers must be launched with `--enable-metrics`; otherwise their `/metrics` endpoint does not exist and the fan-out fails.
+- If no workers are registered, or every worker request fails (for example, none has metrics enabled), the endpoint returns an error (`"All backend requests failed"`) rather than an empty result.
 
 ### OpenTelemetry Tracing
 

--- a/docs/docs/references/production_metrics.mdx
+++ b/docs/docs/references/production_metrics.mdx
@@ -7,6 +7,8 @@ SGLang exposes the following metrics via Prometheus. You can enable it by adding
 
 An example of the monitoring dashboard is available in [examples/monitoring/grafana.json](https://github.com/sgl-project/sglang/blob/main/examples/monitoring/grafana/dashboards/json/sglang-dashboard.json).
 
+When running multiple workers behind the [SGLang Model Gateway](/docs/advanced_features/sgl_model_gateway), the gateway's `GET /engine_metrics` endpoint returns these engine metrics for all registered workers in a single call, with each series labeled by `worker_addr`.
+
 Here is an example of the metrics:
 
 ```text Output


### PR DESCRIPTION
## Motivation

The model gateway's `GET /engine_metrics` endpoint fans out to every registered
worker's `/metrics` endpoint and merges the results with a `worker_addr` label, but
the docs only list the endpoint name with no explanation of the aggregation
semantics, the `--enable-metrics` prerequisite on workers, or the failure mode when
no worker exposes metrics. As a new gateway user I had to read
`src/core/worker_manager.rs` to understand the behavior.

## Modifications

- Add an "Aggregated Worker Engine Metrics (`/engine_metrics`)" subsection under
  Prometheus Metrics in `docs_new/docs/advanced_features/sgl_model_gateway.mdx`,
  with a usage example, the `--enable-metrics` prerequisite, and failure modes.
- Expand the endpoint table description for `/engine_metrics`.
- Cross-reference the endpoint from `docs_new/docs/references/production_metrics.mdx`.

## Checklist

- [x] Format your code according to the pre-commit guide.
- [ ] Add unit tests (N/A — docs only).
- [x] Update documentation.
- [ ] Accuracy / speed benchmarks (N/A).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31067458450](https://github.com/sgl-project/sglang/actions/runs/31067458450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31067458291](https://github.com/sgl-project/sglang/actions/runs/31067458291)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->