### PR TITLE
[diffusion] Enable breakable CUDA graph for LTX-2 (H200 two-stage e2e 10.75 s -> 6.90 s, 1.56x)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
+++ b/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
@@ -236,7 +236,10 @@ class BaseBreakableCudaGraphRunner:
         self._blocked: set[tuple] = set()
         self._disabled_reason: str | None = None
         self.max_entries = max(0, _env_int("SGLANG_DIFFUSION_BCG_MAX_ENTRIES", 32))
-        self.max_segments = max(0, _env_int("SGLANG_DIFFUSION_BCG_MAX_SEGMENTS", 128))
+        # LTX-2 dual-tower blocks carry 6 attention break points each
+        # (video/audio self, video/audio prompt-cross, a2v, v2a), so 48 blocks
+        # capture ~289 segments; keep headroom above that.
+        self.max_segments = max(0, _env_int("SGLANG_DIFFUSION_BCG_MAX_SEGMENTS", 512))
 
     def __getattr__(self, name: str) -> Any:
         # Only reached for attributes the runner itself does not define; proxy
@@ -306,11 +309,40 @@ class BaseBreakableCudaGraphRunner:
         entry = self.entries.get(key)
         if entry is None:
             if not self._should_capture_on_call(key):
+                self._log_signature_miss(key)
                 return self.transformer(**kwargs)
             if not self.capture(**kwargs):
                 return self.transformer(**kwargs)
             entry = self.entries[key]
         return self.replay(entry, kwargs)
+
+    def _log_signature_miss(self, key: tuple) -> None:
+        """One-shot diagnostic: serving signature missed every captured graph."""
+        if getattr(self, "_miss_logged", False) or not self.entries:
+            return
+        self._miss_logged = True
+        key_d = dict(key)
+        logger.warning(
+            "[Diffusion BCG] serving signature MISSED %d captured graph(s); "
+            "running eager.",
+            len(self.entries),
+        )
+        for captured_key in self.entries:
+            cap_d = dict(captured_key)
+            names = sorted(set(key_d) | set(cap_d))
+            diffs = [
+                (
+                    n,
+                    _signature_summary_leaf(key_d.get(n, "<absent>")),
+                    _signature_summary_leaf(cap_d.get(n, "<absent>")),
+                )
+                for n in names
+                if key_d.get(n, "<absent>") != cap_d.get(n, "<absent>")
+            ]
+            logger.warning(
+                "[Diffusion BCG]   differing fields (serving vs captured): %s",
+                diffs[:8],
+            )
 
     def replay(self, entry: _CaptureEntry, kwargs: dict[str, Any]) -> Any:
         live_leaves = _flatten_kwargs(kwargs)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/denoising.py
@@ -1169,6 +1169,28 @@ class LTX2DenoisingStage(DenoisingStage):
                 audio_latent_model_input,
                 num_frames=audio_num_frames_latent,
             )
+            if server_args.enable_breakable_cuda_graph:
+                # The in-model RoPE coordinate construction builds host
+                # tensors (torch.tensor(list, device=cuda)), which is an
+                # unpinned H2D copy and therefore illegal inside CUDA graph
+                # capture. Build the coords outside the captured region with
+                # the exact same rope helpers (start_frame=0 == the sp<=1
+                # in-model path), so values are bit-identical.
+                if video_coords is None:
+                    video_coords = step.current_model.rope.prepare_video_coords(
+                        batch_size=int(latent_model_input.shape[0]),
+                        num_frames=ctx.latent_num_frames_for_model,
+                        height=ctx.latent_height,
+                        width=ctx.latent_width,
+                        device=latent_model_input.device,
+                        fps=batch.fps,
+                    )
+                if audio_coords is None:
+                    audio_coords = step.current_model.audio_rope.prepare_audio_coords(
+                        batch_size=int(audio_latent_model_input.shape[0]),
+                        num_frames=audio_num_frames_latent,
+                        device=audio_latent_model_input.device,
+                    )
 
         batch_size = int(latent_model_input.shape[0])
         use_raw_sigma_timestep = ctx.use_ltx23_hq_timestep_semantics
@@ -1469,6 +1491,28 @@ class LTX2DenoisingStage(DenoisingStage):
             ):
                 yield
 
