### PR TITLE
[gateway] Add opt-in --source-label-header to record a source metric label

### DIFF
--- a/docs/docs/advanced_features/sgl_model_gateway.mdx
+++ b/docs/docs/advanced_features/sgl_model_gateway.mdx
@@ -2138,6 +2138,16 @@ Structured tracing with optional file sink. Log levels: `debug`, `info`, `warn`,
 
 Responses include `x-request-id` header for correlation.
 
+### Client Source Attribution
+
+```bash Command
+--source-label-header x-request-source
+```
+
+When set, `smg_router_requests_total` gains a `source` label carrying the sanitized header value. Values are limited to `[A-Za-z0-9._:-]`, 128 characters, and 2000 distinct values per process (the OpenTelemetry SDK's default cardinality limit), so a client cannot grow cardinality without bound. Missing, malformed or over-long values record `unknown`; values past the distinct-value limit record `overflow`. Disabled by default.
+
+The value is self-reported, so treat it as attribution rather than authentication. When callers are untrusted, have a trusted hop set the header, replacing rather than appending it.
+
 ***
 ## Production Recommendations
 

--- a/sgl-model-gateway/README.md
+++ b/sgl-model-gateway/README.md
@@ -800,6 +800,15 @@ Configure headers for request ID extraction:
 ```
 Responses include `x-request-id` header for correlation.
 
+### Client Source Attribution
+Optionally attribute router request metrics to callers via a client-declared header:
+```bash
+--source-label-header x-request-source
+```
+When set, `smg_router_requests_total` gains a `source` label carrying the sanitized header value. Values are limited to `[A-Za-z0-9._:-]`, 128 characters, and 2000 distinct values per process (the OpenTelemetry SDK's default cardinality limit), so a client cannot grow cardinality without bound. Missing, malformed or over-long values record `unknown`; values past the distinct-value limit record `overflow`. Disabled by default.
+
+The value is self-reported, so treat it as attribution rather than authentication. When callers are untrusted, have a trusted hop set the header, replacing rather than appending it.
+
 ### CORS
 Set `--cors-allowed-origins` for browser access.
 

--- a/sgl-model-gateway/bindings/python/src/lib.rs
+++ b/sgl-model-gateway/bindings/python/src/lib.rs
@@ -383,6 +383,7 @@ struct Router {
     request_timeout_secs: u64,
     shutdown_grace_period_secs: u64,
     request_id_headers: Option<Vec<String>>,
+    source_label_header: Option<String>,
     pd_disaggregation: bool,
     bucket_adjust_interval_secs: usize,
     prefill_urls: Option<Vec<(String, Option<u16>)>>,
@@ -636,6 +637,7 @@ impl Router {
             .maybe_log_dir(self.log_dir.as_ref())
             .maybe_log_level(self.log_level.as_ref())
             .maybe_request_id_headers(self.request_id_headers.clone())
+            .maybe_source_label_header(self.source_label_header.clone())
             .maybe_rate_limit_tokens_per_second(self.rate_limit_tokens_per_second)
             .maybe_model_path(self.model_path.as_ref())
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())
@@ -761,6 +763,7 @@ impl Router {
         pool_max_idle_per_host = 500,
         tcp_keepalive_secs = 30,
         enable_wasm = false,
+        source_label_header = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -853,6 +856,7 @@ impl Router {
         pool_max_idle_per_host: usize,
         tcp_keepalive_secs: u64,
         enable_wasm: bool,
+        source_label_header: Option<String>,
     ) -> PyResult<Self> {
         let mut all_urls = worker_urls.clone();
 
@@ -959,6 +963,7 @@ impl Router {
             pool_max_idle_per_host,
             tcp_keepalive_secs,
             enable_wasm,
+            source_label_header,
         })
     }
 

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router.py
@@ -204,6 +204,10 @@ class Router:
         request_id_headers: List of HTTP headers to check for request IDs. If not specified,
             uses common defaults: ['x-request-id', 'x-correlation-id', 'x-trace-id', 'request-id'].
             Example: ['x-my-request-id', 'x-custom-trace-id']. Default: None
+        source_label_header: HTTP header whose sanitized value is recorded as a `source`
+            label on `smg_router_requests_total`. Process-global: with several routers
+            in one process the first one configured wins.
+            Example: 'x-request-source'. Default: None
         bootstrap_port_annotation: Kubernetes annotation name for bootstrap port (PD mode).
             Default: 'sglang.ai/bootstrap-port'
         request_timeout_secs: Request timeout in seconds. Default: 600

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
@@ -84,6 +84,7 @@ class RouterArgs:
     prometheus_port: Optional[int] = None
     prometheus_host: Optional[str] = None
     prometheus_duration_buckets: Optional[List[float]] = None
+    source_label_header: Optional[str] = None
     # Request ID headers configuration
     request_id_headers: Optional[List[str]] = None
     # Request timeout in seconds
@@ -493,6 +494,12 @@ class RouterArgs:
             type=float,
             nargs="+",
             help="Buckets for Prometheus duration metrics",
+        )
+        prometheus_group.add_argument(
+            f"--{prefix}source-label-header",
+            type=str,
+            default=None,
+            help="HTTP request header whose sanitized value is recorded as a source label on smg_router_requests_total (e.g. x-request-source); disabled when not set",
         )
 
         # Request handling configuration

--- a/sgl-model-gateway/bindings/python/tests/test_arg_parser.py
+++ b/sgl-model-gateway/bindings/python/tests/test_arg_parser.py
@@ -605,6 +605,13 @@ class TestParseRouterArgs:
             "https://example.com",
         ]
 
+    def test_parse_source_label_header_arg(self):
+        """Test parsing the source label header argument."""
+        assert parse_router_args([]).source_label_header is None
+
+        router_args = parse_router_args(["--source-label-header", "x-request-source"])
+        assert router_args.source_label_header == "x-request-source"
+
     def test_parse_tokenizer_args(self):
         """Test parsing tokenizer arguments."""
         # Note: model-path and tokenizer-path arguments are not available in current implementation

--- a/sgl-model-gateway/src/config/builder.rs
+++ b/sgl-model-gateway/src/config/builder.rs
@@ -358,6 +358,11 @@ impl RouterConfigBuilder {
         self
     }
 
+    pub fn source_label_header<S: Into<String>>(mut self, header: S) -> Self {
+        self.config.source_label_header = Some(header.into());
+        self
+    }
+
     // ==================== IGW Mode ====================
 
     pub fn enable_igw(mut self) -> Self {
@@ -528,6 +533,11 @@ impl RouterConfigBuilder {
 
     pub fn maybe_request_id_headers(mut self, headers: Option<Vec<String>>) -> Self {
         self.config.request_id_headers = headers;
+        self
+    }
+
+    pub fn maybe_source_label_header(mut self, header: Option<impl Into<String>>) -> Self {
+        self.config.source_label_header = header.map(|h| h.into());
         self
     }
 
@@ -862,5 +872,25 @@ mod tests {
             }
             _ => panic!("Expected CacheAware policy"),
         }
+    }
+
+    #[test]
+    fn test_builder_source_label_header() {
+        let config = RouterConfigBuilder::new()
+            .regular_mode(vec!["http://worker1:8000".to_string()])
+            .source_label_header("x-request-source")
+            .build()
+            .unwrap();
+        assert_eq!(
+            config.source_label_header.as_deref(),
+            Some("x-request-source")
+        );
+
+        let config = RouterConfigBuilder::new()
+            .regular_mode(vec!["http://worker1:8000".to_string()])
+            .maybe_source_label_header(None::<String>)
+            .build()
+            .unwrap();
+        assert!(config.source_label_header.is_none());
     }
 }

--- a/sgl-model-gateway/src/config/types.rs
+++ b/sgl-model-gateway/src/config/types.rs
@@ -33,6 +33,7 @@ pub struct RouterConfig {
     pub log_dir: Option<String>,
     pub log_level: Option<String>,
     pub request_id_headers: Option<Vec<String>>,
+    pub source_label_header: Option<String>,
     #[serde(default = "default_pool_idle_timeout_secs")]
     pub pool_idle_timeout_secs: u64,
     #[serde(default = "default_connect_timeout_secs")]
@@ -521,6 +522,7 @@ impl Default for RouterConfig {
             log_dir: None,
             log_level: None,
             request_id_headers: None,
+            source_label_header: None,
             pool_idle_timeout_secs: default_pool_idle_timeout_secs(),
             connect_timeout_secs: default_connect_timeout_secs(),
             pool_max_idle_per_host: default_pool_max_idle_per_host(),
@@ -646,6 +648,7 @@ mod tests {
         assert!(config.trace_config.is_none());
         assert!(config.log_dir.is_none());
         assert!(config.log_level.is_none());
+        assert!(config.source_label_header.is_none());
         assert_eq!(
             config.pool_idle_timeout_secs,
             DEFAULT_POOL_IDLE_TIMEOUT_SECS

--- a/sgl-model-gateway/src/config/validation.rs
+++ b/sgl-model-gateway/src/config/validation.rs
@@ -321,6 +321,16 @@ impl ConfigValidator {
             });
         }
 
+        if let Some(header) = &config.source_label_header {
+            if header.parse::<http::HeaderName>().is_err() {
+                return Err(ConfigError::InvalidValue {
+                    field: "source_label_header".to_string(),
+                    value: header.clone(),
+                    reason: "Must be a valid HTTP header name".to_string(),
+                });
+            }
+        }
+
         if config.tcp_keepalive_secs == 0 {
             return Err(ConfigError::InvalidValue {
                 field: "tcp_keepalive_secs".to_string(),
@@ -711,6 +721,22 @@ mod tests {
             PolicyConfig::Random,
         );
 
+        assert!(ConfigValidator::validate(&config).is_err());
+    }
+
+    #[test]
+    fn test_validate_source_label_header() {
+        let mut config = RouterConfig::new(
+            RoutingMode::Regular {
+                worker_urls: vec!["http://worker:8000".to_string()],
+            },
+            PolicyConfig::Random,
+        );
+
+        config.source_label_header = Some("x-request-source".to_string());
+        assert!(ConfigValidator::validate(&config).is_ok());
+
+        config.source_label_header = Some("not a header name".to_string());
         assert!(ConfigValidator::validate(&config).is_err());
     }
 

--- a/sgl-model-gateway/src/main.rs
+++ b/sgl-model-gateway/src/main.rs
@@ -278,6 +278,10 @@ struct CliArgs {
     #[arg(long, num_args = 0.., help_heading = "Prometheus Metrics")]
     prometheus_duration_buckets: Vec<f64>,
 
+    /// Request header recorded as a `source` label on smg_router_requests_total
+    #[arg(long, help_heading = "Prometheus Metrics")]
+    source_label_header: Option<String>,
+
     // ==================== Request Handling ====================
     /// Custom HTTP headers to check for request IDs
     #[arg(long, num_args = 0.., help_heading = "Request Handling")]
@@ -1055,6 +1059,7 @@ impl CliArgs {
             .maybe_request_id_headers(
                 (!self.request_id_headers.is_empty()).then(|| self.request_id_headers.clone()),
             )
+            .maybe_source_label_header(self.source_label_header.as_ref())
             .maybe_rate_limit_tokens_per_second(self.rate_limit_tokens_per_second)
             .maybe_model_path(self.model_path.as_ref())
             .maybe_tokenizer_path(self.tokenizer_path.as_ref())

--- a/sgl-model-gateway/src/observability/metrics.rs
+++ b/sgl-model-gateway/src/observability/metrics.rs
@@ -1,11 +1,12 @@
 use std::{
     borrow::Cow,
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{Arc, OnceLock},
     time::Duration,
 };
 
 use dashmap::DashMap;
+use http::{HeaderMap, HeaderName};
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use once_cell::sync::Lazy;
@@ -49,6 +50,104 @@ pub(crate) fn intern_string(s: &str) -> Arc<str> {
 #[allow(dead_code)]
 pub(crate) fn interner_size() -> usize {
     STRING_INTERNER.len()
+}
+
+// =============================================================================
+// SOURCE LABEL
+// =============================================================================
+//
+// Optional `source` label derived from a configured request header. Unset (the
+// default) leaves the existing label set unchanged.
+
+/// Longer values are rejected rather than truncated: truncating would merge
+/// two callers sharing a prefix into one series.
+const SOURCE_LABEL_MAX_LEN: usize = 128;
+
+/// The value is client-supplied and no series is ever reclaimed, so the number
+/// of distinct values has to be bounded. Matches the OpenTelemetry SDK's
+/// default cardinality limit.
+const SOURCE_LABEL_MAX_DISTINCT: usize = 2000;
+
+/// Set from `--source-label-header`; unset disables the label.
+static SOURCE_LABEL_HEADER: OnceLock<HeaderName> = OnceLock::new();
+
+/// Kept separate from [`STRING_INTERNER`], whose other inputs are all
+/// operator-controlled, so a client cannot grow the shared interner.
+static SOURCE_INTERNER: Lazy<DashMap<String, Arc<str>>> = Lazy::new(DashMap::new);
+
+/// Shared so collapsing onto a sentinel neither spends a slot nor takes a
+/// write lock on every over-cap request.
+static SOURCE_UNKNOWN_LABEL: Lazy<Arc<str>> =
+    Lazy::new(|| Arc::from(metrics_labels::SOURCE_UNKNOWN));
+static SOURCE_OVERFLOW_LABEL: Lazy<Arc<str>> =
+    Lazy::new(|| Arc::from(metrics_labels::SOURCE_OVERFLOW));
+
+/// Returns `false` if a *different* header is already active: the metrics
+/// recorder is process-global, so the first router in the process wins.
+#[must_use]
+pub fn set_source_label_header(header: HeaderName) -> bool {
+    match SOURCE_LABEL_HEADER.set(header) {
+        Ok(()) => true,
+        Err(rejected) => SOURCE_LABEL_HEADER.get() == Some(&rejected),
+    }
+}
+
+/// Non-conforming values, empty and over-long included, map to
+/// [`metrics_labels::SOURCE_UNKNOWN`].
+fn sanitize_source_value(raw: &str) -> &str {
+    let conforming = !raw.is_empty()
+        && raw.len() <= SOURCE_LABEL_MAX_LEN
+        && raw
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b':' | b'-'));
+    if conforming {
+        raw
+    } else {
+        metrics_labels::SOURCE_UNKNOWN
+    }
+}
+
+/// The cap is approximate under concurrent inserts: a growth bound, not a quota.
+fn intern_source_value(
+    interner: &DashMap<String, Arc<str>>,
+    max_distinct: usize,
+    value: &str,
+) -> Arc<str> {
+    if value == metrics_labels::SOURCE_UNKNOWN {
+        return Arc::clone(&SOURCE_UNKNOWN_LABEL);
+    }
+    if value == metrics_labels::SOURCE_OVERFLOW {
+        return Arc::clone(&SOURCE_OVERFLOW_LABEL);
+    }
+    if let Some(entry) = interner.get(value) {
+        return Arc::clone(entry.value());
+    }
+    if interner.len() >= max_distinct {
+        return Arc::clone(&SOURCE_OVERFLOW_LABEL);
+    }
+    interner
+        .entry(value.to_string())
+        .or_insert_with(|| Arc::from(value))
+        .clone()
+}
+
+/// `None` disables the label; a missing or unreadable header yields `unknown`.
+fn source_label_value(
+    header: Option<&HeaderName>,
+    headers: Option<&HeaderMap>,
+) -> Option<Arc<str>> {
+    let header = header?;
+    // Last value, not first: a fronting proxy that appends its own attribution
+    // header must win over a client-supplied one.
+    let value = headers
+        .and_then(|h| h.get_all(header).iter().next_back())
+        .and_then(|v| v.to_str().ok())
+        .map_or(metrics_labels::SOURCE_UNKNOWN, sanitize_source_value);
+    Some(intern_source_value(
+        &SOURCE_INTERNER,
+        SOURCE_LABEL_MAX_DISTINCT,
+        value,
+    ))
 }
 
 // =============================================================================
@@ -175,7 +274,7 @@ pub(crate) fn init_metrics() {
     // Layer 2: Router metrics
     describe_counter!(
         "smg_router_requests_total",
-        "Total routed requests by router_type, backend_type, connection_mode, model, endpoint, streaming"
+        "Total routed requests by router_type, backend_type, connection_mode, model, endpoint, streaming (plus source when configured)"
     );
     describe_histogram!(
         "smg_router_request_duration_seconds",
@@ -414,6 +513,10 @@ pub mod metrics_labels {
     pub const RESULT_TIMEOUT: &str = "timeout";
     pub const RESULT_NOT_FOUND: &str = "not_found";
 
+    // Client source attribution
+    pub const SOURCE_UNKNOWN: &str = "unknown";
+    pub const SOURCE_OVERFLOW: &str = "overflow";
+
     // Discovery sources
     pub const DISCOVERY_STATIC: &str = "static";
     pub const DISCOVERY_KUBERNETES: &str = "kubernetes";
@@ -536,6 +639,7 @@ impl Metrics {
     ///
     /// # Arguments
     /// * `streaming` - Use `bool_to_static_str(request.stream)` or the constants
+    /// * `headers` - Incoming request headers; source of the optional `source` label
     pub fn record_router_request(
         router_type: &'static str,
         backend_type: &'static str,
@@ -543,18 +647,32 @@ impl Metrics {
         model_id: &str,
         endpoint: &'static str,
         streaming: &'static str,
+        headers: Option<&HeaderMap>,
     ) {
         let model = intern_string(model_id);
-        counter!(
-            "smg_router_requests_total",
-            "router_type" => router_type,
-            "backend_type" => backend_type,
-            "connection_mode" => connection_mode,
-            "model" => model,
-            "endpoint" => endpoint,
-            "streaming" => streaming
-        )
-        .increment(1);
+        // Two arms rather than a Vec<Label>: the macro form avoids a per-request allocation.
+        let counter = match source_label_value(SOURCE_LABEL_HEADER.get(), headers) {
+            Some(source) => counter!(
+                "smg_router_requests_total",
+                "router_type" => router_type,
+                "backend_type" => backend_type,
+                "connection_mode" => connection_mode,
+                "model" => model,
+                "endpoint" => endpoint,
+                "streaming" => streaming,
+                "source" => source
+            ),
+            None => counter!(
+                "smg_router_requests_total",
+                "router_type" => router_type,
+                "backend_type" => backend_type,
+                "connection_mode" => connection_mode,
+                "model" => model,
+                "endpoint" => endpoint,
+                "streaming" => streaming
+            ),
+        };
+        counter.increment(1);
     }
 
     /// Record router request duration.
@@ -1197,6 +1315,8 @@ impl Metrics {
 mod tests {
     use std::net::TcpListener;
 
+    use http::HeaderValue;
+
     use super::*;
 
     #[test]
@@ -1429,6 +1549,155 @@ mod tests {
         let socket_addr = SocketAddr::new(ip_addr, config.port);
 
         assert_eq!(socket_addr.to_string(), "127.0.0.1:29000");
+    }
+
+    // ========================================================================
+    // Source label tests
+    // ========================================================================
+
+    #[test]
+    fn test_sanitize_source_value() {
+        assert_eq!(sanitize_source_value("my-service"), "my-service");
+        assert_eq!(
+            sanitize_source_value("team_a.batch:v1-2"),
+            "team_a.batch:v1-2"
+        );
+
+        assert_eq!(sanitize_source_value(""), metrics_labels::SOURCE_UNKNOWN);
+        assert_eq!(
+            sanitize_source_value("has space"),
+            metrics_labels::SOURCE_UNKNOWN
+        );
+        assert_eq!(
+            sanitize_source_value("semi;colon"),
+            metrics_labels::SOURCE_UNKNOWN
+        );
+        assert_eq!(
+            sanitize_source_value("non-ascii-é"),
+            metrics_labels::SOURCE_UNKNOWN
+        );
+
+        let at_limit = "a".repeat(SOURCE_LABEL_MAX_LEN);
+        assert_eq!(sanitize_source_value(&at_limit), at_limit);
+        assert_eq!(
+            sanitize_source_value(&"a".repeat(SOURCE_LABEL_MAX_LEN + 1)),
+            metrics_labels::SOURCE_UNKNOWN
+        );
+    }
+
+    #[test]
+    fn test_intern_source_value_caps_distinct_values() {
+        let interner = DashMap::new();
+        let cap = 4;
+        for i in 0..cap {
+            intern_source_value(&interner, cap, &format!("caller-{i}"));
+        }
+        assert_eq!(interner.len(), cap);
+
+        // Over-cap is reported distinctly from a missing or malformed header.
+        assert_eq!(
+            intern_source_value(&interner, cap, "one-too-many").as_ref(),
+            metrics_labels::SOURCE_OVERFLOW
+        );
+        assert_eq!(
+            intern_source_value(&interner, cap, "caller-0").as_ref(),
+            "caller-0"
+        );
+        // Neither an over-cap value nor a sentinel spends a slot.
+        assert_eq!(interner.len(), cap);
+        intern_source_value(&interner, cap, metrics_labels::SOURCE_UNKNOWN);
+        intern_source_value(&interner, cap, metrics_labels::SOURCE_OVERFLOW);
+        assert_eq!(interner.len(), cap);
+    }
+
+    fn source_header() -> HeaderName {
+        HeaderName::from_static("x-request-source")
+    }
+
+    #[test]
+    fn test_source_label_value_disabled() {
+        let mut headers = HeaderMap::new();
+        headers.insert(source_header(), HeaderValue::from_static("my-service"));
+
+        assert!(source_label_value(None, Some(&headers)).is_none());
+        assert!(source_label_value(None, None).is_none());
+    }
+
+    #[test]
+    fn test_source_label_value_enabled() {
+        let header = source_header();
+
+        let mut headers = HeaderMap::new();
+        headers.insert(source_header(), HeaderValue::from_static("my-service"));
+        assert_eq!(
+            source_label_value(Some(&header), Some(&headers)).as_deref(),
+            Some("my-service")
+        );
+
+        // Absent header, and no headers at all
+        assert_eq!(
+            source_label_value(Some(&header), Some(&HeaderMap::new())).as_deref(),
+            Some(metrics_labels::SOURCE_UNKNOWN)
+        );
+        assert_eq!(
+            source_label_value(Some(&header), None).as_deref(),
+            Some(metrics_labels::SOURCE_UNKNOWN)
+        );
+
+        let mut opaque = HeaderMap::new();
+        opaque.insert(source_header(), HeaderValue::from_bytes(&[0xFF]).unwrap());
+        assert_eq!(
+            source_label_value(Some(&header), Some(&opaque)).as_deref(),
+            Some(metrics_labels::SOURCE_UNKNOWN)
+        );
+
+        // An appended proxy value wins over the client-supplied one
+        let mut appended = HeaderMap::new();
+        appended.append(source_header(), HeaderValue::from_static("client-claim"));
+        appended.append(source_header(), HeaderValue::from_static("proxy-truth"));
+        assert_eq!(
+            source_label_value(Some(&header), Some(&appended)).as_deref(),
+            Some("proxy-truth")
+        );
+    }
+
+    #[test]
+    fn test_set_source_label_header_rejects_a_different_header() {
+        // Process-global, so this test owns it for the whole test binary; the
+        // resolution tests above pass the header explicitly and are unaffected.
+        assert!(set_source_label_header(source_header()));
+        assert!(set_source_label_header(source_header()));
+        assert!(!set_source_label_header(HeaderName::from_static("x-other")));
+    }
+
+    /// The label reaching the exposition output, not just the resolver. Shares
+    /// the process-global header with the test above, which sets the same one.
+    #[test]
+    fn test_record_router_request_emits_source_label() {
+        let _ = set_source_label_header(source_header());
+
+        let mut headers = HeaderMap::new();
+        headers.insert(source_header(), HeaderValue::from_static("my-service"));
+
+        let recorder = PrometheusBuilder::new().build_recorder();
+        let handle = recorder.handle();
+        metrics::with_local_recorder(&recorder, || {
+            Metrics::record_router_request(
+                metrics_labels::ROUTER_HTTP,
+                metrics_labels::BACKEND_REGULAR,
+                metrics_labels::CONNECTION_HTTP,
+                "test-model",
+                metrics_labels::ENDPOINT_CHAT,
+                STREAMING_FALSE,
+                Some(&headers),
+            );
+        });
+
+        let rendered = handle.render();
+        assert!(
+            rendered.contains(r#"source="my-service""#),
+            "expected a source label in:\n{rendered}"
+        );
     }
 
     // ========================================================================

--- a/sgl-model-gateway/src/routers/grpc/pipeline.rs
+++ b/sgl-model-gateway/src/routers/grpc/pipeline.rs
@@ -276,6 +276,7 @@ impl RequestPipeline {
             &request_for_metrics.model,
             metrics_labels::ENDPOINT_CHAT,
             bool_to_static_str(streaming),
+            headers.as_ref(),
         );
 
         let mut ctx = RequestContext::for_chat(request, headers, model_id, components);
@@ -380,6 +381,7 @@ impl RequestPipeline {
             model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
             metrics_labels::ENDPOINT_GENERATE,
             bool_to_static_str(streaming),
+            headers.as_ref(),
         );
 
         let mut ctx = RequestContext::for_generate(request, headers, model_id.clone(), components);
@@ -486,6 +488,7 @@ impl RequestPipeline {
             model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
             metrics_labels::ENDPOINT_EMBEDDINGS,
             bool_to_static_str(false),
+            headers.as_ref(),
         );
 
         let mut ctx = RequestContext::for_embedding(request, headers, model_id.clone(), components);
@@ -586,6 +589,7 @@ impl RequestPipeline {
             model_id.as_deref().unwrap_or(UNKNOWN_MODEL_ID),
             metrics_labels::ENDPOINT_CLASSIFY,
             bool_to_static_str(false), // Classify is never streaming
+            headers.as_ref(),
         );
 
         let mut ctx = RequestContext::for_classify(request, headers, model_id.clone(), components);

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -382,6 +382,7 @@ impl PDRouter {
             model,
             endpoint,
             bool_to_static_str(context.is_stream),
+            headers,
         );
         // Clone request once outside the retry loop, then use Arc to share across attempts
         // This avoids O(retries) clones by sharing the same data

--- a/sgl-model-gateway/src/routers/http/router.rs
+++ b/sgl-model-gateway/src/routers/http/router.rs
@@ -212,6 +212,7 @@ impl Router {
             model,
             endpoint,
             bool_to_static_str(is_stream),
+            headers,
         );
 
         let response = RetryExecutor::execute_response_with_retry(

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -486,6 +486,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             model,
             metrics_labels::ENDPOINT_CHAT,
             bool_to_static_str(streaming),
+            headers,
         );
 
         let auth_header = extract_auth_header(headers, &None);
@@ -710,6 +711,7 @@ impl crate::routers::RouterTrait for OpenAIRouter {
             model,
             metrics_labels::ENDPOINT_RESPONSES,
             bool_to_static_str(streaming),
+            headers,
         );
 
         let auth_header = extract_auth_header(headers, &None);

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -729,6 +729,19 @@ pub async fn startup(config: ServerConfig) -> Result<(), Box<dyn std::error::Err
         None
     };
 
+    if let Some(configured) = config.router_config.source_label_header.as_deref() {
+        match configured.parse::<http::HeaderName>() {
+            Ok(header) => {
+                if !metrics::set_source_label_header(header) {
+                    warn!("Ignoring --source-label-header '{configured}': a different header is already active in this process");
+                }
+            }
+            Err(_) => {
+                warn!("Ignoring --source-label-header '{configured}': not a valid HTTP header name")
+            }
+        }
+    }
+
     if let Some(prometheus_config) = &config.prometheus_config {
         metrics::start_prometheus(prometheus_config.clone());
     }


### PR DESCRIPTION
## Motivation

Operators running sgl-model-gateway in front of shared capacity cannot attribute traffic to callers: `smg_router_requests_total` carries `{router_type, backend_type, connection_mode, model, endpoint, streaming}` (#15105) and nothing identifying *who* sent the request. The OpenAI-compatible API has no caller identity of its own, so for multi-tenant deployments the practical option is a client-declared identity header stamped onto metrics by the gateway.

This adds one as strictly opt-in: `--source-label-header <HEADER_NAME>` (also `RouterConfig.source_label_header`, builder methods, and `RouterArgs.source_label_header`), disabled by default and plumbed like `request_id_headers`. When set, that header's value becomes a `source` label on `smg_router_requests_total`. **When unset — the default — metrics are emitted exactly as today, with no new label.**

Scoped to `smg_router_requests_total` to keep the change small; extending it to the duration/error/upstream-response metrics is a natural follow-up if maintainers want it.

## Modifications

- `config/{types,builder,validation}.rs`, `main.rs`: the new option, builder setters, header-name validation, CLI flag.
- `observability/metrics.rs`: sanitize the value (`[A-Za-z0-9._:-]`, rejected above 128 characters), then intern it in a dedicated bounded interner — kept separate from the shared one, whose other inputs are all operator-controlled — capped at 2000 distinct values, matching the OpenTelemetry SDK's default cardinality limit. Missing, unreadable and non-conforming values record `unknown`; values past the cap record `overflow`, kept distinct so an exhausted budget is visible. Both sentinels are pre-built `Arc`s, so neither collapse path allocates or takes a write lock. The last header value wins, letting a trusted hop that appends the header override a client-supplied one.
- `server.rs`: enable the label at startup, warning rather than silently disabling if the name is unparsable or a different header is already active in the process.
- `routers/{openai,http/router,http/pd_router,grpc/pipeline}.rs`: pass the request headers at the 8 `record_router_request` call sites. Request IDs propagate via a request extension, but these sites already receive the `HeaderMap`, so no handler or trait signature changes were needed.
- `bindings/python`, `README.md`, docs page: the flag, its help/docstring, and the caveats below.

The value is self-reported, so it is attribution rather than authentication, and an untrusted caller can exhaust the distinct-value budget — visible as a rising `overflow` series. Both docs state this.

## Accuracy Tests

Not applicable (no model-output changes).

## Speed Tests and Profiling

No hot-path impact: when disabled the addition is one `OnceLock::get()` returning `None` per routed request. When enabled, a header lookup plus the sanitize-and-intern already used for the `model` label.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) — pre-commit hooks green.
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) — sanitizer edge cases, interner cap, enabled and disabled resolution, last-value-wins, set-once conflict, config validation, the Python CLI flag, and an end-to-end assertion that the label reaches the rendered Prometheus exposition. `cargo test -p sgl-model-gateway --lib`: 400 passed; clippy adds no new warnings.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) — README + gateway docs page.
- [x] Provide accuracy and speed benchmark results — N/A (metrics-only change).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31168689212](https://github.com/sgl-project/sglang/actions/runs/31168689212)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31168688783](https://github.com/sgl-project/sglang/actions/runs/31168688783)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

