### PR TITLE
Warn once when decode batch exceeds the largest captured CUDA graph shape

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1592,6 +1592,27 @@ class ModelRunner:
         forward_batch.mamba_cow_src_indices = None
         forward_batch.mamba_cow_dst_indices = None
 
+    def _maybe_warn_decode_cuda_graph_overflow(
+        self, batch_size: int, max_bs: int
+    ) -> None:
+        if getattr(self, "_warned_decode_cuda_graph_overflow", False):
+            return
+
+        if batch_size <= max_bs:
+            return
+
+        logger.warning(
+            "Decode batch size %d exceeds the largest captured CUDA graph "
+            "shape (%d); falling back to eager decode. Per-token latency may "
+            "degrade substantially, and sustained overload can keep the "
+            "running batch above the captured range. Consider raising "
+            "--cuda-graph-max-bs or lowering --max-running-requests toward "
+            "the largest captured shape.",
+            batch_size,
+            max_bs,
+        )
+        self._warned_decode_cuda_graph_overflow = True
+
     def _forward_raw(
         self,
         forward_batch: ForwardBatch,
@@ -1634,20 +1655,11 @@ class ModelRunner:
             if (
                 forward_batch.forward_mode.is_decode()
                 and self.decode_cuda_graph_runner is not None
-                and forward_batch.batch_size > self.decode_cuda_graph_runner.max_bs
-                and not getattr(self, "_warned_decode_cuda_graph_overflow", False)
             ):
-                logger.warning(
-                    "Decode batch size %d exceeds the largest captured CUDA "
-                    "graph shape (%d); falling back to eager decode. Per-token "
-                    "latency may degrade substantially, and sustained overload "
-                    "can keep the running batch above the captured range. "
-                    "Consider raising --cuda-graph-max-bs or lowering "
-                    "--max-running-requests toward the largest captured shape.",
+                self._maybe_warn_decode_cuda_graph_overflow(
                     forward_batch.batch_size,
                     self.decode_cuda_graph_runner.max_bs,
                 )
-                self._warned_decode_cuda_graph_overflow = True
 
             # DP / MLP-sync padding + attn-tp normalization. Only the decode
             # cuda-graph path above pre-pads its static buffers and returns

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1631,6 +1631,24 @@ class ModelRunner:
                 )
                 return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
 
+            if (
+                forward_batch.forward_mode.is_decode()
+                and self.decode_cuda_graph_runner is not None
+                and forward_batch.batch_size > self.decode_cuda_graph_runner.max_bs
+                and not getattr(self, "_warned_decode_cuda_graph_overflow", False)
+            ):
+                logger.warning(
+                    "Decode batch size %d exceeds the largest captured CUDA "
+                    "graph shape (%d); falling back to eager decode. Per-token "
+                    "latency may degrade substantially, and sustained overload "
+                    "can keep the running batch above the captured range. "
+                    "Consider raising --cuda-graph-max-bs or lowering "
+                    "--max-running-requests toward the largest captured shape.",
+                    forward_batch.batch_size,
+                    self.decode_cuda_graph_runner.max_bs,
+                )
+                self._warned_decode_cuda_graph_overflow = True
+
             # DP / MLP-sync padding + attn-tp normalization. Only the decode
             # cuda-graph path above pre-pads its static buffers and returns
             # early; split prefill, the prefill cuda graph, and the eager

--- a/test/registered/unit/model_executor/test_model_runner.py
+++ b/test/registered/unit/model_executor/test_model_runner.py
@@ -1,0 +1,39 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+
+class TestDecodeCudaGraphOverflowWarning(unittest.TestCase):
+    def test_warns_once_on_overflow(self):
+        runner = SimpleNamespace()
+
+        with self.assertLogs(
+            "sglang.srt.model_executor.model_runner", level="WARNING"
+        ) as logs:
+            ModelRunner._maybe_warn_decode_cuda_graph_overflow(runner, 44, 32)
+            ModelRunner._maybe_warn_decode_cuda_graph_overflow(runner, 51, 32)
+
+        matching = [
+            message
+            for message in logs.output
+            if "largest captured CUDA graph shape" in message
+        ]
+        self.assertEqual(len(matching), 1)
+        self.assertIn("44", matching[0])
+        self.assertIn("32", matching[0])
+
+    def test_does_not_warn_within_capture_range(self):
+        runner = SimpleNamespace()
+
+        with self.assertNoLogs(
+            "sglang.srt.model_executor.model_runner", level="WARNING"
+        ):
+            ModelRunner._maybe_warn_decode_cuda_graph_overflow(runner, 32, 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Falling off the end of the captured CUDA graph shapes is currently silent. When the decode batch exceeds the largest captured shape, decode falls back to eager execution; on a small model this is roughly a 4x per-token latency increase. Because arrivals are admitted directly into the running batch, the slowdown feeds back into the batch size via Little's law and the system settles into a second stable operating point — across 46 observed transitions, none recovered within the run.

This is reachable with default settings. On an L40 at tp=1, `cuda_graph_max_bs` defaults to 32 while `max_running_requests` defaults to 4096, so the scheduler can admit far more concurrent requests than the fast path was captured for. See #33483 for the full measurements and controls.

Today an operator has no signal that this happened. Throughput looks normal, `#queue-req` stays at 0, and median TPOT can still read clean if the transition occurs late in the workload. This PR makes the moment visible.

## Modifications

Adds a one-time warning when the decode batch first exceeds the largest captured CUDA graph shape, naming both values and the two flags that control them.

- `<model_runner.py>`: emit the warning at the point where the batch is found to exceed the largest captured shape, guarded by a boolean on the runner so it fires at most once per server lifetime.
- No behaviour change. No change to scheduling, capture, or execution.

Example output:

```
WARNING: decode batch size 44 exceeds the largest captured CUDA graph shape (32); falling back to eager decode. Per-token latency can degrade substantially and may not recover. Consider raising --cuda-graph-max-bs or lowering
--max-running-requests toward the largest captured shape.
```

## Accuracy Tests

Not applicable — this PR adds a log statement only. No kernel, model forward, sampling, or scheduling code is touched, so model outputs are bit-identical.

## Speed Tests and Profiling

**Impact of this PR: none.** The added code is a boolean check on a path that is already off the CUDA graph fast path, and after the first trigger the branch short-circuits on the guard flag. No hot-path cost.

**Measurements motivating the change** (L40, Qwen2.5-0.5B-Instruct, tp=1, ShareGPT at 31 req/s, n=2000, default settings unless noted; full methodology and controls in #33483):

| | default (ceiling 32) | `--max-running-requests 32` | `--cuda-graph-max-bs 128` |
|---|---|---|---|
| throughput req/s | 28.9 | 30.2 | 30.4 |
| median TTFT ms | 23.5 | 15.1 | 14.9 |
| P99 TTFT ms | 317 | 242 | 65 |
| median TPOT ms | 12.7 | 3.26 | 3.25 |
| runs that fell back | 19/20 | 0/3 | 0/9 |

With the default ceiling, 19 of 20 runs at identical configuration transitioned, at a median of 17 s (range 5.0–55.8 s), and none recovered. Per-token latency after the transition was 12.1–12.8 ms against 3.0 ms before.

## Checklist

- [x] Format your code according to Format code with pre-commit
- [x] Add unit tests according to Run and add unit tests
- [x] Update documentation according to Write documentations
- [x] Provide accuracy and speed benchmark results
- [x] Follow the SGLang code style guidance
