### PR TITLE
test: add unit tests for SchedulePolicy sorting methods

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -418,7 +418,7 @@ class SchedulePolicy:
     def _sort_by_priority_and_fcfs(
         waiting_queue: List[Req], priority_sign: int
     ) -> None:
-        """Sorts the waiting queue based on the request priority then received titmestamp."""
+        """Sorts the waiting queue based on the request priority then received timestamp."""
         waiting_queue.sort(
             key=lambda x: (
                 x.priority * priority_sign,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -439,7 +439,7 @@ class SchedulePolicy:
     def _sort_by_priority_and_fcfs(
         waiting_queue: List[Req], priority_sign: int
     ) -> None:
-        """Sorts the waiting queue based on the request priority then received titmestamp."""
+        """Sorts the waiting queue based on the request priority then received timestamp."""
         waiting_queue.sort(
             key=lambda x: (
                 x.priority * priority_sign,

--- a/test/registered/unit/managers/test_schedule_policy.py
+++ b/test/registered/unit/managers/test_schedule_policy.py
@@ -1,0 +1,165 @@
+"""Unit tests for SchedulePolicy sorting helpers.
+
+Covers the static sorting methods in ``schedule_policy.py`` that decide the
+ordering of the waiting queue. They are pure functions over a list of Req-like
+objects, so we test them in isolation without a server or GPU.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.schedule_policy import SchedulePolicy
+
+
+def make_req(
+    rid,
+    prefix_len=0,
+    max_new_tokens=16,
+    priority=0,
+    entry_time=0.0,
+    routing_key=None,
+):
+    """Build a lightweight Req-like object with only the fields touched by sorting."""
+    return SimpleNamespace(
+        rid=rid,
+        prefix_indices=list(range(prefix_len)),
+        sampling_params=SimpleNamespace(max_new_tokens=max_new_tokens),
+        priority=priority,
+        time_stats=SimpleNamespace(wait_queue_entry_time=entry_time),
+        routing_key=routing_key,
+    )
+
+
+class TestSortByLongestPrefix(unittest.TestCase):
+    def test_longer_prefix_scheduled_first(self):
+        q = [
+            make_req("a", prefix_len=3),
+            make_req("b", prefix_len=10),
+            make_req("c", prefix_len=0),
+        ]
+        SchedulePolicy._sort_by_longest_prefix(q, set())
+        self.assertEqual([r.rid for r in q], ["b", "a", "c"])
+
+    def test_deprioritized_requests_go_last(self):
+        # "a" has the longest prefix but is deprioritized -> must go last.
+        q = [make_req("a", prefix_len=10), make_req("b", prefix_len=2)]
+        SchedulePolicy._sort_by_longest_prefix(q, {"a"})
+        self.assertEqual([r.rid for r in q], ["b", "a"])
+
+    def test_empty_queue_is_noop(self):
+        q = []
+        SchedulePolicy._sort_by_longest_prefix(q, set())
+        self.assertEqual(q, [])
+
+    def test_equal_key_preserves_original_order(self):
+        # Python's sort is stable; equal keys keep arrival order.
+        q = [make_req("a", prefix_len=0), make_req("b", prefix_len=0)]
+        SchedulePolicy._sort_by_longest_prefix(q, set())
+        self.assertEqual([r.rid for r in q], ["a", "b"])
+
+
+class TestSortByLongestOutput(unittest.TestCase):
+    def test_longer_output_first_without_priority(self):
+        q = [
+            make_req("a", max_new_tokens=5),
+            make_req("b", max_new_tokens=50),
+            make_req("c", max_new_tokens=10),
+        ]
+        SchedulePolicy._sort_by_longest_output(
+            q, enable_priority_scheduling=False, priority_sign=-1
+        )
+        self.assertEqual([r.rid for r in q], ["b", "c", "a"])
+
+    def test_priority_dominates_then_output_length(self):
+        # priority_sign=-1 (default) -> higher priority value first.
+        q = [
+            make_req("a", priority=1, max_new_tokens=100),
+            make_req("b", priority=5, max_new_tokens=10),
+            make_req("c", priority=5, max_new_tokens=20),
+        ]
+        SchedulePolicy._sort_by_longest_output(
+            q, enable_priority_scheduling=True, priority_sign=-1
+        )
+        # priority-5 group first (ordered by longer output: c then b), then a.
+        self.assertEqual([r.rid for r in q], ["c", "b", "a"])
+
+    def test_low_priority_values_first_when_sign_flipped(self):
+        # priority_sign=1 -> lower priority value first.
+        q = [
+            make_req("a", priority=5, max_new_tokens=10),
+            make_req("b", priority=1, max_new_tokens=10),
+        ]
+        SchedulePolicy._sort_by_longest_output(
+            q, enable_priority_scheduling=True, priority_sign=1
+        )
+        self.assertEqual([r.rid for r in q], ["b", "a"])
+
+
+class TestSortByPriorityAndFcfs(unittest.TestCase):
+    def test_higher_priority_value_first(self):
+        # priority_sign=-1 (default) -> higher priority scheduled first.
+        q = [
+            make_req("a", priority=1, entry_time=0.0),
+            make_req("b", priority=9, entry_time=0.0),
+            make_req("c", priority=5, entry_time=0.0),
+        ]
+        SchedulePolicy._sort_by_priority_and_fcfs(q, priority_sign=-1)
+        self.assertEqual([r.rid for r in q], ["b", "c", "a"])
+
+    def test_fcfs_breaks_ties_on_equal_priority(self):
+        # same priority -> earlier wait_queue_entry_time first.
+        q = [
+            make_req("a", priority=1, entry_time=3.0),
+            make_req("b", priority=1, entry_time=1.0),
+            make_req("c", priority=1, entry_time=2.0),
+        ]
+        SchedulePolicy._sort_by_priority_and_fcfs(q, priority_sign=-1)
+        self.assertEqual([r.rid for r in q], ["b", "c", "a"])
+
+    def test_low_priority_values_first_when_sign_flipped(self):
+        # priority_sign=1 -> lower priority value first.
+        q = [
+            make_req("a", priority=9, entry_time=0.0),
+            make_req("b", priority=1, entry_time=0.0),
+        ]
+        SchedulePolicy._sort_by_priority_and_fcfs(q, priority_sign=1)
+        self.assertEqual([r.rid for r in q], ["b", "a"])
+
+
+class TestSortByRoutingKey(unittest.TestCase):
+    def _running_batch(self, keys):
+        return SimpleNamespace(reqs=[SimpleNamespace(routing_key=k) for k in keys])
+
+    def test_high_frequency_matching_key_first(self):
+        running = self._running_batch(["k1", "k1", "k1", "k2"])
+        q = [
+            make_req("a", routing_key="k2"),
+            make_req("b", routing_key="k1"),
+            make_req("c", routing_key="kX"),
+        ]
+        SchedulePolicy._sort_by_routing_key(q, running)
+        # k1 (count 3) first, then k2 (count 1), then unmatched kX last.
+        self.assertEqual([r.rid for r in q], ["b", "a", "c"])
+
+    def test_no_usable_keys_in_running_is_noop(self):
+        # running batch has only falsy routing keys -> counter empty -> no sort.
+        running = self._running_batch([None, None])
+        q = [make_req("a", routing_key="k1"), make_req("b", routing_key="k2")]
+        SchedulePolicy._sort_by_routing_key(q, running)
+        self.assertEqual([r.rid for r in q], ["a", "b"])
+
+
+class TestSortRandomly(unittest.TestCase):
+    def test_shuffle_preserves_membership(self):
+        q = [make_req("a"), make_req("b"), make_req("c")]
+        SchedulePolicy._sort_randomly(q)
+        self.assertEqual(len(q), 3)
+        self.assertEqual({r.rid for r in q}, {"a", "b", "c"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_schedule_policy.py
+++ b/test/registered/unit/managers/test_schedule_policy.py
@@ -26,7 +26,9 @@ def make_req(
     """Build a lightweight Req-like object with only the fields touched by sorting."""
     return SimpleNamespace(
         rid=rid,
-        prefix_indices=list(range(prefix_len)),
+        # Total prefix tokens matched against the radix cache; this is what
+        # _sort_by_longest_prefix reads (not len(prefix_indices)).
+        num_matched_prefix_tokens=prefix_len,
         sampling_params=SimpleNamespace(max_new_tokens=max_new_tokens),
         priority=priority,
         time_stats=SimpleNamespace(wait_queue_entry_time=entry_time),

--- a/test/registered/unit/managers/test_schedule_policy.py
+++ b/test/registered/unit/managers/test_schedule_policy.py
@@ -13,6 +13,7 @@ import unittest
 from types import SimpleNamespace
 
 from sglang.srt.managers.schedule_policy import SchedulePolicy
+from sglang.test.test_utils import CustomTestCase
 
 
 def make_req(
@@ -36,7 +37,7 @@ def make_req(
     )
 
 
-class TestSortByLongestPrefix(unittest.TestCase):
+class TestSortByLongestPrefix(CustomTestCase):
     def test_longer_prefix_scheduled_first(self):
         q = [
             make_req("a", prefix_len=3),
@@ -64,7 +65,7 @@ class TestSortByLongestPrefix(unittest.TestCase):
         self.assertEqual([r.rid for r in q], ["a", "b"])
 
 
-class TestSortByLongestOutput(unittest.TestCase):
+class TestSortByLongestOutput(CustomTestCase):
     def test_longer_output_first_without_priority(self):
         q = [
             make_req("a", max_new_tokens=5),
@@ -101,7 +102,7 @@ class TestSortByLongestOutput(unittest.TestCase):
         self.assertEqual([r.rid for r in q], ["b", "a"])
 
 
-class TestSortByPriorityAndFcfs(unittest.TestCase):
+class TestSortByPriorityAndFcfs(CustomTestCase):
     def test_higher_priority_value_first(self):
         # priority_sign=-1 (default) -> higher priority scheduled first.
         q = [
@@ -132,7 +133,7 @@ class TestSortByPriorityAndFcfs(unittest.TestCase):
         self.assertEqual([r.rid for r in q], ["b", "a"])
 
 
-class TestSortByRoutingKey(unittest.TestCase):
+class TestSortByRoutingKey(CustomTestCase):
     def _running_batch(self, keys):
         return SimpleNamespace(reqs=[SimpleNamespace(routing_key=k) for k in keys])
 
@@ -155,7 +156,7 @@ class TestSortByRoutingKey(unittest.TestCase):
         self.assertEqual([r.rid for r in q], ["a", "b"])
 
 
-class TestSortRandomly(unittest.TestCase):
+class TestSortRandomly(CustomTestCase):
     def test_shuffle_preserves_membership(self):
         q = [make_req("a"), make_req("b"), make_req("c")]
         SchedulePolicy._sort_randomly(q)


### PR DESCRIPTION
## Motivation

The static sorting helpers in `managers/schedule_policy.py` (used by `calc_priority` to order the waiting queue) had **no unit-test coverage** — only `PrefillAdder` was tested (`test_prefill_adder.py`). These helpers sit on the scheduling critical path, so they warrant regression protection.

## Modifications

- Add `test/registered/unit/managers/test_schedule_policy.py` covering:
  - `_sort_by_longest_prefix` — longer prefix first, deprioritized requests go last, empty queue, stable tie-break.
  - `_sort_by_longest_output` — with/without priority scheduling; `priority_sign` both directions (`schedule_low_priority_values_first`).
  - `_sort_by_priority_and_fcfs` — priority ordering + FCFS tie-break on `wait_queue_entry_time`; both `priority_sign`.
  - `_sort_by_routing_key` — high-frequency matching key first; no-op when running batch has no usable keys.
  - `_sort_randomly` — membership preserved.
- Fix a typo `titmestamp` → `timestamp` in the docstring of `_sort_by_priority_and_fcfs`.
- Registered for CI via `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`.

## Testing

- Pure CPU unit tests; no server / GPU required.
- Assertions cross-checked against the actual sort-key expressions in `schedule_policy.py`.
- `ruff` (F401/F821), `black`, `codespell` pass locally on both changed files.

## Checklist

- [x] Code passes lint/format checks (ruff / black / codespell verified locally)
- [x] Tests added and registered for CI
- [x] No new dependencies

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32468278680](https://github.com/sgl-project/sglang/actions/runs/32468278680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32468278445](https://github.com/sgl-project/sglang/actions/runs/32468278445)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32468278764](https://github.com/sgl-project/sglang/actions/runs/32468278764)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->