### PR TITLE
[diffusion] Exercise the default SP exchange in Z-Image CI

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -933,14 +933,12 @@ TWO_GPU_CASES = [
         "zimage_image_t2i_2_gpus",
         DiffusionServerArgs(
             model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
-            ulysses_degree=2,
         ),
     ),
     DiffusionTestCase(
         "zimage_image_t2i_2_gpus_non_square",
         DiffusionServerArgs(
             model_path=DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
-            ulysses_degree=2,
         ),
         DiffusionSamplingParams(
             prompt=T2I_sampling_params.prompt,


### PR DESCRIPTION
## Summary

- let the existing 2-GPU Z-Image cases use automatic parallel-strategy selection
- keep the square case as the performance guard for the shipped SP2 default
- keep the non-square case as the padding and distributed-sharding compatibility guard
- retain the existing explicitly configured Ulysses and Ring cases for backend compatibility coverage

## Test impact

No cases or requests are added, so the CI test count and model startup count stay unchanged.

## Validation

- pre-commit on `python/sglang/multimodal_gen/test/server/gpu_cases.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31142564620](https://github.com/sgl-project/sglang/actions/runs/31142564620)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31142564597](https://github.com/sgl-project/sglang/actions/runs/31142564597)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->