### PR TITLE
[perf] Quantize TRTLLM MLA prefill Q once for chunked-prefix attention

### DIFF
--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -132,6 +132,10 @@ class AttentionBackend(ABC):
         should override this hook for both capture and replay.
         """
 
+    def prepare_prefill_query(self, q: torch.Tensor) -> torch.Tensor:
+        """Convert a prefill query to the backend-native attention dtype."""
+        return q
+
     def init_cuda_graph_state(self, max_bs: int, max_num_tokens: int):
         """Init the global shared states for cuda graph."""
         raise NotImplementedError()

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -970,6 +970,9 @@ class HybridLinearAttnBackend(AttentionBackend):
         # side owns the KV cache, so its dtype is authoritative.
         return self.full_attn_backend.data_type
 
+    def prepare_prefill_query(self, q: torch.Tensor) -> torch.Tensor:
+        return self.full_attn_backend.prepare_prefill_query(q)
+
     @property
     def supports_ragged_verify_graph(self) -> bool:
         return (

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -113,8 +113,14 @@ def grow_multi_ctas_kv_counter_buffer_if_needed(
     return torch.zeros(required_bytes, dtype=torch.uint8, device=device)
 
 
+def _quantize_fp8_query(q: torch.Tensor) -> torch.Tensor:
+    if q.dtype == torch.float8_e4m3fn:
+        return q
+    return q.to(torch.float8_e4m3fn)
+
+
 def _quantize_fp8_qkv(q, k, v, layer):
-    q = q.to(torch.float8_e4m3fn)
+    q = _quantize_fp8_query(q)
 
     k_scale = getattr(layer, "k_scale_float", None)
     if k_scale is None:
@@ -890,9 +896,12 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         out_buffer: torch.Tensor,
         o_sf_scale: float = 1.0,
     ):
-        """Hook for subclasses to swap the ragged prefill kernel. Q/K/V arrive
-        in model-native dtype; subclasses do any kernel-specific quantization.
-        Returns the output tensor or (output, lse) if return_lse."""
+        """Hook for subclasses to swap the ragged prefill kernel.
+
+        Q may already be quantized for chunked-prefix reuse; K/V arrive in
+        model-native dtype. Subclasses own any remaining kernel-specific
+        quantization. Returns the output tensor or (output, lse) if requested.
+        """
         q_scale = k_scale = v_scale = 1.0
         if self.data_type == torch.float8_e4m3fn:
             q, k, v, k_scale, v_scale = _quantize_fp8_qkv(q, k, v, layer)
@@ -917,6 +926,12 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             out=out_buffer,
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get(),
         )
+
+    def prepare_prefill_query(self, q: torch.Tensor) -> torch.Tensor:
+        """Quantize a chunked-prefill query once for suffix/prefix reuse."""
+        if self.data_type != torch.float8_e4m3fn:
+            return q
+        return _quantize_fp8_query(q)
 
     def _set_kv_and_concat_q_fused(
         self,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -406,20 +406,32 @@ class DeepseekMHAForwardMixin:
             if hasattr(get_attn_backend(), "init_mha_chunk_metadata"):
                 get_attn_backend().init_mha_chunk_metadata(forward_batch)
 
+        # Q is shared by the causal suffix and every prefix chunk. Quantize it
+        # once at the layer-forward scope while retaining the dtype expected by
+        # prefix KV fetch/projection.
+        kv_a_dtype = None
+        q_attn = q
+        if has_extend_prefix:
+            backend = _resolve_attn_backend(forward_batch)
+            q_attn = backend.prepare_prefill_query(q)
+            if q_attn.dtype != q.dtype:
+                kv_a_dtype = q.dtype
+
         forward_batch.mha_return_lse = has_extend_prefix
         # Do mha for extended part without prefix
         forward_batch.set_attn_attend_prefix_cache(False)
-        attn_output = self.attn_mha(q, k, v, forward_batch, save_kv_cache=False)
+        attn_output = self.attn_mha(q_attn, k, v, forward_batch, save_kv_cache=False)
 
         # Do mha attention with chunked prefix cache if there are any sequence with prefix
         if has_extend_prefix:
             attn_output, lse = attn_output
             forward_batch.set_attn_attend_prefix_cache(True)
             attn_output = self._chunked_prefix_attn_mha(
-                q=q,
+                q=q_attn,
                 accum_output=attn_output,
                 accum_lse=lse,
                 forward_batch=forward_batch,
+                kv_a_dtype=kv_a_dtype,
             )
 
         attn_output = attn_output.reshape(-1, self.num_local_heads * self.v_head_dim)
@@ -462,11 +474,13 @@ class DeepseekMHAForwardMixin:
         accum_output: torch.Tensor,
         accum_lse: torch.Tensor,
         forward_batch: ForwardBatch,
+        kv_a_dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
         # kv_b_proj needs BF16 input, but legacy q.dtype was BF16 by accident.
         backend = _resolve_attn_backend(forward_batch)
         pack_fn = getattr(backend, "pack_prefix_chunk_kv", None)
-        kv_a_dtype = torch.bfloat16 if pack_fn is not None else q.dtype
+        if kv_a_dtype is None:
+            kv_a_dtype = torch.bfloat16 if pack_fn is not None else q.dtype
 
         assert forward_batch.num_prefix_chunks is not None
         for i in range(forward_batch.num_prefix_chunks):

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -721,9 +721,15 @@ class SarvamMoEMLAAttention(nn.Module):
         accum_output: torch.Tensor,
         accum_lse: torch.Tensor,
         forward_batch: ForwardBatch,
+        kv_a_dtype: torch.dtype | None = None,
     ) -> torch.Tensor:
         return DeepseekMHAForwardMixin._chunked_prefix_attn_mha(
-            self, q, accum_output, accum_lse, forward_batch
+            self,
+            q,
+            accum_output,
+            accum_lse,
+            forward_batch,
+            kv_a_dtype=kv_a_dtype,
         )
 
     def _get_mla_kv_buffer(

--- a/test/registered/unit/models/test_deepseek_mha_prefill_q_reuse.py
+++ b/test/registered/unit/models/test_deepseek_mha_prefill_q_reuse.py
@@ -1,0 +1,151 @@
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    HybridLinearAttnBackend,
+)
+from sglang.srt.layers.attention.trtllm_mla_backend import (
+    _quantize_fp8_qkv,
+    _quantize_fp8_query,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods import forward_mha
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class _FakeForwardBatch:
+    def __init__(self, has_prefix: bool):
+        self.extend_prefix_lens_cpu = [1 if has_prefix else 0]
+        self.num_prefix_chunks = 1 if has_prefix else None
+        self.mha_return_lse = False
+        self.attn_attend_prefix_cache: bool | None = None
+
+    def set_attn_attend_prefix_cache(self, value: bool) -> None:
+        self.attn_attend_prefix_cache = value
+
+
+class _FakeAttention:
+    def __init__(self, owner):
+        self.owner = owner
+
+    def __call__(self, q, k, v, forward_batch, save_kv_cache=False):
+        self.owner.suffix_q = q
+        output = torch.zeros(
+            (q.shape[0], 1, self.owner.v_head_dim), dtype=torch.bfloat16
+        )
+        if forward_batch.mha_return_lse:
+            return output, torch.zeros((q.shape[0], 1), dtype=torch.float32)
+        return output
+
+
+class _FakeOutputProjection:
+    def __call__(self, value):
+        return value, None
+
+
+class _FakeMLA:
+    num_local_heads = 1
+    v_head_dim = 2
+
+    def __init__(self):
+        self.attn_mha = _FakeAttention(self)
+        self.o_proj = _FakeOutputProjection()
+        self.suffix_q = None
+        self.prefix_q = None
+        self.prefix_kv_dtype = None
+
+    def _chunked_prefix_attn_mha(
+        self,
+        q,
+        accum_output,
+        accum_lse,
+        forward_batch,
+        kv_a_dtype=None,
+    ):
+        self.prefix_q = q
+        self.prefix_kv_dtype = kv_a_dtype
+        return accum_output
+
+
+class TestDeepseekMHAPrefillQueryReuse(CustomTestCase):
+    def test_prequantized_query_matches_qkv_baseline_and_is_reused(self):
+        q = torch.randn((4, 1, 3), dtype=torch.bfloat16, device="cuda")
+        k = torch.randn((4, 1, 3), dtype=torch.bfloat16, device="cuda")
+        v = torch.randn((4, 1, 2), dtype=torch.bfloat16, device="cuda")
+        layer = mock.Mock(k_scale_float=1.0, v_scale_float=1.0)
+
+        q_baseline, k_baseline, v_baseline, _, _ = _quantize_fp8_qkv(q, k, v, layer)
+        q_prepared = _quantize_fp8_query(q)
+        q_out, k_out, v_out, k_scale, v_scale = _quantize_fp8_qkv(
+            q_prepared, k, v, layer
+        )
+
+        self.assertIs(q_out, q_prepared)
+        self.assertTrue(torch.equal(q_out, q_baseline))
+        self.assertTrue(torch.equal(k_out, k_baseline))
+        self.assertTrue(torch.equal(v_out, v_baseline))
+        self.assertEqual(k_scale, 1.0)
+        self.assertEqual(v_scale, 1.0)
+
+    def test_hybrid_backend_delegates_query_preparation_to_full_attention(self):
+        q = torch.zeros((4, 1, 3), dtype=torch.bfloat16)
+        q_attn = q.clone()
+        full_attn_backend = mock.Mock()
+        full_attn_backend.prepare_prefill_query.return_value = q_attn
+        backend = object.__new__(HybridLinearAttnBackend)
+        backend.full_attn_backend = full_attn_backend
+
+        output = backend.prepare_prefill_query(q)
+
+        full_attn_backend.prepare_prefill_query.assert_called_once_with(q)
+        self.assertIs(output, q_attn)
+
+    def test_chunked_prefill_prepares_query_once_for_suffix_and_prefix(self):
+        model = _FakeMLA()
+        forward_batch = _FakeForwardBatch(has_prefix=True)
+        q = torch.zeros((4, 1, 3), dtype=torch.bfloat16)
+        q_attn = torch.empty((4, 1, 3), dtype=torch.float8_e4m3fn)
+        k = torch.zeros((4, 1, 3), dtype=torch.bfloat16)
+        v = torch.zeros((4, 1, 2), dtype=torch.bfloat16)
+        backend = mock.Mock()
+        backend.prepare_prefill_query.return_value = q_attn
+
+        with mock.patch.object(
+            forward_mha,
+            "_resolve_attn_backend",
+            return_value=backend,
+        ):
+            output = forward_mha.DeepseekMHAForwardMixin.forward_normal_chunked_kv_core(
+                model, q, k, v, forward_batch
+            )
+
+        backend.prepare_prefill_query.assert_called_once_with(q)
+        self.assertIs(model.suffix_q, q_attn)
+        self.assertIs(model.prefix_q, q_attn)
+        self.assertEqual(model.prefix_kv_dtype, torch.bfloat16)
+        self.assertEqual(output.shape, (4, 2))
+
+    def test_no_prefix_keeps_model_query_and_skips_prepare_hook(self):
+        model = _FakeMLA()
+        forward_batch = _FakeForwardBatch(has_prefix=False)
+        q = torch.zeros((4, 1, 3), dtype=torch.bfloat16)
+        k = torch.zeros((4, 1, 3), dtype=torch.bfloat16)
+        v = torch.zeros((4, 1, 2), dtype=torch.bfloat16)
+
+        with mock.patch.object(forward_mha, "_resolve_attn_backend") as resolve_backend:
+            output = forward_mha.DeepseekMHAForwardMixin.forward_normal_chunked_kv_core(
+                model, q, k, v, forward_batch
+            )
+
+        resolve_backend.assert_not_called()
+        self.assertIs(model.suffix_q, q)
+        self.assertIsNone(model.prefix_q)
+        self.assertEqual(output.shape, (4, 2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When TRTLLM MLA prefill uses FP8 attention, `_run_prefill_kernel` converts Q/K/V to FP8 before each attention call.

For chunked-prefix attention, the same query tensor is consumed by both suffix attention and every prefix-chunk attention call. This causes the same Q tensor to be converted from BF16 to FP8 repeatedly within one layer forward.

For a request with `N` prefix chunks, this change reduces Q conversion from `N + 1` times to once. K/V remain call-specific and keep their existing quantization behavior.

This is intentionally narrower than the fused prefill preparation introduced in #25460. It does not change RoPE, KV-cache writes, K/V packing, or the attention kernel.

## Modifications

- Add `AttentionBackend.prepare_prefill_query`, with an identity default.
- Delegate query preparation through `HybridLinearAttnBackend` to its full-attention backend.
- Implement TRTLLM MLA query preparation as an idempotent FP8 conversion.
- Prepare Q once in `forward_normal_chunked_kv_core`.
- Reuse the prepared Q for suffix attention and all prefix chunks.
- Preserve the model-native dtype when reconstructing prefix K/V.
- Keep the Sarvam MLA override compatible with the extended method signature.
- Add a registered CUDA unit test for the new behavior.

The new hook is only used when a prefix cache hit requires chunked-prefix attention. The no-prefix and non-FP8 paths retain their existing behavior.

## Accuracy Tests

Added:

```text
test/registered/unit/models/test_deepseek_mha_prefill_q_reuse.py
```

## Speed Tests and Profiling

A representative long-context prefix-cache-hit workload was profiled with FP8 TRTLLM MLA prefill. Both revisions used the same serving configuration and input.

Every profiled rank removed exactly 240 redundant Q conversions:

| Metric | Baseline | Patched | Delta |
| --- | ---: | ---: | ---: |
| Q-shaped `aten::_to_copy` calls | 336 | 96 | -240 |
| BF16-to-FP8 copy kernel launches | 960 | 720 | -240 |
| Mean BF16-to-FP8 GPU time | 177.048 ms | 164.843 ms | -12.205 ms |
| Mean profiled GPU event span | 5357.530 ms | 5344.202 ms | -13.328 ms |

## Checklist

- [x] Added a registered CUDA unit test.
- [x] Verified formatting and lint checks.
- [x] Added accuracy and profiling results.
- [x] No documentation update is required because this does not add or change
      a public option.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31151726528](https://github.com/sgl-project/sglang/actions/runs/31151726528)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31151726388](https://github.com/sgl-project/sglang/actions/runs/31151726388)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->