### PR TITLE
Fix sgl-deep-ep builder dependencies

### DIFF
--- a/.github/workflows/release-whl-deepep.yml
+++ b/.github/workflows/release-whl-deepep.yml
@@ -27,7 +27,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  TORCH_VERSION: "2.11.0"
+  TORCH_VERSION: "2.13.0"
 
 jobs:
   build-cu129-matrix:

--- a/docker/sgl-deep-ep.Dockerfile
+++ b/docker/sgl-deep-ep.Dockerfile
@@ -8,7 +8,7 @@ ARG CUDA_TAG=cu130
 ARG CUDA_VERSION=13.0
 ARG GDRCOPY_VERSION=2.5.1
 ARG PYTHON_TAG=cp312-cp312
-ARG TORCH_VERSION=2.11.0
+ARG TORCH_VERSION=2.13.0
 
 ENV CUDA_HOME=/usr/local/cuda
 ENV GDRCOPY_HOME=/usr/local
@@ -73,4 +73,5 @@ RUN --mount=type=cache,id=sgl-deep-ep-pip-${CUDA_TAG}-${PYTHON_TAG}-${ARCHITECTU
         packaging \
         setuptools \
         wheel; \
-    "${PYTHON_BIN}" -c 'import torch; assert torch.__version__.startswith("2.11.0"); print(torch.__version__, torch.version.cuda)'
+    TORCH_VERSION="${TORCH_VERSION}" "${PYTHON_BIN}" -c \
+        'import os, torch; assert torch.__version__.startswith(os.environ["TORCH_VERSION"]); print(torch.__version__, torch.version.cuda)'

--- a/docker/sgl-deep-ep.Dockerfile
+++ b/docker/sgl-deep-ep.Dockerfile
@@ -19,7 +19,7 @@ ENV PYTHON_BIN=/opt/python/${PYTHON_TAG}/bin/python
 # These mirror the build and RDMA dependencies used by ci_install_deepep.sh.
 # The image builds only GDRCopy's user-space library: the host owns gdrdrv and
 # passes /dev/gdrdrv through at runtime.
-RUN yum install -y --nogpgcheck \
+RUN yum install -y --nogpgcheck --enablerepo=powertools \
         cmake \
         curl \
         gcc \
@@ -54,6 +54,7 @@ RUN set -eux; \
 RUN git clone --depth 1 --branch "v${GDRCOPY_VERSION}" \
         https://github.com/NVIDIA/gdrcopy.git /opt/gdrcopy \
     && make -C /opt/gdrcopy CUDA="${CUDA_HOME}" prefix=/usr/local lib_install \
+    && printf '%s\n' /usr/local/lib > /etc/ld.so.conf.d/gdrcopy.conf \
     && ldconfig \
     && test -f /usr/local/include/gdrapi.h \
     && ldconfig -p | grep -q libgdrapi

--- a/scripts/build_sgl_deepep.sh
+++ b/scripts/build_sgl_deepep.sh
@@ -114,7 +114,7 @@ docker build \
     --build-arg CUDA_TAG="${CUDA_TAG}" \
     --build-arg PYTHON_TAG="${PYTHON_TAG}" \
     --build-arg ARCHITECTURE="${ARCHITECTURE}" \
-    --build-arg TORCH_VERSION="${TORCH_VERSION:-2.11.0}" \
+    --build-arg TORCH_VERSION="${TORCH_VERSION:-2.13.0}" \
     --tag "${IMAGE_TAG}" \
     --network=host \
     "${REPOSITORY_ROOT}/docker"


### PR DESCRIPTION
## What changed

- explicitly enable the AlmaLinux PowerTools repository so `libfabric-devel` resolves in the x86 manylinux builder
- register `/usr/local/lib` with `ldconfig` so the freshly installed `libgdrapi.so.2` is discoverable during the image build
- upgrade the DeepEP release workflow, build-script default, and Docker image to `torch==2.13.0`
- make the Docker smoke assertion read `TORCH_VERSION` instead of duplicating a hard-coded version

## Root cause

The x86 CUDA 12.9 and CUDA 13.0 builder images had PowerTools disabled, so dependency installation failed before compilation. After enabling it, the next guard failed because `/usr/local/lib` was not in the image dynamic-linker search path.

SGLang `main` now requires PyTorch 2.13. Because `deep_ep_cpp` is a PyTorch C++/CUDA extension, the workflow, container, and wheel metadata must use the same exact version to avoid an ABI-incompatible wheel.

## Validation

- prior builder validation produced Python 3.12 CUDA 12.9 and 13.0 wheels on both x86_64 and aarch64; `twine check` passed for the CUDA-tagged and CUDA 13 PyPI artifacts
- release workflow YAML parsing, `bash -n scripts/build_sgl_deepep.sh`, pre-commit hooks, the cross-repository PyTorch-version contract, and `git diff --check` passed after the 2.13 update
- built and installed the CPython 3.12 CUDA 13 x86_64 wheel on a 4× NVIDIA B300 host with PyTorch 2.13.0+cu130
- verified wheel metadata contains `Requires-Dist: torch==2.13.0` and `import deep_ep` succeeds with both `libgdrapi.so` and `/dev/gdrdrv` absent
- DeepEP 4-rank low-latency test passed over IBGDA after NVSHMEM disabled unavailable GDRCopy, reaching about 180–181 GB/s dispatch+combine bandwidth
- latest SGLang `main@b38caebf09` `TestDSV4FlashFP4B200Balanced`: `Ran 9 tests in 795.371s`, `OK`; GSM8K score 0.96, average speculative accept length 1.9402, and batch-1 speed 201.71 token/s

## Release status

The RC workflow has not been dispatched from this PR. The implementation and x86 B300 runtime gate are ready for review first.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31130390907](https://github.com/sgl-project/sglang/actions/runs/31130390907)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31130391315](https://github.com/sgl-project/sglang/actions/runs/31130391315)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->