### PR TITLE
[speculative] DSpark: support the mask-filling draft convention (verify width = gamma)

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -408,10 +408,13 @@ def _compact_verify_ids_gather_kernel(
     draft_tokens_ptr,
     out_ptr,
     bs,
-    gamma,
+    block_w,
+    draft_w,
     n,
     BLOCK: tl.constexpr,
 ):
+    # block_w = draft_block_ids row width (block rows); draft_w = drafts per
+    # request. Legacy AR heads: equal; mask-filling heads: draft_w = block_w-1.
     pid = tl.program_id(0)
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < n
@@ -419,9 +422,9 @@ def _compact_verify_ids_gather_kernel(
     within = tl.load(within_ptr + offs, mask=mask, other=0)
     valid = req < bs
     safe_req = tl.minimum(req, bs - 1)
-    anchor = tl.load(draft_block_ids_ptr + safe_req * gamma, mask=mask, other=0)
+    anchor = tl.load(draft_block_ids_ptr + safe_req * block_w, mask=mask, other=0)
     wcol = tl.maximum(within - 1, 0)
-    draft = tl.load(draft_tokens_ptr + safe_req * gamma + wcol, mask=mask, other=0)
+    draft = tl.load(draft_tokens_ptr + safe_req * draft_w + wcol, mask=mask, other=0)
     v = tl.where(within == 0, anchor, draft)
     v = tl.where(valid, v, 0)
     tl.store(out_ptr + offs, v.to(tl.int64), mask=mask)
@@ -440,15 +443,16 @@ def compact_verify_ids_triton(
         device=device,
     )
     bs = layout.verify_lens.shape[0]
-    gamma = draft_tokens.shape[1]
+    draft_w = draft_tokens.shape[1]
     draft_block_ids = draft_block_ids.to(device=device, dtype=torch.int64).contiguous()
+    block_w = draft_block_ids.shape[1]
     draft_tokens = draft_tokens.to(device=device, dtype=torch.int64).contiguous()
     n = layout.graph_num_tokens
     out = torch.empty(n, dtype=torch.int64, device=device)
     BLOCK = 256
     grid = (triton.cdiv(n, BLOCK),)
     _compact_verify_ids_gather_kernel[grid](
-        req, within, draft_block_ids, draft_tokens, out, bs, gamma, n, BLOCK=BLOCK
+        req, within, draft_block_ids, draft_tokens, out, bs, block_w, draft_w, n, BLOCK=BLOCK
     )
     return out
 

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -413,10 +413,13 @@ def _compact_verify_ids_gather_kernel(
     draft_tokens_ptr,
     out_ptr,
     bs,
-    gamma,
+    block_w,
+    draft_w,
     n,
     BLOCK: tl.constexpr,
 ):
+    # block_w = draft_block_ids row width (block rows); draft_w = drafts per
+    # request. Legacy AR heads: equal; mask-filling heads: draft_w = block_w-1.
     pid = tl.program_id(0)
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < n
@@ -424,9 +427,9 @@ def _compact_verify_ids_gather_kernel(
     within = tl.load(within_ptr + offs, mask=mask, other=0)
     valid = req < bs
     safe_req = tl.minimum(req, bs - 1)
-    anchor = tl.load(draft_block_ids_ptr + safe_req * gamma, mask=mask, other=0)
+    anchor = tl.load(draft_block_ids_ptr + safe_req * block_w, mask=mask, other=0)
     wcol = tl.maximum(within - 1, 0)
-    draft = tl.load(draft_tokens_ptr + safe_req * gamma + wcol, mask=mask, other=0)
+    draft = tl.load(draft_tokens_ptr + safe_req * draft_w + wcol, mask=mask, other=0)
     v = tl.where(within == 0, anchor, draft)
     v = tl.where(valid, v, 0)
     tl.store(out_ptr + offs, v.to(tl.int64), mask=mask)
@@ -445,15 +448,16 @@ def compact_verify_ids_triton(
         device=device,
     )
     bs = layout.verify_lens.shape[0]
-    gamma = draft_tokens.shape[1]
+    draft_w = draft_tokens.shape[1]
     draft_block_ids = draft_block_ids.to(device=device, dtype=torch.int64).contiguous()
+    block_w = draft_block_ids.shape[1]
     draft_tokens = draft_tokens.to(device=device, dtype=torch.int64).contiguous()
     n = layout.graph_num_tokens
     out = torch.empty(n, dtype=torch.int64, device=device)
     BLOCK = 256
     grid = (triton.cdiv(n, BLOCK),)
     _compact_verify_ids_gather_kernel[grid](
-        req, within, draft_block_ids, draft_tokens, out, bs, gamma, n, BLOCK=BLOCK
+        req, within, draft_block_ids, draft_tokens, out, bs, block_w, draft_w, n, BLOCK=BLOCK
     )
     return out
 

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -418,8 +418,14 @@ def _compact_verify_ids_gather_kernel(
     n,
     BLOCK: tl.constexpr,
 ):
-    # block_w = draft_block_ids row width (block rows); draft_w = drafts per
-    # request. Legacy AR heads: equal; mask-filling heads: draft_w = block_w-1.
+    # Two row widths index this kernel's inputs. block_w is the stride of
+    # draft_block_ids: the draft head's block width, whose slot 0 holds the
+    # anchor token. draft_w is the stride of draft_tokens: the number of
+    # proposed drafts per request. AR-readout heads emit one draft per block
+    # slot, so draft_w == block_w; mask-filling heads emit predictions only
+    # at slots 1..block_w-1 (slot 0 is the anchor input), so
+    # draft_w == block_w - 1 and the anchor is read with a different stride
+    # than the drafts.
     pid = tl.program_id(0)
     offs = pid * BLOCK + tl.arange(0, BLOCK)
     mask = offs < n

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -370,13 +370,29 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             )
 
     if gamma is not None:
-        verify_window = int(gamma) + 1
+        # Mask-filling heads (slot 0 = anchor -> gamma-1 real drafts) serve a
+        # faithful verify width of gamma; upstream AR heads use gamma + 1.
+        from sglang.srt.speculative.dspark_components.dspark_config import (
+            read_draft_checkpoint_is_mask_filling,
+        )
+
+        try:
+            mask_filling = read_draft_checkpoint_is_mask_filling(
+                server_args=server_args
+            )
+        except Exception:
+            mask_filling = False
+        # The runtime convention global is set by DSparkWorkerV2.__init__ in the
+        # scheduler process (the only process whose model runners consult it);
+        # here we only validate the user-facing width arithmetic.
+        verify_window = int(gamma) if mask_filling else int(gamma) + 1
         if (
             server_args.speculative_num_draft_tokens is not None
             and int(server_args.speculative_num_draft_tokens) != verify_window
         ):
             raise ValueError(
-                "DSpark speculative_num_draft_tokens must equal gamma + 1 "
+                "DSpark speculative_num_draft_tokens must equal "
+                f"{'gamma (mask-filling head)' if mask_filling else 'gamma + 1'} "
                 f"(= {verify_window} for gamma={gamma}), but got "
                 f"speculative_num_draft_tokens={server_args.speculative_num_draft_tokens}."
             )

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -477,13 +477,29 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             )
 
     if gamma is not None:
-        verify_window = int(gamma) + 1
+        # Mask-filling heads (slot 0 = anchor -> gamma-1 real drafts) serve a
+        # faithful verify width of gamma; upstream AR heads use gamma + 1.
+        from sglang.srt.speculative.dspark_components.dspark_config import (
+            read_draft_checkpoint_is_mask_filling,
+        )
+
+        try:
+            mask_filling = read_draft_checkpoint_is_mask_filling(
+                server_args=server_args
+            )
+        except Exception:
+            mask_filling = False
+        # The runtime convention global is set by DSparkWorkerV2.__init__ in the
+        # scheduler process (the only process whose model runners consult it);
+        # here we only validate the user-facing width arithmetic.
+        verify_window = int(gamma) if mask_filling else int(gamma) + 1
         if (
             cfg.speculative_num_draft_tokens is not None
             and int(cfg.speculative_num_draft_tokens) != verify_window
         ):
             raise ValueError(
-                "DSpark speculative_num_draft_tokens must equal gamma + 1 "
+                "DSpark speculative_num_draft_tokens must equal "
+                f"{'gamma (mask-filling head)' if mask_filling else 'gamma + 1'} "
                 f"(= {verify_window} for gamma={gamma}), but got "
                 f"speculative_num_draft_tokens={cfg.speculative_num_draft_tokens}."
             )

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -477,36 +477,35 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             )
 
     if gamma is not None:
-        # Mask-filling heads (slot 0 = anchor -> gamma-1 real drafts) serve a
-        # faithful verify width of gamma; upstream AR heads use gamma + 1.
+        # Resolve the verify width from the draft checkpoint's convention.
+        # AR-readout heads emit gamma drafts, so the verify window is the
+        # anchor row plus gamma draft rows (gamma + 1). Mask-filling heads
+        # (dspark_mask_filling: true in the draft config) carry the anchor
+        # inside the block and emit gamma - 1 drafts, so their faithful
+        # verify width is exactly gamma -- a gamma + 1 window would append a
+        # junk token sampled from the clamped last slot.
         from sglang.srt.speculative.dspark_components.dspark_config import (
             read_draft_checkpoint_is_mask_filling,
         )
 
-        try:
-            mask_filling = read_draft_checkpoint_is_mask_filling(
-                server_args=server_args
-            )
-        except Exception:
-            mask_filling = False
-        # The runtime convention global is set by DSparkWorkerV2.__init__ in the
-        # scheduler process (the only process whose model runners consult it);
-        # here we only validate the user-facing width arithmetic.
-        verify_window = int(gamma) if mask_filling else int(gamma) + 1
+        mask_filling = read_draft_checkpoint_is_mask_filling(server_args=server_args)
+        # Here we only validate the user-facing width arithmetic; the runtime
+        # convention global is set by DSparkWorkerV2.__init__.
+        verify_width = int(gamma) if mask_filling else int(gamma) + 1
         if (
             cfg.speculative_num_draft_tokens is not None
-            and int(cfg.speculative_num_draft_tokens) != verify_window
+            and int(cfg.speculative_num_draft_tokens) != verify_width
         ):
             raise ValueError(
                 "DSpark speculative_num_draft_tokens must equal "
                 f"{'gamma (mask-filling head)' if mask_filling else 'gamma + 1'} "
-                f"(= {verify_window} for gamma={gamma}), but got "
+                f"(= {verify_width} for gamma={gamma}), but got "
                 f"speculative_num_draft_tokens={cfg.speculative_num_draft_tokens}."
             )
         declare_resolution(
             server_args,
             "_handle_dspark",
-            speculative_num_draft_tokens=verify_window,
+            speculative_num_draft_tokens=verify_width,
         )
 
     if cfg.speculative_num_draft_tokens is None:

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -122,6 +122,14 @@ class FlashAttentionMetadata:
     # For sliding window attention topk>1 spec decoding
     swa_spec_metadata: Optional[FlashAttentionMetadata] = None
 
+    # fa `causal` for forwards driven by this metadata; False = attend
+    # bidirectionally over exactly the page table's keys (window off).
+    # Consumed by the forward_extend swa-sub-metadata branch.
+    causal: bool = True
+    # The page table holds TOKEN rows (req_to_token), not page_size-divided
+    # page ids; the KV cache must be viewed with page size 1.
+    token_granular_page_table: bool = False
+
 
 class FlashAttentionBackend(AttentionBackend):
     """FlashAttention backend implementation.
@@ -1410,6 +1418,7 @@ class FlashAttentionBackend(AttentionBackend):
         )
 
         # Get the appropriate page table based on whether we're using local attention
+        token_granular_pages = False
         if use_local_attn:
             local_metadata = metadata.local_attn_metadata
             page_table = local_metadata.local_block_table
@@ -1423,6 +1432,12 @@ class FlashAttentionBackend(AttentionBackend):
             cache_seqlens = swa_spec_metadata.cache_seqlens_int32
             max_seqlen_q = swa_spec_metadata.max_seq_len_q
             cu_seqlens_k = swa_spec_metadata.cu_seqlens_k
+            if not swa_spec_metadata.causal:
+                window_size = (-1, -1)
+                causal = False
+            if swa_spec_metadata.token_granular_page_table:
+                # Same page-size-1 KV view pattern as the cascade expand call.
+                token_granular_pages = True
         else:
             page_table = metadata.page_table
             if is_swa_layer and self.use_sliding_window_kv_pool:
@@ -1443,6 +1458,11 @@ class FlashAttentionBackend(AttentionBackend):
             key_cache, value_cache = self.get_paged_mha_kv_cache(
                 layer,
             )
+            if token_granular_pages:
+                key_cache = key_cache.view(-1, 1, layer.tp_k_head_num, layer.head_dim)
+                value_cache = value_cache.view(
+                    -1, 1, layer.tp_v_head_num, layer.v_head_dim
+                )
             if layer.is_cross_attention:
                 page_table = metadata.encoder_page_table
                 cache_seqlens = metadata.encoder_lens_int32

--- a/python/sglang/srt/layers/aux_hidden_states.py
+++ b/python/sglang/srt/layers/aux_hidden_states.py
@@ -17,13 +17,15 @@ class AuxHiddenStatePacker:
     Assumes all captures share leading shape and feature size.
     """
 
-    # ``append`` copies, so producers need not clone a tensor they later mutate.
     copies_on_append = True
 
-    def __init__(self, num_captures: int) -> None:
+    def __init__(
+        self, num_captures: int, *, dtype: Optional[torch.dtype] = None
+    ) -> None:
         self._num_captures = int(num_captures)
         self._buffer: Optional[torch.Tensor] = None
         self._feature_size: Optional[int] = None
+        self._dtype = dtype
         self._idx = 0
 
     def append(self, hidden: torch.Tensor) -> None:
@@ -31,7 +33,8 @@ class AuxHiddenStatePacker:
         if self._buffer is None:
             self._feature_size = feature_size
             self._buffer = hidden.new_empty(
-                (*hidden.shape[:-1], feature_size * self._num_captures)
+                (*hidden.shape[:-1], feature_size * self._num_captures),
+                dtype=self._dtype if self._dtype is not None else hidden.dtype,
             )
         start = self._idx * self._feature_size
         self._buffer[..., start : start + self._feature_size].copy_(hidden)

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -501,8 +501,8 @@ class DSparkDraftMixin:
                 config, quant_config, prefix
             )
         else:
-            self.markov_head = build_markov_head(config)
-        self.confidence_head = build_confidence_head(config)
+            self.markov_head = self._build_markov_head(config, dspark_config)
+        self.confidence_head = self._build_confidence_head(config, dspark_config)
         self.lm_head: Optional[nn.Module] = None
         # Expose the draft's own layer count so the draft ModelRunner sizes the
         # draft KV pool correctly. Some DSpark draft checkpoints inherit the
@@ -513,6 +513,12 @@ class DSparkDraftMixin:
         # out of range. DSv4 (MoE) drafts expose this via ``num_stages``; mirror
         # that convention for dense DSpark drafts.
         self.num_stages = int(config.num_hidden_layers)
