### PR TITLE
[MLX] Commit real KV allocations for chained decode steps

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
+++ b/python/sglang/srt/hardware_backend/mlx/scheduler_mixin.py
@@ -184,15 +184,42 @@ class SchedulerMlxOverlapMixin:
 
         def _launch_chained(prev: MlxPendingJob) -> MlxPendingJob:
             assert prev.decode is not None
-            # Composition is identical to prev: reuse a fresh batch copy
-            # of the same underlying ScheduleBatch so process_batch_result
-            # updates the same req objects with the new token.
-            batch_copy = prev.batch_copy.copy()
-            self._prepare_mlx_launch(batch_copy)
-            # Keep the live scheduler batch's iteration aligned: when the
-            # chain breaks, prepare_for_decode() may run SWA maintenance
-            # before the next fresh launch gets a chance to re-stamp it.
-            prev.schedule_batch.forward_iter = batch_copy.forward_iter
+            # Stamp the live scheduler batch directly (not a copy), BEFORE
+            # prepare_for_decode(): maybe_evict_swa() (called from inside
+            # prepare_for_decode() -> alloc_for_decode()) keys its
+            # maintenance cadence off batch.forward_iter, so that field must
+            # already reflect this step's iteration when allocation runs.
+            self._prepare_mlx_launch(prev.schedule_batch)
+            # Give this chained token the same allocation and accounting
+            # lifecycle as an ordinary decode token: a real req_to_token
+            # slot, and matching seq_lens / kv_committed_len advancement.
+            # Without this, chained steps skip the scheduler entirely, so
+            # req_to_token and kv_committed_len never learn about the
+            # tokens they produce (#30093) -- those positions are then
+            # neither radix-cacheable nor a safe upper bound for the
+            # decode-KV pool sync. prepare_for_decode() is pure CPU/host
+            # bookkeeping (the MLX scheduler tensors all live on
+            # device="cpu"; see model_runner_stub.py), so this adds no MLX
+            # evaluation barrier or host<->device sync. schedule_batch is
+            # the same object identity as self.running_batch for the whole
+            # chain, so this keeps both consistent with what a normal
+            # scheduled decode step would have done.
+            prev.schedule_batch.prepare_for_decode()
+            # Slot 0 is reserved padding (kv_cache/attention_kv_pool.py); a
+            # real allocator draw never returns it. Carries the slot-0 assert
+            # from the #30147 review (jlee5814/LarrySimingDeng, issue #30093
+            # thread): redundant under that PR's sync-side clamp alone, but
+            # this is the allocation that makes each chained position a real,
+            # committed one, so this is where the invariant now lives.
+            assert bool(
+                (prev.schedule_batch.out_cache_loc != 0).all()
+            ), "chained decode committed a position to padding slot 0"
+            # Snapshot AFTER prepare_for_decode() so process_batch_result
+            # observes this step's committed seq_lens / kv_committed_len
+            # instead of a stale pre-allocation copy. Composition (reqs) is
+            # identical to prev, so the copied req objects are the same
+            # ones process_batch_result already knows how to update.
+            batch_copy = prev.schedule_batch.copy()
             lazy_tokens, prefills, extends, decode, mode = (
                 self.tp_worker.async_chained_decode_mlx(prev.decode)
             )
@@ -229,11 +256,22 @@ class SchedulerMlxOverlapMixin:
                 and not self.waiting_queue
             )
             if can_chain and pending_next is None:
-                # Build + launch the chained step BEFORE we block on
-                # pending_curr — this is the "no idle gap" trick.
-                # GPU now has 2 steps queued.
-                pending_next = _launch_chained(pending_curr)
-                self.result_queue.append(pending_next)
+                # Chained steps now allocate a real KV-pool slot per token
+                # (see _launch_chained), so — unlike before, when chaining
+                # had zero allocator cost — extending the chain can run the
+                # pool out of budget. Check before committing to the
+                # allocation instead of letting alloc_for_decode() raise
+                # from inside the hot chained path; on insufficient budget,
+                # decline to chain this iteration and fall through to the
+                # chain-break path below, whose
+                # get_next_batch_to_run() -> update_running_batch() already
+                # knows how to evict/retract correctly.
+                if pending_curr.schedule_batch.check_decode_mem():
+                    # Build + launch the chained step BEFORE we block on
+                    # pending_curr — this is the "no idle gap" trick.
+                    # GPU now has 2 steps queued.
+                    pending_next = _launch_chained(pending_curr)
+                    self.result_queue.append(pending_next)
 
             # 2. Finalize/process on pending_curr's tokens.  (GPU is already
             #    executing pending_next at this point.)