+    def _ltx2_call_current_model(
+        self,
+        ctx: "LTX2DenoisingContext",
+        step: DenoisingStepState,
+        model_kwargs: dict,
+    ):
+        """Run the LTX-2 DiT forward, replaying a breakable CUDA graph when
+        one is captured for this input signature.
+
+        LTX-2 builds its model kwargs locally instead of going through the
+        generic ``predict_noise`` path, so BCG must be routed here. Capture is
+        driven explicitly from the warmup request (``ctx.is_warmup``); LTX-2
+        tokenizes prompts to a fixed max length, so every serving request
+        shares the warmup signatures and no text bucketing is needed.
+        """
+        runner = self._maybe_get_bcg_runner(step.current_model)
+        if runner is None:
+            return step.current_model(**model_kwargs)
+        if ctx.is_warmup:
+            runner.capture(**model_kwargs)
+        return runner(**model_kwargs)
+
     def _prepare_denoising_loop(
         self,
         batch: Req,
@@ -1752,7 +1796,9 @@ class LTX2DenoisingStage(DenoisingStage):
                         )
 
             with self._ltx2_model_forward_context(ctx, step):
-                model_video, model_audio = step.current_model(**model_kwargs)
+                model_video, model_audio = self._ltx2_call_current_model(
+                    ctx, step, model_kwargs
+                )
 
             model_video = model_video.float()
             model_audio = model_audio.float()
@@ -1848,7 +1894,9 @@ class LTX2DenoisingStage(DenoisingStage):
                                 )
 
                         with self._ltx2_model_forward_context(ctx, step):
-                            mid_v, mid_a = step.current_model(**model_kwargs_local)
+                            mid_v, mid_a = self._ltx2_call_current_model(
+                                ctx, step, model_kwargs_local
+                            )
 
                         mid_v = mid_v.float()
                         mid_a = mid_a.float()

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -139,6 +139,8 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
         "ideogram-v4-instant",
         "ideogram-ai/ideogram-4-fp8",
         "ideogram-ai/ideogram-4-nf4",
+        "lightricks/ltx-2",
+        "ltx-2",
         "minimax-h3",
         "minimaxai/minimax-h3",
         "qwen/qwen-image",
