### PR TITLE
[diffusion] fix output-rank test fixture

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/realtime/test_output_materialization.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_output_materialization.py
@@ -60,7 +60,7 @@ def test_save_outputs_can_materialize_without_saving(tmp_path):
 
 def test_file_path_transport_clears_in_memory_outputs():
     worker = GPUWorker.__new__(GPUWorker)
-    worker.rank = 0
+    worker.is_output_rank = True
     output_batch = OutputBatch(
         output=[object()],
         audio=torch.zeros(1),


### PR DESCRIPTION
## Summary

Fix the `GPUWorker.__new__()` unit-test fixture to model the actual output-rank
contract used by `_materialize_file_path_transport`.

## Scope

- Test-only change; no runtime behavior changes.
- Keeps the fixture aligned with `GPUWorker.is_output_rank`, introduced for
  disaggregated output ownership.

## Validation

- Remote CI requested with `/tag-and-rerun-ci extra`.
- No local tests run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31114626198](https://github.com/sgl-project/sglang/actions/runs/31114626198)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31114636790](https://github.com/sgl-project/sglang/actions/runs/31114636790)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->