### PR TITLE
perf(vlm): shard Kimi projector and avoid wasteful DP encoder gathers

### DIFF
--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -761,9 +761,9 @@ class KimiK25ForConditionalGeneration(nn.Module):
                 load_local_pixel_values=materialize_item_features,
                 pixel_values_device=device,
                 pixel_values_dtype=target_dtype,
+                local_postprocess=self.mm_projector,
             )
-            image_features = self.mm_projector(image_embeds)
-            return image_features
+            return image_embeds
 
         pixel_values = materialize_item_features(list(range(len(items))))
         # grid_thws stays on the host: MoonViT3d only reads it as shape metadata

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -3092,8 +3092,9 @@ class KimiK3ForConditionalGeneration(nn.Module):
                 load_local_pixel_values=materialize_item_features,
                 pixel_values_device=device,
                 pixel_values_dtype=target_dtype,
+                local_postprocess=self.mm_projector,
             )
-            return self.mm_projector(image_embeds)
+            return image_embeds
 
         pixel_values = materialize_item_features(list(range(len(items))))
         image_embeds = self.vision_tower(pixel_values, grid_thws_host.to(device))

--- a/python/sglang/srt/models/kimi_k3_vl.py
+++ b/python/sglang/srt/models/kimi_k3_vl.py
@@ -930,8 +930,11 @@ class KimiK3MultiModalProjector(nn.Module):
     ) -> torch.Tensor:
         if isinstance(image_features, (list, tuple)):
             x = concat_or_single(
-                [item.reshape(item.shape[0], -1) for item in image_features]
+                [
+                    item.reshape(item.shape[0], self.hidden_size)
+                    for item in image_features
+                ]
             )
         else:
-            x = image_features.reshape(image_features.shape[0], -1)
+            x = image_features.reshape(image_features.shape[0], self.hidden_size)
         return self.post_norm(self.proj(x))

--- a/python/sglang/srt/multimodal/mm_utils.py
+++ b/python/sglang/srt/multimodal/mm_utils.py
@@ -550,6 +550,64 @@ def concat_or_single(tensors: Sequence[torch.Tensor], dim: int = 0) -> torch.Ten
     return tensors[0] if len(tensors) == 1 else torch.cat(tensors, dim=dim)
 
 
