### PR TITLE
Preserve streaming preamble before DeepSeek DSML tool calls for all marker forms

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -226,6 +226,34 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
+    def _dsml_section_start(self, text: str) -> int:
+        """Index where the (possibly partial) DSML tool-call section starts.
+
+        -1 when the text carries no marker. Looking for ``bot_token`` alone is
+        not enough: DeepSeek-V4 frequently opens with ``<｜DSML｜invoke`` (no
+        enclosing ``tool_calls`` wrapper) and, with speculative decoding, a
+        single delta can carry both the tail of the preamble and a partial
+        tag — so search every marker form and treat a trailing tag prefix as
+        the boundary too.
+        """
+        positions = [
+            i
+            for i in (
+                text.find(self.bot_token),
+                text.find("<｜DSML｜invoke"),
+                text.find("<｜DSML｜"),
+                text.find("｜DSML｜"),
+            )
+            if i != -1
+        ]
+        if positions:
+            return min(positions)
+        stripped = text.rstrip()
+        for prefix in ("</｜", "<｜", "</", "<"):
+            if stripped.endswith(prefix):
+                return len(stripped) - len(prefix)
+        return -1
+
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
     ) -> StreamingParseResult:
@@ -257,6 +285,20 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if e_token in current_text:
                     current_text = current_text.replace(e_token, "")
             return StreamingParseResult(normal_text=current_text)
+
+        # Preserve assistant prose that shares a delta with the tool-call
+        # opener: without this, everything before the DSML marker in
+        # current_text is silently dropped. V4 emits bare ``<｜DSML｜invoke``
+        # (no wrapper token), which is what actually bites under speculative
+        # decoding's multi-token deltas. Guarded to the first tool call so
+        # text between consecutive invokes is not re-emitted.
+        normal_text = ""
+        if self.current_tool_id == -1:
+            split_at = self._dsml_section_start(current_text)
+            if split_at > 0:
+                normal_text = current_text[:split_at]
+                self._buffer = current_text[split_at:]
+                current_text = self._buffer
 
         all_calls: list[ToolCallItem] = []
         try:
@@ -355,11 +397,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     break
 
             # No more invoke blocks found
