### PR TITLE
[feat] Support DeepSeek-V4-Flash-0731 on sm89

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -71,7 +71,7 @@ from sglang.srt.speculative.ragged_verify import (
     resolve_ragged_verify_layout,
 )
 from sglang.srt.utils import ceil_align, is_cuda, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm120_supported, is_sm89_supported
 
 if TYPE_CHECKING:
     from sgl_kernel.flash_mla import FlashMLASchedMeta
@@ -81,6 +81,7 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 _is_sm120 = is_sm120_supported()
+_is_sm89 = is_sm89_supported()
 _is_cuda = is_cuda()
 _is_xpu = is_xpu()
 
@@ -136,7 +137,7 @@ def _pad_last_dim(x: T, multiples_of: int = PAGE_INDEX_ALIGNED_SIZE) -> T:
 
 
 def _create_flashmla_metadata():
-    if _is_sm120 or _is_xpu:
+    if _is_sm120 or _is_sm89 or _is_xpu:
         return None
     import sgl_kernel.flash_mla as flash_mla
 
@@ -1698,10 +1699,13 @@ class DeepseekV4AttnBackend(
                     extra_indices.shape[-1] % 64 == 0
                 ), f"{extra_indices.shape=}'s last dimension is not aligned to 64"
 
-            # sparse_prefill_fwd does not support SM120.
+            # sparse_prefill_fwd does not support SM120 or SM89 (Ada). On SM89
+            # the SM120 sparse-MLA decode kernel (Triton fallback via
+            # SGLANG_SM120_FLASHMLA_BACKEND=triton) handles both prefill and
+            # decode without requiring sgl_kernel.flash_mla_sparse_fwd.
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
-                and not _is_sm120
+                and not (_is_sm120 or _is_sm89)
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
@@ -1717,7 +1721,7 @@ class DeepseekV4AttnBackend(
                     attn_sink=attn_sink,
                 )
 
-            if _is_sm120:
+            if _is_sm120 or _is_sm89:
                 from sglang.kernels.ops.attention.flash_mla_sm120 import (
                     flash_mla_with_kvcache_sm120,
                 )

--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -43,7 +43,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
 from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
 from sglang.srt.utils import add_prefix, is_cuda, is_hip, is_xpu
-from sglang.srt.utils.common import is_sm120_supported
+from sglang.srt.utils.common import is_sm120_supported, is_sm89_supported
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
@@ -710,7 +710,7 @@ class C4IndexerBackendMixin:
         elif envs.SGLANG_OPT_USE_AITER_INDEXER.get():
             fn = _aiter_fp8_paged_mqa_logits
         elif envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.get():
-            if is_sm120_supported():
+            if is_sm120_supported() or is_sm89_supported():
                 fn = fp8_paged_mqa_logits_torch_sm120
             else:
                 fn = fp8_paged_mqa_logits_torch

--- a/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py
@@ -9,7 +9,11 @@ from torch.nn import Module
 from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
 from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import log_info_on_rank0, round_up, set_weight_attrs
