### PR TITLE
[diffusion] FLUX.2 bit-exact residual-gate fast path (H200 klein-4B 50-step denoise -1.2%)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux_2.py
@@ -20,6 +20,10 @@ from diffusers.models.attention import AttentionModuleMixin
 from diffusers.models.embeddings import TimestepEmbedding, Timesteps
 from diffusers.models.normalization import AdaLayerNormContinuous
 
+from sglang.kernels.ops.diffusion.residual_gate_add import (
+    can_use_residual_gate_add_cuda,
+    residual_gate_add_cuda,
+)
 from sglang.multimodal_gen.configs.models.dits.flux import FluxConfig
 from sglang.multimodal_gen.runtime.distributed import (
     divide,
@@ -64,6 +68,40 @@ from sglang.multimodal_gen.runtime.platforms import (
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)  # pylint: disable=invalid-name
+
+_FLUX2_RESIDUAL_GATE_CUDA_DISABLED = False
+
+
+def _flux2_residual_gate_add(
+    residual: torch.Tensor,
+    update: torch.Tensor,
+    gate: torch.Tensor,
+) -> torch.Tensor:
+    """Single-kernel ``residual + gate * update``, bit-exact vs the eager pair.
+
+    Restricted to half dtypes: there the kernel reproduces the eager pair's
+    two-step rounding exactly (verified by ``torch.equal``), while for fp32 it
+    would contract to an fma (one rounding) and stop being bit-exact. The
+    kernel's row-broadcast gate only covers ``[1, ..., 1, D]``; batched
+    ``[B>1, 1, D]`` gates fail ``can_use_residual_gate_add_cuda`` and take the
+    eager fallback below.
+    """
+    global _FLUX2_RESIDUAL_GATE_CUDA_DISABLED
+
+    if (
+        not _FLUX2_RESIDUAL_GATE_CUDA_DISABLED
+        and residual.dtype in (torch.float16, torch.bfloat16)
+        and can_use_residual_gate_add_cuda(residual, update, gate)
+    ):
+        try:
+            return residual_gate_add_cuda(residual, update, gate)
+        except Exception as exc:
+            if torch.compiler.is_compiling():
+                raise
+            logger.warning_once(f"Disabling FLUX.2 residual-gate CUDA fast path: {exc}")
+            _FLUX2_RESIDUAL_GATE_CUDA_DISABLED = True
+
+    return residual + gate * update
 
 
 def _get_qkv_projections(
@@ -656,7 +694,7 @@ class Flux2SingleTransformerBlock(nn.Module):
             **joint_attention_kwargs,
         )
 
-        hidden_states = hidden_states + mod_gate * attn_output
+        hidden_states = _flux2_residual_gate_add(hidden_states, attn_output, mod_gate)
         if hidden_states.dtype == torch.float16:
             hidden_states = hidden_states.clip(-65504, 65504)
 
@@ -774,18 +812,18 @@ class Flux2TransformerBlock(nn.Module):
         attn_output, context_attn_output = attention_outputs
 
         # Process attention outputs for the image stream (`hidden_states`).
-        attn_output = gate_msa * attn_output
-        hidden_states = hidden_states + attn_output
+        hidden_states = _flux2_residual_gate_add(hidden_states, attn_output, gate_msa)
 
         norm_hidden_states = self.norm2(hidden_states)
         norm_hidden_states = norm_hidden_states * (1 + scale_mlp) + shift_mlp
 
         ff_output = self.ff(norm_hidden_states)
-        hidden_states = hidden_states + gate_mlp * ff_output
+        hidden_states = _flux2_residual_gate_add(hidden_states, ff_output, gate_mlp)
 
         # Process attention outputs for the text stream (`encoder_hidden_states`).
-        context_attn_output = c_gate_msa * context_attn_output
-        encoder_hidden_states = encoder_hidden_states + context_attn_output
+        encoder_hidden_states = _flux2_residual_gate_add(
+            encoder_hidden_states, context_attn_output, c_gate_msa
+        )
 
         norm_encoder_hidden_states = self.norm2_context(encoder_hidden_states)
         norm_encoder_hidden_states = (
@@ -793,7 +831,9 @@ class Flux2TransformerBlock(nn.Module):
         )
 
         context_ff_output = self.ff_context(norm_encoder_hidden_states)
-        encoder_hidden_states = encoder_hidden_states + c_gate_mlp * context_ff_output
+        encoder_hidden_states = _flux2_residual_gate_add(
+            encoder_hidden_states, context_ff_output, c_gate_mlp
+        )
         if encoder_hidden_states.dtype == torch.float16:
             encoder_hidden_states = encoder_hidden_states.clip(-65504, 65504)
 

--- a/test/registered/kernels/ops/diffusion/test_residual_gate_add.py
+++ b/test/registered/kernels/ops/diffusion/test_residual_gate_add.py
@@ -18,10 +18,13 @@ CASES = [
     ((1, 512, 4096), (1, 512, 4096)),
     ((1, 17, 65), (1, 1, 65)),
     ((1, 17, 65), (1, 17, 65)),
-    # FLUX.1 1024^2 shapes: dual-stream image/text and single-stream joint.
+    # FLUX.1 / FLUX.2-klein 1024^2 shapes (D=3072): dual-stream image/text
+    # and single-stream/joint concat; gates are [1, 1, D] modulation rows.
     ((1, 4096, 3072), (1, 1, 3072)),
     ((1, 512, 3072), (1, 1, 3072)),
     ((1, 4608, 3072), (1, 1, 3072)),
+    # FLUX.2-dev (D=6144) joint sequence.
+    ((1, 4608, 6144), (1, 1, 6144)),
 ]
 
 


### PR DESCRIPTION
## Motivation

FLUX.2's transformer updates its residual streams through eager two-kernel `gate * update` + `residual + ...` pairs, same pattern as FLUX.1 (#33819) and ERNIE-Image (#33734):

- **FLUX.2-dev** (target config, diffusers `Flux2Transformer2DModel` defaults: 8 dual-stream + 48 single-stream blocks, hidden 48x128=6144): 8 x 4 sites (img attn/mlp + txt attn/mlp) + 48 x 1 site = **80 sites/step x 50 steps = 4,000 eager pairs per 1024x1024 image**.
- **FLUX.2-klein-4B** (validation model, 5 dual + 20 single blocks, hidden 24x128=3072): 40 sites/step = 2,000 pairs at 50 steps, 160 at its default 4-step preset.

This PR wires the existing **`residual_gate_add_cuda`** kernel (in-tree since #29361, already on the LTX-2 default path) into all five FLUX.2 gate sites. For half dtypes the kernel reproduces the eager pair's rounding **bit-for-bit**, so it runs on the **lossless default path** with no quality gate.

Scope notes:

- FLUX.2's FFN is SwiGLU (`Flux2SwiGLU`), so the FLUX.1 GELU-epilogue companion from #33819 does not apply — this PR is the gate wiring only.
- The decode side is already covered by the FLUX.2 VAE fast path (#33451); this PR is DiT-side and independent of it.
- The norm+scale/shift rider was dropped for the same reason as in #33819: the only bit-exact shared implementation (`norm_scale_shift_native`) is hard-gated to Blackwell while this validation lane is H200/SM90.

## Modifications

All changes are `flux_2.py`-local plus test shapes; the kernel is untouched.

- `_flux2_residual_gate_add` (same helper shape as #33734/#33819: half-dtype-only where the kernel is bit-exact, one-time runtime fallback, `torch.compiler.is_compiling()` escape hatch so compiled graphs never bake in a silent fallback) wired into:
  - `Flux2SingleTransformerBlock`: 1 site (joint img+txt stream),
  - `Flux2TransformerBlock`: 4 sites (img attn/mlp + txt attn/mlp).
- FLUX.2's modulation params are already dense `[1, 1, D]` rows (no `unsqueeze` needed); batched `[B>1, 1, D]` gates fail `can_use_residual_gate_add_cuda` and fall back to the eager pair automatically; fp32 stays on the eager pair (the kernel would contract to an fma and stop being bit-exact).
- Coverage evidence: an instrumented smoke run (klein-4B, 1024^2, 4 steps) took the fused path on **all 160 helper calls, zero fallbacks** (per step: 10x `(1,4096,3072)` img + 10x `(1,512,3072)` txt + 20x `(1,4608,3072)` joint).

## Speed Tests (H200)

FLUX.2-klein-4B, 1024x1024, 50 steps, bf16, fixed prompt and `seed=42`. Client wall-clock in one warmed process, 10 consecutive generations, first dropped, median of 9 (#33451/#33536/#33734/#33819 protocol), single H200, `CUDA_VISIBLE_DEVICES` pinned. FLUX.2-dev itself is gated and — unlike FLUX.1-dev at the time of #33819 — has no byte-identical ungated mirror (hf-mirror now 308-redirects to the gated origin), so validation runs on the official, fully public klein-4B distillation: the same five gate sites on the same code paths, at hidden 3072 instead of dev's 6144.

The box is shared (other GPUs under load), so the A/B was run three times, alternating arm order:

| Run (load condition) | main @ 604d3561b0 denoise (s) | this PR denoise (s) | delta |
| --- | ---: | ---: | ---: |
| run 1 (clean) | 3.357 | 3.330 | -0.8% |
| run 2 (clean, PR arm first) | 3.360 | 3.305 | **-1.6%** |
| run 3 (host load spike, both arms show 3.6-3.7 s outliers) | 3.379 | 3.416 | (contaminated) |
| **runs 1+2 combined (n=18/arm)** | **3.358** | **3.318** | **-1.2%** |
| per-run minimum (noise-robust) | 3.327 | 3.271 | -1.2% / -1.7% / -1.2% in runs 1/2/3 |

E2E wall medians are within shared-host noise (stages the PR does not touch — TextEncoding/Decoding — fluctuate by +-25-140 ms between arms with overlapping bimodal distributions; denoise is 86% of klein's 50-step wall).

Attribution closes against kernel microbenchmarks at the real shapes (bf16, 200 iters after warmup):

| Op | shape | eager | fused | speedup |
| --- | --- | ---: | ---: | ---: |
| residual gate | (1, 4096, 3072), gate (1,1,3072) | 53.2 us | 20.6 us | 2.58x |
| residual gate | (1, 512, 3072), gate (1,1,3072) | 12.1 us | 13.0 us | 0.93x |
| residual gate | (1, 4608, 3072), gate (1,1,3072) | 59.3 us | 23.1 us | 2.57x |
| residual gate | (1, 4096, 6144), gate (1,1,6144) | 100.2 us | 39.1 us | 2.56x |
| residual gate | (1, 512, 6144), gate (1,1,6144) | 12.9 us | 12.9 us | 1.00x |
| residual gate | (1, 4608, 6144), gate (1,1,6144) | 112.4 us | 44.0 us | 2.55x |

Summed over klein's 40 sites: 1.04 ms/step = **52 ms per 50-step image**, bracketing the measured 40-55 ms clean-window denoise delta. Sanity anchor: FLUX.1 (#33819) got -1.9% denoise from 114 sites/step at the same hidden 3072; klein's -1.2% from 40 sites/step on a comparable per-step time is proportionally consistent.

Projection for FLUX.2-dev from the measured D=6144 rows: 16 img sites x 61.1 us + 48 joint sites x 68.4 us ≈ 4.3 ms/step ≈ **215 ms per 50-step 1024^2 image**, on the same code paths this PR exercises (dev's much longer 32B-transformer step means a similar relative denoise win with ~4x the absolute saving).

### Benchmark configuration

All arms above run the **default eager configuration** (`performance_mode=auto`; every archived server log shows `enable_torch_compile: false, regional_compile: false`) — i.e. the default production path for this model. Runs with `--enable-torch-compile` are unaffected: the gate helper steps aside via `torch.compiler.is_compiling()` and Inductor keeps its own fusion of the gate chain.

Benchmark driver (local mode, one warmed process; 10 sequential requests per round, first dropped, 3 alternating-order rounds):

```python
from sglang.multimodal_gen import DiffGenerator

gen = DiffGenerator.from_pretrained(
    model_path="black-forest-labs/FLUX.2-klein-4B", num_gpus=1, local_mode=True
)
for i in range(10):
    gen.generate(sampling_params_kwargs=dict(
        prompt=PROMPT, seed=42, width=1024, height=1024,
        num_inference_steps=50,  # md5 also verified at the 4-step preset
        quality="lossless",  # this PR is lossless-only; arms = main tree vs PR tree
    ))
```

## Accuracy Tests

| Check | Result |
| --- | --- |
| Kernel vs eager pair, `torch.equal`, real FLUX.2 shapes (4096/512/4608 x 3072, 4608 x 6144), bf16/fp16 | `True` (`atol=0, rtol=0`) |
| Full 1024x1024 image, same prompt/seed, this PR vs main @ 604d3561b0, 50 steps | **md5 identical** (`99fffc2446f172538c84914f24c77d0b` on both, all 10 iterations, all 3 runs) |
| Full 1024x1024 image, klein default 4-step preset, this PR vs main | **md5 identical** (`5909d6c7f306efa717989de4c9e996d0` on both, all 10 iterations) |
| Determinism within each arm | md5 identical across iterations (`unique=1`) |

Unit tests (extended in place, `base-b-kernel-unit`):

- `test_residual_gate_add.py`: + real FLUX.2 1024^2 shapes (klein dual img/txt and single joint at D=3072, dev joint at D=6144), bit-exact.

```
16 passed
```

`pre-commit run --files ...`: all hooks pass.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31101797363](https://github.com/sgl-project/sglang/actions/runs/31101797363)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31101796636](https://github.com/sgl-project/sglang/actions/runs/31101796636)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
