### PR TITLE
Fix single-request generation being killed early on hybrid-SWA models under DFLASH/DSPARK speculative decoding

### DIFF
--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -1035,6 +1035,17 @@ def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
             server_args.max_speculative_num_draft_tokens,
         )
     if batch.spec_algorithm.is_dflash_family():
+        # Mirror eagle_prepare_for_decode: evict out-of-window SWA KV and
+        # advance decode_batch_idx (the eviction gate requires >= 1). Without
+        # this, hybrid-SWA models retain SWA KV for every generated token and
+        # a single request exhausts the SWA pool after
+        # swa_full_tokens_ratio * max_total_num_tokens generated tokens, at
+        # which point the scheduler retracts it. Pool sizing already assumes
+        # this eviction runs (pool_configurator: trailing_tokens =
+        # window + eviction_interval * draft_tokens + page_size).
+        batch.maybe_evict_swa()
+        for r in batch.reqs:
+            r.decode_batch_idx += 1
         batch.spec_info.prepare_for_decode(batch)
     else:
         from sglang.srt.speculative.eagle_utils import eagle_prepare_for_decode

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -1037,6 +1037,17 @@ def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
             max_speculative_num_draft_tokens(),
         )
     if batch.spec_algorithm.is_dflash_family():
+        # Mirror eagle_prepare_for_decode: evict out-of-window SWA KV and
+        # advance decode_batch_idx (the eviction gate requires >= 1). Without
+        # this, hybrid-SWA models retain SWA KV for every generated token and
+        # a single request exhausts the SWA pool after
+        # swa_full_tokens_ratio * max_total_num_tokens generated tokens, at
+        # which point the scheduler retracts it. Pool sizing already assumes
+        # this eviction runs (pool_configurator: trailing_tokens =
+        # window + eviction_interval * draft_tokens + page_size).
+        batch.maybe_evict_swa()
+        for r in batch.reqs:
+            r.decode_batch_idx += 1
         batch.spec_info.prepare_for_decode(batch)
     else:
         from sglang.srt.speculative.eagle_utils import eagle_prepare_for_decode

