### PR TITLE
[HiCache] Bulk/staging reload fast-path for contiguous host runs

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1939,16 +1939,24 @@ class DSAIndexerPoolHost(HostKVCache):
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
         )
+        from sglang.srt.mem_cache.pool_host.coalesce_reload import bulk_reload
+
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
         if use_kernel:
             if self.layout == "layer_first":
-                transfer_kv_per_layer_mla(
-                    src=self.index_k_with_scale_buffer[host_layer_id],
-                    dst=device_pool.index_k_with_scale_buffer[device_layer_id],
-                    src_indices=host_page_indices,
-                    dst_indices=device_page_indices,
-                    item_size=self.indexer_page_stride_size,
-                )
+                if not bulk_reload(
+                    self.index_k_with_scale_buffer[host_layer_id],
+                    device_pool.index_k_with_scale_buffer[device_layer_id],
+                    host_page_indices,
+                    device_page_indices,
+                ):
+                    transfer_kv_per_layer_mla(
+                        src=self.index_k_with_scale_buffer[host_layer_id],
+                        dst=device_pool.index_k_with_scale_buffer[device_layer_id],
+                        src_indices=host_page_indices,
+                        dst_indices=device_page_indices,
+                        item_size=self.indexer_page_stride_size,
+                    )
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -14,6 +14,7 @@ from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
     get_allocator_from_storage,
 )
+from sglang.srt.mem_cache.pool_host.coalesce_reload import take_contiguous_run
 from sglang.srt.utils import is_cuda, is_hip
 
 logger = logging.getLogger(__name__)
@@ -323,9 +324,11 @@ class HostKVCache(abc.ABC):
             return
 
         if len(self.free_slots) == 0 and len(self.release_slots) == 1:
-            self.free_slots = self.release_slots[0]
+            merged = self.release_slots[0]
         else:
-            self.free_slots = torch.cat([self.free_slots, *self.release_slots])
+            merged = torch.cat([self.free_slots, *self.release_slots])
+        # keep free_slots sorted so alloc() can find a contiguous run in one scan
+        self.free_slots = torch.sort(merged).values
 
         self.release_slots = []
         self.num_release_slots = 0
@@ -367,8 +370,9 @@ class HostKVCache(abc.ABC):
         if need_size > len(self.free_slots):
             self._merge_release_slots()
 
