### PR TITLE
[CI] Restore the full prefill CUDA graph capture range in test launches

### DIFF
--- a/python/sglang/test/test_utils.py
+++ b/python/sglang/test/test_utils.py
@@ -952,15 +952,6 @@ def popen_launch_server(
         other_args = list(other_args)
         other_args += ["--device", str(device)]
 
-    # Prefill dominates capture time: the bucket list runs to chunked_prefill_size
-    # (8192 on H100-class GPUs) and its largest buckets cost seconds each, while
-    # 97% of CI prefill batches are under 1024 tokens -- a server that serves one
-    # test file captures the rest and never replays it. Decode is left alone: its
-    # capture cost is per-phase, not per-bucket. Pass the flag to opt out.
-    prefill_flag = "--cuda-graph-max-bs-prefill"
-    if not any(str(arg).startswith(prefill_flag) for arg in other_args):
-        other_args = list(other_args) + [prefill_flag, "1024"]
-
     # CI-specific: Validate cache and enable offline mode if complete
     if env is None:
         env = os.environ.copy()


### PR DESCRIPTION
Reverts the `--cuda-graph-max-bs-prefill 1024` default injection added to `popen_launch_server` in #33776: it sets `prefill.max_bs` in `_handle_cuda_graph_config()` before `_handle_gpu_memory_settings()` would derive it from `chunked_prefill_size`, which gates off post-capture KV sizing (`test_post_capture_kv_sizing.py` fails on H100-class GPUs, where `chunked_prefill_size` is 8192) and conversely inflates capture from 128 to 1024 for fixtures that set a smaller `chunked_prefill_size`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31085624619](https://github.com/sgl-project/sglang/actions/runs/31085624619)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31085627008](https://github.com/sgl-project/sglang/actions/runs/31085627008)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->