### PR TITLE
[PD] Charge each state component its own item length in the KV transfer metric

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -150,7 +150,14 @@ class CommonKVManager(BaseKVManager):
         self.kv_args = args
         self.kv_cache_dtype_str = args.kv_cache_dtype_str
         self.kv_item_lens_sum = sum(args.kv_item_lens)
-        self.state_item_lens_sum = sum(x for comp in args.state_item_lens for x in comp)
+        # Per-component, NOT flattened across components: every state component
+        # ships its own index list, so the bytes it costs are its own per-layer
+        # item lengths times its own index count. Collapsing this to one scalar
+        # would only be usable if every component shipped the same indices, the
+        # way all layers share one page-index list on the KV side.
+        self.state_item_lens_per_component = [
+            sum(component) for component in args.state_item_lens
+        ]
         self.is_mla_backend = is_mla_backend
         # Per-sender fan-out of a KV copy onto N decode destinations
         # (MLA under Prefill-CP + Decode-TP, or decode_tp > prefill_tp).
@@ -1077,7 +1084,10 @@ class CommonKVSender(BaseKVSender):
         self.conclude_state: Optional[KVPoll] = None
         self._transfer_metric = KVTransferMetric()
         self._transfer_num_kv_indices = 0
-        self._transfer_num_state_indices = 0
+        # Accumulated as bytes rather than as an index count: the cost of a state
+        # index depends on which component it belongs to, and that association is
+        # only available where the indices are recorded.
+        self._transfer_state_bytes = 0
         # inner state
         self.curr_idx = 0
         self.init_time: Optional[float] = None
@@ -1139,10 +1149,12 @@ class CommonKVSender(BaseKVSender):
         return num_pages > 0 or last_chunk
 
     def get_transfer_metric(self) -> KVTransferMetric:
+        # Every layer ships the SAME page indices, so one KV index costs the sum
+        # over layers -- that scalar product is exact. State components each ship
+        # their own indices, so their bytes are accumulated per component in
+        # `_record_transfer_indices` instead.
         total_bytes = self._transfer_num_kv_indices * self.kv_mgr.kv_item_lens_sum
-        total_bytes += (
-            self._transfer_num_state_indices * self.kv_mgr.state_item_lens_sum
-        )
+        total_bytes += self._transfer_state_bytes
         # Pinned to 1 for MHA (disjoint slices); only MLA replication makes it > 1.
         total_bytes *= self.kv_mgr.get_kv_replica_factor()
         self._transfer_metric.transfer_total_bytes = total_bytes
@@ -1154,10 +1166,15 @@ class CommonKVSender(BaseKVSender):
         state_indices: Optional[List],
     ):
         self._transfer_num_kv_indices += len(kv_indices)
-        if state_indices:
-            for component_indices in state_indices:
-                if component_indices is not None:
-                    self._transfer_num_state_indices += len(component_indices)
+        if not state_indices:
+            return
+        item_lens = self.kv_mgr.state_item_lens_per_component
+        for component_id, component_indices in enumerate(state_indices):
+            if component_indices is None:
+                continue
+            self._transfer_state_bytes += (
+                len(component_indices) * item_lens[component_id]
+            )
 
     def _prepare_send_indices(
         self,

--- a/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
@@ -20,7 +20,8 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 KV_ITEM_LENS_SUM = 100
-STATE_ITEM_LENS_SUM = 7
+# One state component, per-layer item lengths summing to 7.
+STATE_ITEM_LENS_PER_COMPONENT = [7]
 
 
 def _room(fan_out):
@@ -35,12 +36,16 @@ def _room(fan_out):
     }
 
 
-def _make_kv_mgr(is_mla_backend):
+def _make_kv_mgr(is_mla_backend, state_item_lens_per_component=None):
     """CommonKVManager bypassing __init__, wiring only the fields the path reads."""
     mgr = CommonKVManager.__new__(CommonKVManager)
     mgr.is_mla_backend = is_mla_backend
     mgr.kv_item_lens_sum = KV_ITEM_LENS_SUM