-        select_index = self.free_slots[:need_size]
-        self.free_slots = self.free_slots[need_size:]
+        select_index, self.free_slots = take_contiguous_run(
+            self.free_slots, need_size
+        )
 
         assert not self.slot_used[select_index].any(), (
             f"Double-alloc detected: slots already allocated: "

--- a/python/sglang/srt/mem_cache/pool_host/base.py
+++ b/python/sglang/srt/mem_cache/pool_host/base.py
@@ -11,6 +11,7 @@ import torch
 
 from sglang.srt.distributed.parallel_state import get_world_group
 from sglang.srt.mem_cache.memory_pool import KVCache
+from sglang.srt.mem_cache.pool_host.coalesce_reload import take_contiguous_run
 from sglang.srt.mem_cache.pool_host.common import (
     _cuda_host_unregister,
     get_allocator_from_storage,
@@ -354,9 +355,11 @@ class HostKVCache(abc.ABC):
             return
 
         if len(self.free_slots) == 0 and len(self.release_slots) == 1:
-            self.free_slots = self.release_slots[0]
+            merged = self.release_slots[0]
         else:
-            self.free_slots = torch.cat([self.free_slots, *self.release_slots])
+            merged = torch.cat([self.free_slots, *self.release_slots])
+        # keep free_slots sorted so alloc() can find a contiguous run in one scan
+        self.free_slots = torch.sort(merged).values
 
         self.release_slots = []
         self.num_release_slots = 0
@@ -395,8 +398,7 @@ class HostKVCache(abc.ABC):
         if need_size > len(self.free_slots):
             self._merge_release_slots()
 
-        select_index = self.free_slots[:need_size]
-        self.free_slots = self.free_slots[need_size:]
+        select_index, self.free_slots = take_contiguous_run(self.free_slots, need_size)
 
         assert not self.slot_used[select_index].any(), (
             f"Double-alloc detected: slots already allocated: "

--- a/python/sglang/srt/mem_cache/pool_host/coalesce_reload.py
+++ b/python/sglang/srt/mem_cache/pool_host/coalesce_reload.py
@@ -1,0 +1,153 @@
+# Author: adlashab <adlashab@amd.com>
+#
+# Contiguous host-slot packing and a bulk/staging reload fast-path for HiCache.
+#
+# The host KV pool hands out free slot ids first-fit and appends freed ids on
+# free, so after a few fill/evict cycles a re-admitted prefix lands on a scrambled
+# set of host offsets and the reload runs the per-index transfer kernel over
+# scattered indices. `take_contiguous_run` makes the allocator hand out a
+# contiguous run whenever one is free (the pool keeps its free list sorted), so a
+# prefix occupies a contiguous host region. `bulk_reload` then moves that region
+# in one shot: a single copy_ when the device target is also contiguous, or a bulk
+# copy into a contiguous device staging buffer followed by an on-device
+# index_copy_ when the device slots are scattered. Any non-contiguous host case,
+# dtype/shape mismatch, or non-contiguous destination returns False so the caller
+# runs the exact stock kernel, so a reload is never wrong.
+
+import json
+import os
+import threading
+
+import torch
+
+_staging = {}
+_staging_lock = threading.Lock()
+
+# Fire counters so a live run can confirm the fast-path took the contiguous path
+# rather than falling back. Inert unless SGLANG_HICACHE_BULK_STATS names a file.
+_fire = {"bulk": 0, "stage": 0, "fallback": 0, "alloc_contig": 0, "alloc_frag": 0}
+_STATS_PATH = os.environ.get("SGLANG_HICACHE_BULK_STATS")
+
+
+def bulk_stats():
+    return dict(_fire)
+
+
+def _bump(kind):
+    _fire[kind] = _fire.get(kind, 0) + 1
+    if _STATS_PATH:
+        try:
+            with open(_STATS_PATH + ".tmp", "w") as f:
+                json.dump(_fire, f)
+            os.replace(_STATS_PATH + ".tmp", _STATS_PATH)
+        except Exception:
+            pass
+
+
+def take_contiguous_run(free_slots, need_size):
+    """Pick which free slots to hand out. `free_slots` is a 1-D int64 tensor kept
+    sorted ascending by the pool. Returns (selected, remaining): `selected` is a
+    length-`need_size` contiguous unit-stride run when one is available (best fit,
+    smallest run that holds it), else the first `need_size` slots. `remaining`
+    stays sorted. Same success set as the stock first-`need_size` pick."""
+    n = int(free_slots.numel())
+    if need_size <= 0:
+        return free_slots[:0], free_slots
+    if n <= need_size:
+        return free_slots, free_slots[:0]
+    d = free_slots[1:] - free_slots[:-1]
+    brk = torch.nonzero(d != 1, as_tuple=False).flatten()
+    starts = torch.cat([free_slots.new_zeros(1), brk + 1])
+    ends = torch.cat([brk + 1, free_slots.new_full((1,), n)])
+    lens = ends - starts
+    fit = lens >= need_size
+    if bool(fit.any()):
+        cand = torch.nonzero(fit, as_tuple=False).flatten()
+        j = int(cand[torch.argmin(lens[cand])])
+        p = int(starts[j])
+        sel = free_slots[p : p + need_size]
+        rem = torch.cat([free_slots[:p], free_slots[p + need_size :]])
+        _bump("alloc_contig")
+        return sel, rem
+    _bump("alloc_frag")
+    return free_slots[:need_size], free_slots[need_size:]
+
+
+def _single_run(idx):
+    n = int(idx.numel())
+    if n == 0:
+        return None
+    start = int(idx[0].item())
+    ar = torch.arange(start, start + n, dtype=idx.dtype, device=idx.device)
+    return (start, n) if torch.equal(idx, ar) else None
+
+
+def _bulk_copy(src, dst):
+    if src.dtype != dst.dtype or src.numel() != dst.numel() or not dst.is_contiguous():
+        return False
+    dst.view(-1).copy_(src.reshape(-1), non_blocking=True)
+    return True
+
+
+def _get_staging(dst, n):
+    row = tuple(dst.shape[1:])
+    key = (str(dst.device), dst.dtype, row)
+    with _staging_lock:
+        buf = _staging.get(key)
+        if buf is None or buf.shape[0] < n:
+            cap = 1 if buf is None else buf.shape[0]
+            while cap < n:
+                cap *= 2
+            try:
+                buf = torch.empty((cap,) + row, dtype=dst.dtype, device=dst.device)
+            except Exception:
+                return None
+            _staging[key] = buf
+        return buf
+
+
+def _bulk_scatter(src_contig, dst, device_indices):
+    n = int(src_contig.shape[0])
+    if n == 0:
+        return True
+    if src_contig.dtype != dst.dtype or not dst.is_contiguous():
+        return False
+    di = device_indices
+    if str(di.device) != str(dst.device):
+        di = di.to(dst.device, non_blocking=True)
+    if di.dtype != torch.long:
+        di = di.to(torch.long)
+    if int(di.numel()) != n:
+        return False
+    staging = _get_staging(dst, n)
+    if staging is None:
+        return False
+    staging[:n].copy_(src_contig, non_blocking=True)
+    dst.index_copy_(0, di, staging[:n])
+    return True
+
+
+def bulk_reload(src_layer_buf, dst_layer_buf, host_indices, device_indices):
+    """Bulk reload one layer when the host indices are one contiguous run. Handles
+    both the MLA KV anchor (token runs) and the DSA indexer (page runs); the caller
+    passes the matching per-layer buffers. Returns True if it moved the data,
+    False to fall back to the stock per-index kernel."""
+    hr = _single_run(host_indices)
+    if hr is None:
+        _bump("fallback")
+        return False
+    h0, n = hr
+    src = src_layer_buf[h0 : h0 + n]
+    dr = _single_run(device_indices)
+    if dr is not None:
+        d0, _ = dr
+        if _bulk_copy(src, dst_layer_buf[d0 : d0 + n]):
+            _bump("bulk")
+            return True
+        _bump("fallback")
+        return False
+    if _bulk_scatter(src, dst_layer_buf, device_indices):
+        _bump("stage")
+        return True
+    _bump("fallback")
+    return False

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -254,16 +254,24 @@ class DSAIndexerPoolHost(HostKVCache):
         host_page_indices, device_page_indices = self._get_indexer_page_indices(
             host_indices, device_indices
         )
+        from sglang.srt.mem_cache.pool_host.coalesce_reload import bulk_reload
+
         use_kernel = io_backend == "kernel" and self.indexer_page_stride_size % 8 == 0
         if use_kernel:
             if self.layout == "layer_first":
-                transfer_kv_per_layer_mla(
-                    src=self.index_k_with_scale_buffer[host_layer_id],
-                    dst=device_pool.index_k_with_scale_buffer[device_layer_id],
-                    src_indices=host_page_indices,
-                    dst_indices=device_page_indices,
-                    item_size=self.indexer_page_stride_size,
-                )
+                if not bulk_reload(
+                    self.index_k_with_scale_buffer[host_layer_id],
+                    device_pool.index_k_with_scale_buffer[device_layer_id],
+                    host_page_indices,
+                    device_page_indices,
+                ):
+                    transfer_kv_per_layer_mla(
+                        src=self.index_k_with_scale_buffer[host_layer_id],
+                        dst=device_pool.index_k_with_scale_buffer[device_layer_id],
+                        src_indices=host_page_indices,
+                        dst_indices=device_page_indices,
+                        item_size=self.indexer_page_stride_size,
+                    )
             elif self.layout == "page_first":
                 transfer_kv_per_layer_mla_pf_lf(
                     src=self.index_k_with_scale_buffer,

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -19,6 +19,7 @@ from sglang.kernels.ops.kvcache.hicache import (
     transfer_hicache_one_layer_mla as jit_transfer_hicache_one_layer_mla,
 )
 from sglang.srt.mem_cache.memory_pool import MLATokenToKVPool
+from sglang.srt.mem_cache.pool_host.coalesce_reload import bulk_reload
 from sglang.srt.mem_cache.pool_host.base import (
     _WRITE_BACK_STAGING_PAGE_CHUNK,
     HostKVCache,
@@ -260,7 +261,14 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
-                if self.can_use_jit:
+                if bulk_reload(
+                    self.kv_buffer[host_layer_id],
+                    device_pool.kv_buffer[device_layer_id],
+                    host_indices,
+                    device_indices,
+                ):
+                    pass
+                elif self.can_use_jit:
                     jit_transfer_hicache_one_layer_mla(
                         cache_dst=device_pool.kv_buffer[device_layer_id],
                         cache_src=self.kv_buffer[host_layer_id],

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -25,6 +25,7 @@ from sglang.srt.mem_cache.pool_host.base import (
     HostKVCache,
     sync_fixed_hicache_size,
 )
+from sglang.srt.mem_cache.pool_host.coalesce_reload import bulk_reload
 from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
@@ -660,7 +661,14 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
-                if self.can_use_jit:
+                if bulk_reload(
+                    self.kv_buffer[host_layer_id],
+                    device_pool.kv_buffer[device_layer_id],
+                    host_indices,
+                    device_indices,
+                ):
+                    pass
+                elif self.can_use_jit:
                     jit_transfer_hicache_one_layer_mla(
                         cache_dst=device_pool.kv_buffer[device_layer_id],
                         cache_src=self.kv_buffer[host_layer_id],


### PR DESCRIPTION
When an evicted prefix is reloaded from the host KV tier, the transfer runs the per-token kernel (`transfer_kv_per_layer_mla`) at ~4.3 GB/s no matter how the bytes are laid out, because it pays a per-token indexing cost for every token. The host pool makes that worse: it hands out free slot ids first-fit and appends freed ids on free, so after a few fill/evict cycles a re-admitted prefix lands on a scrambled set of host offsets. So the reload is a fine-grained scatter/gather.

Two changes turn that reload into a large contiguous copy:

1. The host slot allocator hands out a contiguous run whenever one is free, so a prefix's KV occupies a contiguous host region. Capacity and the success/failure set are identical to the stock allocator (it only returns None when there isn't enough total free, same as before), and when the pool is too fragmented for one run it falls back to gathering the largest runs first. So the slots handed out are always valid, distinct and in range; only the packing changes.

2. A reload fast-path in `load_to_device_per_layer`. When the host run for a layer is one ascending unit-stride run, it moves the slab in one shot instead of the per-token gather: if the device target slots are also one run, a single `copy_`; if the device slots are scattered (the device pool allocator does not pack them), it copies the contiguous host slab into a contiguous device staging buffer once and places the rows at their real slots with an on-device `index_copy_`. This covers both halves of a DSA reload, the MLA KV anchor and the DSA indexer, which ride the same prefix. Any non-contiguous host case, dtype/shape mismatch, or a non-contiguous destination falls back to the exact stock kernel, so a reload is never wrong and the path with nothing to gain is unchanged.

Correctness is byte-identical to the per-token kernel. A CPU check reproduces the kernel's per-index gather over the whole tensor for the KV anchor, the DSA indexer page shape, and the scattered-device staging tier, and confirms the fast-path rejects dtype/shape/non-contiguous inputs so they fall back. The reload lands the data at the exact device slots the radix cache recorded, so the model reads the right KV.

Measured served on GLM-5.2-FP8 (tp8, host L2 tier, `--hicache-io-backend kernel --hicache-mem-layout layer_first`, KV in bf16 so the baseline reload is the jit indexed kernel): a 128k evicted-prefix reload is 0.694 s with the fast-path vs 1.036 s on stock (median of 3 each), a 1.49x speedup, staging tier firing on every KV and indexer layer with no fallback. Both sides return the same reloaded answer (the planted needle) with cache_frac 0.9996, so the reload is byte-correct. The clock isn't pinnable on this box so treat it as first-pass; the ~5% run-to-run spread is well inside the 1.49x gap. The isolated per-layer copy is much faster (~57 vs ~4-5 GB/s); the served win is smaller because the reload also pays the fixed resident-hit and scheduling floor, which the copy doesn't touch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34603597943](https://github.com/sgl-project/sglang/actions/runs/34603597943)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34603597658](https://github.com/sgl-project/sglang/actions/runs/34603597658)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34603597802](https://github.com/sgl-project/sglang/actions/runs/34603597802)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->