### PR TITLE
[Bugfix] Apply additive penalties during DFlash verify

### DIFF
--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -126,8 +126,8 @@ def apply_dflash_verify_logits_adjustments(
     """Apply sampling-time logit adjustments for DFlash verify in place.
 
     This keeps v1 and v2 verify semantics aligned while letting overlap scheduling
-    use the cheaper precomputed `acc_linear_penalties` path instead of allocating a
-    repeated `[bs * draft_token_num, vocab]` penalty tensor every step.
+    use the cheaper precomputed `acc_additive_penalties` path instead of allocating
+    a repeated `[bs * draft_token_num, vocab]` penalty tensor every step.
     """
     if sampling_info is None:
         return
@@ -153,7 +153,7 @@ def apply_dflash_verify_logits_adjustments(
             num_tokens_in_batch=draft_token_num,
         )
 
-    acc_linear_penalties = getattr(sampling_info, "acc_linear_penalties", None)
+    acc_additive_penalties = getattr(sampling_info, "acc_additive_penalties", None)
     penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
     grammar_mask = getattr(sampling_info, "grammar_mask", None)
     logit_bias = getattr(sampling_info, "logit_bias", None)
@@ -167,32 +167,34 @@ def apply_dflash_verify_logits_adjustments(
         return logits_3d
 
     # Dense fallback only when we need live penalizer application or a vocab mask.
-    # In overlap scheduling the common path is `acc_linear_penalties`, which can be
-    # broadcast over the verify block without materializing a repeated buffer.
+    # In overlap scheduling the common path is `acc_additive_penalties`, which can
+    # be broadcast over the verify block without materializing a repeated buffer.
     if (
-        penalizer is not None and penalizer.is_required and acc_linear_penalties is None
+        penalizer is not None
+        and penalizer.is_required
+        and acc_additive_penalties is None
     ) or grammar_mask is not None:
-        linear_penalty = torch.zeros(
+        additive_adjustment = torch.zeros(
             (bs, next_token_logits.shape[1]),
             dtype=torch.float32,
             device=next_token_logits.device,
         )
-        sampling_info.apply_logits_bias(linear_penalty)
+        sampling_info.apply_logits_bias(additive_adjustment)
         get_logits_3d().add_(
-            linear_penalty[:, None, :].to(dtype=next_token_logits.dtype)
+            additive_adjustment[:, None, :].to(dtype=next_token_logits.dtype)
         )
         return
 
-    if acc_linear_penalties is not None:
+    if acc_additive_penalties is not None:
         if (
-            acc_linear_penalties.device != next_token_logits.device
-            or acc_linear_penalties.dtype != next_token_logits.dtype
+            acc_additive_penalties.device != next_token_logits.device
+            or acc_additive_penalties.dtype != next_token_logits.dtype
         ):
-            acc_linear_penalties = acc_linear_penalties.to(
+            acc_additive_penalties = acc_additive_penalties.to(
                 device=next_token_logits.device,
                 dtype=next_token_logits.dtype,
             )
-        get_logits_3d().add_(acc_linear_penalties[:, None, :])
+        get_logits_3d().add_(acc_additive_penalties[:, None, :])
 
     if logit_bias is not None:
         if (

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -216,8 +216,8 @@ def apply_dflash_verify_logits_adjustments(
     """Apply sampling-time logit adjustments for DFlash verify in place.
 
     This keeps v1 and v2 verify semantics aligned while letting overlap scheduling
-    use the cheaper precomputed `acc_linear_penalties` path instead of allocating a
-    repeated `[bs * draft_token_num, vocab]` penalty tensor every step.
+    use the cheaper precomputed `acc_additive_penalties` path instead of allocating
+    a repeated `[bs * draft_token_num, vocab]` penalty tensor every step.
     """
     if sampling_info is None:
         return
@@ -242,7 +242,7 @@ def apply_dflash_verify_logits_adjustments(
             num_tokens_in_batch=draft_token_num,
         )
 
-    acc_linear_penalties = getattr(sampling_info, "acc_linear_penalties", None)
+    acc_additive_penalties = getattr(sampling_info, "acc_additive_penalties", None)
     penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
     grammar_mask = getattr(sampling_info, "grammar_mask", None)
     logit_bias = getattr(sampling_info, "logit_bias", None)
@@ -256,32 +256,34 @@ def apply_dflash_verify_logits_adjustments(
         return logits_3d
 
     # Dense fallback only when we need live penalizer application or a vocab mask.
-    # In overlap scheduling the common path is `acc_linear_penalties`, which can be
-    # broadcast over the verify block without materializing a repeated buffer.
+    # In overlap scheduling the common path is `acc_additive_penalties`, which can
+    # be broadcast over the verify block without materializing a repeated buffer.
     if (
-        penalizer is not None and penalizer.is_required and acc_linear_penalties is None
+        penalizer is not None
+        and penalizer.is_required
+        and acc_additive_penalties is None
     ) or grammar_mask is not None:
-        linear_penalty = torch.zeros(
+        additive_adjustment = torch.zeros(
             (bs, next_token_logits.shape[1]),
             dtype=torch.float32,
             device=next_token_logits.device,
         )
-        sampling_info.apply_logits_bias(linear_penalty)
+        sampling_info.apply_logits_bias(additive_adjustment)
         get_logits_3d().add_(
-            linear_penalty[:, None, :].to(dtype=next_token_logits.dtype)
+            additive_adjustment[:, None, :].to(dtype=next_token_logits.dtype)
         )
         return
 
-    if acc_linear_penalties is not None:
+    if acc_additive_penalties is not None:
         if (
-            acc_linear_penalties.device != next_token_logits.device
-            or acc_linear_penalties.dtype != next_token_logits.dtype
+            acc_additive_penalties.device != next_token_logits.device
+            or acc_additive_penalties.dtype != next_token_logits.dtype
         ):
-            acc_linear_penalties = acc_linear_penalties.to(
+            acc_additive_penalties = acc_additive_penalties.to(
                 device=next_token_logits.device,
                 dtype=next_token_logits.dtype,
             )
-        get_logits_3d().add_(acc_linear_penalties[:, None, :])
+        get_logits_3d().add_(acc_additive_penalties[:, None, :])
 
     if logit_bias is not None:
         if (

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -61,7 +61,7 @@ def verify_logits_adjustments_are_noop(sampling_info) -> bool:
         return True
     if sampling_info.has_custom_logit_processor:
         return False
-    if getattr(sampling_info, "acc_linear_penalties", None) is not None:
+    if getattr(sampling_info, "acc_additive_penalties", None) is not None:
         return False
     penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
     if penalizer is not None and penalizer.is_required:

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -49,7 +49,7 @@ def verify_logits_adjustments_are_noop(sampling_info) -> bool:
         return True
     if sampling_info.has_custom_logit_processor:
         return False
-    if getattr(sampling_info, "acc_linear_penalties", None) is not None:
+    if getattr(sampling_info, "acc_additive_penalties", None) is not None:
         return False
     penalizer = getattr(sampling_info, "penalizer_orchestrator", None)
     if penalizer is not None and penalizer.is_required:

--- a/test/registered/unit/spec/test_dflash_verify_logits_adjustments.py
+++ b/test/registered/unit/spec/test_dflash_verify_logits_adjustments.py
@@ -1,0 +1,78 @@
+"""CPU unit tests for DFlash verify-time logit adjustments."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.speculative.dflash_utils import (
+    apply_dflash_verify_logits_adjustments,
+)
+from sglang.srt.speculative.dspark_components.dspark_verify import (
+    verify_logits_adjustments_are_noop,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _SamplingInfo(SimpleNamespace):
+    def __len__(self) -> int:
+        return self.batch_size
+
+
+def _make_sampling_info(*, batch_size: int, additive_penalties=None):
+    return _SamplingInfo(
+        batch_size=batch_size,
+        has_custom_logit_processor=False,
+        acc_additive_penalties=additive_penalties,
+        penalizer_orchestrator=None,
+        grammar_mask=None,
+        logit_bias=None,
+    )
+
+
+class TestDFlashVerifyLogitsAdjustments(CustomTestCase):
+    def test_broadcasts_additive_penalties_over_verify_block(self):
+        additive_penalties = torch.tensor(
+            [[0.0, -1.5, 2.0], [3.0, 0.5, -4.0]], dtype=torch.float32
+        )
+        sampling_info = _make_sampling_info(
+            batch_size=2, additive_penalties=additive_penalties
+        )
+        logits = torch.zeros((6, 3), dtype=torch.float64)
+
+        apply_dflash_verify_logits_adjustments(
+            next_token_logits=logits,
+            sampling_info=sampling_info,
+            draft_token_num=3,
+        )
+
+        expected = (
+            additive_penalties.to(dtype=logits.dtype)
+            .unsqueeze(1)
+            .expand(-1, 3, -1)
+            .reshape_as(logits)
+        )
+        torch.testing.assert_close(logits, expected)
+
+    def test_additive_penalties_disable_noop_fast_path(self):
+        sampling_info = _make_sampling_info(
+            batch_size=1,
+            additive_penalties=torch.zeros((1, 4), dtype=torch.float32),
+        )
+
+        self.assertFalse(verify_logits_adjustments_are_noop(sampling_info))
+
+    def test_missing_additive_penalties_keep_noop_fast_path(self):
+        sampling_info = _make_sampling_info(batch_size=1)
+
+        self.assertTrue(verify_logits_adjustments_are_noop(sampling_info))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- read the existing `SamplingBatchInfo.acc_additive_penalties` field during DFlash verify
- keep the DSPARK no-adjustment fast path disabled when accumulated additive penalties are present
- add focused CPU regression coverage for verify-block broadcasting and fast-path selection

## Root cause

`SamplingBatchInfo` stores overlap-mode additive penalties in `acc_additive_penalties`, but the DFlash verify path and DSPARK fast-path predicate looked up the nonexistent `acc_linear_penalties` attribute. As a result, accumulated penalties such as the minimum-new-token EOS suppression could be skipped during DSPARK verification.

## Impact

Requests using overlap-mode additive penalties now apply the per-request adjustment to every token in the DFlash/DSPARK verify block. Requests without adjustments retain the existing fast path.

## Validation

- focused CPU pytest: `3 passed`
- Black, isort, Ruff (`F401,F821,UP037`), `py_compile`, and `git diff --check`: passed

Fixes #33493

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34680548624](https://github.com/sgl-project/sglang/actions/runs/34680548624)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34680548471](https://github.com/sgl-project/sglang/actions/runs/34680548471)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34680548509](https://github.com/sgl-project/sglang/actions/runs/34680548509)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->