-from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
+from sglang.srt.utils.common import (
+    is_sm89_supported,
+    is_sm90_supported,
+    is_sm120_supported,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import CombineInput, DispatchOutput
@@ -140,8 +144,14 @@ class Mxfp4MarlinMoEMethod:
         if getattr(layer, "_mega_moe_weights_built", False):
             return
 
-        if not is_sm90_supported() and not is_sm120_supported():
-            raise RuntimeError("MXFP4 Marlin requires SM90 or SM120.")
+        if (
+            not is_sm89_supported()
+            and not is_sm90_supported()
+            and not is_sm120_supported()
+        ):
+            raise RuntimeError(
+                "MXFP4 Marlin requires SM89 (Ada), SM90 (Hopper), or SM120 (Blackwell)."
+            )
 
         if not check_moe_marlin_supports_layer(layer, 32, allow_tile_padding=True):
             raise RuntimeError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -87,6 +87,7 @@ from sglang.srt.utils.common import (
     is_sm100_or_sm110_supported,
     is_sm100_supported,
     is_sm120_supported,
+    is_sm89_supported,
     is_xpu,
     json_list_type,
     nullable_str,
@@ -5308,6 +5309,16 @@ class ServerArgs:
                 envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
                 # Prefer TileLang over the Torch fallback.
                 envs.SGLANG_OPT_USE_TILELANG_INDEXER.set(True)
+            elif is_sm89_supported():
+                # SM89 (Ada / RTX 4090 / L4 / L40S / L20): same Hopper-only
+                # features unavailable as SM120. TileLang indexer is SM120-only,
+                # so leave it off; the Torch SM120 fallback handles multi-dim
+                # seq_lens via fp8_paged_mqa_logits_torch_sm120.
+                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+                envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+                envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
+                envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
+                envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
             elif is_hip():
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
                 envs.SGLANG_OPT_USE_FUSED_COMPRESS.set(True)

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -309,6 +309,15 @@ is_sm90_supported = lru_cache(maxsize=1)(
 )
 
 
+# Ada Lovelace (RTX 4090 / L4 / L40S / L20). Not expressible via
+# _check_cuda_device_version, which only matches on the major (8 would also
+# wrongly include Ampere SM80). Marlin W4A16 MoE only guards on
+# __CUDA_ARCH__ >= 800, so SM89 is eligible for the MXFP4 Marlin path.
+@lru_cache(maxsize=1)
+def is_sm89_supported() -> bool:
+    return is_cuda() and torch.cuda.get_device_capability() == (8, 9)
+
+
 # GB10 (DGX Spark and OEM equivalents). Not expressible via
 # _check_cuda_device_version, which only matches on the major.
 @lru_cache(maxsize=1)

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -1,5 +1,6 @@
 import unittest
 from array import array
+from unittest.mock import patch
 
 import torch
 
@@ -7,6 +8,7 @@ from sglang.srt.utils.common import (
     flatten_arrays_to_int64_tensor,
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
+    is_sm89_supported,
 )
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -142,6 +144,48 @@ class TestGetDeviceSmNvidiaSmi(CustomTestCase):
             self.assertEqual(get_device_sm_nvidia_smi(), (0, 0))
         finally:
             subprocess.run = original
+
+
+class TestIsSm89Supported(CustomTestCase):
+    """`is_sm89_supported` returns True only when CUDA is available, the
+    device capability is exactly (8, 9), and the CUDA runtime is >= 11.0.
+    The lru_cache means results stick across calls within a process, so each
+    test patches the underlying probes and clears the cache in setUp/tearDown.
+    Runs on CPU CI by mocking `is_cuda` and `torch.cuda.get_device_capability`.
+    """
+
+    def setUp(self):
+        is_sm89_supported.cache_clear()
+
+    def tearDown(self):
+        is_sm89_supported.cache_clear()
+
+    @patch("sglang.srt.utils.common.torch.version.cuda", "12.3")
+    @patch("sglang.srt.utils.common.torch.cuda.get_device_capability", return_value=(8, 9))
+    @patch("sglang.srt.utils.common.is_cuda", return_value=True)
+    def test_returns_true_on_sm89(self, _mock_is_cuda, _mock_cap):
+        self.assertTrue(is_sm89_supported())
+
+    @patch("sglang.srt.utils.common.torch.version.cuda", "12.3")
+    @patch("sglang.srt.utils.common.torch.cuda.get_device_capability", return_value=(9, 0))
+    @patch("sglang.srt.utils.common.is_cuda", return_value=True)
+    def test_returns_false_on_sm90(self, _mock_is_cuda, _mock_cap):
+        # SM90 must not be misreported as SM89 — a bare `major==8` check would
+        # wrongly accept SM80 (Ampere) too, which is exactly why this helper
+        # exists instead of reusing `_check_cuda_device_version`.
+        self.assertFalse(is_sm89_supported())
+
+    @patch("sglang.srt.utils.common.torch.version.cuda", "12.3")
+    @patch("sglang.srt.utils.common.torch.cuda.get_device_capability", return_value=(8, 0))
+    @patch("sglang.srt.utils.common.is_cuda", return_value=True)
+    def test_returns_false_on_sm80(self, _mock_is_cuda, _mock_cap):
+        # SM80 (Ampere) shares major=8 with SM89 but is not Ada Lovelace and
+        # lacks the FP8 throughput this gate ultimately guards.
+        self.assertFalse(is_sm89_supported())
+
+    @patch("sglang.srt.utils.common.is_cuda", return_value=False)
+    def test_returns_false_without_cuda(self, _mock_is_cuda):
+        self.assertFalse(is_sm89_supported())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
  SGLang's MXFP4 Marlin MoE path and DSV4 sparse MLA backend were gated to SM90 (Hopper) and SM120 (Blackwell), leaving Ada Lovelace GPUs (SM89 — RTX 4090 / L4 /L40S / L20) unable to run DeepSeek-V4-Flash via the W4A16 Marlin path. The only fallback on SM89 was load-time FP4→FP8 dequant, which materializes a full FP8 weight copy on every TP shard and OOMs at TP8 on a single 8× RTX 4090 (24 GB) node.

  This PR relaxes the software hardware-gate so SM89 takes the existing Marlin + Triton sparse MLA fallback path. No new kernels are introduced; we enable pre-existing code paths that the original authors restricted to SM90/SM120 purely for testing scope, not a hard hardware limitation. The underlying Marlin MoE kernel (moe_wna16_marlin.cuh) only guards on __CUDA_ARCH__ >= 800, and SM89 (8.9) passes that guard.

  Modifications

  Six files, +94 / −10 lines:

  - python/sglang/srt/utils/common.py (+9): Add is_sm89_supported() helper next to is_sm90_supported. Uses torch.cuda.get_device_capability() == (8, 9) rather than  _check_cuda_device_version because the major-only match would wrongly include Ampere SM80, which lacks the FP8 throughput this gate ultimately guards.
  - python/sglang/srt/layers/quantization/mxfp4_marlin_moe.py (+10/−2): Relax the Mxfp4MarlinMoEMethod.
  _build_mega_moe_weights gate from is_sm90_supported() OR is_sm120_supported() to also accept is_sm89_supported(). Update the import block and the RuntimeError message.
  - python/sglang/srt/layers/attention/deepseek_v4_backend.py (+9/−5): Cache _is_sm89 at module load; route SM89 through the same Triton-fallback path as SM120 — _create_flashmla_metadata returns None on SM89 (no compiled sgl_kernel.flash_mla), the sparse_prefill_fwd skip applies on SM89, and flash_mla_with_kvcache_sm120 is dispatched on SM89 the same way as SM120.
  - python/sglang/srt/layers/attention/dsv4/indexer.py (+2/−2): Enable fp8_paged_mqa_logits_torch_sm120 on SM89 in the C4IndexerBackendMixin logits fallback path (same multi-dim seq_lens handling as SM120).
  - python/sglang/srt/server_args.py (+11): Add an elif is_sm89_supported(): branch in ServerArgs._init_sm_specific_envs() mirroring the SM120 branch — disables Hopper-only flags (SGLANG_OPT_FP8_WO_A_GEMM, SGLANG_OPT_USE_TOPK_V2, SGLANG_OPT_USE_TILELANG_MHC_PRE, SGLANG_OPT_DEEPGEMM_HC_PRENORM) and enables SGLANG_FP8_PAGED_MQA_LOGITS_TORCH. TileLang indexer is left off because it is SM120-only.
  - test/registered/unit/utils/test_common.py (+50): Add TestIsSm89Supported with 4 cases — SM89 true, SM90 false, SM80 false (guards against the major==8 trap), no-CUDA false. Each test patches is_cuda and torch.cuda.get_device_capability and clears the lru_cache in setUp/tearDown.

  Accuracy Tests

  Hardware: 8 × RTX 4090 (24 GB, SM89), --tp-size 8 --moe-runner-backend marlin. CUDA graph capture bs=[1,2,4].

  - Smoke test (/generate): "What is 2 + 2? Answer with just the number." → "4" — numerically correct, no NaN / divergent output.
  - To verify numerical accuracy and functional correctness on SM89, we evaluated the model against the already-supported **RTX Pro 5000 (SM120)** baseline using identical datasets:

| Benchmark | Evaluation Setup | RTX 4090 (8× 24GB, SM89) | RTX Pro 5000 (SM120) | Parity |
| :--- | :--- | :---: | :---: | :---: |
| **GSM8K** | 5-shot, 200 questions | **98.0%** | **98.0%** | Exact Match ($\pm 0.0\%$) |
| **HellaSwag** | 20-shot, 200 questions | **77.0%** | **77.0%** | Exact Match ($\pm 0.0\%$) |


  Speed Tests and Profiling

  Hardware: 8 × RTX 4090 (24 GB, SM89), --tp-size 8 --moe-runner-backend marlin --cuda-graph-max-bs-decode 4 --mem-fraction-static 0.91, Triton sparse MLA via SGLANG_SM120_FLASHMLA_BACKEND=triton.

  - Single-concurrent decode (256 tokens): 11.38–12.42 tok/s
  - 4-concurrent decode aggregate (100 tokens): 21.7 tok/s (5.4 tok/s per request)
  - Memory: per-card weight 20.45 GB (Marlin keeps FP4 packed, no FP8 dequant copy), versus 22.88 GB for the FP4→FP8 dequant path which OOMs at TP8 on a single 8× 4090 node. KV pool 0.73 GB, CUDA graph 1.36 GB.

  SGLANG_SM120_FLASHMLA_BACKEND=triton \
  python3 -m sglang.launch_server \
    --model-path deepseek-ai/DeepSeek-V4-Flash-0731 \
    --tp-size 8 \
    --moe-runner-backend marlin \
    --host 0.0.0.0 --port 30000 \
    --mem-fraction-static 0.91 \
    --cuda-graph-max-bs-decode 4 \
    --max-running-requests 12 \
    --trust-remote-code

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31145732652](https://github.com/sgl-project/sglang/actions/runs/31145732652)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31145732474](https://github.com/sgl-project/sglang/actions/runs/31145732474)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->