### PR TITLE
 fix(HiSparse): use logical request capacity in disaggregated decode

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -652,8 +652,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
 
     def _check_if_req_exceed_kv_capacity(self, req: Req) -> bool:
         input_len = self._rebootstrap_prefill_len(req)
-        if input_len > self.max_total_num_tokens:
-            message = f"Request {req.rid} exceeds the maximum number of tokens: {input_len} > {self.max_total_num_tokens}"
+        capacity = (
+            self.scheduler.max_req_token_capacity
+            if self.scheduler.enable_hisparse
+            else self.max_total_num_tokens
+        )
+        if input_len > capacity:
+            message = f"Request {req.rid} exceeds the maximum number of tokens: {input_len} > {capacity}"
             logger.error(message)
             prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1011,6 +1011,7 @@ class Scheduler(
             _,
             _,
             _,
+            self.max_req_token_capacity,
         ) = self.tp_worker.get_worker_info()
         # DFlash auto-enables the legacy formula; other workloads opt in via
         # --min-free-slots-delay. Built independently of the prefill delayer.
@@ -2120,9 +2121,16 @@ class Scheduler(
                 )
             max_new_tokens = min(max_new_tokens, self.max_new_tokens_limit)
 
+        generation_token_capacity = (
+            self.max_req_token_capacity
+            if self.enable_hisparse
+            and self.disaggregation_mode == DisaggregationMode.DECODE
+            else self.max_total_num_tokens * self.server_args.dcp_size
+        )
+
         # Keep this bound consistent with PrefillAdder's admission budget:
         # ceil_page(input_len) + max_new_tokens + page_size must be strictly
-        # smaller than max_total_num_tokens. Otherwise a request can be accepted
+        # smaller than generation_token_capacity. Otherwise a request can be accepted
         # into the waiting queue but can never be scheduled, blocking the queue
         # and eventually making health checks fail.
         paged_input_len = -(-input_len // self.page_size) * self.page_size
@@ -2131,10 +2139,7 @@ class Scheduler(
             min(
                 max_new_tokens,
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens * self.server_args.dcp_size
-                - paged_input_len
-                - self.page_size
-                - 1,
+                generation_token_capacity - paged_input_len - self.page_size - 1,
             ),
         )
         # Clipping above can push max_new_tokens below min_new_tokens, which

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -530,6 +530,7 @@ class TpModelWorker(BaseTpWorker):
             self.model_runner.req_to_token_pool.size,
             self.model_runner.req_to_token_pool.max_context_len,
             self.model_runner.token_to_kv_pool.size,
+            self.model_runner.effective_max_total_num_tokens,
         )
 
     def is_dllm(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1236,6 +1236,8 @@ class ModelRunner:
     @property
     def effective_max_total_num_tokens(self):
         """Return the max token pool size considering hybrid swa settings."""
+        if self.enable_hisparse and self.server_args.disaggregation_mode == "decode":
+            return self.token_to_kv_pool_allocator.size_full
         if self.is_hybrid_swa:
             return self.full_max_total_num_tokens or self.swa_max_total_num_tokens
         else:

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -2,6 +2,7 @@ import logging
 import unittest
 from types import SimpleNamespace
 
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -15,7 +16,8 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
     Rules enforced when clipping a request's max_new_tokens:
       1. context: input_len + max_new_tokens < max_req_len
       2. admission budget (PrefillAdder):
-         ceil_page(input_len) + max_new_tokens + page_size < max_total_num_tokens
+         ceil_page(input_len) + max_new_tokens + page_size < generation capacity
+         (logical per-request capacity for HiSparse decode, physical otherwise)
       3. env limit: <= SGLANG_MAX_NEW_TOKENS_LIMIT when set and positive
       4. never above the requested value
       5. min_new_tokens <= max_new_tokens afterwards
@@ -40,12 +42,22 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
         self,
         max_req_len: int = 128,
         max_total_num_tokens: int = 1024,
+        max_req_token_capacity: int | None = None,
         page_size: int = 1,
+        enable_hisparse: bool = False,
+        disaggregation_mode: DisaggregationMode = DisaggregationMode.NULL,
     ) -> Scheduler:
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.max_req_len = max_req_len
         scheduler.max_total_num_tokens = max_total_num_tokens
+        scheduler.max_req_token_capacity = (
+            max_total_num_tokens
+            if max_req_token_capacity is None
+            else max_req_token_capacity
+        )
         scheduler.page_size = page_size
+        scheduler.enable_hisparse = enable_hisparse
+        scheduler.disaggregation_mode = disaggregation_mode
         scheduler.server_args = SimpleNamespace(dcp_size=1)
         scheduler.max_new_tokens_limit = envs.SGLANG_MAX_NEW_TOKENS_LIMIT.get()
         return scheduler
@@ -71,11 +83,17 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
         paged_input_len = -(-input_len // page_size) * page_size
         limit = scheduler.max_new_tokens_limit
         limit_active = limit is not None and limit > 0
+        generation_token_capacity = (
+            scheduler.max_req_token_capacity
+            if scheduler.enable_hisparse
+            and scheduler.disaggregation_mode == DisaggregationMode.DECODE
+            else scheduler.max_total_num_tokens * scheduler.server_args.dcp_size
+        )
 
         def satisfies_rules(candidate: int) -> bool:
             context_ok = input_len + candidate < scheduler.max_req_len
             budget_ok = (
-                paged_input_len + candidate + page_size < scheduler.max_total_num_tokens
+                paged_input_len + candidate + page_size < generation_token_capacity
             )
             limit_ok = not limit_active or candidate <= limit
             requested_ok = requested is None or candidate <= requested
@@ -135,6 +153,30 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
                 self._init_and_check(scheduler, req),
                 max_total_num_tokens - paged_input_len - page_size - 1,
             )
