### PR TITLE
[diffusion] attention: Allow disabling sequence masking in SP

### DIFF
--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     NVCC_THREADS: str | None = None
     CMAKE_BUILD_TYPE: str | None = None
     VERBOSE: bool = False
+    SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK: bool = False
     SGLANG_DIFFUSION_SERVER_DEV_MODE: bool = False
     SGLANG_DIFFUSION_STAGE_LOGGING: bool = False
     SGLANG_DIFFUSION_CFG_GATE_STEP: float = 1.0
@@ -197,6 +198,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Optional override to force a specific attention backend (e.g. "aiter")
     "SGLANG_DIFFUSION_ATTENTION_BACKEND": _lazy_str(
         "SGLANG_DIFFUSION_ATTENTION_BACKEND"
+    ),
+    # Drop the SP tail-pad attention mask and run dense (unmasked) attention on
+    # the padded layout, instead of the packed-varlen path. Applies only when
+    # sequence parallelism is active and the mask is derived purely from the
+    # shard pad span.
+    "SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK": _lazy_bool(
+        "SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK"
     ),
     # Use dedicated multiprocess context for workers.
     # Both spawn and fork work

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -17,6 +17,7 @@ from sglang.kernels.ops.diffusion.triton.varlen_pack_pad import (
     fused_pack_qkv,
     fused_scatter_to_padded,
 )
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.breakable_cuda_graph.replay_token import (
     get_current_replay_token,
 )
@@ -73,6 +74,10 @@ _PYTORCH_DEFAULT_CUDA_SDP_BACKENDS = [
 # Set ``SGLANG_VARLEN_FA=0`` to disable the varlen FA fast path in
 # USPAttention masked branch and fall back to SDPA.
 _VARLEN_FA_ENABLED = os.environ.get("SGLANG_VARLEN_FA", "1") != "0"
+
+# Set ``SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK=1`` to drop the SP tail-pad mask
+# and run dense attention on the padded layout.
+_SP_PAD_MASK_DISABLED = envs.SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK
 
 
 def build_varlen_mask_meta(
@@ -664,6 +669,14 @@ class USPAttention(nn.Module):
         effective_skip_sp = (
             self.skip_sequence_parallel or skip_sequence_parallel_override
         )
+        if (
+            _SP_PAD_MASK_DISABLED
+            and attn_mask is None
+            and not effective_skip_sp
+            and get_sequence_parallel_world_size() > 1
+        ):
+            attn_mask_meta = None
+
         if isinstance(attn_mask_meta, DynamicVarlenMaskMeta):
             attn_mask_meta = attn_mask_meta.resolve(attn_mask)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Some models (such as Qwen-Image) produce non-divisable tensors for the joint text+image input. These are currently handled via varlen paths, where the non-divisibility does not pose an issue (pad + mask). However, varlen attention backends are often slower than non-varlen versions. The bleeding edge backends rarely support varlen OOB. This means these models cannot achieve the best possible performance.

As the divisiblity requirement is on the whole sequence, the amount currently padded and masked is miniscule, somewhere around 1e-04 of the sequence depending on the params. This is not enough to produce visibly different outputs. As such, this PR adds the option to retain the padding but disable masking, effectively running the attention via the standard dense attention backends. As the padded sections are removed later, the only effect this has is the slight change in attention scores caused by attention attending over the padded section.


## Modifications

<!-- Detail the changes made in this pull request. -->
- Adds a new env variable, `SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK`
- Checks the presence of said env variable to disable masking and running non-varlen in favor of varlen

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

### Mask on (varlen)
<img width="2048" height="2048" alt="maskon" src="https://github.com/user-attachments/assets/8ed02de3-4f7e-4408-8ae5-ac8900abe45c" />

### Mask off (non-varlen)
<img width="2048" height="2048" alt="maskoff" src="https://github.com/user-attachments/assets/201e6b4a-aecd-4a9f-b958-939502e3594e" />

Command used for both:
```
SGLANG_DIFFUSION_DISABLE_SP_PAD_MASK=0/1 sglang generate --model-path Qwen/Qwen-Image-2512 --height 2048 --width 2048 --ulysses-degree 8 --ring-degree 1 --num-gpus 8 --num-inference-steps 50 --guidance-scale 0.0 --prompt "A cat holding a sign that says hello world in a garden full of green plants" --dit-cpu-offload False --dit-layerwise-offload False --text-encoder-cpu-offload False --image-encoder-cpu-offload False --offload-during-compile False --vae-cpu-offload False --warmup True --warmup-steps 2 --vae-precision bf16 --image-encoder-precision bf16 --output-path /outputs/sp_pad_dense --seed 42 --enable-torch-compile
``` 


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 5150.81 ms | 4404.00 ms | **-746.80 ms (-14.5%)** | ✅ |
| **Throughput** | 0.19 req/s | 0.23 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.04 | 0.06 | +0.02 | +63.4% | ⚪️ |
| TextEncodingStage | 17.05 | 17.11 | +0.06 | +0.3% | ⚪️ |
| LatentPreparationStage | 0.11 | 0.12 | +0.01 | +4.9% | ⚪️ |
| TimestepPreparationStage | 0.36 | 0.36 | -0.00 | -0.0% | ⚪️ |
| DenoisingStage | 4719.86 | 4032.14 | -687.73 | -14.6% | 🟢 |
| DecodingStage | 411.04 | 351.73 | -59.31 | -14.4% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.03 | 0.03 | +0.00 | +0.3% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.01 | -0.00 | -6.9% | ⚪️ |

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35609321449](https://github.com/sgl-project/sglang/actions/runs/35609321449)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35609320962](https://github.com/sgl-project/sglang/actions/runs/35609320962)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35609321447](https://github.com/sgl-project/sglang/actions/runs/35609321447)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->