### PR TITLE
[AMD]perf(mamba): avoid temporary extend state copies in Mamba/GDN backend

### DIFF
--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -10,6 +10,209 @@ import torch
 import triton
 import triton.language as tl
 
+_is_hip = torch.version.hip is not None
+_SUPPORTED_STATE_COPY_DTYPES = (torch.bfloat16, torch.float32)
+
+
+def derive_track_ssm_copy_flags(
+    track_ssm_h_src: torch.Tensor,
+    track_ssm_h_dst: torch.Tensor,
+    track_ssm_final_src: torch.Tensor,
+    track_ssm_final_dst: torch.Tensor,
+    *,
+    h_state_rows: int,
+    pool_rows: int | None,
+) -> tuple[bool, bool, bool]:
+    """Derive trusted-index and non-overlap flags for extend tracking metadata."""
+
+    def _all_in_range(indices: torch.Tensor, lower: int, upper: int) -> bool:
+        if indices.numel() == 0:
+            return True
+        if upper <= lower:
+            return False
+        vals = indices.to(device="cpu", dtype=torch.int64).tolist()
+        return all(lower <= int(v) < upper for v in vals)
+
+    h_trusted = _all_in_range(track_ssm_h_src, 0, h_state_rows) and (
+        pool_rows is not None and _all_in_range(track_ssm_h_dst, 0, pool_rows)
+    )
+    final_trusted = (
+        pool_rows is not None
+        and _all_in_range(track_ssm_final_src, 0, pool_rows)
+        and _all_in_range(track_ssm_final_dst, 0, pool_rows)
+    )
+
+    final_disjoint = True
+    if track_ssm_final_src.numel() > 0 and track_ssm_final_dst.numel() > 0:
+        src_set = set(track_ssm_final_src.to(device="cpu", dtype=torch.int64).tolist())
+        dst_set = set(track_ssm_final_dst.to(device="cpu", dtype=torch.int64).tolist())
+        final_disjoint = src_set.isdisjoint(dst_set)
+    return h_trusted, final_trusted, final_disjoint
+
+
+@triton.jit
+def _copy_mamba_state_rows_kernel(
+    src_ptr,
+    dst_ptr,
+    src_indices_ptr,
+    dst_indices_ptr,
+    src_row_stride,
+    dst_row_stride,
+    row_numel: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pair_idx = tl.program_id(0).to(tl.int64)
+    tile_idx = tl.program_id(1).to(tl.int64)
+    offsets = tile_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < row_numel
+
+    src_idx = tl.load(src_indices_ptr + pair_idx).to(tl.int64)
+    dst_idx = tl.load(dst_indices_ptr + pair_idx).to(tl.int64)
+
+    src_row_stride = src_row_stride.to(tl.int64)
+    dst_row_stride = dst_row_stride.to(tl.int64)
+    src_off = src_idx * src_row_stride + offsets
+    dst_off = dst_idx * dst_row_stride + offsets
+
+    data = tl.load(src_ptr + src_off, mask=mask, other=0.0)
+    tl.store(dst_ptr + dst_off, data, mask=mask)
+
+
+def _row_interior_is_contiguous(t: torch.Tensor) -> bool:
+    if t.ndim < 2:
+        return False
+    expected_stride = 1
+    for dim in range(t.ndim - 1, 0, -1):
+        if t.stride(dim) != expected_stride:
+            return False
+        expected_stride *= t.shape[dim]
+    return True
+
+
+def _copy_rows_advanced_index(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+) -> None:
+    dst[dst_indices] = src[src_indices].to(dst.dtype, copy=False)
+
+
+def copy_mamba_state_rows(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+) -> None:
+    """Fast-path row copy for extend tracking.
+
+    Contract:
+    - ``src`` and ``dst`` are CUDA tensors on the same device.
+    - ``src_indices`` / ``dst_indices`` are contiguous int32/int64 tensors on-device.
+    - All indices are valid (no ``-1`` and no out-of-range values).
+    - Caller establishes gather-before-scatter safety for shared-storage copies.
+    """
+    if src_indices.ndim != 1 or dst_indices.ndim != 1:
+        raise ValueError("src_indices and dst_indices must be 1D tensors.")
+    if src_indices.numel() != dst_indices.numel():
+        raise ValueError("src_indices and dst_indices must have the same length.")
+    if src.shape[1:] != dst.shape[1:]:
+        raise ValueError(f"Row shape mismatch: {src.shape[1:]=} vs {dst.shape[1:]=}.")
+    if src.device != dst.device:
+        raise ValueError(
+            f"src and dst must be on the same device: {src.device=} {dst.device=}"
+        )
+    if src_indices.numel() == 0:
+        return
+    if not src.is_cuda or not dst.is_cuda:
+        raise ValueError("copy_mamba_state_rows only supports CUDA tensors.")
+    if src_indices.device != src.device or dst_indices.device != dst.device:
+        raise ValueError("indices must be on the same device as src/dst.")
+    if src_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"src_indices must be int32/int64, got {src_indices.dtype}.")
+    if dst_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"dst_indices must be int32/int64, got {dst_indices.dtype}.")
+    if not src_indices.is_contiguous() or not dst_indices.is_contiguous():
+        raise ValueError("src_indices and dst_indices must be contiguous.")
+    if not (_row_interior_is_contiguous(src) and _row_interior_is_contiguous(dst)):
+        raise ValueError(
+            "src/dst row interiors must be contiguous for copy_mamba_state_rows."
+        )
+
+    row_numel = dst[0].numel()
+    block_size = 1024
+    grid = (src_indices.numel(), triton.cdiv(row_numel, block_size))
+    _copy_mamba_state_rows_kernel[grid](
+        src,
+        dst,
+        src_indices,
+        dst_indices,
+        src.stride(0),
+        dst.stride(0),
+        row_numel=row_numel,
+        BLOCK_SIZE=block_size,
+    )
+
+
+def copy_mamba_state_extend_rows(
+    h: torch.Tensor | None,
+    ssm_states: torch.Tensor,
+    track_ssm_h_src: torch.Tensor,
+    track_ssm_h_dst: torch.Tensor,
+    track_ssm_final_src: torch.Tensor,
+    track_ssm_final_dst: torch.Tensor,
+    *,
+    h_indices_trusted: bool,
+    final_indices_trusted: bool,
+    final_state_disjoint: bool,
+) -> None:
+    """Apply extend-time SSM tracking copies with metadata-driven overlap policy.
+
+    For h->state, src/dst are distinct tensors so direct Triton copy is used when
+    contract preconditions are met and CPU metadata marks indices as trusted. For
+    state->state, direct copy is used only if CPU metadata marks indices as trusted
+    and proves src/dst non-overlap; otherwise fallback uses exact PyTorch advanced
+    indexing gather-before-scatter semantics.
+    """
+    if track_ssm_h_src.numel() > 0:
+        assert h is not None
+        if (
+            h_indices_trusted
+            and _is_hip
+            and h.is_cuda
+            and ssm_states.is_cuda
+            and h.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and ssm_states.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and _row_interior_is_contiguous(h)
+            and _row_interior_is_contiguous(ssm_states)
+        ):
+            copy_mamba_state_rows(h, ssm_states, track_ssm_h_src, track_ssm_h_dst)
+        else:
+            _copy_rows_advanced_index(h, ssm_states, track_ssm_h_src, track_ssm_h_dst)
+
+    if track_ssm_final_src.numel() > 0:
+        if (
+            _is_hip
+            and ssm_states.is_cuda
+            and ssm_states.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and final_indices_trusted
+            and final_state_disjoint
+            and _row_interior_is_contiguous(ssm_states)
+        ):
+            copy_mamba_state_rows(
+                ssm_states,
+                ssm_states,
+                track_ssm_final_src,
+                track_ssm_final_dst,
+            )
+        else:
+            _copy_rows_advanced_index(
+                ssm_states,
+                ssm_states,
+                track_ssm_final_src,
+                track_ssm_final_dst,
+            )
+
 
 @triton.jit
 def track_mamba_state_if_needed_kernel(

--- a/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
+++ b/python/sglang/kernels/ops/mamba/mamba_state_scatter_triton.py
@@ -10,6 +10,209 @@ import torch
 import triton
 import triton.language as tl
 
+_is_hip = torch.version.hip is not None
+_SUPPORTED_STATE_COPY_DTYPES = (torch.bfloat16, torch.float32)
+
+
+def derive_track_ssm_copy_flags(
+    track_ssm_h_src: torch.Tensor,
+    track_ssm_h_dst: torch.Tensor,
+    track_ssm_final_src: torch.Tensor,
+    track_ssm_final_dst: torch.Tensor,
+    *,
+    h_state_rows: int,
+    pool_rows: int | None,
+) -> tuple[bool, bool, bool]:
+    """Derive trusted-index and non-overlap flags for extend tracking metadata."""
+
+    def _all_in_range(indices: torch.Tensor, lower: int, upper: int) -> bool:
+        if indices.numel() == 0:
+            return True
+        if upper <= lower:
+            return False
+        vals = indices.to(device="cpu", dtype=torch.int64).tolist()
+        return all(lower <= int(v) < upper for v in vals)
+
+    h_trusted = _all_in_range(track_ssm_h_src, 0, h_state_rows) and (
+        pool_rows is not None and _all_in_range(track_ssm_h_dst, 0, pool_rows)
+    )
+    final_trusted = (
+        pool_rows is not None
+        and _all_in_range(track_ssm_final_src, 0, pool_rows)
+        and _all_in_range(track_ssm_final_dst, 0, pool_rows)
+    )
+
+    final_disjoint = True
+    if track_ssm_final_src.numel() > 0 and track_ssm_final_dst.numel() > 0:
+        src_set = set(track_ssm_final_src.to(device="cpu", dtype=torch.int64).tolist())
+        dst_set = set(track_ssm_final_dst.to(device="cpu", dtype=torch.int64).tolist())
+        final_disjoint = src_set.isdisjoint(dst_set)
+    return h_trusted, final_trusted, final_disjoint
+
+
+@triton.jit
+def _copy_mamba_state_rows_kernel(
+    src_ptr,
+    dst_ptr,
+    src_indices_ptr,
+    dst_indices_ptr,
+    src_row_stride,
+    dst_row_stride,
+    row_numel: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pair_idx = tl.program_id(0).to(tl.int64)
+    tile_idx = tl.program_id(1).to(tl.int64)
+    offsets = tile_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < row_numel
+
+    src_idx = tl.load(src_indices_ptr + pair_idx).to(tl.int64)
+    dst_idx = tl.load(dst_indices_ptr + pair_idx).to(tl.int64)
+
+    src_row_stride = src_row_stride.to(tl.int64)
+    dst_row_stride = dst_row_stride.to(tl.int64)
+    src_off = src_idx * src_row_stride + offsets
+    dst_off = dst_idx * dst_row_stride + offsets
+
+    data = tl.load(src_ptr + src_off, mask=mask, other=0.0)
+    tl.store(dst_ptr + dst_off, data, mask=mask)
+
+
+def _row_interior_is_contiguous(t: torch.Tensor) -> bool:
+    if t.ndim < 2:
+        return False
+    expected_stride = 1
+    for dim in range(t.ndim - 1, 0, -1):
+        if t.stride(dim) != expected_stride:
+            return False
+        expected_stride *= t.shape[dim]
+    return True
+
+
+def _copy_rows_advanced_index(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+) -> None:
+    dst[dst_indices] = src[src_indices].to(dst.dtype, copy=False)
+
+
+def copy_mamba_state_rows(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    src_indices: torch.Tensor,
+    dst_indices: torch.Tensor,
+) -> None:
+    """Fast-path row copy for extend tracking.
+
+    Contract:
+    - ``src`` and ``dst`` are CUDA tensors on the same device.
+    - ``src_indices`` / ``dst_indices`` are contiguous int32/int64 tensors on-device.
+    - All indices are valid (no ``-1`` and no out-of-range values).
+    - Caller establishes gather-before-scatter safety for shared-storage copies.
+    """
+    if src_indices.ndim != 1 or dst_indices.ndim != 1:
+        raise ValueError("src_indices and dst_indices must be 1D tensors.")
+    if src_indices.numel() != dst_indices.numel():
+        raise ValueError("src_indices and dst_indices must have the same length.")
+    if src.shape[1:] != dst.shape[1:]:
+        raise ValueError(f"Row shape mismatch: {src.shape[1:]=} vs {dst.shape[1:]=}.")
+    if src.device != dst.device:
+        raise ValueError(
+            f"src and dst must be on the same device: {src.device=} {dst.device=}"
+        )
+    if src_indices.numel() == 0:
+        return
+    if not src.is_cuda or not dst.is_cuda:
+        raise ValueError("copy_mamba_state_rows only supports CUDA tensors.")
+    if src_indices.device != src.device or dst_indices.device != dst.device:
+        raise ValueError("indices must be on the same device as src/dst.")
+    if src_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"src_indices must be int32/int64, got {src_indices.dtype}.")
+    if dst_indices.dtype not in (torch.int32, torch.int64):
+        raise ValueError(f"dst_indices must be int32/int64, got {dst_indices.dtype}.")
+    if not src_indices.is_contiguous() or not dst_indices.is_contiguous():
+        raise ValueError("src_indices and dst_indices must be contiguous.")
+    if not (_row_interior_is_contiguous(src) and _row_interior_is_contiguous(dst)):
+        raise ValueError(
+            "src/dst row interiors must be contiguous for copy_mamba_state_rows."
+        )
+
+    row_numel = dst[0].numel()
+    block_size = 1024
+    grid = (src_indices.numel(), triton.cdiv(row_numel, block_size))
+    _copy_mamba_state_rows_kernel[grid](
+        src,
+        dst,
+        src_indices,
+        dst_indices,
+        src.stride(0),
+        dst.stride(0),
+        row_numel=row_numel,
+        BLOCK_SIZE=block_size,
+    )
+
+
+def copy_mamba_state_extend_rows(
+    h: torch.Tensor | None,
+    ssm_states: torch.Tensor,
+    track_ssm_h_src: torch.Tensor,
+    track_ssm_h_dst: torch.Tensor,
+    track_ssm_final_src: torch.Tensor,
+    track_ssm_final_dst: torch.Tensor,
+    *,
+    h_indices_trusted: bool,
+    final_indices_trusted: bool,
+    final_state_disjoint: bool,
+) -> None:
+    """Apply extend-time SSM tracking copies with metadata-driven overlap policy.
+
+    For h->state, src/dst are distinct tensors so direct Triton copy is used when
+    contract preconditions are met and CPU metadata marks indices as trusted. For
+    state->state, direct copy is used only if CPU metadata marks indices as trusted
+    and proves src/dst non-overlap; otherwise fallback uses exact PyTorch advanced
+    indexing gather-before-scatter semantics.
+    """
+    if track_ssm_h_src.numel() > 0:
+        assert h is not None
+        if (
+            h_indices_trusted
+            and _is_hip
+            and h.is_cuda
+            and ssm_states.is_cuda
+            and h.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and ssm_states.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and _row_interior_is_contiguous(h)
+            and _row_interior_is_contiguous(ssm_states)
+        ):
+            copy_mamba_state_rows(h, ssm_states, track_ssm_h_src, track_ssm_h_dst)
+        else:
+            _copy_rows_advanced_index(h, ssm_states, track_ssm_h_src, track_ssm_h_dst)
+
+    if track_ssm_final_src.numel() > 0:
+        if (
+            _is_hip
+            and ssm_states.is_cuda
+            and ssm_states.dtype in _SUPPORTED_STATE_COPY_DTYPES
+            and final_indices_trusted
+            and final_state_disjoint
+            and _row_interior_is_contiguous(ssm_states)
+        ):
+            copy_mamba_state_rows(
+                ssm_states,
+                ssm_states,
+                track_ssm_final_src,
+                track_ssm_final_dst,
+            )
+        else:
+            _copy_rows_advanced_index(
+                ssm_states,
+                ssm_states,
+                track_ssm_final_src,
+                track_ssm_final_dst,
+            )
+
 
 def _require_entry_contiguous_dst(
     dst: torch.Tensor, entry_start_dim: int, fn_name: str

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -10,6 +10,8 @@ from sglang.kernels.ops.mamba.mamba_state_indices_triton import (
     fused_replay_state_indices,
 )
 from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+    copy_mamba_state_extend_rows,
+    derive_track_ssm_copy_flags,
     scatter_mamba_states_after_mtp_verify,
     track_mamba_states_all_layers,
     track_mamba_states_if_needed,
@@ -89,6 +91,9 @@ class MambaAttnBackendBase(AttentionBackend):
         track_ssm_h_dst = None
         track_ssm_final_src = None
         track_ssm_final_dst = None
+        track_ssm_h_trusted = False
+        track_ssm_final_trusted = False
+        track_ssm_final_disjoint = False
 
         mamba_cache_indices = self.req_to_token_pool.get_mamba_indices(
             forward_batch.req_pool_indices
@@ -219,6 +224,9 @@ class MambaAttnBackendBase(AttentionBackend):
                         track_ssm_h_dst,
                         track_ssm_final_src,
                         track_ssm_final_dst,
+                        track_ssm_h_trusted,
+                        track_ssm_final_trusted,
+                        track_ssm_final_disjoint,
                     ) = self._init_track_ssm_indices(mamba_cache_indices, forward_batch)
         else:
             raise ValueError(f"Invalid forward mode: {forward_batch.forward_mode=}")
@@ -237,6 +245,9 @@ class MambaAttnBackendBase(AttentionBackend):
             track_ssm_h_dst=track_ssm_h_dst,
             track_ssm_final_src=track_ssm_final_src,
             track_ssm_final_dst=track_ssm_final_dst,
+            track_ssm_h_trusted=track_ssm_h_trusted,
+            track_ssm_final_trusted=track_ssm_final_trusted,
+            track_ssm_final_disjoint=track_ssm_final_disjoint,
             has_mamba_track_mask=has_mamba_track_mask,
             replayssm_write_pos=replayssm_write_pos,
             replayssm_force_flush=replayssm_force_flush,
@@ -352,11 +363,39 @@ class MambaAttnBackendBase(AttentionBackend):
         )
         track_ssm_h_dst = dst_masked[not_aligned]
 
+        # Trusted-index contract for direct Triton copies:
+        # - h-src rows are in [0, total_h_states)
+        # - state src/dst rows are in [0, pool_rows)
+        # Invalid/unknown metadata routes to exact PyTorch advanced indexing.
+        h_state_rows = int(num_h_states.sum().item())
+        pool_rows = None
+        mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
+        mamba_cache = getattr(mamba_pool, "mamba_cache", None)
+        if mamba_cache is not None and hasattr(mamba_cache, "temporal"):
+            # Global storage convention is [num_layers, pool_rows, ...].
+            pool_rows = int(mamba_cache.temporal.shape[1])
+
+        (
+            track_ssm_h_trusted,
+            track_ssm_final_trusted,
+            track_ssm_final_disjoint,
+        ) = derive_track_ssm_copy_flags(
+            track_ssm_h_src,
+            track_ssm_h_dst,
+            track_ssm_final_src,
+            track_ssm_final_dst,
+            h_state_rows=h_state_rows,
+            pool_rows=pool_rows,
+        )
+
         return (
             track_ssm_h_src.to(self.device, non_blocking=True),
             track_ssm_h_dst.to(self.device, non_blocking=True),
             track_ssm_final_src.to(self.device, non_blocking=True),
             track_ssm_final_dst.to(self.device, non_blocking=True),
+            track_ssm_h_trusted,
+            track_ssm_final_trusted,
+            track_ssm_final_disjoint,
         )
 
     def init_forward_metadata_capture_cpu_graph(
@@ -406,9 +445,9 @@ class MambaAttnBackendBase(AttentionBackend):
         return mask.cpu()
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
-        assert (
-            max_num_tokens % max_bs == 0
-        ), f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        assert max_num_tokens % max_bs == 0, (
+            f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        )
         draft_token_num = max_num_tokens // max_bs
         # Per-bs static write-cursor / force-flush buffers, captured by pointer +
         # refreshed in-place each replay; sized like state_indices_list. None when off.
@@ -463,9 +502,9 @@ class MambaAttnBackendBase(AttentionBackend):
         )
 
     def init_cpu_graph_state(self, max_bs: int, max_num_tokens: int):
-        assert (
-            max_num_tokens % max_bs == 0
-        ), f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        assert max_num_tokens % max_bs == 0, (
+            f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        )
         for i in range(max_bs):
             self.state_indices_list.append(
                 torch.full(
@@ -585,9 +624,9 @@ class MambaAttnBackendBase(AttentionBackend):
         # [-num_decodes:], which on the full max_bs buffer binds the stale tail.
         track_buf = None
         if mamba_track_indices is not None:
-            assert (
-                len(mamba_track_indices) >= bs
-            ), f"{len(mamba_track_indices)=} < {bs=}"
+            assert len(mamba_track_indices) >= bs, (
+                f"{len(mamba_track_indices)=} < {bs=}"
+            )
             track_buf = self.mamba_track_indices_buf[:bs]
             track_buf.copy_(self._translate_mamba_indices(mamba_track_indices[:bs]))
         # Refresh the static write cursor in-place (mirrors the eager
@@ -812,14 +851,17 @@ class MambaAttnBackendBase(AttentionBackend):
             # were requested. Aligned-only tracking reads the final state below.
             if forward_metadata.track_ssm_h_src.numel() > 0:
                 assert h is not None
-                h = h.squeeze(0)
-                ssm_states[forward_metadata.track_ssm_h_dst] = h[
-                    forward_metadata.track_ssm_h_src
-                ].to(ssm_states.dtype, copy=False)
-            if forward_metadata.track_ssm_final_src.numel() > 0:
-                ssm_states[forward_metadata.track_ssm_final_dst] = ssm_states[
-                    forward_metadata.track_ssm_final_src
-                ]
+            copy_mamba_state_extend_rows(
+                None if h is None else h.squeeze(0),
+                ssm_states,
+                forward_metadata.track_ssm_h_src,
+                forward_metadata.track_ssm_h_dst,
+                forward_metadata.track_ssm_final_src,
+                forward_metadata.track_ssm_final_dst,
+                h_indices_trusted=forward_metadata.track_ssm_h_trusted,
+                final_indices_trusted=forward_metadata.track_ssm_final_trusted,
+                final_state_disjoint=forward_metadata.track_ssm_final_disjoint,
+            )
 
 
 class Mamba2AttnBackend(MambaAttnBackendBase):
@@ -837,12 +879,14 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
         )
 
         if model_runner.server_args.enable_mamba_extra_buffer():
-            assert (
-                self.conv_states_shape[-1] < self.mamba_chunk_size
-            ), f"{self.conv_states_shape[-1]=} should be less than {self.mamba_chunk_size}"
+            assert self.conv_states_shape[-1] < self.mamba_chunk_size, (
+                f"{self.conv_states_shape[-1]=} should be less than {self.mamba_chunk_size}"
+            )
             assert (
                 model_runner.server_args.mamba_track_interval >= self.mamba_chunk_size
-            ), f"mamba_track_interval ({model_runner.server_args.mamba_track_interval}) must be >= mamba_chunk_size ({self.mamba_chunk_size})"
+            ), (
+                f"mamba_track_interval ({model_runner.server_args.mamba_track_interval}) must be >= mamba_chunk_size ({self.mamba_chunk_size})"
+            )
 
     def init_forward_metadata_out_graph(
         self,
@@ -870,9 +914,9 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             draft_token_num=draft_token_num,
         )
         # `forward` slices the track destinations from ([-num_decodes:])
-        assert (
-            self.forward_metadata.num_decodes == forward_batch.batch_size
-        ), f"{self.forward_metadata.num_decodes=} != {forward_batch.batch_size=}"
+        assert self.forward_metadata.num_decodes == forward_batch.batch_size, (
+            f"{self.forward_metadata.num_decodes=} != {forward_batch.batch_size=}"
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         metadata = self._forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -10,6 +10,8 @@ from sglang.kernels.ops.mamba.mamba_state_indices_triton import (
     fused_replay_state_indices,
 )
 from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+    copy_mamba_state_extend_rows,
+    derive_track_ssm_copy_flags,
     scatter_mamba_states_after_mtp_verify,
     track_mamba_states_all_layers,
     track_mamba_states_if_needed,
@@ -97,6 +99,9 @@ class MambaAttnBackendBase(AttentionBackend):
         track_ssm_h_dst = None
         track_ssm_final_src = None
         track_ssm_final_dst = None
+        track_ssm_h_trusted = False
+        track_ssm_final_trusted = False
+        track_ssm_final_disjoint = False
 
         mamba_cache_indices = self.req_to_token_pool.get_mamba_indices(
             forward_batch.req_pool_indices
@@ -227,6 +232,9 @@ class MambaAttnBackendBase(AttentionBackend):
                         track_ssm_h_dst,
                         track_ssm_final_src,
                         track_ssm_final_dst,
+                        track_ssm_h_trusted,
+                        track_ssm_final_trusted,
+                        track_ssm_final_disjoint,
                     ) = self._init_track_ssm_indices(mamba_cache_indices, forward_batch)
         else:
             raise ValueError(f"Invalid forward mode: {forward_batch.forward_mode=}")
@@ -245,6 +253,9 @@ class MambaAttnBackendBase(AttentionBackend):
             track_ssm_h_dst=track_ssm_h_dst,
             track_ssm_final_src=track_ssm_final_src,
             track_ssm_final_dst=track_ssm_final_dst,
+            track_ssm_h_trusted=track_ssm_h_trusted,
+            track_ssm_final_trusted=track_ssm_final_trusted,
+            track_ssm_final_disjoint=track_ssm_final_disjoint,
             has_mamba_track_mask=has_mamba_track_mask,
             replayssm_write_pos=replayssm_write_pos,
             replayssm_force_flush=replayssm_force_flush,
@@ -360,11 +371,39 @@ class MambaAttnBackendBase(AttentionBackend):
         )
         track_ssm_h_dst = dst_masked[not_aligned]
 
+        # Trusted-index contract for direct Triton copies:
+        # - h-src rows are in [0, total_h_states)
+        # - state src/dst rows are in [0, pool_rows)
+        # Invalid/unknown metadata routes to exact PyTorch advanced indexing.
+        h_state_rows = int(num_h_states.sum().item())
+        pool_rows = None
+        mamba_pool = getattr(self.req_to_token_pool, "mamba_pool", None)
+        mamba_cache = getattr(mamba_pool, "mamba_cache", None)
+        if mamba_cache is not None and hasattr(mamba_cache, "temporal"):
+            # Global storage convention is [num_layers, pool_rows, ...].
+            pool_rows = int(mamba_cache.temporal.shape[1])
+
+        (
+            track_ssm_h_trusted,
+            track_ssm_final_trusted,
+            track_ssm_final_disjoint,
+        ) = derive_track_ssm_copy_flags(
+            track_ssm_h_src,
+            track_ssm_h_dst,
+            track_ssm_final_src,
+            track_ssm_final_dst,
+            h_state_rows=h_state_rows,
+            pool_rows=pool_rows,
+        )
+
         return (
             track_ssm_h_src.to(self.device, non_blocking=True),
             track_ssm_h_dst.to(self.device, non_blocking=True),
             track_ssm_final_src.to(self.device, non_blocking=True),
             track_ssm_final_dst.to(self.device, non_blocking=True),
+            track_ssm_h_trusted,
+            track_ssm_final_trusted,
+            track_ssm_final_disjoint,
         )
 
     def init_forward_metadata_capture_cpu_graph(
@@ -414,9 +453,9 @@ class MambaAttnBackendBase(AttentionBackend):
         return mask.cpu()
 
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
-        assert (
-            max_num_tokens % max_bs == 0
-        ), f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        assert max_num_tokens % max_bs == 0, (
+            f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        )
         draft_token_num = max_num_tokens // max_bs
         # Per-bs static write-cursor / force-flush buffers, captured by pointer +
         # refreshed in-place each replay; sized like state_indices_list. None when off.
@@ -471,9 +510,9 @@ class MambaAttnBackendBase(AttentionBackend):
         )
 
     def init_cpu_graph_state(self, max_bs: int, max_num_tokens: int):
-        assert (
-            max_num_tokens % max_bs == 0
-        ), f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        assert max_num_tokens % max_bs == 0, (
+            f"max_num_tokens={max_num_tokens} must be divisible by max_bs={max_bs}"
+        )
         for i in range(max_bs):
             self.state_indices_list.append(
                 torch.full(
@@ -593,9 +632,9 @@ class MambaAttnBackendBase(AttentionBackend):
         # [-num_decodes:], which on the full max_bs buffer binds the stale tail.
         track_buf = None
         if mamba_track_indices is not None:
-            assert (
-                len(mamba_track_indices) >= bs
-            ), f"{len(mamba_track_indices)=} < {bs=}"
+            assert len(mamba_track_indices) >= bs, (
+                f"{len(mamba_track_indices)=} < {bs=}"
+            )
             track_buf = self.mamba_track_indices_buf[:bs]
             track_buf.copy_(self._translate_mamba_indices(mamba_track_indices[:bs]))
         # Refresh the static write cursor in-place (mirrors the eager
@@ -820,14 +859,17 @@ class MambaAttnBackendBase(AttentionBackend):
             # were requested. Aligned-only tracking reads the final state below.
             if forward_metadata.track_ssm_h_src.numel() > 0:
                 assert h is not None
-                h = h.squeeze(0)
-                ssm_states[forward_metadata.track_ssm_h_dst] = h[
-                    forward_metadata.track_ssm_h_src
-                ].to(ssm_states.dtype, copy=False)
-            if forward_metadata.track_ssm_final_src.numel() > 0:
-                ssm_states[forward_metadata.track_ssm_final_dst] = ssm_states[
-                    forward_metadata.track_ssm_final_src
-                ]
+            copy_mamba_state_extend_rows(
+                None if h is None else h.squeeze(0),
+                ssm_states,
+                forward_metadata.track_ssm_h_src,
+                forward_metadata.track_ssm_h_dst,
+                forward_metadata.track_ssm_final_src,
+                forward_metadata.track_ssm_final_dst,
+                h_indices_trusted=forward_metadata.track_ssm_h_trusted,
+                final_indices_trusted=forward_metadata.track_ssm_final_trusted,
+                final_state_disjoint=forward_metadata.track_ssm_final_disjoint,
+            )
 
 
 class Mamba2AttnBackend(MambaAttnBackendBase):
@@ -845,12 +887,14 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
         )
 
         if model_runner.server_args.enable_mamba_extra_buffer():
-            assert (
-                self.conv_states_shape[-1] < self.mamba_chunk_size
-            ), f"{self.conv_states_shape[-1]=} should be less than {self.mamba_chunk_size}"
+            assert self.conv_states_shape[-1] < self.mamba_chunk_size, (
+                f"{self.conv_states_shape[-1]=} should be less than {self.mamba_chunk_size}"
+            )
             assert (
                 model_runner.server_args.mamba_track_interval >= self.mamba_chunk_size
-            ), f"mamba_track_interval ({model_runner.server_args.mamba_track_interval}) must be >= mamba_chunk_size ({self.mamba_chunk_size})"
+            ), (
+                f"mamba_track_interval ({model_runner.server_args.mamba_track_interval}) must be >= mamba_chunk_size ({self.mamba_chunk_size})"
+            )
 
     def init_forward_metadata_out_graph(
         self,
@@ -878,9 +922,9 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             draft_token_num=draft_token_num,
         )
         # `forward` slices the track destinations from ([-num_decodes:])
-        assert (
-            self.forward_metadata.num_decodes == forward_batch.batch_size
-        ), f"{self.forward_metadata.num_decodes=} != {forward_batch.batch_size=}"
+        assert self.forward_metadata.num_decodes == forward_batch.batch_size, (
+            f"{self.forward_metadata.num_decodes=} != {forward_batch.batch_size=}"
+        )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         metadata = self._forward_metadata(forward_batch)

--- a/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
+++ b/python/sglang/srt/layers/attention/mamba/mamba2_metadata.py
@@ -55,6 +55,9 @@ class ForwardMetadata:
     track_ssm_h_dst: Optional[torch.Tensor] = None
     track_ssm_final_src: Optional[torch.Tensor] = None
     track_ssm_final_dst: Optional[torch.Tensor] = None
+    track_ssm_h_trusted: bool = False
+    track_ssm_final_trusted: bool = False
+    track_ssm_final_disjoint: bool = False
     state_checkpoint_cu_starts: Optional[torch.Tensor] = None
     num_state_checkpoints: int = 0
     state_checkpoint_every_n_tokens: int = 0
@@ -159,7 +162,6 @@ class Mamba2Metadata(ForwardMetadata):
 
         p = 0  # num of insertions
         for s, e in zip(cu_seqlens[:-1], cu_seqlens[1:]):
-
             # if does not divide chunk_size, then there is one chunk insertion
             p += s % chunk_size > 0
 
@@ -196,6 +198,9 @@ class Mamba2Metadata(ForwardMetadata):
             track_ssm_h_dst=forward_metadata.track_ssm_h_dst,
             track_ssm_final_src=forward_metadata.track_ssm_final_src,
             track_ssm_final_dst=forward_metadata.track_ssm_final_dst,
+            track_ssm_h_trusted=forward_metadata.track_ssm_h_trusted,
+            track_ssm_final_trusted=forward_metadata.track_ssm_final_trusted,
+            track_ssm_final_disjoint=forward_metadata.track_ssm_final_disjoint,
             has_mamba_track_mask=forward_metadata.has_mamba_track_mask,
             num_decodes=len(seq_lens) if num_decodes is None else num_decodes,
             num_prefills=0,
@@ -297,6 +302,9 @@ class Mamba2Metadata(ForwardMetadata):
             track_ssm_h_dst=forward_metadata.track_ssm_h_dst,
             track_ssm_final_src=forward_metadata.track_ssm_final_src,
             track_ssm_final_dst=forward_metadata.track_ssm_final_dst,
+            track_ssm_h_trusted=forward_metadata.track_ssm_h_trusted,
+            track_ssm_final_trusted=forward_metadata.track_ssm_final_trusted,
+            track_ssm_final_disjoint=forward_metadata.track_ssm_final_disjoint,
             has_mamba_track_mask=forward_metadata.has_mamba_track_mask,
             mamba_track_mask_indices=mamba_track_mask_indices,
             conv_states_mask_indices=conv_states_mask_indices,

--- a/test/registered/kernels/benchmark/attention/bench_mamba_extend_state_tracking.py
+++ b/test/registered/kernels/benchmark/attention/bench_mamba_extend_state_tracking.py
@@ -1,0 +1,191 @@
+import torch
+import triton
+import triton.testing
+
+from sglang.kernels.jit.benchmark.utils import DEFAULT_DEVICE, get_benchmark_range
+from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+    copy_mamba_state_extend_rows,
+    derive_track_ssm_copy_flags,
+)
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+register_amd_ci(est_time=30, stage="jit-kernel-benchmark", runner_config="amd")
+
+LOCAL_HV_VALUES = [2, 4, 8, 16, 24, 48]
+V_DIM = 128
+K_DIM = 128
+TRACKED_ROWS_LIST = get_benchmark_range(
+    full_range=[1, 8, 16, 32, 64, 128, 256],
+    ci_range=[32, 128],
+)
+DTYPE = torch.bfloat16
+NUM_LAYERS = 64
+
+
+def _make_h_to_state_case(local_hv: int, tracked_rows: int):
+    src_rows = max(512, tracked_rows * 2 + 32)
+    dst_rows = max(512, tracked_rows * 2 + 32)
+    shape = (local_hv, V_DIM, K_DIM)
+    h = torch.randn((src_rows, *shape), device=DEFAULT_DEVICE, dtype=torch.float32)
+    ssm_states = torch.randn((dst_rows, *shape), device=DEFAULT_DEVICE, dtype=DTYPE)
+    src_indices = torch.randperm(src_rows, device=DEFAULT_DEVICE, dtype=torch.int32)[
+        :tracked_rows
+    ].contiguous()
+    dst_indices = (
+        torch.randperm(dst_rows - NUM_LAYERS, device=DEFAULT_DEVICE, dtype=torch.int32)[
+            :tracked_rows
+        ].contiguous()
+        + NUM_LAYERS
+    )
+    empty = torch.empty((0,), device=DEFAULT_DEVICE, dtype=torch.int32)
+    return h, ssm_states, src_indices, dst_indices, empty, empty, src_rows, dst_rows
+
+
+def _make_state_to_state_case(local_hv: int, tracked_rows: int):
+    rows = max(512, tracked_rows * 3 + 64)
+    shape = (local_hv, V_DIM, K_DIM)
+    ssm_states = torch.randn((rows, *shape), device=DEFAULT_DEVICE, dtype=DTYPE)
+    span = rows - NUM_LAYERS
+    final_src = (
+        torch.randperm(span // 2, device=DEFAULT_DEVICE, dtype=torch.int32)[
+            :tracked_rows
+        ].contiguous()
+        + NUM_LAYERS
+    )
+    final_dst = (
+        torch.randperm(span // 2, device=DEFAULT_DEVICE, dtype=torch.int32)[
+            :tracked_rows
+        ].contiguous()
+        + NUM_LAYERS
+        + span // 2
+    )
+    empty = torch.empty((0,), device=DEFAULT_DEVICE, dtype=torch.int32)
+    h = torch.randn(
+        (tracked_rows + 16, *shape), device=DEFAULT_DEVICE, dtype=torch.float32
+    )
+    return h, ssm_states, empty, empty, final_src, final_dst, tracked_rows + 16, rows
+
+
+def _measure_alloc_bytes(fn):
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+    before = torch.cuda.memory_allocated()
+    fn()
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated()
+    return max(0, peak - before)
+
+
+def _run_integrated(
+    h,
+    ssm_states,
+    track_ssm_h_src,
+    track_ssm_h_dst,
+    track_ssm_final_src,
+    track_ssm_final_dst,
+    *,
+    h_indices_trusted: bool,
+    final_indices_trusted: bool,
+    final_state_disjoint: bool,
+):
+    copy_mamba_state_extend_rows(
+        h,
+        ssm_states,
+        track_ssm_h_src,
+        track_ssm_h_dst,
+        track_ssm_final_src,
+        track_ssm_final_dst,
+        h_indices_trusted=h_indices_trusted,
+        final_indices_trusted=final_indices_trusted,
+        final_state_disjoint=final_state_disjoint,
+    )
+
+
+def _run_advanced(
+    h,
+    ssm_states,
+    track_ssm_h_src,
+    track_ssm_h_dst,
+    track_ssm_final_src,
+    track_ssm_final_dst,
+):
+    if track_ssm_h_src.numel() > 0:
+        ssm_states[track_ssm_h_dst] = h[track_ssm_h_src].to(
+            ssm_states.dtype, copy=False
+        )
+    if track_ssm_final_src.numel() > 0:
+        ssm_states[track_ssm_final_dst] = ssm_states[track_ssm_final_src]
+
+
+def _bench_case(case_name: str, local_hv: int, tracked_rows: int, make_case):
+    h, ssm_states, h_src, h_dst, final_src, final_dst, h_rows, pool_rows = make_case(
+        local_hv, tracked_rows
+    )
+    h_trusted, final_trusted, final_disjoint = derive_track_ssm_copy_flags(
+        h_src,
+        h_dst,
+        final_src,
+        final_dst,
+        h_state_rows=h_rows,
+        pool_rows=pool_rows,
+    )
+
+    for provider in ("integrated_direct", "advanced_indexing"):
+
+        def fn():
+            if provider == "integrated_direct":
+                _run_integrated(
+                    h,
+                    ssm_states,
+                    h_src,
+                    h_dst,
+                    final_src,
+                    final_dst,
+                    h_indices_trusted=h_trusted,
+                    final_indices_trusted=final_trusted,
+                    final_state_disjoint=final_disjoint,
+                )
+            else:
+                _run_advanced(h, ssm_states, h_src, h_dst, final_src, final_dst)
+
+        median_ms = triton.testing.do_bench(
+            fn, warmup=25, rep=200, return_mode="median"
+        )
+        median_us = median_ms * 1000.0
+        alloc_bytes = _measure_alloc_bytes(fn)
+        print(
+            f"{case_name},{provider},{local_hv},{tracked_rows},{median_us:.3f},{alloc_bytes}"
+        )
+
+
+def benchmark():
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA/ROCm device is required for this benchmark.")
+    dev = torch.device(DEFAULT_DEVICE)
+    props = torch.cuda.get_device_properties(dev)
+    print(f"# device={props.name}")
+    print(f"# torch={torch.__version__}")
+    print(f"# triton={triton.__version__}")
+    print("case,provider,local_hv,tracked_rows,median_us,alloc_bytes")
+
+    for local_hv in LOCAL_HV_VALUES:
+        for tracked_rows in TRACKED_ROWS_LIST:
+            _bench_case(
+                "h_to_state",
+                local_hv,
+                tracked_rows,
+                _make_h_to_state_case,
+            )
+            _bench_case(
+                "state_to_state_disjoint",
+                local_hv,
+                tracked_rows,
+                _make_state_to_state_case,
+            )
+
+
+if __name__ == "__main__":
+    benchmark()

