### PR TITLE
[diffusion] align AMD 2-GPU test partitions

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -810,7 +810,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
+        part: [0, 1, 2, 3, 4, 5, 6]  # 7 partitions: 2 parametrized + 5 standalone tests
     runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi300') }}
     steps:
       - name: Checkout code
@@ -907,7 +907,7 @@ jobs:
             ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
               --suite 2-gpu \
               --partition-id ${{ matrix.part }} \
-              --total-partitions 3 \
+              --total-partitions 7 \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
           # Post-test diagnostics


### PR DESCRIPTION
## Summary

Align the AMD 2-GPU CI partition count with the suite's five standalone test
files while retaining two parameterized partitions.

## Scope

- Seven partitions: two parameterized plus five standalone tests.
- No runtime code changes.

## Validation

- Remote CI requested with `/tag-and-rerun-ci extra`.
- No local tests run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31114638531](https://github.com/sgl-project/sglang/actions/runs/31114638531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31114639085](https://github.com/sgl-project/sglang/actions/runs/31114639085)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->