### PR TITLE
[MoE] [minimax-m3] Support FlashInfer TRT-LLM MXFP8 MoE

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -688,8 +688,8 @@ class Envs:
     # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
     # Launch the TRT-LLM MoE grouped GEMMs with PDL only at or below this
-    # token count.
-    SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS = EnvInt(8192)
+    # token count; larger calls can wedge under multi-stream CUDA graph replay.
+    SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS = EnvInt(4096)
     # Unpacked cubin pool for the JIT-built trtllm-gen fused MoE (cubins + flat
     # ABI headers + overlay/). Unset means the path is unavailable, not empty.
     SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL = EnvStr(None)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -701,8 +701,8 @@ class Envs:
     # Enable NVFP4 per-token activation scaling path for FlashInfer TRT-LLM MoE.
     SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION = EnvBool(False)
     # Launch the TRT-LLM MoE grouped GEMMs with PDL only at or below this
-    # token count.
-    SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS = EnvInt(8192)
+    # token count; larger calls can wedge under multi-stream CUDA graph replay.
+    SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS = EnvInt(4096)
     # Unpacked cubin pool for the JIT-built trtllm-gen fused MoE (cubins + flat
     # ABI headers + overlay/). Unset means the path is unavailable, not empty.
     SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL = EnvStr(None)

--- a/python/sglang/srt/layers/moe/flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/moe/flashinfer_trtllm_moe.py
@@ -30,6 +30,9 @@ def _fake_fp8_block_scale_moe_out(
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type: Optional[int] = None,
     activation_type: Optional[int] = None,
+    gemm1_alpha: Optional[torch.Tensor] = None,
+    gemm1_beta: Optional[torch.Tensor] = None,
+    gemm1_clamp_limit: Optional[torch.Tensor] = None,
 ) -> None:
     return None
 
@@ -63,6 +66,9 @@ def trtllm_fp8_block_scale_moe_out_wrapper(
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type: Optional[int] = None,
     activation_type: Optional[int] = None,
+    gemm1_alpha: Optional[torch.Tensor] = None,
+    gemm1_beta: Optional[torch.Tensor] = None,
+    gemm1_clamp_limit: Optional[torch.Tensor] = None,
 ) -> None:
     try:
         from flashinfer.fused_moe import trtllm_fp8_block_scale_moe
@@ -79,6 +85,9 @@ def trtllm_fp8_block_scale_moe_out_wrapper(
         "hidden_states_scale": hidden_states_scale,
         "gemm1_weights": gemm1_weights,
         "gemm1_weights_scale": gemm1_weights_scale,
+        "gemm1_alpha": gemm1_alpha,
+        "gemm1_beta": gemm1_beta,
+        "gemm1_clamp_limit": gemm1_clamp_limit,
         "gemm2_weights": gemm2_weights,
         "gemm2_weights_scale": gemm2_weights_scale,
         "output": output,
@@ -134,6 +143,9 @@ def _fake_fp8_block_scale_routed_moe_out(
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type: Optional[int] = None,
     activation_type: Optional[int] = None,
+    gemm1_alpha: Optional[torch.Tensor] = None,
+    gemm1_beta: Optional[torch.Tensor] = None,
+    gemm1_clamp_limit: Optional[torch.Tensor] = None,
 ) -> None:
     return None
 
@@ -167,6 +179,9 @@ def trtllm_fp8_block_scale_routed_moe_out_wrapper(
     tune_max_num_tokens: int = 8192,
     fp8_quantization_type: Optional[int] = None,
     activation_type: Optional[int] = None,
+    gemm1_alpha: Optional[torch.Tensor] = None,
+    gemm1_beta: Optional[torch.Tensor] = None,
+    gemm1_clamp_limit: Optional[torch.Tensor] = None,
 ) -> None:
     try:
         from flashinfer.fused_moe import trtllm_fp8_block_scale_routed_moe
@@ -183,6 +198,9 @@ def trtllm_fp8_block_scale_routed_moe_out_wrapper(
         "hidden_states_scale": hidden_states_scale,
         "gemm1_weights": gemm1_weights,
         "gemm1_weights_scale": gemm1_weights_scale,
+        "gemm1_alpha": gemm1_alpha,
+        "gemm1_beta": gemm1_beta,
+        "gemm1_clamp_limit": gemm1_clamp_limit,
         "gemm2_weights": gemm2_weights,
         "gemm2_weights_scale": gemm2_weights_scale,
         "output": output,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -768,6 +768,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 ),
                 use_shuffled_weight=use_shuffled_weight,
                 output=symm_output,
+                enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
@@ -803,6 +804,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 routing_method_type=routing_method_type,
                 use_shuffled_weight=use_shuffled_weight,
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+                enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
                 gemm1_alpha=quant_info.gemm1_alpha,
@@ -863,6 +865,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
             use_routing_scales_on_input=False,
             routing_method_type=routing_method_type,
             tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+            enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
             activation_type=quant_info.activation_type,
         )
         symm_output.copy_(output)

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -656,6 +656,9 @@ class FlashInferTrtllmFp8MoeQuantInfo(MoeQuantInfo):
 
     # Activation type (None = kernel default / Swiglu)
     activation_type: int | None = None
+    gemm1_alpha: torch.Tensor | None = None
+    gemm1_beta: torch.Tensor | None = None
+    gemm1_clamp_limit: torch.Tensor | None = None
 
 
 def fused_experts_none_to_flashinfer_trtllm_fp8(
@@ -768,6 +771,9 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
         else:
             assert TopKOutputChecker.format_is_bypassed(topk_output)
@@ -799,6 +805,9 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
+                gemm1_alpha=quant_info.gemm1_alpha,
+                gemm1_beta=quant_info.gemm1_beta,
+                gemm1_clamp_limit=quant_info.gemm1_clamp_limit,
             )
         output = symm_output
     else:

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -771,6 +771,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 ),
                 use_shuffled_weight=use_shuffled_weight,
                 output=symm_output,
+                enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
@@ -806,6 +807,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 routing_method_type=routing_method_type,
                 use_shuffled_weight=use_shuffled_weight,
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+                enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
             )
@@ -863,6 +865,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
             use_routing_scales_on_input=False,
             routing_method_type=routing_method_type,
             tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+            enable_pdl=a_q.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
             activation_type=quant_info.activation_type,
         )
         symm_output.copy_(output)

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -65,6 +65,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     mxfp8_group_quantize,
     normalize_e4m3fn_to_e4m3fnuz,
     requant_block_scale_ue8m0_for_deepgemm,
+    swizzle_mxfp8_scale_128x4,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -772,6 +773,13 @@ class Fp8LinearMethod(LinearMethodBase):
                 .reshape_as(scale_u8)
                 .contiguous(),
             )
+        elif backend.is_flashinfer_cutedsl():
+            n, k = layer.weight.shape
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv_cutedsl",
+                swizzle_mxfp8_scale_128x4(layer.weight_scale_inv.data, m=n, k=k),
+            )
         elif backend.is_flashinfer_cutlass():
             from flashinfer import block_scale_interleave
 
@@ -962,6 +970,8 @@ class Fp8LinearMethod(LinearMethodBase):
             backend = get_fp8_gemm_runner_backend()
             if backend.is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
+            elif backend.is_flashinfer_cutedsl():
+                weight_scale = layer.weight_scale_inv_cutedsl
             elif backend.is_flashinfer_trtllm():
                 weight_scale = layer.weight_scale_inv_shuffled
             elif get_fp8_gemm_runner_backend().is_deep_gemm():

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -2303,6 +2303,32 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             or moe_runner_backend.is_hpc_ops()
         ):
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            if (
+                moe_runner_backend.is_flashinfer_trtllm()
+                or moe_runner_backend.is_flashinfer_trtllm_routed()
+            ):
+                num_local_experts = int(getattr(layer, "num_local_experts"))
+                device = layer.w13_weight.device
+
+                def per_expert(value: Optional[float]) -> Optional[torch.Tensor]:
+                    return (
+                        None
+                        if value is None
+                        else torch.full(
+                            (num_local_experts,),
+                            value,
+                            dtype=torch.float32,
+                            device=device,
+                        )
+                    )
+
+                self._gemm1_alpha_tensor = per_expert(moe_runner_config.gemm1_alpha)
+                self._gemm1_beta_tensor = per_expert(
+                    1.0 if moe_runner_config.gemm1_alpha is not None else None
+                )
+                self._gemm1_clamp_limit_tensor = per_expert(
+                    moe_runner_config.gemm1_clamp_limit
+                )
         else:
             # TODO(cwan): refactor other backends
             pass
@@ -2557,6 +2583,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                     else None
                 ),
                 activation_type=activation_type,
+                gemm1_alpha=self._gemm1_alpha_tensor,
+                gemm1_beta=self._gemm1_beta_tensor,
+                gemm1_clamp_limit=self._gemm1_clamp_limit_tensor,
             )
         elif self.runner.runner_backend.is_hpc_ops():
             quant_info = self._get_hpc_ops_quant_info(layer)

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -65,6 +65,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     normalize_e4m3fn_to_e4m3fnuz,
     requant_block_scale_ue8m0_for_deepgemm,
     resolve_mxfp8_dense_gemm_backend,