@@ -157,6 +159,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS = frozenset(
     {
         "GlmImagePipelineConfig",
         "Ideogram4PipelineConfig",
+        "LTX2PipelineConfig",
         "MiniMaxH3PipelineConfig",
         "QwenImagePipelineConfig",
         "ZImagePipelineConfig",
@@ -529,7 +532,7 @@ class ServerArgs(DisaggServerArgsMixin):
             return
 
         logger.warning(
-            "[Diffusion BCG] disabled for %s: only Ideogram-4, MiniMax-H3, "
+            "[Diffusion BCG] disabled for %s: only Ideogram-4, Lightricks/LTX-2, MiniMax-H3, "
             "Qwen/Qwen-Image, Qwen/Qwen-Image-2512, "
             "Tongyi-MAI/Z-Image/Z-Image-Turbo, and zai-org/GLM-Image are "
             "currently supported.",

--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -240,6 +240,13 @@ def _resolve_warmup_num_frames(
         # use default num frames
         return num_frames
 
+    # Breakable CUDA graph replays only exact latent shapes: the warmup
+    # request must run the full serving frame count so its captured graphs
+    # match serving signatures (mirrors the uncapped-steps rule in
+    # _resolve_warmup_steps).
+    if getattr(server_args, "enable_breakable_cuda_graph", False) is True:
+        return num_frames
+
     return min(num_frames, SERVER_WARMUP_MAX_VIDEO_FRAMES)
 
 
@@ -298,6 +305,14 @@ def should_include_warmup_image(
         return False
     if task_type.requires_image_input():
         return True
+    if getattr(server_args, "enable_breakable_cuda_graph", False) is True:
+        # BCG replays only exact input signatures. A synthetic warmup image
+        # flips optional-TI2V pipelines (e.g. LTX-2) into image-conditioned
+        # kwargs (denoise-mask -> per-token timestep) that pure T2V serving
+        # never produces, so every T2V request would miss the captured
+        # graphs and silently run eager. Capture the T2V signature instead;
+        # image-conditioned requests fall back to eager.
+        return False
     if type(server_args.pipeline_config).__name__ == "GlmImagePipelineConfig":
         return False
     if server_based_warmup:


### PR DESCRIPTION
## Motivation

LTX-2 two-stage (768x512x121f, 2-GPU cfg-parallel) on H200 is launch/dispatch-bound:
under the current whole-model `torch.compile` serving config the steady denoise step
runs 194 ms at only ~56% GPU busy. `--enable-breakable-cuda-graph` (BCG) is built
exactly for this — capture the eager kernel stream once at warmup, replay it per step —
but it currently cannot run on LTX-2. This PR closes the six gaps that blocked it.

## What was broken

1. **Allowlist** (`server_args.py`): `LTX2PipelineConfig` / `Lightricks/LTX-2` were not
   on the BCG allowlist, so the flag silently self-disabled.
2. **Warmup frame cap** (`warmup_request_builder.py`): server-based warmup caps video
   warmup at 17 frames. BCG replays only exact latent shapes, so the warmup request must
   run the full serving frame count (this mirrors the existing BCG uncapped-steps rule).
3. **Warmup image** (`warmup_request_builder.py`): the synthetic warmup image flips
   optional-TI2V pipelines (LTX-2) into image-conditioned kwargs (denoise-mask →
   per-token timestep `(1, seq)` instead of `(1,)`), a signature pure-T2V serving never
   produces — every request silently ran eager. Skip the optional warmup image under BCG;
   TI2V requests fall back to eager (documented).
4. **Model-call routing** (`ltx_2/denoising.py`): LTX-2 builds model kwargs locally and
   calls `step.current_model(...)` directly, bypassing the generic `predict_noise` BCG
   hook. Route the official-CFG and res2s-midpoint call sites through the BCG runner
   (capture driven by `ctx.is_warmup`; LTX-2 pads prompts to a fixed tokenizer length,
   so no text bucketing is needed).
5. **Capture-illegal H2D copies** (`ltx_2/denoising.py`): the in-model RoPE coordinate
   build uses `torch.tensor(list, device=cuda)` — an unpinned host→device copy that is
   illegal inside graph capture. Build the coords outside the captured region with the
   exact same rope helpers (bit-identical values).
6. **Segment cap** (`breakable_cuda_graph/runner.py`): the default
   `SGLANG_DIFFUSION_BCG_MAX_SEGMENTS=128` is below LTX-2's dual-tower reality
   (48 blocks x 6 attention break points = 289 segments). Raise the default to 512.

Plus a one-shot diagnostic: when a serving signature misses every captured graph, the
runner now logs a warning with a per-field diff. The silent eager fallback (gaps 3/5)
produces correct outputs and no error — just no speedup — and was otherwise almost
undetectable.

## Performance (H200, nightly ltx2 workload, 9 back-to-back requests, drop-first median)

| serving config | median e2e | steady stage-1 step |
|---|---|---|
| `--enable-torch-compile` (nightly today) | 10.745 s | ~194 ms |
| eager | 8.538 s | ~148 ms |
| `--enable-breakable-cuda-graph --warmup-resolutions 768x512` | **6.893 s (1.56x)** | **103 ms** |

3-step profiler window: CPU kernel-launch API calls 22,020 → 2,472 (+1,156
`cudaGraphLaunch`); GPU busy fraction of the profiled window 29% → 95%.
Startup: warmup captures at the full serving shape (40 steps); time-to-first-output
still improves (~174 s → ~130 s) because serving replays from request 0.

### Benchmark command

Each arm = one fresh process, 9 back-to-back generations of the nightly ltx2
workload, first dropped, median of the rest (client wall-clock). The driver
loops `DiffGenerator.generate()` with exactly the `sglang generate` CLI args:

```bash
# common workload (all arms)
python driver.py --num-requests 9 -- \
  --model-path Lightricks/LTX-2 \
  --pipeline-class-name=LTX2TwoStagePipeline \
  --prompt "A cat and a dog baking a cake together in a kitchen." \
  --width=768 --height=512 --num-frames=121 \
  --num-gpus=2 --enable-cfg-parallel --seed 42 \
  ${ARM_EXTRA}

# arm A (nightly today):   ARM_EXTRA="--enable-torch-compile"
# arm B (eager):           ARM_EXTRA=""
# arm C (this PR):         ARM_EXTRA="--enable-breakable-cuda-graph --warmup-mode server --warmup-resolutions 768x512"
```

`performance_mode=auto` (default) throughout; 2x H200, `CUDA_VISIBLE_DEVICES` pinned,
fresh `TORCHINDUCTOR_CACHE_DIR` per arm so compile-arm caching is not shared.

### Resolution scaling (applicability domain)

Same three arms at 1920x1088x121f (the `LTX23HQSamplingParams` default; 1080
rounds up to 1088 for the 64-pixel constraint):

| serving config | 768x512 e2e | 1920x1088 e2e | 1920x1088 GPU busy |
|---|---|---|---|
| `--enable-torch-compile` | 10.745 s | **32.705 s (fastest)** | 96.6% |
| eager | 8.538 s | 34.670 s | 96.8% |
| BCG (this PR) | **6.893 s (fastest)** | 34.746 s (+0.2% vs eager) | 97.9% |

At 1080p the workload is compute-bound (eager GPU busy is already 96.8%), so
there is no exposed launch gap left for graph replay to remove — BCG still
works correctly (capture succeeds first try, launches drop 22,020 -> 2,472,
outputs stay md5-identical to eager 9/9, no OOM at ~102 GB peak) but the CPU
time it saves no longer converts to e2e. Inductor's kernel fusion (-12.8% real
GPU work) becomes the winning lever instead. Practical guidance: BCG for
small/medium dispatch-bound resolutions, compile for 1080p-class compute-bound
runs; the two flags target disjoint regimes.

## Serving mode: prompt-length matrix (does a different prompt length re-capture?)

**No — capture happens only at warmup; serving never captures.** LTX-2 tokenizes every
prompt with `padding="max_length", max_length=1024` (`configs/pipeline_configs/ltx_2.py`),
so the DiT always sees `encoder_hidden_states (1, 1024, 3840)` and the BCG signature has
no prompt-length dimension: one warmup request captures **3 graphs x 289 segments**
(two-stage towers), and every serving prompt length replays them.

Real HTTP server (`serve` entrypoint, `POST /v1/videos`), H200 x2 cfg-parallel,
768x512x121f, seed 42, 3 requests/tier, medians:

| prompt tier | eager server e2e (s) | BCG server e2e (s) | delta | capture evidence |
|---|---|---|---|---|
| short (5 words) | 10.05 | 8.39 | **-16.5%** | replay |
| medium (33 words) | 9.82 | 8.30 | **-15.5%** | replay |
| long (126 words) | 10.80 | 8.45 | **-21.8%** | replay |
| xlong (702 words, ~900 tok, near the 1024 cap) | 10.04 | 8.04 | **-19.9%** | replay |

Server-log evidence: all 3 graphs captured before "The server is fired up"; serving-phase
captures = **0** across all 12 requests; `serving signature MISSED` warnings = **0**;
all 12 BCG mp4s **md5-identical** to the eager server's (same seed). Per-step:
stage-1 0.153 -> 0.103 s/step (-33%), stage-2 0.472 -> 0.431 s/step (-9%).

Profiler comparison (5 profiled timesteps, rank 0; eager span is inflated by profiler
overhead — steady-state numbers are in the table):

![ltx2 serving profiler](https://github.com/BBuf/sglang/releases/download/assets-bcg-serving/ltx2_bcg_vs_eager_timeline.png)

eager: GPU busy 27.9%, 21,918 runtime launches; BCG: GPU busy 96.2%, 4,854 launches.

<details>
<summary>Serving commands</summary>

```bash
# server (eager arm; BCG arm adds --enable-breakable-cuda-graph)
python3 -m sglang.multimodal_gen.runtime.entrypoints.cli.main serve \
  --model-path Lightricks/LTX-2 --pipeline-class-name LTX2TwoStagePipeline \
  --num-gpus 2 --enable-cfg-parallel --host 127.0.0.1 --port 31300 \
  --warmup-resolutions 768x512

# client: POST /v1/videos {"prompt", "size": "768x512", "num_frames": 121, "seed": 42},
# poll GET /v1/videos/{id}, download /v1/videos/{id}/content;
# 4 prompt tiers x 3 requests (5 / 33 / 126 / 702 words)
```
</details>

## Correctness

- BCG output is **bit-exact vs eager**: identical mp4 md5 across all 9 requests and
  across sessions (the BCG design contract).
- vs whole-compile: PSNR 18.6 dB — the same magnitude as whole-compile vs itself
  across sessions (compile kernel-selection nondeterminism), i.e. within the
  pipeline's existing band; eager/BCG are the *more* deterministic configs.

## Scope / limitations

- Graphs replay only for the exact declared `--warmup-resolutions` + frame count and
  prompt-length bucket; anything else runs eager (never captures during serving).
- Image-conditioned (TI2V) LTX-2 requests run eager under this PR; capturing the TI2V
  signature needs a warmup request per conditioning variant (follow-up).
- Numbers above are H200 (sm90). B200/sm100 re-validation pending before changing any
  sm100-facing preset docs.

## Test

- 9-request A/B/A runs + md5/PSNR checks (server started with the nightly ltx2
  workload flags per arm; drop-first median of the remaining 8, client wall-clock).
- Existing BCG unit tests (`test_diffusion_bcg_padding.py`, zimage single test) are
  unaffected; the runner change is a default bump + a log line.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31170787723](https://github.com/sgl-project/sglang/actions/runs/31170787723)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31170787525](https://github.com/sgl-project/sglang/actions/runs/31170787525)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
