### PR TITLE
docker: add Kimi K3 artifacts and build hpc-ops with C++20

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,7 @@ RUN --mount=type=cache,target=/var/cache/apt,id=base-apt \
     build-essential \
     cmake \
     perl \
+    patch \
     patchelf \
     ccache \
     git-lfs \
@@ -526,6 +527,18 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /usr/local/lib/python3.12/dist-packages/
+
+# Apply the FlashInfer CuTeDSL MLA decode-context-parallel runtime patch.
+# Exclude tests because they are not included in the installed wheel.
+COPY docker/kimi_k3/flashinfer-perkz-dcp-0.6.15.txt /tmp/flashinfer-perkz-dcp-0.6.15.txt
+RUN FLASHINFER_DCP_PATCH=/tmp/flashinfer-perkz-dcp-0.6.15.txt && \
+    FLASHINFER_SITE_PACKAGES="$(python3 -c 'from pathlib import Path; import flashinfer; print(Path(flashinfer.__file__).resolve().parent.parent)')" && \
+    sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" | \
+      patch --dry-run --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" && \
+    sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" | \
+      patch --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" && \
+    rm -f "${FLASHINFER_DCP_PATCH}" && \
+    rm -rf /root/.cache/flashinfer /root/.cache/pip
 
 # Copy the pinned FlashInfer MXFP4 MoE runner cubin pool
 COPY --from=trtllm_cubin_builder /opt/trtllm_gen_moe_cubin_pool /opt/trtllm_gen_moe_cubin_pool

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -343,7 +343,7 @@ FROM torch_deps AS hpc_ops_builder
 # HPC-Ops (https://github.com/Tencent/hpc-ops, MIT): fused attention / MoE /
 # RoPE kernels from the Tencent Hunyuan AI Infra team, consumed by the opt-in
 # hpc_ops attention and MoE runner backends.
-ARG HPC_OPS_COMMIT=6e2ecede9d6d47b2e680e839cc7ad7422bc8d88b
+ARG HPC_OPS_COMMIT=ab1a402724635507037426068f6cddc3d30dc0a8
 
 WORKDIR /build
 
@@ -356,14 +356,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         git clone https://github.com/Tencent/hpc-ops.git && \
         cd hpc-ops && \
         git checkout ${HPC_OPS_COMMIT} && \
-        # PyTorch 2.13 headers require C++20, while the pinned commit uses C++17.
-        sed -i \
-            -e 's/CXX_STANDARD 17/CXX_STANDARD 20/' \
-            -e 's/CUDA_STANDARD 17/CUDA_STANDARD 20/' \
-            -e 's/-std=c++17/-std=c++20/' \
-            CMakeLists.txt && \
-        test "$(grep -Ec '^[[:space:]]*(CXX|CUDA)_STANDARD 20$' CMakeLists.txt)" -eq 2 && \
-        test "$(grep -c -- '-std=c++20' CMakeLists.txt)" -eq 1 && \
         python3 setup.py bdist_wheel -d /wheels; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -356,6 +356,14 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         git clone https://github.com/Tencent/hpc-ops.git && \
         cd hpc-ops && \
         git checkout ${HPC_OPS_COMMIT} && \
+        # PyTorch 2.13 headers require C++20, while the pinned commit uses C++17.
+        sed -i \
+            -e 's/CXX_STANDARD 17/CXX_STANDARD 20/' \
+            -e 's/CUDA_STANDARD 17/CUDA_STANDARD 20/' \
+            -e 's/-std=c++17/-std=c++20/' \
+            CMakeLists.txt && \
+        test "$(grep -Ec '^[[:space:]]*(CXX|CUDA)_STANDARD 20$' CMakeLists.txt)" -eq 2 && \
+        test "$(grep -c -- '-std=c++20' CMakeLists.txt)" -eq 1 && \
         python3 setup.py bdist_wheel -d /wheels; \
     fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,6 +20,9 @@ ARG UBUNTU_MIRROR
 ARG GITHUB_ARTIFACTORY=github.com
 ARG INSTALL_FLASHINFER_JIT_CACHE=0
 ARG FLASHINFER_VERSION=0.6.15.post1
+ARG TRTLLM_GEN_MOE_CUBIN_URL="https://github.com/sgl-project/whl/releases/download/trtllm_gen_moe_cubin_20260617/trtllm_gen_moe_cubin_pool_20260617_v0613rc1.zip"
+ARG TRTLLM_GEN_MOE_CUBIN_SHA256="4900501cbe782a76b08a5858f9f07152287b97cb68114466dac286366b66c192"
+ARG TRTLLM_GEN_MOE_CUBIN_ARCHIVE_ROOT="trtllm_gen_moe_cubin_pool_20260617_v0613rc1"
 ARG MOONCAKE_VERSION=0.3.12.post1
 ARG MSCCLPP_VERSION=sglang-v0.9.1
 #if need other arg please add in MOONCAKE_COMPILE_ARG
@@ -28,7 +31,8 @@ ARG MOONCAKE_COMPILE_ARG="-DUSE_HTTP=ON -DUSE_MNNVL=ON -DUSE_CUDA=ON -DWITH_EP=O
 ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
     GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/ \
-    FLASHINFER_VERSION=${FLASHINFER_VERSION}
+    FLASHINFER_VERSION=${FLASHINFER_VERSION} \
+    SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
 
 # Add GKE default lib and bin locations
 ENV PATH="${PATH}:/usr/local/nvidia/bin" \
