### PR TITLE
[KV Cache] Add a unified post-hoc sparsity framework with StreamingLLM visibility

### DIFF
--- a/python/sglang/srt/arg_groups/kv_sparsity_hook.py
+++ b/python/sglang/srt/arg_groups/kv_sparsity_hook.py
@@ -1,0 +1,115 @@
+"""Validation for HBM-resident post-hoc KV-cache sparsity."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from sglang.srt.server_args import ServerArgs
+
+logger = logging.getLogger(__name__)
+
+
+def validate_kv_cache_sparsity(server_args: ServerArgs) -> None:
+    if not server_args.enable_kv_cache_sparsity:
+        if server_args.kv_cache_sparsity_config is not None:
+            raise ValueError(
+                "--kv-cache-sparsity-config requires --enable-kv-cache-sparsity"
+            )
+        return
+
+    from sglang.srt.arg_groups.overrides import attention_backends_of, resolved_view
+    from sglang.srt.configs.hybrid_arch import mambaish_config
+    from sglang.srt.configs.model_config import AttentionArch
+    from sglang.srt.environ import envs
+    from sglang.srt.mem_cache.sparsity.factory import parse_kv_sparsity_config
+    from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+    from sglang.srt.server_args import is_cuda, is_hip
+
+    view = resolved_view(server_args)
+
+    if view.enable_hisparse:
+        raise ValueError(
+            "HBM-resident KV sparsity and --enable-hisparse are separate placement "
+            "modes and cannot be enabled together"
+        )
+    if is_hip() or not is_cuda():
+        raise ValueError("The initial KV sparsity runtime requires NVIDIA CUDA FA3")
+    if envs.SGLANG_USE_HND_KVCACHE.get():
+        raise ValueError("KV sparsity currently requires the NHD KV-cache layout")
+
+    config = parse_kv_sparsity_config(server_args)
+    if config.policy != "streaming_llm":
+        raise ValueError(
+            "PR 1 supports only policy='streaming_llm'; Quest is provided by PR 2"
+        )
+    if config.backend != "fa3":
+        raise ValueError("The initial KV sparsity runtime supports backend='fa3'")
+
+    prefill_backend, decode_backend = attention_backends_of(view)
+    allowed_backends = {"fa3", "flashattention"}
+    if (
+        prefill_backend not in allowed_backends
+        or decode_backend not in allowed_backends
+    ):
+        raise ValueError(
+            "KV sparsity requires FA3 for prefill and decode, but got "
+            f"prefill={prefill_backend!r}, decode={decode_backend!r}"
+        )
+
+    unsupported = (
+        (view.speculative_algorithm is not None, "speculative decoding"),
+        (view.dllm_algorithm is not None, "diffusion LLM inference"),
+        (view.enable_pdmux, "PD multiplexing"),
+        (view.disaggregation_mode != "null", "PD disaggregation"),
+        (view.enable_two_batch_overlap, "two-batch overlap"),
+        (view.enable_mixed_chunk, "mixed chunked prefill"),
+        (view.enable_torch_compile, "torch.compile"),
+        (view.enable_dp_attention, "DP attention"),
+        (view.enable_prefill_cp, "prefill context parallelism"),
+        (view.attn_cp_size > 1, "attention context parallelism"),
+        (view.dcp_size > 1, "decode context parallelism"),
+    )
+    for enabled, label in unsupported:
+        if enabled:
+            raise ValueError(f"KV sparsity does not yet support {label}")
+
+    model_config = view.get_model_config()
+    if model_config.attention_arch != AttentionArch.MHA:
+        raise ValueError("KV sparsity currently supports standard MHA/GQA models only")
+    if model_config.is_encoder_decoder or model_config.is_multimodal:
+        raise ValueError("KV sparsity currently supports decoder-only text models")
+    if not model_config.is_generation:
+        raise ValueError("KV sparsity is supported only for generation models")
+    if model_config.num_attention_layers != model_config.num_hidden_layers:
+        raise ValueError("KV sparsity requires one attention layer per hidden layer")
+
+    sliding_window_size = model_config.sliding_window_size
+    has_sliding_window = isinstance(sliding_window_size, (int, float)) and (
+        sliding_window_size > -1
+    )
+    if (
+        model_config.is_hybrid_swa
+        or has_sliding_window
+        or model_config.attention_chunk_size is not None
+        or mambaish_config(model_config) is not None
+    ):
+        raise ValueError("KV sparsity does not yet support local or hybrid attention")
+    num_kv_shared_layers = (
+        getattr(model_config.hf_text_config, "num_kv_shared_layers", 0) or 0
+    )
+    if num_kv_shared_layers > 0:
+        raise ValueError("KV sparsity does not yet support cross-layer KV sharing")
+
+    locked = getattr(server_args, "_cuda_graph_config_locked", set())
+    for phase, phase_config in (
+        (Phase.DECODE, server_args.cuda_graph_config.decode),
+        (Phase.PREFILL, server_args.cuda_graph_config.prefill),
+    ):
+        if (phase, "backend") in locked and phase_config.backend != Backend.DISABLED:
+            raise ValueError(
+                f"KV sparsity PR 1 requires {phase} CUDA graph to be disabled"
+            )
+        phase_config.backend = Backend.DISABLED
+    logger.info("Enabled HBM-resident StreamingLLM visibility with FA3 in eager mode")

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1775,6 +1775,8 @@ def _attention_backend_default(view: Any) -> dict:
         view.prefill_attention_backend == view.decode_attention_backend
     ):  # override the default attention backend
         return {"attention_backend": view.prefill_attention_backend}
+    if view.is_attention_backend_not_set() and view.enable_kv_cache_sparsity:
+        return {"attention_backend": "fa3"}
     if view.attention_backend is None:
         backend = view._get_default_attn_backend(
             view.use_mla_backend(), view.get_model_config()

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -24,7 +24,10 @@ import torch
 from torch import nn
 
 from sglang.srt.compilation.compilation_config import register_split_op
-from sglang.srt.model_executor.forward_context import get_attn_backend
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_forward_context,
+)
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
     is_in_breakable_cuda_graph,
@@ -71,6 +74,7 @@ def _zero_padded_pcg_tail(buf: torch.Tensor, context) -> None:
 
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
+    from sglang.srt.mem_cache.sparsity.core import KVSparsityController
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
@@ -276,15 +280,58 @@ class RadixAttention(nn.Module):
                 return output.view(-1, self.tp_q_head_num, self.v_head_dim), lse
             return output
         else:
-            return get_attn_backend().forward(
-                q,
-                k,
-                v,
+            attn_backend = get_attn_backend()
+            controller = get_forward_context().kv_sparsity_controller
+            if _should_run_kv_sparsity_hook(
                 self,
                 forward_batch,
+                k,
                 save_kv_cache,
-                **kwargs,
+                controller,
+            ):
+                metadata = getattr(attn_backend, "forward_metadata", None)
+                controller.before_attention(q, k, v, self, forward_batch, metadata)
+                output = attn_backend.forward(
+                    q,
+                    k,
+                    v,
+                    self,
+                    forward_batch,
+                    save_kv_cache,
+                    **kwargs,
+                )
+                controller.after_attention(
+                    q, k, v, output, self, forward_batch, metadata
+                )
+                return output
+            return attn_backend.forward(
+                q, k, v, self, forward_batch, save_kv_cache, **kwargs
             )
+
+
+def _should_run_kv_sparsity_hook(
+    layer: RadixAttention,
+    forward_batch: ForwardBatch,
+    key: Optional[torch.Tensor],
+    save_kv_cache: bool,
+    controller: Optional[KVSparsityController],
+) -> bool:
+    """Keep unsupported execution modes on the byte-identical dense path."""
+    return bool(
+        controller is not None
+        and (
+            forward_batch.forward_mode.is_decode()
+            or forward_batch.forward_mode.is_extend(include_draft_extend_v2=True)
+        )
+        and forward_batch.spec_info is None
+        and save_kv_cache
+        and key is not None
+        and not layer.is_cross_attention
+        and layer.attn_type == AttentionType.DECODER
+        and get_tc_piecewise_forward_context() is None
+        and forward_batch.req_pool_indices is not None
+        and forward_batch.seq_lens is not None
+    )
 
 
 def _unified_attention_with_output_impl(

--- a/python/sglang/srt/mem_cache/sparsity/README.md
+++ b/python/sglang/srt/mem_cache/sparsity/README.md
@@ -1,0 +1,88 @@
+# HBM-resident KV-cache sparsity
+
+This package contains the common policy/controller/adaptor contracts for
+post-hoc sparse attention. The initial runtime keeps every KV entry allocated
+in HBM and changes only the subset visible to attention. It does not free,
+compact, migrate, or swap KV-cache storage.
+
+## Initial supported path
+
+- NVIDIA CUDA, decoder-only MHA/GQA text models
+- FA3 prefill and decode backends
+- eager execution (CUDA Graph is disabled while this path is experimental)
+- normal prefill followed by non-speculative decode
+- page-granular StreamingLLM-style sink + recent visibility
+
+Other backends, speculative decoding, local/hybrid attention, PD
+disaggregation, DP/CP attention, physical eviction, and hierarchical placement
+are rejected explicitly.
+
+The implementation keeps logical policy output independent from physical KV
+locations:
+
+1. `SparsityPolicy` returns request-relative logical page indices.
+2. `KVSparsityController` applies request/step/layer lifecycle rules.
+3. `HBMResidentPlacement` translates logical pages through `req_to_token`.
+4. `FlashAttentionVisibilityAdaptor` rewrites and later restores FA3 metadata.
+
+During prefill, the controller publishes lifecycle contexts without changing
+attention visibility. This lets a later KV-derived policy build auxiliary
+representations without adding another model-forward hook.
+
+## Launch
+
+```bash
+python -m sglang.launch_server \
+  --model-path Qwen/Qwen3-4B \
+  --attention-backend fa3 \
+  --enable-kv-cache-sparsity \
+  --kv-cache-sparsity-config '{
+    "policy": "streaming_llm",
+    "backend": "fa3",
+    "min_sparse_tokens": 4096,
+    "policy_config": {
+      "sink_pages": 4,
+      "recent_pages": 2048
+    }
+  }'
+```
+
+The runtime `--page-size` and optional JSON `page_size` must match. With the
+default page size of one, `sink_pages` and `recent_pages` are token counts.
+
+## Validation
+
+Run the CPU policy/controller/adaptor conformance tests with:
+
+```bash
+python -m pytest -q \
+  test/registered/unit/mem_cache/test_kv_sparsity_framework.py
+```
+
+For an end-to-end dense-path parity smoke test, first set
+`min_sparse_tokens` above the tested context length. Then lower it below the
+context length and benchmark a genuinely sparse budget. Use the same FA3 eager
+configuration for the dense baseline so CUDA Graph does not confound the
+comparison.
+
+```bash
+python -m sglang.benchmark.serving \
+  --backend sglang \
+  --base-url http://127.0.0.1:30000 \
+  --dataset-name random-ids \
+  --random-input-len 8192 \
+  --random-output-len 256 \
+  --num-prompts 64 \
+  --max-concurrency 16 \
+  --warmup-requests 4 \
+  --tokenize-prompt
+```
+
+Launch the dense comparison with the same `--attention-backend fa3` and
+`--cuda-graph-config '{"decode":{"backend":"disabled"},"prefill":{"backend":"disabled"}}'`
+settings used by the sparse path.
+
+Report input/output throughput, inter-token latency, the exact sparse budget,
+GPU type, dtype, batch/concurrency, and whether prefix caching was warm. This
+mode reduces attention work and memory traffic but does not increase KV-cache
+capacity because the complete cache remains resident.

--- a/python/sglang/srt/mem_cache/sparsity/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/__init__.py
@@ -5,12 +5,32 @@ from sglang.srt.mem_cache.sparsity.algorithms import (
     QuestAlgorithm,
 )
 from sglang.srt.mem_cache.sparsity.backend import BackendAdaptor, FlashAttentionAdaptor
-from sglang.srt.mem_cache.sparsity.core import SparseConfig, SparseCoordinator
+from sglang.srt.mem_cache.sparsity.config import KVSparsityConfig
+from sglang.srt.mem_cache.sparsity.contracts import (
+    DecisionScope,
+    Granularity,
+    KVStateAction,
+    SelectionContext,
+    SelectionEvidence,
+    SelectionResult,
+    SparsityCapabilities,
+)
+from sglang.srt.mem_cache.sparsity.core import (
+    KVSparsityController,
+    SparseConfig,
+    SparseCoordinator,
+)
 from sglang.srt.mem_cache.sparsity.factory import (
+    create_kv_sparsity_controller,
     create_sparse_coordinator,
     get_sparse_coordinator,
     parse_hisparse_config,
+    parse_kv_sparsity_config,
     register_sparse_coordinator,
+)
+from sglang.srt.mem_cache.sparsity.policies import (
+    SparsityPolicy,
+    StreamingLLMPolicy,
 )
 
 __all__ = [
@@ -22,6 +42,19 @@ __all__ = [
     "FlashAttentionAdaptor",
     "SparseConfig",
     "SparseCoordinator",
+    "KVSparsityConfig",
+    "KVSparsityController",
+    "KVStateAction",
+    "Granularity",
+    "SelectionEvidence",
+    "DecisionScope",
+    "SparsityCapabilities",
+    "SelectionContext",
+    "SelectionResult",
+    "SparsityPolicy",
+    "StreamingLLMPolicy",
+    "create_kv_sparsity_controller",
+    "parse_kv_sparsity_config",
     "create_sparse_coordinator",
     "get_sparse_coordinator",
     "parse_hisparse_config",

--- a/python/sglang/srt/mem_cache/sparsity/backend/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/backend/__init__.py
@@ -3,5 +3,17 @@ from sglang.srt.mem_cache.sparsity.backend.backend_adaptor import (
     DSABackendAdaptor,
     FlashAttentionAdaptor,
 )
+from sglang.srt.mem_cache.sparsity.backend.visibility_adaptor import (
+    FlashAttentionVisibilityAdaptor,
+    HBMResidentPlacement,
+    MetadataAdaptor,
+)
 
-__all__ = ["BackendAdaptor", "FlashAttentionAdaptor", "DSABackendAdaptor"]
+__all__ = [
+    "BackendAdaptor",
+    "FlashAttentionAdaptor",
+    "DSABackendAdaptor",
+    "MetadataAdaptor",
+    "HBMResidentPlacement",
+    "FlashAttentionVisibilityAdaptor",
+]

--- a/python/sglang/srt/mem_cache/sparsity/backend/visibility_adaptor.py
+++ b/python/sglang/srt/mem_cache/sparsity/backend/visibility_adaptor.py
@@ -1,0 +1,179 @@
+"""Metadata adaptors for HBM-resident visibility-only sparsity."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from sglang.srt.mem_cache.sparsity.contracts import Granularity, SelectionResult
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class MetadataAdaptor(ABC):
+    """Translate logical selections into backend-owned metadata."""
+
+    def bind_attention_backend(self, attention_backend: Any) -> None:
+        """Bind optional backend services after attention backend creation."""
+
+    @abstractmethod
+    def capture_dense_metadata(self, metadata: Any) -> None: ...
+
+    @abstractmethod
+    def apply(
+        self,
+        result: SelectionResult,
+        metadata: Any,
+        forward_batch: ForwardBatch,
+    ) -> Any: ...
+
+    @abstractmethod
+    def restore_dense_metadata(self, metadata: Any) -> None: ...
+
+
+class HBMResidentPlacement:
+    """Map request-relative logical pages to their resident HBM page IDs."""
+
+    def __init__(self, req_to_token: torch.Tensor, page_size: int):
+        self.req_to_token = req_to_token
+        self.page_size = page_size
+
+    def logical_to_physical_pages(
+        self,
+        logical_pages: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        if logical_pages.ndim != 2:
+            raise ValueError("logical_pages must have shape [batch, capacity]")
+        if req_pool_indices.ndim != 1:
+            raise ValueError("req_pool_indices must have shape [batch]")
+        if logical_pages.shape[0] != req_pool_indices.shape[0]:
+            raise ValueError("selection and request batch sizes must match")
+
+        token_positions = (logical_pages * self.page_size).clamp(min=0).long()
+        rows = req_pool_indices.long().unsqueeze(1).expand_as(token_positions)
+        physical_tokens = self.req_to_token[rows, token_positions]
+        physical_pages = torch.div(
+            physical_tokens, self.page_size, rounding_mode="floor"
+        )
+        return torch.where(
+            logical_pages >= 0,
+            physical_pages,
+            torch.zeros_like(physical_pages),
+        ).to(torch.int32)
+
+
+class FlashAttentionVisibilityAdaptor(MetadataAdaptor):
+    """Rewrite FA3 page-table metadata without moving or freeing KV data."""
+
+    def __init__(self, placement: HBMResidentPlacement):
+        self.placement = placement
+        self._dense_page_table = None
+        self._dense_cache_seqlens = None
+        self._dense_cu_seqlens_k = None
+        self._dense_max_seq_len_k = None
+        self._dense_scheduler_metadata = None
+        self._sparse_scheduler_metadata = None
+        self._scheduler_metadata_prepared = False
+        self._scheduler_metadata_builder = None
+
+    def bind_attention_backend(self, attention_backend: Any) -> None:
+        builder = getattr(attention_backend, "_compute_scheduler_metadata", None)
+        if builder is None:
+            raise TypeError(
+                "FA3 visibility requires an attention backend with scheduler "
+                "metadata support"
+            )
+        self._scheduler_metadata_builder = builder
+
+    def capture_dense_metadata(self, metadata: Any) -> None:
+        required = (
+            "page_table",
+            "cache_seqlens_int32",
+            "cu_seqlens_k",
+            "max_seq_len_k",
+        )
+        if metadata is None or not all(hasattr(metadata, name) for name in required):
+            raise TypeError("FA3 sparse visibility requires FlashAttention metadata")
+        self._dense_page_table = metadata.page_table.clone()
+        self._dense_cache_seqlens = metadata.cache_seqlens_int32.clone()
+        self._dense_cu_seqlens_k = metadata.cu_seqlens_k.clone()
+        self._dense_max_seq_len_k = metadata.max_seq_len_k
+        self._dense_scheduler_metadata = getattr(metadata, "scheduler_metadata", None)
+        self._sparse_scheduler_metadata = None
+        self._scheduler_metadata_prepared = False
+
+    def apply(
+        self,
+        result: SelectionResult,
+        metadata: Any,
+        forward_batch: ForwardBatch,
+    ) -> Any:
+        if result.granularity != Granularity.PAGE:
+            raise ValueError("FA3 visibility adaptor requires page selections")
+        if self._dense_page_table is None:
+            raise RuntimeError("capture_dense_metadata must be called before apply")
+        # During warmup or short decode, no row is sparse and FA3 may publish a
+        # page table narrower than the policy's fixed capacity. Truncating is
+        # safe: if any row were sparse, its sequence would already be wider
+        # than the retained capacity and so would the batch page table.
+        visible_capacity = min(result.capacity, metadata.page_table.shape[1])
+
+        physical_pages = self.placement.logical_to_physical_pages(
+            result.logical_indices[:, :visible_capacity],
+            forward_batch.req_pool_indices,
+        )
+        columns = torch.arange(
+            visible_capacity, device=physical_pages.device
+        ).unsqueeze(0)
+        valid = columns < result.valid_lengths.unsqueeze(1)
+        update = result.sparse_mask.unsqueeze(1) & valid
+
+        dense_prefix = self._dense_page_table[:, :visible_capacity]
+        metadata.page_table[:, :visible_capacity].copy_(
+            torch.where(update, physical_pages, dense_prefix)
+        )
+        metadata.cache_seqlens_int32.copy_(
+            torch.where(
+                result.sparse_mask,
+                result.visible_kv_lens.to(torch.int32),
+                self._dense_cache_seqlens,
+            )
+        )
+        metadata.cu_seqlens_k[0].zero_()
+        metadata.cu_seqlens_k[1:].copy_(
+            torch.cumsum(metadata.cache_seqlens_int32, dim=0, dtype=torch.int32)
+        )
+        sparse_max_seq_len_k = self._dense_max_seq_len_k
+        if result.max_visible_kv_len is not None:
+            sparse_max_seq_len_k = min(sparse_max_seq_len_k, result.max_visible_kv_len)
+        metadata.max_seq_len_k = sparse_max_seq_len_k
+        if hasattr(metadata, "scheduler_metadata"):
+            # A schedule precomputed for dense lengths is invalid. Recompute it
+            # once per decode step and reuse it across every sparse layer.
+            if (
+                not self._scheduler_metadata_prepared
+                and self._scheduler_metadata_builder is not None
+            ):
+                self._sparse_scheduler_metadata = self._scheduler_metadata_builder(
+                    metadata.cache_seqlens_int32.shape[0],
+                    max(sparse_max_seq_len_k, 1),
+                    metadata.cache_seqlens_int32,
+                    metadata.cu_seqlens_q,
+                )
+                self._scheduler_metadata_prepared = True
+            metadata.scheduler_metadata = self._sparse_scheduler_metadata
+        return metadata
+
+    def restore_dense_metadata(self, metadata: Any) -> None:
+        if self._dense_page_table is None:
+            return
+        metadata.page_table.copy_(self._dense_page_table)
+        metadata.cache_seqlens_int32.copy_(self._dense_cache_seqlens)
+        metadata.cu_seqlens_k.copy_(self._dense_cu_seqlens_k)
+        metadata.max_seq_len_k = self._dense_max_seq_len_k
+        if hasattr(metadata, "scheduler_metadata"):
+            metadata.scheduler_metadata = self._dense_scheduler_metadata

--- a/python/sglang/srt/mem_cache/sparsity/config.py
+++ b/python/sglang/srt/mem_cache/sparsity/config.py
@@ -1,0 +1,43 @@
+"""Configuration for HBM-resident post-hoc KV sparsity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class KVSparsityConfig:
+    """Resolved configuration shared by policy, controller, and adaptor."""
+
+    policy: str = "streaming_llm"
+    backend: str = "fa3"
+    page_size: int = 1
+    min_sparse_tokens: int = 2048
+    start_layer: int = 0
+    end_layer: int = -1
+    policy_config: dict = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for name, value in (("policy", self.policy), ("backend", self.backend)):
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"{name} must be a non-empty string")
+        if not isinstance(self.page_size, int) or isinstance(self.page_size, bool):
+            raise TypeError("page_size must be an integer")
+        if self.page_size <= 0:
+            raise ValueError("page_size must be positive")
+        if (
+            not isinstance(self.min_sparse_tokens, int)
+            or isinstance(self.min_sparse_tokens, bool)
+            or self.min_sparse_tokens < 0
+        ):
+            raise ValueError("min_sparse_tokens must be a non-negative integer")
+        if not isinstance(self.start_layer, int) or isinstance(self.start_layer, bool):
+            raise TypeError("start_layer must be an integer")
+        if not isinstance(self.end_layer, int) or isinstance(self.end_layer, bool):
+            raise TypeError("end_layer must be an integer")
+        if self.start_layer < 0:
+            raise ValueError("start_layer must be non-negative")
+        if self.end_layer != -1 and self.end_layer <= self.start_layer:
+            raise ValueError("end_layer must be -1 or greater than start_layer")
+        if not isinstance(self.policy_config, dict):
+            raise TypeError("policy_config must be a JSON object")

--- a/python/sglang/srt/mem_cache/sparsity/contracts.py
+++ b/python/sglang/srt/mem_cache/sparsity/contracts.py
@@ -1,0 +1,137 @@
+"""Backend-independent contracts for post-hoc KV-cache sparsity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class KVStateAction(str, Enum):
+    """What happens to KV entries excluded by a policy."""
+
+    VISIBILITY_ONLY = "visibility_only"
+    EVICT = "evict"
+    HIERARCHICAL = "hierarchical"
+
+
+class Granularity(str, Enum):
+    """Logical unit returned by a sparsity policy."""
+
+    TOKEN = "token"
+    PAGE = "page"
+
+
+class SelectionEvidence(str, Enum):
+    """Runtime evidence used to make a sparse selection."""
+
+    POSITION = "position"
+    KV_DERIVED = "kv_derived"
+    CURRENT_QUERY = "current_query"
+    ATTENTION_HISTORY = "attention_history"
+
+
+class DecisionScope(str, Enum):
+    """Lifetime of a policy decision."""
+
+    REQUEST = "request"
+    STEP = "step"
+    LAYER = "layer"
+
+
+@dataclass(frozen=True)
+class SparsityCapabilities:
+    """Explicit policy requirements used for compatibility validation."""
+
+    state_action: KVStateAction
+    granularity: Granularity
+    evidence: SelectionEvidence
+    scope: DecisionScope
+    requires_request_state: bool = False
+    supports_cuda_graph: bool = False
+
+
+@dataclass(frozen=True)
+class RequestIdentity:
+    """Generation-aware identity for a reusable request-pool slot."""
+
+    pool_index: int
+    generation: int
+
+
+@dataclass(frozen=True)
+class SelectionContext:
+    """Logical inputs available to a sparsity policy."""
+
+    query: Optional[torch.Tensor]
+    layer_id: int
+    req_pool_indices: torch.Tensor
+    seq_lens: torch.Tensor
+    key: Optional[torch.Tensor] = None
+    value: Optional[torch.Tensor] = None
+    output: Optional[torch.Tensor] = None
+    forward_batch: Optional[ForwardBatch] = None
+    attention_layer: Optional[RadixAttention] = None
+    request_generations: Optional[torch.Tensor] = None
+    metadata: Any = None
+
+
+@dataclass(frozen=True)
+class SelectionResult:
+    """A backend-independent sparse view over request-relative KV positions.
+
+    ``logical_indices`` is padded to a fixed capacity with ``-1``. For PAGE
+    selections, ``visible_kv_lens`` carries the exact token count exposed to
+    attention, including a possible partial final page.
+    """
+
+    granularity: Granularity
+    logical_indices: torch.Tensor
+    valid_lengths: torch.Tensor
+    visible_kv_lens: torch.Tensor
+    sparse_mask: torch.Tensor
+    layer_id: Optional[int] = None
+    max_visible_kv_len: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.logical_indices.ndim != 2:
+            raise ValueError("logical_indices must have shape [batch, capacity]")
+        batch_size = self.logical_indices.shape[0]
+        for name, tensor in (
+            ("valid_lengths", self.valid_lengths),
+            ("visible_kv_lens", self.visible_kv_lens),
+            ("sparse_mask", self.sparse_mask),
+        ):
+            if tensor.ndim != 1 or tensor.shape[0] != batch_size:
+                raise ValueError(f"{name} must have shape [batch]")
+        if self.sparse_mask.dtype != torch.bool:
+            raise TypeError("sparse_mask must use torch.bool")
+        if self.logical_indices.dtype not in (torch.int32, torch.int64):
+            raise TypeError("logical_indices must use an integer dtype")
+        if self.valid_lengths.dtype not in (torch.int32, torch.int64):
+            raise TypeError("valid_lengths must use an integer dtype")
+        if self.visible_kv_lens.dtype not in (torch.int32, torch.int64):
+            raise TypeError("visible_kv_lens must use an integer dtype")
+        if not (
+            self.logical_indices.device
+            == self.valid_lengths.device
+            == self.visible_kv_lens.device
+            == self.sparse_mask.device
+        ):
+            raise ValueError("all SelectionResult tensors must share a device")
+        if self.max_visible_kv_len is not None and (
+            not isinstance(self.max_visible_kv_len, int)
+            or isinstance(self.max_visible_kv_len, bool)
+            or self.max_visible_kv_len <= 0
+        ):
+            raise ValueError("max_visible_kv_len must be a positive integer")
+
+    @property
+    def capacity(self) -> int:
+        return self.logical_indices.shape[1]

--- a/python/sglang/srt/mem_cache/sparsity/core/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/core/__init__.py
@@ -1,3 +1,6 @@
+from sglang.srt.mem_cache.sparsity.core.kv_sparsity_controller import (
+    KVSparsityController,
+)
 from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import (
     RequestTrackers,
     SparseConfig,
@@ -5,6 +8,7 @@ from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import (
 )
 
 __all__ = [
+    "KVSparsityController",
     "RequestTrackers",
     "SparseConfig",
     "SparseCoordinator",

--- a/python/sglang/srt/mem_cache/sparsity/core/kv_sparsity_controller.py
+++ b/python/sglang/srt/mem_cache/sparsity/core/kv_sparsity_controller.py
@@ -1,0 +1,210 @@
+"""Lifecycle controller for post-hoc KV-cache sparsity."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Optional
+
+import torch
+
+from sglang.srt.mem_cache.sparsity.backend.visibility_adaptor import MetadataAdaptor
+from sglang.srt.mem_cache.sparsity.config import KVSparsityConfig
+from sglang.srt.mem_cache.sparsity.contracts import (
+    DecisionScope,
+    KVStateAction,
+    RequestIdentity,
+    SelectionContext,
+    SelectionResult,
+)
+from sglang.srt.mem_cache.sparsity.policies.base import SparsityPolicy
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class KVSparsityController:
+    """Coordinate policy selection and backend metadata adaptation.
+
+    The initial controller accepts visibility-only policies and never mutates KV
+    allocation ownership. Request state, when required by a policy, is keyed by
+    both pool slot and ``ReqToTokenPool.req_generation``.
+    """
+
+    def __init__(
+        self,
+        config: KVSparsityConfig,
+        policy: SparsityPolicy,
+        adaptor: MetadataAdaptor,
+        req_to_token_pool: ReqToTokenPool,
+        start_layer: int,
+        end_layer: int,
+    ):
+        if policy.capabilities.state_action != KVStateAction.VISIBILITY_ONLY:
+            raise ValueError("the initial KV sparsity controller is visibility-only")
+        if policy.capabilities.scope == DecisionScope.REQUEST:
+            raise ValueError("request-scoped selection caching is not implemented yet")
+        self.config = config
+        self.policy = policy
+        self.adaptor = adaptor
+        self.req_to_token_pool = req_to_token_pool
+        self.start_layer = max(start_layer, config.start_layer)
+        configured_end = end_layer if config.end_layer == -1 else config.end_layer
+        self.end_layer = min(end_layer, configured_end)
+        if self.end_layer <= self.start_layer:
+            raise ValueError("configured sparse layer range is empty")
+
+        # Keep the metadata object itself, not only id(metadata): Python may
+        # reuse an id immediately after the previous eager metadata is freed.
+        self._metadata: Any = None
+        self._selection_cache: Optional[SelectionResult] = None
+        self._request_generations: Optional[torch.Tensor] = None
+        self._request_identities: dict[int, RequestIdentity] = {}
+        self._dense_metadata_captured = False
+
+    def applies_to_layer(self, layer_id: int) -> bool:
+        return self.start_layer <= layer_id < self.end_layer
+
+    def bind_attention_backend(self, attention_backend: Any) -> None:
+        self.adaptor.bind_attention_backend(attention_backend)
+
+    def _sync_request_identities(
+        self, forward_batch: ForwardBatch
+    ) -> Optional[torch.Tensor]:
+        if not self.policy.capabilities.requires_request_state:
+            return None
+
+        pool_indices_cpu = forward_batch.req_pool_indices.detach().to("cpu").long()
+        generations = self.req_to_token_pool.req_generation[pool_indices_cpu]
+        for pool_index, generation in zip(
+            pool_indices_cpu.tolist(), generations.tolist()
+        ):
+            identity = RequestIdentity(pool_index=pool_index, generation=generation)
+            previous = self._request_identities.get(pool_index)
+            if previous == identity:
+                continue
+            if previous is not None:
+                self.policy.on_request_end(previous)
+            self.policy.on_request_begin(identity)
+            self._request_identities[pool_index] = identity
+        return generations
+
+    def _make_context(
+        self,
+        *,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
+        output: Optional[torch.Tensor],
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        metadata: Any,
+    ) -> SelectionContext:
+        return SelectionContext(
+            query=query,
+            key=key,
+            value=value,
+            output=output,
+            layer_id=layer.layer_id,
+            req_pool_indices=forward_batch.req_pool_indices,
+            seq_lens=forward_batch.seq_lens,
+            forward_batch=forward_batch,
+            attention_layer=layer,
+            request_generations=self._request_generations,
+            metadata=metadata,
+        )
+
+    def _begin_forward(
+        self,
+        metadata: Any,
+        forward_batch: ForwardBatch,
+        context: SelectionContext,
+    ) -> None:
+        self._metadata = metadata
+        self._selection_cache = None
+        self._request_generations = self._sync_request_identities(forward_batch)
+        context = self._make_context(
+            query=context.query,
+            key=context.key,
+            value=context.value,
+            output=None,
+            layer=context.attention_layer,
+            forward_batch=forward_batch,
+            metadata=metadata,
+        )
+        self.policy.begin_forward(context)
+        self._dense_metadata_captured = forward_batch.forward_mode.is_decode()
+        if self._dense_metadata_captured:
+            self.adaptor.capture_dense_metadata(metadata)
+
+    def before_attention(
+        self,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        metadata: Any,
+    ) -> Any:
+        if not self.applies_to_layer(layer.layer_id):
+            return metadata
+        context = self._make_context(
+            query=query,
+            key=key,
+            value=value,
+            output=None,
+            layer=layer,
+            forward_batch=forward_batch,
+            metadata=metadata,
+        )
+        if metadata is not self._metadata:
+            self._begin_forward(metadata, forward_batch, context)
+
+        context = self._make_context(
+            query=query,
+            key=key,
+            value=value,
+            output=None,
+            layer=layer,
+            forward_batch=forward_batch,
+            metadata=metadata,
+        )
+        if not forward_batch.forward_mode.is_decode():
+            return metadata
+        scope = self.policy.capabilities.scope
+        if scope == DecisionScope.LAYER or self._selection_cache is None:
+            result = self.policy.select(context)
+            if scope != DecisionScope.LAYER:
+                self._selection_cache = result
+        else:
+            # FA3 metadata is shared across layers and remains sparse until the
+            # configured final layer. A STEP decision therefore needs one
+            # adaptor rewrite, not one rewrite per layer.
+            return metadata
+        return self.adaptor.apply(result, metadata, forward_batch)
+
+    def after_attention(
+        self,
+        query: torch.Tensor,
+        key: Optional[torch.Tensor],
+        value: Optional[torch.Tensor],
+        output: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        metadata: Any,
+    ) -> None:
+        if not self.applies_to_layer(layer.layer_id):
+            return
+        context = self._make_context(
+            query=query,
+            key=key,
+            value=value,
+            output=output,
+            layer=layer,
+            forward_batch=forward_batch,
+            metadata=metadata,
+        )
+        self.policy.on_attention_complete(context)
+        if self._dense_metadata_captured and layer.layer_id == self.end_layer - 1:
+            self.adaptor.restore_dense_metadata(metadata)
+            self._dense_metadata_captured = False

--- a/python/sglang/srt/mem_cache/sparsity/factory.py
+++ b/python/sglang/srt/mem_cache/sparsity/factory.py
@@ -11,12 +11,37 @@ from sglang.srt.mem_cache.sparsity.backend.backend_adaptor import (
     DSABackendAdaptor,
     FlashAttentionAdaptor,
 )
+from sglang.srt.mem_cache.sparsity.backend.visibility_adaptor import (
+    FlashAttentionVisibilityAdaptor,
+    HBMResidentPlacement,
+)
+from sglang.srt.mem_cache.sparsity.config import KVSparsityConfig
+from sglang.srt.mem_cache.sparsity.core.kv_sparsity_controller import (
+    KVSparsityController,
+)
 from sglang.srt.mem_cache.sparsity.core.sparse_coordinator import (
     SparseConfig,
     SparseCoordinator,
 )
+from sglang.srt.mem_cache.sparsity.policies.streaming_llm import StreamingLLMPolicy
 
 logger = logging.getLogger(__name__)
+
+_KV_SPARSITY_POLICIES = {
+    "streaming_llm": StreamingLLMPolicy,
+}
+_KV_SPARSITY_BACKEND_ALIASES = {
+    "flashattention": "fa3",
+}
+_KV_SPARSITY_CONFIG_FIELDS = {
+    "policy",
+    "backend",
+    "page_size",
+    "min_sparse_tokens",
+    "start_layer",
+    "end_layer",
+    "policy_config",
+}
 
 _global_sparse_coordinator: Optional[SparseCoordinator] = None
 
@@ -114,6 +139,91 @@ def _parse_sparse_config(server_args) -> SparseConfig:
 def parse_hisparse_config(server_args) -> SparseConfig:
     """Parse hisparse config from server_args, returning defaults if no config provided."""
     return _parse_sparse_config(server_args)
+
+
+def parse_kv_sparsity_config(server_args) -> KVSparsityConfig:
+    """Parse the independent HBM-resident sparse-attention configuration."""
+    raw_config = getattr(server_args, "kv_cache_sparsity_config", None)
+    if raw_config:
+        try:
+            values = json.loads(raw_config)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"Failed to parse kv_cache_sparsity_config: {exc}"
+            ) from exc
+        if not isinstance(values, dict):
+            raise ValueError("kv_cache_sparsity_config must be a JSON object")
+    else:
+        values = {}
+
+    unknown = sorted(set(values) - _KV_SPARSITY_CONFIG_FIELDS)
+    if unknown:
+        raise ValueError(f"Unknown KV sparsity config field(s): {unknown}")
+
+    runtime_page_size = getattr(server_args, "page_size", None)
+    configured_page_size = values.get("page_size", runtime_page_size)
+    if configured_page_size is None:
+        configured_page_size = 1
+    if runtime_page_size is not None and configured_page_size != runtime_page_size:
+        raise ValueError(
+            "KV sparsity page_size must match the runtime --page-size "
+            f"({runtime_page_size}), got {configured_page_size}"
+        )
+
+    policy = values.get("policy", "streaming_llm")
+    backend = values.get("backend", "fa3")
+    if not isinstance(policy, str) or not policy.strip():
+        raise ValueError("KV sparsity policy must be a non-empty string")
+    if not isinstance(backend, str) or not backend.strip():
+        raise ValueError("KV sparsity backend must be a non-empty string")
+    policy = policy.strip().lower()
+    backend = _KV_SPARSITY_BACKEND_ALIASES.get(
+        backend.strip().lower(), backend.strip().lower()
+    )
+
+    return KVSparsityConfig(
+        policy=policy,
+        backend=backend,
+        page_size=configured_page_size,
+        min_sparse_tokens=values.get("min_sparse_tokens", 2048),
+        start_layer=values.get("start_layer", 0),
+        end_layer=values.get("end_layer", -1),
+        policy_config=values.get("policy_config", {}),
+    )
+
+
+def create_kv_sparsity_controller(
+    *,
+    device: torch.device,
+    req_to_token_pool,
+    start_layer: int,
+    end_layer: int,
+    server_args,
+) -> KVSparsityController:
+    config = parse_kv_sparsity_config(server_args)
+    policy_class = _KV_SPARSITY_POLICIES.get(config.policy)
+    if policy_class is None:
+        raise ValueError(
+            f"Unknown KV sparsity policy {config.policy!r}; "
+            f"available policies: {sorted(_KV_SPARSITY_POLICIES)}"
+        )
+    if config.backend != "fa3":
+        raise ValueError("The initial KV sparsity runtime supports only FA3")
+
+    policy = policy_class(config, device)
+    placement = HBMResidentPlacement(
+        req_to_token=req_to_token_pool.req_to_token,
+        page_size=config.page_size,
+    )
+    adaptor = FlashAttentionVisibilityAdaptor(placement)
+    return KVSparsityController(
+        config=config,
+        policy=policy,
+        adaptor=adaptor,
+        req_to_token_pool=req_to_token_pool,
+        start_layer=start_layer,
+        end_layer=end_layer,
+    )
 
 
 def create_sparse_coordinator(

--- a/python/sglang/srt/mem_cache/sparsity/policies/__init__.py
+++ b/python/sglang/srt/mem_cache/sparsity/policies/__init__.py
@@ -1,0 +1,6 @@
+from sglang.srt.mem_cache.sparsity.policies.base import SparsityPolicy
+from sglang.srt.mem_cache.sparsity.policies.streaming_llm import (
+    StreamingLLMPolicy,
+)
+
+__all__ = ["SparsityPolicy", "StreamingLLMPolicy"]

--- a/python/sglang/srt/mem_cache/sparsity/policies/base.py
+++ b/python/sglang/srt/mem_cache/sparsity/policies/base.py
@@ -1,0 +1,35 @@
+"""Policy interface for post-hoc KV-cache sparsity."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from sglang.srt.mem_cache.sparsity.contracts import (
+    RequestIdentity,
+    SelectionContext,
+    SelectionResult,
+    SparsityCapabilities,
+)
+
+
+class SparsityPolicy(ABC):
+    """Selects logical KV entries without mutating backend metadata or pools."""
+
+    @property
+    @abstractmethod
+    def capabilities(self) -> SparsityCapabilities: ...
+
+    @abstractmethod
+    def select(self, context: SelectionContext) -> SelectionResult: ...
+
+    def on_request_begin(self, identity: RequestIdentity) -> None:
+        """Initialize policy state for a generation-aware request identity."""
+
+    def on_request_end(self, identity: RequestIdentity) -> None:
+        """Release policy state for a generation-aware request identity."""
+
+    def begin_forward(self, context: SelectionContext) -> None:
+        """Prepare policy state once for a new prefill or decode forward."""
+
+    def on_attention_complete(self, context: SelectionContext) -> None:
+        """Optionally update an incremental policy representation."""

--- a/python/sglang/srt/mem_cache/sparsity/policies/streaming_llm.py
+++ b/python/sglang/srt/mem_cache/sparsity/policies/streaming_llm.py
@@ -1,0 +1,118 @@
+"""Position-only sink + recent-window visibility policy."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.mem_cache.sparsity.config import KVSparsityConfig
+from sglang.srt.mem_cache.sparsity.contracts import (
+    DecisionScope,
+    Granularity,
+    KVStateAction,
+    SelectionContext,
+    SelectionEvidence,
+    SelectionResult,
+    SparsityCapabilities,
+)
+from sglang.srt.mem_cache.sparsity.policies.base import SparsityPolicy
+
+
+class StreamingLLMPolicy(SparsityPolicy):
+    """Expose initial sink pages and the most recent pages.
+
+    This is visibility-only: excluded pages remain allocated in HBM. With the
+    default runtime page size of one, pages are identical to tokens and the
+    policy matches the usual StreamingLLM sink/window visibility pattern.
+    """
+
+    _CAPABILITIES = SparsityCapabilities(
+        state_action=KVStateAction.VISIBILITY_ONLY,
+        granularity=Granularity.PAGE,
+        evidence=SelectionEvidence.POSITION,
+        scope=DecisionScope.STEP,
+        requires_request_state=False,
+        supports_cuda_graph=False,
+    )
+
+    def __init__(self, config: KVSparsityConfig, device: torch.device):
+        self.config = config
+        self.device = device
+        unknown = sorted(set(config.policy_config) - {"sink_pages", "recent_pages"})
+        if unknown:
+            raise ValueError(f"Unknown StreamingLLM policy field(s): {unknown}")
+        self.sink_pages = self._positive_int("sink_pages", 4, allow_zero=True)
+        self.recent_pages = self._positive_int("recent_pages", 1024)
+        if self.sink_pages + self.recent_pages <= 0:
+            raise ValueError("StreamingLLM must retain at least one page")
+
+    def _positive_int(self, name: str, default: int, allow_zero: bool = False) -> int:
+        value = self.config.policy_config.get(name, default)
+        lower_bound = 0 if allow_zero else 1
+        if not isinstance(value, int) or isinstance(value, bool) or value < lower_bound:
+            qualifier = "non-negative" if allow_zero else "positive"
+            raise ValueError(f"{name} must be a {qualifier} integer, got {value!r}")
+        return value
+
+    @property
+    def capabilities(self) -> SparsityCapabilities:
+        return self._CAPABILITIES
+
+    def select(self, context: SelectionContext) -> SelectionResult:
+        seq_lens = context.seq_lens
+        if seq_lens.ndim != 1:
+            raise ValueError("seq_lens must have shape [batch]")
+
+        page_size = self.config.page_size
+        num_pages = torch.div(
+            seq_lens + page_size - 1, page_size, rounding_mode="floor"
+        )
+        capacity = self.sink_pages + self.recent_pages
+        sparse_mask = (seq_lens >= self.config.min_sparse_tokens) & (
+            num_pages > capacity
+        )
+
+        sink_offsets = torch.arange(
+            self.sink_pages, dtype=torch.int64, device=seq_lens.device
+        )
+        recent_offsets = torch.arange(
+            self.recent_pages, dtype=torch.int64, device=seq_lens.device
+        )
+        recent_starts = num_pages - self.recent_pages
+
+        sink = sink_offsets.unsqueeze(0).expand(seq_lens.shape[0], -1)
+        recent = recent_starts.unsqueeze(1) + recent_offsets.unsqueeze(0)
+        logical_indices = torch.cat((sink, recent), dim=1).to(torch.int32)
+        logical_indices = torch.where(
+            sparse_mask.unsqueeze(1),
+            logical_indices,
+            torch.full_like(logical_indices, -1),
+        )
+
+        valid_lengths = torch.where(
+            sparse_mask,
+            torch.full_like(seq_lens, capacity, dtype=torch.int32),
+            torch.zeros_like(seq_lens, dtype=torch.int32),
+        )
+        final_page_padding = num_pages * page_size - seq_lens
+        sparse_kv_lens = capacity * page_size - final_page_padding
+        visible_kv_lens = torch.where(
+            sparse_mask,
+            sparse_kv_lens.to(torch.int32),
+            torch.zeros_like(seq_lens, dtype=torch.int32),
+        )
+
+        return SelectionResult(
+            granularity=Granularity.PAGE,
+            logical_indices=logical_indices,
+            valid_lengths=valid_lengths,
+            visible_kv_lens=visible_kv_lens,
+            sparse_mask=sparse_mask,
+            layer_id=None,
+            # Dense rows are either below the activation threshold or no
+            # longer than the retained page budget. This is therefore a safe
+            # scheduler upper bound without synchronizing seq_lens to host.
+            max_visible_kv_len=max(
+                capacity * page_size,
+                max(self.config.min_sparse_tokens - 1, 1),
+            ),
+        )

--- a/python/sglang/srt/model_executor/forward_context.py
+++ b/python/sglang/srt/model_executor/forward_context.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Optional
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
     from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+    from sglang.srt.mem_cache.sparsity.core import KVSparsityController
 
 
 @dataclass(frozen=True, slots=True)
@@ -38,6 +39,7 @@ class ForwardContext:
     write time — use dataclasses.replace for per-call overrides."""
 
     attn_backend: AttentionBackend
+    kv_sparsity_controller: Optional[KVSparsityController] = None
 
 
 _current: Optional[ForwardContext] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -387,6 +387,7 @@ class ModelRunner:
 
         # For hisparse (must be set before initialize() so CUDA graph capture can see it)
         self.hisparse_coordinator = None
+        self.kv_sparsity_controller = None
 
         # Load model weights and configure
         self.initialize()
@@ -785,6 +786,7 @@ class ModelRunner:
         self.init_ngram_embedding_manager()
 
         self.maybe_init_hisparse_coordinator()
+        self.maybe_init_kv_sparsity_controller()
 
         self.init_routed_experts_capturer()
         self.init_indexer_capturer()
@@ -814,6 +816,19 @@ class ModelRunner:
             ),
             host_to_device_ratio=hisparse_cfg.host_to_device_ratio,
             swap_in_block_size=hisparse_cfg.swap_in_block_size,
+        )
+
+    def maybe_init_kv_sparsity_controller(self):
+        if not self.server_args.enable_kv_cache_sparsity:
+            return
+        from sglang.srt.mem_cache.sparsity import create_kv_sparsity_controller
+
+        self.kv_sparsity_controller = create_kv_sparsity_controller(
+            device=torch.device(self.device),
+            req_to_token_pool=self.req_to_token_pool,
+            start_layer=self.layer_info.start_layer,
+            end_layer=self.layer_info.end_layer,
+            server_args=self.server_args,
         )
 
     def post_capture_resize_kv_pool(self):
