### PR TITLE
[HiCache] Route --file-storage-path to the file storage backend

### DIFF
--- a/python/sglang/srt/arg_groups/fields/serving.py
+++ b/python/sglang/srt/arg_groups/fields/serving.py
@@ -175,9 +175,9 @@ class Serving(msgspec.Struct):
         "The buliltin completion template name or the path of the completion template file. This is only used for OpenAI-compatible API server. only for code completion currently.",
     ] = None
     file_storage_path: A[
-        str,
+        Optional[str],
         "The path of the file storage in backend.",
-    ] = "sglang_storage"
+    ] = None
     enable_cache_report: A[
         bool,
         "Return number of cached tokens in usage.prompt_tokens_details for each openai request.",

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -363,7 +363,11 @@ class HiCacheFile(HiCacheStorage):
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):
-        self.file_path = envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.get() or file_path
+        self.file_path = (
+            envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.get()
+            or (storage_config.extra_config or {}).get("file_storage_path")
+            or file_path
+        )
 
         tp_rank, tp_size, pp_rank, pp_size, model_name, is_mla_model = (
             storage_config.tp_rank,

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -374,7 +374,11 @@ class HiCacheFile(HiCacheStorage):
     def __init__(
         self, storage_config: HiCacheStorageConfig, file_path: str = "/tmp/hicache"
     ):
-        self.file_path = envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.get() or file_path
+        self.file_path = (
+            envs.SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR.get()
+            or (storage_config.extra_config or {}).get("file_storage_path")
+            or file_path
+        )
 
         tp_rank, tp_size, pp_rank, pp_size, model_name, is_mla_model = (
             storage_config.tp_rank,

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -134,6 +134,9 @@ class HiRadixCache(RadixCache):
         ) = self._parse_storage_backend_extra_config(
             server_args.hicache_storage_backend_extra_config
         )
+        if server_args.file_storage_path:
+            extra_config = dict(extra_config or {})
+            extra_config.setdefault("file_storage_path", server_args.file_storage_path)
         # TODO: support more timeout check functions
         self.is_prefetch_timeout = self._prefetch_timeout_check_linear_func
         self.prefetch_stop_policy = server_args.hicache_storage_prefetch_policy

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -137,6 +137,9 @@ class HiRadixCache(RadixCache):
         ) = self._parse_storage_backend_extra_config(
             get_memory().hicache_storage_backend_extra_config
         )
+        if server_args.file_storage_path:
+            extra_config = dict(extra_config or {})
+            extra_config.setdefault("file_storage_path", server_args.file_storage_path)
         # TODO: support more timeout check functions
         self.is_prefetch_timeout = self._prefetch_timeout_check_linear_func
         self.prefetch_stop_policy = get_memory().hicache_storage_prefetch_policy

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -345,6 +345,11 @@ class UnifiedRadixCache(BasePrefixCache):
             ) = HybridCacheController.parse_storage_backend_extra_config(
                 server_args.hicache_storage_backend_extra_config
             )
+            if server_args.file_storage_path:
+                storage_extra_config = dict(storage_extra_config or {})
+                storage_extra_config.setdefault(
+                    "file_storage_path", server_args.file_storage_path
+                )
 
         attach_hybrid_pool_to_unified_cache(
             self,

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -419,6 +419,11 @@ class UnifiedRadixCache(BasePrefixCache):
             ) = HybridCacheController.parse_storage_backend_extra_config(
                 get_memory().hicache_storage_backend_extra_config
             )
