### PR TITLE
[PD] Fix asymmetric MTP metadata buffer mismatch

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1293,8 +1293,10 @@ class Scheduler(
                 get_draft_recurrent_hidden_state_spec(draft_runner)
             )
         else:
-            disagg_hidden_size = 16  # minimal padding size for RDMA
-            disagg_hidden_states_dtype = torch.float32
+            # MetadataBuffers is part of the P/D wire schema, so its layout
+            # cannot depend on whether this local node runs speculative decode.
+            disagg_hidden_size = self.model_config.spec_hidden_size
+            disagg_hidden_states_dtype = self.model_config.dtype
 
         # The PD metadata wire schema must match on P and D even when only D
         # enables spec decoding; a seedless prefill writes the invalid sentinel.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When serving GLM-5.2-FP8 with PD disaggregation, Prefill without MTP and with `tc_piecewise` CUDA Graph, and Decode with MTP, both nodes start normally but Mooncake fails during transfer:

```text
Failed to get segment descriptor for segment
KVTransferError: Failed due to an unknown reason from another rank
```

The Prefill and Decode nodes allocate different `output_hidden_states` metadata buffer schemas: Prefill uses the 16-element FP32 padding buffer, while Decode uses the model's MTP hidden size and dtype.

This follows the fix in [#23958](https://github.com/sgl-project/sglang/pull/23958), which was merged into `dsv4-rebase` but not `main`.

## Modifications

- Use the model-defined speculative hidden size and dtype on nodes without MTP.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31114867744](https://github.com/sgl-project/sglang/actions/runs/31114867744)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31114867915](https://github.com/sgl-project/sglang/actions/runs/31114867915)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->