@@ -876,6 +891,8 @@ class ModelRunner:
         self.decode_attn_backend_group = backends.decode_attn_backend_group
         self.prefill_attention_backend_str = backends.prefill_attention_backend_str
         self.decode_attention_backend_str = backends.decode_attention_backend_str
+        if self.kv_sparsity_controller is not None:
+            self.kv_sparsity_controller.bind_attention_backend(self.attn_backend)
 
         if self.server_args.dcp_size > 1 and get_parallel().dcp_replicate_q_proj:
             self._prepare_replicated_q_proj()
@@ -1474,7 +1491,12 @@ class ModelRunner:
         if has_forward_context():
             ctx_mgr = contextlib.nullcontext()
         else:
-            ctx_mgr = forward_context(ForwardContext(attn_backend=self.attn_backend))
+            ctx_mgr = forward_context(
+                ForwardContext(
+                    attn_backend=self.attn_backend,
+                    kv_sparsity_controller=self.kv_sparsity_controller,
+                )
+            )
         with ctx_mgr:
             mode_check = (
                 forward_batch.forward_mode.is_cpu_graph

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2648,6 +2648,27 @@ class ServerArgs:
     ] = None
 
     # -------------------------------------------------------------------------
+    # HBM-resident post-hoc KV-cache sparsity
+    # -------------------------------------------------------------------------
+    enable_kv_cache_sparsity: A[
+        bool,
+        "Enable visibility-only post-hoc KV-cache sparsity",
+        NS("memory"),
+    ] = False
+    kv_cache_sparsity_config: A[
+        Optional[str],
+        Arg(
+            help=(
+                "JSON configuration for HBM-resident KV-cache sparsity. Example: "
+                '\'{"policy":"streaming_llm","backend":"fa3",'
+                '"min_sparse_tokens":4096,"policy_config":{'
+                '"sink_pages":4,"recent_pages":2048}}\''
+            )
+        ),
+        NS("memory"),
+    ] = None
+
+    # -------------------------------------------------------------------------
     # Multi-modal optimization configs
     # -------------------------------------------------------------------------
     enable_broadcast_mm_inputs_process: A[
@@ -4822,6 +4843,7 @@ class ServerArgs:
             and not self.prefill_only_disable_kv_cache
             and not self.enable_memory_saver
             and envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is None
+            and not self.enable_kv_cache_sparsity
             # Accurate sizing assumes graph-covered execution (graphs retain the
             # activation workspace, so it is measured post-capture). An eager
             # phase would pay activations outside the measurement: DP attention
@@ -8656,6 +8678,12 @@ class ServerArgs:
             raise ValueError(
                 "--retraction-policy priority requires --enable-priority-scheduling"
             )
+
+        from sglang.srt.arg_groups.kv_sparsity_hook import (
+            validate_kv_cache_sparsity,
+        )
+
+        validate_kv_cache_sparsity(self)
 
         # Check hisparse
         # Moved to the resolution pipeline (arg_groups/overrides.py:

--- a/test/registered/kernels/ops/attention/test_kv_sparsity_fa3_visibility.py
+++ b/test/registered/kernels/ops/attention/test_kv_sparsity_fa3_visibility.py
@@ -1,0 +1,90 @@
+import math
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.kernels.ops.attention.flash_attention import flash_attn_with_kvcache
+from sglang.kernels.ops.attention.flash_attention_v3 import _is_fa3_supported
+from sglang.srt.mem_cache.sparsity.backend.visibility_adaptor import (
+    FlashAttentionVisibilityAdaptor,
+    HBMResidentPlacement,
+)
+from sglang.srt.mem_cache.sparsity.contracts import Granularity, SelectionResult
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+@unittest.skipUnless(
+    torch.cuda.is_available() and _is_fa3_supported(), "FA3 requires a supported GPU"
+)
+class TestKVSparsityFA3Visibility(unittest.TestCase):
+    def test_noncontiguous_sparse_page_table_matches_reference_attention(self):
+        torch.manual_seed(1)
+        device = torch.device("cuda")
+        dtype = torch.bfloat16
+
+        query = torch.randn((1, 1, 64), device=device, dtype=dtype)
+        key_cache = torch.randn((8, 1, 1, 64), device=device, dtype=dtype)
+        value_cache = torch.randn((8, 1, 1, 64), device=device, dtype=dtype)
+        req_to_token = torch.zeros((2, 8), device=device, dtype=torch.int32)
+        req_to_token[1] = torch.arange(8, device=device, dtype=torch.int32)
+        metadata = SimpleNamespace(
+            page_table=req_to_token[1:2].clone(),
+            cache_seqlens_int32=torch.tensor([8], device=device, dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 8], device=device, dtype=torch.int32),
+            cu_seqlens_q=torch.tensor([0, 1], device=device, dtype=torch.int32),
+            max_seq_len_k=8,
+            scheduler_metadata=None,
+        )
+        dense_page_table = metadata.page_table.clone()
+        adaptor = FlashAttentionVisibilityAdaptor(
+            HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+        )
+        result = SelectionResult(
+            granularity=Granularity.PAGE,
+            logical_indices=torch.tensor(
+                [[0, 1, 6, 7]], device=device, dtype=torch.int32
+            ),
+            valid_lengths=torch.tensor([4], device=device, dtype=torch.int32),
+            visible_kv_lens=torch.tensor([4], device=device, dtype=torch.int32),
+            sparse_mask=torch.tensor([True], device=device),
+        )
+
+        adaptor.capture_dense_metadata(metadata)
+        adaptor.apply(
+            result,
+            metadata,
+            SimpleNamespace(req_pool_indices=torch.tensor([1], device=device)),
+        )
+        output = flash_attn_with_kvcache(
+            q=query,
+            k_cache=key_cache,
+            v_cache=value_cache,
+            page_table=metadata.page_table,
+            cache_seqlens=metadata.cache_seqlens_int32,
+            cu_seqlens_q=metadata.cu_seqlens_q,
+            max_seqlen_q=1,
+            causal=False,
+            softmax_scale=1 / math.sqrt(64),
+            ver=3,
+        )
+
+        selected_pages = metadata.page_table[0, :4].long()
+        selected_keys = key_cache[selected_pages, 0, 0].float()
+        selected_values = value_cache[selected_pages, 0, 0].float()
+        weights = torch.softmax(
+            query[0, 0].float() @ selected_keys.T / math.sqrt(64), dim=-1
+        )
+        reference = weights @ selected_values
+
+        torch.testing.assert_close(
+            output[0, 0].float(), reference, atol=0.02, rtol=0.02
+        )
+        adaptor.restore_dense_metadata(metadata)
+        torch.testing.assert_close(metadata.page_table, dense_page_table)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_kv_sparsity_framework.py
+++ b/test/registered/unit/mem_cache/test_kv_sparsity_framework.py
@@ -1,0 +1,640 @@
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.arg_groups.kv_sparsity_hook import validate_kv_cache_sparsity
+from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.mem_cache.sparsity.backend.visibility_adaptor import (
+    FlashAttentionVisibilityAdaptor,
+    HBMResidentPlacement,
+)
+from sglang.srt.mem_cache.sparsity.config import KVSparsityConfig
+from sglang.srt.mem_cache.sparsity.contracts import (
+    Granularity,
+    RequestIdentity,
+    SelectionContext,
+    SelectionResult,
+)
+from sglang.srt.mem_cache.sparsity.core.kv_sparsity_controller import (
+    KVSparsityController,
+)
+from sglang.srt.mem_cache.sparsity.factory import parse_kv_sparsity_config
+from sglang.srt.mem_cache.sparsity.policies.streaming_llm import (
+    StreamingLLMPolicy,
+)
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    Phase,
+)
+from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_parse_kv_sparsity_config_is_independent_from_hisparse():
+    args = SimpleNamespace(
+        page_size=1,
+        kv_cache_sparsity_config=(
+            '{"policy":"streaming_llm","backend":"flashattention",'
+            '"min_sparse_tokens":16,"policy_config":{'
+            '"sink_pages":2,"recent_pages":4}}'
+        ),
+    )
+
+    config = parse_kv_sparsity_config(args)
+
+    assert config.policy == "streaming_llm"
+    assert config.backend == "fa3"
+    assert config.page_size == 1
+    assert config.min_sparse_tokens == 16
+    assert config.policy_config == {"sink_pages": 2, "recent_pages": 4}
+
+
+def test_parse_kv_sparsity_config_rejects_unknown_fields():
+    args = SimpleNamespace(
+        page_size=1,
+        kv_cache_sparsity_config='{"policy":"streaming_llm","evict":true}',
+    )
+    with pytest.raises(ValueError, match="Unknown KV sparsity config"):
+        parse_kv_sparsity_config(args)
+
+
+def test_validation_uses_resolved_fa3_default_and_disables_graphs(monkeypatch):
+    hf_text_config = SimpleNamespace(num_kv_shared_layers=0)
+    hf_config = SimpleNamespace(
+        architectures=["Qwen3ForCausalLM"],
+        model_type="qwen3",
+        get_text_config=lambda: hf_text_config,
+    )
+    model_config = SimpleNamespace(
+        attention_arch=AttentionArch.MHA,
+        is_encoder_decoder=False,
+        is_multimodal=False,
+        is_generation=True,
+        num_attention_layers=2,
+        num_hidden_layers=2,
+        sliding_window_size=None,
+        is_hybrid_swa=False,
+        attention_chunk_size=None,
+        hf_text_config=hf_text_config,
+        hf_config=hf_config,
+        is_draft_model=False,
+        linear_attn_registry_result=None,
+    )
+    args = SimpleNamespace(
+        enable_kv_cache_sparsity=True,
+        kv_cache_sparsity_config=None,
+        page_size=1,
+        enable_hisparse=False,
+        attention_backend=None,
+        prefill_attention_backend=None,
+        decode_attention_backend=None,
+        speculative_algorithm=None,
+        dllm_algorithm=None,
+        enable_pdmux=False,
+        disaggregation_mode="null",
+        enable_two_batch_overlap=False,
+        enable_mixed_chunk=False,
+        enable_torch_compile=False,
+        enable_dp_attention=False,
+        enable_prefill_cp=False,
+        attn_cp_size=1,
+        dcp_size=1,
+        cuda_graph_config=CudaGraphConfig(),
+        _cuda_graph_config_locked=set(),
+        _resolved_overrides=[("test", {"attention_backend": "fa3"})],
+        get_model_config=lambda: model_config,
+    )
+    monkeypatch.setattr("sglang.srt.server_args.is_cuda", lambda: True)
+    monkeypatch.setattr("sglang.srt.server_args.is_hip", lambda: False)
+
+    validate_kv_cache_sparsity(args)
+
+    assert args.cuda_graph_config[Phase.DECODE].backend == Backend.DISABLED
+    assert args.cuda_graph_config[Phase.PREFILL].backend == Backend.DISABLED
+
+
+def test_streaming_llm_rejects_unknown_policy_fields():
+    config = KVSparsityConfig(policy_config={"recent_pages": 4, "typo": 1})
+    with pytest.raises(ValueError, match="Unknown StreamingLLM policy field"):
+        StreamingLLMPolicy(config, torch.device("cpu"))
+
+
+def test_streaming_llm_selects_sink_and_recent_pages_without_host_reads():
+    config = KVSparsityConfig(
+        page_size=1,
+        min_sparse_tokens=6,
+        policy_config={"sink_pages": 2, "recent_pages": 3},
+    )
+    policy = StreamingLLMPolicy(config, torch.device("cpu"))
+    seq_lens = torch.tensor([4, 6, 10], dtype=torch.int64)
+
+    result = policy.select(
+        SelectionContext(
+            query=None,
+            layer_id=0,
+            req_pool_indices=torch.tensor([1, 2, 3]),
+            seq_lens=seq_lens,
+        )
+    )
+
+    assert result.granularity == Granularity.PAGE
+    assert result.capacity == 5
+    torch.testing.assert_close(result.sparse_mask, torch.tensor([False, True, True]))
+    torch.testing.assert_close(
+        result.logical_indices,
+        torch.tensor(
+            [
+                [-1, -1, -1, -1, -1],
+                [0, 1, 3, 4, 5],
+                [0, 1, 7, 8, 9],
+            ],
+            dtype=torch.int32,
+        ),
+    )
+    torch.testing.assert_close(
+        result.valid_lengths, torch.tensor([0, 5, 5], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        result.visible_kv_lens, torch.tensor([0, 5, 5], dtype=torch.int32)
+    )
+
+
+def test_streaming_llm_accounts_for_a_partial_final_page():
+    config = KVSparsityConfig(
+        page_size=4,
+        min_sparse_tokens=0,
+        policy_config={"sink_pages": 1, "recent_pages": 2},
+    )
+    policy = StreamingLLMPolicy(config, torch.device("cpu"))
+
+    result = policy.select(
+        SelectionContext(
+            query=None,
+            layer_id=0,
+            req_pool_indices=torch.tensor([1, 2]),
+            seq_lens=torch.tensor([12, 13]),
+        )
+    )
+
+    torch.testing.assert_close(result.sparse_mask, torch.tensor([False, True]))
+    torch.testing.assert_close(
+        result.logical_indices[1], torch.tensor([0, 2, 3], dtype=torch.int32)
+    )
+    assert result.visible_kv_lens[1].item() == 9
+
+
+def test_selection_result_rejects_mismatched_batch_shapes():
+    with pytest.raises(ValueError, match="valid_lengths"):
+        SelectionResult(
+            granularity=Granularity.PAGE,
+            logical_indices=torch.zeros((2, 4), dtype=torch.int32),
+            valid_lengths=torch.zeros(1, dtype=torch.int32),
+            visible_kv_lens=torch.zeros(2, dtype=torch.int32),
+            sparse_mask=torch.zeros(2, dtype=torch.bool),
+        )
+
+
+def test_fa3_adaptor_rewrites_sparse_rows_and_restores_dense_metadata():
+    req_to_token = torch.zeros((3, 8), dtype=torch.int32)
+    req_to_token[1] = torch.tensor([10, 11, 12, 13, 14, 15, 16, 17])
+    req_to_token[2] = torch.tensor([20, 21, 22, 23, 24, 25, 26, 27])
+    placement = HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+    adaptor = FlashAttentionVisibilityAdaptor(placement)
+    metadata = SimpleNamespace(
+        page_table=torch.tensor(
+            [[10, 11, 12, 13, 14, 15, 16, 17], [20, 21, 22, 23, 24, 25, 26, 27]],
+            dtype=torch.int32,
+        ),
+        cache_seqlens_int32=torch.tensor([8, 4], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 8, 12], dtype=torch.int32),
+        max_seq_len_k=8,
+        cu_seqlens_q=torch.tensor([0, 1, 2], dtype=torch.int32),
+        scheduler_metadata=torch.ones(1),
+    )
+    dense_page_table = metadata.page_table.clone()
+    forward_batch = SimpleNamespace(req_pool_indices=torch.tensor([1, 2]))
+    result = SelectionResult(
+        granularity=Granularity.PAGE,
+        logical_indices=torch.tensor([[0, 1, 6, 7], [-1, -1, -1, -1]]),
+        valid_lengths=torch.tensor([4, 0], dtype=torch.int32),
+        visible_kv_lens=torch.tensor([4, 0], dtype=torch.int32),
+        sparse_mask=torch.tensor([True, False]),
+        max_visible_kv_len=4,
+    )
+
+    adaptor.capture_dense_metadata(metadata)
+    adaptor.apply(result, metadata, forward_batch)
+
+    torch.testing.assert_close(
+        metadata.page_table[0, :4],
+        torch.tensor([10, 11, 16, 17], dtype=torch.int32),
+    )
+    torch.testing.assert_close(metadata.page_table[1], dense_page_table[1])
+    torch.testing.assert_close(
+        metadata.cache_seqlens_int32, torch.tensor([4, 4], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        metadata.cu_seqlens_k, torch.tensor([0, 4, 8], dtype=torch.int32)
+    )
+    assert metadata.max_seq_len_k == 4
+    assert metadata.scheduler_metadata is None
+
+    adaptor.restore_dense_metadata(metadata)
+    torch.testing.assert_close(metadata.page_table, dense_page_table)
+    torch.testing.assert_close(
+        metadata.cache_seqlens_int32, torch.tensor([8, 4], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        metadata.cu_seqlens_k, torch.tensor([0, 8, 12], dtype=torch.int32)
+    )
+    assert metadata.max_seq_len_k == 8
+
+
+def test_fa3_adaptor_rebuilds_sparse_scheduler_metadata_once_per_step():
+    req_to_token = torch.arange(8, dtype=torch.int32).unsqueeze(0)
+    adaptor = FlashAttentionVisibilityAdaptor(
+        HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+    )
+    calls = []
+
+    def build_scheduler(batch_size, max_seq_len_k, cache_seqlens, cu_seqlens_q):
+        calls.append(
+            (
+                batch_size,
+                max_seq_len_k,
+                cache_seqlens.clone(),
+                cu_seqlens_q.clone(),
+            )
+        )
+        return torch.tensor([17])
+
+    adaptor.bind_attention_backend(
+        SimpleNamespace(_compute_scheduler_metadata=build_scheduler)
+    )
+    metadata = SimpleNamespace(
+        page_table=req_to_token.clone(),
+        cache_seqlens_int32=torch.tensor([8], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 8], dtype=torch.int32),
+        cu_seqlens_q=torch.tensor([0, 1], dtype=torch.int32),
+        max_seq_len_k=8,
+        scheduler_metadata=torch.tensor([99]),
+    )
+    result = SelectionResult(
+        granularity=Granularity.PAGE,
+        logical_indices=torch.tensor([[0, 1, 6, 7]], dtype=torch.int32),
+        valid_lengths=torch.tensor([4], dtype=torch.int32),
+        visible_kv_lens=torch.tensor([4], dtype=torch.int32),
+        sparse_mask=torch.tensor([True]),
+        max_visible_kv_len=4,
+    )
+    forward_batch = SimpleNamespace(req_pool_indices=torch.tensor([0]))
+
+    adaptor.capture_dense_metadata(metadata)
+    adaptor.apply(result, metadata, forward_batch)
+    adaptor.apply(result, metadata, forward_batch)
+
+    assert len(calls) == 1
+    assert calls[0][0:2] == (1, 4)
+    torch.testing.assert_close(calls[0][2], torch.tensor([4], dtype=torch.int32))
+    torch.testing.assert_close(metadata.scheduler_metadata, torch.tensor([17]))
+
+    adaptor.restore_dense_metadata(metadata)
+    assert metadata.max_seq_len_k == 8
+    torch.testing.assert_close(metadata.scheduler_metadata, torch.tensor([99]))
+
+
+def test_fa3_adaptor_keeps_short_dense_rows_when_capacity_exceeds_page_table():
+    req_to_token = torch.arange(4, dtype=torch.int32).unsqueeze(0)
+    adaptor = FlashAttentionVisibilityAdaptor(
+        HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+    )
+    metadata = SimpleNamespace(
+        page_table=req_to_token.clone(),
+        cache_seqlens_int32=torch.tensor([4], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 4], dtype=torch.int32),
+        max_seq_len_k=4,
+    )
+    result = SelectionResult(
+        granularity=Granularity.PAGE,
+        logical_indices=torch.full((1, 8), -1, dtype=torch.int32),
+        valid_lengths=torch.tensor([0], dtype=torch.int32),
+        visible_kv_lens=torch.tensor([0], dtype=torch.int32),
+        sparse_mask=torch.tensor([False]),
+        max_visible_kv_len=8,
+    )
+
+    adaptor.capture_dense_metadata(metadata)
+    adaptor.apply(
+        result,
+        metadata,
+        SimpleNamespace(req_pool_indices=torch.tensor([0])),
+    )
+
+    torch.testing.assert_close(metadata.page_table, req_to_token)
+    torch.testing.assert_close(
+        metadata.cache_seqlens_int32, torch.tensor([4], dtype=torch.int32)
+    )
+    assert metadata.max_seq_len_k == 4
+
+
+def test_hbm_placement_maps_logical_pages_to_physical_pages():
+    req_to_token = torch.zeros((2, 16), dtype=torch.int32)
+    req_to_token[1] = torch.arange(40, 56, dtype=torch.int32)
+    placement = HBMResidentPlacement(req_to_token=req_to_token, page_size=4)
+
+    physical = placement.logical_to_physical_pages(
+        logical_pages=torch.tensor([[0, 2, 3, -1]], dtype=torch.int32),
+        req_pool_indices=torch.tensor([1]),
+    )
+
+    torch.testing.assert_close(
+        physical, torch.tensor([[10, 12, 13, 0]], dtype=torch.int32)
+    )
+
+
+def test_controller_reuses_step_selection_and_restores_after_layer_range():
+    class CountingStreamingPolicy(StreamingLLMPolicy):
+        def __init__(self, config, device):
+            super().__init__(config, device)
+            self.select_calls = 0
+
+        def select(self, context):
+            self.select_calls += 1
+            return super().select(context)
+
+    config = KVSparsityConfig(
+        page_size=1,
+        min_sparse_tokens=0,
+        policy_config={"sink_pages": 1, "recent_pages": 2},
+    )
+    req_to_token = torch.zeros((2, 8), dtype=torch.int32)
+    req_to_token[1] = torch.arange(10, 18, dtype=torch.int32)
+    pool = SimpleNamespace(
+        req_to_token=req_to_token,
+        req_generation=torch.tensor([0, 1], dtype=torch.int64),
+    )
+    adaptor = FlashAttentionVisibilityAdaptor(
+        HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+    )
+    policy = CountingStreamingPolicy(config, torch.device("cpu"))
+    controller = KVSparsityController(
+        config=config,
+        policy=policy,
+        adaptor=adaptor,
+        req_to_token_pool=pool,
+        start_layer=0,
+        end_layer=2,
+    )
+    metadata = SimpleNamespace(
+        page_table=req_to_token[1:2].clone(),
+        cache_seqlens_int32=torch.tensor([8], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 8], dtype=torch.int32),
+        max_seq_len_k=8,
+        scheduler_metadata=None,
+    )
+    forward_batch = SimpleNamespace(
+        req_pool_indices=torch.tensor([1]),
+        seq_lens=torch.tensor([8]),
+        forward_mode=SimpleNamespace(is_decode=lambda: True),
+    )
+    query = torch.zeros((1, 1, 1))
+    layer_0 = SimpleNamespace(layer_id=0)
+    layer_1 = SimpleNamespace(layer_id=1)
+
+    controller.before_attention(query, None, None, layer_0, forward_batch, metadata)
+    controller.after_attention(
+        query, None, None, query, layer_0, forward_batch, metadata
+    )
+    controller.before_attention(query, None, None, layer_1, forward_batch, metadata)
+
+    assert policy.select_calls == 1
+    torch.testing.assert_close(
+        metadata.page_table[0, :3],
+        torch.tensor([10, 16, 17], dtype=torch.int32),
+    )
+    controller.after_attention(
+        query, None, None, query, layer_1, forward_batch, metadata
+    )
+    torch.testing.assert_close(metadata.page_table, req_to_token[1:2])
+    torch.testing.assert_close(
+        metadata.cache_seqlens_int32, torch.tensor([8], dtype=torch.int32)
+    )
+
+
+def test_controller_observes_prefill_without_rewriting_dense_metadata():
+    class TrackingStreamingPolicy(StreamingLLMPolicy):
+        def __init__(self, config, device):
+            super().__init__(config, device)
+            self.forward_contexts = []
+            self.completed_contexts = []
+
+        def begin_forward(self, context):
+            self.forward_contexts.append(context)
+
+        def on_attention_complete(self, context):
+            self.completed_contexts.append(context)
+
+    config = KVSparsityConfig(
+        min_sparse_tokens=0,
+        policy_config={"sink_pages": 1, "recent_pages": 2},
+    )
+    req_to_token = torch.zeros((2, 8), dtype=torch.int32)
+    req_to_token[1] = torch.arange(10, 18, dtype=torch.int32)
+    policy = TrackingStreamingPolicy(config, torch.device("cpu"))
+    controller = KVSparsityController(
+        config=config,
+        policy=policy,
+        adaptor=FlashAttentionVisibilityAdaptor(
+            HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+        ),
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=req_to_token,
+            req_generation=torch.tensor([0, 1], dtype=torch.int64),
+        ),
+        start_layer=0,
+        end_layer=1,
+    )
+    metadata = SimpleNamespace(page_table=req_to_token[1:2].clone())
+    dense_page_table = metadata.page_table.clone()
+    forward_batch = SimpleNamespace(
+        req_pool_indices=torch.tensor([1]),
+        seq_lens=torch.tensor([8]),
+        forward_mode=SimpleNamespace(is_decode=lambda: False),
+    )
+    query = torch.zeros((8, 1, 1))
+    key = torch.ones((8, 1, 1))
+    output = torch.full((8, 1, 1), 2.0)
+    layer = SimpleNamespace(layer_id=0)
+
+    controller.before_attention(query, key, None, layer, forward_batch, metadata)
+    controller.after_attention(query, key, None, output, layer, forward_batch, metadata)
+
+    torch.testing.assert_close(metadata.page_table, dense_page_table)
+    assert len(policy.forward_contexts) == 1
+    assert len(policy.completed_contexts) == 1
+    assert policy.completed_contexts[0].key is key
+    assert policy.completed_contexts[0].output is output
+
+
+def test_controller_resets_state_when_a_pool_slot_generation_changes():
+    class StatefulStreamingPolicy(StreamingLLMPolicy):
+        _CAPABILITIES = replace(
+            StreamingLLMPolicy._CAPABILITIES, requires_request_state=True
+        )
+
+        def __init__(self, config, device):
+            super().__init__(config, device)
+            self.begun = []
+            self.ended = []
+
+        def on_request_begin(self, identity):
+            self.begun.append(identity)
+
+        def on_request_end(self, identity):
+            self.ended.append(identity)
+
+    config = KVSparsityConfig(
+        min_sparse_tokens=0,
+        policy_config={"sink_pages": 1, "recent_pages": 2},
+    )
+    req_to_token = torch.zeros((2, 8), dtype=torch.int32)
+    req_to_token[1] = torch.arange(10, 18, dtype=torch.int32)
+    pool = SimpleNamespace(
+        req_to_token=req_to_token,
+        req_generation=torch.tensor([0, 7], dtype=torch.int64),
+    )
+    policy = StatefulStreamingPolicy(config, torch.device("cpu"))
+    controller = KVSparsityController(
+        config=config,
+        policy=policy,
+        adaptor=FlashAttentionVisibilityAdaptor(
+            HBMResidentPlacement(req_to_token=req_to_token, page_size=1)
+        ),
+        req_to_token_pool=pool,
+        start_layer=0,
+        end_layer=1,
+    )
+    forward_batch = SimpleNamespace(
+        req_pool_indices=torch.tensor([1]),
+        seq_lens=torch.tensor([8]),
+        forward_mode=SimpleNamespace(is_decode=lambda: True),
+    )
+    query = torch.zeros((1, 1, 1))
+    layer = SimpleNamespace(layer_id=0)
+
+    def run_forward():
+        metadata = SimpleNamespace(
+            page_table=req_to_token[1:2].clone(),
+            cache_seqlens_int32=torch.tensor([8], dtype=torch.int32),
+            cu_seqlens_k=torch.tensor([0, 8], dtype=torch.int32),
+            max_seq_len_k=8,
+            scheduler_metadata=None,
+        )
+        controller.before_attention(query, None, None, layer, forward_batch, metadata)
+        controller.after_attention(
+            query, None, None, query, layer, forward_batch, metadata
+        )
+
+    run_forward()
+    pool.req_generation[1] = 8
+    run_forward()
+
+    assert policy.begun == [RequestIdentity(1, 7), RequestIdentity(1, 8)]
+    assert policy.ended == [RequestIdentity(1, 7)]
+
+
+@pytest.mark.parametrize("is_decode", [False, True])
+def test_radix_attention_runs_sparsity_hooks_around_existing_backend(is_decode):
+    calls = []
+    metadata = object()
+
+    class Backend:
+        forward_metadata = metadata
+
+        def forward(self, query, key, value, layer, batch, save_kv_cache, **kwargs):
+            calls.append(("backend", key, value))
+            return query + 1
+
+    class Controller:
+        def before_attention(self, query, key, value, layer, batch, attn_metadata):
+            calls.append(("before", attn_metadata))
+
+        def after_attention(
+            self, query, key, value, output, layer, batch, attn_metadata
+        ):
+            calls.append(("after", output, attn_metadata))
+
+    class ForwardMode:
+        def is_decode(self):
+            return is_decode
+
+        def is_extend(self, include_draft_extend_v2=False):
+            return not is_decode
+
+    layer = RadixAttention(
+        num_heads=2,
+        head_dim=4,
+        scaling=0.5,
+        num_kv_heads=1,
+        layer_id=0,
+    )
+    batch = SimpleNamespace(
+        forward_mode=ForwardMode(),
+        spec_info=None,
+        req_pool_indices=torch.tensor([1]),
+        seq_lens=torch.tensor([8]),
+    )
+    query = torch.zeros((1, 2, 4))
+    key = torch.ones((1, 1, 4))
+    value = torch.full((1, 1, 4), 2.0)
+
+    with forward_context(
+        ForwardContext(attn_backend=Backend(), kv_sparsity_controller=Controller())
+    ):
+        output = layer(query, key, value, batch)
+
+    assert [call[0] for call in calls] == ["before", "backend", "after"]
+    assert calls[0][1] is metadata
+    assert calls[1][1].shape == (1, 1, 4)
+    torch.testing.assert_close(output, query + 1)
+    assert calls[2][1] is output
+
+
+def test_radix_attention_dense_path_does_not_require_a_controller():
+    class Backend:
+        def forward(self, query, key, value, layer, batch, save_kv_cache, **kwargs):
+            return query + 3
+
+    class ForwardMode:
+        def is_decode(self):
+            return True
+
+        def is_extend(self, include_draft_extend_v2=False):
+            return False
+
+    layer = RadixAttention(
+        num_heads=2,
+        head_dim=4,
+        scaling=0.5,
+        num_kv_heads=1,
+        layer_id=0,
+    )
+    batch = SimpleNamespace(forward_mode=ForwardMode())
+    query = torch.zeros((1, 2, 4))
+    key = torch.ones((1, 1, 4))
+    value = torch.full((1, 1, 4), 2.0)
+
+    with forward_context(ForwardContext(attn_backend=Backend())):
+        output = layer(query, key, value, batch)
+
+    torch.testing.assert_close(output, query + 3)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