+            if server_args.file_storage_path:
+                storage_extra_config = dict(storage_extra_config or {})
+                storage_extra_config.setdefault(
+                    "file_storage_path", server_args.file_storage_path
+                )
 
         attach_hybrid_pool_to_unified_cache(
             self,

--- a/test/registered/unit/mem_cache/test_hicache_file_storage_path_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_storage_path_unit.py
@@ -72,7 +72,9 @@ class TestFileStoragePathRouting(CustomTestCase):
 
     def test_set_flag_is_routed(self):
         extra = _inject("/mnt/nvme/hicache")
-        self.assertEqual(HiCacheFile(_make_config(extra)).file_path, "/mnt/nvme/hicache")
+        self.assertEqual(
+            HiCacheFile(_make_config(extra)).file_path, "/mnt/nvme/hicache"
+        )
 
     def test_env_var_wins_over_flag(self):
         os.environ[_ENV] = "/env/hicache"

--- a/test/registered/unit/mem_cache/test_hicache_file_storage_path_unit.py
+++ b/test/registered/unit/mem_cache/test_hicache_file_storage_path_unit.py
@@ -1,0 +1,84 @@
+"""
+Unit test for --file-storage-path routing to the file HiCache backend, plus the
+regression guard that an UNSET flag keeps HiCacheFile on its /tmp/hicache default
+instead of routing the arg's default value into the backend.
+
+Pure CPU test; no server, no CUDA.
+Run with:
+    python3 -m pytest test/registered/unit/mem_cache/test_hicache_file_storage_path_unit.py -v
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+import dataclasses
+import os
+import unittest
+
+from sglang.srt.mem_cache.hicache_storage import HiCacheFile, HiCacheStorageConfig
+from sglang.srt.server_args import ServerArgs
+from sglang.test.test_utils import CustomTestCase
+
+_ENV = "SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR"
+
+
+def _make_config(extra_config):
+    # tp_rank=1 so HiCacheFile does not create the storage dir as a side effect.
+    return HiCacheStorageConfig(
+        tp_rank=1,
+        tp_size=1,
+        pp_rank=0,
+        pp_size=1,
+        attn_cp_rank=0,
+        attn_cp_size=1,
+        is_mla_model=True,
+        enable_storage_metrics=False,
+        is_page_first_layout=True,
+        model_name="testmodel",
+        extra_config=extra_config,
+    )
+
+
+def _inject(file_storage_path, extra_config=None):
+    # Mirrors the HiRadixCache / UnifiedRadixCache routing: only route the arg
+    # when it is set, so an unset (default) value is left out of extra_config.
+    extra_config = dict(extra_config or {})
+    if file_storage_path:
+        extra_config.setdefault("file_storage_path", file_storage_path)
+    return extra_config
+
+
+class TestFileStoragePathRouting(CustomTestCase):
+    def setUp(self):
+        self._saved = os.environ.pop(_ENV, None)
+
+    def tearDown(self):
+        if self._saved is not None:
+            os.environ[_ENV] = self._saved
+        else:
+            os.environ.pop(_ENV, None)
+
+    def test_arg_default_is_unset(self):
+        # If the default were a real path, an unset flag would silently reroute the
+        # backend off its /tmp/hicache default, so keep it None.
+        field = {f.name: f for f in dataclasses.fields(ServerArgs)}["file_storage_path"]
+        self.assertIsNone(field.default)
+
+    def test_unset_flag_keeps_tmp_hicache(self):
+        extra = _inject(None)
+        self.assertNotIn("file_storage_path", extra)
+        self.assertEqual(HiCacheFile(_make_config(extra)).file_path, "/tmp/hicache")
+
+    def test_set_flag_is_routed(self):
+        extra = _inject("/mnt/nvme/hicache")
+        self.assertEqual(HiCacheFile(_make_config(extra)).file_path, "/mnt/nvme/hicache")
+
+    def test_env_var_wins_over_flag(self):
+        os.environ[_ENV] = "/env/hicache"
+        extra = _inject("/mnt/nvme/hicache")
+        self.assertEqual(HiCacheFile(_make_config(extra)).file_path, "/env/hicache")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`--file-storage-path` is parsed into `server_args.file_storage_path` but nothing reads it. The `file` HiCache storage backend (`HiCacheFile`) only looks at the `SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR` env var and otherwise falls back to `/tmp/hicache`, so the flag is silently ignored and L3 lands in `/tmp` no matter what you pass. On a box where `/tmp` is tmpfs or a small partition that is either a surprise (the tier is much smaller than intended) or it fills the wrong disk.

Repro: launch with `--hicache-storage-backend file --file-storage-path /mnt/nvme/hicache` and no env var. The backend writes under `/tmp/hicache`, not `/mnt/nvme/hicache`.

Fix: route the arg to the backend through the shared storage `extra_config`, which every pool-assembler path already threads into `HiCacheStorageConfig` (the plain `HiCacheController` path and the DSA/hybrid `build_anchor_sidecar_stack` path both carry it). `HiCacheFile` then prefers, in order: the env var, `--file-storage-path`, then the `/tmp/hicache` default. I used `extra_config` rather than a first-class field because the DSA path builds the storage config inside the pool assembler, not in the plain controller branch, and `extra_config` is the one thing all of those paths already pass down. Three files, and nothing changes when the flag is unset (still `/tmp/hicache`) or when the env var is set (still wins).

Validation on GLM-5.2-FP8 (TP8, DSA pool, `file` backend, env var unset):
- With `--file-storage-path <dir>`: L3 wrote to `<dir>` (26882 `.bin` files, 81 GB) and `/tmp/hicache` stayed empty.
- Flag unset and env unset: still resolves to `/tmp/hicache` (no regression).
- Env var set: still takes precedence over the flag.
- Evicted-prefix reload still served from the tier at cache_frac 0.9996 and returns the correct output: a passphrase embedded in the cached prefix comes back byte-identical on the reload, the resident hit, and a cold recompute.

`HiCacheFile` resolution was also checked in isolation: flag set -> the flag path, flag unset -> `/tmp/hicache`, env var set -> the env path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35755929619](https://github.com/sgl-project/sglang/actions/runs/35755929619)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35755929237](https://github.com/sgl-project/sglang/actions/runs/35755929237)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:hourglass_flowing_sand: [Run #35755929785](https://github.com/sgl-project/sglang/actions/runs/35755929785)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->