+    swizzle_mxfp8_scale_128x4,
 )
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.marlin_utils_fp8 import prepare_fp8_layer_for_marlin
@@ -773,6 +774,13 @@ class Fp8LinearMethod(LinearMethodBase):
                 .reshape_as(scale_u8)
                 .contiguous(),
             )
+        elif backend.is_flashinfer_cutedsl():
+            n, k = layer.weight.shape
+            copy_or_rebind_param(
+                layer,
+                "weight_scale_inv_cutedsl",
+                swizzle_mxfp8_scale_128x4(layer.weight_scale_inv.data, m=n, k=k),
+            )
         elif backend.is_flashinfer_cutlass():
             from flashinfer import block_scale_interleave
 
@@ -976,6 +984,8 @@ class Fp8LinearMethod(LinearMethodBase):
             extra_kwargs = {}
             if backend.is_flashinfer_cutlass():
                 weight_scale = layer.weight_scale_inv_swizzled
+            elif backend.is_flashinfer_cutedsl():
+                weight_scale = layer.weight_scale_inv_cutedsl
             elif backend.is_flashinfer_trtllm():
                 weight_scale = layer.weight_scale_inv_shuffled
             elif backend.is_deep_gemm():

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -277,6 +277,7 @@ class Fp8GemmRunnerBackend(Enum):
     AUTO = "auto"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
+    FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
     FLASHINFER_DEEPGEMM = "flashinfer_deepgemm"
     CUTLASS = "cutlass"
     DEEP_GEMM = "deep_gemm"
@@ -291,6 +292,9 @@ class Fp8GemmRunnerBackend(Enum):
 
     def is_flashinfer_cutlass(self) -> bool:
         return self == Fp8GemmRunnerBackend.FLASHINFER_CUTLASS
+
+    def is_flashinfer_cutedsl(self) -> bool:
+        return self == Fp8GemmRunnerBackend.FLASHINFER_CUTEDSL
 
     def is_flashinfer_deepgemm(self) -> bool:
         return self == Fp8GemmRunnerBackend.FLASHINFER_DEEPGEMM
@@ -499,7 +503,11 @@ def dispatch_w8a8_mxfp8_linear() -> Callable:
     backend = get_fp8_gemm_runner_backend()
     if backend.is_deep_gemm():
         return _deepgemm_w8a8_mxfp8_linear_with_fallback
-    elif backend.is_flashinfer_cutlass() or backend.is_flashinfer_trtllm():
+    elif (
+        backend.is_flashinfer_cutlass()
+        or backend.is_flashinfer_cutedsl()
+        or backend.is_flashinfer_trtllm()
+    ):
         return flashinfer_mxfp8_blockscaled_linear
     elif backend.is_triton():
         return triton_mxfp8_blockscaled_linear
