### PR TITLE
[diffusion] Ideogram 4: fuse RMSNorm modulate/gate chains via the Z-Image Triton suite behind quality=high (H200 e2e -2.9%/-3.4%)

### DIFF
--- a/python/sglang/kernels/ops/diffusion/fused_gate_rmsnorm.py
+++ b/python/sglang/kernels/ops/diffusion/fused_gate_rmsnorm.py
@@ -1,0 +1,135 @@
+"""Quality-gated fused RMSNorm modulate/gate sites (Z-Image Triton suite reuse).
+
+Adaln-style DiT blocks (Ideogram 4) spend four elementwise chains per block on
+modulate/gate around each RMSNorm: ``RMSNorm(x) * scale`` before
+attention/FFN and ``x + tanh(gate) * RMSNorm(out)`` after. The Z-Image
+bf16-native Triton kernels
+(:mod:`sglang.kernels.ops.diffusion.triton.zimage_native_norm`) fuse each
+chain into a single kernel (RMSNorm + tanh + mul + add in one pass).
+
+Z-Image mounts those kernels unconditionally because they reproduce its own
+native-bf16 reference RMSNorm. Ideogram's reference norm is ``F.rms_norm``
+(fp32 internal statistics), so the fused path is numerically close (the norm
+statistics round through bf16) but **not bit-exact**. Following the
+fused-linear-GELU precedent, sites are therefore mounted only for
+``quality="high"`` requests via :func:`mount_fused_gate_rmsnorm` /
+:func:`unmount_fused_gate_rmsnorm` at batch boundaries; the default
+``"lossless"`` path keeps the unmodified reference chain bit-for-bit.
+
+Mounting is all-or-nothing per transformer: if any marked site fails the
+static guards (non-bf16 norm weight, hidden size above the kernel limit, ...)
+every site on that transformer stays on the reference path.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterator
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# Attributes of the site protocol (set by ``mark_fused_gate_rmsnorm_site``).
+_SITE_NORM_ATTRS = "_sgl_fused_gate_rmsnorm_norm_attrs"
+_SITE_ENABLED_ATTR = "_sgl_fused_gate_rmsnorm_enabled"
+
+# The Triton kernels mask a single block over the hidden dim.
+_MAX_HIDDEN_SIZE = 8192
+
+
+def fused_rmsnorm_scale(
+    x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor, eps: float
+) -> torch.Tensor | None:
+    """``RMSNorm(x, weight, eps) * scale`` in one Triton kernel (or None)."""
+    from sglang.kernels.ops.diffusion.triton.zimage_native_norm import (
+        zimage_rmsnorm_scale,
+    )
+
+    return zimage_rmsnorm_scale(x, weight, scale, eps)
+
+
+def fused_rmsnorm_tanh_residual(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> torch.Tensor | None:
+    """``residual + tanh(gate) * RMSNorm(x, weight, eps)`` fused (or None)."""
+    from sglang.kernels.ops.diffusion.triton.zimage_native_norm import (
+        zimage_rmsnorm_tanh_residual,
+    )
+
+    return zimage_rmsnorm_tanh_residual(x, gate, residual, weight, eps)
+
+
+def _static_reject_reason(site: nn.Module) -> str | None:
+    """Why ``site`` may never use the fused kernels, or None if it may."""
+    try:
+        import triton  # type: ignore # noqa: F401
+    except ImportError:
+        return "triton unavailable"
+    for attr in getattr(site, _SITE_NORM_ATTRS, ()):
+        norm = getattr(site, attr, None)
+        weight = getattr(norm, "weight", None)
+        if weight is None or weight.dim() != 1:
+            return f"{attr}: missing or non-1D norm weight"
+        if weight.dtype != torch.bfloat16:
+            return f"{attr}: non-bf16 norm weight dtype {weight.dtype}"
+        if weight.numel() > _MAX_HIDDEN_SIZE:
+            return f"{attr}: hidden size {weight.numel()} above kernel limit"
+    return None
+
+
+def mark_fused_gate_rmsnorm_site(module: nn.Module, norm_attrs: tuple[str, ...]):
+    """Declare ``module`` as a fused RMSNorm modulate/gate site.
+
+    ``norm_attrs`` names the site's RMSNorm submodules (checked by the static
+    guards at mount time). The site starts unmounted
+    (``_sgl_fused_gate_rmsnorm_enabled = False``): the module's forward must
+    keep the reference path bit-exact until :func:`mount_fused_gate_rmsnorm`
+    enables it.
+    """
+    setattr(module, _SITE_NORM_ATTRS, tuple(norm_attrs))
+    setattr(module, _SITE_ENABLED_ATTR, False)
+
+
+def iter_fused_gate_rmsnorm_sites(root: nn.Module) -> Iterator[nn.Module]:
+    """Yield every marked site under ``root`` (including ``root``)."""
+    for module in root.modules():
+        if getattr(module, _SITE_NORM_ATTRS, None) is not None:
+            yield module
+
+
+def mount_fused_gate_rmsnorm(root: nn.Module) -> bool:
+    """Enable the fused kernels on every marked site under ``root``.
+
+    All-or-nothing: if any marked site fails the static guards, every site is
+    left (or reset) on the reference path and False is returned. Returns False
+    as well when ``root`` has no marked sites.
+    """
+    sites = list(iter_fused_gate_rmsnorm_sites(root))
+    if not sites:
+        return False
+    for site in sites:
+        reason = _static_reject_reason(site)
+        if reason is not None:
+            unmount_fused_gate_rmsnorm(root)
+            logger.info(
+                "fused gate RMSNorm: %s site failed static guards (%s); "
+                "keeping the whole model on the reference path",
+                type(site).__name__,
+                reason,
+            )
+            return False
+    for site in sites:
+        setattr(site, _SITE_ENABLED_ATTR, True)
+    return True
+
+
+def unmount_fused_gate_rmsnorm(root: nn.Module) -> None:
+    """Reset every marked site under ``root`` to the bit-exact reference path."""
+    for site in iter_fused_gate_rmsnorm_sites(root):
+        setattr(site, _SITE_ENABLED_ATTR, False)

--- a/python/sglang/multimodal_gen/runtime/models/dits/ideogram.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ideogram.py
@@ -7,6 +7,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from sglang.kernels.ops.diffusion.fused_gate_rmsnorm import (
+    fused_rmsnorm_scale,
+    fused_rmsnorm_tanh_residual,
+    mark_fused_gate_rmsnorm_site,
+)
 from sglang.multimodal_gen.configs.models.dits.ideogram import Ideogram4DiTConfig
 from sglang.multimodal_gen.runtime.distributed import (
     divide,
@@ -294,6 +299,46 @@ class Ideogram4MLP(nn.Module):
         return self.w2(F.silu(self.w1(x)) * self.w3(x))
 
 
+def _norm_scale(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    norm: Ideogram4RMSNorm,
+    enable_fused: bool,
+) -> torch.Tensor:
+    """``RMSNorm(x) * (1 + scale)``, fused for ``quality="high"`` batches."""
+    if enable_fused:
+        y = fused_rmsnorm_scale(
+            x,
+            norm.weight.data.to(device=x.device, dtype=x.dtype).contiguous(),
+            1.0 + scale,
+            norm.eps,
+        )
+        if y is not None:
+            return y
+    return norm(x) * (1.0 + scale)
+
+
+def _gate_residual(
+    x: torch.Tensor,
+    gate: torch.Tensor,
+    residual: torch.Tensor,
+    norm: Ideogram4RMSNorm,
+    enable_fused: bool,
+) -> torch.Tensor:
+    """``residual + tanh(gate) * RMSNorm(x)``, fused for ``quality="high"``."""
+    if enable_fused:
+        y = fused_rmsnorm_tanh_residual(
+            x,
+            gate,
+            residual,
+            norm.weight.data.to(device=x.device, dtype=x.dtype).contiguous(),
+            norm.eps,
+        )
+        if y is not None:
+            return y
+    return residual + torch.tanh(gate) * norm(x)
+
+
 class Ideogram4TransformerBlock(nn.Module):
     def __init__(
         self,
@@ -328,6 +373,13 @@ class Ideogram4TransformerBlock(nn.Module):
         self.ffn_norm1 = Ideogram4RMSNorm(hidden_size, eps=norm_eps)
         self.attention_norm2 = Ideogram4RMSNorm(hidden_size, eps=norm_eps)
         self.ffn_norm2 = Ideogram4RMSNorm(hidden_size, eps=norm_eps)
+        # quality="high" fusion sites: each RMSNorm modulate/gate chain
+        # collapses into one Triton kernel (Z-Image bf16-native suite). Off by
+        # default (bit-exact reference path); mounted per batch by the
+        # denoising stage.
+        mark_fused_gate_rmsnorm_site(
+            self, ("attention_norm1", "attention_norm2", "ffn_norm1", "ffn_norm2")
+        )
         self.adaln_modulation = _linear(
             adaln_dim,
             4 * hidden_size,
@@ -341,20 +393,21 @@ class Ideogram4TransformerBlock(nn.Module):
         scale_msa, gate_msa, scale_mlp, gate_mlp = self.adaln_modulation(
             adaln_input
         ).chunk(4, dim=-1)
-        gate_msa = torch.tanh(gate_msa)
-        gate_mlp = torch.tanh(gate_mlp)
+        enable_fused = (
+            self._sgl_fused_gate_rmsnorm_enabled and not torch.compiler.is_compiling()
+        )
         attn_out = self.attention(
-            self.attention_norm1(x) * (1.0 + scale_msa),
+            _norm_scale(x, scale_msa, self.attention_norm1, enable_fused),
             cos=cos,
             sin=sin,
             attn_mask=attn_mask,
             attn_mask_meta=attn_mask_meta,
         )
-        x = x + gate_msa * self.attention_norm2(attn_out)
-        x = x + gate_mlp * self.ffn_norm2(
-            self.feed_forward(self.ffn_norm1(x) * (1.0 + scale_mlp))
+        x = _gate_residual(attn_out, gate_msa, x, self.attention_norm2, enable_fused)
+        ffn_out = self.feed_forward(
+            _norm_scale(x, scale_mlp, self.ffn_norm1, enable_fused)
         )
-        return x
+        return _gate_residual(ffn_out, gate_mlp, x, self.ffn_norm2, enable_fused)
 
 
 def _sinusoidal_embedding(t: torch.Tensor, dim: int, scale: float = 1e4):

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -20,6 +20,10 @@ from typing import Any
 import torch
 import torch.nn as nn
 
+from sglang.kernels.ops.diffusion.fused_gate_rmsnorm import (
+    mount_fused_gate_rmsnorm,
+    unmount_fused_gate_rmsnorm,
+)
 from sglang.kernels.ops.diffusion.fused_linear_gelu import (
     mount_fused_linear_gelu,
     unmount_fused_linear_gelu,
@@ -226,9 +230,9 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         # cache-dit state (for delayed mounting and idempotent control)
         self._cache_dit_enabled = False
         self._cached_num_steps = None
-        # fused linear+GELU state: whether the cublasLt-epilogue fusion is
-        # currently mounted on the transformers (quality="high" batches only).
-        self._fused_gelu_mounted = False
+        # quality="high" fusion state: whether the cublasLt linear+GELU and
+        # fused gate-RMSNorm sites are currently mounted on the transformers.
+        self._quality_fusions_mounted = False
         self._torch_compile_registry = CompiledModuleRegistry()
         # Breakable CUDA graph runners, one per transformer module (lazy).
         self._bcg_runners: dict[int, Any] = {}
@@ -450,37 +454,46 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         self, num_inference_steps: int | tuple[int, int], batch: Req
     ) -> None:
         """Apply request-dependent transformer acceleration in trace-safe order."""
-        self._maybe_toggle_fused_gelu(batch)
+        self._maybe_toggle_quality_fusions(batch)
         self._maybe_enable_cache_dit(num_inference_steps, batch)
         for transformer in filter(None, [self.transformer, self.transformer_2]):
             self._maybe_torch_compile(transformer)
 
-    def _maybe_toggle_fused_gelu(self, batch: Req) -> None:
-        """Mount/unmount the cublasLt linear+GELU fusion for this batch.
+    def _maybe_toggle_quality_fusions(self, batch: Req) -> None:
+        """Mount/unmount the ``quality="high"`` fusions for this batch.
 
-        The fused epilogue is numerically equivalent only at half-precision
-        rounding level (not bit-exact), so it is mounted for
-        ``quality="high"`` requests and unmounted otherwise -- the
-        ``"lossless"`` default runs the unmodified reference path bit-for-bit.
-        ``quality`` participates in the dynamic-batch signature, so a worker
-        batch is uniform in ``quality`` and this process-wide transition is
-        safe at the batch boundary. Mounting is all-or-nothing per
-        transformer (any ineligible marked site keeps the whole transformer
-        on the reference path); models without marked sites are no-ops.
+        The cublasLt linear+GELU epilogue and the fused gate-RMSNorm Triton
+        kernels are numerically equivalent only at half-precision rounding
+        level (not bit-exact), so they are mounted for ``quality="high"``
+        requests and unmounted otherwise -- the ``"lossless"`` default runs
+        the unmodified reference path bit-for-bit. ``quality`` participates
+        in the dynamic-batch signature, so a worker batch is uniform in
+        ``quality`` and this process-wide transition is safe at the batch
+        boundary. Mounting is all-or-nothing per transformer and per fusion
+        family (any ineligible marked site keeps the whole transformer on
+        that family's reference path); models without marked sites are
+        no-ops.
         """
         want = getattr(batch.sampling_params, "quality", "lossless") == "high"
