### PR TITLE
[Fix] Prevent PP deadlock during weight update group initialization

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -100,14 +100,7 @@ class SchedulerPPMixin:
                 next_mb_id = (mb_id + 1) % self.pp_loop_size
                 with torch.profiler.record_function("recv_requests"):
                     recv_reqs = self.request_receiver.recv_requests()
-                    self.process_input_requests(recv_reqs)
-                if not self.pp_group.is_last_rank:
-                    self._pp_commit_comm_work(self.send_req_work)
-                    with torch.profiler.record_function("send_reqs_to_next_stage"):
-                        self.send_req_work = self._pp_send_pyobj_to_next_stage(
-                            recv_reqs,
-                            async_send=True,
-                        )
+                self._pp_forward_and_process_input_requests(recv_reqs)
                 with torch.profiler.record_function("get_next_batch_to_run"):
                     plan = self.get_next_batch_to_run(
                         running_batch=self.running_batch, last_batch=self.last_batch
@@ -240,10 +233,7 @@ class SchedulerPPMixin:
                 next_batch_result = None
 
                 recv_reqs = self.request_receiver.recv_requests()
-                self.process_input_requests(recv_reqs)
-
-                if not self.pp_group.is_last_rank:
-                    self._pp_commit_comm_work(self.send_req_work)
+                self._pp_forward_and_process_input_requests(recv_reqs)
 
                 bootstrapped_rids = self._pp_pd_get_bootstrapped_ids()
                 bmbs[mb_id] = bootstrapped_rids
@@ -329,9 +319,6 @@ class SchedulerPPMixin:
                 if tmbs[next_mb_id] is not None:
                     self.process_disagg_prefill_inflight_queue(next_release_rids)
                 if not self.pp_group.is_last_rank:
-                    self.send_req_work = self._pp_send_pyobj_to_next_stage(
-                        recv_reqs, async_send=True
-                    )
                     send_bootstrapped_work = self._pp_send_pyobj_to_next_stage(
                         bootstrapped_rids, async_send=True
                     )
@@ -392,10 +379,7 @@ class SchedulerPPMixin:
                 next_batch_result = None
 
                 recv_reqs = self.request_receiver.recv_requests()
-                self.process_input_requests(recv_reqs)
-
-                if not self.pp_group.is_last_rank:
-                    self._pp_commit_comm_work(self.send_req_work)
+                self._pp_forward_and_process_input_requests(recv_reqs)
 
                 # reaching consensus through PP ranks
                 retract_rids = self._pp_pd_get_retract_ids(mb_id)
@@ -515,9 +499,6 @@ class SchedulerPPMixin:
                     self.last_mbs[next_mb_id] = self.mbs[next_mb_id]
 
                 if not self.pp_group.is_last_rank:
-                    self.send_req_work = self._pp_send_pyobj_to_next_stage(
-                        recv_reqs, async_send=True
-                    )
                     send_retract_work = self._pp_send_pyobj_to_next_stage(
                         retract_rids, async_send=True
                     )
@@ -555,6 +536,20 @@ class SchedulerPPMixin:
 
             if server_is_idle and queue_size == 0:
                 self.on_idle()
+
+    def _pp_forward_and_process_input_requests(
+        self: Scheduler, recv_reqs: List
+    ) -> None:
+        """Forward PP requests before running handlers that may block on peers."""
+        if not self.pp_group.is_last_rank:
+            self._pp_commit_comm_work(self.send_req_work)
+            with torch.profiler.record_function("send_reqs_to_next_stage"):
+                self.send_req_work = self._pp_send_pyobj_to_next_stage(
+                    recv_reqs,
+                    async_send=True,
+                )
+
+        self.process_input_requests(recv_reqs)
 
     def init_pp_loop_state(self: Scheduler):
         self.pp_loop_size: int = self.ps.pp_size + get_parallel().pp_async_batch_depth

--- a/test/registered/unit/managers/test_scheduler_pp_request_order.py
+++ b/test/registered/unit/managers/test_scheduler_pp_request_order.py
@@ -1,0 +1,76 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, call
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    InitWeightsUpdateGroupReqInput,
+)
+from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestSchedulerPPRequestOrder(CustomTestCase):
+    def test_forwards_weight_update_group_init_before_local_processing(self):
+        scheduler = SchedulerPPMixin()
+        scheduler.pp_group = SimpleNamespace(is_last_rank=False)
+        previous_send_work = ["previous-send"]
+        current_send_work = ["current-send"]
+        recv_reqs = [
+            InitWeightsUpdateGroupReqInput(
+                master_address="127.0.0.1",
+                master_port=12345,
+                rank_offset=0,
+                world_size=2,
+            )
+        ]
+        scheduler.send_req_work = previous_send_work
+
+        calls = Mock()
+        scheduler._pp_commit_comm_work = calls.commit
+        scheduler._pp_send_pyobj_to_next_stage = calls.forward
+        scheduler.process_input_requests = calls.process
+        calls.forward.return_value = current_send_work
+
+        scheduler._pp_forward_and_process_input_requests(recv_reqs)
+
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                call.commit(previous_send_work),
+                call.forward(recv_reqs, async_send=True),
+                call.process(recv_reqs),
+            ],
+        )
+        self.assertIs(scheduler.send_req_work, current_send_work)
+
+    def test_last_stage_only_processes_requests(self):
+        scheduler = SchedulerPPMixin()
+        scheduler.pp_group = SimpleNamespace(is_last_rank=True)
+        scheduler.send_req_work = []
+        recv_reqs = [
+            InitWeightsUpdateGroupReqInput(
+                master_address="127.0.0.1",
+                master_port=12345,
+                rank_offset=0,
+                world_size=2,
+            )
+        ]
+
+        calls = Mock()
+        scheduler._pp_commit_comm_work = calls.commit
+        scheduler._pp_send_pyobj_to_next_stage = calls.forward
+        scheduler.process_input_requests = calls.process
+
+        scheduler._pp_forward_and_process_input_requests(recv_reqs)
+
+        self.assertEqual(calls.mock_calls, [call.process(recv_reqs)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When pipeline parallelism is enabled (`pp_size > 1`), received control requests were processed locally before being forwarded to the next PP stage. `InitWeightsUpdateGroupReqInput` processing can block while initializing a process group and waiting for peer ranks. In that case, an upstream stage waits for downstream peers while those peers are still waiting to receive the initialization request, creating a circular wait.

## Modifications

- Forward received PP requests before running their local handlers.
- Share the ordering across the normal, disaggregated-prefill, and disaggregated-decode PP loops.
- Add CPU unit coverage for the forwarding order and the last-stage path using `InitWeightsUpdateGroupReqInput`.

## Accuracy Tests

Not applicable. This change only reorders control-plane request propagation and does not modify model computation or outputs.

## Speed Tests and Profiling

Not applicable. The existing asynchronous request send is preserved and starts earlier in the loop.

## Tests

- `pre-commit run --files python/sglang/srt/managers/scheduler_pp_mixin.py test/registered/unit/managers/test_scheduler_pp_request_order.py` — passed.
- `python -m py_compile python/sglang/srt/managers/scheduler_pp_mixin.py test/registered/unit/managers/test_scheduler_pp_request_order.py` — passed.
- Isolated execution of `_pp_forward_and_process_input_requests` for non-last and last PP stages — passed.
- The registered pytest was not run locally: the development host is Windows (missing the Unix `resource` module), and the available WSL environment does not have PyTorch/SGLang runtime dependencies. The new test is registered in `base-a-test-cpu` for CI.

## Checklist

- [x] Format the code with the repository's pre-commit hooks.
- [x] Add a regression unit test.
- [x] Documentation changes are not required for this internal scheduler ordering fix.
- [x] Accuracy and speed tests are not applicable, as explained above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31143599513](https://github.com/sgl-project/sglang/actions/runs/31143599513)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31143599445](https://github.com/sgl-project/sglang/actions/runs/31143599445)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->