### PR TITLE
[diffusion] Generalize the FLUX.2 VAE decoder fast path to AutoencoderKL (Z-Image / FLUX.1) behind quality=high

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/vaes/flux2_vae_cuda_opt.py
+++ b/python/sglang/multimodal_gen/runtime/models/vaes/flux2_vae_cuda_opt.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
-"""CUDA fast paths for the FLUX.2 VAE decoder (AutoencoderKLFlux2).
+"""CUDA fast paths for KL VAE decoders built on the diffusers ``Decoder``.
+
+Covers the FLUX.2 VAE (``AutoencoderKLFlux2``) and the generic
+``AutoencoderKL`` (FLUX.1 / Z-Image / SD3); both share the exact same
+decoder module family (``ResnetBlock2D`` GroupNorm+SiLU chains,
+``Upsample2D``, single-head mid-block ``Attention``).
 
 All rewrites are mathematically exact re-associations of the original
 operators. Wrappers are installed once at VAE load and dispatch on a
@@ -326,7 +331,8 @@ def _decoder_layout_forward(self, *args, **kwargs):
         )
         self._sgl_channels_last = want_cl
         logger.info(
-            "FLUX.2 VAE: decoder switched to %s layout.",
+            "%s: decoder switched to %s layout.",
+            self._sgl_label,
             "channels_last (NHWC)" if want_cl else "contiguous (NCHW)",
         )
     return type(self).forward(self, *args, **kwargs)
@@ -337,23 +343,16 @@ def _decoder_layout_forward(self, *args, **kwargs):
 # ---------------------------------------------------------------------------
 
 
-def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
-    """Install the quality-gated CUDA FLUX.2 VAE decoder fast paths."""
+def _install_decoder_fast_paths(vae: nn.Module, label: str) -> nn.Module:
+    """Install the quality-gated fast paths on a diffusers ``Decoder`` VAE."""
     from diffusers.models.attention_processor import Attention, AttnProcessor2_0
-    from diffusers.models.autoencoders.vae import Decoder
     from diffusers.models.resnet import ResnetBlock2D
     from diffusers.models.upsampling import Upsample2D
 
-    from sglang.multimodal_gen.runtime.models.vaes.autoencoder_kl_flux2 import (
-        AutoencoderKLFlux2,
-    )
-
-    if not isinstance(vae, AutoencoderKLFlux2) or type(vae.decoder) is not Decoder:
-        return vae
     if getattr(vae, "_spatial_parallel_decode_enabled", False):
         logger.info(
-            "FLUX.2 VAE: spatial-parallel decode enabled; "
-            "skipping CUDA decoder fast paths."
+            "%s: spatial-parallel decode enabled; skipping CUDA decoder fast paths.",
+            label,
         )
         return vae
     if not _HAS_TRITON:
@@ -362,7 +361,7 @@ def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
         # GroupNorm+SiLU fuse (measured: 97 -> 141 ms at 1024^2 with
         # channels_last alone vs 97 -> 29 ms with both).
         logger.warning(
-            "FLUX.2 VAE: Triton unavailable; skipping CUDA decoder fast paths."
+            "%s: Triton unavailable; skipping CUDA decoder fast paths.", label
         )
         return vae
 
@@ -378,8 +377,9 @@ def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
         # channels_last tensors; without a layout-safe rewrite for every
         # attention block the layout switch cannot be applied (fail closed).
         logger.warning(
-            "FLUX.2 VAE: %d/%d attention blocks lack a layout-safe rewrite; "
+            "%s: %d/%d attention blocks lack a layout-safe rewrite; "
             "skipping CUDA decoder fast paths.",
+            label,
             n_attn_total - len(attn_modules),
             n_attn_total,
         )
@@ -387,6 +387,7 @@ def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
 
     gate = VaeFastPathGate()
     decoder._sgl_gate = gate
+    decoder._sgl_label = label
     decoder._sgl_channels_last = False
     decoder.forward = MethodType(_decoder_layout_forward, decoder)
     n_up = _install_fused_upsample(decoder, Upsample2D, gate)
@@ -397,11 +398,37 @@ def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
     n_norm = _install_norm_silu(decoder, ResnetBlock2D, gate)
     setattr(vae, GATE_ATTR, gate)
     logger.info(
-        "FLUX.2 VAE: installed quality-gated decoder fast paths "
+        "%s: installed quality-gated decoder fast paths "
         "(channels_last dispatch, %d fused upsamplers, %d fast attention "
         "blocks, %d GroupNorm+SiLU fusions).",
+        label,
         n_up,
         len(attn_modules),
         n_norm,
     )
     return vae