+
+    def _build_markov_head(self, config, dspark_config) -> Optional[nn.Module]:
+        return build_markov_head(config)
+
+    def _build_confidence_head(self, config, dspark_config) -> Optional[nn.Module]:
+        return build_confidence_head(config)
 
     def attach_shared_modules(
         self, *, embed_tokens: nn.Module, lm_head: nn.Module

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -57,6 +57,12 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     mask_token_id: Optional[int]
     markov_rank: int
     markov_head_type: Optional[str]
+    # Mask-filling heads (slot 0 = anchor, slots 1..gamma-1 = predictions)
+    # emit gamma-1 real drafts per block, so their faithful verify width is
+    # gamma (= config block_size), not gamma+1. Declared by the draft
+    # checkpoint config (dspark_mask_filling); builtin AR heads keep
+    # drafts = gamma and verify = gamma+1.
+    mask_filling: bool = False
 
     def resolve_gamma(self, *, default: Optional[int] = None) -> Optional[int]:
         return self.gamma if self.gamma is not None else default
@@ -87,12 +93,28 @@ def resolve_runtime_config(
             f"markov_rank={draft_config.markov_rank}."
         )
 
+    mask_filling = draft_config.mask_filling
     if speculative_num_draft_tokens is None:
         gamma = int(draft_config.resolve_gamma(default=None) or 0)
         if gamma < 1:
             raise ValueError(
                 "DSpark could not resolve gamma from the draft config and "
                 "speculative_num_draft_tokens is unset."
+            )
+    elif mask_filling:
+        gamma = int(speculative_num_draft_tokens)
+        if gamma < 2:
+            raise ValueError(
+                "DSpark(mask-filling) speculative_num_draft_tokens must be >= 2 "
+                f"(= gamma = block_size), got {speculative_num_draft_tokens}."
+            )
+        config_gamma = draft_config.resolve_gamma(default=None)
+        if config_gamma is not None and int(config_gamma) != gamma:
+            raise ValueError(
+                "Faithful DSpark(mask-filling) contract: "
+                f"speculative_num_draft_tokens ({gamma}) must equal the draft "
+                f"config block_size ({config_gamma}); verify width = block_size "
+                "with drafts = block_size - 1."
             )
     else:
         gamma = dspark_gamma_from_num_draft_tokens(int(speculative_num_draft_tokens))
@@ -119,7 +141,7 @@ def resolve_runtime_config(
 
     return DSparkRuntimeConfig(
         gamma=gamma,
-        verify_num_draft_tokens=gamma + 1,
+        verify_num_draft_tokens=gamma if mask_filling else gamma + 1,
         mask_token_id=mask_token_id,
     )
 
@@ -127,6 +149,18 @@ def resolve_runtime_config(
 def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
     """Load the draft checkpoint's hf config and read its DSpark gamma
     (block_size). Raises on config-load failure; callers pick the fallback."""
+    return _read_draft_checkpoint_config(server_args=server_args).resolve_gamma(
+        default=None
+    )
+
+
+def read_draft_checkpoint_is_mask_filling(*, server_args: ServerArgs) -> bool:
+    """Mask-filling heads (slot 0 = anchor) serve verify width = gamma, not
+    gamma + 1. See resolve_runtime_config."""
+    return _read_draft_checkpoint_config(server_args=server_args).mask_filling
+
+
+def _read_draft_checkpoint_config(*, server_args: ServerArgs) -> DSparkDraftConfig:
     from sglang.srt.utils.hf_transformers_utils import get_config
 
     draft_hf_config = get_config(
@@ -135,9 +169,7 @@ def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
         revision=server_args.speculative_draft_model_revision,
         model_override_args=json.loads(server_args.json_model_override_args),
     )
-    return parse_dspark_draft_config(draft_hf_config=draft_hf_config).resolve_gamma(
-        default=None
-    )
+    return parse_dspark_draft_config(draft_hf_config=draft_hf_config)
 
 
 def checkpoint_bundles_dspark_draft(hf_config: Any) -> bool:
@@ -239,9 +271,16 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         raise ValueError(
             "DSpark requires markov_head_type when markov_rank > 0, got None."
         )
+    mask_filling = bool(_cfg_get(draft_hf_config, "dspark_mask_filling", False))
     if markov_head_type is not None:
         markov_head_type = str(markov_head_type).lower()
-        if markov_head_type not in SUPPORTED_DSPARK_MARKOV_HEAD_TYPES:
+        # No builtin head is mask-filling: a config declaring the convention
+        # names an out-of-tree head whose implementation is validated at
+        # draft-model build, so only builtin names are checked here.
+        if (
+            not mask_filling
+            and markov_head_type not in SUPPORTED_DSPARK_MARKOV_HEAD_TYPES
+        ):
             raise ValueError(
                 f"Unsupported DSpark markov_head_type={markov_head_type!r}. "
                 f"Supported: {SUPPORTED_DSPARK_MARKOV_HEAD_TYPES}."
@@ -292,4 +331,5 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         mask_token_id=mask_token_id,
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
+        mask_filling=mask_filling,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -67,6 +67,12 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     mask_token_id: Optional[int]
     markov_rank: int
     markov_head_type: Optional[str]
+    # Mask-filling heads (slot 0 = anchor, slots 1..gamma-1 = predictions)
+    # emit gamma-1 real drafts per block, so their faithful verify width is
+    # gamma (= config block_size), not gamma+1. Declared by the draft
+    # checkpoint config (dspark_mask_filling); builtin AR heads keep
+    # drafts = gamma and verify = gamma+1.
+    mask_filling: bool = False
 
     def resolve_gamma(self, *, default: Optional[int] = None) -> Optional[int]:
         return self.gamma if self.gamma is not None else default
@@ -97,12 +103,28 @@ def resolve_runtime_config(
             f"markov_rank={draft_config.markov_rank}."
         )
 
+    mask_filling = draft_config.mask_filling
     if speculative_num_draft_tokens is None:
         gamma = int(draft_config.resolve_gamma(default=None) or 0)
         if gamma < 1:
             raise ValueError(
                 "DSpark could not resolve gamma from the draft config and "
                 "speculative_num_draft_tokens is unset."
+            )
+    elif mask_filling:
+        gamma = int(speculative_num_draft_tokens)
+        if gamma < 2:
+            raise ValueError(
+                "DSpark(mask-filling) speculative_num_draft_tokens must be >= 2 "
+                f"(= gamma = block_size), got {speculative_num_draft_tokens}."
+            )
+        config_gamma = draft_config.resolve_gamma(default=None)
+        if config_gamma is not None and int(config_gamma) != gamma:
+            raise ValueError(
+                "Faithful DSpark(mask-filling) contract: "
+                f"speculative_num_draft_tokens ({gamma}) must equal the draft "
+                f"config block_size ({config_gamma}); verify width = block_size "
+                "with drafts = block_size - 1."
             )
     else:
         gamma = dspark_gamma_from_num_draft_tokens(int(speculative_num_draft_tokens))
@@ -129,7 +151,7 @@ def resolve_runtime_config(
 
     return DSparkRuntimeConfig(
         gamma=gamma,
-        verify_num_draft_tokens=gamma + 1,
+        verify_num_draft_tokens=gamma if mask_filling else gamma + 1,
         mask_token_id=mask_token_id,
     )
 
@@ -143,6 +165,7 @@ def read_draft_checkpoint_config(*, server_args: ServerArgs) -> DSparkDraftConfi
     silently drops the checkpoint's gamma and the cross-check with
     `--speculative-num-draft-tokens` along with it.
     """
+    from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.utils.hf_transformers_utils import get_config
 
     resolving = resolved_view(server_args)
@@ -159,6 +182,12 @@ def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
     return read_draft_checkpoint_config(server_args=server_args).resolve_gamma(
         default=None
     )
+
+
+def read_draft_checkpoint_is_mask_filling(*, server_args: ServerArgs) -> bool:
+    """Mask-filling heads (slot 0 = anchor) serve verify width = gamma, not
+    gamma + 1. See resolve_runtime_config."""
+    return read_draft_checkpoint_config(server_args=server_args).mask_filling
 
 
 def checkpoint_bundles_dspark_draft(hf_config: Any) -> bool:
@@ -260,9 +289,16 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         raise ValueError(
             "DSpark requires markov_head_type when markov_rank > 0, got None."
         )
+    mask_filling = bool(_cfg_get(draft_hf_config, "dspark_mask_filling", False))
     if markov_head_type is not None:
         markov_head_type = str(markov_head_type).lower()
-        if markov_head_type not in SUPPORTED_DSPARK_MARKOV_HEAD_TYPES:
+        # No builtin head is mask-filling: a config declaring the convention
+        # names an out-of-tree head whose implementation is validated at
+        # draft-model build, so only builtin names are checked here.
+        if (
+            not mask_filling
+            and markov_head_type not in SUPPORTED_DSPARK_MARKOV_HEAD_TYPES
+        ):
             raise ValueError(
                 f"Unsupported DSpark markov_head_type={markov_head_type!r}. "
                 f"Supported: {SUPPORTED_DSPARK_MARKOV_HEAD_TYPES}."
@@ -313,4 +349,5 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         mask_token_id=mask_token_id,
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
+        mask_filling=mask_filling,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -292,9 +292,8 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     mask_filling = bool(_cfg_get(draft_hf_config, "dspark_mask_filling", False))
     if markov_head_type is not None:
         markov_head_type = str(markov_head_type).lower()
-        # No builtin head is mask-filling: a config declaring the convention
-        # names an out-of-tree head whose implementation is validated at
-        # draft-model build, so only builtin names are checked here.
+        # Mask-filling configs name an out-of-tree head; only builtin head
+        # names are checked here.
         if (
             not mask_filling
             and markov_head_type not in SUPPORTED_DSPARK_MARKOV_HEAD_TYPES

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -244,8 +244,14 @@ class DraftBlockProposer:
                         .clamp_min(1e-5)
                     )
                 corrected_logits = None
+            # Mask-filling heads emit gamma-1 drafts per gamma-row block.
+            n_drafts = (
+                self.gamma - 1
+                if getattr(self.draft_model.markov_head, "mask_filling", False)
+                else self.gamma
+            )
             draft_block = DraftBlockResult(
-                draft_tokens=draft_sampler.out[: bs * self.gamma].view(bs, self.gamma),
+                draft_tokens=draft_sampler.out[: bs * n_drafts].view(bs, n_drafts),
                 corrected_logits=corrected_logits,
                 greedy_mask=greedy_mask,
                 temperatures=temperatures,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -217,6 +217,12 @@ class DraftBlockProposer:
         self.gamma = gamma
         self.sample_from_anchor = bool(draft_model.sample_from_anchor)
         self.query_token_num = self.gamma if self.sample_from_anchor else self.gamma + 1
+        # Mask-filling heads emit gamma-1 drafts per gamma-row block.
+        self.num_drafts = (
+            gamma - 1
+            if getattr(draft_model.markov_head, "mask_filling", False)
+            else gamma
+        )
         self._mask_token_id = mask_token_id
         self._draft_block_spec_info = draft_block_spec_info
         self._tp_sync = tp_sync
@@ -282,8 +288,8 @@ class DraftBlockProposer:
                 corrected_logits = (
                     None
                     if all_greedy
-                    else draft_sampler.corrected_out[: bs * self.gamma].view(
-                        bs, self.gamma, -1
+                    else draft_sampler.corrected_out[: bs * self.num_drafts].view(
+                        bs, self.num_drafts, -1
                     )
                 )
             else:
@@ -301,14 +307,10 @@ class DraftBlockProposer:
                         .clamp_min(1e-5)
                     )
                 corrected_logits = None
-            # Mask-filling heads emit gamma-1 drafts per gamma-row block.
-            n_drafts = (
-                self.gamma - 1
-                if getattr(self.draft_model.markov_head, "mask_filling", False)
-                else self.gamma
-            )
             draft_block = DraftBlockResult(
-                draft_tokens=draft_sampler.out[: bs * n_drafts].view(bs, n_drafts),
+                draft_tokens=draft_sampler.out[: bs * self.num_drafts].view(
+                    bs, self.num_drafts
+                ),
                 corrected_logits=corrected_logits,
                 greedy_mask=greedy_mask,
                 temperatures=temperatures,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -301,8 +301,14 @@ class DraftBlockProposer:
                         .clamp_min(1e-5)
                     )
                 corrected_logits = None
+            # Mask-filling heads emit gamma-1 drafts per gamma-row block.
+            n_drafts = (
+                self.gamma - 1
+                if getattr(self.draft_model.markov_head, "mask_filling", False)
+                else self.gamma
+            )
             draft_block = DraftBlockResult(
-                draft_tokens=draft_sampler.out[: bs * self.gamma].view(bs, self.gamma),
+                draft_tokens=draft_sampler.out[: bs * n_drafts].view(bs, n_drafts),
                 corrected_logits=corrected_logits,
                 greedy_mask=greedy_mask,
                 temperatures=temperatures,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -277,7 +277,7 @@ class DraftBlockProposer:
             envs.SGLANG_DSPARK_FOLDED_PROPOSAL.get()
             and draft_sampler is not None
             and fwd.can_run_graph
-            and (all_greedy or draft_sampler.folded_sampling)
+            and (all_greedy or draft_sampler.samples_any_temperature)
         ):
             folded = True
             if draft_sampler.folded_sampling:

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -44,20 +44,22 @@ class DsparkDraftSampler:
         *,
         model,
         gamma,
-        num_drafts,
+        num_drafts: Optional[int] = None,
         max_bs,
         device,
         tp_sync: SpecTpSync,
         confidence_fn=None,
         out=None,
         folded_sampling: bool = True,
+        samples_any_temperature: Optional[bool] = None,
     ):
         self.model = model
         self.markov_head = model.markov_head
         self.gamma = int(gamma)
         self.sample_from_anchor = bool(model.sample_from_anchor)
         self.query_token_num = self.gamma if self.sample_from_anchor else self.gamma + 1
-        self.num_drafts = int(num_drafts)
+        # Drafts per block; the autoregressive convention (one per row) when unset.
+        self.num_drafts = int(gamma if num_drafts is None else num_drafts)
         max_bs = int(max_bs)
         # Resolved once: this sampler runs inside cuda-graph capture, so the
         # branch below is baked into the captured graph anyway.
@@ -76,6 +78,10 @@ class DsparkDraftSampler:
             else None
         )
         self.folded_sampling = folded_sampling
+        # Whether the captured draft graph samples correctly at any temperature.
+        self.samples_any_temperature = (
+            folded_sampling if samples_any_temperature is None else samples_any_temperature
+        )
         self._tp_sync = tp_sync
         self.temperatures = None
         self.greedy_mask = None
@@ -234,9 +240,11 @@ def maybe_build_draft_sampler(
     available_memory_gb: float,
     confidence_fn=None,
     out=None,
+    folded_sampling: Optional[bool] = None,
+    samples_any_temperature: Optional[bool] = None,
 ) -> Optional[DsparkDraftSampler]:
     """Build the graph-folded draft sampler, or None (reason logged) when the
-    proposal must stay eager."""
+    proposal must stay eager. folded_sampling defaults to the AUTO resolution."""
 
     def _eager(reason):
         if tp_rank == 0:
@@ -249,14 +257,15 @@ def maybe_build_draft_sampler(
         return _eager("no compute_base_logits")
     if getattr(draft_model, "markov_head", None) is None:
         return _eager("no markov head")
-    folded_sampling = _resolve_folded_sampling(
-        model=draft_model,
-        num_drafts=num_drafts,
-        max_bs=max_bs,
-        device=device,
-        tp_rank=tp_rank,
-        available_memory_gb=available_memory_gb,
-    )
+    if folded_sampling is None:
+        folded_sampling = _resolve_folded_sampling(
+            model=draft_model,
+            num_drafts=num_drafts,
+            max_bs=max_bs,
+            device=device,
+            tp_rank=tp_rank,
+            available_memory_gb=available_memory_gb,
+        )
     if tp_rank == 0:
         logger.info(
             "DSpark draft proposal (%s) folded into the draft cuda graph.",
@@ -272,4 +281,5 @@ def maybe_build_draft_sampler(
         confidence_fn=confidence_fn,
         out=out,
         folded_sampling=folded_sampling,
+        samples_any_temperature=samples_any_temperature,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -44,6 +44,7 @@ class DsparkDraftSampler:
         *,
         model,
         gamma,
+        num_drafts,
         max_bs,
         device,
         tp_sync: SpecTpSync,
@@ -56,20 +57,21 @@ class DsparkDraftSampler:
         self.gamma = int(gamma)
         self.sample_from_anchor = bool(model.sample_from_anchor)
         self.query_token_num = self.gamma if self.sample_from_anchor else self.gamma + 1
+        self.num_drafts = int(num_drafts)
         max_bs = int(max_bs)
         # Resolved once: this sampler runs inside cuda-graph capture, so the
         # branch below is baked into the captured graph anyway.
         self._fused_greedy = envs.SGLANG_DSPARK_OPT_FUSED_GREEDY_MARKOV.get()
         if out is not None:
-            assert out.shape == (max_bs * self.gamma,) and out.dtype == torch.int64
+            assert out.shape == (max_bs * self.num_drafts,) and out.dtype == torch.int64
             self.out = out
         else:
             self.out = torch.empty(
-                (max_bs * self.gamma,), dtype=torch.int64, device=device
+                (max_bs * self.num_drafts,), dtype=torch.int64, device=device
             )
         self.confidence_fn = confidence_fn
         self.confidence_out = (
-            torch.empty((max_bs, self.gamma), dtype=torch.float32, device=device)
+            torch.empty((max_bs, self.num_drafts), dtype=torch.float32, device=device)
             if confidence_fn is not None
             else None
         )
@@ -89,7 +91,7 @@ class DsparkDraftSampler:
                 (max_bs, vocab), dtype=torch.float32, device=device
             )
             self.corrected_out = torch.empty(
-                (max_bs * self.gamma, vocab),
+                (max_bs * self.num_drafts, vocab),
                 dtype=_base_logits_dtype(model),
                 device=device,
             )
@@ -171,9 +173,11 @@ class DsparkDraftSampler:
                 sampler=sampler,
                 collect_corrected=self.folded_sampling,
             )
+            assert draft_tokens.shape == (bs, self.num_drafts)
             if self.folded_sampling:
-                self.corrected_out[: bs * self.gamma].copy_(
-                    corrected_logits.reshape(bs * self.gamma, -1)
+                assert corrected_logits.shape[:2] == (bs, self.num_drafts)
+                self.corrected_out[: bs * self.num_drafts].copy_(
+                    corrected_logits.reshape(bs * self.num_drafts, -1)
                 )
 
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
@@ -184,11 +188,12 @@ class DsparkDraftSampler:
                 draft_tokens=draft_tokens,
                 confidence_tap=confidence_tap,
             )
+            assert confidence.shape == (bs, self.num_drafts)
             self.confidence_out[:bs].copy_(confidence)
 
 
 def _resolve_folded_sampling(
-    *, model, gamma, max_bs, device, tp_rank, available_memory_gb: float
+    *, model, num_drafts, max_bs, device, tp_rank, available_memory_gb: float
 ) -> bool:
     """The sampling buffers are baked into the captured draft graph, so AUTO
     must decide before capture from a free-memory probe. ``available_memory_gb``
@@ -200,7 +205,7 @@ def _resolve_folded_sampling(
         return True
     vocab = int(model.lm_head.org_vocab_size)
     noise_bytes = max_bs * vocab * 4
-    logits_bytes = max_bs * gamma * vocab * _base_logits_dtype(model).itemsize
+    logits_bytes = max_bs * num_drafts * vocab * _base_logits_dtype(model).itemsize
     need_gb = (noise_bytes + logits_bytes) / (1 << 30)
     if available_memory_gb - need_gb >= _CAPTURE_HEADROOM_GB:
         return True
@@ -221,6 +226,7 @@ def maybe_build_draft_sampler(
     *,
     draft_model,
     gamma: int,
+    num_drafts: int,
     max_bs: int,
     device,
     tp_rank: int,
@@ -245,7 +251,7 @@ def maybe_build_draft_sampler(
         return _eager("no markov head")
     folded_sampling = _resolve_folded_sampling(
         model=draft_model,
-        gamma=gamma,
+        num_drafts=num_drafts,
         max_bs=max_bs,
         device=device,
         tp_rank=tp_rank,
@@ -259,6 +265,7 @@ def maybe_build_draft_sampler(
     return DsparkDraftSampler(
         model=draft_model,
         gamma=gamma,
+        num_drafts=num_drafts,
         max_bs=max_bs,
         device=device,
         tp_sync=tp_sync,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -130,7 +130,9 @@ class DSparkVerifyPlanner:
                 )
 
         self._ragged_verify_mode = read_ragged_verify_mode()
-        self._schedule_cfg = DSparkScheduleConfig(gamma=self.gamma)
+        self._schedule_cfg = DSparkScheduleConfig(
+            gamma=self.gamma, verify_width=int(self.verify_num_draft_tokens)
+        )
         self._budget_planner: Optional[HostConfidenceBudgetPlanner] = None
         self._dynamic_graph_tier = False
         self._dp_tier_gather_enabled = False
@@ -927,17 +929,23 @@ class DSparkScheduleConfig(msgspec.Struct):
     min_verify_len: int = 1
     max_verify_len: int = 0
     survival_eps: float = 1e-6
+    # Verify rows per request. Legacy AR drafts: gamma + 1; mask-filling
+    # drafts: gamma (runtime verify_num_draft_tokens). 0 = legacy default.
+    verify_width: int = 0
+
+    def resolved_verify_width(self) -> int:
+        return self.verify_width or (self.gamma + 1)
 
     def resolved_max_verify_len(self) -> int:
-        return self.max_verify_len or (self.gamma + 1)
+        return self.max_verify_len or self.resolved_verify_width()
 
     def validate(self) -> None:
         max_len = self.resolved_max_verify_len()
         if self.gamma < 1:
             raise ValueError(f"DSpark gamma must be >= 1, got {self.gamma}.")
-        if not (0 <= self.min_verify_len <= max_len <= self.gamma + 1):
+        if not (0 <= self.min_verify_len <= max_len <= self.resolved_verify_width()):
             raise ValueError(
-                "DSpark verify-len config must satisfy 0 <= min <= max <= gamma+1, "
+                "DSpark verify-len config must satisfy 0 <= min <= max <= verify_width, "
                 f"got min={self.min_verify_len}, max={max_len}, gamma={self.gamma}."
             )
         if self.survival_eps < 0:

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -130,7 +130,9 @@ class DSparkVerifyPlanner:
                 )
 
         self._ragged_verify_mode = read_ragged_verify_mode()
-        self._schedule_cfg = DSparkScheduleConfig(gamma=self.gamma)
+        self._schedule_cfg = DSparkScheduleConfig(
+            gamma=self.gamma, verify_width=int(self.verify_num_draft_tokens)
+        )
         self._budget_planner: Optional[HostConfidenceBudgetPlanner] = None
         self._dynamic_graph_tier = False
         self._dp_tier_gather_enabled = False
@@ -908,17 +910,23 @@ class DSparkScheduleConfig(msgspec.Struct):
     min_verify_len: int = 1
     max_verify_len: int = 0
     survival_eps: float = 1e-6
+    # Verify rows per request. Legacy AR drafts: gamma + 1; mask-filling
+    # drafts: gamma (runtime verify_num_draft_tokens). 0 = legacy default.
+    verify_width: int = 0
+
+    def resolved_verify_width(self) -> int:
+        return self.verify_width or (self.gamma + 1)
 
     def resolved_max_verify_len(self) -> int:
-        return self.max_verify_len or (self.gamma + 1)
+        return self.max_verify_len or self.resolved_verify_width()
 
     def validate(self) -> None:
         max_len = self.resolved_max_verify_len()
         if self.gamma < 1:
             raise ValueError(f"DSpark gamma must be >= 1, got {self.gamma}.")
-        if not (0 <= self.min_verify_len <= max_len <= self.gamma + 1):
+        if not (0 <= self.min_verify_len <= max_len <= self.resolved_verify_width()):
             raise ValueError(
-                "DSpark verify-len config must satisfy 0 <= min <= max <= gamma+1, "
+                "DSpark verify-len config must satisfy 0 <= min <= max <= verify_width, "
                 f"got min={self.min_verify_len}, max={max_len}, gamma={self.gamma}."
             )
         if self.survival_eps < 0:

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -71,7 +71,6 @@ class TargetVerifyExecutor:
         self,
         *,
         target_worker,
-        gamma: int,
         verify_num_draft_tokens: int,
         model_runner,
         kv_injector: TargetHiddenKvInjector,
@@ -79,7 +78,12 @@ class TargetVerifyExecutor:
         simulate_acc_len: float = 0.0,
     ) -> None:
         self.target_worker = target_worker
-        self.gamma = int(gamma)
+        # Drafts per request. Verify rows = [anchor, drafts...] under BOTH
+        # conventions, so drafts = verify width - 1; the block-row gamma
+        # param equals this only for legacy AR heads (mask-filling blocks
+        # carry one extra prediction slot). The accept/out-token kernels all
+        # take the DRAFTS width.
+        self.gamma = int(verify_num_draft_tokens) - 1
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self.model_runner = model_runner
         self.kv_injector = kv_injector

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -83,7 +83,6 @@ class TargetVerifyExecutor:
         self,
         *,
         target_worker,
-        gamma: int,
         verify_num_draft_tokens: int,
         model_runner,
         kv_injector: TargetHiddenKvInjector,
@@ -92,7 +91,12 @@ class TargetVerifyExecutor:
         simulate_acc_len: float = 0.0,
     ) -> None:
         self.target_worker = target_worker
-        self.gamma = int(gamma)
+        # Drafts per request. Verify rows = [anchor, drafts...] under BOTH
+        # conventions, so drafts = verify width - 1; the block-row gamma
+        # param equals this only for legacy AR heads (mask-filling blocks
+        # carry one extra prediction slot). The accept/out-token kernels all
+        # take the DRAFTS width.
+        self.gamma = int(verify_num_draft_tokens) - 1
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self.model_runner = model_runner
         self.kv_injector = kv_injector

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -79,6 +79,14 @@ class TargetVerifyResult(msgspec.Struct, frozen=True):
 
 
 class TargetVerifyExecutor:
+    # Verify pre-inits attention metadata in prepare_for_verify; runners whose
+    # eager prep re-pads the batch afterwards must re-init post-pad instead of
+    # trusting the pre-init.
+    verify_skip_attn_backend_init: bool = True
+    # Subclasses that restore per-request state post-accept opt in to keep a
+    # reference to the verify forward batch (rebound every round).
+    _retain_verify_forward_batch: bool = False
+
     def __init__(
         self,
         *,
@@ -91,12 +99,8 @@ class TargetVerifyExecutor:
         simulate_acc_len: float = 0.0,
     ) -> None:
         self.target_worker = target_worker
-        # Drafts per request. Verify rows = [anchor, drafts...] under BOTH
-        # conventions, so drafts = verify width - 1; the block-row gamma
-        # param equals this only for legacy AR heads (mask-filling blocks
-        # carry one extra prediction slot). The accept/out-token kernels all
-        # take the DRAFTS width.
-        self.gamma = int(verify_num_draft_tokens) - 1
+        # Drafts per request (verify width - 1).
+        self.num_drafts = int(verify_num_draft_tokens) - 1
         self.verify_num_draft_tokens = verify_num_draft_tokens
         self.model_runner = model_runner
         self.kv_injector = kv_injector
@@ -136,7 +140,7 @@ class TargetVerifyExecutor:
             draft_block=draft_block,
             sampling_info=sampling_info,
             draft_input=draft_input,
-            gamma=self.gamma,
+            gamma=self.num_drafts,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             cutoff_layout=layout,
         )
@@ -164,7 +168,7 @@ class TargetVerifyExecutor:
             correct_len=correct_len,
             bonus=bonus,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
-            gamma=self.gamma,
+            gamma=self.num_drafts,
         )
         return AcceptOuts(
             correct_len=correct_len,
@@ -189,7 +193,7 @@ class TargetVerifyExecutor:
             self._simulated_correct_drafts_buf = buf
 
         simulated_acc_len = sample_simulated_acc_len(
-            self._simulate_acc_len, SIMULATE_ACC_METHOD, self.gamma + 1
+            self._simulate_acc_len, SIMULATE_ACC_METHOD, self.num_drafts + 1
         )
         return buf[:bs].fill_(simulated_acc_len - 1)
 
@@ -303,6 +307,8 @@ class TargetVerifyExecutor:
         verify_forward_batch, _ = verify_input.prepare_for_verify(
             batch, self.target_worker
         )
+        if self._retain_verify_forward_batch:
+            self._last_verify_forward_batch = verify_forward_batch
         batch.seq_lens_cpu = seq_lens_cpu_backup
         batch.seq_lens_sum = seq_lens_sum_backup
 
@@ -310,7 +316,9 @@ class TargetVerifyExecutor:
             batch=None,
             forward_batch=verify_forward_batch,
             is_verify=True,
-            skip_attn_backend_init=True if not _is_npu else None,
+            skip_attn_backend_init=(
+                self.verify_skip_attn_backend_init if not _is_npu else None
+            ),
         )
         return TargetVerifyResult(
             logits_output=target_out.logits_output,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -134,15 +134,15 @@ class TargetVerifyExecutor:
         if folded_accept:
             return self.verify_epilogue.read_accept(bs)
 
-        correct_len, bonus, cap_trim_lens = accept_draft_tokens(
-            candidates=verify_ids_2d,
+        correct_len, bonus, cap_trim_lens = self._accept_draft_tokens(
+            bs=bs,
+            verify_ids_2d=verify_ids_2d,
             target_logits=target_logits,
             draft_block=draft_block,
             sampling_info=sampling_info,
             draft_input=draft_input,
-            gamma=self.num_drafts,
-            verify_num_draft_tokens=self.verify_num_draft_tokens,
-            cutoff_layout=layout,
+            layout=layout,
+            prefix_lens=prefix_lens,
         )
         if self._simulate_acc_len > 0:
             correct_len = self._simulated_correct_len(
@@ -177,6 +177,30 @@ class TargetVerifyExecutor:
             commit_lens=finalized.commit_lens,
             new_seq_lens=finalized.new_seq_lens,
             out_tokens=out_tokens,
+        )
+
+    def _accept_draft_tokens(
+        self,
+        *,
+        bs: int,
+        verify_ids_2d: torch.Tensor,
+        target_logits: Optional[torch.Tensor],
+        draft_block: DraftBlockResult,
+        sampling_info,
+        draft_input: DFlashDraftInputV2,
+        layout: Optional[RaggedVerifyLayout],
+        prefix_lens: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Accept primitive; returns cutoff-capped (correct_len, bonus, cap_trim_lens)."""
+        return accept_draft_tokens(
+            candidates=verify_ids_2d,
+            target_logits=target_logits,
+            draft_block=draft_block,
+            sampling_info=sampling_info,
+            draft_input=draft_input,
+            gamma=self.num_drafts,
+            verify_num_draft_tokens=self.verify_num_draft_tokens,
+            cutoff_layout=layout,
         )
 
     def _simulated_correct_len(

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -107,6 +107,25 @@ class DSparkWorkerV2(BaseSpecWorker):
                 "MoE-under-DP all-reduce."
             )
 
+        # Set the draft block-row convention BEFORE the draft runner exists:
+        # its CG capture widths / logits buffers derive from
+        # get_num_tokens_per_req_for_target_verify at construction. The
+        # server-args hook also sets this, but scheduler actor processes may
+        # receive an already-resolved ServerArgs without re-running hooks.
+        from sglang.srt.speculative.dspark_components.dspark_config import (
+            read_draft_checkpoint_is_mask_filling,
+        )
+        from sglang.srt.speculative.spec_info import (
+            set_dspark_mask_filling_convention,
+        )
+
+        # No fallback: a draft config that cannot be read here would silently
+        # serve the wrong verify geometry (bs*(gamma-1) rows reshaped as
+        # (-1, gamma)); fail at startup instead.
+        set_dspark_mask_filling_convention(
+            read_draft_checkpoint_is_mask_filling(server_args=server_args)
+        )
+
         with self._draft_context():
             bundle = build_draft_tp_worker(
                 server_args=server_args,
@@ -255,7 +274,6 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         self._verify_executor = TargetVerifyExecutor(
             target_worker=self.target_worker,
-            gamma=self.gamma,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             model_runner=self.model_runner,
             kv_injector=self._kv_injector,
@@ -601,6 +619,13 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
         run_compact = self._verify_planner.should_run_compact(layout=layout)
 
+        # Contract joint: anchor + drafts must equal the verify width every
+        # site downstream (CG buffers, ragged layout, result rail) is sized to.
+        assert draft_tokens.shape[1] + 1 == self.verify_num_draft_tokens, (
+            draft_tokens.shape,
+            self.verify_num_draft_tokens,
+            self.gamma,
+        )
         verify_ids_2d = torch.cat(
             [draft_block_ids[:, :1], draft_tokens], dim=1
         ).contiguous()

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -441,6 +441,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         return maybe_build_draft_sampler(
             draft_model=self.draft_model,
             gamma=self.gamma,
+            num_drafts=self.verify_num_draft_tokens - 1,
             max_bs=max(get_exec().graph.cuda_graph_config.decode.bs),
             device=self.device,
             tp_rank=self.ps.tp_rank,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -437,7 +437,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 capture_decode_cuda_graph=capture_decode_cuda_graph
             )
 
-    def _maybe_build_draft_sampler(self, *, available_memory_gb: float):
+    def _maybe_build_draft_sampler(self, *, available_memory_gb: float, **overrides):
         return maybe_build_draft_sampler(
             draft_model=self.draft_model,
             gamma=self.gamma,
@@ -457,6 +457,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 if self._verify_epilogue is not None
                 else None
             ),
+            **overrides,
         )
 
     def clear_cache_pool(self):

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -130,6 +130,25 @@ class DSparkWorkerV2(BaseSpecWorker):
                 "MoE-under-DP all-reduce."
             )
 
+        # Set the draft block-row convention BEFORE the draft runner exists:
+        # its CG capture widths / logits buffers derive from
+        # get_num_tokens_per_req_for_target_verify at construction. The
+        # server-args hook also sets this, but scheduler actor processes may
+        # receive an already-resolved ServerArgs without re-running hooks.
+        from sglang.srt.speculative.dspark_components.dspark_config import (
+            read_draft_checkpoint_is_mask_filling,
+        )
+        from sglang.srt.speculative.spec_info import (
+            set_dspark_mask_filling_convention,
+        )
+
+        # No fallback: a draft config that cannot be read here would silently
+        # serve the wrong verify geometry (bs*(gamma-1) rows reshaped as
+        # (-1, gamma)); fail at startup instead.
+        set_dspark_mask_filling_convention(
+            read_draft_checkpoint_is_mask_filling(server_args=server_args)
+        )
+
         with self._draft_context():
             bundle = build_draft_tp_worker(
                 server_args=server_args,
@@ -312,7 +331,6 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         self._verify_executor = TargetVerifyExecutor(
             target_worker=self.target_worker,
-            gamma=self.gamma,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             model_runner=self.model_runner,
             kv_injector=self._kv_injector,
@@ -689,6 +707,13 @@ class DSparkWorkerV2(BaseSpecWorker):
         )
         run_compact = self._verify_planner.should_run_compact(layout=layout)
 
+        # Contract joint: anchor + drafts must equal the verify width every
+        # site downstream (CG buffers, ragged layout, result rail) is sized to.
+        assert draft_tokens.shape[1] + 1 == self.verify_num_draft_tokens, (
+            draft_tokens.shape,
+            self.verify_num_draft_tokens,
+            self.gamma,
+        )
         verify_ids_2d = torch.cat(
             [draft_block_ids[:, :1], draft_tokens], dim=1
         ).contiguous()

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -132,9 +132,7 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         # Set the draft block-row convention BEFORE the draft runner exists:
         # its CG capture widths / logits buffers derive from
-        # get_num_tokens_per_req_for_target_verify at construction. The
-        # server-args hook also sets this, but scheduler actor processes may
-        # receive an already-resolved ServerArgs without re-running hooks.
+        # get_num_tokens_per_req_for_target_verify at construction.
         from sglang.srt.speculative.dspark_components.dspark_config import (
             read_draft_checkpoint_is_mask_filling,
         )
@@ -329,7 +327,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 f"{self._simulate_acc_len}."
             )
 
-        self._verify_executor = TargetVerifyExecutor(
+        self._verify_executor = self._build_verify_executor(
             target_worker=self.target_worker,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             model_runner=self.model_runner,
@@ -492,6 +490,16 @@ class DSparkWorkerV2(BaseSpecWorker):
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
+    def _build_verify_executor(self, **kwargs) -> TargetVerifyExecutor:
+        """Hook: subclasses substitute a specialized TargetVerifyExecutor;
+        kwargs are the base construction arguments, forward them through."""
+        return TargetVerifyExecutor(**kwargs)
+
+    def _on_prefill_target_hidden(self, batch, target_hidden) -> None:
+        """Hook: called with the CaptureHiddenMode.FULL prefill hiddens
+        ([sum(extend_lens), T*H], batch request order) just before they are
+        dropped. Idle prefill never reaches this (no injection)."""
+
     def _forward_prefill(
         self, batch: ScheduleBatch, on_publish
     ) -> GenerationBatchResult:
@@ -561,6 +569,9 @@ class DSparkWorkerV2(BaseSpecWorker):
             state_slot=state_slot,
             final_pos=final_pos,
         )
+        # Last point where the FULL prefill capture is reachable; subclasses
+        # that stage per-request draft features read it here.
+        self._on_prefill_target_hidden(batch, logits_output.hidden_states)
         # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
         logits_output.hidden_states = None
 

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -27,6 +27,19 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
+# DSpark draft block-row convention. Legacy AR heads run gamma = verify-1
+# block rows; mask-filling heads (slot 0 = anchor) run gamma = verify width.
+# Set from server-args resolution (speculative_hook) BEFORE any model runner
+# is constructed -- decode CG capture widths and logits buffers derive from
+# get_num_tokens_per_req_for_target_verify at runner init.
+_DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY = False
+
+
+def set_dspark_mask_filling_convention(mask_filling: bool) -> None:
+    global _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY
+    _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY = bool(mask_filling)
+
+
 class SpeculativeAlgorithm(Enum):
     """Builtin speculative decoding algorithms. Plugin-registered ones are
     ``CustomSpecAlgo`` instances; ``from_string`` returns either type, and
@@ -239,6 +252,10 @@ class SpeculativeAlgorithm(Enum):
         # other cases which is not target verify but fixed length prefill.
         # Here, we expose this interface to allow the other use cases.
         if self.is_dspark() and is_draft_worker:
+            # Mask-filling drafts: block rows == verify width (see
+            # set_dspark_mask_filling_convention); legacy AR drafts: verify-1.
+            if _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY:
+                return num_draft_tokens
             return num_draft_tokens - 1
         return num_draft_tokens
 

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -42,6 +42,10 @@ def set_dspark_mask_filling_convention(mask_filling: bool) -> None:
     _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY = bool(mask_filling)
 
 
+def dspark_mask_filling_convention() -> bool:
+    return _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY
+
+
 class SpeculativeAlgorithm(Enum):
     """Builtin speculative decoding algorithms. Plugin-registered ones are
     ``CustomSpecAlgo`` instances; ``from_string`` returns either type, and

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -29,6 +29,19 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
+# DSpark draft block-row convention. Legacy AR heads run gamma = verify-1
+# block rows; mask-filling heads (slot 0 = anchor) run gamma = verify width.
+# Set from server-args resolution (speculative_hook) BEFORE any model runner
+# is constructed -- decode CG capture widths and logits buffers derive from
+# get_num_tokens_per_req_for_target_verify at runner init.
+_DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY = False
+
+
+def set_dspark_mask_filling_convention(mask_filling: bool) -> None:
+    global _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY
+    _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY = bool(mask_filling)
+
+
 class SpeculativeAlgorithm(Enum):
     """Builtin speculative decoding algorithms. Plugin-registered ones are
     ``CustomSpecAlgo`` instances; ``from_string`` returns either type, and
@@ -271,6 +284,10 @@ class SpeculativeAlgorithm(Enum):
         # other cases which is not target verify but fixed length prefill.
         # Here, we expose this interface to allow the other use cases.
         if self.is_dspark() and is_draft_worker:
+            # Mask-filling drafts: block rows == verify width (see
+            # set_dspark_mask_filling_convention); legacy AR drafts: verify-1.
+            if _DSPARK_DRAFT_BLOCK_ROWS_EQUAL_VERIFY:
+                return num_draft_tokens
             return num_draft_tokens - 1
         return num_draft_tokens
 

--- a/test/registered/spec/dspark/test_dspark_draft_sampler.py
+++ b/test/registered/spec/dspark/test_dspark_draft_sampler.py
@@ -1,0 +1,102 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
+    DsparkDraftSampler,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _MaskFillingHead:
+    def __init__(self, *, num_drafts: int) -> None:
+        self.num_drafts = num_drafts
+
+    def sample_block(
+        self,
+        base_logits,
+        *,
+        first_prev_tokens,
+        hidden_states,
+        sampler,
+    ):
+        del first_prev_tokens, hidden_states, sampler
+        bs, _, vocab_size = base_logits.shape
+        draft_tokens = torch.arange(bs * self.num_drafts).view(bs, self.num_drafts)
+        corrected_logits = torch.arange(
+            bs * self.num_drafts * vocab_size, dtype=base_logits.dtype
+        ).view(bs, self.num_drafts, vocab_size)
+        return draft_tokens, corrected_logits
+
+
+class _MaskFillingModel:
+    def __init__(self, *, num_drafts: int, vocab_size: int) -> None:
+        self.markov_head = _MaskFillingHead(num_drafts=num_drafts)
+        self.lm_head = SimpleNamespace(
+            org_vocab_size=vocab_size,
+            weight=torch.empty(vocab_size, 2),
+        )
+
+    def compute_base_logits(self, hidden_states):
+        return (
+            torch.zeros(hidden_states.shape[0], self.lm_head.org_vocab_size),
+            None,
+        )
+
+
+def _confidence(*, draft_hidden, anchor_tokens, draft_tokens, confidence_tap):
+    del draft_hidden, anchor_tokens, confidence_tap
+    return torch.ones(draft_tokens.shape, dtype=torch.float32)
+
+
+class TestDsparkDraftSampler(CustomTestCase):
+    def test_mask_filling_outputs_use_draft_width(self):
+        """A gamma-row mask-filling block emits gamma-1 sampler outputs."""
+        gamma = 4
+        num_drafts = gamma - 1
+        max_bs = 2
+        vocab_size = 7
+        shared_out = torch.empty(max_bs * num_drafts, dtype=torch.int64)
+        sampler = DsparkDraftSampler(
+            model=_MaskFillingModel(num_drafts=num_drafts, vocab_size=vocab_size),
+            gamma=gamma,
+            num_drafts=num_drafts,
+            max_bs=max_bs,
+            device="cpu",
+            confidence_fn=_confidence,
+            out=shared_out,
+            folded_sampling=True,
+        )
+
+        sampler(
+            hidden_states=torch.zeros(max_bs * gamma, 2),
+            input_ids=torch.arange(max_bs * gamma),
+        )
+
+        self.assertIs(sampler.out, shared_out)
+        self.assertEqual(sampler.out.shape, (max_bs * num_drafts,))
+        self.assertEqual(
+            sampler.corrected_out.shape,
+            (max_bs * num_drafts, vocab_size),
+        )
+        self.assertEqual(sampler.confidence_out.shape, (max_bs, num_drafts))
+        self.assertTrue(torch.equal(sampler.out, torch.arange(max_bs * num_drafts)))
+        self.assertTrue(
+            torch.equal(
+                sampler.corrected_out,
+                torch.arange(
+                    max_bs * num_drafts * vocab_size, dtype=torch.float32
+                ).view(max_bs * num_drafts, vocab_size),
+            )
+        )
+        self.assertTrue(
+            torch.equal(sampler.confidence_out, torch.ones(max_bs, num_drafts))
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DSpark currently assumes the autoregressive draft-block convention: a gamma-row block emits gamma drafts and the verify window is gamma + 1 rows. DFlash-style mask-filling draft heads use a different block layout — slot 0 carries the anchor token and slots 1..gamma-1 are the predictions — so a gamma-row block emits gamma-1 real drafts and the faithful verify width is gamma (= the config block_size). Serving such a head under the AR convention appends a junk token sampled from the clamped last slot and mis-sizes every width-derived buffer (CG capture widths, ragged verify layout, committed-token rail).

## Background: the two draft-block conventions

Both conventions build the identical block input per request per round: a width-gamma row `[anchor, MASK, MASK, ..., MASK]` (anchor = last accepted token) plus the injected target-model features. They differ in how the head's outputs are read — the GPT-vs-BERT distinction applied to the draft block (gamma = 4):

```
input slots:      [ t0(anchor) | MASK | MASK | MASK ]

AR readout (existing convention; causal in-block, next-token loss):
  out@0->draft1   out@1->draft2   out@2->draft3   out@3->draft4
  4 drafts from 4 slots; verify = 1+4 = 5 rows (num_draft_tokens = gamma+1)

Mask-filling readout (this PR; bidirectional in-block, masked-token loss):
  out@0->(unused) out@1->draft1   out@2->draft2   out@3->draft3
  3 drafts from 4 slots; verify = 4 rows (num_draft_tokens = gamma)
```

For readers more familiar with GPT-style models: a masked LM (BERT-style) replaces some input positions with a learned `[MASK]` embedding (content removed, position kept), attends bidirectionally, and reads the output at each masked position as a prediction for that same position — reconstruction in place rather than continuation. A mask-filling draft head is that objective specialized to speculation: "given the anchor token and the target model's features, predict the next gamma-1 positions jointly in one forward."

Why heads are trained this way:
1. **Information flow**: every predicted slot attends the anchor directly and all sibling positions bidirectionally; under the AR readout, slot i sees only the anchor plus i content-free mask placeholders.
2. **Train/serve input match**: a mask-filling head trains on `[anchor, MASK, ...]` — byte-identical to the serving-time input — so there is no teacher-forcing/exposure gap on the block input. AR-readout block heads train on true tokens in the slots and serve on masks, a mismatch that compounds with slot depth.
3. The known weakness of in-place parallel prediction (slots are conditionally independent given the block context, so joint samples can be incoherent) is what DSpark's sequential Markov head compensates for — which is why this head family pairs naturally with the existing DSpark machinery.

The two readouts are different functions of the same block (out@i means "token i+1" in one and "token i" in the other), so a mask-filling checkpoint cannot be served by re-indexing or padding under the AR convention — padding fabricates a draft the head never produced and wastes a verify row per request per round. The convention therefore has to be declared by the checkpoint and respected at every width-derived site, which is what this PR wires up. Note the bidirectional in-block attention is load-bearing at serve time (mask keys absorb a significant share of attention mass, acting as attention sinks); attention backends must reproduce the trained block geometry rather than approximate it causally.

## Modifications

The convention is declared by the draft checkpoint config (`dspark_mask_filling: true`), parsed into `DSparkDraftConfig.mask_filling`. Builtin AR heads are unaffected: the flag defaults off and the verify width stays gamma + 1. A config declaring the convention names an out-of-tree head, so builtin head-name validation is skipped for it (the implementation is validated at draft-model build).

Width choke points updated:
- `dspark_config`: mask-filling heads hard-error on `speculative_num_draft_tokens != block_size`; `read_draft_checkpoint_is_mask_filling` helper.
- `speculative_hook`: faithful verify width at the arg-validation site.
- `spec_info.get_num_tokens_per_req_for_target_verify`: draft block rows == verify width at the CG/buffer sizing choke point; `set_dspark_mask_filling_convention` is called at server-args resolution AND at `DSparkWorkerV2` init (worker processes may not re-run arg hooks).
- `dspark_planner`: `DSparkScheduleConfig` gains `verify_width`; the ragged layout must match the runtime verify width (one row wider makes the host committed-token stream read neighbor-row metadata as token ids at bs>1).
- `dspark_verify`: `TargetVerifyExecutor` derives the drafts width as `verify_num_draft_tokens - 1` (identical for legacy AR heads).
- `dspark_draft`: the folded sampler takes the gamma-1 draft view for mask-filling heads (duck-typed `markov_head.mask_filling`).
- `dspark_worker_v2`: assert drafts+1 == verify width at the verify-ids joint.
- `kernels/ops dspark_verify_window`: `compact_verify_ids` splits `block_w` (anchor stride over `draft_block_ids`) from `draft_w` (drafts stride); both shapes covered.
- `dspark_draft_sampler` + `dspark_worker_v2` + `dspark_draft`: the sampler carries `samples_any_temperature` (default: its `folded_sampling` flag) and the proposer consults it; `maybe_build_draft_sampler` and the worker hook accept `folded_sampling` / `samples_any_temperature` overrides so an out-of-tree head that samples in-graph itself can fold at any temperature with sampler-side folding off. `num_drafts` defaults to gamma (the autoregressive convention), so callers predating the width split keep working.
- Extension seams for out-of-tree runner subclasses: a `_build_verify_executor` factory, an opt-in verify-forward-batch retention for post-accept state restoration, a `verify_skip_attn_backend_init` opt-out for runners whose eager prep re-pads the batch after `prepare_for_verify`, and an `_on_prefill_target_hidden` callback exposing the full prefill hiddens for draft-feature staging.

## Checklist

- Default behavior for existing DSpark drafts is unchanged (flag off => gamma + 1 everywhere; drafts-width derivation is identity for AR heads).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33784558372](https://github.com/sgl-project/sglang/actions/runs/33784558372)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33784557617](https://github.com/sgl-project/sglang/actions/runs/33784557617)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33784558026](https://github.com/sgl-project/sglang/actions/runs/33784558026)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->