-    mgr.state_item_lens_sum = STATE_ITEM_LENS_SUM
+    mgr.state_item_lens_per_component = (
+        STATE_ITEM_LENS_PER_COMPONENT
+        if state_item_lens_per_component is None
+        else state_item_lens_per_component
+    )
     mgr._kv_replica_factor = None if is_mla_backend else 1
     return mgr
 
@@ -50,7 +55,7 @@ def _make_sender(kv_mgr):
     sender = CommonKVSender.__new__(CommonKVSender)
     sender._transfer_metric = KVTransferMetric()
     sender._transfer_num_kv_indices = 0
-    sender._transfer_num_state_indices = 0
+    sender._transfer_state_bytes = 0
     sender.kv_mgr = kv_mgr
     return sender
 
@@ -67,7 +72,7 @@ class TestKVTransferReplicaMetric(CustomTestCase):
         sender._record_transfer_indices(
             np.arange(8, dtype=np.int32), [np.arange(5, dtype=np.int32)]
         )
-        expected = (8 * KV_ITEM_LENS_SUM + 5 * STATE_ITEM_LENS_SUM) * 4
+        expected = (8 * KV_ITEM_LENS_SUM + 5 * STATE_ITEM_LENS_PER_COMPONENT[0]) * 4
         self.assertEqual(sender.get_transfer_metric().transfer_total_bytes, expected)
 
     def test_non_mla_factor_is_one_regardless_of_destinations(self):
@@ -82,6 +87,57 @@ class TestKVTransferReplicaMetric(CustomTestCase):
         self.assertEqual(
             sender.get_transfer_metric().transfer_total_bytes, 6 * KV_ITEM_LENS_SUM
         )
+
+    def test_each_state_component_is_charged_its_own_item_length(self):
+        """State components ship independent index lists of independent sizes.
+
+        The metric used to flatten both sides -- one summed index count times one
+        summed item length -- which is a cross product: every index of every
+        component was charged the item length of every OTHER component too. It
+        only agreed with reality when a single component was in play, so the
+        error grew with the number of components and was invisible to a
+        single-component test.
+
+        DeepSeek-V4 ships SWA_RING and C128_STATE together, with a small
+        sliding-window index list against a much longer compressed-state one.
+        """
+        # 2 components: 3 indices at 10 bytes/index, 1 index at 1000 bytes/index.
+        mgr = _make_kv_mgr(
+            is_mla_backend=False, state_item_lens_per_component=[10, 1000]
+        )
+        sender = _make_sender(mgr)
+
+        sender._record_transfer_indices(
+            np.arange(2, dtype=np.int32),
+            [np.arange(3, dtype=np.int32), np.arange(1, dtype=np.int32)],
+        )
+
+        expected = 2 * KV_ITEM_LENS_SUM + (3 * 10 + 1 * 1000)
+        self.assertEqual(sender.get_transfer_metric().transfer_total_bytes, expected)
+        # The flattened form would have charged (3 + 1) * (10 + 1000) = 4040
+        # instead of 1030 -- roughly 4x, and independent of which component the
+        # indices actually belonged to.
+        self.assertNotEqual(
+            sender.get_transfer_metric().transfer_total_bytes,
+            2 * KV_ITEM_LENS_SUM + (3 + 1) * (10 + 1000),
+        )
+
+    def test_a_component_with_no_indices_costs_nothing(self):
+        """A `None` slot means that component shipped nothing this transfer.
+
+        Charging it anything at all reintroduces the cross product in miniature:
+        under the flattened form an absent component still inflated the per-index
+        price paid by its neighbours.
+        """
+        mgr = _make_kv_mgr(
+            is_mla_backend=False, state_item_lens_per_component=[10, 1000]
+        )
+        sender = _make_sender(mgr)
+
+        sender._record_transfer_indices(
+            np.empty(0, dtype=np.int32), [np.arange(4, dtype=np.int32), None]
+        )
+        self.assertEqual(sender.get_transfer_metric().transfer_total_bytes, 4 * 10)
 
     def test_unresolved_factor_does_not_crash_metric(self):
         # An empty room or a missing required_dst_info_num leaves the factor