--- a/scripts/lint/check_decode_bookkeeping_ownership.py
+++ b/scripts/lint/check_decode_bookkeeping_ownership.py
@@ -50,6 +50,9 @@ _OWNER_SITES = {
     ("mem_cache/allocation.py", "alloc_for_extend", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_extend", "kv_allocated_len"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "evict"): 1,
+    # spec: the dflash-family branch mirrors eagle_prepare_for_decode.
+    ("speculative/spec_utils.py", "spec_prepare_for_decode", "decode_batch_idx"): 1,
+    ("speculative/spec_utils.py", "spec_prepare_for_decode", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "kv_allocated_len"): 1,
     # spec v2: no pre-claim; resolve commits the full accepted run uniformly.
     # kv_allocated_len for spec v2 draft decode (eagle + dflash) is settled

--- a/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
+++ b/test/registered/unit/spec/test_decode_bookkeeping_ownership.py
@@ -56,6 +56,9 @@ _OWNER_SITES = {
     ("mem_cache/allocation.py", "alloc_for_extend", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_extend", "kv_allocated_len"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "evict"): 1,
+    # spec: the dflash-family branch mirrors eagle_prepare_for_decode.
+    ("speculative/spec_utils.py", "spec_prepare_for_decode", "decode_batch_idx"): 1,
+    ("speculative/spec_utils.py", "spec_prepare_for_decode", "evict"): 1,
     ("mem_cache/allocation.py", "alloc_for_decode", "kv_allocated_len"): 1,
     # spec v2: no pre-claim; resolve commits the full accepted run uniformly.
     # kv_allocated_len for spec v2 draft decode (eagle + dflash) is settled

--- a/test/registered/unit/speculative/test_spec_prepare_swa_eviction.py
+++ b/test/registered/unit/speculative/test_spec_prepare_swa_eviction.py
@@ -1,0 +1,83 @@
+"""spec_prepare_for_decode must run SWA eviction on the dflash-family path.
+
+The dflash-family branch (DFLASH, DSPARK) historically skipped both
+``maybe_evict_swa`` and the ``decode_batch_idx`` tick that
+``eagle_prepare_for_decode`` performs. On hybrid-SWA models that retained
+SWA KV for every generated token, so a single request exhausted the SWA pool
+after ``swa_full_tokens_ratio * max_total_num_tokens`` generated tokens and
+was retracted by the scheduler. Pool sizing assumes the eviction runs
+(``pool_configurator``: ``trailing_tokens = sliding_window +
+eviction_interval * draft_tokens + page_size``).
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_batch(spec_is_dflash_family: bool):
+    batch = MagicMock()
+    batch.spec_algorithm.is_dflash_family.return_value = spec_is_dflash_family
+    req = SimpleNamespace(decode_batch_idx=0)
+    batch.reqs = [req]
+    return batch, req
+
+
+class TestSpecPrepareSwaEviction(CustomTestCase):
+    def _run(self, batch):
+        from sglang.srt.speculative import spec_utils
+
+        with patch.object(
+            spec_utils, "get_server_args", return_value=MagicMock()
+        ) as server_args:
+            server_args.return_value.enable_mamba_extra_buffer_lazy.return_value = False
+            spec_utils.spec_prepare_for_decode(batch)
+
+    def test_dflash_family_evicts_and_ticks(self):
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        self._run(batch)
+        batch.maybe_evict_swa.assert_called_once_with()
+        self.assertEqual(req.decode_batch_idx, 1)
+        batch.spec_info.prepare_for_decode.assert_called_once_with(batch)
+
+    def test_tick_advances_every_iteration(self):
+        """decode_batch_idx is a clock, not a flag: it must keep advancing so
+        the SWA leaf-lock release gate (decode_batch_idx >= sliding_window_size)
+        can fire."""
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        self._run(batch)
+        self._run(batch)
+        self.assertEqual(req.decode_batch_idx, 2)
+        self.assertEqual(batch.maybe_evict_swa.call_count, 2)
+
+    def test_dflash_family_evicts_before_tick(self):
+        """The overlap-scheduler gate (decode_batch_idx >= 1) must see the
+        pre-tick value, exactly as in eagle_prepare_for_decode."""
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        seen_idx = []
+        batch.maybe_evict_swa.side_effect = lambda: seen_idx.append(
+            req.decode_batch_idx
+        )
+        self._run(batch)
+        self.assertEqual(seen_idx, [0])
+        self.assertEqual(req.decode_batch_idx, 1)
+
+    def test_eagle_path_unchanged(self):
+        batch, req = _make_batch(spec_is_dflash_family=False)
+        with patch(
+            "sglang.srt.speculative.eagle_utils.eagle_prepare_for_decode"
+        ) as eagle_prep:
+            self._run(batch)
+        eagle_prep.assert_called_once_with(batch)
+        # The dflash-branch tick must not run on the eagle path.
+        self.assertEqual(req.decode_batch_idx, 0)
+        batch.spec_info.prepare_for_decode.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/speculative/test_spec_prepare_swa_eviction.py
+++ b/test/registered/unit/speculative/test_spec_prepare_swa_eviction.py
@@ -1,0 +1,82 @@
+"""spec_prepare_for_decode must run SWA eviction on the dflash-family path.
+
+The dflash-family branch (DFLASH, DSPARK) historically skipped both
+``maybe_evict_swa`` and the ``decode_batch_idx`` tick that
+``eagle_prepare_for_decode`` performs. On hybrid-SWA models that retained
+SWA KV for every generated token, so a single request exhausted the SWA pool
+after ``swa_full_tokens_ratio * max_total_num_tokens`` generated tokens and
+was retracted by the scheduler. Pool sizing assumes the eviction runs
+(``pool_configurator``: ``trailing_tokens = sliding_window +
+eviction_interval * draft_tokens + page_size``).
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_batch(spec_is_dflash_family: bool):
+    batch = MagicMock()
+    batch.spec_algorithm.is_dflash_family.return_value = spec_is_dflash_family
+    req = SimpleNamespace(decode_batch_idx=0)
+    batch.reqs = [req]
+    return batch, req
+
+
+class TestSpecPrepareSwaEviction(CustomTestCase):
+    def _run(self, batch):
+        from sglang.srt.speculative import spec_utils
+
+        with patch.object(
+            spec_utils, "mamba_extra_buffer_lazy_enabled", return_value=False
+        ):
+            spec_utils.spec_prepare_for_decode(batch)
+
+    def test_dflash_family_evicts_and_ticks(self):
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        self._run(batch)
+        batch.maybe_evict_swa.assert_called_once_with()
+        self.assertEqual(req.decode_batch_idx, 1)
+        batch.spec_info.prepare_for_decode.assert_called_once_with(batch)
+
+    def test_tick_advances_every_iteration(self):
+        """decode_batch_idx is a clock, not a flag: it must keep advancing so
+        the SWA leaf-lock release gate (decode_batch_idx >= sliding_window_size)
+        can fire."""
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        self._run(batch)
+        self._run(batch)
+        self.assertEqual(req.decode_batch_idx, 2)
+        self.assertEqual(batch.maybe_evict_swa.call_count, 2)
+
+    def test_dflash_family_evicts_before_tick(self):
+        """The overlap-scheduler gate (decode_batch_idx >= 1) must see the
+        pre-tick value, exactly as in eagle_prepare_for_decode."""
+        batch, req = _make_batch(spec_is_dflash_family=True)
+        seen_idx = []
+        batch.maybe_evict_swa.side_effect = lambda: seen_idx.append(
+            req.decode_batch_idx
+        )
+        self._run(batch)
+        self.assertEqual(seen_idx, [0])
+        self.assertEqual(req.decode_batch_idx, 1)
+
+    def test_eagle_path_unchanged(self):
+        batch, req = _make_batch(spec_is_dflash_family=False)
+        with patch(
+            "sglang.srt.speculative.eagle_utils.eagle_prepare_for_decode"
+        ) as eagle_prep:
+            self._run(batch)
+        eagle_prep.assert_called_once_with(batch)
+        # The dflash-branch tick must not run on the eagle path.
+        self.assertEqual(req.decode_batch_idx, 0)
+        batch.spec_info.prepare_for_decode.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`spec_prepare_for_decode` routes dflash-family algorithms (DFLASH, DSPARK) to `DFlashDraftInputV2.prepare_for_decode`, which never calls `maybe_evict_swa` and never advances `decode_batch_idx` — which the eviction gate requires to be `>= 1`. `eagle_prepare_for_decode` does both. On hybrid-SWA models the sliding-window eviction is therefore unreachable under DFLASH/DSPARK: SWA KV is retained for every generated token, so a single request exhausts the SWA pool after roughly `swa_full_tokens_ratio * max_total_num_tokens` generated tokens and is retracted by the scheduler mid-generation.

Reproduced on DeepSeek-V4-Flash-0731 (2x RTX PRO 6000, SM120, TP=2, DSPARK block size 5, `swa_full_tokens_ratio=0.1`, `max_total_num_tokens=778496`). `#swa token` tracks generated tokens 1:1, and the request is retracted at exactly 77,824 tokens — `align_page_size(int(778496 * 0.1))`, the full SWA pool — while the full pool is only 10% used:

```
#full token: 77824, full token usage: 0.10, #swa token: 77824, swa token usage: 1.00
KV cache pool is full. Retract requests. #new_tokens_gained: 77824
```

Long prompts are unaffected — a 131k-token prefill holds ~8.5K SWA tokens. Only generated tokens accumulate.

The same missing call also skips the DSV4 compress-state drain (`maybe_evict_dsv4_state`, documented "called every decode step from ScheduleBatch"), so the NPU + DSV4 + DFLASH combination leaks state-pool slots for the same reason.

## Modifications

`speculative/spec_utils.py`: in the dflash-family branch, mirror `eagle_prepare_for_decode` — call `batch.maybe_evict_swa()` and advance `decode_batch_idx`. Eviction runs before the tick so the overlap-scheduler gate (`decode_batch_idx >= 1`) still skips the first decode iteration, exactly as on the eagle path.

`test/registered/unit/spec/test_decode_bookkeeping_ownership.py`: record the new bookkeeping owner in `_OWNER_SITES`, as that guard requires for a genuinely new owner.

`test/registered/unit/speculative/test_spec_prepare_swa_eviction.py` (new): asserts the dflash branch evicts, ticks, evicts *before* ticking, keeps advancing across iterations (so the counter stays a clock rather than a flag), and that the eagle path is unchanged.

## Accuracy Tests

Eviction frees only SWA slots behind the window — `max(sliding_window, page_size)` back from the sequence on the radix path, page-floored `pre_len - sliding_window` on the chunk-cache path. SWA layers attend within the window, and both the eagle and non-spec paths already call this same code every decode step (`eagle_utils.py`, `mem_cache/allocation.py`). No output change observed.

## Speed Tests and Profiling

The `ignore_eos` request that previously died at 77,809 tokens completed 100,000 tokens with the fix, at a sustained ~159 tok/s and zero retractions. `#swa token` sampled repeatedly across the run stayed between 512 and 1,024 (~1% of the SWA pool), against 77,824 at the point of failure before the fix.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). The new test fails on the pre-fix code and passes with the fix.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Prepared with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31830154702](https://github.com/sgl-project/sglang/actions/runs/31830154702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31830154341](https://github.com/sgl-project/sglang/actions/runs/31830154341)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->