### PR TITLE
[DCP] Scope DCP off for draft init and take the draft pool's shape from its allocator

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2673,6 +2673,27 @@ def patch_tensor_parallel_group(tp_group: GroupCoordinator):
         _TP = old_tp_group
 
 
+@contextmanager
+def patch_decode_context_parallel_group(dcp_group: Optional[GroupCoordinator]):
+    """Patch the dcp group temporarily until this function ends.
+
+    This method is for draft workers of speculative decoding, which are TP-sharded
+    and never split the token dimension: they run with ``None``, the same state a
+    process without decode context parallelism is in. Unlike the tp patch this
+    nests, so an inner scope does not have to know whether an outer one is active.
+
+    Args:
+        dcp_group (Optional[GroupCoordinator]): the dcp group coordinator, or None
+    """
+    global _DCP
+    old_dcp_group = _DCP
+    _DCP = dcp_group
+    try:
+        yield
+    finally:
+        _DCP = old_dcp_group
+
+
 def get_world_size():
     """Return world size for the world group."""
     return get_world_group().world_size

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -285,6 +285,7 @@ from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_utils import validate_dflash_request
 from sglang.srt.speculative.eagle_utils import get_draft_recurrent_hidden_state_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import draft_dcp_context
 from sglang.srt.utils import (
     DynamicGradMode,
     configure_gc_logger,
@@ -919,7 +920,8 @@ class Scheduler(
         )
 
         DraftWorkerClass = self.spec_algorithm.create_worker(self.server_args)
-        self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
+        with draft_dcp_context():
+            self.draft_worker = DraftWorkerClass(**draft_worker_kwargs)
 
         if self.spec_algorithm.is_ngram():
             from sglang.srt.speculative.external_corpus_manager import (
@@ -948,24 +950,27 @@ class Scheduler(
         self.init_target_memory_pool()
         if self.draft_worker is not None:
             pool, allocator = self.tp_worker.get_memory_pool()
-            self.draft_worker.alloc_memory_pool(
-                memory_pool_config=self.tp_worker.model_runner.memory_pool_config,
-                req_to_token_pool=pool,
-                token_to_kv_pool_allocator=allocator,
-            )
-            self.draft_worker.init_hicache_draft_plan()
+            with draft_dcp_context():
+                self.draft_worker.alloc_memory_pool(
+                    memory_pool_config=self.tp_worker.model_runner.memory_pool_config,
+                    req_to_token_pool=pool,
+                    token_to_kv_pool_allocator=allocator,
+                )
+                self.draft_worker.init_hicache_draft_plan()
 
     def init_all_attention_backends(self):
         """Initialize attention backends for all workers."""
         self.tp_worker.init_attention_backends()
         if self.draft_worker is not None:
-            self.draft_worker.init_attention_backends()
+            with draft_dcp_context():
+                self.draft_worker.init_attention_backends()
 
     def init_all_cuda_graphs(self):
         """Capture cuda graphs for all workers."""
         self.tp_worker.init_cuda_graphs()
         if self.draft_worker is not None:
-            self.draft_worker.init_cuda_graphs()
+            with draft_dcp_context():
+                self.draft_worker.init_cuda_graphs()
 
     def init_model_worker(self):
         # Load model weights.

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -275,10 +275,13 @@ class KVCacheConfigurator:
     # 1. A replicated draft indexes the allocator's virtual locs raw, so its pools
     #    span and page that space; the sharded target translates and stays per-rank.
     # 2. A pool must page as its allocator does, or its last page falls short.
+    # 3. Read that shape off the allocator rather than re-deriving it from dcp_size.
     @property
     def loc_space_scale(self) -> int:
-        dcp_size = get_parallel().attn_dcp_size
-        return dcp_size if (self.is_draft_worker and dcp_size > 1) else 1
+        allocator = self.token_to_kv_pool_allocator
+        if not self.is_draft_worker or allocator is None:
+            return 1
+        return allocator.page_size // get_schedule().page_size
 
     @property
     def pool_page_size(self) -> int:

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -35,6 +35,7 @@ from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.constrained.base_grammar_backend import GrammarMask
 from sglang.srt.distributed.parallel_state import (
     GroupCoordinator,
+    patch_decode_context_parallel_group,
     patch_tensor_parallel_group,
 )
 from sglang.srt.environ import envs
@@ -674,6 +675,12 @@ def draft_tp_context(tp_group: GroupCoordinator):
     # Draft model doesn't use dp and has its own tp group.
     # We disable mscclpp now because it doesn't support 2 comm groups.
     with patch_tensor_parallel_group(tp_group):
+        yield
+
+
+@contextmanager
+def draft_dcp_context():
+    with patch_decode_context_parallel_group(None):
         yield
 
 

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -162,8 +162,6 @@ class TestGetDcpLens(CustomTestCase):
                 device="cpu",
                 is_draft_worker=False,
             )
-            # The allocator widens from get_parallel(), not from the injected
-            # server_args stand-in -- drive the cause, not the effect.
             with patch(
                 "sglang.srt.mem_cache.kv_cache_configurator.current_platform.is_out_of_tree",
                 return_value=False,
@@ -189,6 +187,39 @@ class TestGetDcpLens(CustomTestCase):
         self.assertEqual(dcp4_allocator.size, 4096)
         self.assertEqual(dcp4_allocator.page_size, 256)
         self.assertEqual(dcp4_allocator.num_pages, 16)
+
+    def test_draft_pool_shape_comes_from_its_allocator_not_from_dcp(self):
+        """The draft's pool shape follows its allocator, not attn_dcp_size."""
+        physical_page_size = 64
+        override = rc.get_context().override_server_args(
+            page_size=physical_page_size,
+            disaggregation_mode="null",
+            enable_hisparse=False,
+        )
+        override.install()
+        self.addCleanup(override.restore)
+
+        # pool_page_size composes loc_space_scale, so both must be real properties.
+        class _Configurator:
+            loc_space_scale = KVCacheConfigurator.loc_space_scale
+            pool_page_size = KVCacheConfigurator.pool_page_size
+
+            def __init__(self, *, is_draft_worker, allocator):
+                self.is_draft_worker = is_draft_worker
+                self.token_to_kv_pool_allocator = allocator
+
+        # The widened allocator the target built (dcp_size=4).
+        widened = SimpleNamespace(page_size=physical_page_size * 4, size=4096)
+        draft = _Configurator(is_draft_worker=True, allocator=widened)
+        target = _Configurator(is_draft_worker=False, allocator=widened)
+
+        # attn_dcp_size=1 stands in for a draft-scoped "DCP is off" context.
+        for attn_dcp_size in (4, 1):
+            with rc.get_parallel().override(attn_dcp_size=attn_dcp_size):
+                self.assertEqual(draft.loc_space_scale, 4)
+                self.assertEqual(draft.pool_page_size, widened.page_size)
+                self.assertEqual(target.loc_space_scale, 1)
+                self.assertEqual(target.pool_page_size, physical_page_size)
 
     def test_live_cell_and_page_ownership_formulas(self):
         dcp_size = 4

--- a/test/registered/dcp/test_draft_dcp_scope.py
+++ b/test/registered/dcp/test_draft_dcp_scope.py
@@ -1,0 +1,118 @@
+"""Draft init in the scheduler runs under draft_dcp_context."""
+
+import ast
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+import sglang.srt
+from sglang.srt import runtime_context as rc
+from sglang.srt.distributed.parallel_state import patch_decode_context_parallel_group
+from sglang.srt.speculative.spec_utils import draft_dcp_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_SCHEDULER = Path(next(iter(sglang.srt.__path__))) / "managers" / "scheduler.py"
+
+_SCOPED_METHODS = (
+    "maybe_init_draft_worker",
+    "init_memory_pools",
+    "init_all_attention_backends",
+    "init_all_cuda_graphs",
+)
+
+
+def _scheduler_methods():
+    tree = ast.parse(_SCHEDULER.read_text(), filename=str(_SCHEDULER))
+    cls = next(
+        n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "Scheduler"
+    )
+    return {
+        n.name: n
+        for n in cls.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _scoped_line_ranges(fn):
+    ranges = []
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.With):
+            continue
+        for item in node.items:
+            call = item.context_expr
+            if (
+                isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Name)
+                and call.func.id == "draft_dcp_context"
+            ):
+                ranges.append((node.body[0].lineno, node.end_lineno))
+    return ranges
+
+
+def _draft_init_uses(fn):
+    uses = []
+    for node in ast.walk(fn):
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "draft_worker"
+            and isinstance(node.value.value, ast.Name)
+            and node.value.value.id == "self"
+        ):
+            uses.append((node.lineno, f"self.draft_worker.{node.attr}"))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "DraftWorkerClass"
+        ):
+            uses.append((node.lineno, "DraftWorkerClass(...)"))
+    return uses
+
+
+class TestDraftDcpScope(CustomTestCase):
+    def test_scheduler_draft_init_runs_under_the_scope(self):
+        methods = _scheduler_methods()
+        unscoped = []
+        for name in _SCOPED_METHODS:
+            self.assertIn(name, methods, f"Scheduler.{name} was renamed or removed")
+            fn = methods[name]
+            ranges = _scoped_line_ranges(fn)
+            uses = _draft_init_uses(fn)
+            self.assertTrue(uses, f"{name}: found no draft init to check")
+            unscoped += [
+                f"{name}:{lineno} {what}"
+                for lineno, what in uses
+                if not any(lo <= lineno <= hi for lo, hi in ranges)
+            ]
+        self.assertEqual(
+            unscoped,
+            [],
+            "draft init outside draft_dcp_context:\n  " + "\n  ".join(unscoped),
+        )
+
+    def test_the_scope_removes_the_dcp_group(self):
+        """The draft must reach the state a process without DCP is in, so that
+        every dcp_enabled guard short-circuits and attn_dcp_* derives to 1/0.
+        Neutralizing attn_dcp_* alone would leave the group in place: the guards
+        would still fire and the draft would take DCP paths it cannot run."""
+        target_group = SimpleNamespace(world_size=4, rank_in_group=3)
+        with patch_decode_context_parallel_group(target_group):
+            self.assertTrue(rc.get_parallel().dcp_enabled)
+            self.assertEqual(rc.get_parallel().attn_dcp_size, 4)
+            self.assertEqual(rc.get_parallel().attn_dcp_rank, 3)
+
+            with draft_dcp_context():
+                parallel = rc.get_parallel()
+                self.assertFalse(parallel.dcp_enabled)
+                self.assertEqual(parallel.attn_dcp_size, 1)
+                self.assertEqual(parallel.attn_dcp_rank, 0)
+
+            self.assertTrue(rc.get_parallel().dcp_enabled)
+            self.assertEqual(rc.get_parallel().attn_dcp_size, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Drafts are TP-sharded and never split the token dimension, but DCP topology is process-global and shared with the target. Draft code that reads it unscoped gets the target's layout:

- `triton_backend` takes `dcp_size` / `dcp_rank` from it and token-shards the draft against a pool that is replicated.
- Sizing a draft pool with DCP-replicated KV heads over-allocates by `dcp_size` — at TP4/DCP4 the draft pool asks for 4 KV heads where `DFlashAttention` builds 1, a 4x over-allocation that OOMs.

## Modifications

**1. Take the draft KV pool's page size and span from its allocator.**

The draft shares the target's `token_to_kv_pool_allocator`, which under DCP is widened: locs in `[0, max_total * dcp_size)`, paged at `page_size * dcp_size`. The target translates (`out_cache_loc // dcp_size`) and stays per-rank; the draft indexes those locs raw, so its pool must span and page the whole widened space.

`loc_space_scale` re-derived that shape from `attn_dcp_size` instead of reading it off the allocator it was handed. Same number today, but *derived* — so the two can desync. A scope over draft pool construction changes `attn_dcp_size` and cannot change the already-materialised allocator, leaving the pool paged at `page_size` against an allocator paging `page_size * dcp_size`. The allocator's last page then addresses rows the pool does not have: a silent out-of-bounds KV write at high occupancy, not an OOM.

Reading the scale off the allocator makes the two agree by construction.

**2. Scope DCP off for draft init, at the scheduler boundary.**

The scheduler is where the two workers are already separated, so the scope goes there — `maybe_init_draft_worker` (which builds the draft model), the draft branch of `init_memory_pools`, `init_all_attention_backends`, and `init_all_cuda_graphs`. Each sits next to its target counterpart, and a spec worker cannot bypass them: they are what calls it.

Wrapping model construction is what an in-worker hook could not do — the draft model is built in the worker's `__init__`, before any post-construction hook runs.

The mechanism mirrors `patch_tensor_parallel_group`, which exists for exactly this reason — its docstring reads *"for draft workers of speculative decoding to run draft model with different tp degree from that of target model workers."* The DCP equivalent, `patch_decode_context_parallel_group(None)`, puts the draft in the state a process **without** decode context parallelism is already in: `dcp_enabled` becomes False structurally (its getter is `get_dcp_group_no_assert() is None`), and `attn_dcp_size` / `attn_dcp_rank` derive to 1 / 0 with nothing pinned beside them.

That matters more than it looks. Neutralizing `attn_dcp_*` alone would leave the group in place, so every `dcp_enabled` guard would still fire and the draft would take DCP paths it cannot run — allocating the fi_a2a workspace (which barriers cross-rank), building `attn_mqa_for_dcp_decode`, taking `dcp_replicate_q_proj`, entering the HiCache DCP branch with its `use_mla` assert — in a `dcp_size=N, attn_dcp_size=1` combination no real topology produces. Patching the group cannot produce an unreachable state, because it *is* a reachable one. It also means a raw `dcp_size` read under the scope raises exactly as it would on a non-DCP boot, instead of quietly returning a number.

Unlike the tp patch, this one nests, so an inner scope need not know whether an outer one is active.

Turning the group off is only safe because of change 1: the draft pool takes its span and page size from the allocator it was handed, so no draft-side value re-derives them from `dcp_size`. The target's own init is unscoped, so the checks that gate on `dcp_enabled` — the trtllm_mla + speculative rejection, the KV-pool invariant check — still fire.

### Scope

This covers **init only**. Draft forwards still read the target's DCP topology (`memory_pool.set_kv_buffer`, `forward_batch_info`), unchanged from before this PR. Scoping those needs a per-forward draft context and is deliberately left out.

## Accuracy Test

- `test/registered/dcp/test_draft_dcp_scope.py` (new, CPU): asserts every draft-init call in those four scheduler methods sits inside the scope — scopes fail open, so this is the guard. Verified it reports all five sites unscoped against `main`. A second case installs a real group via `patch_decode_context_parallel_group`, then pins that the draft scope removes it and `attn_dcp_*` derives to 1/0.
- `test/registered/dcp/test_dcp_layout_unit.py`: the draft pool's shape follows its allocator, not `attn_dcp_size`.

Change 1 was verified on 8-GPU DCP8: draft pool identical to the old derivation, full benchmark clean at 0.97 occupancy. Change 2 has not been run on multi-GPU hardware yet — it needs a DCP + speculative boot before merge.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/bench_profile.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_eval.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31245303285](https://github.com/sgl-project/sglang/actions/runs/31245303285)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31245303208](https://github.com/sgl-project/sglang/actions/runs/31245303208)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->