### PR TITLE
fix(dsv4): avoid fused TopK v2 on Hopper

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v2.cuh
@@ -12,6 +12,7 @@
 #include <sgl_kernel/tensor.h>
 #include <sgl_kernel/utils.h>
 
+#include <sgl_kernel/runtime.cuh>
 #include <sgl_kernel/utils.cuh>
 
 #include <sgl_kernel/deepseek_v4/topk_impl.cuh>
@@ -430,8 +431,12 @@ struct TopKKernel {
 
     const bool use_cluster = (max_seq_len > params.cluster_floor) && (batch_size <= kClusterMaxBatch);
     constexpr bool kUsePDL = true;
+    // The fused small-batch DSMEM path is tuned and validated on SM100. On
+    // Hopper it can leave output slots unwritten; keep the correct
+    // persistent-cluster + main-kernel path there.
+    static const bool kUseFusedSmallBatch = host::runtime::get_sm_version(device.device_id) >= 100;
     if (use_cluster) {
-      if (batch_size <= kNumPersistentClusters) {
+      if (kUseFusedSmallBatch && batch_size <= kNumPersistentClusters) {
         LaunchKernel({batch_size, kClusterSize}, kBlockSize, device)
             .config({.use_pdl = kUsePDL, .cluster_dim = dim3{1, kClusterSize}})
             .launch(topk_small_batch_kernel<kUsePDL>, params);

--- a/test/registered/kernels/ops/attention/test_topk_v2.py
+++ b/test/registered/kernels/ops/attention/test_topk_v2.py
@@ -185,6 +185,34 @@ def test_topk_v2(batch: int, seq: int, k: int, page_mode: str) -> None:
     _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
 
 
+@torch.inference_mode()
+def test_topk_v2_small_batch_cluster_floor_transition() -> None:
+    """Exercise mixed rows around the 32K small-batch cluster floor.
+
+    On Hopper, the fused DSMEM path returned incomplete top-k output for the
+    rows just above the floor while the register and streaming rows were
+    correct. The Hopper fallback must preserve all rows in the same launch.
+    """
+    torch.manual_seed(32769)
+    device = "cuda"
+    k = 512
+    lengths = [32767, 32768, 32769, 33000, 2000, 12000, 16385, 1000]
+    batch, seq = len(lengths), max(lengths)
+    scores = torch.randn(batch, seq, dtype=torch.float32, device=device)
+    seq_lens = torch.tensor(lengths, dtype=torch.int32, device=device)
+    num_pages = (seq + PAGE_SIZE - 1) // PAGE_SIZE
+    page_table, _ = _make_page_table(
+        batch,
+        num_pages,
+        "identity",
+        device,
+    )
+
+    our_raw = _run_raw(scores, seq_lens, page_table, k)
+    ref_raw = _reference(scores, seq_lens, k)
+    _assert_topk_close(scores.cpu(), ref_raw, our_raw, batch, seq_lens.cpu(), k)
+
+
 @pytest.mark.parametrize("k", [512, 1024, 2048])
 @pytest.mark.parametrize(
     "batch,shape",


### PR DESCRIPTION
## Motivation

DeepSeek-V4 decode can produce incomplete DSA TopK v2 output on Hopper when a small mixed batch crosses the 32K C4 cluster floor. In an 8x H200 TP8 deployment, this surfaced as a reproducible downstream CUDA illegal-memory access when one long request crossed raw token 131072 while seven short requests remained active.

The failure is in the current fused small-batch DSMEM path, not in Marlin, Mooncake, FP8 KV cache, or the general persistent-cluster implementation.

## Root cause

Calling `topk_transform_512_v2` directly on H200 with an identity page table gave the following result:

```text
C4 seq_len:       32767  32768  32769  33000  2000  12000  16385  1000
unique/512 slots:   512    512    115    207    512    512    512   512
```

For `batch_size <= 15`, the small-batch cluster floor is 32768. The two rows just above that floor enter `Cluster::forward` in `topk_small_batch_kernel` and return incomplete output on SM90. Register and streaming rows in the same launch are correct.

Additional isolation:

- Moving the PDL wait before the first `seq_lens` read did not repair the two failing rows.
- The existing persistent-cluster path was correct: `batch=31, seq_len=65537` returned 512 unique valid indices for all 31 rows.
- Disabling TopK v2 made the full workload stable, and restoring the original v2 dispatch reproduced the crash at the same C4 boundary.

The direct kernel corruption is deterministic. The link from stale/duplicate TopK slots to the downstream sparse-attention illegal access is supported by the full-model boundary A/B.

## Changes

- Keep the fused small-batch path on SM100+.
- On Hopper, route the same shapes through the existing persistent-cluster plus main-kernel path.
- Add a regression test with mixed row lengths immediately below, at, and above the 32768 small-batch cluster floor.

Blackwell dispatch is unchanged.

## Validation

Tested environment:

```text
GPU: 8x NVIDIA H200 (SM90a)
Model: DeepSeek-V4-Flash-0731
SGLang base: 7adf2f4a9a4389d1c021a2caf128cf7e2f4adb35
PyTorch: 2.11.0
CUDA toolkit: 13.1
TP: 8
KV cache: FP8 E4M3
MoE runner: Marlin
Context length: 400000
Decode CUDA Graph: enabled
```

Results with the Hopper fallback:

- Direct mixed-boundary kernel check: all 8 rows returned 512 unique indices, all in range.
- Deterministic boundary reproducer (`1 x 130800 -> 10000` plus `7 x 2000 -> 10000`): all requests completed; 80,000 output tokens; no CUDA error.
- Full stability gate (`40 x 200000 -> 40000`, concurrency 40): 40/40 requests completed; 8,000,000 input and 1,600,000 output tokens; 1566.01 output tok/s; HTTP health remained 200.
- Persistent-path regression (`1 x 298933 -> 10000` plus `7 x 9731 -> 10000`): all requests completed, including the C4 `> 65536` row.
- The same full stability gate with Mooncake HiCache write-through: 40/40 completed; actual Mooncake SSD read/write counters increased; no CUDA error.

The deployed validation branch also contained a PDL-wait placement cleanup inside the fused kernel. A PDL-only A/B did not fix the corruption, and the fused kernel is not launched on SM90 after this dispatch change. This PR intentionally excludes that unrelated cleanup and contains only the minimal Hopper fallback.

The tested `topk_v2.cuh` and regression-test base blobs are unchanged on current `main` as of 2026-08-06.

## Related work

- #26788 introduced the current TopK v2 implementation.
- #25574 / #25575 concern the pre-#26788 fused kernel and code that no longer exists.
- #25785 adds a PDL trigger for the older implementation; it does not address this output corruption.
- #31123 handles negative padded `seq_lens`, a different failure class.
- #32910 fixes the CUDA 13 compiler crash when building this kernel, separate from the runtime correctness issue here.

## Checklist

- [x] The change is scoped to the affected architecture and dispatch path.
- [x] A focused regression test is included.
- [x] `git diff --check` passes.
- [x] Full-model correctness and long-running serving validation are reported above.
- [ ] CI (this PR).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31081928822](https://github.com/sgl-project/sglang/actions/runs/31081928822)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31081928039](https://github.com/sgl-project/sglang/actions/runs/31081928039)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->