### PR TITLE
[AMD] Move test_load_weights_from_remote_instance.py to extra CI

### DIFF
--- a/test/registered/model_loading/test_load_weights_from_remote_instance.py
+++ b/test/registered/model_loading/test_load_weights_from_remote_instance.py
@@ -39,7 +39,7 @@ from sglang.utils import terminate_process
 mp.set_start_method("spawn", force=True)
 
 register_cuda_ci(est_time=145, stage="extra-a", runner_config="2-gpu-large")
-register_amd_ci(est_time=72, suite="stage-b-test-2-gpu-large-amd")
+register_amd_ci(est_time=72, stage="extra-a", runner_config="2-gpu-large-amd")
 
 
 def verify_params_close(params1, params2, error_msg):


### PR DESCRIPTION
## Summary
- move the AMD remote-instance weight-loading test from the default stage-b suite to the label-gated extra-a 2-GPU suite
- mirror the existing CUDA registration so the flaky AMD TransferEngine path no longer blocks default CI while retaining opt-in coverage

## Context
The CI-reduced test randomly selects NCCL or TransferEngine. On AMD, the current Mooncake TransferEngine path can report success while leaving destination weights zeroed. This is an alternative to #30035: it preserves TransferEngine coverage in extra CI instead of forcing AMD CI to NCCL.

## Test plan
- [x] `git diff --check`
- [x] `python3 -m py_compile test/registered/model_loading/test_load_weights_from_remote_instance.py`
- [x] parse CI registrations and verify CUDA maps to `extra-a-test-2-gpu-large` and AMD maps to `extra-a-test-2-gpu-large-amd`
- [ ] run `PR Test Extra (AMD)` on the MI300 2-GPU runner
- [ ] run the ROCm 7.2 extra suite if broader coverage is desired

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31070413873](https://github.com/sgl-project/sglang/actions/runs/31070413873)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31070413799](https://github.com/sgl-project/sglang/actions/runs/31070413799)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->