+
+
+def maybe_optimize_flux2_vae(vae: nn.Module) -> nn.Module:
+    """Install the quality-gated CUDA FLUX.2 VAE decoder fast paths."""
+    from diffusers.models.autoencoders.vae import Decoder
+
+    from sglang.multimodal_gen.runtime.models.vaes.autoencoder_kl_flux2 import (
+        AutoencoderKLFlux2,
+    )
+
+    if not isinstance(vae, AutoencoderKLFlux2) or type(vae.decoder) is not Decoder:
+        return vae
+    return _install_decoder_fast_paths(vae, "FLUX.2 VAE")
+
+
+def maybe_optimize_autoencoder_kl(vae: nn.Module) -> nn.Module:
+    """Install the quality-gated CUDA fast paths on the generic
+    ``AutoencoderKL`` decoder (FLUX.1 / Z-Image / SD3)."""
+    from diffusers.models.autoencoders.vae import Decoder
+
+    from sglang.multimodal_gen.runtime.models.vaes.autoencoder import AutoencoderKL
+
+    if not isinstance(vae, AutoencoderKL) or type(vae.decoder) is not Decoder:
+        return vae
+    return _install_decoder_fast_paths(vae, "AutoencoderKL VAE")

--- a/python/sglang/multimodal_gen/runtime/platforms/cuda.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/cuda.py
@@ -550,7 +550,8 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def optimize_vae(cls, vae: torch.nn.Module) -> torch.nn.Module:
-        """Install the quality-gated FLUX.2 / Wan VAE decoder fast paths.
+        """Install the quality-gated FLUX.2 / AutoencoderKL / Wan VAE decoder
+        fast paths.
 
         Requests with quality == "high" run the fast paths; the "lossless"
         default runs the original module path bit-for-bit. See