This PR is the first implementation PR for the design proposed in
[#32657: A Unified KV-Cache Sparsity Framework for Post-Hoc Sparse Attention](https://github.com/sgl-project/sglang/issues/32657).

SGLang already contains initial sparse-algorithm, coordinator, and backend-adaptor
abstractions under `mem_cache/sparsity`, but they do not provide a complete
serving path for attaching a post-hoc sparse policy to an existing dense MHA/GQA
checkpoint. This PR adds that serving path and uses a StreamingLLM-style
sink/recent visibility policy as the first end-to-end implementation.

The initial scope is deliberately visibility-only: all KV entries remain in
HBM and retain their original allocator ownership, while attention sees a
smaller logical KV set. The feature is disabled by default and does not change
the dense path unless explicitly enabled.

This is PR1 of the following stack:

1. common KSE framework and StreamingLLM visibility;
2. optimized Quest and Breakable CUDA Graph support;
3. Triton attention-backend support;
4. ChunkKV visibility policy.

## Modifications

### Framework interfaces

This PR adds four explicit classification dimensions to every policy:

- `KVStateAction`: visibility-only, eviction, or hierarchical placement;
- `Granularity`: token or page;
- `SelectionEvidence`: position, KV-derived, current-query, or attention history;
- `DecisionScope`: request, decode step, or layer.

The main interfaces are:

- `SparsityPolicy.select(SelectionContext) -> SelectionResult`;
- `KVSparsityController` for forward/layer lifecycle and selection reuse;
- `MetadataAdaptor` for backend-owned metadata capture, sparse apply, and dense restore;
- `HBMResidentPlacement` for request-relative logical-to-physical KV translation.

`SelectionResult` provides a fixed-capacity, device-resident contract:

- logical request-relative indices;
- `-1` padding;
- per-row `valid_lengths`;
- exact `visible_kv_lens`, including a partial final page;
- mixed dense/sparse rows through `sparse_mask`;
- an optional static maximum visible length for graph-compatible backends.

### Changes from the previous `mem_cache/sparsity` interfaces

- Algorithm-specific runtime behavior is represented as a policy with explicit
  capabilities instead of being inferred from `BaseSparseAlgorithm` methods.
- `SparseCoordinator`-style responsibilities are split into policy selection,
  controller lifecycle, placement, and backend metadata adaptation.
- Selected indices have an explicit logical granularity and never transfer KV
  allocator ownership.
- Backend adaptation consumes `SelectionResult` instead of separate untyped
  index, page-size, request-map, and layer arguments.
- Request identities include the reusable request-pool slot generation.
- The new configuration is independent of HiSparse placement and uses
  `--enable-kv-cache-sparsity` plus a JSON policy configuration.

The existing sparse/HiSparse interfaces remain available; this PR does not
replace their placement or offload path.

### Runtime integration

- `ModelRunner` creates and owns the controller after KV pools are initialized.
- `ForwardContext` publishes the controller to attention layers.
- `RadixAttention` invokes the controller before and after eligible
  prefill/decode attention calls.
- Unsupported execution modes fail during initialization instead of silently
  applying an approximate mapping.
- The dense metadata is restored after the configured sparse layer range.

### StreamingLLM reference policy

The policy retains a fixed number of sink pages and the current recent window.
Excluded pages remain allocated in HBM. The implementation supports mixed
dense/sparse batches and partial final pages through the common
`SelectionResult` contract.

Example:

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3-4B \
  --attention-backend fa3 \
  --page-size 1 \
  --disable-radix-cache \
  --enable-kv-cache-sparsity \
  --kv-cache-sparsity-config '{
    "policy": "streaming_llm",
    "backend": "fa3",
    "page_size": 1,
    "min_sparse_tokens": 2048,
    "policy_config": {
      "sink_pages": 4,
      "recent_pages": 1024
    }
  }'