-            return StreamingParseResult(normal_text="", calls=all_calls)
+            return StreamingParseResult(normal_text=normal_text, calls=all_calls)
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult(normal_text=current_text)
+            return StreamingParseResult(normal_text=normal_text + current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/test/registered/unit/function_call/test_deepseekv32_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv32_detector.py
@@ -1,0 +1,227 @@
+"""
+Unit tests for the DeepSeek V3.2 / V4 DSML tool-call detectors.
+
+Focus: streaming preamble preservation. Assistant prose that arrives in the
+same streaming delta as the DSML tool-call opener must be emitted as normal
+text instead of being silently dropped. Speculative decoding makes
+multi-token deltas common, so the prose/opener boundary is exercised at every
+possible chunk split point. The load-bearing invariant is that the total
+normal_text emitted across a stream equals the normal_text returned by the
+non-streaming ``detect_and_parse`` for the same input.
+
+DeepSeek-V4 frequently opens a tool-call section with a bare
+``<｜DSML｜invoke`` (no enclosing wrapper token), so preamble preservation is
+tested for every DSML marker form, not just ``bot_token``.
+"""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=7, suite="base-a-test-cpu")
+
+INVOKE_END = "</｜DSML｜invoke>"
+PREAMBLE = "Let me look up the weather in Beijing for you."
+
+
+def _invoke(city):
+    return (
+        '<｜DSML｜invoke name="get_weather">'
+        f'<｜DSML｜parameter name="city" string="true">{city}</｜DSML｜parameter>'
+        + INVOKE_END
+    )
+
+
+def _make_tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_weather",
+                description="Get weather information",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "city": {"type": "string", "description": "City name"},
+                    },
+                    "required": ["city"],
+                },
+            ),
+        ),
+    ]
+
+
+def _collect_streamed_tool_calls(all_calls):
+    tools = {}
+    for c in all_calls:
+        idx = c.tool_index
+        if idx not in tools:
+            tools[idx] = {"name": c.name or "", "parameters": c.parameters or ""}
+        else:
+            if c.name:
+                tools[idx]["name"] += c.name
+            if c.parameters:
+                tools[idx]["parameters"] += c.parameters
+    return [tools[i] for i in sorted(tools.keys())]
+
+
+class _StreamingPreambleTestsMixin:
+    """Shared streaming-preamble tests, run against both DSML detectors."""
+
+    detector_class = None
+
+    def setUp(self):
+        self.tools = _make_tools()
+        detector = self.detector_class()
+        self.bot_token = detector.bot_token
+        self.eot_token = detector.eot_token
+
+    def _wrapped_call(self, *cities):
+        return (
+            self.bot_token + "".join(_invoke(city) for city in cities) + self.eot_token
+        )
+
+    def _stream(self, detector, chunks):
+        normal_text = ""
+        all_calls = []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal_text += result.normal_text
+            all_calls.extend(result.calls)
+        return normal_text, all_calls
+
+    def _assert_calls(self, all_calls, *cities):
+        collected = _collect_streamed_tool_calls(all_calls)
+        self.assertEqual(len(collected), len(cities))
+        for call, city in zip(collected, cities):
+            self.assertEqual(call["name"], "get_weather")
+            self.assertEqual(json.loads(call["parameters"]), {"city": city})
+
+    def test_prose_and_wrapped_opener_in_one_delta(self):
+        """Prose + full wrapped tool call arriving in a single delta."""
+        text = PREAMBLE + self._wrapped_call("Beijing")
+        normal_text, calls = self._stream(self.detector_class(), [text])
+        self.assertEqual(normal_text, PREAMBLE)
+        self._assert_calls(calls, "Beijing")
+
+    def test_prose_and_bare_invoke_in_one_delta(self):
+        """Prose + bare ``<｜DSML｜invoke`` (no wrapper token) in one delta."""
+        text = PREAMBLE + _invoke("Beijing")
+        normal_text, calls = self._stream(self.detector_class(), [text])
+        self.assertEqual(normal_text, PREAMBLE)
+        self._assert_calls(calls, "Beijing")
+
+    def test_prose_emitted_once_at_every_split_point(self):
+        """Two-chunk streams split at every boundary: prose exactly once."""
+        text = PREAMBLE + self._wrapped_call("Beijing")
+        for i in range(1, len(text)):
+            with self.subTest(split=i):
+                chunks = [text[:i], text[i:]]
+                normal_text, calls = self._stream(self.detector_class(), chunks)
+                self.assertEqual(normal_text, PREAMBLE)
+                self._assert_calls(calls, "Beijing")
+
+    def test_bare_invoke_prose_at_every_split_point(self):
+        """Same boundary sweep for the bare-invoke opener form."""
+        text = PREAMBLE + _invoke("Beijing")
+        for i in range(1, len(text)):
+            with self.subTest(split=i):
+                chunks = [text[:i], text[i:]]
+                normal_text, calls = self._stream(self.detector_class(), chunks)
+                self.assertEqual(normal_text, PREAMBLE)
+                self._assert_calls(calls, "Beijing")
+
+    def test_fixed_size_chunkings(self):
+        """Small fixed-size chunks split the opener across >2 deltas."""
+        text = PREAMBLE + self._wrapped_call("Beijing")
+        for size in (1, 3, 7):
+            with self.subTest(chunk_size=size):
+                chunks = [text[i : i + size] for i in range(0, len(text), size)]
+                normal_text, calls = self._stream(self.detector_class(), chunks)
+                self.assertEqual(normal_text, PREAMBLE)
+                self._assert_calls(calls, "Beijing")
+
+    def test_partial_tag_prefix_held_back(self):
+        """A delta ending in a partial tag prefix emits the preceding prose
+        immediately and holds back only the prefix."""
+        full_call = self._wrapped_call("Beijing")
+        for prefix in ("<", "<｜"):
+            with self.subTest(prefix=prefix):
+                detector = self.detector_class()
+                first = detector.parse_streaming_increment(
+                    PREAMBLE + prefix, self.tools
+                )
+                self.assertEqual(first.normal_text, PREAMBLE)
+                second = detector.parse_streaming_increment(
+                    full_call[len(prefix) :], self.tools
+                )
+                normal_text = first.normal_text + second.normal_text
+                self.assertEqual(normal_text, PREAMBLE)
+                self._assert_calls(first.calls + second.calls, "Beijing")
+
+    def test_literal_angle_bracket_without_tool_call(self):
+        """A literal ``<`` in plain prose is never swallowed."""
+        chunks = ["The check 3 <", " 5 held, done."]
+        normal_text, calls = self._stream(self.detector_class(), chunks)
+        self.assertEqual(normal_text, "The check 3 < 5 held, done.")
+        self.assertEqual(calls, [])
+
+    def test_literal_angle_bracket_before_tool_call(self):
+        """A literal ``<`` inside the prose of a tool-call delta stays in the
+        prose; the split happens at the DSML marker, not the first ``<``."""
+        prose = "Since 3 < 5 holds, calling the tool. "
+        text = prose + self._wrapped_call("Beijing")
+        normal_text, calls = self._stream(self.detector_class(), [text])
+        self.assertEqual(normal_text, prose)
+        self._assert_calls(calls, "Beijing")
+
+    def test_multiple_invokes_after_prose(self):
+        """Prose + two invokes in one wrapped section: prose exactly once,
+        both calls parsed, regardless of chunking."""
+        text = PREAMBLE + self._wrapped_call("Beijing", "Tokyo")
+        chunkings = [
+            [text],
+            [text[i : i + 8] for i in range(0, len(text), 8)],
+        ]
+        for chunks in chunkings:
+            with self.subTest(num_chunks=len(chunks)):
+                normal_text, calls = self._stream(self.detector_class(), chunks)
+                self.assertEqual(normal_text, PREAMBLE)
+                self._assert_calls(calls, "Beijing", "Tokyo")
+
+    def test_streaming_matches_detect_and_parse(self):
+        """Invariant: total streamed normal_text equals the non-streaming
+        ``detect_and_parse`` normal_text for the same input, at every split."""
+        text = PREAMBLE + self._wrapped_call("Beijing")
+        reference = self.detector_class().detect_and_parse(text, self.tools)
+        splits = [[text]] + [[text[:i], text[i:]] for i in range(1, len(text))]
+        for chunks in splits:
+            with self.subTest(split=len(chunks[0]) if len(chunks) > 1 else "one-shot"):
+                normal_text, calls = self._stream(self.detector_class(), chunks)
+                self.assertEqual(normal_text, reference.normal_text)
+                collected = _collect_streamed_tool_calls(calls)
+                self.assertEqual(
+                    [c["name"] for c in collected],
+                    [c.name for c in reference.calls],
+                )
+                self.assertEqual(
+                    [json.loads(c["parameters"]) for c in collected],
+                    [json.loads(c.parameters) for c in reference.calls],
+                )
+
+
+class TestDeepSeekV4StreamingPreamble(_StreamingPreambleTestsMixin, CustomTestCase):
+    detector_class = DeepSeekV4Detector
+
+
+class TestDeepSeekV32StreamingPreamble(_StreamingPreambleTestsMixin, CustomTestCase):
+    detector_class = DeepSeekV32Detector
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`DeepSeekV32Detector.parse_streaming_increment` (inherited by `DeepSeekV4Detector`) returns `normal_text=""` on the tool-call branch, so any assistant prose that arrives in the *same streaming delta* as the DSML tool-call opener is silently dropped. The visible message ends mid-sentence, or is empty when the whole preamble lands in that delta. Non-streaming `detect_and_parse` already preserves that prefix, so the two paths disagree.