@@ -558,6 +559,7 @@ class CudaPlatformBase(Platform):
         """
         try:
             from sglang.multimodal_gen.runtime.models.vaes.flux2_vae_cuda_opt import (
+                maybe_optimize_autoencoder_kl,
                 maybe_optimize_flux2_vae,
             )
             from sglang.multimodal_gen.runtime.models.vaes.wan_vae_cuda_opt import (
@@ -565,6 +567,7 @@ class CudaPlatformBase(Platform):
             )
 
             vae = maybe_optimize_flux2_vae(vae)
+            vae = maybe_optimize_autoencoder_kl(vae)
             vae = maybe_optimize_wan_vae(vae)
         except Exception:
             logger.warning(

--- a/test/registered/kernels/ops/diffusion/test_autoencoder_kl_fastpath.py
+++ b/test/registered/kernels/ops/diffusion/test_autoencoder_kl_fastpath.py
@@ -1,5 +1,7 @@
 """Install-path checks for the generic AutoencoderKL CUDA fast path."""
 
+import sys
+
 import pytest
 import torch
 
@@ -48,3 +50,7 @@ def test_autoencoder_kl_fastpath_install():
     torch.testing.assert_close(opt.decode(z).float(), ref.float(), atol=0.1, rtol=0)
     gate.enabled = False
     assert torch.equal(opt.decode(z), ref)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/kernels/ops/diffusion/test_autoencoder_kl_fastpath.py
+++ b/test/registered/kernels/ops/diffusion/test_autoencoder_kl_fastpath.py
@@ -1,0 +1,50 @@
+"""Install-path checks for the generic AutoencoderKL CUDA fast path."""
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.configs.models.vaes.stablediffusion3 import (
+    StableDiffusion3VAEConfig,
+)
+from sglang.multimodal_gen.runtime.models.vaes import flux2_vae_cuda_opt as vae_opt
+from sglang.multimodal_gen.runtime.models.vaes.autoencoder import AutoencoderKL
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=40, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+
+
+def _small_config():
+    config = StableDiffusion3VAEConfig()
+    config.arch_config.latent_channels = 2
+    config.arch_config.block_out_channels = (4, 4)
+    config.arch_config.down_block_types = ("DownEncoderBlock2D",) * 2
+    config.arch_config.up_block_types = ("UpDecoderBlock2D",) * 2
+    config.arch_config.layers_per_block = 1
+    config.arch_config.norm_num_groups = 1
+    config.arch_config.sample_size = 8
+    return config
+
+
+@torch.no_grad()
+def test_autoencoder_kl_fastpath_install():
+    torch.manual_seed(0)
+    vae = AutoencoderKL(_small_config()).to("cuda", torch.bfloat16).eval()
+    ref_names = {n for n, _ in vae.named_parameters()}
+    ref_sd = {k: v.clone() for k, v in vae.state_dict().items()}
+    z = torch.randn(1, 2, 8, 8, device="cuda", dtype=torch.bfloat16)
+    ref = vae.decode(z)
+
+    opt = vae_opt.maybe_optimize_autoencoder_kl(vae)
+    gate = getattr(opt, vae_opt.GATE_ATTR, None)
+    assert gate is not None and not gate.enabled
+    # Wrappers must not change parameter FQNs; strict load must round-trip.
+    assert {n for n, _ in opt.named_parameters()} == ref_names
+    opt.load_state_dict(ref_sd, strict=True)
+    # Gate off: bit-for-bit the original path.
+    assert torch.equal(opt.decode(z), ref)
+    # Gate on: fast path runs and stays close; gate off again restores exact.
+    gate.enabled = True
+    torch.testing.assert_close(opt.decode(z).float(), ref.float(), atol=0.1, rtol=0)
+    gate.enabled = False
+    assert torch.equal(opt.decode(z), ref)


### PR DESCRIPTION
Generalization of the merged #33451 (FLUX.2 VAE fast path) to the generic `AutoencoderKL`; no new kernels, no new gate machinery.

## Motivation

#33451 introduced a request-scoped, quality-gated CUDA fast path for the FLUX.2 VAE decoder (two-pass Triton GroupNorm+SiLU, fused nearest-2x upsample + conv, single-head attention V/proj fold, channels_last dispatch). Everything it installs operates on the diffusers `Decoder` module family (`ResnetBlock2D` GroupNorm+SiLU chains, `Upsample2D`, single-head mid-block `Attention`) — which is exactly the decoder of the generic `AutoencoderKL` (`runtime/models/vaes/autoencoder.py`) used by Z-Image, FLUX.1 and SD3.

Distilled few-step pipelines are the sweet spot: VAE decode is a fixed per-image cost, so the fewer the denoise steps, the larger its share. Measured decode share of e2e on H200 (1024^2, bf16, explicit sync around the DecodingStage decode call):

- Z-Image-Turbo (9 steps): 95.8 ms of 1.126 s e2e = **8.5%**
- FLUX.1-schnell (4 steps): 89.9 ms of 0.834 s e2e = **10.8%**

## Modifications

**`runtime/models/vaes/flux2_vae_cuda_opt.py` (+52/−16)** — the FLUX.2-only entry point is split into `_install_decoder_fast_paths(vae, label)` (the existing install body, unchanged except the parameterized log label) and two thin type-guarded entry points: `maybe_optimize_flux2_vae` (exactly as before) and the new `maybe_optimize_autoencoder_kl` (exact `AutoencoderKL` + diffusers `Decoder` type check).

**`runtime/platforms/cuda.py` (+3/−1)** — `optimize_vae` additionally calls `maybe_optimize_autoencoder_kl`.

All #33451 semantics carry over verbatim (`VaeFastPathGate` / `GATE_ATTR` stay shared with the Wan path from #33546):

- `quality == "high"` (#33453 tier) runs the fast paths; the `"lossless"` default runs the original module path bit-for-bit, so golden-output CI is unaffected;
- install is all-or-nothing and fail-closed: no Triton, spatial-parallel decode enabled, or any attention block lacking the layout-safe rewrite → nothing is installed;
- wrappers keep parameter FQNs unchanged (state-dict strict load and weight transfer stay name-stable).

On Z-Image / FLUX.1 the installer reports: 3 fused upsamplers, 1 fast attention block, 29 GroupNorm+SiLU fusions.

## Speedup

All numbers H200, bf16 decode, 1024^2, seed 42, GPU pinned via `CUDA_VISIBLE_DEVICES`. e2e protocol as in #33451: one warmed process, 10 sequential identical requests, first dropped, median of 9, client-side per-request wall-clock (the pipeline stage timer stops at decode kernel launch without a sync, so it is decode-blind by construction — see #33451).

**Component (VAE decode wall-clock, explicit `torch.cuda.synchronize()` around the DecodingStage decode call, median of 9):**

| model | lossless (= main) | quality=high | speedup |
|---|---|---|---|
| Z-Image-Turbo (9 steps) | 95.8 ms | **39.3 ms** | 2.44x |
| FLUX.1-schnell (4 steps) | 89.9 ms | **33.2 ms** | 2.71x |

**End-to-end:**

| model | lossless | `--quality high` | Δ per request |
|---|---|---|---|
| Z-Image-Turbo (9 steps) | 1.126 s | **1.071 s** | −55 ms (**−4.9%**) |
| FLUX.1-schnell (4 steps) | 0.834 s | **0.774 s** | −60 ms (**−7.2%**) |

The e2e deltas match the component decode deltas within run-to-run noise (Z-Image −56.5 ms component vs −55 ms e2e; schnell −56.7 ms vs −60 ms), closing the attribution loop. The log confirms the fast path engages only for `quality=high` ("AutoencoderKL VAE: decoder switched to channels_last (NHWC) layout" never appears in lossless runs).

Note on weights: `black-forest-labs/FLUX.1-schnell` recently became gated on HF, so the schnell numbers use the `unsloth/FLUX.1-schnell` mirror (Apache-2.0, file-for-file diffusers copy of the official checkpoint).

Side-by-side samples (lossless left, quality=high right):

**Z-Image-Turbo**
![zimage](https://github.com/BBuf/sglang/releases/download/assets-prb-autoencoderkl/sample_zimage_lossless_vs_high.png)

**FLUX.1-schnell**
![schnell](https://github.com/BBuf/sglang/releases/download/assets-prb-autoencoderkl/sample_schnell_lossless_vs_high.png)

### Benchmark configuration

All arms above run the **default eager configuration** (`performance_mode=auto`; every archived server log shows `enable_torch_compile: false, regional_compile: false`) — i.e. the default production path for this model. Runs with `--enable-torch-compile` are unaffected: `--enable-torch-compile` compiles the DiT only; the VAE decode path is eager in both tiers and the fast path is mounted per-request for `quality="high"` exactly as in #33451.

Benchmark driver (local mode, one warmed process; 10 sequential requests, first dropped, median of 9):

```python
from sglang.multimodal_gen import DiffGenerator

gen = DiffGenerator.from_pretrained(
    model_path="Tongyi-MAI/Z-Image-Turbo"  # and "unsloth/FLUX.1-schnell" (4 steps), num_gpus=1, local_mode=True
)
for i in range(10):
    gen.generate(sampling_params_kwargs=dict(
        prompt=PROMPT, seed=42, width=1024, height=1024,
        num_inference_steps=9,
        quality="lossless",  # or "high" to engage the decoder fast path
    ))
```

## Accuracy

- **Lossless default is bit-exact end-to-end**: gate-off runs on this branch produce byte-identical PNGs (md5) to `origin/main` (604d3561b0) for both models x 2 prompts (4/4 pairs identical).
- **quality=high**: PSNR/SSIM vs the lossless output, same seed and prompt (maintainer bar for the high tier: PSNR > 25 dB):

| model | prompt | PSNR (dB) | SSIM | maxdiff | PASS |
|---|---|---|---|---|---|
| Z-Image-Turbo | red panda | 57.90 | 0.99923 | 5/255 | yes |
| Z-Image-Turbo | stormy shore | 57.51 | 0.99929 | 7/255 | yes |
| FLUX.1-schnell | red panda | 55.56 | 0.99917 | 16/255 | yes |
| FLUX.1-schnell | stormy shore | 55.17 | 0.99924 | 11/255 | yes |

All pairs sit 30 dB above the bar — bf16 rounding-order level, the same deviation class as #33451 (whose fp32 ground-truth check showed the fast path is not statistically further from an fp32 reference than the baseline bf16 decoder; the numerics here are the same kernels on the same module family).

- **Unit test**: `test/registered/kernels/ops/diffusion/test_autoencoder_kl_fastpath.py` (+50, registered CUDA CI): install on a small `AutoencoderKL` publishes the gate, keeps the parameter-FQN set unchanged, round-trips a strict state-dict load, decodes bit-exactly with the gate off (also after a gate-on decode), and stays close with the gate on. Existing `test_flux2_vae_fastpath.py` / `test_wan_vae_fastpath.py` still pass (4 passed).

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31099436033](https://github.com/sgl-project/sglang/actions/runs/31099436033)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31099436117](https://github.com/sgl-project/sglang/actions/runs/31099436117)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