@@ -166,6 +170,7 @@ ENV LANG=en_US.UTF-8 \
 #     |
 #     +-- devtools_builder (independent)
 #     +-- gateway_builder  (independent, only needs gateway source)
+#     +-- trtllm_cubin_builder (independent)
 #     |
 #     v
 #   framework (combines all artifacts)
@@ -461,6 +466,27 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && rm -rf /root/.cargo /root/.rustup /build/sgl-model-gateway/target /build/sgl-model-gateway/bindings/python/target
 
 ########################################################
+# PARALLEL STAGE 6: TRT-LLM Generated-MoE Cubin Pool
+########################################################
+FROM base AS trtllm_cubin_builder
+
+RUN cubin_archive="/tmp/trtllm_gen_moe_cubin_pool.zip" && \
+    cubin_extract_dir="/tmp/trtllm_gen_moe_cubin_extract" && \
+    wget --no-verbose --output-document="${cubin_archive}" \
+      "${TRTLLM_GEN_MOE_CUBIN_URL}" && \
+    echo "${TRTLLM_GEN_MOE_CUBIN_SHA256}  ${cubin_archive}" | \
+      sha256sum --check --strict - && \
+    mkdir -p "${cubin_extract_dir}" && \
+    unzip -q "${cubin_archive}" -d "${cubin_extract_dir}" && \
+    test ! -e "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" && \
+    mv "${cubin_extract_dir}/${TRTLLM_GEN_MOE_CUBIN_ARCHIVE_ROOT}" \
+      "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" && \
+    test "$(find "${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL}" \
+      -type f -name '*.cubin' | wc -l)" -eq 1696 && \
+    rm -f "${cubin_archive}" && \
+    rm -rf "${cubin_extract_dir}"
+
+########################################################
 ########## Final Framework Image ######################
 ########################################################
 #
@@ -500,6 +526,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /usr/local/lib/python3.12/dist-packages/
+
+# Copy the pinned FlashInfer MXFP4 MoE runner cubin pool
+COPY --from=trtllm_cubin_builder /opt/trtllm_gen_moe_cubin_pool /opt/trtllm_gen_moe_cubin_pool
 
 # Copy dev tools
 COPY --from=devtools_builder /tools/diff-so-fancy /usr/local/bin/
@@ -765,7 +794,8 @@ ARG GDRCOPY_VERSION=2.5.1
 
 ENV DEBIAN_FRONTEND=noninteractive \
     CUDA_HOME=/usr/local/cuda \
-    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/
+    GDRCOPY_HOME=/usr/src/gdrdrv-${GDRCOPY_VERSION}/ \
+    SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
 
 # Add GKE default lib and bin locations + CUDA compiler paths for FlashInfer JIT
 ENV PATH="${PATH}:/usr/local/nvidia/bin:/usr/local/cuda/bin:/usr/local/cuda/nvvm/bin" \
@@ -850,6 +880,9 @@ RUN --mount=type=cache,target=/var/cache/apt,id=runtime-apt \
 
 # Copy Python site-packages from framework (already cleaned of __pycache__/tests/pyc files)
 COPY --from=framework_final /usr/local/lib/python3.12/dist-packages /usr/local/lib/python3.12/dist-packages
+
+# Copy the pinned FlashInfer MXFP4 MoE runner cubin pool
+COPY --from=framework_final /opt/trtllm_gen_moe_cubin_pool /opt/trtllm_gen_moe_cubin_pool
 
 # Copy SGLang workspace
 COPY --from=framework_final /sgl-workspace /sgl-workspace


### PR DESCRIPTION
## Motivation

The generic CUDA image does not include the pinned TRT-LLM generated-MoE cubin pool or the FlashInfer CuTeDSL MLA decode-context-parallel runtime patch currently installed by the Kimi K3 CUDA 12 and CUDA 13 images.

## Modifications

- Add an independent builder stage that downloads the pinned cubin archive, verifies its SHA-256 digest, extracts it, and requires exactly 1,696 cubin files.
- Copy the verified pool into both framework and runtime images and export `SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL`.
- Install the build-time `patch` utility and apply the existing seven-file FlashInfer 0.6.15.post1 runtime patch, excluding test diffs absent from the wheel.
- Keep the existing CUDA 12.6, CUDA 12.9, and CUDA 13.0 FlashInfer dependency-selection paths unchanged.
- Pin HPC-Ops to upstream commit `ab1a402`, which switches CXX, CUDA, and NVCC to C++20 and removes the broad PyTorch includes that conflict with NVCC C++20 parsing.

## Accuracy Tests

This is a Docker packaging-only change and does not alter model output code.

Validation performed:

- `pre-commit run --files docker/Dockerfile`
- Dockerfile integration contract checks for builder/copy/env/patch wiring
- Downloaded the pinned archive and verified its SHA-256 digest and 1,696-cubin count
- Downloaded `flashinfer-python==0.6.15.post1` and dry-ran all seven runtime patch files successfully
- Confirmed the two Kimi K3 Dockerfiles remain unchanged
- Confirmed the pinned HPC-Ops commit contains all three C++20 settings and removes the two broad PyTorch includes that triggered the NVCC parser error

A full image build was not run locally because the workspace does not provide the Docker CLI.

## Speed Tests and Profiling

Not applicable; this changes image contents and build staging, not inference execution paths.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Covered by targeted Dockerfile integration and artifact checks.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change is required.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable to Docker packaging.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31157787110](https://github.com/sgl-project/sglang/actions/runs/31157787110)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31157786806](https://github.com/sgl-project/sglang/actions/runs/31157786806)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