-        if want == self._fused_gelu_mounted:
+        if want == self._quality_fusions_mounted:
             return
-        mounted = False
+        mounted_gelu = False
+        mounted_gate_norm = False
         for transformer in filter(None, [self.transformer, self.transformer_2]):
             if want:
-                mounted |= mount_fused_linear_gelu(transformer)
+                mounted_gelu |= mount_fused_linear_gelu(transformer)
+                mounted_gate_norm |= mount_fused_gate_rmsnorm(transformer)
             else:
                 unmount_fused_linear_gelu(transformer)
-        self._fused_gelu_mounted = want
-        if want and mounted:
+                unmount_fused_gate_rmsnorm(transformer)
+        self._quality_fusions_mounted = want
+        if want and mounted_gelu:
             logger.info(
                 "Mounted fused linear+GELU (cublasLt epilogue) for quality=high"
+            )
+        if want and mounted_gate_norm:
+            logger.info(
+                "Mounted fused gate RMSNorm (Z-Image Triton suite) for quality=high"
             )
 
     def _cache_dit_dual_model_name(self) -> str:

--- a/test/registered/kernels/ops/diffusion/test_fused_gate_rmsnorm.py
+++ b/test/registered/kernels/ops/diffusion/test_fused_gate_rmsnorm.py
@@ -1,0 +1,54 @@
+"""Core checks for the quality-gated fused gate-RMSNorm (Z-Image suite reuse)."""
+
+import sys
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from sglang.kernels.ops.diffusion import fused_gate_rmsnorm as fgn
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=4, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+pytestmark = pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA required")
+DIM, EPS = 4608, 1e-5  # Ideogram 4 hidden size / norm_eps
+
+
+class _Site(nn.Module):
+    def __init__(self, dtype=torch.bfloat16):
+        super().__init__()
+        self.norm = nn.RMSNorm(DIM, eps=EPS, device="cuda", dtype=dtype)
+        fgn.mark_fused_gate_rmsnorm_site(self, ("norm",))
+
+
+def test_fused_matches_ideogram_reference():
+    torch.manual_seed(0)
+    site = _Site()
+    w = site.norm.weight.data
+    x = torch.randn(1, 64, DIM, device="cuda", dtype=torch.bfloat16)
+    residual = torch.randn_like(x)
+    # adaln-style strided chunks, as produced by Ideogram's modulation .chunk()
+    mods = torch.randn(1, 1, 2 * DIM, device="cuda", dtype=torch.bfloat16)
+    scale, gate = mods.chunk(2, dim=-1)
+    assert fgn.mount_fused_gate_rmsnorm(site)
+    got_scale = fgn.fused_rmsnorm_scale(x, w, 1.0 + scale, EPS)
+    got_gate = fgn.fused_rmsnorm_tanh_residual(x, gate, residual, w, EPS)
+    ref_scale = F.rms_norm(x, (DIM,), w, EPS) * (1.0 + scale)
+    ref_gate = residual + torch.tanh(gate) * F.rms_norm(x, (DIM,), w, EPS)
+    # fused path uses bf16-native norm statistics: close, not bit-exact
+    torch.testing.assert_close(got_scale, ref_scale, atol=8e-2, rtol=4e-2)
+    torch.testing.assert_close(got_gate, ref_gate, atol=8e-2, rtol=4e-2)
+
+
+def test_mount_guards_all_or_nothing():
+    good, bad = _Site(), _Site(torch.float32)
+    assert not fgn.mount_fused_gate_rmsnorm(nn.ModuleList([good, bad]))
+    assert not good._sgl_fused_gate_rmsnorm_enabled
+    assert fgn.mount_fused_gate_rmsnorm(good)
+    fgn.unmount_fused_gate_rmsnorm(good)
+    assert not good._sgl_fused_gate_rmsnorm_enabled
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Reuses the Z-Image bf16-native norm kernels already in-tree (`kernels/ops/diffusion/triton/zimage_native_norm.py`) — **no new kernels**; adds the mount/unmount site protocol for them (same shape as #33536's `fused_linear_gelu`). 4 files, +283/−28.

## Motivation

The adaptation-matrix audit (main @ 407a65d3c) flagged Ideogram 4's transformer block as form-identical to Z-Image's modulate/gate structure, for which a fused Triton suite already ships on Z-Image's default path:

- **Gate sites**: `x + tanh(gate) * RMSNorm(out)` — 2 sites/block x 34 blocks = 68 sites/step; eager = tanh + RMSNorm + mul + add over the `[tokens, 4608]` stream.
- **Modulate sites** (rider, covered by the same suite): `RMSNorm(x) * (1 + scale)` — 2 sites/block x 34 blocks; eager = RMSNorm + add + mul.

At V4_FAST_20 (guidance 1.0, single forward per step) that is 1,360 gate + 1,360 modulate eager chains per 1024x1024 image; V4_INSTANT_8 has 544 + 544. `zimage_rmsnorm_tanh_residual` / `zimage_rmsnorm_scale` fuse each chain into one kernel.

## Why quality=high and not the lossless default

Z-Image mounts these kernels unconditionally because they reproduce its own native-bf16 reference RMSNorm by design. Ideogram's reference norm is `F.rms_norm` (fp32 internal statistics), so on Ideogram the fused path is close but **not bit-exact** — probed at real shapes (`[1, 4096..4736, 4608]`, bf16): max abs diff 0.0625, i.e. bf16 rounding of the norm statistics. Following the #33536 precedent (and the same disposition as the FLUX.1 GELU gate in #33819), the sites are **mounted only for `quality="high"` requests**; the `"lossless"` default runs the unmodified reference chain byte-for-byte (md5 proof below).

## Modifications

- **`kernels/ops/diffusion/fused_gate_rmsnorm.py` (new)** — mount/unmount site protocol for the existing Z-Image Triton kernels, mirroring `fused_linear_gelu`: `mark_fused_gate_rmsnorm_site(module, norm_attrs)`, all-or-nothing `mount_fused_gate_rmsnorm` with static guards (bf16 1-D norm weight, hidden <= 8192 kernel limit, Triton available), `unmount_...` resets to the bit-exact reference. Thin `fused_rmsnorm_scale` / `fused_rmsnorm_tanh_residual` wrappers re-export the kernels, which keep their own runtime shape/stride/dtype guards and return `None` to fall back per call.
- **`runtime/models/dits/ideogram.py`** — the four per-block chains route through `_norm_scale` / `_gate_residual` helpers: fused when the site is mounted, `torch.compiler.is_compiling()` escape hatch (compiled graphs never bake in the Triton path), eager fallback otherwise. The reference expressions are unchanged from main (verified `torch.equal` at operator level and md5-identical e2e). The kernels consume the raw adaln `.chunk()` slices directly (strided-gate support is native), so no extra copies.
- **`runtime/pipelines_core/stages/denoising.py`** — `_maybe_toggle_fused_gelu` generalized to `_maybe_toggle_quality_fusions`: the same batch-boundary toggle now mounts/unmounts both quality=high fusion families (cublasLt linear+GELU and gate-RMSNorm). Models without marked sites are no-ops, exactly as before; log-confirmed on Ideogram: `Mounted fused gate RMSNorm (Z-Image Triton suite) for quality=high`.

## Speed Tests (H200)

`cocktailpeanut/ideogram-4-fp8` — byte-layout-identical ungated mirror of `ideogram-ai/ideogram-4-fp8` (official repo and both `fal/ideogram-v4-*` distilled repos are HF-gated) — 1024x1024, fixed prompt, `seed=42`, guidance 1.0 presets (single DiT forward per step). Client wall-clock in one warmed process, 10 consecutive generations, first dropped, median of 9 (#33451/#33536/#33734 protocol), single H200 (`CUDA_VISIBLE_DEVICES=7`).

| Preset | Arm | E2E wall (s) | DenoisingStage (ms) |
| --- | --- | ---: | ---: |
| V4_FAST_20 | this PR, lossless (default) | 8.482 | 8259 |
| V4_FAST_20 | this PR, quality=high | 8.239 (**-2.9%**) | 7977 (**-3.4%**) |
| V4_INSTANT_8 | this PR, lossless (default) | 3.488 | 3243 |
| V4_INSTANT_8 | this PR, quality=high | 3.371 (**-3.4%**) | 3118 (**-3.9%**) |

main @ 604d3561b0 single-shot sanity anchors agree with the lossless arm within noise (FAST_20 8.548 s / denoise 8219 ms; INSTANT_8 3.498 s / denoise 3224 ms), as they must — the lossless path is byte-identical (below).

Attribution closes against kernel microbenchmarks at the real shapes (bf16, 200 iters after warmup, H200):

| Op | shape | eager | fused | speedup |
| --- | --- | ---: | ---: | ---: |
| gate+residual | (1, 4096, 4608), gate (1,1,4608) | 107.5 us | 34.5 us | **3.12x** |
| norm+modulate | (1, 4096, 4608), scale (1,1,4608) | 77.7 us | 39.2 us | **1.98x** |
| gate+residual | (1, 4736, 4608) | 123.6 us | 38.0 us | **3.26x** |
| norm+modulate | (1, 4736, 4608) | 89.7 us | 38.7 us | **2.32x** |

Summed over sites: ~223 us/block x 34 blocks ≈ 7.6 ms/step ≈ 152 ms per FAST_20 image from the four chains alone; measured denoise delta is 282 ms (the fused calls also drop the standalone per-block `tanh` launches and their sync/launch overhead at 2.4 it/s). Per-step saving is preset-independent (~14 ms/step), so the few-step INSTANT preset shows the larger relative win.

### Benchmark configuration

All arms above run the **default eager configuration** (`performance_mode=auto`; every archived server log shows `enable_torch_compile: false, regional_compile: false`) — i.e. the default production path for this model. Runs with `--enable-torch-compile` are unaffected: the fused helpers step aside via `torch.compiler.is_compiling()` and the reference chain runs under Inductor.

Benchmark driver (local mode, one warmed process; 10 sequential requests, first dropped, median of 9):

```python
from sglang.multimodal_gen import DiffGenerator

gen = DiffGenerator.from_pretrained(
    model_path="cocktailpeanut/ideogram-4-fp8"  # byte-layout-identical ungated mirror, num_gpus=1, local_mode=True
)
for i in range(10):
    gen.generate(sampling_params_kwargs=dict(
        prompt=PROMPT, seed=42, width=1024, height=1024,
        preset="V4_FAST_20",  # or "V4_INSTANT_8"
        quality="lossless",  # or "high" to mount the fused gate-RMSNorm sites
    ))
```

## Accuracy Tests

| Check | Result |
| --- | --- |
| Reference (unmounted) helpers vs main expressions, `torch.equal`, real shapes | `True` |
| Full 1024x1024 image, same prompt/seed, this PR lossless vs main @ 604d3561b0 | **md5 identical**, both presets x both prompts (e.g. `a742d0b0...` FAST_20 p0 on both) |
| quality=high determinism | stable across repeated runs |

quality=high vs lossless, same seed, full-image:

| Preset / prompt | PSNR (dB) | SSIM |
| --- | ---: | ---: |
| FAST_20 / fox photo | 37.91 | 0.9981 |
| FAST_20 / typography poster | 58.07 | 0.9996 |
| INSTANT_8 / fox photo | 41.13 | 0.9989 |
| INSTANT_8 / typography poster | 58.00 | 0.9996 |

All comfortably above the quality="high" bar (PSNR > 25); the typography prompt — Ideogram's signature use case — is essentially indistinguishable.

Side-by-side samples (lossless left, quality=high right, FAST_20):

**fox photo**
![fox](https://github.com/BBuf/sglang/releases/download/assets-prd-ideogram/sample_ideogram_fox_lossless_vs_high.png)

**typography poster**
![typography](https://github.com/BBuf/sglang/releases/download/assets-prd-ideogram/sample_ideogram_typography_lossless_vs_high.png)

Unit tests (new `test_fused_gate_rmsnorm.py`, `base-b-kernel-unit`, mirrors `test_fused_linear_gelu.py`): fused vs `F.rms_norm` reference at the Ideogram hidden size incl. adaln-strided chunk gates; mount all-or-nothing guard (one fp32 site rejects the whole model); unmount restores the reference. Existing `test_zimage_native_norm.py` untouched and passing (8/8 across both files on H200).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31075920352](https://github.com/sgl-project/sglang/actions/runs/31075920352)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31075922438](https://github.com/sgl-project/sglang/actions/runs/31075922438)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