This is the same defect #31786 identifies, and **that PR's fix is correct** — this change builds on it rather than replacing it. The difference: #31786 anchors the split on `self.bot_token` (`<｜DSML｜tool_calls>`), but DeepSeek-V4 frequently opens a tool call with a bare `<｜DSML｜invoke` and no enclosing wrapper. When that happens `find(bot_token)` returns -1, no split occurs, and the preamble is still lost. **If it is easier to fold these hunks into #31786, that works just as well — the two are not in competition.**

Speculative decoding makes this common rather than rare: multi-token deltas mean "prose and opening tag in the same delta" is the normal case, not a boundary condition.

## Modifications

- `_dsml_section_start()`: returns the index where the (possibly partial) DSML section begins, searching every marker form (`bot_token`, `<｜DSML｜invoke`, `<｜DSML｜`, `｜DSML｜`) and treating a trailing partial tag prefix (`<`, `<｜`, `</`, `</｜`) as the boundary so a chunk that ends mid-tag holds back only the prefix.
- `parse_streaming_increment()`: on entering the tool-call branch, split off any preceding prose, keep only the tag portion buffered, and return the prose as `normal_text`. Guarded to the first tool call (`current_tool_id == -1`) so text between consecutive invokes is not re-emitted.

Tool-call parsing itself is unchanged.

## Accuracy Tests

Measured on 4× RTX PRO 6000 Blackwell (sm_120), TP=4 + DP attention, DeepSeek-V4-Flash-0731, DSPARK speculative decoding, `tool_call_parser=deepseekv4`, thinking enabled. Prompt engineered to force a preamble before the tool call, 8 paired runs, streaming vs non-streaming on the same server:

| build | streaming | non-streaming (control) |
|---|---|---|
| unpatched | **4/8 cut mid-sentence** | 8/8 complete |
| patched | **8/8 complete, 0 cut** | 8/8 complete |

Tool-call arguments remained valid JSON in every run and no DSML markup leaked into content. The serving environment those runs were measured in (image build, patch set, flags) is published at https://github.com/ombori/deepseek-v4-flash-0731-sglang-4x-rtx-pro-6000 if anyone wants to reproduce the streaming behaviour on SM120.

New unit test at `test/registered/unit/function_call/test_deepseekv32_detector.py`, run against both `DeepSeekV4Detector` and `DeepSeekV32Detector`:

- prose + wrapped opener in one delta; prose + bare `<｜DSML｜invoke` in one delta;
- boundary-exhaustive: both opener forms split at **every** index, plus fixed 1/3/7-char chunkings so the opener spans more than two deltas;
- a chunk ending in a partial tag prefix — prefix held back, preceding prose emitted immediately;
- a literal `<` in prose that is not a tag (must not be swallowed, with and without a following tool call);
- two consecutive invokes — prose is not duplicated;
- the load-bearing invariant: concatenated streamed `normal_text` equals non-streaming `detect_and_parse` `normal_text`, and streamed calls equal non-streaming calls (names + parsed arguments), at every split point.

The suite fails on unpatched `main` (9 of 10 test methods, 1144 subtest failures) and passes patched (20/20 tests, 1146 subtests). It is hermetic — pure Python, no GPU, no model.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31072114031](https://github.com/sgl-project/sglang/actions/runs/31072114031)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31072113886](https://github.com/sgl-project/sglang/actions/runs/31072113886)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->