+_MROPE_ALL_GATHERV_MIN_PADDING_FACTOR = 4
+_MROPE_LOCAL_PROJECTOR_MAX_IMBALANCE = 3
+_MROPE_LOCAL_PROJECTOR_MIN_RAW_BYTES = 64 * 1024 * 1024
+
+
+def _can_use_mrope_all_gatherv(tensor: torch.Tensor, group: object) -> bool:
+    """Whether the NVIDIA group can gather unequal encoder output lengths."""
+
+    pynccl_comm = getattr(group, "pynccl_comm", None)
+    return (
+        tensor.is_cuda
+        and pynccl_comm is not None
+        and getattr(pynccl_comm, "available", False)
+    )
+
+
+def _should_use_mrope_all_gatherv(
+    tensor: torch.Tensor, group: object, output_lengths: Sequence[int]
+) -> bool:
+    """Use variable gather only when it avoids padding or excessive waste."""
+
+    if not _can_use_mrope_all_gatherv(tensor, group):
+        return False
+    if not output_lengths:
+        return False
+    total_length = sum(output_lengths)
+    if total_length == 0:
+        return False
+    if all(length == output_lengths[0] for length in output_lengths):
+        return True
+    padding_factor = max(output_lengths) * len(output_lengths) / total_length
+    # Unequal NCCL all-gatherv is implemented as grouped broadcasts. For modest
+    # skew, one regular all-gather is faster even though it carries some padding.
+    return padding_factor >= _MROPE_ALL_GATHERV_MIN_PADDING_FACTOR
+
+
+def _should_run_mrope_local_postprocess(
+    tensor: torch.Tensor, output_lengths: Sequence[int]
+) -> bool:
+    """Whether sharding projector work is worth the larger output collective."""
+
+    if not output_lengths:
+        return False
+    total_length = sum(output_lengths)
+    if total_length == 0:
+        return False
+    if all(length == output_lengths[0] for length in output_lengths):
+        return True
+    imbalance = max(output_lengths) * len(output_lengths) / total_length
+    raw_payload_bytes = (
+        total_length * math.prod(tensor.shape[1:]) * tensor.element_size()
+    )
+    return (
+        imbalance <= _MROPE_LOCAL_PROJECTOR_MAX_IMBALANCE
+        and raw_payload_bytes >= _MROPE_LOCAL_PROJECTOR_MIN_RAW_BYTES
+    )
+
+
 # Adapted from https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/vision.py
 def run_dp_sharded_mrope_vision_model(
     vision_model: torch.nn.Module,
@@ -562,6 +620,7 @@ def run_dp_sharded_mrope_vision_model(
     pixel_values_device: Optional[torch.device] = None,
     pixel_values_dtype: Optional[torch.dtype] = None,
     pass_grid_thw_list: bool = False,
+    local_postprocess: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
 ):
     """Run a vision model with data parallelism (DP) sharding.
     The function will shard the input image tensor on the
@@ -583,6 +642,9 @@ def run_dp_sharded_mrope_vision_model(
                    the spatial merge area instead of t * h * w divided by it.
         pass_grid_thw_list: Forward the existing host grid list to the vision
             model so graph-aware towers do not materialize it from a CUDA tensor.
+        local_postprocess: Optional per-token projection to run on each vision
+            owner before outputs are exchanged. This avoids repeating replicated
+            projectors on every TP rank.
     Returns:
         torch.Tensor: Output image embeddings
 
@@ -632,14 +694,23 @@ def run_dp_sharded_mrope_vision_model(
             # already concatenates these tensors before returning, so keep the
             # TP=1 DP-encoder path on the same projector-facing contract.
             if isinstance(image_embeds, list):
-                return concat_or_single(image_embeds, dim=0)
-            return image_embeds
+                image_embeds = concat_or_single(image_embeds, dim=0)
+            return (
+                local_postprocess(image_embeds)
+                if local_postprocess is not None
+                else image_embeds
+            )
         if rope_type == "rope_2d_packed":
             image_embeds = vision_model(pixel_values, grid_thw)
             if isinstance(image_embeds, list):
-                return concat_or_single(image_embeds, dim=0)
-            return image_embeds
-        return vision_model(pixel_values, grid_thw=grid_thw)
+                image_embeds = concat_or_single(image_embeds, dim=0)
+        else:
+            image_embeds = vision_model(pixel_values, grid_thw=grid_thw)
+        return (
+            local_postprocess(image_embeds)
+            if local_postprocess is not None
+            else image_embeds
+        )
 
     # GPU_0 tp_rank_local = 0
     # GPU_1 tp_rank_local = 1
@@ -765,6 +836,16 @@ def run_dp_sharded_mrope_vision_model(
                 dtype=input_dtype,
             )
 
+    run_local_postprocess = (
+        local_postprocess is not None
+        and len(grid_thw_list) > 1
+        and _should_run_mrope_local_postprocess(
+            image_embeds_local, grouped_output_lengths
+        )
+    )
+    if run_local_postprocess:
+        image_embeds_local = local_postprocess(image_embeds_local)
+
     # Single-image fast path. Bit-identical to the all-gather below, which for
     # one image just pads the owner's rows and slices them back out.
     if len(grid_thw_list) == 1:
@@ -775,27 +856,45 @@ def run_dp_sharded_mrope_vision_model(
         else:
             out_embeddings = torch.empty(
                 (n_tok, *image_embeds_local.shape[1:]),
-                dtype=input_dtype,
-                device=input_device,
+                dtype=image_embeds_local.dtype,
+                device=image_embeds_local.device,
             )
         get_parallel().attn_tp_group.broadcast(out_embeddings, src=owner_local)
-        return out_embeddings
+        return (
+            local_postprocess(out_embeddings)
+            if local_postprocess is not None
+            else out_embeddings
+        )
 
-    # The TP all-gather needs a common first dimension. Allocate that final
-    # shape directly instead of materializing a padding fragment and catting it.
-    image_embeds_local_padded = _pad_mrope_vision_embeddings_for_tp_gather(
-        image_embeds_local, max_len_per_rank
-    )
-
-    # Do all_gather to collect embeddings from all ranks
-    gathered_embeds = get_parallel().attn_tp_group.all_gather(
-        image_embeds_local_padded, dim=0
-    )
+    attn_tp_group = get_parallel().attn_tp_group
+    if run_local_postprocess or _should_use_mrope_all_gatherv(
+        image_embeds_local, attn_tp_group, grouped_output_lengths
+    ):
+        gathered_embeds = torch.empty(
+            (sum(grouped_output_lengths), *image_embeds_local.shape[1:]),
+            dtype=image_embeds_local.dtype,
+            device=image_embeds_local.device,
+        )
+        attn_tp_group.all_gatherv(
+            image_embeds_local.contiguous(),
+            sizes=grouped_output_lengths,
+            output=gathered_embeds,
+        )
+        rank_embedding_offsets = [0, *itertools.accumulate(grouped_output_lengths)]
+    else:
+        # Backends without NCCL all_gatherv retain the common-size fallback.
+        image_embeds_local_padded = _pad_mrope_vision_embeddings_for_tp_gather(
+            image_embeds_local, max_len_per_rank
+        )
+        gathered_embeds = attn_tp_group.all_gather(image_embeds_local_padded, dim=0)
+        rank_embedding_offsets = [
+            rank * max_len_per_rank for rank in range(tp_size + 1)
+        ]
 
     # Remove padding and reconstruct per-rank embeddings
     rank_embeddings = list[torch.Tensor]()
     for rank in range(tp_size):
-        start_idx = rank * max_len_per_rank
+        start_idx = rank_embedding_offsets[rank]
         end_idx = start_idx + grouped_output_lengths[rank]
         rank_embeddings.append(gathered_embeds[start_idx:end_idx])
 
@@ -821,4 +920,8 @@ def run_dp_sharded_mrope_vision_model(
                 embed_start += img_patches
             current_idx += count
     out_embeddings = torch.cat(original_order_embeddings, dim=0)
-    return out_embeddings
+    return (
+        out_embeddings
+        if run_local_postprocess or local_postprocess is None
+        else local_postprocess(out_embeddings)
+    )

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -467,6 +467,7 @@ def test_kimi_k25_encoder_dp_selects_packed_moonvit_contract():
     assert grid_thws == [[1, 2, 2]]
     assert run_dp.call_args.kwargs["rope_type"] == "rope_2d_packed"
     assert callable(run_dp.call_args.kwargs["load_local_pixel_values"])
+    assert run_dp.call_args.kwargs["local_postprocess"] is model.mm_projector
 
 
 def test_kimi_non_dp_keeps_grid_thws_on_the_host():

--- a/test/registered/unit/models/test_kimi_k3_vision.py
+++ b/test/registered/unit/models/test_kimi_k3_vision.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.attention.vision import (
 )
 from sglang.srt.models import kimi_k3_vl
 from sglang.srt.models.kimi_k3_vl import (
+    KimiK3MultiModalProjector,
     KimiK3VisionTower,
     MoonViT3dEncoder,
     _resolve_mm_attention_backend,
@@ -25,6 +26,21 @@ from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def test_kimi_k3_projector_accepts_empty_owner_input():
+    config = SimpleNamespace(
+        mm_hidden_size=4,
+        vt_hidden_size=4,
+        merge_kernel_size=(2, 2),
+        text_hidden_size=8,
+        projector_ln_eps=1e-5,
+    )
+    projector = KimiK3MultiModalProjector(config)
+
+    output = projector(torch.empty(0, 4, 4))
+
+    assert output.shape == (0, 8)
 
 
 @pytest.mark.parametrize(
@@ -487,6 +503,7 @@ def test_kimi_k3_encoder_dp_defers_feature_materialization(monkeypatch):
     assert run_dp.call_args.kwargs["rope_type"] == "rope_2d"
     assert run_dp.call_args.kwargs["pass_grid_thw_list"] is True
     assert run_dp.call_args.kwargs["pool_temporal_dimension"] is True
+    assert run_dp.call_args.kwargs["local_postprocess"] is model.mm_projector
     loader = run_dp.call_args.kwargs["load_local_pixel_values"]
     assert callable(loader)
 

--- a/test/registered/unit/multimodal/test_mrope_encoder_utils.py
+++ b/test/registered/unit/multimodal/test_mrope_encoder_utils.py
@@ -2,11 +2,14 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
 from sglang.srt.multimodal.mm_utils import (
     _pad_mrope_vision_embeddings_for_tp_gather,
+    _should_run_mrope_local_postprocess,
+    _should_use_mrope_all_gatherv,
     run_dp_sharded_mrope_vision_model,
 )
 from sglang.srt.runtime_context import get_parallel
@@ -26,15 +29,85 @@ class _RecordingGather:
         return torch.cat([rank_zero_embeddings, input_], dim=dim)
 
 
+class _RecordingAllGatherv:
+    def __init__(self):
+        self.input = None
+        self.sizes = None
+
+    def all_gatherv(self, input_, sizes, output):
+        self.input = input_
+        self.sizes = sizes
+        output[: sizes[0]].fill_(99)
+        output[sizes[0] :].copy_(input_)
+
+
+class _RecordingBroadcast:
+    def __init__(self):
+        self.input = None
+
+    def broadcast(self, input_, src):
+        self.input = input_
+        self.src = src
+        input_.fill_(7)
+
+
+class _AvailablePyNccl:
+    available = True
+    disabled = True
+
+
 class _Rope2dVisionTower:
     merge_kernel_size = (1, 1)
     config = SimpleNamespace(hidden_size=1)
+    device = torch.device("cpu")
 
     def __call__(self, pixel_values, grid_hw, max_seqlen):
         return pixel_values.reshape(-1, 1, 1)
 
 
 class TestMropeVisionEncoderPadding(CustomTestCase):
+    def test_all_gatherv_capability_does_not_depend_on_eager_state(self):
+        from sglang.srt.multimodal.mm_utils import _can_use_mrope_all_gatherv
+
+        group = SimpleNamespace(pynccl_comm=_AvailablePyNccl())
+        tensor = SimpleNamespace(is_cuda=True)
+
+        self.assertTrue(_can_use_mrope_all_gatherv(tensor, group))
+
+    def test_variable_gather_policy_avoids_modest_imbalance(self):
+        group = SimpleNamespace(pynccl_comm=_AvailablePyNccl())
+        tensor = SimpleNamespace(is_cuda=True)
+
+        self.assertTrue(_should_use_mrope_all_gatherv(tensor, group, [4] * 8))
+        self.assertFalse(
+            _should_use_mrope_all_gatherv(
+                tensor, group, [1024, 768, 512, 384, 256, 128, 64, 32]
+            )
+        )
+        self.assertTrue(
+            _should_use_mrope_all_gatherv(tensor, group, [1024, 64, 32, 16, 8, 4, 2, 1])
+        )
+
+    def test_local_projector_policy_requires_balance_or_large_payload(self):
+        tensor = torch.empty(0, 4, 1024, dtype=torch.bfloat16)
+
+        self.assertTrue(_should_run_mrope_local_postprocess(tensor, [384] * 8))
+        self.assertFalse(
+            _should_run_mrope_local_postprocess(
+                tensor, [1024, 768, 512, 384, 256, 128, 64, 32]
+            )
+        )
+        self.assertTrue(
+            _should_run_mrope_local_postprocess(
+                tensor, [4096, 3072, 2048, 1536, 1024, 512, 256, 128]
+            )
+        )
+        self.assertFalse(
+            _should_run_mrope_local_postprocess(
+                tensor, [4096, 256, 128, 64, 32, 16, 8, 4]
+            )
+        )
+
     def test_padding_preserves_2d_embedding_prefix(self):
         embeddings = torch.arange(12, dtype=torch.float32).reshape(3, 4)
 
@@ -86,6 +159,56 @@ class TestMropeVisionEncoderPadding(CustomTestCase):
         self.assertTrue(torch.equal(gather.input[:1], torch.tensor([[[7.0]]])))
         self.assertTrue(torch.equal(embeddings[:4], torch.full((4, 1, 1), 99.0)))
         self.assertTrue(torch.equal(embeddings[4:], torch.tensor([[[7.0]]])))
+
+    def test_single_image_projects_after_raw_broadcast(self):
+        broadcast = _RecordingBroadcast()
+        pixel_values = torch.tensor([[1]], dtype=torch.float32)
+
+        with get_parallel().override(
+            attn_tp_size=2,
+            attn_tp_rank=1,
+            attn_tp_group=broadcast,
+        ):
+            embeddings = run_dp_sharded_mrope_vision_model(
+                _Rope2dVisionTower(),
+                pixel_values,
+                [[1, 1]],
+                rope_type="rope_2d",
+                local_postprocess=lambda value: value.reshape(value.shape[0], -1) * 10,
+            )
+
+        self.assertEqual(broadcast.src, 0)
+        self.assertEqual(broadcast.input.shape, (1, 1, 1))
+        self.assertTrue(torch.equal(embeddings, torch.tensor([[70.0]])))
+
+    def test_dp_encoder_projects_on_owner_before_variable_gather(self):
+        gather = _RecordingAllGatherv()
+        pixel_values = torch.tensor([[1], [2], [3], [4], [7]], dtype=torch.float32)
+
+        with get_parallel().override(
+            attn_tp_size=2,
+            attn_tp_rank=1,
+            attn_tp_group=gather,
+        ), patch(
+            "sglang.srt.multimodal.mm_utils._can_use_mrope_all_gatherv",
+            return_value=True,
+        ), patch(
+            "sglang.srt.multimodal.mm_utils._should_run_mrope_local_postprocess",
+            return_value=True,
+        ):
+            embeddings = run_dp_sharded_mrope_vision_model(
+                _Rope2dVisionTower(),
+                pixel_values,
+                [[2, 2], [1, 1]],
+                rope_type="rope_2d",
+                local_postprocess=lambda value: value.reshape(value.shape[0], -1) * 10,
+            )
+
+        self.assertEqual(gather.sizes, [4, 1])
+        self.assertEqual(gather.input.shape, (1, 1))
+        self.assertTrue(torch.equal(gather.input, torch.tensor([[70.0]])))
+        self.assertTrue(torch.equal(embeddings[:4], torch.full((4, 1), 99.0)))
+        self.assertTrue(torch.equal(embeddings[4:], torch.tensor([[70.0]])))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Status: measured, not recommended for merge

This PR tested two ideas for Kimi-K2.5/K2.7/K3 encoder DP:

- project vision features only on their encoder-owner ranks instead of repeating the projector on every TP rank
- use exact variable gather when padded DP-encoder gathers are sufficiently wasteful

The isolated microbenchmark looked promising, but strict real-server A/B on both TP4 and TP8 did **not** show a stable serving win. Profiling explains why: the projector is small compared with MoonViT, while gathering the wider projected features costs more than the projector work saved. I am preserving the data here and closing the PR rather than adding a gate around a negative optimization.

## Real Kimi-K2.5 server A/B: 2-node TP8

Setup: two GB300 NVL4 nodes, real `nvidia/Kimi-K2.5-NVFP4` weights, TP8, encoder DP, CPU multimodal transport, symmetric memory, FP8 KV cache, eight seeded random JPEG images per request (896x896 through 1536x1536), 24 requests x 3 clean-cache runs per rate. Each cell is the median of three runs. Base: `4d4f8023c405cade959afb5073e23505b2643a2a`; head: `a7ac33672595b3f50c5311682575769b251ebfa3`.

| Rate | Base req/s | Head req/s | Throughput | Base p50 TTFT | Head p50 TTFT | p50 | p99 | Median E2E |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0.5 | 0.500 | 0.500 | -0.04% | 1806 ms | 1816 ms | +0.59% | +14.58% | -1.92% |
| 2 | 1.246 | 1.246 | -0.02% | 5977 ms | 6042 ms | +1.08% | -0.90% | -1.24% |
| unlimited | 1.236 | 1.241 | +0.40% | 8397 ms | 8484 ms | +1.04% | -3.76% | -0.72% |

All 432 base and 432 head requests succeeded with zero errors and identical seeded workloads. Server logs show roughly 13K-16K real prefill tokens/request; the low vision-token number printed by this `bench_serving` revision is accounting-only.

## Follow-up collective experiment

The original owner path used grouped-broadcast all-gatherv even for balanced/modestly skewed outputs. I tested an uncommitted variant that uses one padded all-gather in those cases. Against the same TP8 base:

| Rate | Throughput | p50 TTFT | p99 TTFT | Median E2E |
| ---: | ---: | ---: | ---: | ---: |
| 0.5 | +0.00% | +2.75% | +75.50% | +14.91% |
| 2 | +0.16% | -6.74% | -4.49% | -0.25% |
| unlimited | -1.60% | -3.60% | -1.66% | +1.22% |

This is still not a stable win and was not committed.

## Profiler breakdown

A clean one-request torch-profiler run (`warmup_requests=0`, eight random images, 13,184 server-side prefill tokens) confirms that the owner-projector branch executed on TP8. TP0 critical-path GPU time inside the VLM annotations was approximately:

| Component | Time |
| --- | ---: |
| MoonViT main forward kernel | 197.3 ms |
| grouped-broadcast feature gather | 26.6 ms |
| local projector kernels | ~5.0 ms |
| full multimodal embedding annotation | 242.1 ms |
| LLM prefill annotation | 339.5 ms |

The optimization removes only a few milliseconds of replicated projector compute but introduces a much larger collective over projected features (7168-wide versus 4x1152 raw MoonViT features). That is why isolated projector numbers do not translate into server throughput.

## Earlier TP4 result

One GB300 NVL4 node, real weights, TP4, encoder DP, CUDA IPC, the same eight-image random workload and three-run median:

| Rate | Throughput | p50 TTFT | p99 TTFT | Median E2E |
| ---: | ---: | ---: | ---: | ---: |
| 0.5 | -0.0% | -0.6% | +0.4% | -0.2% |
| 2 | +0.2% | +0.7% | +4.2% | +3.5% |
| unlimited | -4.2% | +10.1% | +2.5% | -0.4% |

## Correctness

- distributed TP8 output parity covered empty-owner and variable-size multi-image cases
- 68 relevant Kimi/mRoPE tests passed on the submitted commit
- the follow-up collective variant passed its focused 11-test suite, but was discarded due to the negative server result

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31149080026](https://github.com/sgl-project/sglang/actions/runs/31149080026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31149079801](https://github.com/sgl-project/sglang/actions/runs/31149079801)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
