### PR TITLE
[diffusion] fix: MiniMax-H3 text encoder device mismatch under --text-encoder-cpu-offload

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/encoders/minimax_h3_qwen3vl.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/minimax_h3_qwen3vl.py
@@ -15,6 +15,7 @@ from sglang.multimodal_gen.configs.models.encoders.minimax_h3_qwen3vl import (
     MINIMAX_H3_QWEN3VL_SELECTED_LM_LAYER,
     MiniMaxH3Qwen3VLConfig,
 )
+from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.loader.weight_utils import default_weight_loader
 from sglang.multimodal_gen.runtime.models.encoders.base import TextEncoder
 from sglang.multimodal_gen.runtime.models.encoders.qwen3vl import Qwen3VLModel
@@ -68,7 +69,15 @@ class MiniMaxH3Qwen3VLEncoder(TextEncoder):
 
     @property
     def device(self) -> torch.device:
-        return next(self.parameters()).device
+        """Device this encoder's forward runs on.
+
+        Deliberately not `next(self.parameters()).device`. `--text-encoder-cpu-offload`
+        loads this component under an FSDP CPU offload policy, which keeps the sharded
+        parameters on CPU and all-gathers them to the accelerator for the forward. The
+        parameter device then names the storage side, not the compute side, so inputs
+        built from it stay on CPU while the forward runs on the accelerator.
+        """
+        return get_local_torch_device()
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_encoder_device.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_encoder_device.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.multimodal_gen.runtime.models.encoders import minimax_h3_qwen3vl
+from sglang.multimodal_gen.runtime.models.encoders.minimax_h3_qwen3vl import (
+    MiniMaxH3Qwen3VLEncoder,
+)
+
+
+class TestMiniMaxH3EncoderDevice(unittest.TestCase):
+    """`device` must name the compute side, not the parameter storage side.
+
+    `--text-encoder-cpu-offload` loads this encoder under an FSDP CPU offload
+    policy: the sharded parameters sit on CPU and are all-gathered to the
+    accelerator for the forward. Reporting the parameter device there sent
+    `encode_ids` to build `input_ids`/`attention_mask`/`position_ids` on CPU
+    while the forward ran on the accelerator, and the rope matmul died with
+    "Expected all tensors to be on the same device ... mat2 is on cpu".
+    """
+
+    def _encoder_with_param_on(self, device: torch.device) -> MiniMaxH3Qwen3VLEncoder:
+        encoder = MiniMaxH3Qwen3VLEncoder.__new__(MiniMaxH3Qwen3VLEncoder)
+        torch.nn.Module.__init__(encoder)
+        encoder.register_parameter(
+            "offloaded", torch.nn.Parameter(torch.zeros(1, device=device))
+        )
+        return encoder
+
+    def test_device_ignores_cpu_offloaded_parameters(self):
+        encoder = self._encoder_with_param_on(torch.device("cpu"))
+        compute_device = torch.device("cuda", 3)
+
+        with mock.patch.object(
+            minimax_h3_qwen3vl, "get_local_torch_device", return_value=compute_device
+        ):
+            self.assertEqual(encoder.device, compute_device)
+
+        # The parameter really is on CPU: the property is not just echoing it back.
+        self.assertEqual(next(encoder.parameters()).device.type, "cpu")
+
+    def test_device_follows_local_device_on_cpu_only_platforms(self):
+        encoder = self._encoder_with_param_on(torch.device("cpu"))
+        cpu = torch.device("cpu")
+
+        with mock.patch.object(
+            minimax_h3_qwen3vl, "get_local_torch_device", return_value=cpu
+        ):
+            self.assertEqual(encoder.device, cpu)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--text-encoder-cpu-offload` is unusable on MiniMax-H3: every request fails during text encoding with

```
RuntimeError: Expected all tensors to be on the same device, but got mat2 is on cpu,
different from other tensors on cuda:0 (when checking argument in method wrapper_CUDA_bmm)
  transformers/models/qwen3_vl/modeling_qwen3_vl.py:367  (Qwen3VLRotaryEmbedding.forward)
```

Reproduced 3/3 on 1x RTX PRO 5000, and it blocks the flag for both the model-wise-only
combination and any combination that mixes it with DiT layerwise offload.

Root cause: `MiniMaxH3Qwen3VLEncoder.device` returned `next(self.parameters()).device`.
`--text-encoder-cpu-offload` routes this component through `maybe_load_fsdp_model` with an
FSDP CPU offload policy, which keeps the sharded parameters on CPU and all-gathers them to
the accelerator for the forward. The parameter device then names the *storage* side, not
the *compute* side.

`encode_ids` places `input_ids`, `attention_mask` and `position_ids` with `.to(self.device)`,
so those inputs stayed on CPU while the forward ran on the accelerator. Instrumented run:

```
self.device=cpu  cpu_params=902/902  cpu_buffers=0/3
inputs={'input_ids': cpu, 'attention_mask': cpu}
hidden=cuda:0  pos_ids=cpu  inv_freq=cuda:0
```

The rope forward hard-pins one operand to the activation device
(`inv_freq_expanded = ... .to(x.device)`) but leaves `position_ids_expanded` on the device
`position_ids` arrived on, so the mismatch surfaces as a failing `bmm`.

## Modifications

- `MiniMaxH3Qwen3VLEncoder.device` now reports `get_local_torch_device()` — the device the
  forward actually runs on — instead of the parameter storage device. The property is used
  in exactly four places, all of them placing inputs for the forward.
- Added `test_minimax_h3_encoder_device.py` pinning the invariant: with a parameter on CPU,
  `device` must still report the local compute device.

When the encoder is GPU-resident both expressions already evaluate to the same device, so
only the offloaded path changes behaviour.

## Accuracy Tests

MiniMax-H3 t2va, 1344x768, 124 frames @ 24fps, 5 denoise steps, BF16, `quality=lossless`,
1x RTX PRO 5000 (72 GB), whole-node exclusive.

| Config | Before | After |
|---|---|---|
| `--layerwise-offload-components dit --dit-layerwise-resident-layers 20 --text-encoder-cpu-offload` | device mismatch | **ok**, peak 43.4 GB, e2e 85.2 s |
| `--dit-cpu-offload --text-encoder-cpu-offload --vae-cpu-offload` | device mismatch | OOM |

The second row now reaches the memory check instead of crashing in text encoding; a
model-wise DiT needs the full 62 GB resident, so OOM is the correct outcome for that
combination on a single 72 GB card (it matches the independently measured
`--dit-cpu-offload` + text-encoder-layerwise result).

Outputs verified with `ffprobe`: 1344x768, 124 frames, 24 fps, audio track present.

## Speed Tests and Profiling

Regression check on a path that does not use `--text-encoder-cpu-offload`
(`--layerwise-offload-components dit text_encoder --dit-layerwise-resident-layers 0
--dit-offload-prefetch-size 1 --vae-cpu-offload`):

| | Before | After |
|---|---|---|
| `peak_reserved` | 23138.0 MB | **23138.0 MB** |
| e2e | 84.4 s | 85.4 s |

Peak memory is byte-identical. The 1.2% e2e difference is run-to-run noise; the "after" run
shared the node with another tenant.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31090596059](https://github.com/sgl-project/sglang/actions/runs/31090596059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31090595506](https://github.com/sgl-project/sglang/actions/runs/31090595506)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->