```

## Accuracy Tests

### Automated coverage

- framework, controller, configuration, and ServerArgs: 150 passed;
- ServerArgs subtests: 21 passed;
- L40S FA3 visibility numerical test: 1 passed;
- mixed dense/sparse rows, logical-to-physical mapping, partial final pages,
  metadata restore, layer ranges, request generations, and unsupported-mode
  validation are covered.

### LongBench quality curve

Qwen3-4B BF16 on an L40S, FA3 eager, `page_size=16`, greedy decoding, 80 fixed examples from
Qasper, HotpotQA, 2WikiMQA, and PassageRetrieval-en. Average prompt length was
14,481 tokens.

| Visible page budget | Mean sparsity | Macro score | Dense-relative change |
|---:|---:|---:|---:|
| Dense | 0.0% | 51.16 | 0.00 |
| 640 | 28.2% | 44.78 | -6.37 |
| 448 | 47.1% | 42.58 | -8.57 |
| 224 | 73.5% | 32.88 | -18.28 |
| 112 | 86.7% | 28.54 | -22.62 |

The curve matches the position-only policy semantics: evidence outside the
sink/recent window is intentionally hidden. StreamingLLM visibility is intended
for workloads with local dependencies or known sink/recent locality, not as a
quality-preserving default for arbitrary long-context retrieval.

## Speed Tests and Profiling

Environment: NVIDIA L40S, Qwen3-4B BF16, TP=1, FA3 eager, radix cache disabled.

### 8K input, 128 output, 16 requests, concurrency 8

| Mode | Output throughput | Mean TPOT |
|---|---:|---:|
| Dense FA3 eager | 145.11 tok/s | 39.86 ms |
| StreamingLLM sparse eager | 167.43 tok/s | 32.53 ms |

- output throughput: **+15.4%**;
- TPOT: **-18.4%**;
- TTFT remained effectively unchanged.

### 24K input, 64 output, 8 requests, concurrency 4

| Mode | Output throughput | TPOT | TTFT | E2E |
|---|---:|---:|---:|---:|
| Dense FA3 eager | 26.72 tok/s | 77.19 ms | 4692.65 ms | 9555.38 ms |
| StreamingLLM sparse eager | 29.51 tok/s | 62.56 ms | 4717.79 ms | 8658.95 ms |

- output throughput: **+10.4%**;
- TPOT: **-19.0%**;
- E2E latency: **-9.4%**.

This mode reduces attention computation and memory traffic. It does not increase
KV-cache capacity because the complete KV cache remains resident.

## Checklist

- [x] Format the changed files with pre-commit.
- [x] Add CPU and GPU unit tests.
- [x] Update `mem_cache/sparsity/README.md` with interfaces and launch commands.
- [x] Provide accuracy and speed results.
- [x] Keep the feature default-off and preserve the dense fallback.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->