+
+    def test_hisparse_decode_uses_logical_generation_capacity(self):
+        scheduler = self._new_scheduler(
+            max_req_len=4095,
+            max_total_num_tokens=1024,
+            max_req_token_capacity=4096,
+            enable_hisparse=True,
+            disaggregation_mode=DisaggregationMode.DECODE,
+        )
+        req = self._new_req(max_new_tokens=128, input_len=2048)
+
+        self.assertEqual(self._init_and_check(scheduler, req), 128)
+        self.assertEqual(scheduler.max_total_num_tokens, 1024)
+
+    def test_hisparse_aggregate_keeps_physical_generation_capacity(self):
+        scheduler = self._new_scheduler(
+            max_req_len=4095,
+            max_total_num_tokens=1024,
+            max_req_token_capacity=4096,
+            enable_hisparse=True,
+        )
+        req = self._new_req(max_new_tokens=128, input_len=900)
+
+        self.assertEqual(self._init_and_check(scheduler, req), 122)
 
     def test_min_new_tokens_clamped_to_limit(self):
         with envs.SGLANG_MAX_NEW_TOKENS_LIMIT.override(16):

--- a/test/registered/unit/mem_cache/test_hisparse_request_capacity.py
+++ b/test/registered/unit/mem_cache/test_hisparse_request_capacity.py
@@ -1,0 +1,110 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def make_model_runner(
+    *,
+    enable_hisparse: bool,
+    disaggregation_mode: str,
+    device_capacity: int,
+    logical_capacity: int,
+):
+    runner = object.__new__(ModelRunner)
+    runner.enable_hisparse = enable_hisparse
+    runner.server_args = SimpleNamespace(disaggregation_mode=disaggregation_mode)
+    runner.token_to_kv_pool_allocator = SimpleNamespace(size_full=logical_capacity)
+    runner.is_hybrid_swa = False
+    runner.max_total_num_tokens = device_capacity
+    return runner
+
+
+class TestHiSparseRequestCapacity(CustomTestCase):
+    def test_decode_uses_logical_capacity(self):
+        runner = make_model_runner(
+            enable_hisparse=True,
+            disaggregation_mode="decode",
+            device_capacity=1024,
+            logical_capacity=4096,
+        )
+        self.assertEqual(runner.effective_max_total_num_tokens, 4096)
+
+    def test_aggregate_uses_device_capacity(self):
+        runner = make_model_runner(
+            enable_hisparse=True,
+            disaggregation_mode="null",
+            device_capacity=1024,
+            logical_capacity=4096,
+        )
+        self.assertEqual(runner.effective_max_total_num_tokens, 1024)
+
+    def test_non_hisparse_uses_device_capacity(self):
+        runner = make_model_runner(
+            enable_hisparse=False,
+            disaggregation_mode="decode",
+            device_capacity=1024,
+            logical_capacity=4096,
+        )
+        self.assertEqual(runner.effective_max_total_num_tokens, 1024)
+
+
+def make_decode_queue(*, runner: ModelRunner, enable_hisparse: bool):
+    queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+    queue.max_total_num_tokens = runner.max_total_num_tokens
+    queue.token_to_kv_pool_allocator = SimpleNamespace(size_swa=10**9)
+    queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
+    queue.scheduler = SimpleNamespace(
+        enable_hisparse=enable_hisparse,
+        max_req_token_capacity=runner.effective_max_total_num_tokens,
+        tp_worker=SimpleNamespace(model_runner=runner),
+        output_streamer=MagicMock(),
+    )
+    return queue
+
+
+def make_request(prompt_len: int):
+    return SimpleNamespace(
+        rid="test",
+        origin_input_ids=[0] * prompt_len,
+        output_ids=[],
+        return_logprob=False,
+        pd_rebootstrap_in_progress=False,
+        finished_reason=None,
+    )
+
+
+class TestDecodePreallocCapacity(CustomTestCase):
+    def setUp(self):
+        self.runner = make_model_runner(
+            enable_hisparse=True,
+            disaggregation_mode="decode",
+            device_capacity=1024,
+            logical_capacity=4096,
+        )
+        self.queue = make_decode_queue(
+            runner=self.runner,
+            enable_hisparse=True,
+        )
+
+    def test_admits_request_larger_than_device_pool(self):
+        self.assertFalse(
+            self.queue._check_if_req_exceed_kv_capacity(make_request(2048))
+        )
+        self.queue.scheduler.output_streamer.stream_output.assert_not_called()
+
+    def test_rejects_request_larger_than_logical_pool(self):
+        req = make_request(4097)
+        self.assertTrue(self.queue._check_if_req_exceed_kv_capacity(req))
+        self.assertIsNotNone(req.finished_reason)
+        self.queue.scheduler.output_streamer.stream_output.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

HiSparse decode workers can handle prompts larger than the physical GPU KV pool using host-backed cache. However, decode admission and generation limits still used the physical capacity, causing long prompts to be rejected or generate zero tokens.

## Modifications

- Use the logical HiSparse capacity when admitting transferred prompts on decode workers.
- Use the same capacity when calculating the generation budget.
- Preserve physical-capacity behavior for other configurations.
- Add regression tests for long prompts and `max_new_tokens` initialization.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31113609576](https://github.com/sgl-project/sglang/actions/runs/31113609576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31113613701](https://github.com/sgl-project/sglang/actions/runs/31113613701)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->