### PR TITLE
[NIXL] Doca memos backend support

### DIFF
--- a/docs_new/docs/references/environment_variables.mdx
+++ b/docs_new/docs/references/environment_variables.mdx
@@ -1139,8 +1139,13 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_HUGEPAGE_SIZE</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use huge pages for host KV cache allocations (HiCache / disaggregation offload). Valid values: <code>2MB</code> (2 MiB pages via <code>MAP_HUGE_2MB</code>) or <code>1GB</code> (1 GiB pages via <code>MAP_HUGE_1GB</code>). Requires huge pages to be pre-allocated on the host OS (<code>/proc/sys/vm/nr_hugepages</code> or <code>/sys/kernel/mm/hugepages</code>). If the allocation fails, the allocator logs a warning and falls back to regular page-size mmap automatically.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Huge page size for host KV cache allocations (HiCache / disaggregation offload). Valid values: <code>2MB</code> (2 MiB pages via <code>MAP_HUGE_2MB</code>) or <code>1GB</code> (1 GiB pages via <code>MAP_HUGE_1GB</code>). Requires huge pages to be pre-allocated on the host OS (<code>/proc/sys/vm/nr_hugepages</code> or <code>/sys/kernel/mm/hugepages</code>). Fallback behavior is controlled by <code>SGLANG_HUGEPAGE_MODE</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set (uses OS default page size)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_HUGEPAGE_MODE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Huge page allocation policy. <code>off</code> uses normal pages, <code>prefer</code> tries huge pages and falls back to normal pages, and <code>required</code> uses only huge pages and fails immediately if they are unavailable. NIXL DOCA_MEMOS requires <code>required</code> with <code>SGLANG_HUGEPAGE_SIZE=2MB</code>. When unset, the mode is <code>off</code> if no huge page size is configured and <code>prefer</code> otherwise.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Not set (backward-compatible inference)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_HICACHE_HF3FS_CONFIG_PATH</code></td>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -495,6 +495,10 @@ class Envs:
     # "use_direct_io": false key in --hicache-storage-backend-extra-config.
     SGLANG_HICACHE_NIXL_USE_DIRECT_IO = EnvBool(True)
     SGLANG_HUGEPAGE_SIZE = EnvStr("")
+    # off: normal pages; prefer: hugepages with normal-page fallback;
+    # required: hugepages only, failing immediately when unavailable.
+    # Empty preserves compatibility: off when SIZE is empty, otherwise prefer.
+    SGLANG_HUGEPAGE_MODE = EnvStr("")
     # Staging buffer for heterogeneous TP KV transfer
     SGLANG_DISAGG_STAGING_BUFFER = EnvBool(False)
     SGLANG_DISAGG_STAGING_POOL_SIZE_MB = EnvInt(4096)

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
 
 import numpy as np
-import psutil
 import torch
 
 from sglang.kernels.ops.kvcache.hicache import (
@@ -21,6 +20,7 @@ from sglang.kernels.ops.kvcache.hicache import (
 )
 from sglang.kernels.ops.kvcache.hisparse import transfer_cache_dsv4_mla
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool, MambaPool
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import memory_available_bytes
 from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
@@ -52,7 +52,6 @@ logger = logging.getLogger(__name__)
 from sglang.srt.mem_cache.pool_host import HostKVCache
 from sglang.srt.mem_cache.pool_host.base import (
     _WRITE_BACK_STAGING_PAGE_CHUNK,
-    HICACHE_HOST_MEMORY_RESERVE_BYTES,
     sync_fixed_hicache_size,
     synchronized,
 )
@@ -121,9 +120,8 @@ class MambaPoolHost(HostKVCache):
                 device_pool.size,
             )
 
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory available. Requesting "
@@ -758,8 +756,7 @@ class DeepSeekV4PagedHostPool(HiSparseHostPoolMixin, HostKVCache):
         self.gpu_device = device_buffers[0].device if device_buffers else device
 
         requested_bytes = self.layer_num * num_host_pages * self.item_bytes
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for V4 paged pool {pool_name}. "
@@ -1155,8 +1152,7 @@ class DeepSeekV4StateHostPool(HostKVCache):
         self.size_per_token = self.state_page_bytes
 
         requested_bytes = self.layer_num * num_host_pages * self.state_page_bytes
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for V4 state pool {pool_name}. "
@@ -1706,8 +1702,7 @@ class DSAIndexerPoolHost(HostKVCache):
 
         buf_elem_size = self.page_num * self.layer_num * self.indexer_page_stride_size
         requested_bytes = buf_elem_size * self.indexer_dtype.itemsize
-        host_mem = psutil.virtual_memory()
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for DSA indexer hierarchical cache. "

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -6,7 +6,6 @@ import threading
 from functools import wraps
 from typing import Optional
 
-import psutil
 import torch
 
 from sglang.srt.mem_cache.memory_pool import KVCache
@@ -14,15 +13,15 @@ from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
     get_allocator_from_storage,
 )
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+    memory_available_bytes,
+)
 from sglang.srt.utils import is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
-
-# Host RAM to leave free when sizing HiCache pools (OS, other processes).
-HICACHE_HOST_MEMORY_RESERVE_BYTES: int = 10 * (1024**3)
 
 _WRITE_BACK_STAGING_PAGE_CHUNK = 64
 
@@ -123,9 +122,8 @@ class HostKVCache(abc.ABC):
             )
 
         # Verify there is enough available host memory.
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory available. Requesting "

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -167,6 +167,12 @@ class MHATokenToKVPoolHost(HostKVCache):
         )
         return buffer
 
+    def get_hybrid_pool_buffer(self):
+        """Return every host tensor that v2 storage backends must register."""
+        if isinstance(self.kv_buffer, (list, tuple)):
+            return list(self.kv_buffer)
+        return [self.kv_buffer]
+
     def _init_write_back_staging_buffers(self):
         self.staging_page_capacity = 0
         self.staging_token_capacity = 0

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import logging
 import threading
 