--- a/test/registered/unit/hardware_backend/mlx/test_chained_decode_accounting.py
+++ b/test/registered/unit/hardware_backend/mlx/test_chained_decode_accounting.py
@@ -1,0 +1,575 @@
+"""Regression tests for MLX chained-decode accounting (#30093).
+
+Before this fix, `event_loop_overlap_mlx`'s chained-decode path
+(`_launch_chained` in `hardware_backend/mlx/scheduler_mixin.py`) never called
+`ScheduleBatch.prepare_for_decode()`. Chained tokens therefore never went
+through `alloc_for_decode()`: no real KV-pool slot was reserved, no entry was
+written into `req_to_token`, and `seq_lens` / `kv_committed_len` never
+advanced. Two observable consequences:
+
+* Corruption risk: the MLX decode-KV pool sync (`_sync_decode_kv_to_pool`)
+  derives its copy range from the per-request MLX cache offset, which keeps
+  advancing every chained step. Reading `req_to_token` past the real
+  scheduler-committed bound returns either the reserved padding slot (fresh
+  row) or another request's slot ids (reused row).
+* Accounting loss: `kv_committed_len` — the radix-insertion boundary read by
+  `cache_finished_req` (see `RadixCache.cache_finished_req`,
+  `mem_cache/radix_cache.py`) — permanently undercounts chained output, so
+  those tokens are never prefix-cacheable.
+
+These tests exercise the real scheduling primitives `ScheduleBatch`, `Req`,
+`ReqToTokenPool`, `TokenToKVPoolAllocator`, and `RadixCache` directly (no
+mocked scheduler internals) to prove that after the fix:
+
+1. every chained step gets a real, freshly allocated, non-zero, sequential
+   KV-pool slot recorded in `req_to_token`;
+2. `kv_committed_len` / `seq_lens` track the number of generated tokens
+   exactly, not just the pre-chain prefix;
+3. those chained positions are visible to a subsequent radix prefix match;
+4. two concurrently chaining requests never collide on the same slots;
+5. the MLX overlap loop (`event_loop_overlap_mlx`) declines to extend a
+   chain instead of raising when the KV pool is exhausted, several chained
+   steps compound correctly, and accounting is continuous across a
+   chain-break back into an ordinary scheduled decode step.
+
+This module intentionally does not re-test the decode-KV pool *sync*
+mechanism (`_sync_decode_kv_to_pool`, `_req_synced_offset`) or the
+release-boundary flush for a freed-and-reused `req_to_token` row: those are
+a separate invariant (a request finishing while holding unflushed decode KV,
+addressed by the open PR #30147's `flush_request_decode_kv` /
+`prepare_for_kv_cache_release` changes) that this fix does not touch.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
+
+from sglang.srt.managers.schedule_batch import Req, ReqKvInfo
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.common import release_kv_cache
+from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_context
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "requires mlx"
+
+
+class _DummyKVCache(KVCache):
+    """Scheduler-facing KV cache that allocates no real GPU/Metal memory.
+
+    Mirrors `hardware_backend/mlx/model_runner_stub.py`'s `_DummyKVCache`:
+    the MLX backend manages real attention KV itself, so the core scheduler
+    only needs this to size `TokenToKVPoolAllocator`'s slot free-list.
+    """
+
+    def __init__(self, size, dtype, device):
+        self.size = size
+        self.page_size = 1
+        self.dtype = dtype
+        self.store_dtype = dtype
+        self.device = device
+        self.layer_num = 0
+        self.start_layer = 0
+        self.end_layer = 0
+        self.mem_usage = 0
+        self.cpu_offloading_chunk_size = 8192
+        self.layer_transfer_counter = None
+        self.enable_custom_mem_pool = False
+        self.custom_mem_pool = None
+
+    def get_key_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no key buffer")
+
+    def get_value_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no value buffer")
+
+    def get_kv_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no kv buffer")
+
+    def set_kv_buffer(self, layer, loc, cache_k, cache_v):
+        raise RuntimeError("_DummyKVCache cannot set kv buffer")
+
+    def get_kv_size_bytes(self):
+        return 0, 0
+
+
+def _install_server_args(test_case, **fields):
+    """Publish a throwaway ServerArgs for the duration of one test.
+
+    prepare_for_decode() reads get_server_args()/get_exec() internally;
+    real ScheduleBatch/Req plumbing requires the runtime context to be
+    published, same as `test_chunked_prefix_cache_gate.py`.
+    """
+    override = get_context().override_server_args(**fields)
+    override.install()
+    test_case.addCleanup(override.restore)
+
+
+def _make_pools(pool_size=64, req_slots=8, max_context_len=128, disable_radix=False):
+    rtp = ReqToTokenPool(
+        size=req_slots,
+        max_context_len=max_context_len,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    dummy_kv = _DummyKVCache(pool_size, torch.float32, "cpu")
+    allocator = TokenToKVPoolAllocator(
+        size=pool_size,
+        dtype=torch.float32,
+        device="cpu",
+        kvcache=dummy_kv,
+        need_sort=False,
+    )
+    tree_cache = RadixCache(
+        CacheInitParams(
+            disable=disable_radix,
+            req_to_token_pool=rtp,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+    return rtp, allocator, tree_cache
+
+
+def _make_req(rid, prompt_len, max_new_tokens=64):
+    sp = SamplingParams()
+    sp.max_new_tokens = max_new_tokens
+    req = Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=array("q", range(prompt_len)),
+        sampling_params=sp,
+    )
+    return req
+
+
+def _admit_prefill(req, rtp, allocator, tree_cache):
+    """Simulate the prefill admission that would have run before decode:
+    allocate the row + real prefix slots and write them into req_to_token,
+    exactly like `alloc_for_extend` does. Returns req_pool_idx.
+    """
+    prompt_len = len(req.origin_input_ids)
+    req_pool_idx = rtp.alloc([req])[0]
+    prefix_slots = allocator.alloc(prompt_len)
+    assert prefix_slots is not None
+    rtp.write((req_pool_idx, slice(0, prompt_len)), prefix_slots.to(torch.int32))
+    req.req_pool_idx = req_pool_idx
+    req.kv_committed_len = prompt_len
+    req.kv = ReqKvInfo(kv_allocated_len=prompt_len, swa_evicted_seqlen=0)
+    req.decode_batch_idx = 0
+    return req_pool_idx
+
+
+def _make_decode_batch(reqs, req_pool_indices, rtp, allocator, tree_cache):
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+    model_config = SimpleNamespace(is_encoder_decoder=False, vocab_size=100)
+    batch = ScheduleBatch(
+        reqs=reqs,
+        req_to_token_pool=rtp,
+        token_to_kv_pool_allocator=allocator,
+        tree_cache=tree_cache,
+        model_config=model_config,
+        enable_overlap=False,
+        device="cpu",
+        forward_mode=ForwardMode.DECODE,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+    )
+    seq_lens = [r.kv_committed_len for r in reqs]
+    batch.req_pool_indices = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.orig_seq_lens = torch.tensor(seq_lens, dtype=torch.int32)
+    batch.sampling_info = SimpleNamespace(
+        penalizer_orchestrator=SimpleNamespace(is_required=False)
+    )
+    batch.hisparse_coordinator = None
+    return batch
+
+
+class TestChainedPrepareForDecodeAccounting(CustomTestCase):
+    """Direct calls to the real `ScheduleBatch.prepare_for_decode()`.
+
+    This is exactly what `_launch_chained` now calls once per chained
+    step (`hardware_backend/mlx/scheduler_mixin.py`), so these tests pin the
+    core mechanism the MLX fix depends on, with zero MLX/mocking involved.
+    """
+
+    def setUp(self):
+        _install_server_args(self)
+
+    def test_fresh_row_chained_steps_get_real_sequential_nonzero_slots(self):
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=5)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        # Simulate 4 chained decode steps: each is exactly what
+        # _launch_chained does for one chained token.
+        for _ in range(4):
+            batch.prepare_for_decode()
+
+        row = rtp.req_to_token[req_pool_idx, :9].tolist()
+        # 5 prefix + 4 chained positions: real, non-zero, strictly
+        # sequential, no duplicates. Before the fix, positions 5..8 would
+        # never have been written at all (they would still read the
+        # zero-initialized padding value).
+        self.assertEqual(row, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+        self.assertNotIn(0, row)
+        self.assertEqual(len(set(row)), len(row))
+
+    def test_kv_committed_len_and_seq_lens_track_every_chained_token(self):
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        n_chained = 7
+        for _ in range(n_chained):
+            batch.prepare_for_decode()
+
+        self.assertEqual(req.kv_committed_len, 3 + n_chained)
+        self.assertEqual(int(batch.seq_lens.item()), 3 + n_chained)
+        self.assertEqual(int(batch.seq_lens_cpu.item()), 3 + n_chained)
+        self.assertEqual(req.decode_batch_idx, n_chained)
+
+    def test_chained_positions_become_prefix_cacheable(self):
+        # Reproduces the issue's exact accounting-loss scenario: a single
+        # request's decode output must be fully radix-visible, not
+        # truncated at the pre-chain prefix.
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=4)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        n_chained = 5
+        for _ in range(n_chained):
+            batch.prepare_for_decode()
+
+        total_len = 4 + n_chained
+        req.output_ids = array("q", range(100, 100 + n_chained))
+        req.to_finish = None
+        release_kv_cache(req, tree_cache, is_insert=True)
+
+        full_ids = req.origin_input_ids + req.output_ids
+        match = tree_cache.match_prefix(MatchPrefixParams(key=RadixKey(full_ids, None)))
+        self.assertEqual(len(match.device_indices), total_len)
+
+    def test_two_concurrently_chaining_requests_never_collide(self):
+        rtp, allocator, tree_cache = _make_pools(pool_size=64, req_slots=8)
+        req_a = _make_req("a", prompt_len=3)
+        req_b = _make_req("b", prompt_len=3)
+        idx_a = _admit_prefill(req_a, rtp, allocator, tree_cache)
+        idx_b = _admit_prefill(req_b, rtp, allocator, tree_cache)
+        batch = _make_decode_batch(
+            [req_a, req_b], [idx_a, idx_b], rtp, allocator, tree_cache
+        )
+
+        for _ in range(4):
+            batch.prepare_for_decode()
+
+        slots_a = set(rtp.req_to_token[idx_a, :7].tolist())
+        slots_b = set(rtp.req_to_token[idx_b, :7].tolist())
+        self.assertEqual(len(slots_a & slots_b), 0)
+        self.assertNotIn(0, slots_a)
+        self.assertNotIn(0, slots_b)
+
+    def test_allocation_exhaustion_raises_instead_of_silently_corrupting(self):
+        # Pins why the MLX loop must check check_decode_mem() before
+        # extending the chain: an unguarded prepare_for_decode() call on an
+        # exhausted pool fails loud rather than silently reusing/aliasing a
+        # slot.
+        rtp, allocator, tree_cache = _make_pools(pool_size=4, req_slots=4)
+        req = _make_req("r1", prompt_len=4)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        self.assertFalse(batch.check_decode_mem())
+        with self.assertRaises(RuntimeError):
+            batch.prepare_for_decode()
+
+
+class _StopLoop(Exception):
+    """Sentinel to break out of event_loop_overlap_mlx's `while True`."""
+
+
+def _run_loop(scheduler):
+    from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+        SchedulerMlxOverlapMixin,
+    )
+
+    try:
+        SchedulerMlxOverlapMixin.event_loop_overlap_mlx(scheduler)
+    except _StopLoop:
+        pass
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestEventLoopOverlapMlxRealAccounting(CustomTestCase):
+    """Drives the real `event_loop_overlap_mlx` loop with a real
+    `ScheduleBatch`/`Req`/pool stack, mocking only the scheduler wrapper and
+    the MLX forward pass itself (the model), per the MLX test conventions
+    (`test/registered/unit/README.md`): fake the model, not the scheduling
+    logic under test.
+    """
+
+    def setUp(self):
+        _install_server_args(self)
+
+    def _make_scheduler(self, batch, *, recv_side_effect):
+        from collections import deque
+        from unittest.mock import MagicMock
+
+        from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+            SchedulerMlxOverlapMixin,
+        )
+
+        scheduler = MagicMock()
+        scheduler.forward_ct = 0
+        scheduler.running_batch = batch
+        scheduler.last_batch = None
+        scheduler.gracefully_exit = False
+        scheduler._engine_paused = False
+        scheduler.waiting_queue = []
+        scheduler.result_queue = deque()
+        scheduler.request_receiver.recv_requests.side_effect = recv_side_effect
+        scheduler._prepare_mlx_launch.side_effect = lambda b: (
+            SchedulerMlxOverlapMixin._prepare_mlx_launch(scheduler, b)
+        )
+        result = MagicMock()
+        result.next_token_ids = None
+        scheduler.tp_worker.finalize_mlx_result.return_value = result
+        return scheduler
+
+    def test_several_chained_steps_advance_real_req_to_token(self):
+        from unittest.mock import MagicMock
+
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        # recv_requests: empty every iteration; enough iterations for one
+        # fresh launch + several chained continuations.
+        n_iters = 6
+        scheduler = self._make_scheduler(
+            batch, recv_side_effect=[[] for _ in range(n_iters)] + [_StopLoop()]
+        )
+        plan = SimpleNamespace(batch_to_run=batch, running_batch=batch)
+        scheduler.get_next_batch_to_run.return_value = plan
+
+        pending_decode = MagicMock()
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            pending_decode,
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.side_effect = lambda _decode: (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+
+        _run_loop(scheduler)
+
+        n_chained_calls = scheduler.tp_worker.async_chained_decode_mlx.call_count
+        self.assertGreater(n_chained_calls, 0)
+        expected_committed = 3 + n_chained_calls
+        self.assertEqual(req.kv_committed_len, expected_committed)
+        row = rtp.req_to_token[req_pool_idx, :expected_committed].tolist()
+        self.assertNotIn(0, row)
+        self.assertEqual(len(set(row)), len(row))
+
+    def test_check_decode_mem_declines_chain_when_pool_exhausted(self):
+        from unittest.mock import MagicMock
+
+        # Pool has exactly 2 spare tokens beyond the 3-token prefix: one
+        # fresh decode step (consumes 1) leaves exactly 1 more available,
+        # so the chain can extend once and must then decline rather than
+        # raising out of alloc_for_decode().
+        rtp, allocator, tree_cache = _make_pools(pool_size=5, req_slots=4)
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        n_iters = 6
+        scheduler = self._make_scheduler(
+            batch, recv_side_effect=[[] for _ in range(n_iters)] + [_StopLoop()]
+        )
+
+        def get_next_batch_to_run(**_kwargs):
+            # Emulates update_running_batch(): real accounting call, same
+            # object identity, exactly what the standard scheduler path does
+            # for a fresh/post-break decode step.
+            if batch.check_decode_mem():
+                batch.prepare_for_decode()
+            return SimpleNamespace(batch_to_run=batch, running_batch=batch)
+
+        scheduler.get_next_batch_to_run.side_effect = get_next_batch_to_run
+
+        pending_decode = MagicMock()
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            pending_decode,
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.side_effect = lambda _decode: (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+
+        _run_loop(scheduler)
+
+        # Never raised (the loop must have declined to chain rather than
+        # calling alloc_for_decode() on an exhausted pool), and committed
+        # length must never exceed the pool's real capacity.
+        self.assertLessEqual(req.kv_committed_len, 3 + 2)
+        row = rtp.req_to_token[req_pool_idx, : req.kv_committed_len].tolist()
+        self.assertNotIn(0, row)
+        self.assertEqual(len(set(row)), len(row))
+
+    def test_chain_extends_correctly_with_radix_cache_disabled(self):
+        # disable_radix_cache only turns off the MLX-side pool sync
+        # (model_runner.py, untouched by this patch); the core scheduler
+        # accounting this patch adds to _launch_chained does not depend on
+        # it and must behave identically.
+        from unittest.mock import MagicMock
+
+        rtp, allocator, tree_cache = _make_pools(disable_radix=True)
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        n_iters = 5
+        scheduler = self._make_scheduler(
+            batch, recv_side_effect=[[] for _ in range(n_iters)] + [_StopLoop()]
+        )
+        plan = SimpleNamespace(batch_to_run=batch, running_batch=batch)
+        scheduler.get_next_batch_to_run.return_value = plan
+
+        pending_decode = MagicMock()
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            pending_decode,
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.side_effect = lambda _decode: (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+
+        _run_loop(scheduler)
+
+        n_chained_calls = scheduler.tp_worker.async_chained_decode_mlx.call_count
+        self.assertGreater(n_chained_calls, 0)
+        self.assertEqual(req.kv_committed_len, 3 + n_chained_calls)
+
+    def test_chain_break_then_ordinary_decode_continues_accounting(self):
+        # A new prefill arriving mid-chain forces a break: pending_next is
+        # finalized and the loop falls back to get_next_batch_to_run(),
+        # which (in the real scheduler) calls update_running_batch() ->
+        # prepare_for_decode() again on the SAME schedule_batch identity.
+        # The break must not skip a position or double count one.
+        from unittest.mock import MagicMock
+
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator, tree_cache)
+        batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+        n_iters = 8
+        scheduler = self._make_scheduler(batch, recv_side_effect=[])
+
+        # After 3 iterations, a new prefill shows up in the waiting queue,
+        # forcing exactly one chain break; get_next_batch_to_run() then
+        # clears it (in the real scheduler this would be consumed by the
+        # prefill branch -- here we only care about the decode
+        # continuation, so just clear it back out) and continues decoding
+        # via a real prepare_for_decode() call, exactly like
+        # update_running_batch() would.
+        def get_next_batch_to_run(**_kwargs):
+            scheduler.waiting_queue = []
+            batch.prepare_for_decode()
+            return SimpleNamespace(batch_to_run=batch, running_batch=batch)
+
+        scheduler.get_next_batch_to_run.side_effect = get_next_batch_to_run
+
+        pending_decode = MagicMock()
+        scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+            MagicMock(),
+            [],
+            [],
+            pending_decode,
+            "decode",
+        )
+        scheduler.tp_worker.async_chained_decode_mlx.side_effect = lambda _decode: (
+            MagicMock(),
+            [],
+            [],
+            MagicMock(),
+            "decode",
+        )
+
+        recv_count = {"n": 0}
+
+        def recv_requests():
+            recv_count["n"] += 1
+            if recv_count["n"] == 4:
+                # Simulate a new prefill request landing mid-chain.
+                scheduler.waiting_queue = [MagicMock()]
+            if recv_count["n"] > n_iters:
+                raise _StopLoop()
+            return []
+
+        scheduler.request_receiver.recv_requests.side_effect = recv_requests
+
+        _run_loop(scheduler)
+
+        n_chained_calls = scheduler.tp_worker.async_chained_decode_mlx.call_count
+        n_fresh_calls = scheduler.get_next_batch_to_run.call_count
+        total_decode_steps = n_chained_calls + n_fresh_calls
+        self.assertGreater(n_chained_calls, 0)
+        self.assertGreater(n_fresh_calls, 1)
+        # No gap, no double count across the break: every decode step
+        # (chained or fresh) advanced kv_committed_len by exactly 1.
+        self.assertEqual(req.kv_committed_len, 3 + total_decode_steps)
+        row = rtp.req_to_token[req_pool_idx, : req.kv_committed_len].tolist()
+        self.assertNotIn(0, row)
+        self.assertEqual(len(set(row)), len(row))
+        self.assertEqual(row, sorted(row))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_chained_decode_slot_zero_baseline.py
+++ b/test/registered/unit/hardware_backend/mlx/test_chained_decode_slot_zero_baseline.py
@@ -1,0 +1,407 @@
+"""Phase 0 baseline for #30093: real decode-KV-sync slot-zero reproduction.
+
+Drives the real `event_loop_overlap_mlx` chained-decode loop against a real
+(fake-weights) `MlxModelRunner` / `ContiguousAttentionKVCache` /
+`MlxAttentionKVPool` stack -- the same objects and the same
+`_sync_decode_kv_to_pool` call site the issue's own repro script and the
+serving-level measurement on the #30093 thread exercised -- and tallies, per
+generated position, which shared-pool slot the sync actually resolves. This
+mirrors the issue thread's serving-level framing ("a 220 token generation
+resolved 164 then 56 slot resolutions, of which 163 and 56 were slot 0") at
+unit scale: exact counts differ, the mechanism does not.
+
+`test_committed_position_sync_never_resolves_padding_slot_zero` is the
+dedicated slot-0 assert requested in the #30093 accounting-patch task: no
+position the request has actually generated may have its KV synced to
+padding slot 0. Before the fix in `scheduler_mixin.py` (`_launch_chained`
+never calling `prepare_for_decode()`), chained positions are unwritten
+`req_to_token` cells -- zero-initialized, i.e. slot 0 -- so this is red on
+unpatched main. After the fix, every chained position gets a real allocation
+from `alloc_for_decode()`, which never hands out slot 0 (reserved as
+padding, see `kv_cache/attention_kv_pool.py`), so it is green.
+
+This module deliberately drives the real `_sync_decode_kv_to_pool`
+(`model_runner.py`, untouched by this patch) rather than only inspecting
+`req_to_token` directly (as `test_chained_decode_accounting.py` does), to
+pin the exact mechanism the issue and the serving-level measurement used.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from array import array
+from collections import deque
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
+
+from sglang.srt.managers.schedule_batch import Req, ReqKvInfo
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_context
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "requires mlx"
+
+_N_KV_HEADS = 2
+_HEAD_DIM = 4
+
+
+class _DummyKVCache(KVCache):
+    """Scheduler-facing KV cache sized only to back a real allocator free-list.
+
+    Mirrors `hardware_backend/mlx/model_runner_stub.py`'s `_DummyKVCache`: the
+    MLX backend stores real attention KV itself (in `MlxAttentionKVPool`), so
+    the core scheduler's pool object only needs to size the slot free-list.
+    """
+
+    def __init__(self, size, dtype, device):
+        self.size = size
+        self.page_size = 1
+        self.dtype = dtype
+        self.store_dtype = dtype
+        self.device = device
+        self.layer_num = 0
+        self.start_layer = 0
+        self.end_layer = 0
+        self.mem_usage = 0
+        self.cpu_offloading_chunk_size = 8192
+        self.layer_transfer_counter = None
+        self.enable_custom_mem_pool = False
+        self.custom_mem_pool = None
+
+    def get_key_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no key buffer")
+
+    def get_value_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no value buffer")
+
+    def get_kv_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no kv buffer")
+
+    def set_kv_buffer(self, layer, loc, cache_k, cache_v):
+        raise RuntimeError("_DummyKVCache cannot set kv buffer")
+
+    def get_kv_size_bytes(self):
+        return 0, 0
+
+
+def _install_server_args(test_case, **fields):
+    override = get_context().override_server_args(**fields)
+    override.install()
+    test_case.addCleanup(override.restore)
+
+
+def _make_pools(pool_size=64, req_slots=8, max_context_len=128):
+    rtp = ReqToTokenPool(
+        size=req_slots,
+        max_context_len=max_context_len,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    dummy_kv = _DummyKVCache(pool_size, torch.float32, "cpu")
+    allocator = TokenToKVPoolAllocator(
+        size=pool_size,
+        dtype=torch.float32,
+        device="cpu",
+        kvcache=dummy_kv,
+        need_sort=False,
+    )
+    tree_cache = RadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=rtp,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+    return rtp, allocator, tree_cache
+
+
+def _make_req(rid, prompt_len, max_new_tokens=64):
+    sp = SamplingParams()
+    sp.max_new_tokens = max_new_tokens
+    return Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=array("q", range(prompt_len)),
+        sampling_params=sp,
+    )
+
+
+def _admit_prefill(req, rtp, allocator):
+    prompt_len = len(req.origin_input_ids)
+    req_pool_idx = rtp.alloc([req])[0]
+    prefix_slots = allocator.alloc(prompt_len)
+    assert prefix_slots is not None
+    rtp.write((req_pool_idx, slice(0, prompt_len)), prefix_slots.to(torch.int32))
+    req.req_pool_idx = req_pool_idx
+    req.kv_committed_len = prompt_len
+    req.kv = ReqKvInfo(kv_allocated_len=prompt_len, swa_evicted_seqlen=0)
+    req.decode_batch_idx = 0
+    return req_pool_idx
+
+
+def _make_decode_batch(reqs, req_pool_indices, rtp, allocator, tree_cache):
+    from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+    model_config = SimpleNamespace(is_encoder_decoder=False, vocab_size=100)
+    batch = ScheduleBatch(
+        reqs=reqs,
+        req_to_token_pool=rtp,
+        token_to_kv_pool_allocator=allocator,
+        tree_cache=tree_cache,
+        model_config=model_config,
+        enable_overlap=False,
+        device="cpu",
+        forward_mode=ForwardMode.DECODE,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+    )
+    seq_lens = [r.kv_committed_len for r in reqs]
+    batch.req_pool_indices = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.orig_seq_lens = torch.tensor(seq_lens, dtype=torch.int32)
+    batch.sampling_info = SimpleNamespace(
+        penalizer_orchestrator=SimpleNamespace(is_required=False)
+    )
+    batch.hisparse_coordinator = None
+    return batch
+
+
+def _make_runner(rtp, pool_size=64):
+    """A real, partially wired `MlxModelRunner` -- same pattern as the issue's
+    own deterministic repro script: `__new__` bypasses `__init__` (no model
+    weights needed), then only the attributes `_sync_decode_kv_to_pool`
+    actually reads are set, using the real `MlxModelCacheLayout` /
+    `MlxAttentionKVPool` classes, not stand-ins.
+    """
+    import mlx.core as mx
+
+    from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_pool import (
+        MlxAttentionKVPool,
+    )
+    from sglang.srt.hardware_backend.mlx.kv_cache.layout import MlxModelCacheLayout
+    from sglang.srt.hardware_backend.mlx.model_runner import MlxModelRunner
+
+    runner = MlxModelRunner.__new__(MlxModelRunner)
+    runner.disable_radix_cache = False
+    runner._cache_layout = MlxModelCacheLayout.from_attention_discovery(
+        layers=["attn"], attention_attrs=["self_attn"]
+    )
+    runner._attention_kv_pool = MlxAttentionKVPool(
+        pool_size=pool_size,
+        num_layers=1,
+        n_kv_heads=_N_KV_HEADS,
+        head_dim=_HEAD_DIM,
+        dtype=mx.float32,
+    )
+    runner._req_to_token_pool = rtp  # same object identity the scheduler writes
+    runner._req_caches = {}
+    runner._req_pool_idx = {}
+    runner._req_synced_offset = {}
+    return runner
+
+
+def _make_fake_attention_cache():
+    import mlx.core as mx
+
+    from sglang.srt.hardware_backend.mlx.kv_cache.attention_kv_cache import (
+        ContiguousAttentionKVCache,
+    )
+
+    return [
+        ContiguousAttentionKVCache(
+            n_kv_heads=_N_KV_HEADS,
+            head_dim=_HEAD_DIM,
+            max_seq_len=64,
+            dtype=mx.float32,
+        )
+    ]
+
+
+def _advance_cache_one_token(cache, value):
+    """Simulate one MLX forward step writing this token's KV into the
+    per-request private cache -- exactly what `decode_batch_start` /
+    `decode_batch_start_chained` do internally, advancing `cache.offset` by
+    one regardless of whether the scheduler committed the position.
+    """
+    import mlx.core as mx
+
+    k = mx.full((1, _N_KV_HEADS, 1, _HEAD_DIM), value, dtype=mx.float32)
+    cache[0].write_token(k, k)
+
+
+def _read_slot_resolutions(runner, req_id, req_pool_idx):
+    """Recompute the exact read `_sync_decode_kv_to_pool` performs, without
+    consuming it (so the real call afterwards still has work to do): for
+    every position between the last synced offset and the current MLX cache
+    offset, what `req_to_token` slot id does it resolve to.
+    """
+    cache = runner._req_caches[req_id]
+    current_offset = runner._first_attention_cache(cache).offset
+    synced_offset = runner._req_synced_offset.get(req_id, 0)
+    return (
+        runner._req_to_token_pool.req_to_token[
+            req_pool_idx, synced_offset:current_offset
+        ]
+        .to(dtype=int)
+        .tolist()
+    )
+
+
+class _StopLoop(Exception):
+    pass
+
+
+def _run_chained_decode(rtp, allocator, tree_cache, req, req_pool_idx, n_iters):
+    """Drive the real `event_loop_overlap_mlx` for `n_iters` recv cycles
+    (one fresh launch + several chained continuations under steady decode,
+    no concurrent arrivals -- exactly the `can_chain` precondition), while a
+    real `MlxModelRunner` + `ContiguousAttentionKVCache` advance in lockstep
+    with each MLX-level step, mirroring what a real forward does.
+
+    Returns the runner, so callers can inspect/sync pool state afterwards.
+    """
+    from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+        SchedulerMlxOverlapMixin,
+    )
+
+    batch = _make_decode_batch([req], [req_pool_idx], rtp, allocator, tree_cache)
+
+    runner = _make_runner(rtp)
+    fake_cache = _make_fake_attention_cache()
+    runner._req_caches[req.rid] = fake_cache
+    runner._req_pool_idx[req.rid] = req_pool_idx
+    runner._req_synced_offset[req.rid] = 0
+    token_value = [100.0]
+
+    def _step_mlx_forward(*_args, **_kwargs):
+        _advance_cache_one_token(fake_cache, token_value[0])
+        token_value[0] += 1.0
+        return MagicMock(), [], [], MagicMock(), "decode"
+
+    scheduler = MagicMock()
+    scheduler.forward_ct = 0
+    scheduler.running_batch = batch
+    scheduler.last_batch = None
+    scheduler.gracefully_exit = False
+    scheduler._engine_paused = False
+    scheduler.waiting_queue = []
+    scheduler.result_queue = deque()
+    scheduler.request_receiver.recv_requests.side_effect = [
+        [] for _ in range(n_iters)
+    ] + [_StopLoop()]
+    scheduler._prepare_mlx_launch.side_effect = lambda b: (
+        SchedulerMlxOverlapMixin._prepare_mlx_launch(scheduler, b)
+    )
+    result = MagicMock()
+    result.next_token_ids = None
+    scheduler.tp_worker.finalize_mlx_result.return_value = result
+
+    plan = SimpleNamespace(batch_to_run=batch, running_batch=batch)
+    scheduler.get_next_batch_to_run.return_value = plan
+    scheduler.tp_worker.async_forward_batch_generation_mlx.side_effect = (
+        _step_mlx_forward
+    )
+    scheduler.tp_worker.async_chained_decode_mlx.side_effect = (
+        lambda _decode: _step_mlx_forward()
+    )
+
+    try:
+        SchedulerMlxOverlapMixin.event_loop_overlap_mlx(scheduler)
+    except _StopLoop:
+        pass
+
+    n_chained_calls = scheduler.tp_worker.async_chained_decode_mlx.call_count
+    return runner, n_chained_calls
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestChainedDecodeSlotZeroBaseline(CustomTestCase):
+    """Real `_sync_decode_kv_to_pool` slot-resolution reproduction (#30093)."""
+
+    def setUp(self):
+        _install_server_args(self)
+
+    def test_chain_scatters_kv_to_padding_slot_zero(self):
+        """Phase 0.1: reproduce the scatter at unit scale, same mechanism as
+        the issue's own repro and the serving-level measurement -- drive a
+        chain, then read what shared-pool slot each generated position's KV
+        actually resolves to via the real sync.
+        """
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=3)
+        req_pool_idx = _admit_prefill(req, rtp, allocator)
+
+        runner, n_chained_calls = _run_chained_decode(
+            rtp, allocator, tree_cache, req, req_pool_idx, n_iters=6
+        )
+        self.assertGreater(n_chained_calls, 0)
+
+        resolutions = _read_slot_resolutions(runner, req.rid, req_pool_idx)
+        n_slot_zero = sum(1 for slot_id in resolutions if slot_id == 0)
+        print(
+            f"[#30093 baseline] {len(resolutions)} slot resolutions, "
+            f"{n_slot_zero} were padding slot 0 "
+            f"(kv_committed_len={req.kv_committed_len}, chained_calls={n_chained_calls})"
+        )
+
+        # Drive the real production sync too: it must not raise, and on the
+        # unpatched base it writes garbage into the pool's reserved slot 0
+        # (mirrors the issue repro's "decode KV written to reserved padding
+        # slot 0" observation).
+        runner._sync_decode_kv_to_pool(req.rid)
+
+        self.assertEqual(
+            n_slot_zero,
+            0,
+            f"{n_slot_zero} of {len(resolutions)} slot resolutions were "
+            "padding slot 0 -- chained positions never received a real "
+            "allocation before their KV was synced",
+        )
+
+    def test_committed_position_sync_never_resolves_padding_slot_zero(self):
+        """Phase 0.2: the dedicated slot-0 assert, as a test. No position the
+        request has actually generated -- committed by definition once this
+        patch lands -- may have its KV sync read or write padding slot 0.
+        Longer chain, includes the loop's normal steady-state shape.
+        """
+        rtp, allocator, tree_cache = _make_pools()
+        req = _make_req("r1", prompt_len=5)
+        req_pool_idx = _admit_prefill(req, rtp, allocator)
+
+        runner, n_chained_calls = _run_chained_decode(
+            rtp, allocator, tree_cache, req, req_pool_idx, n_iters=10
+        )
+        self.assertGreater(n_chained_calls, 0)
+
+        resolutions = _read_slot_resolutions(runner, req.rid, req_pool_idx)
+        self.assertNotIn(
+            0,
+            resolutions,
+            "a generated position's decode KV sync resolved padding slot 0",
+        )
+
+        runner._sync_decode_kv_to_pool(req.rid)
+        # The real sync must have advanced past every position the MLX cache
+        # produced -- not just up to whatever kv_committed_len says today.
+        cache_offset = runner._first_attention_cache(runner._req_caches[req.rid]).offset
+        self.assertEqual(runner._req_synced_offset[req.rid], cache_offset)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_finish_during_chain.py
+++ b/test/registered/unit/hardware_backend/mlx/test_finish_during_chain.py
@@ -1,0 +1,492 @@
+"""Adversarial regression guard for the Codex P1 comment on PR #33874.
+
+PR #33874 makes ``_launch_chained`` (``hardware_backend/mlx/scheduler_mixin.py``)
+call ``ScheduleBatch.prepare_for_decode()`` once per chained continuation. The
+Codex review raised a P1: ``_launch_chained`` commits a chained step's
+position (real ``req_to_token`` slot, advanced ``kv_committed_len`` /
+``seq_lens``) BEFORE ``pending_curr`` is finalized, so a request that
+finishes at step N (its actual last forwarded token) still has step N+1
+committed underneath it. If the finish path's radix insert then used that
+over-committed length as its bound, it would cache a position whose KV was
+never legitimately produced for that request's real continuation.
+
+This module drives the real ``event_loop_overlap_mlx`` against real
+``ScheduleBatch``/``Req``/``ReqToTokenPool``/``TokenToKVPoolAllocator``/
+``RadixCache`` objects (mocking only the MLX model-forward boundary via
+``tp_worker.*``, same harness discipline as ``test_chained_decode_accounting.py``)
+to settle the claim empirically instead of by inspection alone.
+
+Triage result (see issues/33874/reports/codex-p1-triage.md for the full
+trace): the over-commit itself is real (confirmed below: ``kv_committed_len``
+ends up one past ``len(output_ids)``), but ``RadixCache.cache_finished_req``
+(``mem_cache/radix_cache.py``) derives its insert key from
+``req.origin_input_ids + req.output_ids`` and only *then* bounds it by
+``kv_len_to_handle`` -- a Python list slice past the list's real length is a
+no-op, not an out-of-bounds read -- so the over-committed position is never
+inserted into radix regardless of how far ``kv_committed_len`` overshot. The
+P1 as Codex framed it (radix serves KV that was never produced) does not
+reproduce. What the same over-commit *does* cause is a narrower, previously
+unflagged defect: the one over-committed token-pool slot is neither inserted
+nor freed, so it permanently leaks from the allocator. That leak is recorded
+here as a documented, separate, pre-existing-shape hazard (see
+``test_documents_leaked_kv_slot_on_finish_during_chain`` below) — it is not
+part of Codex's P1 claim and this module does not attempt to fix it.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_mlx_ci(est_time=5, suite="stage-a-unit-test-mlx")
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_batch import Req, ReqKvInfo, ScheduleBatch
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import KVCache, ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_context
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+_HAS_MLX = importlib.util.find_spec("mlx") is not None
+_SKIP_REASON = "requires mlx"
+
+EOS_ID = 999
+
+
+class _DummyKVCache(KVCache):
+    """Scheduler-facing KV cache that allocates no real GPU/Metal memory.
+
+    Mirrors `hardware_backend/mlx/model_runner_stub.py`'s `_DummyKVCache`:
+    the MLX backend manages real attention KV itself, so the core scheduler
+    only needs this to size `TokenToKVPoolAllocator`'s slot free-list.
+    """
+
+    def __init__(self, size, dtype, device):
+        self.size = size
+        self.page_size = 1
+        self.dtype = dtype
+        self.store_dtype = dtype
+        self.device = device
+        self.layer_num = 0
+        self.start_layer = 0
+        self.end_layer = 0
+        self.mem_usage = 0
+        self.cpu_offloading_chunk_size = 8192
+        self.layer_transfer_counter = None
+        self.enable_custom_mem_pool = False
+        self.custom_mem_pool = None
+
+    def get_key_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no key buffer")
+
+    def get_value_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no value buffer")
+
+    def get_kv_buffer(self, layer_id):
+        raise RuntimeError("_DummyKVCache has no kv buffer")
+
+    def set_kv_buffer(self, layer, loc, cache_k, cache_v):
+        raise RuntimeError("_DummyKVCache cannot set kv buffer")
+
+    def get_kv_size_bytes(self):
+        return 0, 0
+
+
+def _install_server_args(test_case, **fields):
+    override = get_context().override_server_args(**fields)
+    override.install()
+    test_case.addCleanup(override.restore)
+
+
+def _make_pools(pool_size=64, req_slots=4, max_context_len=128):
+    rtp = ReqToTokenPool(
+        size=req_slots,
+        max_context_len=max_context_len,
+        device="cpu",
+        enable_memory_saver=False,
+    )
+    dummy_kv = _DummyKVCache(pool_size, torch.float32, "cpu")
+    allocator = TokenToKVPoolAllocator(
+        size=pool_size,
+        dtype=torch.float32,
+        device="cpu",
+        kvcache=dummy_kv,
+        need_sort=False,
+    )
+    tree_cache = RadixCache(
+        CacheInitParams(
+            disable=False,
+            req_to_token_pool=rtp,
+            token_to_kv_pool_allocator=allocator,
+            page_size=1,
+        )
+    )
+    return rtp, allocator, tree_cache
+
+
+def _make_req(rid, prompt_len, max_new_tokens=64, id_base=0):
+    # id_base keeps each request's prompt token IDs in a disjoint range so
+    # RadixCache's content-based prefix matching can't spuriously match one
+    # request's prompt against another's cached output (both would
+    # otherwise start from token 0).
+    sp = SamplingParams()
+    sp.max_new_tokens = max_new_tokens
+    sp.normalize(None)
+    req = Req(
+        rid=rid,
+        origin_input_text="",
+        origin_input_ids=array("q", range(id_base, id_base + prompt_len)),
+        sampling_params=sp,
+        vocab_size=1_000_000,
+    )
+    req.eos_token_ids = {EOS_ID}
+    return req
+
+
+def _admit_prefill(req, rtp, allocator, tree_cache):
+    """Simulate the prefill admission that would run before decode: allocate
+    the row + real prefix slots and write them into req_to_token, exactly
+    like `alloc_for_extend` does. Returns req_pool_idx.
+    """
+    prompt_len = len(req.origin_input_ids)
+    req_pool_idx = rtp.alloc([req])[0]
+    prefix_slots = allocator.alloc(prompt_len)
+    assert prefix_slots is not None
+    rtp.write((req_pool_idx, slice(0, prompt_len)), prefix_slots.to(torch.int32))
+    req.req_pool_idx = req_pool_idx
+    req.kv_committed_len = prompt_len
+    req.kv = ReqKvInfo(kv_allocated_len=prompt_len, swa_evicted_seqlen=0)
+    req.decode_batch_idx = 0
+    return req_pool_idx
+
+
+def _make_decode_batch(reqs, req_pool_indices, rtp, allocator, tree_cache):
+    model_config = SimpleNamespace(
+        is_encoder_decoder=False, vocab_size=2000, think_end_ids=None
+    )
+    batch = ScheduleBatch(
+        reqs=reqs,
+        req_to_token_pool=rtp,
+        token_to_kv_pool_allocator=allocator,
+        tree_cache=tree_cache,
+        model_config=model_config,
+        enable_overlap=False,
+        device="cpu",
+        forward_mode=ForwardMode.DECODE,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+    )
+    seq_lens = [r.kv_committed_len for r in reqs]
+    batch.req_pool_indices = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+    batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
+    batch.orig_seq_lens = torch.tensor(seq_lens, dtype=torch.int32)
+    batch.sampling_info = SimpleNamespace(
+        penalizer_orchestrator=SimpleNamespace(is_required=False),
+        filter_batch=lambda *a, **k: None,
+    )
+    batch.hisparse_coordinator = None
+    return batch
+
+
+def _make_result_processor(rtp, allocator, tree_cache, model_config):
+    """A real SchedulerBatchResultProcessor: this is what turns a decoded
+    token into update_finish_state() + release_kv_cache(), i.e. the exact
+    scheduler-side logic the P1 claim is about. Nothing here is mocked.
+    """
+    return SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=DisaggregationMode.NULL,
+        enable_overlap=False,
+        enable_overlap_mlx=True,
+        server_args=None,
+        model_config=model_config,
+        token_to_kv_pool_allocator=allocator,
+        tree_cache=tree_cache,
+        hisparse_coordinator=None,
+        req_to_token_pool=rtp,
+        decode_offload_manager=None,
+        metrics_collector=MagicMock(),
+        metrics_reporter=MagicMock(),
+        draft_worker=None,
+        model_worker=None,
+        logprob_result_processor=MagicMock(),
+        output_streamer=MagicMock(),
+        abort_request=MagicMock(),
+    )
+
+
+class _StopLoop(Exception):
+    """Sentinel to break out of event_loop_overlap_mlx's `while True`."""
+
+
+def _make_scheduler(batch, processor, *, n_iters, eos_at_call, eos_rid):
+    """A MagicMock scheduler whose scheduling primitives are wired to the
+    real implementations (`_prepare_mlx_launch`, `_finalize_mlx_pending_job`,
+    `process_batch_result` -> `process_batch_result_decode`,
+    `get_next_batch_to_run` -> filter_batch + prepare_for_decode, mirroring
+    `update_running_batch`). Only the MLX model-forward boundary
+    (`tp_worker.*`) is a bare mock: nothing about scheduler-side accounting,
+    finish detection, or KV release is faked.
+    """
+    from collections import deque
+
+    from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+        SchedulerMlxOverlapMixin,
+    )
+
+    scheduler = MagicMock()
+    scheduler.forward_ct = 0
+    scheduler.running_batch = batch
+    scheduler.last_batch = None
+    scheduler.gracefully_exit = False
+    scheduler._engine_paused = False
+    scheduler.waiting_queue = []
+    scheduler.result_queue = deque()
+    scheduler.batch_result_processor = processor
+
+    scheduler._prepare_mlx_launch.side_effect = lambda b: (
+        SchedulerMlxOverlapMixin._prepare_mlx_launch(scheduler, b)
+    )
+    scheduler._finalize_mlx_pending_job.side_effect = lambda p: (
+        SchedulerMlxOverlapMixin._finalize_mlx_pending_job(scheduler, p)
+    )
+    scheduler.process_batch_result.side_effect = (
+        lambda b, r: processor.process_batch_result_decode(b, r)
+    )
+
+    def get_next_batch_to_run(**_kwargs):
+        # Mirrors update_running_batch(): filter finished reqs, then commit
+        # this step's real allocation via prepare_for_decode() -- exactly
+        # what the real scheduler does before handing back batch_to_run.
+        batch.filter_batch()
+        if not batch.is_empty() and batch.check_decode_mem():
+            batch.prepare_for_decode()
+        return SimpleNamespace(batch_to_run=batch, running_batch=batch)
+
+    scheduler.get_next_batch_to_run.side_effect = get_next_batch_to_run
+
+    call_count = {"n": 0}
+
+    def finalize_mlx_result(prefills, extends, decode, mode, reqs):
+        call_count["n"] += 1
+        n = call_count["n"]
+        result = MagicMock()
+        result.copy_done = None
+        result.routed_experts_output = None
+        result.indexer_topk_output = None
+        result.can_run_cuda_graph = False
+        result.speculative_num_draft_tokens = None
+        result.num_correct_drafts = None
+        result.num_block_accept_tokens = None
+        result.num_cap_tokens = None
+        logits_output = MagicMock()
+        logits_output.hidden_states = None
+        result.logits_output = logits_output
+        tokens = [
+            EOS_ID if (n == eos_at_call and r.rid == eos_rid) else (100 + n)
+            for r in reqs
+        ]
+        result.next_token_ids = torch.tensor(tokens, dtype=torch.long)
+        return result
+
+    scheduler.tp_worker.finalize_mlx_result.side_effect = finalize_mlx_result
+    scheduler.tp_worker.async_forward_batch_generation_mlx.return_value = (
+        MagicMock(),
+        [],
+        [],
+        MagicMock(),
+        "decode",
+    )
+    scheduler.tp_worker.async_chained_decode_mlx.side_effect = lambda _decode: (
+        MagicMock(),
+        [],
+        [],
+        MagicMock(),
+        "decode",
+    )
+
+    recv_count = {"n": 0}
+
+    def recv_requests():
+        recv_count["n"] += 1
+        if recv_count["n"] > n_iters:
+            raise _StopLoop()
+        return []
+
+    scheduler.request_receiver.recv_requests.side_effect = recv_requests
+    return scheduler
+
+
+def _run_loop(scheduler):
+    from sglang.srt.hardware_backend.mlx.scheduler_mixin import (
+        SchedulerMlxOverlapMixin,
+    )
+
+    try:
+        SchedulerMlxOverlapMixin.event_loop_overlap_mlx(scheduler)
+    except _StopLoop:
+        pass
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestFinishDuringChainRegressionGuard(CustomTestCase):
+    """Drives the real event_loop_overlap_mlx through a request that EOSes
+    while the chain has already committed one more position underneath it,
+    with a second live request in the pool so a freed-and-reused row is
+    observable. Mocks only tp_worker (the MLX model-forward boundary).
+    """
+
+    def setUp(self):
+        _install_server_args(self)
+
+    def _drive_finish_during_chain(self, *, req_slots=4, pool_size=64):
+        rtp, allocator, tree_cache = _make_pools(
+            pool_size=pool_size, req_slots=req_slots
+        )
+        req_a = _make_req("a", prompt_len=3, id_base=10_000)  # EOSes mid-chain
+        req_b = _make_req("b", prompt_len=3, id_base=20_000)  # stays alive
+        idx_a = _admit_prefill(req_a, rtp, allocator, tree_cache)
+        idx_b = _admit_prefill(req_b, rtp, allocator, tree_cache)
+        batch = _make_decode_batch(
+            [req_a, req_b], [idx_a, idx_b], rtp, allocator, tree_cache
+        )
+        processor = _make_result_processor(
+            rtp, allocator, tree_cache, batch.model_config
+        )
+        # Call 1: fresh-launch finalize (both get an ordinary token).
+        # Call 2: pending_curr finalize -- req_a's real last token is EOS,
+        #         but _launch_chained already committed step N+1 for req_a
+        #         earlier in this same iteration (the race under test).
+        # Call 3: the chain-break finalize of the already-launched N+1 step;
+        #         req_a is already finished() by then, so
+        #         process_batch_result_decode must skip it (line ~847-852).
+        scheduler = _make_scheduler(
+            batch, processor, n_iters=3, eos_at_call=2, eos_rid="a"
+        )
+        _run_loop(scheduler)
+        return rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b
+
+    def test_no_phantom_committed_position_is_radix_inserted(self):
+        """The Codex P1 claim: does the over-committed chain step leak into
+        the radix cache as if it were real, forwarded KV? It must not.
+        """
+        rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b = (
+            self._drive_finish_during_chain()
+        )
+
+        self.assertTrue(req_a.finished())
+        correct_len = len(req_a.origin_input_ids) + len(req_a.output_ids)
+
+        # C1: _launch_chained's prepare_for_decode() really did commit one
+        # position past what req_a's real (EOS) token authorizes.
+        self.assertGreater(req_a.kv_committed_len, correct_len)
+        self.assertEqual(req_a.kv_committed_len, correct_len + 1)
+
+        # C2 (the actual P1 claim): the radix insert must be bounded by
+        # what was really produced (origin_input_ids + output_ids), not by
+        # the over-committed kv_committed_len. A match on req_a's true
+        # sequence must land exactly on correct_len -- not correct_len + 1.
+        full_ids = req_a.origin_input_ids + req_a.output_ids
+        match = tree_cache.match_prefix(MatchPrefixParams(key=RadixKey(full_ids, None)))
+        self.assertEqual(len(match.device_indices), correct_len)
+
+        # And the specific over-committed slot must not appear among the
+        # values radix now serves for req_a.
+        phantom_slot = int(rtp.req_to_token[idx_a, correct_len].item())
+        inserted = set(int(x) for x in match.device_indices.tolist())
+        self.assertNotIn(phantom_slot, inserted)
+
+    def test_row_reuse_does_not_corrupt_the_new_owner_at_the_scheduler_level(
+        self,
+    ):
+        """req_a's row frees on finish; admit a third request onto it and
+        confirm the new owner's own committed range is exactly its own --
+        req_a's leftover slot ids do not leak into req_c's serving range.
+
+        This checks the scheduler-side (req_to_token / radix) half of the
+        row-reuse concern the Codex comment raised. It does not exercise
+        MlxModelRunner._sync_decode_kv_to_pool / remove_request (the
+        deferred MLX-native KV copy) -- see the triage report's C4 section:
+        that mechanism is real but pre-existing and tracked separately
+        (#30147), not introduced by this PR, and out of this test's scope.
+        """
+        rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b = (
+            self._drive_finish_during_chain(req_slots=2)
+        )
+        self.assertIsNone(req_a.req_pool_idx)  # freed
+
+        req_c = _make_req("c", prompt_len=2, id_base=30_000)
+        idx_c = _admit_prefill(req_c, rtp, allocator, tree_cache)
+        self.assertEqual(idx_c, idx_a, "test setup expects the freed row to be reused")
+
+        full_ids_c = req_c.origin_input_ids
+        match_c = tree_cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(full_ids_c, None))
+        )
+        # req_c has no cached prefix of its own yet (fresh prompt): the
+        # reused row must not let req_a's old radix entries satisfy req_c.
+        self.assertEqual(len(match_c.device_indices), 0)
+
+        row_c_committed = rtp.req_to_token[idx_c, : req_c.kv_committed_len].tolist()
+        row_b_committed = rtp.req_to_token[idx_b, : req_b.kv_committed_len].tolist()
+        self.assertEqual(len(set(row_c_committed) & set(row_b_committed)), 0)
+
+    def test_documents_leaked_kv_slot_on_finish_during_chain(self):
+        """NOT part of the Codex P1 claim (which was about radix serving
+        unforwarded KV, refuted above). Separate, narrower finding from the
+        same trace: the one over-committed token-pool slot from
+        `_launch_chained`'s prepare_for_decode() is excluded from both the
+        radix insert (good -- see above) and release_kv_cache's
+        overallocation-release path, because `req.kv.kv_allocated_len` was
+        advanced in lockstep with `kv_committed_len` by the same
+        prepare_for_decode() call (`mem_cache/allocation.py`
+        `alloc_for_decode`), so `_release_overallocated_kv_indices` sees
+        `start_p == end_p` and frees nothing. The slot is allocated forever.
+
+        This is a pre-existing-shape hazard (mainline's non-chained overlap
+        decode has the structurally identical one-step-ahead allocation;
+        see the triage report's pivotal-question trace) made newly reachable
+        here because chained steps now draw real slots at all. Recorded,
+        not fixed, per the triage guardrails.
+        """
+        rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b = (
+            self._drive_finish_during_chain()
+        )
+        correct_len = len(req_a.origin_input_ids) + len(req_a.output_ids)
+        phantom_slot = int(rtp.req_to_token[idx_a, correct_len].item())
+
+        free_pages = (
+            set(int(x) for x in allocator.free_pages.tolist())
+            if allocator.free_pages is not None
+            else set()
+        )
+        release_pages = (
+            set(int(x) for x in allocator.release_pages.tolist())
+            if getattr(allocator, "release_pages", None) is not None
+            else set()
+        )
+        # Documents current behavior (the leak): flip this to assertIn(...)
+        # once the leak is closed (mainline-shared fix; see report).
+        self.assertNotIn(phantom_slot, free_pages | release_pages)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/mlx/test_finish_during_chain.py
+++ b/test/registered/unit/hardware_backend/mlx/test_finish_during_chain.py
@@ -1,36 +1,11 @@
-"""Adversarial regression guard for the Codex P1 comment on PR #33874.
+"""Finish during chain regression guards for the MLX overlap loop (PR #33874).
 
-PR #33874 makes ``_launch_chained`` (``hardware_backend/mlx/scheduler_mixin.py``)
-call ``ScheduleBatch.prepare_for_decode()`` once per chained continuation. The
-Codex review raised a P1: ``_launch_chained`` commits a chained step's
-position (real ``req_to_token`` slot, advanced ``kv_committed_len`` /
-``seq_lens``) BEFORE ``pending_curr`` is finalized, so a request that
-finishes at step N (its actual last forwarded token) still has step N+1
-committed underneath it. If the finish path's radix insert then used that
-over-committed length as its bound, it would cache a position whose KV was
-never legitimately produced for that request's real continuation.
-
-This module drives the real ``event_loop_overlap_mlx`` against real
-``ScheduleBatch``/``Req``/``ReqToTokenPool``/``TokenToKVPoolAllocator``/
-``RadixCache`` objects (mocking only the MLX model-forward boundary via
-``tp_worker.*``, same harness discipline as ``test_chained_decode_accounting.py``)
-to settle the claim empirically instead of by inspection alone.
-
-Triage result (see issues/33874/reports/codex-p1-triage.md for the full
-trace): the over-commit itself is real (confirmed below: ``kv_committed_len``
-ends up one past ``len(output_ids)``), but ``RadixCache.cache_finished_req``
-(``mem_cache/radix_cache.py``) derives its insert key from
-``req.origin_input_ids + req.output_ids`` and only *then* bounds it by
-``kv_len_to_handle`` -- a Python list slice past the list's real length is a
-no-op, not an out-of-bounds read -- so the over-committed position is never
-inserted into radix regardless of how far ``kv_committed_len`` overshot. The
-P1 as Codex framed it (radix serves KV that was never produced) does not
-reproduce. What the same over-commit *does* cause is a narrower, previously
-unflagged defect: the one over-committed token-pool slot is neither inserted
-nor freed, so it permanently leaks from the allocator. That leak is recorded
-here as a documented, separate, pre-existing-shape hazard (see
-``test_documents_leaked_kv_slot_on_finish_during_chain`` below) — it is not
-part of Codex's P1 claim and this module does not attempt to fix it.
+A request that finishes at step N while _launch_chained has prepared step N+1
+ends with kv_committed_len one past len(output_ids). These tests pin the
+consequences: the phantom position never enters the radix key, since
+cache_finished_req bounds by the token list rather than kv_committed_len; a
+reused row does not expose the old owner's entries; and the phantom slot
+currently leaks, documented below and tracked separately.
 """
 
 from __future__ import annotations
@@ -417,16 +392,10 @@ class TestFinishDuringChainRegressionGuard(CustomTestCase):
     def test_row_reuse_does_not_corrupt_the_new_owner_at_the_scheduler_level(
         self,
     ):
-        """req_a's row frees on finish; admit a third request onto it and
-        confirm the new owner's own committed range is exactly its own --
-        req_a's leftover slot ids do not leak into req_c's serving range.
-
-        This checks the scheduler-side (req_to_token / radix) half of the
-        row-reuse concern the Codex comment raised. It does not exercise
-        MlxModelRunner._sync_decode_kv_to_pool / remove_request (the
-        deferred MLX-native KV copy) -- see the triage report's C4 section:
-        that mechanism is real but pre-existing and tracked separately
-        (#30147), not introduced by this PR, and out of this test's scope.
+        """The freed row's new owner sees only its own committed range: req_a's
+        leftover slot ids and radix entries do not reach req_c. The deferred
+        MLX KV sync half of the row reuse concern is out of scope here,
+        tracked in #30147.
         """
         rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b = (
             self._drive_finish_during_chain(req_slots=2)
@@ -450,22 +419,11 @@ class TestFinishDuringChainRegressionGuard(CustomTestCase):
         self.assertEqual(len(set(row_c_committed) & set(row_b_committed)), 0)
 
     def test_documents_leaked_kv_slot_on_finish_during_chain(self):
-        """NOT part of the Codex P1 claim (which was about radix serving
-        unforwarded KV, refuted above). Separate, narrower finding from the
-        same trace: the one over-committed token-pool slot from
-        `_launch_chained`'s prepare_for_decode() is excluded from both the
-        radix insert (good -- see above) and release_kv_cache's
-        overallocation-release path, because `req.kv.kv_allocated_len` was
-        advanced in lockstep with `kv_committed_len` by the same
-        prepare_for_decode() call (`mem_cache/allocation.py`
-        `alloc_for_decode`), so `_release_overallocated_kv_indices` sees
-        `start_p == end_p` and frees nothing. The slot is allocated forever.
-
-        This is a pre-existing-shape hazard (mainline's non-chained overlap
-        decode has the structurally identical one-step-ahead allocation;
-        see the triage report's pivotal-question trace) made newly reachable
-        here because chained steps now draw real slots at all. Recorded,
-        not fixed, per the triage guardrails.
+        """Documents the leak, separate from the P1 claim: the over committed
+        slot is excluded from the radix insert and from
+        _release_overallocated_kv_indices, because kv_allocated_len advanced
+        in lockstep with kv_committed_len, so start_p == end_p and nothing
+        frees it. Flip the final assert to assertIn once the leak is fixed.
         """
         rtp, allocator, tree_cache, req_a, req_b, idx_a, idx_b = (
             self._drive_finish_during_chain()

--- a/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
+++ b/test/registered/unit/hardware_backend/mlx/test_scheduler_mixin.py
@@ -16,6 +16,8 @@ import platform
 import unittest
 from unittest.mock import MagicMock, patch
 
+import torch
+
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -183,11 +185,27 @@ class TestOverlapLoopStampsLaunchTs(unittest.TestCase):
         req.finished.return_value = False
         batch = MagicMock()
         batch.reqs = [req]
-        fresh_copy = MagicMock()
-        batch.copy.return_value = fresh_copy
-        chained_copy = MagicMock()
-        chained_copy.launch_ts = None
-        fresh_copy.copy.return_value = chained_copy
+        # A real prepare_for_decode() would set this to the newly allocated,
+        # never-zero slot id(s) (see the slot-0 assert in _launch_chained,
+        # #30093); the mocked prepare_for_decode() below does not run the
+        # real allocator, so set it explicitly.
+        batch.out_cache_loc = torch.tensor([1])
+        # _launch_fresh takes the first schedule_batch.copy(); _launch_chained
+        # takes a second one (after prepare_for_decode(), so the copy carries
+        # this step's committed seq_lens / kv_committed_len — see #30093).
+        # A real ScheduleBatch.copy() snapshots the live object's current
+        # attributes; emulate that here instead of a fixed canned mock, since
+        # the whole point under test is that the copy sees a *fresh* stamp.
+        copies = []
+
+        def make_copy():
+            snapshot = MagicMock()
+            snapshot.launch_ts = batch.launch_ts
+            snapshot.forward_iter = batch.forward_iter
+            copies.append(snapshot)
+            return snapshot
+
+        batch.copy.side_effect = make_copy
         plan = MagicMock()
         plan.batch_to_run = batch
         scheduler.get_next_batch_to_run.return_value = plan
@@ -226,11 +244,19 @@ class TestOverlapLoopStampsLaunchTs(unittest.TestCase):
 
         scheduler.tp_worker.async_chained_decode_mlx.assert_called_once()
         self.assertLess(events.index("launch_ts:2.0"), events.index("chained_forward"))
+        self.assertEqual(len(copies), 2)
+        fresh_copy, chained_copy = copies
+        self.assertEqual(fresh_copy.launch_ts, 1.0)
         self.assertEqual(chained_copy.launch_ts, 2.0)
-        # The live batch only needs the iteration for SWA maintenance before
-        # the next fresh launch; per-step timing consumes the batch copy.
+        # The chained step stamps the live schedule_batch directly (not a
+        # copy) before prepare_for_decode(), since maybe_evict_swa() keys its
+        # cadence off batch.forward_iter -- see _launch_chained.
         self.assertEqual(batch.forward_iter, 2)
-        self.assertEqual(batch.launch_ts, 1.0)
+        self.assertEqual(batch.launch_ts, 2.0)
+        # The chained token must get the same allocation/accounting
+        # lifecycle as an ordinary decode token (#30093).
+        batch.prepare_for_decode.assert_called_once()
+        batch.check_decode_mem.assert_called_once()
 
 
 @unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)


### PR DESCRIPTION
## Motivation

Closes #30093

Chained decode reused a copy of the previous `ScheduleBatch` and went straight to the MLX forward. It never called `ScheduleBatch.prepare_for_decode()`, so a chained token never passed through `alloc_for_decode()`: no slot drawn from the shared KV pool, no entry written into `req_to_token`, no advance of `kv_committed_len` or `seq_lens`. The decode KV sync then read those unwritten positions as slot ids and resolved them to padding slot 0. Every position past the pre chain length stayed outside `kv_committed_len`, so a long generation was almost entirely uncacheable for a later turn.

## Modifications

`_launch_chained` now calls `prepare_for_decode()` once per chained continuation, on the same `ScheduleBatch` the running batch already uses. This is the single owner function the ordinary decode path already calls through `update_running_batch`, so a chained token now gets what an ordinary decode token gets: a real slot, a real `req_to_token` write and a real advance of `kv_committed_len` and `seq_lens`. The call is gated on `check_decode_mem()` just before the loop decides to chain. When the pool cannot fit the next allocation, the loop declines to chain this iteration and falls through to the existing chain break path, whose `get_next_batch_to_run` retracts with the logic every other backend uses. No allocation happens inside the hot chained path when the pool is short.

Carries the slot zero assert from the #30147 review. Redundant under the clamp alone, since positions past `kv_committed_len` are never read once the clamp is in place; meaningful once chained positions carry real allocations, since a real allocation reaching slot zero would mean the invariant this patch establishes had broken. It sits right after `prepare_for_decode()`, checking the slots just drawn are never zero.

Touches one function in one file, `_launch_chained` in `hardware_backend/mlx/scheduler_mixin.py`. No new state, no change to `model_runner.py` or `tp_worker.py`. The change stays file disjoint from #30578, whose diff lands in `model_runner.py`, `tp_worker.py`, and a different function in `scheduler_mixin.py` with no line overlap, so the eventual rebase stays clean. One interaction worth knowing at review time: #30578's clamp keys on a runner local `_req_committed_len` that advances only on non chained forwards, so with both patches landed its sync still truncates at the pre chain boundary. The natural follow up is for that clamp to read `req.kv_committed_len`, the single owner this patch feeds, restoring full sync of chained positions.

## Accuracy Tests

New registered unit tests in `test/registered/unit/hardware_backend/mlx/`: a baseline module that drives the real `event_loop_overlap_mlx` loop against a real runner, pool, and allocator stack and asserts no committed position's sync resolves slot 0 and an accounting module covering chain break into ordinary decode, chaining with radix cache disabled and `req_to_token` advancement across several chained steps. Red on unpatched main (3 of 6 slot resolutions were slot 0 at unit scale); 18 of 18 pass with the patch. Reverting only the `prepare_for_decode()` call reds 6 of 18. Full `hardware_backend/mlx/` suite: 121 passed, 4 skipped, 1 pre existing unrelated failure (`test_metal_profiler`, identical on clean main).

Serving level, real MLX server, Qwen3-0.6B-4bit, one 220 token generation with the pool sync instrumented: 219 of 220 resolved slots were padding slot 0 before, 0 of 220 after, all committed positions in real sequential slots. No assertion failures, clean logs.

## Speed Tests and Profiling

Chained decode exists to remove the scheduler round trip from the hot path; this patch puts allocator work back inside it. Single request, 300 tokens per run, seven measured runs per side after one discarded warmup, same model and settings both sides.

| | before | after |
|---|---|---|
| mean tok/s | 280.70 | 278.93 |
| median tok/s | 292.78 | 295.60 |
| stdev | 51.11 | 48.59 |

Mean delta ~ -0.6%, median ~ +1%. Both sides carry the same outlier run at roughly 170 tok/s, so that noise is shared, not introduced by this patch. Excluding it from both sides: 299.63 before, 296.65 after. All deltas sit well inside one run's own spread. No regression outside noise.

## Checklist

- [x] Format your code according to Format code with pre-commit.
- [x] Add unit tests according to Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31289444202](https://github.com/sgl-project/sglang/actions/runs/31289444202)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31289444143](https://github.com/sgl-project/sglang/actions/runs/31289444143)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->