### PR TITLE
[CI] Reject duplicate server flags in test launches

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -961,6 +961,15 @@ def popen_launch_server(
     if not any(str(arg).startswith(prefill_flag) for arg in other_args):
         other_args = list(other_args) + [prefill_flag, "1024"]
 
+    # argparse keeps the last value, so a repeated flag either says nothing or
+    # silently overrides an earlier one -- both are mistakes, and a test class
+    # that extends a shared args list in place produces them without a trace.
+    seen = [
+        str(arg).split("=", 1)[0] for arg in other_args if str(arg).startswith("--")
+    ]
+    repeated = sorted({flag for flag in seen if seen.count(flag) > 1})
+    assert not repeated, f"server args repeat {repeated}: {other_args}"
+
     # CI-specific: Validate cache and enable offline mode if complete
     if env is None:
         env = os.environ.copy()

--- a/test/registered/attention/test_deterministic.py
+++ b/test/registered/attention/test_deterministic.py
@@ -25,7 +25,7 @@ class TestFlashinferDeterministic(TestDeterministicBase):
     # Test with flashinfer attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
+        args = list(COMMON_SERVER_ARGS)
         args.extend(
             [
                 "--attention-backend",
@@ -40,7 +40,7 @@ class TestFa3Deterministic(TestDeterministicBase):
     # Test with fa3 attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
+        args = list(COMMON_SERVER_ARGS)
         args.extend(
             [
                 "--attention-backend",
@@ -54,7 +54,7 @@ class TestTritonDeterministic(TestDeterministicBase):
     # Test with triton attention backend
     @classmethod
     def get_server_args(cls):
-        args = COMMON_SERVER_ARGS
+        args = list(COMMON_SERVER_ARGS)
         args.extend(
             [
                 "--attention-backend",

--- a/test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
+++ b/test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms_gpqa.py
@@ -84,10 +84,6 @@ MINIMAX_M2_5_W8A8_4P_IN64K_OUT1K_PREFIX90_OTHER_ARGS = [
     "--dtype",
     "bfloat16",
     "--trust-remote-code",
-    "--reasoning-parser",
-    "minimax-append-think",
-    "--tool-call-parser",
-    "minimax-m2",
 ]
 
 

--- a/test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
+++ b/test/registered/npu/accuracy/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms_gpqa.py
@@ -82,10 +82,6 @@ MINIMAX_M2_5_HIGH_THROUGHPUT_OTHER_ARGS = [
     "unquant",
     "--dtype",
     "bfloat16",
-    "--reasoning-parser",
-    "minimax-append-think",
-    "--tool-call-parser",
-    "minimax-m2",
 ]
 
 

--- a/test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms.py
+++ b/test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_4p_in64k_out1k_prefix90_50ms.py
@@ -83,10 +83,6 @@ MINIMAX_M2_5_W8A8_4P_IN64K_OUT1K_PREFIX90_OTHER_ARGS = [
     "--dtype",
     "bfloat16",
     "--trust-remote-code",
-    "--reasoning-parser",
-    "minimax-append-think",
-    "--tool-call-parser",
-    "minimax-m2",
 ]
 
 

--- a/test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms.py
+++ b/test/registered/npu/performance/minimax_m2_5/test_npu_minimax_m2_5_w8a8_8p_in3k5_out1k5_50ms.py
@@ -82,10 +82,6 @@ MINIMAX_M2_5_HIGH_THROUGHPUT_OTHER_ARGS = [
     "unquant",
     "--dtype",
     "bfloat16",
-    "--reasoning-parser",
-    "minimax-append-think",
-    "--tool-call-parser",
-    "minimax-m2",
 ]
 
 


### PR DESCRIPTION
`test_deterministic.py` aliased the shared `COMMON_SERVER_ARGS` list and extended it in place, so each class appended another `--attention-backend` for the next one to inherit -- three backends still resolved correctly only because argparse keeps the last value. Copy the list instead, drop the same copy-paste in four NPU minimax files, and have `popen_launch_server` assert that no flag repeats so the next one fails loudly.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31070472730](https://github.com/sgl-project/sglang/actions/runs/31070472730)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31070472643](https://github.com/sgl-project/sglang/actions/runs/31070472643)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->