### PR DESCRIPTION
## Motivation

`CommonKVSender.get_transfer_metric()` computes the state contribution as a product of two independently flattened sums:

```python
total_bytes += self._transfer_num_state_indices * self.kv_mgr.state_item_lens_sum
```

`KVArgs.state_item_lens` is `List[List[int]]` — per component, then per layer — and it is flattened at construction:

```python
self.state_item_lens_sum = sum(x for comp in args.state_item_lens for x in comp)
```

`_record_transfer_indices` flattens the index side the same way, adding `len(component_indices)` into a single counter without keeping track of which component it came from.

The product of those two is a **cross product**. With `N` components of index counts `n_i` and item-length sums `L_i`, the metric reports

```
(Σ n_i) · (Σ L_i)      instead of      Σ n_i · L_i
```

— inflated by exactly the cross terms `Σ_{i≠j} n_i · L_j`. Every index of every component is charged the item length of every *other* component as well.

It is correct only when a single component is in play, which is why `test_kv_transfer_replica_metric.py` (one component) never caught it.

## Why it matters

The overcharge is worst when component sizes are lopsided, which is the normal case. A sliding-window ring ships a short index list; a compressed-state component ships a much longer one. Each ends up paying the other's price, and the two errors do not cancel.

It also makes the metric **partly insensitive to transfer length**: the cross terms scale with the other component's size rather than with what this component actually sent, so a large share of the reported bytes does not move when the real transfer does. That defeats the metric's main use — telling whether a change reduced KV traffic.

Concretely, with 2 components — 3 indices at 10 B and 1 index at 1000 B:

| | bytes |
|---|---:|
| actual (`3·10 + 1·1000`) | 1,030 |
| reported (`(3+1)·(10+1000)`) | 4,040 |

## Change

Accumulate state bytes where the component association still exists, instead of trying to reconstruct them afterwards from two sums that have each lost it:

```python
item_lens = self.kv_mgr.state_item_lens_per_component
for component_id, component_indices in enumerate(state_indices):
    if component_indices is None:
        continue
    self._transfer_state_bytes += len(component_indices) * item_lens[component_id]
```

The KV side keeps its scalar product — all layers ship the *same* page indices, so one KV index genuinely costs the sum over layers. Only the state side needed the per-component treatment.

`state_item_lens_sum` becomes `state_item_lens_per_component`, and the sender's `_transfer_num_state_indices` counter becomes `_transfer_state_bytes`. Both were private to this path; no other caller in the tree reads either.

## Scope

Applies to **every** PD backend: mooncake, nixl and mori all call the inherited `CommonKVSender._record_transfer_indices` and none override `get_transfer_metric`. Notably the backends' *data* paths already index `state_item_lens` per component when computing offsets — only the accounting flattened it, so the transfers themselves were always correct.

## Tests

`test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py`:

- `test_each_state_component_is_charged_its_own_item_length` — two components with deliberately lopsided item lengths; asserts the exact byte count and, separately, that it is *not* the flattened value.
- `test_a_component_with_no_indices_costs_nothing` — a `None` slot must not inflate its neighbours' per-index price.

The existing replication cases are updated to the new field names and still pass unchanged in meaning.

Mutation-checked: restoring the flattened form fails exactly those two new cases and nothing else. Full `test/registered/unit/disaggregation/` suite: 130 passed.

## Interaction with #31993

#31993 (open) reworks this same function to fix a different problem — bytes being paired with a latency window that covers only the last chunk. It preserves the byte formula as-is, carrying the cross product into its new `_transfer_bytes()` helper:

```python
def _transfer_bytes(self, num_kv_indices: int, num_state_indices: int) -> int:
    return (num_kv_indices * self.kv_item_lens_sum
            + num_state_indices * self.state_item_lens_sum)
```

The two changes are complementary — that one fixes *when* bytes are measured, this one fixes *how many* — but they touch adjacent lines and will conflict textually. Happy to rebase onto whichever lands first.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31069926741](https://github.com/sgl-project/sglang/actions/runs/31069926741)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31069926654](https://github.com/sgl-project/sglang/actions/runs/31069926654)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->