-import psutil
 import torch
 
 from sglang.kernels.ops.kvcache.hicache import (
@@ -31,13 +30,13 @@ from sglang.kernels.ops.kvcache.hicache import (
 from sglang.srt.mem_cache.memory_pool import MHATokenToKOnlyPool, MHATokenToKVPool
 from sglang.srt.mem_cache.pool_host.base import (
     _WRITE_BACK_STAGING_PAGE_CHUNK,
-    HICACHE_HOST_MEMORY_RESERVE_BYTES,
     HostKVCache,
 )
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
 )
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import memory_available_bytes
 from sglang.srt.utils import is_cuda, is_hip, is_mps, is_npu, is_xpu
 
 _is_cuda = is_cuda()
@@ -657,9 +656,8 @@ class MHATokenToKOnlyPoolHost(HostKVCache):
         self.page_num = anchor_host.page_num
         self.size_per_token = self.get_size_per_token()
 
-        host_mem = psutil.virtual_memory()
         requested_bytes = self.size * self.size_per_token
-        available_bytes = host_mem.available - HICACHE_HOST_MEMORY_RESERVE_BYTES
+        available_bytes = memory_available_bytes()
         if requested_bytes > available_bytes:
             raise ValueError(
                 f"Not enough host memory for MiniMax index-K hierarchical cache. "

--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -7,6 +7,7 @@ import os
 import uuid
 import weakref
 
+import psutil
 import torch
 
 from sglang.srt.environ import envs
@@ -42,6 +43,132 @@ _MAP_HUGE_1GB = 30 << 26  # 0x78000000
 _MAP_FAILED = ctypes.c_void_p(-1).value
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
 
+MEM_BACKEND_UNKNOWN = 0
+MEM_BACKEND_MMAP = 1
+MEM_BACKEND_HUGEPAGE = 2
+
+HUGEPAGE_BYTES_2MB = 2 * 1024 * 1024
+HUGEPAGE_BYTES_1GB = 1024 * 1024 * 1024
+
+_HUGEPAGE_SIZE_BYTES = {
+    "2MB": HUGEPAGE_BYTES_2MB,
+    "1GB": HUGEPAGE_BYTES_1GB,
+}
+_HUGEPAGE_MMAP_FLAGS = {
+    HUGEPAGE_BYTES_2MB: _MAP_HUGETLB | _MAP_HUGE_2MB,
+    HUGEPAGE_BYTES_1GB: _MAP_HUGETLB | _MAP_HUGE_1GB,
+}
+_HUGEPAGE_SYSFS_PATHS = {
+    HUGEPAGE_BYTES_2MB: "/sys/kernel/mm/hugepages/hugepages-2048kB",
+    HUGEPAGE_BYTES_1GB: "/sys/kernel/mm/hugepages/hugepages-1048576kB",
+}
+
+HUGEPAGE_MODE_OFF = "off"
+HUGEPAGE_MODE_PREFER = "prefer"
+HUGEPAGE_MODE_REQUIRED = "required"
+_HUGEPAGE_MODES = {
+    HUGEPAGE_MODE_OFF,
+    HUGEPAGE_MODE_PREFER,
+    HUGEPAGE_MODE_REQUIRED,
+}
+
+# Host RAM to leave free when sizing HiCache pools (OS, other processes).
+# This reserve applies only to normal RAM. Pre-reserved hugetlb pages are
+# dedicated to hugepage allocations and must not be reduced by it.
+HICACHE_HOST_MEMORY_RESERVE_BYTES = 10 * (1024**3)
+
+_tensor_mem_backend: dict[int, int] = {}
+
+
+def hugepage_size_requested() -> int:
+    configured_size = (envs.SGLANG_HUGEPAGE_SIZE.get() or "").strip().upper()
+    if not configured_size:
+        return 0
+    hugepage_size = _HUGEPAGE_SIZE_BYTES.get(configured_size)
+    if hugepage_size is None:
+        logger.warning(
+            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'.",
+            envs.SGLANG_HUGEPAGE_SIZE.get(),
+        )
+        return 0
+    return hugepage_size
+
+
+def hugepage_mode(hugepage_size: int) -> str:
+    default_mode = HUGEPAGE_MODE_PREFER if hugepage_size > 0 else HUGEPAGE_MODE_OFF
+    configured_mode = (envs.SGLANG_HUGEPAGE_MODE.get() or "").strip().lower()
+    if not configured_mode:
+        return default_mode
+    if configured_mode not in _HUGEPAGE_MODES:
+        logger.warning(
+            "Unrecognized SGLANG_HUGEPAGE_MODE=%r; expected off, prefer, or "
+            "required. Using default mode %s.",
+            configured_mode,
+            default_mode,
+        )
+        return default_mode
+    return configured_mode
+
+
+def hugepage_available_bytes(hugepage_size: int) -> int:
+    sysfs_path = _HUGEPAGE_SYSFS_PATHS.get(hugepage_size)
+    if sysfs_path is None:
+        return 0
+    try:
+        with open(os.path.join(sysfs_path, "free_hugepages")) as f:
+            return int(f.read().strip()) * hugepage_size
+    except (OSError, ValueError) as e:
+        logger.warning("Failed to read free_hugepages from %s: %s", sysfs_path, e)
+        return 0
+
+
+def memory_available_bytes() -> int:
+    """Bytes available for HiCache host pool preflight.
+
+    ``off`` uses normal RAM after keeping a system reserve. ``prefer`` returns
+    the larger of usable normal RAM and free hugetlb because either allocation
+    path may satisfy the request. ``required`` returns only free hugetlb and
+    never counts normal RAM.
+    """
+    hugepage_size = hugepage_size_requested()
+    mode = hugepage_mode(hugepage_size)
+    if mode == HUGEPAGE_MODE_REQUIRED:
+        return hugepage_available_bytes(hugepage_size)
+
+    normal_available_bytes = max(
+        psutil.virtual_memory().available - HICACHE_HOST_MEMORY_RESERVE_BYTES,
+        0,
+    )
+    if mode == HUGEPAGE_MODE_OFF:
+        return normal_available_bytes
+    if mode == HUGEPAGE_MODE_PREFER:
+        return max(
+            normal_available_bytes,
+            hugepage_available_bytes(hugepage_size),
+        )
+    raise AssertionError(f"Unexpected hugepage mode: {mode}")
+
+
+def _tensor_storage_key(tensor: torch.Tensor) -> int:
+    return tensor.untyped_storage().data_ptr()
+
+
+def _track_tensor_backend(tensor: torch.Tensor, backend: int) -> torch.Tensor:
+    key = _tensor_storage_key(tensor)
+    _tensor_mem_backend[key] = backend
+    weakref.finalize(tensor, _tensor_mem_backend.pop, key, None)
+    return tensor
+
+
+def tensor_mem_backend(tensor: torch.Tensor) -> int:
+    return _tensor_mem_backend.get(_tensor_storage_key(tensor), MEM_BACKEND_UNKNOWN)
+
+
+def _mmap_page_size_and_flags(mode: str, hugepage_size: int) -> tuple[int, int]:
+    if mode == HUGEPAGE_MODE_OFF or hugepage_size == 0:
+        return mmap.PAGESIZE, 0
+    return hugepage_size, _HUGEPAGE_MMAP_FLAGS[hugepage_size]
+
 
 def _alloc_hugepage(n_bytes: int, alloc_bytes: int, extra_flags: int) -> ctypes.Array:
     """Call mmap via libc with hugepage flags and return an owning ctypes array.
@@ -66,55 +193,56 @@ def _alloc_hugepage(n_bytes: int, alloc_bytes: int, extra_flags: int) -> ctypes.
 
 
 def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
-    """Allocate a host tensor via anonymous mmap. Set SGLANG_HUGEPAGE_SIZE=2MB or 1GB for hugepages.
+    """Allocate a host tensor via anonymous mmap.
 
     MAP_SHARED + MAP_POPULATE are both required so cudaHostRegister pins real,
     pre-faulted physical pages (otherwise pinning can race with COW or page
     faults and the device ends up reading stale data).
 
+    ``SGLANG_HUGEPAGE_MODE=prefer`` falls back to normal pages when hugetlb
+    allocation fails. ``required`` raises instead of falling back.
+
     The tensor owns the mapping; munmap fires when the tensor is freed.
     """
     # Re-read per call (not cached) so that envs.SGLANG_HUGEPAGE_SIZE.override()
     # works correctly in tests.
-    hugepage_size = (envs.SGLANG_HUGEPAGE_SIZE.get() or "").strip().upper()
-    n_bytes = math.prod(dims) * torch.empty([], dtype=dtype).element_size()
-
-    if hugepage_size == "":
-        page_size, extra_flags = mmap.PAGESIZE, 0
-    elif hugepage_size == "2MB":
-        page_size, extra_flags = 2 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_2MB
-    elif hugepage_size == "1GB":
-        page_size, extra_flags = 1024 * 1024 * 1024, _MAP_HUGETLB | _MAP_HUGE_1GB
-    else:
-        logger.warning(
-            "Unrecognized SGLANG_HUGEPAGE_SIZE=%r; expected '2MB' or '1GB'. "
-            "Falling back to plain page-size mmap.",
-            envs.SGLANG_HUGEPAGE_SIZE.get(),
+    hugepage_size = hugepage_size_requested()
+    mode = hugepage_mode(hugepage_size)
+    page_size, extra_flags = _mmap_page_size_and_flags(mode, hugepage_size)
+    if mode == HUGEPAGE_MODE_REQUIRED and not extra_flags:
+        raise ValueError(
+            "SGLANG_HUGEPAGE_MODE=required requires " "SGLANG_HUGEPAGE_SIZE=2MB or 1GB."
         )
-        page_size, extra_flags = mmap.PAGESIZE, 0
+    n_bytes = math.prod(dims) * torch.empty([], dtype=dtype).element_size()
 
     alloc_bytes = math.ceil(n_bytes / page_size) * page_size
 
     if extra_flags:
         if _libc is None:
-            logger.error(
+            error_message = (
                 "Hugepage mmap requested but libc.so.6 could not be loaded; "
-                "falling back to plain mmap. SGLANG_HUGEPAGE_SIZE=%s will be ignored.",
-                hugepage_size,
+                f"SGLANG_HUGEPAGE_SIZE={envs.SGLANG_HUGEPAGE_SIZE.get()}."
             )
+            if mode == HUGEPAGE_MODE_REQUIRED:
+                raise RuntimeError(error_message)
+            logger.error("%s Falling back to plain mmap.", error_message)
         else:
             try:
                 array = _alloc_hugepage(n_bytes, alloc_bytes, extra_flags)
-                return torch.frombuffer(
-                    array, dtype=dtype, count=math.prod(dims)
-                ).reshape(dims)
-            except OSError as e:
-                logger.error(
-                    "Hugepage mmap via libc failed (%s); falling back to plain mmap. "
-                    "SGLANG_HUGEPAGE_SIZE=%s will be ignored.",
-                    e,
-                    hugepage_size,
+                return _track_tensor_backend(
+                    torch.frombuffer(array, dtype=dtype, count=math.prod(dims)).reshape(
+                        dims
+                    ),
+                    MEM_BACKEND_HUGEPAGE,
                 )
+            except OSError as e:
+                error_message = (
+                    f"Hugepage mmap via libc failed ({e}); "
+                    f"SGLANG_HUGEPAGE_SIZE={envs.SGLANG_HUGEPAGE_SIZE.get()}."
+                )
+                if mode == HUGEPAGE_MODE_REQUIRED:
+                    raise RuntimeError(error_message) from e
+                logger.error("%s Falling back to plain mmap.", error_message)
         alloc_bytes = math.ceil(n_bytes / mmap.PAGESIZE) * mmap.PAGESIZE
 
     # Plain mmap path -- used directly when no hugepages requested, or as fallback.
@@ -133,7 +261,10 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
     except OSError:
         # Fall back to MAP_POPULATE if MADV_POPULATE_WRITE is not supported (<5.14 kernel).
         pass
-    return torch.frombuffer(mm, dtype=dtype, count=math.prod(dims)).reshape(dims)
+    return _track_tensor_backend(
+        torch.frombuffer(mm, dtype=dtype, count=math.prod(dims)).reshape(dims),
+        MEM_BACKEND_MMAP,
+    )
 
 
 def alloc_shm(dims: tuple, dtype: torch.dtype) -> tuple[torch.Tensor, int, mmap.mmap]:

--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import os
 import time
@@ -20,6 +21,10 @@ from sglang.srt.mem_cache.hicache_storage import (
 )
 from sglang.srt.mem_cache.pool_host import HostKVCache
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+    MEM_BACKEND_HUGEPAGE,
+    tensor_mem_backend,
+)
 from sglang.srt.mem_cache.storage.nixl.nixl_cleaner import HiCacheL3Cleaner
 
 from .nixl_registry import NixlRegistry
@@ -182,6 +187,13 @@ class HiCacheNixl(HiCacheStorage):
         if self._l3_cleaner is not None:
             self._l3_cleaner.start()
 
+    def _format_key(self, key: str) -> str:
+        if self.backend_selector.backend_name == "DOCA_MEMOS":
+            return hashlib.sha256(key.encode("utf-8")).hexdigest()[:32]
+        if self.backend_selector.mem_type == "FILE":
+            return self.file_manager.get_file_path(key)
+        return key
+
     def _get_suffixed_key(self, key: str) -> str:
         return key + self.config_suffix
 
@@ -220,9 +232,7 @@ class HiCacheNixl(HiCacheStorage):
 
     def _create_query_tuple(self, key: str) -> tuple:
         """Build the NIXL query_memory tuple for a single key."""
-        if self.backend_selector.mem_type == "FILE":
-            return (0, 0, 0, self.file_manager.get_file_path(key))
-        return (0, 0, 0, key)
+        return (0, 0, 0, self._format_key(key))
 
     def _query_keys_exist(self, keys: List[str]) -> List[bool]:
         if not keys:
@@ -333,11 +343,10 @@ class HiCacheNixl(HiCacheStorage):
         raise NotImplementedError("deprecated; use batch_set_v1")
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
-        super().register_mem_pool_host(mem_pool_host)
         self._logical_anchor = False
 
         # enable zero-copy automatically if mem layout is page_first or page_first_direct
-        self.is_zero_copy = self.mem_pool_host.layout in [
+        self.is_zero_copy = mem_pool_host.layout in [
             "page_first",
             "page_first_direct",
         ]
@@ -348,6 +357,7 @@ class HiCacheNixl(HiCacheStorage):
             # actual KV bytes; component pools carry the data through v2 APIs.
             # Still write a small marker object per page so batch_exists_v2 can
             # use the anchor key to gate sidecar lookups.
+            super().register_mem_pool_host(mem_pool_host)
             self.is_zero_copy = False
             self._logical_anchor = True
             marker_numel = 4096 if self.needs_page_alignment else 1
@@ -366,6 +376,13 @@ class HiCacheNixl(HiCacheStorage):
             )
             return
 
+        self._validate_host_pool_doca_memos(
+            mem_pool_host,
+            is_zero_copy=self.is_zero_copy,
+            buffers=[kv],
+        )
+        super().register_mem_pool_host(mem_pool_host)
+
         if self.needs_page_alignment and self.is_zero_copy:
             # Check that the kv_buffer base AND per-page strides are multiples of
             # the OS page size so every pointer passed to NIXL (base + p * stride)
@@ -374,7 +391,7 @@ class HiCacheNixl(HiCacheStorage):
             # if either condition fails.
             # 4096: O_DIRECT alignment is FS-dependent (some allow 512 B); 4 KiB
             # is the safe lower bound all known FSes accept, and real page-sizes meet it.
-            if not self.mem_pool_host.is_stride_page_aligned(4096):
+            if not mem_pool_host.is_stride_page_aligned(4096):
                 logger.warning(
                     "HiCacheNixl: O_DIRECT is active but the host kv_buffer is "
                     "not OS-page-aligned (base or per-page stride). Falling back "
@@ -410,11 +427,23 @@ class HiCacheNixl(HiCacheStorage):
     def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
         if host_pool_name == PoolName.KV:
             return
-        super().register_mem_host_pool_v2(host_pool, host_pool_name)
 
         is_zero_copy = self._hybrid_pool_supports_zero_copy(host_pool, host_pool_name)
+        buffers = (
+            [buf for buf in host_pool.get_hybrid_pool_buffer() if buf.numel() > 0]
+            if is_zero_copy
+            else []
+        )
+        self._validate_host_pool_doca_memos(
+            host_pool,
+            is_zero_copy=is_zero_copy,
+            buffers=buffers,
+        )
+
+        super().register_mem_host_pool_v2(host_pool, host_pool_name)
+
         if is_zero_copy:
-            for i, buf in enumerate(host_pool.get_hybrid_pool_buffer()):
+            for i, buf in enumerate(buffers):
                 self._pre_register_host(
                     buf.data_ptr(),
                     buf.numel() * buf.element_size(),
@@ -449,6 +478,36 @@ class HiCacheNixl(HiCacheStorage):
             host_pool_name,
             is_zero_copy,
         )
+
+    def _validate_host_pool_doca_memos(
+        self,
+        host_pool: HostKVCache,
+        is_zero_copy: bool,
+        buffers: List[torch.Tensor],
+    ) -> None:
+        if self.backend_selector.backend_name != "DOCA_MEMOS":
+            return
+        if getattr(host_pool, "layout", None) not in (
+            "page_first",
+            "page_first_direct",
+        ):
+            raise RuntimeError(
+                "HiCache NIXL DOCA_MEMOS requires host pools to use "
+                "page_first or page_first_direct layout."
+            )
+        if not is_zero_copy:
+            raise RuntimeError(
+                "HiCache NIXL DOCA_MEMOS requires host pools to support "
+                "zero-copy page buffers."
+            )
+        if not buffers or any(
+            tensor_mem_backend(buf) != MEM_BACKEND_HUGEPAGE for buf in buffers
+        ):
+            raise RuntimeError(
+                "HiCache NIXL DOCA_MEMOS requires every host-pool buffer to be "
+                "hugetlb-backed. Set SGLANG_HUGEPAGE_MODE=required, "
+                "SGLANG_HUGEPAGE_SIZE=2MB, and reserve enough 2 MiB huge pages."
+            )
 
     def _hybrid_pool_supports_zero_copy(
         self, host_pool: HostKVCache, host_pool_name: PoolName
@@ -760,11 +819,8 @@ class HiCacheNixl(HiCacheStorage):
             logger.error("Mismatch between number of key_strs and host_buffers")
             return [False] * len(keys)
 
-        if self.backend_selector.mem_type == "FILE":
-            file_paths = [self.file_manager.get_file_path(key) for key in key_strs]
-            success = self._xfer_pre_registered(host_buffers, file_paths, direction)
-        else:  # mem_type == "OBJ"
-            success = self._xfer_pre_registered(host_buffers, key_strs, direction)
+        storage_keys = [self._format_key(k) for k in key_strs]
+        success = self._xfer_pre_registered(host_buffers, storage_keys, direction)
 
         # READ results are consumed by _batch_get_postprocess, which pairs
         # entries 2*i / 2*i+1 for non-MLA zero-copy: it needs one bool per

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl.config.toml.sample
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl.config.toml.sample
@@ -5,6 +5,14 @@
 #    are mutually exclusive
 ################################################################################
 
+# Whether to enable the progress thread. Default: True
+# nixl_enable_prog_thread = true
+# Thread synchronization mode. Default: None
+# nixl_sync_mode = "strict"
+# HiCache host KV hugepages: set env SGLANG_HUGEPAGE_SIZE=2MB.
+# DOCA_MEMOS also requires SGLANG_HUGEPAGE_MODE=required.
+# Required for NIXL DOCA_MEMOS; reserve vm.nr_hugepages on the host.
+# DOCA_MEMOS L3 I/O requires --hicache-mem-layout page_first or page_first_direct.
 
 ########################################
 # GLOBAL NIXL HICACHE SETTINGS
@@ -131,3 +139,16 @@ use_virtual_addressing = "true"
 
 # Default bucket name
 bucket = ""
+
+
+########################################
+# DOCA_MEMOS OBJECT BACKEND
+########################################
+# Configuration for DOCA_MEMOS backend.
+# Requires pre-allocated hugepages (``sysctl vm.nr_hugepages``).
+
+# [plugin.doca_memos]
+# active = true
+# device_name = "/dev/ng0n1"  # NVMe namespace character device
+# nguid = "00000000000000000000000000000000"
+# query_mem_mode = "actual"  # required for correct HiCache existence checks

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_utils.py
@@ -108,7 +108,7 @@ class NixlBackendConfig:
 
         for key, value in config_data.items():
             # These keys are consumed by SGLang itself, not by NIXL plugins.
-            if key in _SGLANG_NIXL_CONFIG_KEYS:
+            if key in _SGLANG_NIXL_CONFIG_KEYS or key == "active":
                 continue
             initparams[key] = str(value)
 
@@ -121,7 +121,7 @@ class NixlBackendSelection:
     # Priority order for File-based plugins in case of auto selection
     FILE_PLUGINS = ["3FS", "POSIX", "GDS_MT", "GDS"]
     # Priority order for File-based plugins in case of auto selection (add more as needed)
-    OBJ_PLUGINS = ["OBJ"]  # Based on Amazon S3 SDK
+    OBJ_PLUGINS = ["OBJ", "DOCA_MEMOS"]
 
     def __init__(
         self, plugin: str = "auto", nixlconfig: Optional[NixlBackendConfig] = None
@@ -130,7 +130,7 @@ class NixlBackendSelection:
         Args:
             plugin: Plugin to use (default "auto" selects best available).
                    Can be a file plugin (3FS, POSIX, GDS, GDS_MT) or
-                   an object plugin (OBJ).
+                   an object plugin (OBJ, DOCA_MEMOS).
         """
         self.plugin = plugin
         self.backend_name = None
@@ -166,19 +166,43 @@ class NixlBackendSelection:
                 )
                 return False
 
+            if self.backend_name == "DOCA_MEMOS":
+                from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+                    HUGEPAGE_BYTES_2MB,
+                    HUGEPAGE_MODE_REQUIRED,
+                    hugepage_mode,
+                    hugepage_size_requested,
+                )
+
+                hugepage_size = hugepage_size_requested()
+                if (
+                    hugepage_mode(hugepage_size) != HUGEPAGE_MODE_REQUIRED
+                    or hugepage_size != HUGEPAGE_BYTES_2MB
+                ):
+                    logger.error(
+                        "NIXL DOCA_MEMOS requires "
+                        "SGLANG_HUGEPAGE_MODE=required, "
+                        "SGLANG_HUGEPAGE_SIZE=2MB, and hugetlb-backed host pools."
+                    )
+                    return False
+
             # obtain initparams for the backend from the NIXL config
             initparams = (
                 self.nixlconfig.get_backend_initparams(self.backend_name)
                 if self.nixlconfig
                 else {}
             )
+            if self.backend_name == "DOCA_MEMOS":
+                # HiCache requires real existence checks rather than the
+                # plugin's assume-success default.
+                initparams.setdefault("query_mem_mode", "actual")
 
-            # Create backend and set memory type
-            if self.backend_name in self.OBJ_PLUGINS and "bucket" not in initparams:
+            # Create backend and set memory type (S3 OBJ requires a bucket; DOCA_MEMOS does not)
+            if self.backend_name == "OBJ" and "bucket" not in initparams:
                 bucket = os.environ.get("AWS_DEFAULT_BUCKET")
                 if not bucket:
                     logger.error(
-                        "AWS_DEFAULT_BUCKET environment variable must be set for object storage"
+                        "AWS_DEFAULT_BUCKET environment variable must be set for OBJ object storage"
                     )
                     return False
 

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -867,5 +867,63 @@ class TestNixlFileLayout(CustomTestCase):
         self.assertFalse(os.path.exists(file_path))
 
 
+class TestHiCacheHostMemoryPreflight(unittest.TestCase):
+    """HiCache host pool memory preflight (RAM + optional hugetlb)."""
+
+    def test_memory_available_bytes_uses_max_of_ram_and_hugetlb(self):
+        from unittest.mock import MagicMock, patch
+
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache import mmap_allocator
+        from sglang.srt.mem_cache.mmap_allocator import (
+            HUGEPAGE_BYTES_2MB,
+            memory_available_bytes,
+        )
+
+        normal_ram_100mb = 100 * 1024 * 1024
+        hugetlb_100mb = 100 * HUGEPAGE_BYTES_2MB
+        hugetlb_200mb = 200 * HUGEPAGE_BYTES_2MB
+        low_ram = MagicMock(available=normal_ram_100mb)
+        with patch.object(
+            mmap_allocator.psutil, "virtual_memory", return_value=low_ram
+        ):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                self.assertEqual(memory_available_bytes(), normal_ram_100mb)
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator, "hugepage_available_bytes", return_value=0
+                ):
+                    self.assertEqual(memory_available_bytes(), normal_ram_100mb)
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "hugepage_available_bytes",
+                    return_value=hugetlb_100mb,
+                ):
+                    self.assertEqual(memory_available_bytes(), hugetlb_100mb)
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "hugepage_available_bytes",
+                    return_value=hugetlb_200mb,
+                ):
+                    self.assertEqual(memory_available_bytes(), hugetlb_200mb)
+
+    def test_hugepage_size_requested(self):
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.mmap_allocator import (
+            HUGEPAGE_BYTES_1GB,
+            HUGEPAGE_BYTES_2MB,
+            hugepage_size_requested,
+        )
+
+        with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+            self.assertEqual(hugepage_size_requested(), 0)
+        with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+            self.assertEqual(hugepage_size_requested(), HUGEPAGE_BYTES_2MB)
+        with envs.SGLANG_HUGEPAGE_SIZE.override("1GB"):
+            self.assertEqual(hugepage_size_requested(), HUGEPAGE_BYTES_1GB)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -297,7 +297,10 @@ class TestNixlUnified(CustomTestCase):
             self.skipTest("NIXL not available, skipping NIXL storage tests")
 
     def tearDown(self):
-        """Clean up test directories."""
+        """Release NIXL registrations before their backing tensors are collected."""
+        hicache = getattr(self, "hicache", None)
+        if hicache is not None:
+            hicache.close()
         if os.path.exists(self.test_dir):
             shutil.rmtree(self.test_dir, ignore_errors=True)
 
@@ -518,9 +521,11 @@ class TestNixlUnified(CustomTestCase):
             },
         )
         try:
-            return HiCacheNixl(storage_config=obj_config, file_path="")
+            hicache = HiCacheNixl(storage_config=obj_config, file_path="")
         except Exception as e:
             self.skipTest(f"NIXL OBJ backend unavailable: {e}")
+        self.addCleanup(hicache.close)
+        return hicache
 
     @unittest.skipUnless(
         MinioFixture.is_available(), "minio binary or boto3 not available"
@@ -867,62 +872,277 @@ class TestNixlFileLayout(CustomTestCase):
         self.assertFalse(os.path.exists(file_path))
 
 
+class TestDocaMemosNixl(unittest.TestCase):
+    """DOCA_MEMOS key hashing, hugepage config, and backend gating."""
+
+    @staticmethod
+    def _make_registration_target():
+        from unittest.mock import MagicMock
+
+        dummy = HiCacheNixl.__new__(HiCacheNixl)
+        dummy.backend_selector = MagicMock(backend_name="DOCA_MEMOS")
+        dummy.needs_page_alignment = False
+        dummy._hybrid_pool_ctx = {}
+        dummy.registered_pools = {}
+        dummy._pre_register_host = MagicMock()
+        return dummy
+
+    @staticmethod
+    def _make_hybrid_pool(*, expose_zero_copy: bool = True):
+        host = MockHybridPool(expose_zero_copy=expose_zero_copy)
+        host.layout = "page_first"
+        return host
+
+    def test_batch_exists_formats_doca_memos_key(self):
+        import hashlib
+        from unittest.mock import MagicMock
+
+        dummy = HiCacheNixl.__new__(HiCacheNixl)
+        dummy.backend_selector = MagicMock(backend_name="DOCA_MEMOS", mem_type="OBJ")
+        dummy.agent = MagicMock()
+        dummy.agent.query_memory.return_value = [object()]
+        dummy.config_suffix = "@suffix"
+        dummy.is_zero_copy = False
+
+        self.assertEqual(dummy.batch_exists(["some/cache/key"]), 1)
+        formatted = hashlib.sha256(b"some/cache/key@suffix").hexdigest()[:32]
+        dummy.agent.query_memory.assert_called_once_with(
+            [(0, 0, 0, formatted)],
+            "DOCA_MEMOS",
+            mem_type="OBJ",
+        )
+
+    def test_register_mem_pool_host_doca_memos(self):
+        from unittest.mock import patch
+
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            MEM_BACKEND_HUGEPAGE,
+        )
+
+        dummy = self._make_registration_target()
+        host = MockMemPoolHost(is_zero_copy_mode=False)
+        with self.assertRaisesRegex(RuntimeError, "page_first"):
+            dummy.register_mem_pool_host(host)
+        self.assertFalse(hasattr(dummy, "mem_pool_host"))
+
+        dummy = self._make_registration_target()
+        host = MockMemPoolHost(is_zero_copy_mode=True)
+        with self.assertRaisesRegex(RuntimeError, "hugetlb-backed"):
+            dummy.register_mem_pool_host(host)
+        self.assertFalse(hasattr(dummy, "mem_pool_host"))
+
+        dummy = self._make_registration_target()
+        host = MockMemPoolHost(is_zero_copy_mode=True)
+        with patch(
+            "sglang.srt.mem_cache.storage.nixl.hicache_nixl.tensor_mem_backend",
+            return_value=MEM_BACKEND_HUGEPAGE,
+        ):
+            dummy.register_mem_pool_host(host)
+        self.assertIs(dummy.mem_pool_host, host)
+
+    def test_register_mem_host_pool_v2_doca_memos(self):
+        from unittest.mock import patch
+
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            MEM_BACKEND_HUGEPAGE,
+        )
+
+        dummy = self._make_registration_target()
+        host = self._make_hybrid_pool(expose_zero_copy=False)
+        with self.assertRaisesRegex(RuntimeError, "zero-copy"):
+            dummy.register_mem_host_pool_v2(host, PoolName.MAMBA)
+
+        dummy = self._make_registration_target()
+        host = self._make_hybrid_pool()
+        with self.assertRaisesRegex(RuntimeError, "hugetlb-backed"):
+            dummy.register_mem_host_pool_v2(host, PoolName.MAMBA)
+        self.assertNotIn(PoolName.MAMBA, dummy.registered_pools)
+
+        dummy = self._make_registration_target()
+        host = self._make_hybrid_pool()
+        host.temporal_buffer = torch.empty((4, 0), dtype=torch.uint8)
+        with patch(
+            "sglang.srt.mem_cache.storage.nixl.hicache_nixl.tensor_mem_backend",
+            return_value=MEM_BACKEND_HUGEPAGE,
+        ):
+            dummy.register_mem_host_pool_v2(host, PoolName.MAMBA)
+
+        self.assertIs(dummy.registered_pools[PoolName.MAMBA], host)
+        dummy._pre_register_host.assert_called_once()
+
+    def test_doca_memos_initparams(self):
+        from sglang.srt.mem_cache.storage.nixl.nixl_utils import NixlBackendConfig
+
+        config = NixlBackendConfig(
+            {
+                "plugin": {
+                    "doca_memos": {
+                        "active": True,
+                        "device_name": "/dev/ng4n1",
+                        "nguid": "0123456789abcdef0123456789abcdef",
+                        "query_mem_mode": "actual",
+                    }
+                }
+            }
+        )
+        self.assertEqual(
+            config.get_backend_initparams("DOCA_MEMOS"),
+            {
+                "device_name": "/dev/ng4n1",
+                "nguid": "0123456789abcdef0123456789abcdef",
+                "query_mem_mode": "actual",
+            },
+        )
+
+    def test_doca_memos_backend_requires_hugepage_policy(self):
+        from unittest.mock import MagicMock
+
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.storage.nixl.nixl_utils import (
+            NixlBackendConfig,
+            NixlBackendSelection,
+        )
+
+        agent = MagicMock()
+        agent.get_plugin_list.return_value = ["DOCA_MEMOS"]
+        agent.get_backend_params.return_value = {}
+        selector = NixlBackendSelection(
+            plugin="DOCA_MEMOS",
+            nixlconfig=NixlBackendConfig({}),
+        )
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                self.assertFalse(selector.create_backend(agent))
+            with envs.SGLANG_HUGEPAGE_SIZE.override("1GB"):
+                self.assertFalse(selector.create_backend(agent))
+        with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                self.assertFalse(selector.create_backend(agent))
+
+        selector = NixlBackendSelection(
+            plugin="DOCA_MEMOS",
+            nixlconfig=NixlBackendConfig({}),
+        )
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                self.assertTrue(selector.create_backend(agent))
+        agent.create_backend.assert_called_once_with(
+            "DOCA_MEMOS", {"query_mem_mode": "actual"}
+        )
+
+    def test_alloc_mmap_hugepage_modes(self):
+        import ctypes
+        from unittest.mock import patch
+
+        import torch
+
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.storage.mmap import mmap_allocator
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            MEM_BACKEND_HUGEPAGE,
+            MEM_BACKEND_MMAP,
+            tensor_mem_backend,
+        )
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("off"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_MMAP)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(mmap_allocator, "_alloc_hugepage") as mock_hp:
+                    mock_hp.return_value = (ctypes.c_uint8 * 16)()
+                    buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_HUGEPAGE)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "_alloc_hugepage",
+                    side_effect=OSError("no hugepages"),
+                ):
+                    with patch.object(mmap_allocator, "_libc", object()):
+                        buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_MMAP)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "_alloc_hugepage",
+                    side_effect=OSError("no hugepages"),
+                ):
+                    with patch.object(mmap_allocator, "_libc", object()):
+                        with patch.object(mmap_allocator.mmap, "mmap") as plain_mmap:
+                            with self.assertRaisesRegex(RuntimeError, "no hugepages"):
+                                mmap_allocator.alloc_mmap((4,), torch.float32)
+                            plain_mmap.assert_not_called()
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                with self.assertRaisesRegex(ValueError, "SGLANG_HUGEPAGE_SIZE"):
+                    mmap_allocator.alloc_mmap((4,), torch.float32)
+
+
 class TestHiCacheHostMemoryPreflight(unittest.TestCase):
     """HiCache host pool memory preflight (RAM + optional hugetlb)."""
 
-    def test_memory_available_bytes_uses_max_of_ram_and_hugetlb(self):
+    def test_memory_available_bytes_hugepage_modes(self):
         from unittest.mock import MagicMock, patch
 
         from sglang.srt.environ import envs
-        from sglang.srt.mem_cache import mmap_allocator
-        from sglang.srt.mem_cache.mmap_allocator import (
+        from sglang.srt.mem_cache.storage.mmap import mmap_allocator
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            HICACHE_HOST_MEMORY_RESERVE_BYTES,
             HUGEPAGE_BYTES_2MB,
             memory_available_bytes,
         )
 
-        normal_ram_100mb = 100 * 1024 * 1024
-        hugetlb_100mb = 100 * HUGEPAGE_BYTES_2MB
-        hugetlb_200mb = 200 * HUGEPAGE_BYTES_2MB
-        low_ram = MagicMock(available=normal_ram_100mb)
+        normal_usable_100mb = 100 * 1024 * 1024
+        normal_ram_with_reserve = (
+            HICACHE_HOST_MEMORY_RESERVE_BYTES + normal_usable_100mb
+        )
+        hugetlb_200mb = 100 * HUGEPAGE_BYTES_2MB
+        low_ram = MagicMock(available=normal_ram_with_reserve)
         with patch.object(
             mmap_allocator.psutil, "virtual_memory", return_value=low_ram
         ):
-            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
-                self.assertEqual(memory_available_bytes(), normal_ram_100mb)
-            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
-                with patch.object(
-                    mmap_allocator, "hugepage_available_bytes", return_value=0
-                ):
-                    self.assertEqual(memory_available_bytes(), normal_ram_100mb)
-            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
-                with patch.object(
-                    mmap_allocator,
-                    "hugepage_available_bytes",
-                    return_value=hugetlb_100mb,
-                ):
-                    self.assertEqual(memory_available_bytes(), hugetlb_100mb)
-            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
-                with patch.object(
-                    mmap_allocator,
-                    "hugepage_available_bytes",
-                    return_value=hugetlb_200mb,
-                ):
-                    self.assertEqual(memory_available_bytes(), hugetlb_200mb)
+            with envs.SGLANG_HUGEPAGE_MODE.override("off"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                    self.assertEqual(memory_available_bytes(), normal_usable_100mb)
+            with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator, "hugepage_available_bytes", return_value=0
+                    ):
+                        self.assertEqual(memory_available_bytes(), normal_usable_100mb)
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator,
+                        "hugepage_available_bytes",
+                        return_value=hugetlb_200mb,
+                    ):
+                        self.assertEqual(memory_available_bytes(), hugetlb_200mb)
 
-    def test_hugepage_size_requested(self):
-        from sglang.srt.environ import envs
-        from sglang.srt.mem_cache.mmap_allocator import (
-            HUGEPAGE_BYTES_1GB,
-            HUGEPAGE_BYTES_2MB,
-            hugepage_size_requested,
-        )
-
-        with envs.SGLANG_HUGEPAGE_SIZE.override(""):
-            self.assertEqual(hugepage_size_requested(), 0)
-        with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
-            self.assertEqual(hugepage_size_requested(), HUGEPAGE_BYTES_2MB)
-        with envs.SGLANG_HUGEPAGE_SIZE.override("1GB"):
-            self.assertEqual(hugepage_size_requested(), HUGEPAGE_BYTES_1GB)
+        normal_ram = HICACHE_HOST_MEMORY_RESERVE_BYTES + 32 * 1024**3
+        hugetlb_bytes = 16 * 1024**3
+        with patch.object(
+            mmap_allocator.psutil,
+            "virtual_memory",
+            return_value=MagicMock(available=normal_ram),
+        ) as normal_memory:
+            with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator,
+                        "hugepage_available_bytes",
+                        return_value=hugetlb_bytes,
+                    ) as huge_available:
+                        self.assertEqual(memory_available_bytes(), hugetlb_bytes)
+                        huge_available.assert_called_once_with(HUGEPAGE_BYTES_2MB)
+                        normal_memory.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -25,6 +25,111 @@ class TestMmapAllocator(unittest.TestCase):
         # Verify it has mapped memory address
         self.assertGreater(tensor.data_ptr(), 0)
 
+    def test_alloc_mmap_hugepage_modes(self):
+        import ctypes
+        from unittest.mock import patch
+
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.storage.mmap import mmap_allocator
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            MEM_BACKEND_HUGEPAGE,
+            MEM_BACKEND_MMAP,
+            tensor_mem_backend,
+        )
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("off"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_MMAP)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(mmap_allocator, "_alloc_hugepage") as mock_hp:
+                    mock_hp.return_value = (ctypes.c_uint8 * 16)()
+                    buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_HUGEPAGE)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "_alloc_hugepage",
+                    side_effect=OSError("no hugepages"),
+                ):
+                    with patch.object(mmap_allocator, "_libc", object()):
+                        buf = mmap_allocator.alloc_mmap((4,), torch.float32)
+                self.assertEqual(tensor_mem_backend(buf), MEM_BACKEND_MMAP)
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                with patch.object(
+                    mmap_allocator,
+                    "_alloc_hugepage",
+                    side_effect=OSError("no hugepages"),
+                ):
+                    with patch.object(mmap_allocator, "_libc", object()):
+                        with patch.object(mmap_allocator.mmap, "mmap") as plain_mmap:
+                            with self.assertRaisesRegex(RuntimeError, "no hugepages"):
+                                mmap_allocator.alloc_mmap((4,), torch.float32)
+                            plain_mmap.assert_not_called()
+
+        with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+            with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                with self.assertRaisesRegex(ValueError, "SGLANG_HUGEPAGE_SIZE"):
+                    mmap_allocator.alloc_mmap((4,), torch.float32)
+
+    def test_memory_available_bytes_hugepage_modes(self):
+        from unittest.mock import MagicMock, patch
+
+        from sglang.srt.environ import envs
+        from sglang.srt.mem_cache.storage.mmap import mmap_allocator
+        from sglang.srt.mem_cache.storage.mmap.mmap_allocator import (
+            HICACHE_HOST_MEMORY_RESERVE_BYTES,
+            HUGEPAGE_BYTES_2MB,
+            memory_available_bytes,
+        )
+
+        normal_usable_100mb = 100 * 1024 * 1024
+        normal_ram_with_reserve = (
+            HICACHE_HOST_MEMORY_RESERVE_BYTES + normal_usable_100mb
+        )
+        hugetlb_200mb = 100 * HUGEPAGE_BYTES_2MB
+        low_ram = MagicMock(available=normal_ram_with_reserve)
+        with patch.object(
+            mmap_allocator.psutil, "virtual_memory", return_value=low_ram
+        ):
+            with envs.SGLANG_HUGEPAGE_MODE.override("off"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override(""):
+                    self.assertEqual(memory_available_bytes(), normal_usable_100mb)
+            with envs.SGLANG_HUGEPAGE_MODE.override("prefer"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator, "hugepage_available_bytes", return_value=0
+                    ):
+                        self.assertEqual(memory_available_bytes(), normal_usable_100mb)
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator,
+                        "hugepage_available_bytes",
+                        return_value=hugetlb_200mb,
+                    ):
+                        self.assertEqual(memory_available_bytes(), hugetlb_200mb)
+
+        hugetlb_bytes = 3 * HUGEPAGE_BYTES_2MB
+        with patch.object(
+            mmap_allocator.psutil,
+            "virtual_memory",
+            return_value=MagicMock(available=1 << 50),
+        ):
+            with envs.SGLANG_HUGEPAGE_MODE.override("required"):
+                with envs.SGLANG_HUGEPAGE_SIZE.override("2MB"):
+                    with patch.object(
+                        mmap_allocator,
+                        "hugepage_available_bytes",
+                        return_value=hugetlb_bytes,
+                    ):
+                        self.assertEqual(memory_available_bytes(), hugetlb_bytes)
+
     def test_alloc_shm(self):
         dims = (10, 1024)
         dtype = torch.float32


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add DOCA_MEMOS as a NIXL HiCache object backend and make hugepage allocation policy explicit. DOCA_MEMOS requires hugetlb-backed registered memory, 2 MiB pages, and real storage-existence queries.

This PR is stacked on `doca-memos/01-hugepage-preflight-mode`.

## Modifications

- **Hugepage allocation policy**
  - Add `SGLANG_HUGEPAGE_MODE=off|prefer|required`, with backward-compatible inference when unset.
  - Make `required` fail instead of silently falling back when hugetlb allocation is unavailable or misconfigured.
  - Track whether each mmap-backed tensor uses ordinary mmap or hugetlb so storage backends can validate registered buffers.
  - Make host preflight follow the selected policy: ordinary RAM for `off`, usable RAM/hugetlb capacity for `prefer`, and hugetlb capacity for `required`.
- **NIXL / DOCA_MEMOS**
  - Add DOCA_MEMOS to NIXL object plugin selection without requiring an S3 bucket.
  - Require `SGLANG_HUGEPAGE_MODE=required` and `SGLANG_HUGEPAGE_SIZE=2MB` before backend creation.
  - Set `query_mem_mode=actual` so HiCache performs real existence checks.
  - Hash storage keys to 32-character SHA-256 hex identifiers for DOCA_MEMOS metadata.
  - Validate zero-copy host-pool layouts and hugetlb-backed buffers before registration.
- **Config and docs**
  - Document the hugepage mode environment variable and fallback behavior.
  - Add a DOCA_MEMOS example to `nixl.config.toml.sample`.
- **Tests**
  - Cover backend selection, init parameters, key formatting, hugepage policy, registration validation, and allocator backend tracking.

## Usage (DOCA_MEMOS)

```bash
export SGLANG_HUGEPAGE_MODE=required
export SGLANG_HUGEPAGE_SIZE=2MB

# Reserve enough 2 MiB huge pages on the host before starting SGLang.
# Select DOCA_MEMOS in the NIXL plugin configuration.
# Use page_first or page_first_direct for zero-copy host pools.
```

## Accuracy Tests

N/A — storage and host-memory plumbing only; no model forward or kernel math changes.

## Speed Tests and Profiling

Not run in this PR. Hardware benchmarking requires a system with DOCA_MEMOS and reserved 2 MiB huge pages.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->