@@ -560,6 +568,10 @@ def _deepgemm_w8a8_mxfp8_linear_with_fallback(
 
 def _dispatch_explicit_backend(backend: Fp8GemmRunnerBackend) -> Callable:
     """Dispatch based on explicitly selected backend."""
+    if backend.is_flashinfer_cutedsl():
+        raise RuntimeError(
+            "--fp8-gemm-backend=flashinfer_cutedsl currently supports MXFP8 only."
+        )
     if backend.is_flashinfer_trtllm():
         if not (is_sm100_supported() and is_flashinfer_available()):
             raise RuntimeError(
@@ -1323,6 +1335,27 @@ def triton_mxfp8_blockscaled_linear(
     )
 
 
+def swizzle_mxfp8_scale_128x4(scale: torch.Tensor, m: int, k: int) -> torch.Tensor:
+    """Swizzle row-major MXFP8 scales into FlashInfer's 128x4 layout."""
+    block_size = 32
+    num_m_tiles = ceil_div(m, 128)
+    num_k_tiles = ceil_div(k, block_size * 4)
+    scale_cols = k // block_size
+
+    padded = torch.zeros(
+        (num_m_tiles * 128, num_k_tiles * 4),
+        dtype=scale.dtype,
+        device=scale.device,
+    )
+    padded[:m, :scale_cols] = scale.reshape(m, scale_cols)
+    return (
+        padded.view(num_m_tiles, 4, 32, num_k_tiles, 4)
+        .transpose(1, 3)
+        .contiguous()
+        .view(-1)
+    )
+
+
 def flashinfer_mxfp8_blockscaled_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1386,6 +1419,16 @@ def flashinfer_mxfp8_blockscaled_linear(
             out_dtype=output_dtype,
             use_8x4_sf_layout=False,
             backend="cutlass",
+        )
+    elif get_fp8_gemm_runner_backend().is_flashinfer_cutedsl():
+        output = flashinfer_mm_mxfp8(
+            q_input,
+            weight_t,
+            x_scale_u8,
+            weight_scale.contiguous().view(-1),
+            out_dtype=output_dtype,
+            use_8x4_sf_layout=False,
+            backend="cute-dsl",
         )
 
     if bias is not None:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -542,7 +542,11 @@ def resolve_mxfp8_dense_gemm_backend() -> Mxfp8DenseGemmBackend:
         return Mxfp8DenseGemmBackend.FLASHINFER_TRTLLM
 
     if backend.is_flashinfer_cutedsl():
-        if not (_is_sm100_supported and is_flashinfer_available()):
+        if not (
+            _is_sm100_supported
+            and get_device_capability() in ((10, 0), (10, 3))
+            and is_flashinfer_available()
+        ):
             raise RuntimeError(
                 "MXFP8 dense GEMM requested via --fp8-gemm-backend=flashinfer_cutedsl, "
                 "but that kernel requires SM100/SM103 GPUs and FlashInfer."

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -276,6 +276,7 @@ class Fp8GemmRunnerBackend(Enum):
     AUTO = "auto"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
+    FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
     FLASHINFER_DEEPGEMM = "flashinfer_deepgemm"
     CUTLASS = "cutlass"
     DEEP_GEMM = "deep_gemm"
@@ -290,6 +291,9 @@ class Fp8GemmRunnerBackend(Enum):
 
     def is_flashinfer_cutlass(self) -> bool:
         return self == Fp8GemmRunnerBackend.FLASHINFER_CUTLASS
+
+    def is_flashinfer_cutedsl(self) -> bool:
+        return self == Fp8GemmRunnerBackend.FLASHINFER_CUTEDSL
 
     def is_flashinfer_deepgemm(self) -> bool:
         return self == Fp8GemmRunnerBackend.FLASHINFER_DEEPGEMM
@@ -312,6 +316,7 @@ class Mxfp8DenseGemmBackend(Enum):
     `Fp8GemmRunnerBackend`."""
 
     FLASHINFER_CUTLASS = "flashinfer_cutlass"
+    FLASHINFER_CUTEDSL = "flashinfer_cutedsl"
     FLASHINFER_TRTLLM = "flashinfer_trtllm"
     DEEP_GEMM = "deep_gemm"
     GFX95_DOT_SCALED = "gfx95_dot_scaled"
@@ -319,6 +324,9 @@ class Mxfp8DenseGemmBackend(Enum):
 
     def is_flashinfer_cutlass(self) -> bool:
         return self == Mxfp8DenseGemmBackend.FLASHINFER_CUTLASS
+
+    def is_flashinfer_cutedsl(self) -> bool:
+        return self == Mxfp8DenseGemmBackend.FLASHINFER_CUTEDSL
 
     def is_flashinfer_trtllm(self) -> bool:
         return self == Mxfp8DenseGemmBackend.FLASHINFER_TRTLLM
@@ -533,6 +541,14 @@ def resolve_mxfp8_dense_gemm_backend() -> Mxfp8DenseGemmBackend:
             )
         return Mxfp8DenseGemmBackend.FLASHINFER_TRTLLM
 
+    if backend.is_flashinfer_cutedsl():
+        if not (_is_sm100_supported and is_flashinfer_available()):
+            raise RuntimeError(
+                "MXFP8 dense GEMM requested via --fp8-gemm-backend=flashinfer_cutedsl, "
+                "but that kernel requires SM100/SM103 GPUs and FlashInfer."
+            )
+        return Mxfp8DenseGemmBackend.FLASHINFER_CUTEDSL
+
     if backend.is_deep_gemm():
         if not deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM:
             raise RuntimeError(
@@ -568,6 +584,8 @@ def dispatch_w8a8_mxfp8_linear() -> Callable:
         return _deepgemm_w8a8_mxfp8_linear_with_fallback
     elif backend.is_flashinfer_trtllm():
         return partial(flashinfer_mxfp8_blockscaled_linear, backend="trtllm")
+    elif backend.is_flashinfer_cutedsl():
+        return partial(flashinfer_mxfp8_blockscaled_linear, backend="cute-dsl")
     elif backend.is_flashinfer_cutlass():
         return partial(flashinfer_mxfp8_blockscaled_linear, backend="cutlass")
     elif backend.is_unsupported():
@@ -638,6 +656,10 @@ def _deepgemm_w8a8_mxfp8_linear_with_fallback(
 
 def _dispatch_explicit_backend(backend: Fp8GemmRunnerBackend) -> Callable:
     """Dispatch based on explicitly selected backend."""
+    if backend.is_flashinfer_cutedsl():
+        raise RuntimeError(
+            "--fp8-gemm-backend=flashinfer_cutedsl currently supports MXFP8 only."
+        )
     if backend.is_flashinfer_trtllm():
         if not (is_sm100_supported() and is_flashinfer_available()):
             raise RuntimeError(
@@ -1210,6 +1232,27 @@ def mxfp8_group_quantize(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     return q_input.contiguous(), scale_u8.contiguous()
 
 
+def swizzle_mxfp8_scale_128x4(scale: torch.Tensor, m: int, k: int) -> torch.Tensor:
+    """Swizzle row-major MXFP8 scales into FlashInfer's 128x4 layout."""
+    block_size = 32
+    num_m_tiles = ceil_div(m, 128)
+    num_k_tiles = ceil_div(k, block_size * 4)
+    scale_cols = k // block_size
+
+    padded = torch.zeros(
+        (num_m_tiles * 128, num_k_tiles * 4),
+        dtype=scale.dtype,
+        device=scale.device,
+    )
+    padded[:m, :scale_cols] = scale.reshape(m, scale_cols)
+    return (
+        padded.view(num_m_tiles, 4, 32, num_k_tiles, 4)
+        .transpose(1, 3)
+        .contiguous()
+        .view(-1)
+    )
+
+
 def flashinfer_mxfp8_blockscaled_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -1253,7 +1296,7 @@ def flashinfer_mxfp8_blockscaled_linear(
     if backend == "cutlass" and q_input.shape[0] <= 64:
         backend = "cute-dsl"
 
-    if backend == "trtllm":
+    if backend in ("trtllm", "cute-dsl"):
         weight_scale_t = weight_scale.view(-1)
     else:
         weight_scale_t = weight_scale.t() if weight_scale.ndim == 2 else weight_scale

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -115,10 +115,7 @@ def should_run_flashinfer_autotune(
     fp8_gemm_needs_autotune = (
         fp8_gemm_backend.is_flashinfer_cutlass()
         or fp8_gemm_backend.is_flashinfer_cutedsl()
-        or (
-            model_uses_modelopt_fp8
-            and (is_sm100_supported() or is_sm120_supported())
-        )
+        or (model_uses_modelopt_fp8 and (is_sm100_supported() or is_sm120_supported()))
     )
 
     if not (moe_needs_autotune or fp4_gemm_needs_autotune or fp8_gemm_needs_autotune):

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -36,7 +36,8 @@ FLASHINFER_AUTOTUNE_WORKAROUND_SKIPS = frozenset({"mxfp8_gemm"})
 
 def get_flashinfer_autotune_skip_ops(model_runner: ModelRunner) -> set[str]:
     skip_ops = set(model_runner.server_args.flashinfer_autotune_skip_ops or ())
-    skip_ops.update(FLASHINFER_AUTOTUNE_WORKAROUND_SKIPS)
+    if model_runner.server_args.fp8_gemm_runner_backend != "flashinfer_cutedsl":
+        skip_ops.update(FLASHINFER_AUTOTUNE_WORKAROUND_SKIPS)
     return skip_ops
 
 
@@ -102,8 +103,11 @@ def should_run_flashinfer_autotune(
         "modelopt_fp8",
         "modelopt_mixed",
     )
-    fp8_gemm_needs_autotune = get_fp8_gemm_runner_backend().is_flashinfer_cutlass() or (
-        model_uses_modelopt_fp8 and is_sm100_supported()
+    fp8_gemm_backend = get_fp8_gemm_runner_backend()
+    fp8_gemm_needs_autotune = (
+        fp8_gemm_backend.is_flashinfer_cutlass()
+        or fp8_gemm_backend.is_flashinfer_cutedsl()
+        or (model_uses_modelopt_fp8 and is_sm100_supported())
     )
 
     if not (moe_needs_autotune or fp4_gemm_needs_autotune or fp8_gemm_needs_autotune):

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -111,8 +111,14 @@ def should_run_flashinfer_autotune(
     # SM120 satisfies is_blackwell_supported(), so resolve_mxfp8_dense_gemm_backend
     # sends it to the same tunable FlashInfer CUTLASS MXFP8 dense GEMM as SM100;
     # without this the kernel always runs at tactic=-1.
-    fp8_gemm_needs_autotune = get_fp8_gemm_runner_backend().is_flashinfer_cutlass() or (
-        model_uses_modelopt_fp8 and (is_sm100_supported() or is_sm120_supported())
+    fp8_gemm_backend = get_fp8_gemm_runner_backend()
+    fp8_gemm_needs_autotune = (
+        fp8_gemm_backend.is_flashinfer_cutlass()
+        or fp8_gemm_backend.is_flashinfer_cutedsl()
+        or (
+            model_uses_modelopt_fp8
+            and (is_sm100_supported() or is_sm120_supported())
+        )
     )
 
     if not (moe_needs_autotune or fp4_gemm_needs_autotune or fp8_gemm_needs_autotune):

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -54,7 +54,7 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
-from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.layers.moe.utils import RoutingMethodType, get_moe_a2a_backend
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.rotary_embedding import get_rope
@@ -323,8 +323,10 @@ class MiniMaxM3MoE(nn.Module):
             is_gated=True,
             gemm1_alpha=config.swiglu_alpha,
             gemm1_clamp_limit=config.swiglu_limit,
+            routed_scaling_factor=self.routed_scaling_factor,
             prefix=add_prefix("experts", prefix),
             gate_up_interleaved=False,
+            routing_method_type=RoutingMethodType.MiniMax2,
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
@@ -334,7 +336,9 @@ class MiniMaxM3MoE(nn.Module):
             correction_bias=self.e_score_correction_bias,
             num_fused_shared_experts=self.num_fused_shared_experts,
             routed_scaling_factor=self.routed_scaling_factor,
-            apply_routed_scaling_factor_on_output=True,
+            apply_routed_scaling_factor_on_output=(
+                self.experts.should_fuse_routed_scaling_factor_in_topk
+            ),
         )
 
         if self.n_shared_experts is not None and self.num_fused_shared_experts == 0:

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -74,13 +74,14 @@ from sglang.srt.model_executor.forward_context import (
     get_forward_context,
     has_forward_context,
 )
+from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.minimax_m2 import MiniMaxM2RMSNormTP
 from sglang.srt.models.utils import WeightsMapper
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_stream
 from sglang.srt.utils import (
     add_prefix,
     get_device_sm,
@@ -281,10 +282,12 @@ class MiniMaxM3MoE(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
         prefix: str = "",
     ):
         super().__init__()
         self.tp_size = get_parallel().tp_size
+        self.alt_stream = alt_stream
         self.n_shared_experts = getattr(config, "n_shared_experts", None)
         self.num_fused_shared_experts = (
             0
@@ -399,14 +402,24 @@ class MiniMaxM3MoE(nn.Module):
         use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
         if hidden_states.shape[0] > 0:
-            shared_output = self._forward_shared_experts(hidden_states)
-            router_logits = self._compute_router_logits(hidden_states)
-            topk_output = self.topk(hidden_states, router_logits)
+            if (
+                self.alt_stream is not None
+                and self.shared_experts is not None
+                and get_is_capture_mode()
+            ):
+                current_stream = torch.cuda.current_stream()
+                self.alt_stream.wait_stream(current_stream)
+                shared_output = self._forward_shared_experts(hidden_states)
+                with torch.cuda.stream(self.alt_stream):
+                    final_hidden_states = self._forward_router_experts(hidden_states)
+                current_stream.wait_stream(self.alt_stream)
+            else:
+                shared_output = self._forward_shared_experts(hidden_states)
+                final_hidden_states = self._forward_router_experts(hidden_states)
         else:
             shared_output = None
             topk_output = self.topk.empty_topk_output(hidden_states.device)
-
-        final_hidden_states = self.experts(hidden_states, topk_output)
+            final_hidden_states = self.experts(hidden_states, topk_output)
 
         if shared_output is not None:
             final_hidden_states = final_hidden_states + shared_output
@@ -414,6 +427,11 @@ class MiniMaxM3MoE(nn.Module):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         return final_hidden_states
+
+    def _forward_router_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        router_logits = self._compute_router_logits(hidden_states)
+        topk_output = self.topk(hidden_states, router_logits)
+        return self.experts(hidden_states, topk_output)
 
     def forward_deepep(
         self, hidden_states: torch.Tensor, forward_batch: ForwardBatch
@@ -1144,6 +1162,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -1183,6 +1202,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 config=config,
                 layer_id=layer_id,
                 quant_config=quant_config,
+                alt_stream=alt_stream,
                 prefix=add_prefix("mlp", prefix),
             )
         else:
@@ -1326,11 +1346,14 @@ class MiniMaxM3Model(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
 
+        alt_stream = get_stream("alt") if _is_cuda else None
+
         def layer_fn(idx, prefix: str) -> nn.Module:
             return MiniMaxM3DecoderLayer(
                 config=config,
                 layer_id=idx,
                 quant_config=quant_config,
+                alt_stream=alt_stream,
                 prefix=prefix,
             )
 

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -98,6 +98,7 @@ from sglang.srt.utils.hf_transformers_utils import get_rope_config
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _device_sm = get_device_sm()
 
 _FP8_KV_DTYPES = (
@@ -343,7 +344,7 @@ class MiniMaxM3MoE(nn.Module):
             num_fused_shared_experts=self.num_fused_shared_experts,
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scaling_factor_on_output=(
-                self.experts.should_fuse_routed_scaling_factor_in_topk
+                self.experts.should_fuse_routed_scaling_factor_in_topk or _use_aiter
             ),
         )
 

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -55,6 +55,7 @@ from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.moe.topk import TopK
 from sglang.srt.layers.moe.utils import (
+    RoutingMethodType,
     get_moe_a2a_backend,
     is_shared_experts_fusion_disabled,
 )
@@ -325,8 +326,10 @@ class MiniMaxM3MoE(nn.Module):
             gemm1_alpha=config.swiglu_alpha,
             gemm1_beta=1.0,
             gemm1_clamp_limit=config.swiglu_limit,
+            routed_scaling_factor=self.routed_scaling_factor,
             prefix=add_prefix("experts", prefix),
             gate_up_interleaved=False,
+            routing_method_type=RoutingMethodType.MiniMax2,
         )
         self.topk = TopK(
             top_k=config.num_experts_per_tok + self.num_fused_shared_experts,
@@ -336,7 +339,9 @@ class MiniMaxM3MoE(nn.Module):
             correction_bias=self.e_score_correction_bias,
             num_fused_shared_experts=self.num_fused_shared_experts,
             routed_scaling_factor=self.routed_scaling_factor,
-            apply_routed_scaling_factor_on_output=True,
+            apply_routed_scaling_factor_on_output=(
+                self.experts.should_fuse_routed_scaling_factor_in_topk
+            ),
         )
 
         if self.n_shared_experts is not None and self.num_fused_shared_experts == 0:

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -78,13 +78,14 @@ from sglang.srt.model_executor.forward_context import (
     get_forward_context,
     has_forward_context,
 )
+from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_loader.weight_utils import (
     default_weight_loader,
     maybe_remap_kv_scale_name,
 )
 from sglang.srt.models.minimax_m2 import MiniMaxM2RMSNormTP
 from sglang.srt.models.utils import WeightsMapper
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel, get_stream
 from sglang.srt.utils import (
     add_prefix,
     get_device_sm,
@@ -285,10 +286,12 @@ class MiniMaxM3MoE(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
         prefix: str = "",
     ):
         super().__init__()
         self.tp_size = get_parallel().tp_size
+        self.alt_stream = alt_stream
         self.n_shared_experts = getattr(config, "n_shared_experts", None)
         self.num_fused_shared_experts = (
             0 if is_shared_experts_fusion_disabled() else config.n_shared_experts
@@ -402,14 +405,24 @@ class MiniMaxM3MoE(nn.Module):
         use_reduce_scatter: bool = False,
     ) -> torch.Tensor:
         if hidden_states.shape[0] > 0:
-            shared_output = self._forward_shared_experts(hidden_states)
-            router_logits = self._compute_router_logits(hidden_states)
-            topk_output = self.topk(hidden_states, router_logits)
+            if (
+                self.alt_stream is not None
+                and self.shared_experts is not None
+                and get_is_capture_mode()
+            ):
+                current_stream = torch.cuda.current_stream()
+                self.alt_stream.wait_stream(current_stream)
+                shared_output = self._forward_shared_experts(hidden_states)
+                with torch.cuda.stream(self.alt_stream):
+                    final_hidden_states = self._forward_router_experts(hidden_states)
+                current_stream.wait_stream(self.alt_stream)
+            else:
+                shared_output = self._forward_shared_experts(hidden_states)
+                final_hidden_states = self._forward_router_experts(hidden_states)
         else:
             shared_output = None
             topk_output = self.topk.empty_topk_output(hidden_states.device)
-
-        final_hidden_states = self.experts(hidden_states, topk_output)
+            final_hidden_states = self.experts(hidden_states, topk_output)
 
         if shared_output is not None:
             final_hidden_states = final_hidden_states + shared_output
@@ -417,6 +430,11 @@ class MiniMaxM3MoE(nn.Module):
             final_hidden_states = tensor_model_parallel_all_reduce(final_hidden_states)
 
         return final_hidden_states
+
+    def _forward_router_experts(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        router_logits = self._compute_router_logits(hidden_states)
+        topk_output = self.topk(hidden_states, router_logits)
+        return self.experts(hidden_states, topk_output)
 
     def forward_deepep(
         self, hidden_states: torch.Tensor, forward_batch: ForwardBatch
@@ -1147,6 +1165,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
         config: PretrainedConfig,
         layer_id: int,
         quant_config: Optional[QuantizationConfig] = None,
+        alt_stream: Optional[torch.cuda.Stream] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -1186,6 +1205,7 @@ class MiniMaxM3DecoderLayer(nn.Module):
                 config=config,
                 layer_id=layer_id,
                 quant_config=quant_config,
+                alt_stream=alt_stream,
                 prefix=add_prefix("mlp", prefix),
             )
         else:
@@ -1329,11 +1349,14 @@ class MiniMaxM3Model(nn.Module):
         else:
             self.embed_tokens = PPMissingLayer()
 
+        alt_stream = get_stream("alt") if _is_cuda else None
+
         def layer_fn(idx, prefix: str) -> nn.Module:
             return MiniMaxM3DecoderLayer(
                 config=config,
                 layer_id=idx,
                 quant_config=quant_config,
+                alt_stream=alt_stream,
                 prefix=prefix,
             )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1779,7 +1779,8 @@ class ServerArgs:
             help=(
                 "FlashInfer custom-op identifiers to skip during autotuning. "
                 "Skipped ops use FlashInfer's heuristic fallback. SGLang "
-                "temporarily skips mxfp8_gemm by default due to an IMA."
+                "temporarily skips mxfp8_gemm by default due to an IMA, "
+                "except for the FlashInfer CuTeDSL backend."
             ),
             nargs="+",
         ),

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -289,6 +289,7 @@ FP8_GEMM_RUNNER_BACKEND_CHOICES = [
     "deep_gemm",
     "flashinfer_trtllm",
     "flashinfer_cutlass",
+    "flashinfer_cutedsl",
     "flashinfer_deepgemm",
     "cutlass",
     "triton",
@@ -1710,7 +1711,7 @@ class ServerArgs:
     fp8_gemm_runner_backend: A[
         str,
         Arg(
-            help="Choose the runner backend for Blockwise FP8 GEMM operations. Options: 'auto' (default, auto-selects based on hardware), 'deep_gemm' (JIT-compiled; enabled by default on NVIDIA Hopper (SM90) and Blackwell (SM100) when DeepGEMM is installed), 'flashinfer_trtllm' (optimal for Blackwell and low-latency), 'flashinfer_cutlass' (FlashInfer CUTLASS groupwise FP8 GEMM), 'flashinfer_deepgemm' (Hopper SM90 only; uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for SM120 GPUs), 'triton' (fallback, widely compatible), 'aiter' (ROCm only). ",
+            help="Choose the runner backend for Blockwise FP8 GEMM operations. Options: 'auto' (default, auto-selects based on hardware), 'deep_gemm' (JIT-compiled; enabled by default on NVIDIA Hopper (SM90) and Blackwell (SM100) when DeepGEMM is installed), 'flashinfer_trtllm' (optimal for Blackwell and low-latency), 'flashinfer_cutlass' (FlashInfer CUTLASS groupwise FP8 GEMM), 'flashinfer_cutedsl' (FlashInfer CuTe DSL MXFP8 GEMM), 'flashinfer_deepgemm' (Hopper SM90 only; uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for SM120 GPUs), 'triton' (fallback, widely compatible), 'aiter' (ROCm only). ",
             cli_name="--fp8-gemm-backend",
             choices=FP8_GEMM_RUNNER_BACKEND_CHOICES,
             resolvable=True,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -293,6 +293,7 @@ FP8_GEMM_RUNNER_BACKEND_CHOICES = [
     "deep_gemm",
     "flashinfer_trtllm",
     "flashinfer_cutlass",
+    "flashinfer_cutedsl",
     "flashinfer_deepgemm",
     "cutlass",
     "triton",
@@ -1733,7 +1734,7 @@ class ServerArgs:
     fp8_gemm_runner_backend: A[
         str,
         Arg(
-            help="Choose the runner backend for Blockwise FP8 GEMM operations. Options: 'auto' (default, auto-selects based on hardware), 'deep_gemm' (JIT-compiled; enabled by default on NVIDIA Hopper (SM90) and Blackwell (SM100) when DeepGEMM is installed), 'flashinfer_trtllm' (optimal for Blackwell and low-latency), 'flashinfer_cutlass' (FlashInfer CUTLASS groupwise FP8 GEMM), 'flashinfer_deepgemm' (Hopper SM90 only; uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for SM120 GPUs), 'triton' (fallback, widely compatible), 'aiter' (ROCm only). ",
+            help="Choose the runner backend for Blockwise FP8 GEMM operations. Options: 'auto' (default, auto-selects based on hardware), 'deep_gemm' (JIT-compiled; enabled by default on NVIDIA Hopper (SM90) and Blackwell (SM100) when DeepGEMM is installed), 'flashinfer_trtllm' (optimal for Blackwell and low-latency), 'flashinfer_cutlass' (FlashInfer CUTLASS groupwise FP8 GEMM), 'flashinfer_cutedsl' (FlashInfer CuTe DSL MXFP8 GEMM), 'flashinfer_deepgemm' (Hopper SM90 only; uses swapAB optimization for small M dimensions in decoding), 'cutlass' (optimal for SM120 GPUs), 'triton' (fallback, widely compatible), 'aiter' (ROCm only). ",
             cli_name="--fp8-gemm-backend",
             choices=FP8_GEMM_RUNNER_BACKEND_CHOICES,
             resolvable=True,

--- a/test/manual/layers/moe/test_flashinfer_trtllm_mxfp8_pdl_graph.py
+++ b/test/manual/layers/moe/test_flashinfer_trtllm_mxfp8_pdl_graph.py
@@ -1,0 +1,342 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Reproduce the FlashInfer MXFP8 MoE PDL CUDA-graph wedge.
+
+This is intentionally a manual, single-GPU test because the known-bad path can
+leave a CUDA kernel resident until its process is killed.  The CUDA workload is
+isolated in a spawned child process so pytest can detect the stall and recover.
+
+Run on an SM100 GPU with FlashInfer TRT-LLM MoE support:
+
+    CUDA_VISIBLE_DEVICES=0 pytest -s \
+      test/manual/layers/moe/test_flashinfer_trtllm_mxfp8_pdl_graph.py
+
+Override SGLANG_MXFP8_PDL_TEST_TOKENS and SGLANG_MXFP8_PDL_TEST_REPLAYS
+to sweep other capture shapes without editing this file.
+
+The explicit PDL-off control must finish.  The policy run derives enable_pdl
+from SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS.  With the old 8192-token default, the
+7680-token case enables PDL and typically stops making progress during replay.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import queue
+import statistics
+import time
+import traceback
+
+import pytest
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe.flashinfer_trtllm_moe import (
+    trtllm_fp8_block_scale_moe_out_wrapper,
+)
+from sglang.srt.layers.moe.utils import RoutingMethodType
+from sglang.srt.utils.common import next_power_of_2
+
+# MiniMax-M3 TP8-local routed-expert shape at the failing prefill capture size.
+NUM_TOKENS = int(os.getenv("SGLANG_MXFP8_PDL_TEST_TOKENS", "7680"))
+HIDDEN_SIZE = 6144
+NUM_EXPERTS = 128
+INTERMEDIATE_SIZE = 384
+TOP_K = 4
+NUM_LAYERS = 57
+NUM_REPLAYS = int(os.getenv("SGLANG_MXFP8_PDL_TEST_REPLAYS", "1000"))
+SYNC_EVERY = int(os.getenv("SGLANG_MXFP8_PDL_TEST_SYNC_EVERY", "10"))
+PDL_MAX_TOKENS = envs.SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS.get()
+STALL_TIMEOUT_S = 45
+STARTUP_TIMEOUT_S = 900
+
+
+def _shuffle_weights(w31, w31_scale, w2, w2_scale):
+    from flashinfer import (
+        reorder_rows_for_gated_act_gemm,
+        shuffle_matrix_a,
+        shuffle_matrix_sf_a,
+    )
+
+    tile_m = 128
+    q31, s31, q2, s2 = [], [], [], []
+    for expert in range(NUM_EXPERTS):
+        q31_expert = reorder_rows_for_gated_act_gemm(w31[expert])
+        s31_expert = reorder_rows_for_gated_act_gemm(w31_scale[expert])
+        q31.append(shuffle_matrix_a(q31_expert.view(torch.uint8), tile_m))
+        s31.append(shuffle_matrix_sf_a(s31_expert.view(torch.uint8), tile_m))
+        q2.append(shuffle_matrix_a(w2[expert].view(torch.uint8), tile_m))
+        s2.append(shuffle_matrix_sf_a(w2_scale[expert].view(torch.uint8), tile_m))
+    return (
+        torch.stack(q31).view(torch.float8_e4m3fn),
+        torch.stack(s31),
+        torch.stack(q2).view(torch.float8_e4m3fn),
+        torch.stack(s2),
+    )
+
+
+@torch.inference_mode()
+def _build_case():
+    from flashinfer import mxfp8_quantize
+    from flashinfer.fused_moe import Fp8QuantizationType
+    from flashinfer.fused_moe.core import ActivationType
+
+    torch.manual_seed(42)
+    device = torch.device("cuda")
+
+    hidden = (
+        torch.randn(NUM_TOKENS, HIDDEN_SIZE, device=device, dtype=torch.bfloat16) / 8
+    )
+    routing_logits = torch.randn(
+        NUM_TOKENS, NUM_EXPERTS, device=device, dtype=torch.bfloat16
+    )
+    routing_bias = torch.randn(NUM_EXPERTS, device=device, dtype=torch.float32) / 8
+
+    w31 = (
+        torch.randn(
+            NUM_EXPERTS,
+            2 * INTERMEDIATE_SIZE,
+            HIDDEN_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / HIDDEN_SIZE**0.5
+    )
+    w2 = (
+        torch.randn(
+            NUM_EXPERTS,
+            HIDDEN_SIZE,
+            INTERMEDIATE_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / INTERMEDIATE_SIZE**0.5
+    )
+    w31_q, w31_scale = mxfp8_quantize(w31.flatten(0, 1), False)
+    w2_q, w2_scale = mxfp8_quantize(w2.flatten(0, 1), False)
+    w31_q = w31_q.view_as(w31)
+    w2_q = w2_q.view_as(w2)
+    w31_scale = w31_scale.reshape(NUM_EXPERTS, 2 * INTERMEDIATE_SIZE, -1)
+    w2_scale = w2_scale.reshape(NUM_EXPERTS, HIDDEN_SIZE, -1)
+    del w31, w2
+    torch.cuda.empty_cache()
+
+    w31_q, w31_scale, w2_q, w2_scale = _shuffle_weights(
+        w31_q, w31_scale, w2_q, w2_scale
+    )
+    hidden_q, hidden_scale = mxfp8_quantize(hidden, False, backend="cute-dsl")
+
+    # This models the separate shared-expert branch running on the primary
+    # stream while routed MoE runs on the alternate stream.
+    shared_w1 = (
+        torch.randn(
+            HIDDEN_SIZE,
+            2 * INTERMEDIATE_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / HIDDEN_SIZE**0.5
+    )
+    shared_w2 = (
+        torch.randn(
+            INTERMEDIATE_SIZE,
+            HIDDEN_SIZE,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / INTERMEDIATE_SIZE**0.5
+    )
+    shared_gate = torch.empty(
+        NUM_TOKENS,
+        2 * INTERMEDIATE_SIZE,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    shared_out = torch.empty_like(hidden)
+    routed_out = torch.empty_like(hidden)
+    combined = torch.empty_like(hidden)
+
+    def expert_param(value: float):
+        return torch.full((NUM_EXPERTS,), value, device=device, dtype=torch.float32)
+
+    moe_args = dict(
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+        hidden_states=hidden_q,
+        hidden_states_scale=hidden_scale.reshape(NUM_TOKENS, -1),
+        gemm1_weights=w31_q,
+        gemm1_weights_scale=w31_scale,
+        gemm2_weights=w2_q,
+        gemm2_weights_scale=w2_scale,
+        output=routed_out,
+        num_experts=NUM_EXPERTS,
+        top_k=TOP_K,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=INTERMEDIATE_SIZE,
+        local_expert_offset=0,
+        local_num_experts=NUM_EXPERTS,
+        routed_scaling_factor=None,
+        routing_method_type=int(RoutingMethodType.MiniMax2),
+        use_shuffled_weight=True,
+        tune_max_num_tokens=next_power_of_2(NUM_TOKENS),
+        fp8_quantization_type=int(Fp8QuantizationType.MxFp8),
+        activation_type=ActivationType.Swiglu.value,
+        gemm1_alpha=expert_param(1.702),
+        gemm1_beta=expert_param(1.0),
+        gemm1_clamp_limit=expert_param(7.0),
+    )
+    shared = (hidden, shared_w1, shared_w2, shared_gate, shared_out, combined)
+    return moe_args, shared
+
+
+@torch.inference_mode()
+def _run_graph(case, enable_pdl: bool, label: str, report):
+    moe_args, shared = case
+    hidden, shared_w1, shared_w2, shared_gate, shared_out, combined = shared
+    primary_stream = torch.cuda.Stream()
+    routed_stream = torch.cuda.Stream()
+
+    def pattern():
+        current_stream = torch.cuda.current_stream()
+        for _ in range(NUM_LAYERS):
+            routed_stream.wait_stream(current_stream)
+            torch.mm(hidden, shared_w1, out=shared_gate)
+            torch.mm(
+                shared_gate[:, :INTERMEDIATE_SIZE],
+                shared_w2,
+                out=shared_out,
+            )
+            with torch.cuda.stream(routed_stream):
+                trtllm_fp8_block_scale_moe_out_wrapper(
+                    **moe_args, enable_pdl=enable_pdl
+                )
+            current_stream.wait_stream(routed_stream)
+            torch.add(shared_out, moe_args["output"], out=combined)
+
+    report((label, "warmup", 0))
+    primary_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(primary_stream):
+        for _ in range(3):
+            pattern()
+    torch.cuda.current_stream().wait_stream(primary_stream)
+    torch.cuda.synchronize()
+
+    report((label, "capture", 0))
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph, stream=primary_stream):
+        pattern()
+    torch.cuda.synchronize()
+
+    report((label, "replay", 0))
+    chunk_times_us = []
+    with torch.cuda.stream(primary_stream):
+        chunk_start = torch.cuda.Event(enable_timing=True)
+        chunk_end = torch.cuda.Event(enable_timing=True)
+        chunk_start.record()
+        for replay in range(1, NUM_REPLAYS + 1):
+            graph.replay()
+            if replay % SYNC_EVERY == 0:
+                chunk_end.record()
+                chunk_end.synchronize()
+                latency_us = chunk_start.elapsed_time(chunk_end) * 1000 / SYNC_EVERY
+                chunk_times_us.append(latency_us)
+                report((label, "replay", (replay, round(latency_us, 3))))
+                if replay != NUM_REPLAYS:
+                    chunk_start.record()
+    primary_stream.synchronize()
+    stable_times = chunk_times_us[1:] or chunk_times_us
+    report(
+        (
+            label,
+            "done",
+            {
+                "replays": NUM_REPLAYS,
+                "median_us": round(statistics.median(stable_times), 3),
+            },
+        )
+    )
+
+
+def _worker(messages):
+    try:
+        messages.put(("worker", "build", 0))
+        case = _build_case()
+        torch.cuda.synchronize()
+        messages.put(("worker", "built", 0))
+        _run_graph(case, False, "pdl_off_control", messages.put)
+        _run_graph(
+            case,
+            NUM_TOKENS <= PDL_MAX_TOKENS,
+            "production_policy",
+            messages.put,
+        )
+    except BaseException:
+        messages.put(("worker", "error", traceback.format_exc()))
+        raise
+
+
+def _stop(process: mp.Process):
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=30)
+
+
+def test_flashinfer_trtllm_mxfp8_pdl_multistream_graph_replay():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required")
+    if torch.cuda.get_device_capability() < (10, 0):
+        pytest.skip("The MiniMax-M3 MXFP8 path requires SM100 or newer")
+
+    ctx = mp.get_context("spawn")
+    messages = ctx.Queue()
+    process = ctx.Process(target=_worker, args=(messages,))
+    process.start()
+
+    history = []
+    started = time.monotonic()
+    last_progress = started
+    replay_stage = None
+    try:
+        while process.is_alive():
+            try:
+                message = messages.get(timeout=1)
+                history.append(message)
+                print(message, flush=True)
+                label, stage, _ = message
+                if stage == "replay":
+                    replay_stage = label
+                    last_progress = time.monotonic()
+                else:
+                    replay_stage = None
+            except queue.Empty:
+                pass
+
+            now = time.monotonic()
+            if replay_stage is not None and now - last_progress > STALL_TIMEOUT_S:
+                _stop(process)
+                pytest.fail(
+                    f"{replay_stage} CUDA graph replay made no progress for "
+                    f"{STALL_TIMEOUT_S}s; last messages: {history[-8:]}"
+                )
+            if now - started > STARTUP_TIMEOUT_S:
+                _stop(process)
+                pytest.fail(
+                    f"worker exceeded {STARTUP_TIMEOUT_S}s; "
+                    f"last messages: {history[-8:]}"
+                )
+
+        process.join()
+        while True:
+            try:
+                message = messages.get_nowait()
+                history.append(message)
+                print(message, flush=True)
+            except queue.Empty:
+                break
+        assert process.exitcode == 0, (
+            f"worker exited with code {process.exitcode}; "
+            f"last messages: {history[-8:]}"
+        )
+    finally:
+        _stop(process)

--- a/test/registered/kernels/ops/moe/test_flashinfer_trtllm_mxfp8.py
+++ b/test/registered/kernels/ops/moe/test_flashinfer_trtllm_mxfp8.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from sglang.srt.layers.moe.flashinfer_trtllm_moe import (
+    trtllm_fp8_block_scale_moe_out_wrapper,
+)
+from sglang.srt.layers.moe.utils import RoutingMethodType
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+if not torch.cuda.is_available() or torch.cuda.get_device_capability() < (10, 0):
+    pytest.skip(
+        "FlashInfer TRT-LLM MXFP8 MoE requires compute capability 10 or newer.",
+        allow_module_level=True,
+    )
+
+
+def _dequant_mxfp8(x: torch.Tensor, scale: torch.Tensor) -> torch.Tensor:
+    scale_f32 = (scale.view(torch.uint8).to(torch.int32) << 23).view(torch.float32)
+    scale_f32 = scale_f32.reshape(*x.shape[:-1], -1)
+    scale_f32 = scale_f32.repeat_interleave(32, dim=-1)
+    return x.float() * scale_f32
+
+
+def _reference_moe(
+    hidden_states: torch.Tensor,
+    routing_logits: torch.Tensor,
+    routing_bias: torch.Tensor,
+    w31: torch.Tensor,
+    w2: torch.Tensor,
+    top_k: int,
+    alpha: float,
+    beta: float,
+    limit: float,
+) -> torch.Tensor:
+    from flashinfer import mxfp8_quantize
+
+    scores = routing_logits.sigmoid()
+    topk_ids = (scores + routing_bias).topk(top_k, dim=-1).indices
+    expert_weights = scores.gather(-1, topk_ids)
+    expert_weights /= expert_weights.sum(dim=-1, keepdim=True) + 1e-20
+    selected_w31 = w31[topk_ids]
+    up, gate = torch.einsum("th,tkoh->tko", hidden_states, selected_w31).chunk(
+        2, dim=-1
+    )
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    act = gate * torch.sigmoid(alpha * gate) * (up + beta)
+    act_q, act_scale = mxfp8_quantize(
+        act.to(torch.bfloat16), is_sf_swizzled_layout=False
+    )
+    act = _dequant_mxfp8(act_q, act_scale)
+    expert_out = torch.einsum("tki,tkhi->tkh", act, w2[topk_ids])
+    return (expert_out * expert_weights[..., None]).sum(dim=1).to(torch.bfloat16)
+
+
+def _shuffle_mxfp8_weights(
+    w31: torch.Tensor,
+    w31_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    from flashinfer import (
+        reorder_rows_for_gated_act_gemm,
+        shuffle_matrix_a,
+        shuffle_matrix_sf_a,
+    )
+
+    epilogue_tile_m = 128
+    w31_out, w31_scale_out, w2_out, w2_scale_out = [], [], [], []
+    for expert_idx in range(w31.shape[0]):
+        w31_expert = reorder_rows_for_gated_act_gemm(w31[expert_idx])
+        w31_scale_expert = reorder_rows_for_gated_act_gemm(w31_scale[expert_idx])
+        w31_out.append(shuffle_matrix_a(w31_expert.view(torch.uint8), epilogue_tile_m))
+        w31_scale_out.append(
+            shuffle_matrix_sf_a(w31_scale_expert.view(torch.uint8), epilogue_tile_m)
+        )
+        w2_out.append(
+            shuffle_matrix_a(w2[expert_idx].view(torch.uint8), epilogue_tile_m)
+        )
+        w2_scale_out.append(
+            shuffle_matrix_sf_a(w2_scale[expert_idx].view(torch.uint8), epilogue_tile_m)
+        )
+    return (
+        torch.stack(w31_out).view(torch.float8_e4m3fn),
+        torch.stack(w31_scale_out),
+        torch.stack(w2_out).view(torch.float8_e4m3fn),
+        torch.stack(w2_scale_out),
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8])
+@torch.inference_mode()
+def test_flashinfer_trtllm_mxfp8_minimax_swiglu(num_tokens: int):
+    from flashinfer import mxfp8_quantize
+    from flashinfer.fused_moe import Fp8QuantizationType
+    from flashinfer.fused_moe.core import ActivationType
+
+    torch.manual_seed(42)
+    device = "cuda"
+    num_experts, top_k = 4, 2
+    hidden_size = intermediate_size = 256
+    alpha, beta, limit = 1.702, 1.0, 7.0
+
+    hidden_states = (
+        torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16) / 4
+    )
+    gate = (
+        torch.randn(
+            num_experts,
+            intermediate_size,
+            hidden_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / hidden_size**0.5
+    )
+    up = torch.randn_like(gate) / hidden_size**0.5
+    w31 = torch.cat((up, gate), dim=1)
+    w2 = (
+        torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        / intermediate_size**0.5
+    )
+    routing_logits = torch.randn(
+        num_tokens, num_experts, device=device, dtype=torch.bfloat16
+    )
+    routing_bias = torch.randn(num_experts, device=device, dtype=torch.float32) / 8
+
+    w31_q, w31_scale = mxfp8_quantize(w31.flatten(0, 1), False)
+    w2_q, w2_scale = mxfp8_quantize(w2.flatten(0, 1), False)
+    w31_q = w31_q.view_as(w31)
+    w2_q = w2_q.view_as(w2)
+    w31_scale = w31_scale.reshape(num_experts, 2 * intermediate_size, -1)
+    w2_scale = w2_scale.reshape(num_experts, hidden_size, -1)
+
+    hidden_q, hidden_scale = mxfp8_quantize(hidden_states, False, backend="cute-dsl")
+    hidden_ref = _dequant_mxfp8(hidden_q, hidden_scale)
+    w31_ref = _dequant_mxfp8(w31_q, w31_scale)
+    w2_ref = _dequant_mxfp8(w2_q, w2_scale)
+    expected = _reference_moe(
+        hidden_ref,
+        routing_logits.float(),
+        routing_bias,
+        w31_ref,
+        w2_ref,
+        top_k,
+        alpha,
+        beta,
+        limit,
+    )
+
+    w31_kernel, w31_scale_kernel, w2_kernel, w2_scale_kernel = _shuffle_mxfp8_weights(
+        w31_q, w31_scale, w2_q, w2_scale
+    )
+
+    def expert_param(value: float) -> torch.Tensor:
+        return torch.full((num_experts,), value, device=device, dtype=torch.float32)
+
+    output = torch.empty_like(hidden_states)
+    trtllm_fp8_block_scale_moe_out_wrapper(
+        routing_logits=routing_logits,
+        routing_bias=routing_bias,
+        hidden_states=hidden_q,
+        hidden_states_scale=hidden_scale.reshape(num_tokens, -1),
+        gemm1_weights=w31_kernel,
+        gemm1_weights_scale=w31_scale_kernel,
+        gemm2_weights=w2_kernel,
+        gemm2_weights_scale=w2_scale_kernel,
+        output=output,
+        num_experts=num_experts,
+        top_k=top_k,
+        n_group=None,
+        topk_group=None,
+        intermediate_size=intermediate_size,
+        local_expert_offset=0,
+        local_num_experts=num_experts,
+        routed_scaling_factor=None,
+        routing_method_type=int(RoutingMethodType.MiniMax2),
+        use_shuffled_weight=True,
+        tune_max_num_tokens=8,
+        fp8_quantization_type=int(Fp8QuantizationType.MxFp8),
+        activation_type=ActivationType.Swiglu.value,
+        gemm1_alpha=expert_param(alpha),
+        gemm1_beta=expert_param(beta),
+        gemm1_clamp_limit=expert_param(limit),
+    )
+
+    relative_error = (
+        output.float() - expected.float()
+    ).norm() / expected.float().norm()
+    assert relative_error.item() < 0.25

--- a/test/registered/kernels/ops/moe/test_flashinfer_trtllm_mxfp8.py
+++ b/test/registered/kernels/ops/moe/test_flashinfer_trtllm_mxfp8.py
@@ -35,6 +35,7 @@ def _reference_moe(
     alpha: float,
     beta: float,
     limit: float,
+    routed_scaling_factor: float,
 ) -> torch.Tensor:
     from flashinfer import mxfp8_quantize
 
@@ -54,7 +55,8 @@ def _reference_moe(
     )
     act = _dequant_mxfp8(act_q, act_scale)
     expert_out = torch.einsum("tki,tkhi->tkh", act, w2[topk_ids])
-    return (expert_out * expert_weights[..., None]).sum(dim=1).to(torch.bfloat16)
+    routed_output = (expert_out * expert_weights[..., None]).sum(dim=1)
+    return (routed_output * routed_scaling_factor).to(torch.bfloat16)
 
 
 def _shuffle_mxfp8_weights(
@@ -104,6 +106,7 @@ def test_flashinfer_trtllm_mxfp8_minimax_swiglu(num_tokens: int):
     num_experts, top_k = 4, 2
     hidden_size = intermediate_size = 256
     alpha, beta, limit = 1.702, 1.0, 7.0
+    routed_scaling_factor = 2.0
 
     hidden_states = (
         torch.randn(num_tokens, hidden_size, device=device, dtype=torch.bfloat16) / 4
@@ -156,6 +159,7 @@ def test_flashinfer_trtllm_mxfp8_minimax_swiglu(num_tokens: int):
         alpha,
         beta,
         limit,
+        routed_scaling_factor=routed_scaling_factor,
     )
 
     w31_kernel, w31_scale_kernel, w2_kernel, w2_scale_kernel = _shuffle_mxfp8_weights(
@@ -183,7 +187,7 @@ def test_flashinfer_trtllm_mxfp8_minimax_swiglu(num_tokens: int):
         intermediate_size=intermediate_size,
         local_expert_offset=0,
         local_num_experts=num_experts,
-        routed_scaling_factor=None,
+        routed_scaling_factor=routed_scaling_factor,
         routing_method_type=int(RoutingMethodType.MiniMax2),
         use_shuffled_weight=True,
         tune_max_num_tokens=8,

--- a/test/registered/ops/test_aiter_minimax_topk_scaling_amd.py
+++ b/test/registered/ops/test_aiter_minimax_topk_scaling_amd.py
@@ -1,0 +1,128 @@
+import importlib.util
+import os
+from types import SimpleNamespace
+
+os.environ["SGLANG_USE_AITER"] = "1"
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+from torch import nn  # noqa: E402
+
+from sglang.test.ci.ci_register import register_amd_ci  # noqa: E402
+
+register_amd_ci(
+    est_time=30,
+    suite="stage-b-test-1-gpu-small-amd",
+)
+
+if torch.version.hip is None or not torch.cuda.is_available():
+    pytest.skip("AITER TopK requires ROCm and an AMD GPU.", allow_module_level=True)
+if importlib.util.find_spec("aiter") is None:
+    pytest.skip("AITER is not installed.", allow_module_level=True)
+
+import sglang.srt.layers.moe.topk as topk_module  # noqa: E402
+import sglang.srt.models.minimax_m3 as minimax_m3  # noqa: E402
+
+
+class _FakeExperts(nn.Module):
+    should_fuse_routed_scaling_factor_in_topk = False
+
+    def __init__(self, **kwargs):
+        super().__init__()
+
+
+def test_aiter_minimax_topk_applies_routed_scaling_once(monkeypatch):
+    assert topk_module._use_aiter
+    assert minimax_m3._use_aiter
+
+    exec_context = SimpleNamespace(
+        moe=SimpleNamespace(ep_num_redundant_experts=0, enable_waterfill=False)
+    )
+    monkeypatch.setattr(minimax_m3, "get_parallel", lambda: SimpleNamespace(tp_size=1))
+    monkeypatch.setattr(minimax_m3, "get_exec", lambda: exec_context)
+    monkeypatch.setattr(topk_module, "get_exec", lambda: exec_context)
+    monkeypatch.setattr(
+        minimax_m3, "get_moe_impl_class", lambda quant_config: _FakeExperts
+    )
+    monkeypatch.setattr(
+        minimax_m3, "is_shared_experts_fusion_disabled", lambda: True
+    )
+    monkeypatch.setattr(
+        minimax_m3,
+        "get_moe_a2a_backend",
+        lambda: SimpleNamespace(is_deepep=lambda: False),
+    )
+    monkeypatch.setattr(
+        minimax_m3, "ReplicatedLinear", lambda *args, **kwargs: nn.Identity()
+    )
+
+    config = SimpleNamespace(
+        n_shared_experts=None,
+        num_local_experts=4,
+        num_experts_per_tok=2,
+        hidden_size=4,
+        intermediate_size=8,
+        routed_scaling_factor=2.0,
+        use_routing_bias=True,
+        scoring_func="sigmoid",
+        swiglu_alpha=1.702,
+        swiglu_limit=7.0,
+    )
+    device = torch.device("cuda")
+    moe = minimax_m3.MiniMaxM3MoE(
+        config, layer_id=0, quant_config=object()
+    ).to(device)
+    topk_config = moe.topk.topk_config
+
+    routing_logits = torch.tensor(
+        [
+            [2.0, 0.5, -1.0, -2.0],
+            [-1.5, 1.5, 0.25, -0.75],
+            [0.0, -2.0, 2.5, 0.75],
+            [1.0, -0.5, -1.5, 2.0],
+        ],
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    routing_bias = torch.tensor(
+        [0.05, -0.10, 0.15, 0.0], dtype=torch.float32, device=device
+    )
+    with torch.no_grad():
+        moe.e_score_correction_bias.copy_(routing_bias)
+    topk_config.correction_bias = moe.e_score_correction_bias
+
+    actual_weights, actual_ids = topk_module.fused_topk(
+        hidden_states=torch.zeros_like(routing_logits),
+        gating_output=routing_logits,
+        topk=topk_config.top_k,
+        renormalize=topk_config.renormalize,
+        correction_bias=topk_config.correction_bias,
+        scoring_func=topk_config.scoring_func,
+        routed_scaling_factor=topk_config.routed_scaling_factor,
+        apply_routed_scaling_factor_on_output=(
+            topk_config.apply_routed_scaling_factor_on_output
+        ),
+        num_fused_shared_experts=topk_config.num_fused_shared_experts,
+    )
+
+    scores = routing_logits.float().sigmoid()
+    expected_ids = (scores + routing_bias).topk(topk_config.top_k, dim=-1).indices
+    expected_weights = scores.gather(-1, expected_ids)
+    expected_weights /= expected_weights.sum(dim=-1, keepdim=True) + 1e-20
+    expected_weights *= config.routed_scaling_factor
+
+    actual_dense = torch.zeros_like(scores)
+    actual_dense.scatter_(1, actual_ids.long(), actual_weights)
+    expected_dense = torch.zeros_like(scores)
+    expected_dense.scatter_(1, expected_ids, expected_weights)
+    torch.testing.assert_close(actual_dense, expected_dense, rtol=5e-3, atol=5e-3)
+
+    assert actual_weights.sum(dim=-1).cpu().tolist() == pytest.approx(
+        [config.routed_scaling_factor] * routing_logits.shape[0],
+        rel=1e-5,
+        abs=1e-5,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/ops/test_aiter_minimax_topk_scaling_amd.py
+++ b/test/registered/ops/test_aiter_minimax_topk_scaling_amd.py
@@ -44,9 +44,7 @@ def test_aiter_minimax_topk_applies_routed_scaling_once(monkeypatch):
     monkeypatch.setattr(
         minimax_m3, "get_moe_impl_class", lambda quant_config: _FakeExperts
     )
-    monkeypatch.setattr(
-        minimax_m3, "is_shared_experts_fusion_disabled", lambda: True
-    )
+    monkeypatch.setattr(minimax_m3, "is_shared_experts_fusion_disabled", lambda: True)
     monkeypatch.setattr(
         minimax_m3,
         "get_moe_a2a_backend",
@@ -69,9 +67,7 @@ def test_aiter_minimax_topk_applies_routed_scaling_once(monkeypatch):
         swiglu_limit=7.0,
     )
     device = torch.device("cuda")
-    moe = minimax_m3.MiniMaxM3MoE(
-        config, layer_id=0, quant_config=object()
-    ).to(device)
+    moe = minimax_m3.MiniMaxM3MoE(config, layer_id=0, quant_config=object()).to(device)
     topk_config = moe.topk.topk_config
 
     routing_logits = torch.tensor(

--- a/test/registered/unit/layers/quantization/test_fp8_blockwise_linear_backends.py
+++ b/test/registered/unit/layers/quantization/test_fp8_blockwise_linear_backends.py
@@ -67,7 +67,12 @@ def _fp8_block_backends():
 def _mxfp8_backends():
     # MXFP8 linear is validated on SM100/103 only.
     if 100 <= get_device_sm() < 110:
-        return ["triton", "flashinfer_trtllm", "flashinfer_cutlass"]
+        return [
+            "triton",
+            "flashinfer_trtllm",
+            "flashinfer_cutlass",
+            "flashinfer_cutedsl",
+        ]
     return []
 
 
@@ -196,6 +201,9 @@ class TestMxfp8LinearBackends(_LinearBackendCheck):
 
     def test_flashinfer_cutlass(self):
         self._run("flashinfer_cutlass")
+
+    def test_flashinfer_cutedsl(self):
+        self._run("flashinfer_cutedsl")
 
 
 @unittest.skipIf(get_device_sm() < 90, "FP8 GEMM backends require SM90+")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

FlashInfer 0.6.14 already supports the GEMM1 alpha, beta, and clamp parameters required by MiniMax-M3 in its TRT-LLM block-scale FP8 MoE kernels. However, the SGLang integration does not pass these parameters through its wrapper and quantization metadata, so MiniMax-M3 cannot use this backend correctly.

This PR primarily extends the existing FlashInfer TRT-LLM FP8 MoE integration to forward the required MiniMax-M3 parameters and routing configuration. It also adds FlashInfer CuTeDSL as an MXFP8 dense GEMM backend and overlaps the standalone shared-expert and routed-expert branches during CUDA Graph capture.

## Modifications

- Extend the SGLang FlashInfer TRT-LLM wrapper and quantization metadata with per-expert GEMM1 alpha, beta, and clamp tensors.
- Pass the MiniMax routing method and routed-scaling ownership through the existing MoE runner configuration.
- Run the standalone shared expert and routed MoE on separate CUDA streams during CUDA Graph capture.
- Add `flashinfer_cutedsl` as an MXFP8 dense GEMM backend, including its weight-scale layout conversion and FlashInfer autotuning support.
- Disable TRT-LLM MoE PDL above 4096 tokens to avoid hangs under large multi-stream CUDA Graph workloads.
- Add MXFP8 MoE correctness tests and CUDA Graph coverage for the PDL threshold.

## Accuracy Tests

```bash
python -m sglang.test.run_eval --eval-name gsm8k --num-examples 1319 --port 8000

python -m sglang.test.run_eval --host 127.0.0.1 --port 8000 --eval-name longbench_v2 \
  --model $MODEL_PATH --num-examples 100 --max-context-length 500000 --max-tokens 16384
```

| Backend | GSM8k Score | LongBench Score |
|---|---:|---:|
| DeepGEMM MoE + DeepGEMM FP8 GEMM | 0.9726 | 0.5484 |
| FlashInfer TRT-LLM MoE + FlashInfer CuTeDSL FP8 GEMM | 0.9726 | 0.5484 |

## Speed Tests and Profiling

Both backends were tested with the same TP4 serving configuration and fixed 8K input / 1K output requests.

The `--mem-fraction-static 0.75` and `--chunked-prefill-size 4096` settings are chosen to keep the DeepGEMM baseline runnable. For MiniMax-M3, the DeepGEMM masked MoE layout can require about 25.8x the workspace of the logical routed-token payload. PR [#32524](https://github.com/sgl-project/sglang/pull/32524) explored the contiguous DeepGEMM layout to reduce this memory amplification. The FlashInfer path in this PR does not require the masked workspace and is faster in the tested workload; the same memory and chunk settings are retained for a fair comparison.

```bash
sglang serve \
  --model-path "$MODEL_PATH" \
  --host 0.0.0.0 --port 8000 \
  --tp 4 --dtype bfloat16 --trust-remote-code \
  --moe-runner-backend deep_gemm \
  --fp8-gemm-backend deep_gemm \
  --mem-fraction-static 0.75 --chunked-prefill-size 4096 \
  --cuda-graph-backend-prefill tc_piecewise \
  --disable-radix-cache

sglang serve \
  --model-path "$MODEL_PATH" \
  --host 0.0.0.0 --port 8000 \
  --tp 4 --dtype bfloat16 --trust-remote-code \
  --moe-runner-backend flashinfer_trtllm \
  --fp8-gemm-backend flashinfer_cutedsl \
  --mem-fraction-static 0.75  --chunked-prefill-size 4096 \
  --cuda-graph-backend-prefill tc_piecewise \
  --disable-radix-cache
```


| C | DeepGEMM P50 TTFT(ms) | FlashInfer P50 TTFT | DeepGEMM P50 TPOT(ms) | FlashInfer P50 TPOT | DeepGEMM Interactivity(tok/s) | FlashInfer Interactivity |
|---:|---:|---:|---:|---:|---:|---:|
| 1  | 574.73 | 565.36 | 7.61 | 5.05 | 131.39 | 198.10 |
| 2  | 869.32 | 868.86 | 8.09 | 5.71 | 123.55 | 175.01 |
| 4  | 1464.34 | 1466.20 | 9.22 | 6.84 | 108.45 | 146.11 |
| 8  | 2656.06 | 2676.69 | 10.83 | 8.27 | 92.33 | 120.92 |
| 16 | 5027.99 | 5117.72 | 13.59 | 10.75 | 73.57 | 93.00 |
| 32 | 9853.00 | 9951.84 | 17.79 | 14.38 | 56.23 | 69.57 |
| 64 | 19471.14 | 19754.59 | 23.15 | 19.49 | 43.19 | 51.30 |

The DeepGEMM `tc_piecewise` baseline initially hit an existing lazy JIT import error in per-token quantization. The kernel callable was pre-resolved for baseline measurement only; this PR does not modify the DeepGEMM path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31385190917](https://github.com/sgl-project/sglang/actions/runs/31385190917)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31385190844](https://github.com/sgl-project/sglang/actions/runs/31385190844)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->