--- a/test/registered/unit/layers/test_mamba_extend_tracking_backend.py
+++ b/test/registered/unit/layers/test_mamba_extend_tracking_backend.py
@@ -1,0 +1,355 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=8, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+try:
+    import sglang.srt.layers.attention.hybrid_linear_attn_backend as hybrid_backend
+    from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+        MambaAttnBackendBase,
+    )
+    from sglang.srt.layers.attention.mamba.mamba2_metadata import (
+        ForwardMetadata,
+        Mamba2Metadata,
+    )
+
+    _BACKEND_IMPORT_ERROR = None
+except Exception as e:  # pragma: no cover
+    MambaAttnBackendBase = None
+    hybrid_backend = None
+    ForwardMetadata = None
+    Mamba2Metadata = None
+    _BACKEND_IMPORT_ERROR = e
+
+
+class _FakeReqToTokenPool:
+    def __init__(self, *, device: torch.device, num_layers: int, pool_rows: int):
+        self._device = device
+        self._pool_rows = pool_rows
+        self.mamba_pool = SimpleNamespace(
+            mamba_cache=SimpleNamespace(
+                temporal=torch.empty(
+                    (num_layers, pool_rows, 2, 128, 128), device=device
+                )
+            )
+        )
+
+    def get_mamba_indices(self, req_pool_indices: torch.Tensor) -> torch.Tensor:
+        return req_pool_indices.to(device=self._device, dtype=torch.int64)
+
+    def translate_mamba_indices(self, mamba_indices: torch.Tensor) -> torch.Tensor:
+        return mamba_indices
+
+
+def _build_backend(
+    device: torch.device, pool_rows: int, *, num_layers: int = 4
+) -> MambaAttnBackendBase:
+    backend = MambaAttnBackendBase.__new__(MambaAttnBackendBase)
+    backend.device = device
+    backend.topk = 0
+    backend.enable_unified_memory = False
+    backend.req_to_token_pool = _FakeReqToTokenPool(
+        device=device, num_layers=num_layers, pool_rows=pool_rows
+    )
+    backend.conv_states_shape = (num_layers, pool_rows, 32)
+    return backend
+
+
+class TestMambaExtendTrackingBackend(unittest.TestCase):
+    def setUp(self):
+        if MambaAttnBackendBase is None:
+            self.skipTest(f"backend import failed: {_BACKEND_IMPORT_ERROR}")
+
+    def test_init_track_ssm_indices_mixed_alignment_and_trust(self):
+        device = torch.device("cpu")
+        backend = _build_backend(device, pool_rows=64, num_layers=4)
+        chunk = 16
+
+        mamba_cache_indices = torch.tensor([12, 20], device=device, dtype=torch.int64)
+        forward_batch = SimpleNamespace(
+            mamba_track_mask=torch.tensor([True, True], device=device),
+            extend_seq_lens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            mamba_track_indices=torch.tensor(
+                [33, 40], device=device, dtype=torch.int64
+            ),
+            mamba_track_seqlens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            extend_prefix_lens=torch.tensor([0, 0], device=device, dtype=torch.int64),
+        )
+
+        with mock.patch.object(
+            hybrid_backend,
+            "get_server_args",
+            return_value=SimpleNamespace(mamba_cache_chunk_size=chunk),
+        ):
+            (
+                h_src,
+                h_dst,
+                final_src,
+                final_dst,
+                h_trusted,
+                final_trusted,
+                final_disjoint,
+            ) = backend._init_track_ssm_indices(mamba_cache_indices, forward_batch)
+
+        self.assertEqual(h_src.numel(), 1)
+        self.assertEqual(final_src.numel(), 1)
+        self.assertTrue(h_trusted)
+        self.assertTrue(final_trusted)
+        self.assertTrue(final_disjoint)
+        self.assertTrue(torch.equal(h_dst.cpu(), torch.tensor([33], dtype=torch.int64)))
+        self.assertTrue(
+            torch.equal(final_dst.cpu(), torch.tensor([40], dtype=torch.int64))
+        )
+
+    def test_init_track_ssm_indices_invalid_routes_untrusted(self):
+        device = torch.device("cpu")
+        backend = _build_backend(device, pool_rows=32, num_layers=4)
+        chunk = 16
+
+        mamba_cache_indices = torch.tensor([12, 14], device=device, dtype=torch.int64)
+        forward_batch = SimpleNamespace(
+            mamba_track_mask=torch.tensor([True, True], device=device),
+            extend_seq_lens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            mamba_track_indices=torch.tensor(
+                [28, 100], device=device, dtype=torch.int64
+            ),
+            mamba_track_seqlens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            extend_prefix_lens=torch.tensor([0, 0], device=device, dtype=torch.int64),
+        )
+
+        with mock.patch.object(
+            hybrid_backend,
+            "get_server_args",
+            return_value=SimpleNamespace(mamba_cache_chunk_size=chunk),
+        ):
+            (
+                _h_src,
+                _h_dst,
+                _final_src,
+                _final_dst,
+                h_trusted,
+                final_trusted,
+                _final_disjoint,
+            ) = backend._init_track_ssm_indices(mamba_cache_indices, forward_batch)
+
+        self.assertTrue(h_trusted)
+        self.assertFalse(final_trusted)
+
+    def test_track_mamba_state_extend_mixed_aligned_unaligned(self):
+        device = torch.device("cpu")
+        backend = _build_backend(device, pool_rows=64, num_layers=4)
+
+        h = torch.randn((1, 6, 2, 128, 128), device=device, dtype=torch.float32)
+        ssm_states = torch.randn((64, 2, 128, 128), device=device, dtype=torch.bfloat16)
+        ref = ssm_states.clone()
+
+        h_src = torch.tensor([1, 4], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([31, 42], device=device, dtype=torch.int32)
+        final_src = torch.tensor([33, 36], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([50, 57], device=device, dtype=torch.int32)
+        ref[h_dst] = h.squeeze(0)[h_src].to(ref.dtype, copy=False)
+        ref[final_dst] = ref[final_src]
+
+        metadata = ForwardMetadata(
+            query_start_loc=torch.zeros((1,), device=device, dtype=torch.int32),
+            mamba_cache_indices=torch.zeros((1,), device=device, dtype=torch.int32),
+            has_mamba_track_mask=True,
+            track_ssm_h_src=h_src,
+            track_ssm_h_dst=h_dst,
+            track_ssm_final_src=final_src,
+            track_ssm_final_dst=final_dst,
+            track_ssm_h_trusted=True,
+            track_ssm_final_trusted=True,
+            track_ssm_final_disjoint=True,
+        )
+        forward_batch = SimpleNamespace()
+
+        def _ref_extend_copy(
+            h_local,
+            ssm_local,
+            h_src_local,
+            h_dst_local,
+            final_src_local,
+            final_dst_local,
+            *,
+            h_indices_trusted,
+            final_indices_trusted,
+            final_state_disjoint,
+        ):
+            self.assertTrue(h_indices_trusted)
+            self.assertTrue(final_indices_trusted)
+            self.assertTrue(final_state_disjoint)
+            ssm_local[h_dst_local] = h_local[h_src_local].to(
+                ssm_local.dtype, copy=False
+            )
+            ssm_local[final_dst_local] = ssm_local[final_src_local]
+
+        with mock.patch.object(
+            hybrid_backend, "copy_mamba_state_extend_rows", side_effect=_ref_extend_copy
+        ) as patched:
+            backend._track_mamba_state_extend(forward_batch, h, ssm_states, metadata)
+            self.assertEqual(patched.call_count, 1)
+        self.assertTrue(torch.equal(ssm_states, ref))
+
+    def test_track_mamba_state_extend_propagates_overlap_fallback(self):
+        device = torch.device("cpu")
+        backend = _build_backend(device, pool_rows=32, num_layers=4)
+
+        h = None
+        ssm_states = torch.randn((16, 2, 128, 128), device=device, dtype=torch.bfloat16)
+        ref = ssm_states.clone()
+
+        final_src = torch.tensor([12, 13, 14], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([13, 14, 15], device=device, dtype=torch.int32)
+        ref[final_dst] = ref[final_src]
+
+        metadata = ForwardMetadata(
+            query_start_loc=torch.zeros((1,), device=device, dtype=torch.int32),
+            mamba_cache_indices=torch.zeros((1,), device=device, dtype=torch.int32),
+            has_mamba_track_mask=True,
+            track_ssm_h_src=torch.empty((0,), device=device, dtype=torch.int32),
+            track_ssm_h_dst=torch.empty((0,), device=device, dtype=torch.int32),
+            track_ssm_final_src=final_src,
+            track_ssm_final_dst=final_dst,
+            track_ssm_h_trusted=True,
+            track_ssm_final_trusted=True,
+            track_ssm_final_disjoint=False,
+        )
+        forward_batch = SimpleNamespace()
+
+        def _ref_extend_copy(
+            h_local,
+            ssm_local,
+            h_src_local,
+            h_dst_local,
+            final_src_local,
+            final_dst_local,
+            *,
+            h_indices_trusted,
+            final_indices_trusted,
+            final_state_disjoint,
+        ):
+            self.assertIsNone(h_local)
+            self.assertTrue(h_indices_trusted)
+            self.assertTrue(final_indices_trusted)
+            self.assertFalse(final_state_disjoint)
+            ssm_local[final_dst_local] = ssm_local[final_src_local]
+
+        with mock.patch.object(
+            hybrid_backend, "copy_mamba_state_extend_rows", side_effect=_ref_extend_copy
+        ) as patched:
+            backend._track_mamba_state_extend(forward_batch, h, ssm_states, metadata)
+            self.assertEqual(patched.call_count, 1)
+        self.assertTrue(torch.equal(ssm_states, ref))
+
+    def test_extend_metadata_chain_propagates_flags(self):
+        device = torch.device("cpu")
+        backend = _build_backend(device, pool_rows=96, num_layers=6)
+        chunk = 16
+
+        class _FakeMode:
+            def is_decode_or_idle(self):
+                return False
+
+            def is_extend(self, include_draft_extend_v2=True):
+                return True
+
+            def is_draft_extend_v2(self):
+                return False
+
+            def is_target_verify(self):
+                return False
+
+        forward_batch = SimpleNamespace(
+            batch_size=2,
+            req_pool_indices=torch.tensor([12, 20], device=device, dtype=torch.int64),
+            mamba_track_indices=torch.tensor(
+                [41, 63], device=device, dtype=torch.int64
+            ),
+            _original_batch_size=None,
+            forward_mode=_FakeMode(),
+            extend_start_loc=torch.tensor(
+                [0, chunk + 1], device=device, dtype=torch.int32
+            ),
+            extend_seq_lens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            extend_seq_lens_cpu=[chunk + 1, chunk],
+            mamba_track_mask=torch.tensor([True, True], device=device),
+            mamba_track_seqlens=torch.tensor(
+                [chunk + 1, chunk], device=device, dtype=torch.int64
+            ),
+            extend_prefix_lens=torch.tensor([0, 0], device=device, dtype=torch.int64),
+            extend_num_tokens=2 * chunk + 1,
+            seq_lens=torch.tensor([chunk + 1, chunk], device=device, dtype=torch.int32),
+            spec_info=None,
+        )
+        h = torch.randn((1, 6, 2, 128, 128), device=device, dtype=torch.float32)
+        ssm_states = torch.randn((96, 2, 128, 128), device=device, dtype=torch.bfloat16)
+        ref = ssm_states.clone()
+
+        with mock.patch.object(
+            hybrid_backend,
+            "get_server_args",
+            return_value=SimpleNamespace(mamba_cache_chunk_size=chunk),
+        ):
+            forward_metadata = backend._forward_metadata(forward_batch)
+        mamba2_meta = Mamba2Metadata.prepare_mixed(
+            forward_metadata, chunk_size=chunk, forward_batch=forward_batch
+        )
+
+        self.assertTrue(mamba2_meta.track_ssm_h_trusted)
+        self.assertTrue(mamba2_meta.track_ssm_final_trusted)
+        self.assertTrue(mamba2_meta.track_ssm_final_disjoint)
+        self.assertGreater(int(mamba2_meta.track_ssm_h_dst.min().item()), 6)
+        self.assertGreater(int(mamba2_meta.track_ssm_final_dst.min().item()), 6)
+
+        ref[mamba2_meta.track_ssm_h_dst] = h.squeeze(0)[mamba2_meta.track_ssm_h_src].to(
+            ref.dtype, copy=False
+        )
+        ref[mamba2_meta.track_ssm_final_dst] = ref[mamba2_meta.track_ssm_final_src]
+
+        def _ref_extend_copy(
+            h_local,
+            ssm_local,
+            h_src_local,
+            h_dst_local,
+            final_src_local,
+            final_dst_local,
+            *,
+            h_indices_trusted,
+            final_indices_trusted,
+            final_state_disjoint,
+        ):
+            self.assertTrue(h_indices_trusted)
+            self.assertTrue(final_indices_trusted)
+            self.assertTrue(final_state_disjoint)
+            ssm_local[h_dst_local] = h_local[h_src_local].to(
+                ssm_local.dtype, copy=False
+            )
+            ssm_local[final_dst_local] = ssm_local[final_src_local]
+
+        with mock.patch.object(
+            hybrid_backend, "copy_mamba_state_extend_rows", side_effect=_ref_extend_copy
+        ) as patched:
+            backend._track_mamba_state_extend(forward_batch, h, ssm_states, mamba2_meta)
+            self.assertEqual(patched.call_count, 1)
+        self.assertTrue(torch.equal(ssm_states, ref))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/test/registered/unit/layers/test_mamba_state_scatter_triton.py
+++ b/test/registered/unit/layers/test_mamba_state_scatter_triton.py
@@ -1,19 +1,26 @@
-from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
-
-register_cuda_ci(est_time=7, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=7, suite="stage-b-test-1-gpu-small-amd-mi35x")
-
 import unittest
+from unittest import mock
 
 import torch
 
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=40, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
 try:
+    import sglang.kernels.ops.mamba.mamba_state_scatter_triton as mamba_state_scatter
     from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
+        copy_mamba_state_extend_rows,
+        copy_mamba_state_rows,
         fused_mamba_state_scatter_with_mask,
     )
 
     _FUSED_IMPORT_ERROR = None
 except Exception as e:  # pragma: no cover
+    mamba_state_scatter = None
+    copy_mamba_state_extend_rows = None
+    copy_mamba_state_rows = None
     fused_mamba_state_scatter_with_mask = None
     _FUSED_IMPORT_ERROR = e
 
@@ -211,6 +218,435 @@ class TestMambaStateScatterCorrectness(unittest.TestCase):
 
         torch.testing.assert_close(ssm_fused, ssm_ref)
         torch.testing.assert_close(conv_fused, conv_ref)
+
+
+def _ref_copy_rows(src, dst, src_indices, dst_indices):
+    dst[dst_indices] = src[src_indices].to(dst.dtype, copy=False)
+
+
+class TestCopyMambaStateRows(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_copy_api_is_available(self):
+        self.assertIsNotNone(
+            copy_mamba_state_rows,
+            msg=f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}",
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_h_to_state_bf16_fp32_and_dtype_conversion(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(123)
+        src_indices = torch.tensor([1, 5, 7, 9], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([0, 3, 6, 8], device=device, dtype=torch.int32)
+
+        for src_dtype, dst_dtype in [
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float32, torch.float32),
+            (torch.float32, torch.bfloat16),
+            (torch.bfloat16, torch.float32),
+        ]:
+            src = torch.randn((16, 128), device=device, dtype=src_dtype)
+            dst = torch.randn((16, 128), device=device, dtype=dst_dtype)
+            ref = dst.clone()
+
+            _ref_copy_rows(src, ref, src_indices, dst_indices)
+            copy_mamba_state_rows(src, dst, src_indices, dst_indices)
+            torch.testing.assert_close(dst, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_nontrivial_row_stride_view_and_empty_indices(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(0)
+
+        src_base = torch.randn((48, 300), device=device, dtype=torch.float32)
+        dst_base = torch.randn((64, 320), device=device, dtype=torch.bfloat16)
+
+        src = src_base.as_strided(
+            (20, 128), (src_base.stride(0) * 2, 1), storage_offset=17
+        )
+        dst = dst_base.as_strided(
+            (24, 128), (dst_base.stride(0) * 2, 1), storage_offset=11
+        )
+        ref = dst.clone()
+
+        src_indices = torch.tensor([0, 4, 7, 13, 19], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([2, 5, 9, 15, 23], device=device, dtype=torch.int32)
+        _ref_copy_rows(src, ref, src_indices, dst_indices)
+        copy_mamba_state_rows(src, dst, src_indices, dst_indices)
+        torch.testing.assert_close(dst, ref)
+
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        dst_before = dst.clone()
+        copy_mamba_state_rows(src, dst, empty, empty)
+        torch.testing.assert_close(dst, dst_before)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_disjoint_copy(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(7)
+        state = torch.randn((12, 96), device=device, dtype=torch.bfloat16)
+        ref = state.clone()
+
+        src_indices = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([4, 5, 6, 7], device=device, dtype=torch.int32)
+
+        _ref_copy_rows(ref, ref, src_indices, dst_indices)
+        copy_mamba_state_rows(state, state, src_indices, dst_indices)
+        torch.testing.assert_close(state, ref)
+
+
+class TestCopyMambaStateExtendRows(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_non_hip_platform_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((8, 2, 128, 128), device=device, dtype=torch.float32)
+        ssm_states = torch.randn((16, 2, 128, 128), device=device, dtype=torch.bfloat16)
+        h_src = torch.tensor([0, 2], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([8, 10], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with (
+            mock.patch.object(mamba_state_scatter, "_is_hip", False),
+            mock.patch.object(
+                mamba_state_scatter,
+                "copy_mamba_state_rows",
+                side_effect=AssertionError("direct helper should not run"),
+            ),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_unvalidated_dtype_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((8, 2, 128, 128), device=device, dtype=torch.float16)
+        ssm_states = torch.randn((16, 2, 128, 128), device=device, dtype=torch.float16)
+        h_src = torch.tensor([0, 2], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([8, 10], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("direct helper should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_h_to_state_direct_canonical_shape(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(13)
+        hv, v_dim, k_dim = 4, 128, 128
+        h = torch.randn((1, 32, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        ssm_states = torch.randn(
+            (64, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h2 = h.squeeze(0)
+
+        h_src = torch.tensor([1, 3, 5, 7], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([2, 9, 15, 21], device=device, dtype=torch.int32)
+        final_src = torch.empty((0,), device=device, dtype=torch.int32)
+        final_dst = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+
+        _ref_copy_rows(h2, ref, h_src, h_dst)
+        copy_mamba_state_extend_rows(
+            h2,
+            ssm_states,
+            h_src,
+            h_dst,
+            final_src,
+            final_dst,
+            h_indices_trusted=True,
+            final_indices_trusted=True,
+            final_state_disjoint=True,
+        )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.hip is not None,
+        "ROCm GPU is required for direct large-shape coverage.",
+    )
+    def test_h_to_state_direct_qwen_shapes(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        torch.manual_seed(91)
+
+        for hv in (8, 16, 24, 48):
+            for tracked_rows in (1, 64, 256):
+                with self.subTest(hv=hv, tracked_rows=tracked_rows):
+                    h = torch.empty(
+                        (tracked_rows, hv, 128, 128),
+                        device=device,
+                        dtype=torch.bfloat16,
+                    ).uniform_(-1, 1)
+                    ssm_states = torch.zeros_like(h)
+                    indices = torch.arange(
+                        tracked_rows, device=device, dtype=torch.int32
+                    )
+
+                    with mock.patch.object(
+                        mamba_state_scatter,
+                        "_copy_rows_advanced_index",
+                        side_effect=AssertionError(
+                            "large trusted HIP shapes must use direct copy"
+                        ),
+                    ):
+                        copy_mamba_state_extend_rows(
+                            h,
+                            ssm_states,
+                            indices,
+                            indices,
+                            empty,
+                            empty,
+                            h_indices_trusted=True,
+                            final_indices_trusted=True,
+                            final_state_disjoint=True,
+                        )
+
+                    self.assertTrue(torch.equal(ssm_states, h))
+                    del h, ssm_states, indices
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.hip is None,
+        "A CUDA GPU is required for the real-platform fallback test.",
+    )
+    def test_real_cuda_platform_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((4, 8, 128, 128), device=device, dtype=torch.bfloat16)
+        ssm_states = torch.zeros_like(h)
+        indices = torch.arange(4, device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("CUDA must not launch the HIP direct helper"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                indices,
+                indices,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+
+        self.assertTrue(torch.equal(ssm_states, h))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_disjoint_uses_direct_path(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(31)
+        hv, v_dim, k_dim = 2, 128, 128
+        ssm_states = torch.randn(
+            (32, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h = torch.randn((16, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        final_src = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([8, 9, 10, 11], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "_copy_rows_advanced_index",
+            side_effect=AssertionError("advanced-index fallback should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                empty,
+                empty,
+                final_src,
+                final_dst,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_overlap_uses_fallback(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(52)
+        hv, v_dim, k_dim = 2, 128, 128
+        ssm_states = torch.randn(
+            (24, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h = torch.randn((12, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        final_src = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([1, 2, 3, 4], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+
+        copy_mamba_state_extend_rows(
+            h,
+            ssm_states,
+            empty,
+            empty,
+            final_src,
+            final_dst,
+            h_indices_trusted=True,
+            final_indices_trusted=True,
+            final_state_disjoint=False,
+        )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_page_like_row_stride(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(77)
+        hv, v_dim, k_dim = 2, 128, 128
+        row_elems = hv * v_dim * k_dim
+        row_stride = row_elems + 37
+        storage = torch.randn((64 * row_stride,), device=device, dtype=torch.bfloat16)
+        ssm_states = storage.as_strided(
+            (64, hv, v_dim, k_dim),
+            (row_stride, v_dim * k_dim, k_dim, 1),
+        )
+        h = torch.randn((32, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        h_src = torch.tensor([0, 3, 6, 9], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([7, 11, 14, 20], device=device, dtype=torch.int32)
+        final_src = torch.tensor([2, 4, 5], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([22, 23, 24], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+
+        _ref_copy_rows(h, ref, h_src, h_dst)
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+        with mock.patch.object(
+            mamba_state_scatter,
+            "_copy_rows_advanced_index",
+            side_effect=AssertionError("fallback should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                final_src,
+                final_dst,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_untrusted_indices_route_to_pytorch_fallback(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        hv, v_dim, k_dim = 2, 128, 128
+        h = torch.randn((8, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        ssm_states = torch.randn(
+            (8, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        ref = ssm_states.clone()
+        h_src = torch.tensor([0, -1], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([1, 6], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("direct helper should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=False,
+                final_indices_trusted=False,
+                final_state_disjoint=False,
+            )
+        torch.testing.assert_close(ssm_states, ref)
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/test/registered/unit/layers/test_mamba_state_scatter_triton.py
+++ b/test/registered/unit/layers/test_mamba_state_scatter_triton.py
@@ -1,21 +1,29 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.mem_cache.layout.page_major import (
+    build_page_major_mamba_views,
+    mamba_entry_bytes,
+)
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
     register_cuda_ci,
 )
 
-register_cuda_ci(est_time=7, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=7, suite="stage-b-test-1-gpu-small-amd-mi35x")
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=40, suite="stage-b-test-1-gpu-small-amd-mi35x")
 # The dst layout-contract tests run on CPU (no kernel launch).
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
-import unittest
-
-import torch
-
 try:
+    import sglang.kernels.ops.mamba.mamba_state_scatter_triton as mamba_state_scatter
     from sglang.kernels.ops.mamba.mamba_state_scatter_triton import (
         _require_entry_contiguous_dst,
+        copy_mamba_state_extend_rows,
+        copy_mamba_state_rows,
         fused_conv_window_scatter_with_mask,
         fused_mamba_state_scatter_with_mask,
     )
@@ -23,15 +31,12 @@ try:
     _FUSED_IMPORT_ERROR = None
 except Exception as e:  # pragma: no cover
     _require_entry_contiguous_dst = None
+    mamba_state_scatter = None
+    copy_mamba_state_extend_rows = None
+    copy_mamba_state_rows = None
     fused_conv_window_scatter_with_mask = None
     fused_mamba_state_scatter_with_mask = None
     _FUSED_IMPORT_ERROR = e
-
-from sglang.srt.mem_cache.layout.page_major import (
-    build_page_major_mamba_views,
-    mamba_entry_bytes,
-)
-
 
 def _ref_scatter(dst, src, dst_indices, src_indices, step_indices):
     """Reference implementation using PyTorch advanced indexing."""
@@ -363,6 +368,435 @@ class TestMambaStateScatterEnvelopeDst(unittest.TestCase):
 
         torch.testing.assert_close(temporal, expect_temporal)
         torch.testing.assert_close(conv_views[0], expect_conv)
+
+
+def _ref_copy_rows(src, dst, src_indices, dst_indices):
+    dst[dst_indices] = src[src_indices].to(dst.dtype, copy=False)
+
+
+class TestCopyMambaStateRows(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_copy_api_is_available(self):
+        self.assertIsNotNone(
+            copy_mamba_state_rows,
+            msg=f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}",
+        )
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_h_to_state_bf16_fp32_and_dtype_conversion(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(123)
+        src_indices = torch.tensor([1, 5, 7, 9], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([0, 3, 6, 8], device=device, dtype=torch.int32)
+
+        for src_dtype, dst_dtype in [
+            (torch.bfloat16, torch.bfloat16),
+            (torch.float32, torch.float32),
+            (torch.float32, torch.bfloat16),
+            (torch.bfloat16, torch.float32),
+        ]:
+            src = torch.randn((16, 128), device=device, dtype=src_dtype)
+            dst = torch.randn((16, 128), device=device, dtype=dst_dtype)
+            ref = dst.clone()
+
+            _ref_copy_rows(src, ref, src_indices, dst_indices)
+            copy_mamba_state_rows(src, dst, src_indices, dst_indices)
+            torch.testing.assert_close(dst, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_nontrivial_row_stride_view_and_empty_indices(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(0)
+
+        src_base = torch.randn((48, 300), device=device, dtype=torch.float32)
+        dst_base = torch.randn((64, 320), device=device, dtype=torch.bfloat16)
+
+        src = src_base.as_strided(
+            (20, 128), (src_base.stride(0) * 2, 1), storage_offset=17
+        )
+        dst = dst_base.as_strided(
+            (24, 128), (dst_base.stride(0) * 2, 1), storage_offset=11
+        )
+        ref = dst.clone()
+
+        src_indices = torch.tensor([0, 4, 7, 13, 19], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([2, 5, 9, 15, 23], device=device, dtype=torch.int32)
+        _ref_copy_rows(src, ref, src_indices, dst_indices)
+        copy_mamba_state_rows(src, dst, src_indices, dst_indices)
+        torch.testing.assert_close(dst, ref)
+
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        dst_before = dst.clone()
+        copy_mamba_state_rows(src, dst, empty, empty)
+        torch.testing.assert_close(dst, dst_before)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_disjoint_copy(self):
+        if copy_mamba_state_rows is None:
+            self.skipTest(f"copy_mamba_state_rows import failed: {_FUSED_IMPORT_ERROR}")
+
+        device = torch.device("cuda")
+        torch.manual_seed(7)
+        state = torch.randn((12, 96), device=device, dtype=torch.bfloat16)
+        ref = state.clone()
+
+        src_indices = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        dst_indices = torch.tensor([4, 5, 6, 7], device=device, dtype=torch.int32)
+
+        _ref_copy_rows(ref, ref, src_indices, dst_indices)
+        copy_mamba_state_rows(state, state, src_indices, dst_indices)
+        torch.testing.assert_close(state, ref)
+
+
+class TestCopyMambaStateExtendRows(unittest.TestCase):
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_non_hip_platform_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((8, 2, 128, 128), device=device, dtype=torch.float32)
+        ssm_states = torch.randn((16, 2, 128, 128), device=device, dtype=torch.bfloat16)
+        h_src = torch.tensor([0, 2], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([8, 10], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with (
+            mock.patch.object(mamba_state_scatter, "_is_hip", False),
+            mock.patch.object(
+                mamba_state_scatter,
+                "copy_mamba_state_rows",
+                side_effect=AssertionError("direct helper should not run"),
+            ),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_unvalidated_dtype_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((8, 2, 128, 128), device=device, dtype=torch.float16)
+        ssm_states = torch.randn((16, 2, 128, 128), device=device, dtype=torch.float16)
+        h_src = torch.tensor([0, 2], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([8, 10], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("direct helper should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_h_to_state_direct_canonical_shape(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(13)
+        hv, v_dim, k_dim = 4, 128, 128
+        h = torch.randn((1, 32, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        ssm_states = torch.randn(
+            (64, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h2 = h.squeeze(0)
+
+        h_src = torch.tensor([1, 3, 5, 7], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([2, 9, 15, 21], device=device, dtype=torch.int32)
+        final_src = torch.empty((0,), device=device, dtype=torch.int32)
+        final_dst = torch.empty((0,), device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+
+        _ref_copy_rows(h2, ref, h_src, h_dst)
+        copy_mamba_state_extend_rows(
+            h2,
+            ssm_states,
+            h_src,
+            h_dst,
+            final_src,
+            final_dst,
+            h_indices_trusted=True,
+            final_indices_trusted=True,
+            final_state_disjoint=True,
+        )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.hip is not None,
+        "ROCm GPU is required for direct large-shape coverage.",
+    )
+    def test_h_to_state_direct_qwen_shapes(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        torch.manual_seed(91)
+
+        for hv in (8, 16, 24, 48):
+            for tracked_rows in (1, 64, 256):
+                with self.subTest(hv=hv, tracked_rows=tracked_rows):
+                    h = torch.empty(
+                        (tracked_rows, hv, 128, 128),
+                        device=device,
+                        dtype=torch.bfloat16,
+                    ).uniform_(-1, 1)
+                    ssm_states = torch.zeros_like(h)
+                    indices = torch.arange(
+                        tracked_rows, device=device, dtype=torch.int32
+                    )
+
+                    with mock.patch.object(
+                        mamba_state_scatter,
+                        "_copy_rows_advanced_index",
+                        side_effect=AssertionError(
+                            "large trusted HIP shapes must use direct copy"
+                        ),
+                    ):
+                        copy_mamba_state_extend_rows(
+                            h,
+                            ssm_states,
+                            indices,
+                            indices,
+                            empty,
+                            empty,
+                            h_indices_trusted=True,
+                            final_indices_trusted=True,
+                            final_state_disjoint=True,
+                        )
+
+                    self.assertTrue(torch.equal(ssm_states, h))
+                    del h, ssm_states, indices
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and torch.version.hip is None,
+        "A CUDA GPU is required for the real-platform fallback test.",
+    )
+    def test_real_cuda_platform_uses_advanced_index_fallback(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        h = torch.randn((4, 8, 128, 128), device=device, dtype=torch.bfloat16)
+        ssm_states = torch.zeros_like(h)
+        indices = torch.arange(4, device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("CUDA must not launch the HIP direct helper"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                indices,
+                indices,
+                empty,
+                empty,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+
+        self.assertTrue(torch.equal(ssm_states, h))
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_disjoint_uses_direct_path(self):
+        if copy_mamba_state_extend_rows is None or mamba_state_scatter is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(31)
+        hv, v_dim, k_dim = 2, 128, 128
+        ssm_states = torch.randn(
+            (32, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h = torch.randn((16, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        final_src = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([8, 9, 10, 11], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "_copy_rows_advanced_index",
+            side_effect=AssertionError("advanced-index fallback should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                empty,
+                empty,
+                final_src,
+                final_dst,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_state_to_state_overlap_uses_fallback(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(52)
+        hv, v_dim, k_dim = 2, 128, 128
+        ssm_states = torch.randn(
+            (24, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        h = torch.randn((12, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        final_src = torch.tensor([0, 1, 2, 3], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([1, 2, 3, 4], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+
+        copy_mamba_state_extend_rows(
+            h,
+            ssm_states,
+            empty,
+            empty,
+            final_src,
+            final_dst,
+            h_indices_trusted=True,
+            final_indices_trusted=True,
+            final_state_disjoint=False,
+        )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_page_like_row_stride(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        torch.manual_seed(77)
+        hv, v_dim, k_dim = 2, 128, 128
+        row_elems = hv * v_dim * k_dim
+        row_stride = row_elems + 37
+        storage = torch.randn((64 * row_stride,), device=device, dtype=torch.bfloat16)
+        ssm_states = storage.as_strided(
+            (64, hv, v_dim, k_dim),
+            (row_stride, v_dim * k_dim, k_dim, 1),
+        )
+        h = torch.randn((32, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        h_src = torch.tensor([0, 3, 6, 9], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([7, 11, 14, 20], device=device, dtype=torch.int32)
+        final_src = torch.tensor([2, 4, 5], device=device, dtype=torch.int32)
+        final_dst = torch.tensor([22, 23, 24], device=device, dtype=torch.int32)
+        ref = ssm_states.clone()
+
+        _ref_copy_rows(h, ref, h_src, h_dst)
+        _ref_copy_rows(ref, ref, final_src, final_dst)
+        with mock.patch.object(
+            mamba_state_scatter,
+            "_copy_rows_advanced_index",
+            side_effect=AssertionError("fallback should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                final_src,
+                final_dst,
+                h_indices_trusted=True,
+                final_indices_trusted=True,
+                final_state_disjoint=True,
+            )
+        torch.testing.assert_close(ssm_states, ref)
+
+    @unittest.skipUnless(torch.cuda.is_available(), "CUDA is required for this test.")
+    def test_untrusted_indices_route_to_pytorch_fallback(self):
+        if copy_mamba_state_extend_rows is None:
+            self.skipTest(
+                f"copy_mamba_state_extend_rows import failed: {_FUSED_IMPORT_ERROR}"
+            )
+
+        device = torch.device("cuda")
+        hv, v_dim, k_dim = 2, 128, 128
+        h = torch.randn((8, hv, v_dim, k_dim), device=device, dtype=torch.float32)
+        ssm_states = torch.randn(
+            (8, hv, v_dim, k_dim), device=device, dtype=torch.bfloat16
+        )
+        ref = ssm_states.clone()
+        h_src = torch.tensor([0, -1], device=device, dtype=torch.int32)
+        h_dst = torch.tensor([1, 6], device=device, dtype=torch.int32)
+        empty = torch.empty((0,), device=device, dtype=torch.int32)
+        _ref_copy_rows(h, ref, h_src, h_dst)
+
+        with mock.patch.object(
+            mamba_state_scatter,
+            "copy_mamba_state_rows",
+            side_effect=AssertionError("direct helper should not run"),
+        ):
+            copy_mamba_state_extend_rows(
+                h,
+                ssm_states,
+                h_src,
+                h_dst,
+                empty,
+                empty,
+                h_indices_trusted=False,
+                final_indices_trusted=False,
+                final_state_disjoint=False,
+            )
+        torch.testing.assert_close(ssm_states, ref)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION


Use trusted metadata and direct Triton row copies for prefix-state tracking while retaining exact fallbacks for unsafe layouts and indices.


## Motivation

Mamba/GDN extend-time prefix tracking currently uses PyTorch advanced indexing:

```python
dst[dst_indices] = src[src_indices]
```

For recurrent state rows such as `[HV, V, K]`, advanced indexing materializes a temporary gather tensor before scattering it into the tracking slots. The temporary allocation and additional indexing kernels introduce prefill stalls and memory pressure when Mamba radix/prefix tracking is enabled.

## Impact

The optimization removes the temporary gather allocation and reduces the state-copy kernel latency.

MI308X, `V=K=128`, 25 warmup iterations and 200 measured iterations:

| Copy type | Dtype | Local HV | Tracked rows | Direct (µs) | Advanced indexing (µs) | Speedup | Direct temporary allocation | Advanced temporary allocation |
|---|---|---:|---:|---:|---:|---:|---:|---:|
| state → state | BF16 → BF16 | 2 | 8 | 9.061 | 22.291 | 2.46× | 0 bytes | 0.50 MiB |
| h → state | FP32 → BF16 | 4 | 64 | 20.367 | 86.840 | 4.26× | 0 bytes | 24 MiB |
| state → state | BF16 → BF16 | 4 | 128 | 28.305 | 116.949 | 4.13× | 0 bytes | 16 MiB |
| h → state | FP32 → BF16 | 8 | 128 | 56.650 | 275.813 | 4.87× | 0 bytes | 96 MiB |
| h → state | FP32 → BF16 | 8 | 256 | 101.433 | 528.132 | 5.21× | 0 bytes | 192 MiB |
| h → state | FP32 → BF16 | 16 | 64 | 57.452 | 276.234 | 4.81× | 0 bytes | 96 MiB |
| h → state | FP32 → BF16 | 24 | 64 | 79.843 | 397.833 | 4.98× | 0 bytes | 144 MiB |
| h → state | FP32 → BF16 | 48 | 64 | 142.888 | 777.605 | 5.44× | 0 bytes | 288 MiB |

The full sweep covers local HV 2/4/8/16/24/48 and 1–256 tracked rows: 2.46–6.58× speedup, 0-byte direct-copy temporary allocation, and up to 1.125 GiB advanced-indexing temporary allocation.

Controlled end-to-end A/B used the same commit, alternated direct-copy on/off order, flushed cache before each run, and enabled `mamba_radix_cache_strategy=extra_buffer` with a 256-token tracking interval.

| Target scenario | Mean TTFT | P99 TTFT | Output throughput | Duration |
|---|---:|---:|---:|---:|
| 27B TP2, ISL/OSL 2176/64, concurrency 16 | +5.00% | +5.97% | +2.09% | +2.01% |
| 397B TP8, 64 independent 8K prefixes, OSL 1, concurrency 128 | +0.105% | +0.088% | +0.089% | +0.089% |

Across the broader TP1/TP2/TP8 shared-prefix and high-concurrency matrix, no reproducible model-level performance regression was observed. Mixed-prefix GSM8K likewise showed no reproducible accuracy regression. Normal inference without Mamba prefix tracking is unchanged.

## Modifications

- Add a Triton row-copy kernel with:
  - independent source/destination row strides;
  - int64 address arithmetic for large page/envelope strides;
  - BF16/FP32 store conversion;
  - no intermediate gather tensor.
- Derive trusted-index and source/destination-disjointness flags on CPU while extend metadata is prepared.
- Propagate the flags through `ForwardMetadata` and `Mamba2Metadata`.
- Use direct copies for:
  - intermediate chunk state `h -> ssm_states`;
  - disjoint final state `ssm_states -> ssm_states`.
- Enable the direct path only on HIP/ROCm for BF16/FP32 state tensors.
- Preserve exact PyTorch advanced-index behavior for:
  - invalid or untrusted metadata;
  - overlapping source/destination slots;
  - non-compact row interiors;
  - NVIDIA CUDA, CPU, NPU, and XPU paths;
  - unvalidated state dtypes.
- Add helper, backend-integration, metadata-propagation, page-stride, aliasing, and fallback tests.
- Add an MI308X benchmark covering representative Qwen3.5 state rows.

The optimization is active only when Mamba prefix tracking produces trusted GPU metadata. Normal inference without tracking is unchanged.

## Accuracy and Correctness Tests

### Unit and Integration

| Test file | Platform | Shapes / routes | Cases | Result |
|---|---|---|---:|---:|
| `test_mamba_state_scatter_triton.py` | MI308X | BF16/FP32, HV2/HV4/HV8/HV16/HV24/HV48, rows 1/64/256, V=K=128, strided rows, direct/fallback, overlap/untrusted | 14 | 13 passed, 1 CUDA-only skipped |
| `test_mamba_extend_tracking_backend.py` | CPU metadata | pools 32/64/96, layers 4/6, aligned/unaligned/invalid/overlap | 5 | 5 passed |
| `test_gdn_noncontiguous_stride.py` | MI308X | TP1 HV48, TP2 HV24, B=1/4/8/16/32, decode T=1, verify T=4, KDA | 8 | 8 passed |
| **Local total** |  |  | **27** | **26 passed, 1 skipped** |

### Model Accuracy

| Model | TP | Evaluation | Examples | Threads | Prefix mix | Max output | Sampling | Baseline | This PR |
|---|---:|---|---:|---:|---|---:|---|---:|---:|
| Qwen3.5-27B-FP8 | 1 | Mixed-prefix GSM8K | 100 | 64 | primary 0–5, secondary 0–15, seed 42 | 4096 | temperature 0, top-p 1 | 0.90 | 0.91 |
| Qwen3.5-27B-FP8, TP2 cycle 1 | 2 | Deterministic mixed-prefix GSM8K | 100 | 64 | primary 0–5, secondary 0–15, seed 42 | 4096 | temperature 0, top-p 1 | 0.82 | 0.78 |
| Qwen3.5-27B-FP8, TP2 cycle 2 | 2 | Deterministic mixed-prefix GSM8K | 100 | 64 | primary 0–5, secondary 0–15, seed 42 | 4096 | temperature 0, top-p 1 | 0.80 | 0.81 |
| Qwen3.5-397B-A17B-PTPC | 8 | Mixed-prefix GSM8K | 100 | 64 | primary 0–5, secondary 0–15, seed 42 | 4096 | temperature 0, top-p 1 | 0.90 | 0.89 |

Test commands:

```bash
PYTHONPATH=python python3 -m pytest -q \
  test/registered/unit/layers/test_mamba_state_scatter_triton.py

PYTHONPATH="/tmp/mamba-extend-pydeps-min:python" python3 -m pytest -q \
  test/registered/unit/layers/test_mamba_extend_tracking_backend.py

PYTHONPATH=python python3 -m pytest -q \
  test/registered/attention/test_gdn_noncontiguous_stride.py
```

## Speed Tests and Profiling

Environment:

```text
GPU: AMD Instinct MI308X
Torch: 2.9.1+rocm7.2.0.git7e1940d4
Triton: 3.7.1
Timing: triton.testing.do_bench(return_mode="median")
```

The per-configuration latency, speedup, and allocation results are reported in the Impact section above.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: no user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32701301603](https://github.com/sgl-project/sglang/actions/runs/32701301603)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32701301200](https://github.com/sgl-project/sglang/actions/runs/32701301200)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32701301411](https://github.com/sgl-project/sglang/actions/runs/32701301411)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->