### PR TITLE
fix(connector): Honor Redis file selection

### DIFF
--- a/python/sglang/srt/connector/azure.py
+++ b/python/sglang/srt/connector/azure.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import fnmatch
 import os
 from pathlib import Path
 from typing import Generator, Optional, Tuple
@@ -8,22 +7,7 @@ from typing import Generator, Optional, Tuple
 import torch
 
 from sglang.srt.connector import BaseFileConnector
-
-
-def _filter_allow(paths: list[str], patterns: list[str]) -> list[str]:
-    return [
-        path
-        for path in paths
-        if any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
-    ]
-
-
-def _filter_ignore(paths: list[str], patterns: list[str]) -> list[str]:
-    return [
-        path
-        for path in paths
-        if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
-    ]
+from sglang.srt.connector.utils import filter_file_paths
 
 
 def _normalize_url(url: str) -> str:
@@ -54,11 +38,8 @@ def list_files(
     base_dir = _normalize_url(path)
     files = [p for p in bf.glob(base_dir + "/**") if not bf.isdir(p)]
 
-    files = _filter_ignore(files, ["*/"])
-    if allow_pattern is not None:
-        files = _filter_allow(files, allow_pattern)
-    if ignore_pattern is not None:
-        files = _filter_ignore(files, ignore_pattern)
+    files = filter_file_paths(files, ignore_pattern=["*/"])
+    files = filter_file_paths(files, allow_pattern, ignore_pattern)
 
     return base_dir, files
 

--- a/python/sglang/srt/connector/redis.py
+++ b/python/sglang/srt/connector/redis.py
@@ -62,7 +62,7 @@ class RedisConnector(BaseKVConnector):
             if cursor == 0:
                 break
 
-        return [key.decode("utf-8") for key in all_keys]
+        return [key.decode("utf-8") for key in dict.fromkeys(all_keys)]
 
     def weight_iterator(
         self, rank: int = 0

--- a/python/sglang/srt/connector/redis.py
+++ b/python/sglang/srt/connector/redis.py
@@ -62,7 +62,9 @@ class RedisConnector(BaseKVConnector):
             if cursor == 0:
                 break
 
-        return [key.decode("utf-8") for key in dict.fromkeys(all_keys)]
+        # SCAN may return duplicate keys; dict preserves first-seen order.
+        unique_keys = dict.fromkeys(all_keys)
+        return [key.decode("utf-8") for key in unique_keys]
 
     def weight_iterator(
         self, rank: int = 0

--- a/python/sglang/srt/connector/redis.py
+++ b/python/sglang/srt/connector/redis.py
@@ -61,7 +61,7 @@ class RedisConnector(BaseKVConnector):
             if cursor == 0:
                 break
 
-        return [key.decode("utf-8") for key in all_keys]
+        return [key.decode("utf-8") for key in dict.fromkeys(all_keys)]
 
     def weight_iterator(
         self, rank: int = 0

--- a/python/sglang/srt/connector/redis.py
+++ b/python/sglang/srt/connector/redis.py
@@ -61,7 +61,9 @@ class RedisConnector(BaseKVConnector):
             if cursor == 0:
                 break
 
-        return [key.decode("utf-8") for key in dict.fromkeys(all_keys)]
+        # SCAN may return duplicate keys; dict preserves first-seen order.
+        unique_keys = dict.fromkeys(all_keys)
+        return [key.decode("utf-8") for key in unique_keys]
 
     def weight_iterator(
         self, rank: int = 0

--- a/python/sglang/srt/connector/s3.py
+++ b/python/sglang/srt/connector/s3.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-import fnmatch
 import os
 from pathlib import Path
 from typing import Generator, Optional, Tuple
@@ -8,22 +7,7 @@ from typing import Generator, Optional, Tuple
 import torch
 
 from sglang.srt.connector import BaseFileConnector
-
-
-def _filter_allow(paths: list[str], patterns: list[str]) -> list[str]:
-    return [
-        path
-        for path in paths
-        if any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
-    ]
-
-
-def _filter_ignore(paths: list[str], patterns: list[str]) -> list[str]:
-    return [
-        path
-        for path in paths
-        if not any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
-    ]
+from sglang.srt.connector.utils import filter_file_paths
 
 
 def list_files(
@@ -56,12 +40,8 @@ def list_files(
     objects = s3.list_objects_v2(Bucket=bucket_name, Prefix=prefix)
     paths = [obj["Key"] for obj in objects.get("Contents", [])]
 
-    paths = _filter_ignore(paths, ["*/"])
-    if allow_pattern is not None:
-        paths = _filter_allow(paths, allow_pattern)
-
-    if ignore_pattern is not None:
-        paths = _filter_ignore(paths, ignore_pattern)
+    paths = filter_file_paths(paths, ignore_pattern=["*/"])
+    paths = filter_file_paths(paths, allow_pattern, ignore_pattern)
 
     return bucket_name, prefix, paths
 

--- a/python/sglang/srt/connector/utils.py
+++ b/python/sglang/srt/connector/utils.py
@@ -6,7 +6,28 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
-from sglang.srt.connector import BaseConnector
+from sglang.srt.connector.base_connector import BaseKVConnector
+
+
+def filter_file_paths(
+    paths: list[str],
+    allow_pattern: Optional[list[str]] = None,
+    ignore_pattern: Optional[list[str]] = None,
+) -> list[str]:
+    """Apply allow patterns first, then exclude paths matching ignore patterns."""
+    if allow_pattern is not None:
+        paths = [
+            path
+            for path in paths
+            if any(fnmatch.fnmatch(path, pattern) for pattern in allow_pattern)
+        ]
+    if ignore_pattern is not None:
+        paths = [
+            path
+            for path in paths
+            if not any(fnmatch.fnmatch(path, pattern) for pattern in ignore_pattern)
+        ]
+    return paths
 
 
 def parse_model_name(url: str) -> str:
@@ -19,29 +40,18 @@ def parse_model_name(url: str) -> str:
 
 
 def pull_files_from_db(
-    connector: BaseConnector,
+    connector: BaseKVConnector,
     model_name: str,
     allow_pattern: Optional[list[str]] = None,
     ignore_pattern: Optional[list[str]] = None,
 ) -> None:
+    """Download database-backed model files into the connector's local directory."""
     prefix = f"{model_name}/files/"
     download_root = connector.get_local_dir()
-    files = connector.list(prefix)
-
-    if allow_pattern is not None:
-        files = [
-            file
-            for file in files
-            if any(fnmatch.fnmatch(file, pattern) for pattern in allow_pattern)
-        ]
-    if ignore_pattern is not None:
-        files = [
-            file
-            for file in files
-            if not any(fnmatch.fnmatch(file, pattern) for pattern in ignore_pattern)
-        ]
+    files = filter_file_paths(connector.list(prefix), allow_pattern, ignore_pattern)
 
     for file in files:
+        # Anchor every destination to the connector root, regardless of key order.
         destination_file = os.path.join(download_root, file.removeprefix(prefix))
         parent_dir = Path(destination_file).parent
         os.makedirs(parent_dir, exist_ok=True)

--- a/python/sglang/srt/connector/utils.py
+++ b/python/sglang/srt/connector/utils.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import fnmatch
 import os
 from pathlib import Path
 from typing import Optional
@@ -24,12 +25,25 @@ def pull_files_from_db(
     ignore_pattern: Optional[list[str]] = None,
 ) -> None:
     prefix = f"{model_name}/files/"
-    local_dir = connector.get_local_dir()
+    download_root = connector.get_local_dir()
     files = connector.list(prefix)
 
+    if allow_pattern is not None:
+        files = [
+            file
+            for file in files
+            if any(fnmatch.fnmatch(file, pattern) for pattern in allow_pattern)
+        ]
+    if ignore_pattern is not None:
+        files = [
+            file
+            for file in files
+            if not any(fnmatch.fnmatch(file, pattern) for pattern in ignore_pattern)
+        ]
+
     for file in files:
-        destination_file = os.path.join(local_dir, file.removeprefix(prefix))
-        local_dir = Path(destination_file).parent
-        os.makedirs(local_dir, exist_ok=True)
+        destination_file = os.path.join(download_root, file.removeprefix(prefix))
+        parent_dir = Path(destination_file).parent
+        os.makedirs(parent_dir, exist_ok=True)
         with open(destination_file, "wb") as f:
             f.write(connector.getstr(file).encode("utf-8"))

--- a/test/registered/unit/connector/test_redis_connector.py
+++ b/test/registered/unit/connector/test_redis_connector.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+from pathlib import Path
+
+from sglang.srt.connector.redis import RedisConnector
+from sglang.srt.connector.utils import pull_files_from_db
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeFileConnector:
+
+    def __init__(self, local_dir: str, files: dict[str, str]):
+        self.local_dir = local_dir
+        self.files = files
+        self.read_keys = []
+
+    def get_local_dir(self) -> str:
+        return self.local_dir
+
+    def list(self, prefix: str) -> list[str]:
+        return list(self.files)
+
+    def getstr(self, key: str) -> str:
+        self.read_keys.append(key)
+        return self.files[key]
+
+
+class _FakeRedisConnection:
+
+    def __init__(self, pages: list[tuple[int, list[bytes]]]):
+        self.pages = iter(pages)
+        self.scan_calls = []
+
+    def scan(self, cursor: int, match: str) -> tuple[int, list[bytes]]:
+        self.scan_calls.append((cursor, match))
+        return next(self.pages)
+
+    def close(self) -> None:
+        pass
+
+
+class TestRedisConnector(CustomTestCase):
+
+    def test_pull_files_applies_allow_then_ignore_patterns(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prefix = "model/files/"
+            connector = _FakeFileConnector(
+                tmpdir,
+                {
+                    f"{prefix}config.json": "config",
+                    f"{prefix}tokenizer.json": "tokenizer",
+                    f"{prefix}weights.bin": "weights",
+                },
+            )
+
+            pull_files_from_db(
+                connector,
+                "model",
+                allow_pattern=["*.json"],
+                ignore_pattern=["*tokenizer.json"],
+            )
+
+            self.assertEqual((Path(tmpdir) / "config.json").read_text(), "config")
+            self.assertFalse((Path(tmpdir) / "tokenizer.json").exists())
+            self.assertFalse((Path(tmpdir) / "weights.bin").exists())
+            self.assertEqual(connector.read_keys, [f"{prefix}config.json"])
+
+    def test_pull_files_keeps_download_root_for_nested_and_flat_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            prefix = "model/files/"
+            connector = _FakeFileConnector(
+                tmpdir,
+                {
+                    f"{prefix}nested/config.json": "config",
+                    f"{prefix}tokenizer.json": "tokenizer",
+                },
+            )
+
+            pull_files_from_db(connector, "model")
+
+            self.assertEqual(
+                (Path(tmpdir) / "nested" / "config.json").read_text(), "config"
+            )
+            self.assertEqual((Path(tmpdir) / "tokenizer.json").read_text(), "tokenizer")
+            self.assertFalse((Path(tmpdir) / "nested" / "tokenizer.json").exists())
+
+    def test_list_deduplicates_scan_results_in_first_seen_order(self):
+        connection = _FakeRedisConnection(
+            [
+                (7, [b"model/keys/b", b"model/keys/a"]),
+                (0, [b"model/keys/a", b"model/keys/c", b"model/keys/b"]),
+            ]
+        )
+        connector = RedisConnector.__new__(RedisConnector)
+        connector.connection = connection
+        connector.closed = True
+
+        self.assertEqual(
+            connector.list("model/keys/"),
+            ["model/keys/b", "model/keys/a", "model/keys/c"],
+        )
+        self.assertEqual(
+            connection.scan_calls,
+            [(0, "model/keys/*"), (7, "model/keys/*")],
+        )
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/connector/test_redis_connector.py
+++ b/test/registered/unit/connector/test_redis_connector.py
@@ -12,7 +12,6 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 class _FakeFileConnector:
-
     def __init__(self, local_dir: str, files: dict[str, str]):
         self.local_dir = local_dir
         self.files = files
@@ -30,7 +29,6 @@ class _FakeFileConnector:
 
 
 class _FakeRedisConnection:
-
     def __init__(self, pages: list[tuple[int, list[bytes]]]):
         self.pages = iter(pages)
         self.scan_calls = []
@@ -44,7 +42,6 @@ class _FakeRedisConnection:
 
 
 class TestRedisConnector(CustomTestCase):
-
     def test_pull_files_applies_allow_then_ignore_patterns(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             prefix = "model/files/"


### PR DESCRIPTION
Redis-backed metadata downloads now apply allow and ignore glob patterns, keep every destination anchored to the connector download root, and deduplicate Redis `SCAN` results while preserving first-seen order.

Previously, the database helper ignored both filters and reused each downloaded file's parent as the next root. Redis `SCAN` may also return the same key more than once. Together, these behaviors could download unwanted files, misplace mixed nested/flat metadata, or load a weight key twice.

The connector architecture now centralizes allow-then-ignore path filtering in one utility shared by Redis, S3, and Azure. The database helper depends on the narrower `BaseKVConnector` interface, and English comments document the non-obvious root anchoring and `SCAN` duplicate guarantees.

CPU-only regression tests cover filtering precedence, mixed nested/flat paths, and duplicate scan pages.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34680708949](https://github.com/sgl-project/sglang/actions/runs/34680708949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34680708761](https://github.com/sgl-project/sglang/actions/runs/34680708761)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34680708843](https://github.com/sgl-project/sglang/actions/runs/34680708843)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->