### PR TITLE
[AMD][DI] Bound stalled MORI KV transfers

### DIFF
--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1515,6 +1515,10 @@ class MoriKVSender(CommonKVSender):
             ):
                 sla_tripped = True
                 self._finalize_failure(f"KV transfer exceeded SLA {sla_ms}ms")
+                # _finalize_failure terminalizes the request, but does not cancel
+                # IOEngine.wait_all. Return so this transfer worker is not leaked
+                # forever after the SLA has already decided the request failed.
+                return StatusCode.ERR_RDMA_OP
 
     def _fail_from_worker(self, reason: str) -> None:
         self._finalize_failure(reason)

--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -294,7 +294,11 @@ DSV4_ENV_STR="${DSV4_ENV[*]}"
 # A recipe carrying a `model:` block supplies its OWN docker env (below), so the
 # DSV4 env must not leak into it; the DSV4 recipes keep the string above.
 [[ "$HAS_MODEL" == "1" ]] && DSV4_ENV_STR=""
-MORI_ENV="-e MORI_DISABLE_AUTO_XGMI=1 -e NCCL_IB_HCA=ionic -e NCCL_IB_GID_INDEX=1 -e NCCL_CROSS_NIC=1"
+# Bound a lost MORI completion notification. Healthy MI355X transfers completed in
+# under 30s in instrumented runs; 300s gives 10x headroom while turning the
+# observed 2h30m SLURM_TIME_LIMIT hang into an explicit, actionable failure.
+# The MORI default remains unchanged for every caller outside this workflow.
+MORI_ENV="-e MORI_DISABLE_AUTO_XGMI=1 -e NCCL_IB_HCA=ionic -e NCCL_IB_GID_INDEX=1 -e NCCL_CROSS_NIC=1 -e SGLANG_MORI_TRANSFER_TIMEOUT_MS=300000"
 # Wide-EP (engine spans >1 node) adds mori all-to-all MoE tuning + the cross-node
 # torch-dist socket NIC. Gated on nodes-per-engine>1 so EP<=8 recipes are untouched.
 if (( PN_PER > 1 || DN_PER > 1 )); then


### PR DESCRIPTION
## Motivation

MI355X disagg nightly [run 31071106418](https://github.com/sgl-project/sglang/actions/runs/31071106418/job/92519092785) completed 1023/1024 requests at concurrency 256, then one PD request remained stuck for 2h08m until Slurm's 2h30m limit killed the allocation.

Runtime evidence showed prefill holding one request in `disagg_prefill_inflight_queue` while decode stayed healthy but made no further progress. This is the second observed tail-request hang: [R292 / bingxche/sglang-ci-bot#148](https://github.com/bingxche/sglang-ci-bot/issues/148) had the same 1023/1024 signature in July across a different DSV4 model/precision.

MORI's `_wait_chunk` polls `IOEngine.wait_all` forever while it returns `IN_PROGRESS`. A transfer SLA already exists, but:

1. `SGLANG_MORI_TRANSFER_TIMEOUT_MS` defaults to `0`, so it is disabled.
2. Even when configured and tripped, `_finalize_failure` terminalizes the request but `_wait_chunk` does not return, leaking that transfer worker forever.

## Modifications

- Enable a 300-second MORI transfer SLA in the MI355X Slurm launcher. Instrumented healthy transfers completed in under 30 seconds, so this provides 10x headroom while converting a 2h30m cluster hang into an explicit transfer failure.
- Return `StatusCode.ERR_RDMA_OP` after SLA terminalization so the worker exits instead of continuing to poll forever.

The global MORI default remains unchanged. Other MORI callers and NVIDIA paths are unaffected; only the MI355X CI launcher opts in.

## Verification

- [Healthy instrumented run 31128162002](https://github.com/sgl-project/sglang/actions/runs/31128162002): success; conc256 completed; no transfer exceeded 30s.
- [Healthy instrumented run 31129440564](https://github.com/sgl-project/sglang/actions/runs/31129440564): success; conc256 completed; no transfer exceeded 30s.
- [Deterministic timeout run 31134505729](https://github.com/sgl-project/sglang/actions/runs/31134505729): forced five transfers past the 300,000ms SLA. Every request emitted `KV transfer exceeded SLA 300000ms`, every worker logged `worker exits` and returned `ERR_RDMA_OP`, and the job failed in 10.5 minutes total rather than waiting for Slurm's limit.
- [Clean production-path run 31135697312](https://github.com/sgl-project/sglang/actions/runs/31135697312): success in ~22 minutes with the 300-second SLA enabled and no debug force hook.
- `py_compile` clean for the MORI module; `bash -n` clean for the launcher.

## Accuracy Tests

Unchanged. The clean verification passed the existing GSM8K gate and full performance sweep, including concurrency 256.

## Scope

This bounds the failure and prevents worker leakage; it does not claim to fix the underlying rare lost completion notification inside MORI/RDMA.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31137121349](https://github.com/sgl-project/sglang/actions/runs/31137121349)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31137121171](https://github.com/sgl-project/sglang/actions/runs/31137121171)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->