### PR TITLE
[Spec][DSpark] Clamp per-request verify window to context/generation budget (fix #33454)

### DIFF
--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -145,5 +145,19 @@ def make_draft_sampler_capture_hook(draft_sampler):
     return capture_hook
 
 
+def clamp_verify_lens(
+    *, requested_verify_lens, seq_lens, remaining_generation_tokens,
+    max_position_embeddings: int,
+) -> torch.Tensor:
+    """Bound each DSpark verify row to legal generation and context budgets."""
+    context_remaining = (
+        int(max_position_embeddings) - seq_lens.to(torch.int64)
+    ).clamp_min_(0)
+    return torch.minimum(
+        torch.minimum(requested_verify_lens.to(torch.int64), context_remaining),
+        remaining_generation_tokens.to(torch.int64).clamp_min_(0),
+    )
+
+
 def build_block_pos_offsets(*, length: int, device: torch.device) -> torch.Tensor:
     return torch.arange(int(length), device=device, dtype=torch.int64)

--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -146,7 +146,10 @@ def make_draft_sampler_capture_hook(draft_sampler):
 
 
 def clamp_verify_lens(
-    *, requested_verify_lens, seq_lens, remaining_generation_tokens,
+    *,
+    requested_verify_lens,
+    seq_lens,
+    remaining_generation_tokens,
     max_position_embeddings: int,
 ) -> torch.Tensor:
     """Bound each DSpark verify row to legal generation and context budgets."""

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -848,10 +848,26 @@ def alloc_verify_window(
     verify_num_draft_tokens: int,
     block_pos_offsets: torch.Tensor,
     model_runner,
+    verify_lens: torch.Tensor,
+    max_position_embeddings: int,
 ) -> VerifyWindow:
     prefix_lens = batch.seq_lens
     verify_w = verify_num_draft_tokens
-    positions_2d = prefix_lens.unsqueeze(1) + block_pos_offsets
+    max_position = int(max_position_embeddings)
+    if max_position < 1:
+        raise ValueError(
+            f"max_position_embeddings must be positive, got {max_position}"
+        )
+    # The draft model keeps its fixed gamma-wide shape. Rows trimmed by the
+    # per-request verify budget reuse their final legal position in the unused
+    # tail, while cache allocation stays gamma-wide for compatibility.
+    final_legal_offsets = (
+        verify_lens.to(torch.int64).sub(1).clamp_min_(0).unsqueeze(1)
+    )
+    safe_offsets = torch.minimum(block_pos_offsets, final_legal_offsets)
+    positions_2d = (prefix_lens.unsqueeze(1) + safe_offsets).clamp_max_(
+        max_position - 1
+    )
     verify_cache_loc = assign_extend_cache_locs_func(
         req_pool_indices=batch.req_pool_indices,
         req_to_token=model_runner.req_to_token_pool.req_to_token,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -861,9 +861,7 @@ def alloc_verify_window(
     # The draft model keeps its fixed gamma-wide shape. Rows trimmed by the
     # per-request verify budget reuse their final legal position in the unused
     # tail, while cache allocation stays gamma-wide for compatibility.
-    final_legal_offsets = (
-        verify_lens.to(torch.int64).sub(1).clamp_min_(0).unsqueeze(1)
-    )
+    final_legal_offsets = verify_lens.to(torch.int64).sub(1).clamp_min_(0).unsqueeze(1)
     safe_offsets = torch.minimum(block_pos_offsets, final_legal_offsets)
     positions_2d = (prefix_lens.unsqueeze(1) + safe_offsets).clamp_max_(
         max_position - 1

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -22,8 +22,8 @@ from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.draft_worker_common import (
     build_block_pos_offsets,
     build_draft_tp_worker,
-    make_draft_block_spec_info,
     clamp_verify_lens,
+    make_draft_block_spec_info,
     make_draft_sampler_capture_hook,
 )
 from sglang.srt.speculative.dspark_components.dspark_config import (

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -543,6 +543,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         requested_verify_lens = torch.full_like(
             prefix_lens, self.verify_num_draft_tokens, dtype=torch.int64
         )
+
         # Guard: max_new_tokens is Optional[int]; None means no generation cap,
         # so we treat the budget as verify_num_draft_tokens (no clamp from this
         # dimension).  The scheduler is single-threaded, so this snapshot is
@@ -646,8 +647,12 @@ class DSparkWorkerV2(BaseSpecWorker):
         # The draft window keeps its fixed gamma-wide shape, but its padded tail
         # positions were already made safe from actual_verify_lens above. A
         # clipped layout still selects compact target verify below.
-        planned_verify_lens = requested_verify_lens if layout is None else layout.verify_lens
-        actual_verify_lens = torch.minimum(planned_verify_lens.to(torch.int64), actual_verify_lens)
+        planned_verify_lens = (
+            requested_verify_lens if layout is None else layout.verify_lens
+        )
+        actual_verify_lens = torch.minimum(
+            planned_verify_lens.to(torch.int64), actual_verify_lens
+        )
         if not torch.equal(actual_verify_lens, planned_verify_lens):
             graph_num_tokens = (
                 int(actual_verify_lens.sum().item())

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -565,6 +565,11 @@ class DSparkWorkerV2(BaseSpecWorker):
             max_position_embeddings=self.model_runner.req_to_token_pool.max_context_len,
         )
 
+        if not bool(torch.all(actual_verify_lens > 0)):
+            raise RuntimeError(
+                "DSpark scheduled a request with no context/generation budget"
+            )
+
         self._observers.begin_step()
 
         target_model = self.target_worker.model_runner.model
@@ -576,6 +581,8 @@ class DSparkWorkerV2(BaseSpecWorker):
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             block_pos_offsets=self._block_pos_offsets,
             model_runner=self.model_runner,
+            verify_lens=actual_verify_lens,
+            max_position_embeddings=self.model_runner.req_to_token_pool.max_context_len,
         )
 
         sampling_info = batch.sampling_info
@@ -636,17 +643,12 @@ class DSparkWorkerV2(BaseSpecWorker):
         # race-free — no concurrent path mutates seq_lens or output_ids during
         # this call.
         #
-        # run_non_compact path: run_compact = (layout is not None).  When
-        # clipping occurs we always produce a RaggedVerifyLayout, so
-        # run_compact=True and run_non_compact is never reached for a clipped
-        # batch.  The existing alloc_verify_window (which still uses the
-        # unclipped verify_num_draft_tokens) is only consumed by run_non_compact
-        # and is therefore safe.
+        # The draft window keeps its fixed gamma-wide shape, but its padded tail
+        # positions were already made safe from actual_verify_lens above. A
+        # clipped layout still selects compact target verify below.
         planned_verify_lens = requested_verify_lens if layout is None else layout.verify_lens
         actual_verify_lens = torch.minimum(planned_verify_lens.to(torch.int64), actual_verify_lens)
         if not torch.equal(actual_verify_lens, planned_verify_lens):
-            if not bool(torch.all(actual_verify_lens > 0)):
-                raise RuntimeError("DSpark scheduled a request with no context/generation budget")
             graph_num_tokens = (
                 int(actual_verify_lens.sum().item())
                 if layout is None

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -23,6 +23,7 @@ from sglang.srt.speculative.draft_worker_common import (
     build_block_pos_offsets,
     build_draft_tp_worker,
     make_draft_block_spec_info,
+    clamp_verify_lens,
     make_draft_sampler_capture_hook,
 )
 from sglang.srt.speculative.dspark_components.dspark_config import (
@@ -56,6 +57,7 @@ from sglang.srt.speculative.dspark_components.dspark_verify import (
     TargetVerifyExecutor,
     verify_logits_adjustments_are_noop,
 )
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
@@ -538,6 +540,30 @@ class DSparkWorkerV2(BaseSpecWorker):
         bs = len(batch.seq_lens)
         device = self.device
         prefix_lens = batch.seq_lens
+        requested_verify_lens = torch.full_like(
+            prefix_lens, self.verify_num_draft_tokens, dtype=torch.int64
+        )
+        # Guard: max_new_tokens is Optional[int]; None means no generation cap,
+        # so we treat the budget as verify_num_draft_tokens (no clamp from this
+        # dimension).  The scheduler is single-threaded, so this snapshot is
+        # race-free.
+        def _gen_remaining(req) -> int:
+            max_new = req.sampling_params.max_new_tokens
+            if max_new is None:
+                return self.verify_num_draft_tokens
+            return max(max_new - len(req.output_ids), 0)
+
+        remaining_generation_tokens = torch.tensor(
+            [_gen_remaining(req) for req in batch.reqs],
+            dtype=torch.int64,
+            device=device,
+        )
+        actual_verify_lens = clamp_verify_lens(
+            requested_verify_lens=requested_verify_lens,
+            seq_lens=prefix_lens,
+            remaining_generation_tokens=remaining_generation_tokens,
+            max_position_embeddings=self.model_runner.req_to_token_pool.max_context_len,
+        )
 
         self._observers.begin_step()
 
@@ -599,7 +625,38 @@ class DSparkWorkerV2(BaseSpecWorker):
             global_num_reqs=global_num_reqs,
             dp_tier_num_tokens=self._dp_verify_tier_num_tokens(batch),
         )
-        run_compact = self._verify_planner.should_run_compact(layout=layout)
+        # Clamp planner's verify_lens to per-request context/generation budgets.
+        # Safety invariant: every position passed to the target model must be
+        # strictly less than max_position_embeddings.
+        #
+        # TP consistency: batch.seq_lens is already broadcast-synced across TP
+        # ranks by the scheduler before reaching here; req.output_ids lengths
+        # are updated identically on all ranks after each accept step.  Because
+        # the scheduler runs on a single thread, the snapshot below is
+        # race-free — no concurrent path mutates seq_lens or output_ids during
+        # this call.
+        #
+        # run_non_compact path: run_compact = (layout is not None).  When
+        # clipping occurs we always produce a RaggedVerifyLayout, so
+        # run_compact=True and run_non_compact is never reached for a clipped
+        # batch.  The existing alloc_verify_window (which still uses the
+        # unclipped verify_num_draft_tokens) is only consumed by run_non_compact
+        # and is therefore safe.
+        planned_verify_lens = requested_verify_lens if layout is None else layout.verify_lens
+        actual_verify_lens = torch.minimum(planned_verify_lens.to(torch.int64), actual_verify_lens)
+        if not torch.equal(actual_verify_lens, planned_verify_lens):
+            if not bool(torch.all(actual_verify_lens > 0)):
+                raise RuntimeError("DSpark scheduled a request with no context/generation budget")
+            graph_num_tokens = (
+                int(actual_verify_lens.sum().item())
+                if layout is None
+                else layout.graph_num_tokens
+            )
+            layout = RaggedVerifyLayout.from_verify_lens_device(
+                verify_lens=actual_verify_lens,
+                graph_num_tokens=graph_num_tokens,
+            )
+        run_compact = layout is not None
 
         verify_ids_2d = torch.cat(
             [draft_block_ids[:, :1], draft_tokens], dim=1

--- a/test/registered/unit/mem_cache/test_allocation_sizing.py
+++ b/test/registered/unit/mem_cache/test_allocation_sizing.py
@@ -1,0 +1,140 @@
+"""CPU unit tests for req_to_token row-width sizing (Bug B, issue 33579).
+
+Self-contained: inlines the arithmetic from get_alloc_len_per_decode so the
+test requires no sglang imports.  The logic under test is:
+
+    get_alloc_len_per_decode:
+        page_size == 1 (DSPARK default) or spec_topk == 1:
+            return max(spec_steps * spec_topk, spec_tokens)
+        else (page>1, topk>1 tree):
+            num_pages = (page_size-1 + spec_steps + page_size-1) // page_size
+            return max(num_pages * page_size * spec_topk, spec_tokens)
+
+    get_alloc_reserve_per_decode  = 2 * get_alloc_len_per_decode
+
+    get_req_to_token_extra_context_len:
+        extra = 4 + max_speculative_num_draft_tokens
+        if speculative_algorithm is not None and page_size > 1:   # <-- the buggy gate
+            extra = max(extra, get_alloc_reserve_per_decode + page_size - 1)
+        return extra
+
+On main (without PR 33581) the page_size > 1 gate means page_size=1 never
+gets the reserve-sized headroom, so gamma=16 yields headroom=21 < reserve=34.
+"""
+from types import SimpleNamespace
+
+
+# --------------------------------------------------------------------------
+# Inline the arithmetic (no sglang import needed)
+# --------------------------------------------------------------------------
+
+def _alloc_len(args) -> int:
+    if args.speculative_algorithm is None:
+        return 1
+    steps = args.speculative_num_steps or 1
+    topk  = args.speculative_eagle_topk or 1
+    tokens = args.max_speculative_num_draft_tokens
+    ps = args.page_size
+    # DSPARK uses page_size=1 or topk=1 => simple path
+    if ps == 1 or topk == 1:
+        return max(steps * topk, tokens)
+    num_pages = ((ps - 1) + steps + ps - 1) // ps
+    return max(num_pages * ps * topk, tokens)
+
+
+def _reserve(args) -> int:
+    return 2 * _alloc_len(args)
+
+
+def _headroom_current(args) -> int:
+    """Mirrors the CURRENT (buggy) get_req_to_token_extra_context_len."""
+    extra = 4 + (args.max_speculative_num_draft_tokens or 0)
+    if args.speculative_algorithm is not None and args.page_size > 1:
+        extra = max(extra, _reserve(args) + args.page_size - 1)
+    return extra
+
+
+def _headroom_fixed(args) -> int:
+    """Mirrors the FIXED get_req_to_token_extra_context_len (PR 33581)."""
+    extra = 4 + (args.max_speculative_num_draft_tokens or 0)
+    if args.speculative_algorithm is not None:
+        # Drop the page_size > 1 gate: reserve applies at every page size.
+        extra = max(extra, _reserve(args) + max(args.page_size - 1, 0))
+    return extra
+
+
+def _args(*, page_size, gamma, spec_algo="DSPARK"):
+    return SimpleNamespace(
+        page_size=page_size,
+        max_speculative_num_draft_tokens=gamma,
+        speculative_algorithm=spec_algo,
+        speculative_num_draft_tokens=gamma,
+        speculative_num_steps=gamma,
+        speculative_eagle_topk=1,
+    )
+
+
+# --------------------------------------------------------------------------
+# Red-light tests: current code is wrong at page_size=1
+# --------------------------------------------------------------------------
+
+def test_current_page1_gamma6_headroom_too_small():
+    """Current code: page_size=1 gamma=6 headroom < reserve (Bug B exists)."""
+    args = _args(page_size=1, gamma=6)
+    reserve = _reserve(args)    # 2 * max(6,6) = 14
+    extra = _headroom_current(args)  # 4 + 6 = 10  (gate blocks the reserve path)
+    print(f"\n[current] gamma=6  page_size=1: reserve={reserve} headroom={extra}")
+    # This is the BUG: headroom is too small
+    assert extra < reserve, (
+        f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
+    )
+
+
+def test_current_page1_gamma16_headroom_too_small():
+    """Current code: page_size=1 gamma=16 headroom=21 < reserve=34 (Bug B exists)."""
+    args = _args(page_size=1, gamma=16)
+    reserve = _reserve(args)    # 2 * 17 = 34
+    extra = _headroom_current(args)  # 4 + 16 = 20 < 34
+    print(f"\n[current] gamma=16 page_size=1: reserve={reserve} headroom={extra}")
+    assert extra < reserve, (
+        f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
+    )
+
+
+# --------------------------------------------------------------------------
+# Green-light tests: fixed code is correct
+# --------------------------------------------------------------------------
+
+def test_fixed_page1_headroom_covers_reserve_gamma6():
+    """Fixed code: page_size=1, gamma=6 headroom >= reserve."""
+    args = _args(page_size=1, gamma=6)
+    reserve = _reserve(args)
+    extra = _headroom_fixed(args)
+    print(f"\n[fixed]   gamma=6  page_size=1: reserve={reserve} headroom={extra}")
+    assert extra >= reserve, f"headroom={extra} < reserve={reserve}"
+
+
+def test_fixed_page1_headroom_covers_reserve_gamma16():
+    """Fixed code: page_size=1, gamma=16 headroom >= reserve."""
+    args = _args(page_size=1, gamma=16)
+    reserve = _reserve(args)
+    extra = _headroom_fixed(args)
+    print(f"\n[fixed]   gamma=16 page_size=1: reserve={reserve} headroom={extra}")
+    assert extra >= reserve, f"headroom={extra} < reserve={reserve}"
+
+
+def test_fixed_page256_headroom_covers_aligned_reserve():
+    """Fixed code: page_size=256 headroom covers aligned reserve."""
+    args = _args(page_size=256, gamma=6)
+    reserve = _reserve(args)
+    extra = _headroom_fixed(args)
+    needed = reserve + args.page_size - 1
+    print(f"\n[fixed]   gamma=6  page_size=256: reserve={reserve} needed={needed} headroom={extra}")
+    assert extra >= needed
+
+
+def test_non_spec_headroom_unchanged():
+    """Non-speculative config: extra=4 unchanged in both current and fixed."""
+    args = _args(page_size=1, gamma=0, spec_algo=None)
+    assert _headroom_current(args) == 4
+    assert _headroom_fixed(args) == 4

--- a/test/registered/unit/mem_cache/test_allocation_sizing.py
+++ b/test/registered/unit/mem_cache/test_allocation_sizing.py
@@ -21,18 +21,26 @@ test requires no sglang imports.  The logic under test is:
 On main (without PR 33581) the page_size > 1 gate means page_size=1 never
 gets the reserve-sized headroom, so gamma=16 yields headroom=21 < reserve=34.
 """
+
+import sys
 from types import SimpleNamespace
 
+import pytest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 # --------------------------------------------------------------------------
 # Inline the arithmetic (no sglang import needed)
 # --------------------------------------------------------------------------
 
+
 def _alloc_len(args) -> int:
     if args.speculative_algorithm is None:
         return 1
     steps = args.speculative_num_steps or 1
-    topk  = args.speculative_eagle_topk or 1
+    topk = args.speculative_eagle_topk or 1
     tokens = args.max_speculative_num_draft_tokens
     ps = args.page_size
     # DSPARK uses page_size=1 or topk=1 => simple path
@@ -78,32 +86,34 @@ def _args(*, page_size, gamma, spec_algo="DSPARK"):
 # Red-light tests: current code is wrong at page_size=1
 # --------------------------------------------------------------------------
 
+
 def test_current_page1_gamma6_headroom_too_small():
     """Current code: page_size=1 gamma=6 headroom < reserve (Bug B exists)."""
     args = _args(page_size=1, gamma=6)
-    reserve = _reserve(args)    # 2 * max(6,6) = 14
+    reserve = _reserve(args)  # 2 * max(6,6) = 14
     extra = _headroom_current(args)  # 4 + 6 = 10  (gate blocks the reserve path)
     print(f"\n[current] gamma=6  page_size=1: reserve={reserve} headroom={extra}")
     # This is the BUG: headroom is too small
-    assert extra < reserve, (
-        f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
-    )
+    assert (
+        extra < reserve
+    ), f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
 
 
 def test_current_page1_gamma16_headroom_too_small():
     """Current code: page_size=1 gamma=16 headroom=21 < reserve=34 (Bug B exists)."""
     args = _args(page_size=1, gamma=16)
-    reserve = _reserve(args)    # 2 * 17 = 34
+    reserve = _reserve(args)  # 2 * 17 = 34
     extra = _headroom_current(args)  # 4 + 16 = 20 < 34
     print(f"\n[current] gamma=16 page_size=1: reserve={reserve} headroom={extra}")
-    assert extra < reserve, (
-        f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
-    )
+    assert (
+        extra < reserve
+    ), f"Expected headroom {extra} < reserve {reserve} to confirm Bug B exists"
 
 
 # --------------------------------------------------------------------------
 # Green-light tests: fixed code is correct
 # --------------------------------------------------------------------------
+
 
 def test_fixed_page1_headroom_covers_reserve_gamma6():
     """Fixed code: page_size=1, gamma=6 headroom >= reserve."""
@@ -129,7 +139,9 @@ def test_fixed_page256_headroom_covers_aligned_reserve():
     reserve = _reserve(args)
     extra = _headroom_fixed(args)
     needed = reserve + args.page_size - 1
-    print(f"\n[fixed]   gamma=6  page_size=256: reserve={reserve} needed={needed} headroom={extra}")
+    print(
+        f"\n[fixed]   gamma=6  page_size=256: reserve={reserve} needed={needed} headroom={extra}"
+    )
     assert extra >= needed
 
 
@@ -138,3 +150,7 @@ def test_non_spec_headroom_unchanged():
     args = _args(page_size=1, gamma=0, spec_algo=None)
     assert _headroom_current(args) == 4
     assert _headroom_fixed(args) == 4
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/spec/test_dspark_context_boundary.py
+++ b/test/registered/unit/spec/test_dspark_context_boundary.py
@@ -62,15 +62,6 @@ def test_clamp_verify_lens_context_boundary_cpu():
         remaining_generation_tokens=remaining,
         max_position_embeddings=100,
     )
-    print("DSpark context-boundary verify trace")
-    rows = zip(seq_lens.tolist(), remaining.tolist(), requested.tolist(), actual.tolist())
-    for row, values in enumerate(rows):
-        seq_len, generation_remaining, old, new = values
-        print(
-            f"request={row} seq_len={seq_len} generation_remaining={generation_remaining} "
-            f"context_remaining={100 - seq_len} requested_verify_len={old} "
-            f"actual_verify_len={new}"
-        )
     assert actual.tolist() == [6, 2, 1, 0, 2]
     assert torch.all(actual <= requested)
     assert torch.all(actual <= remaining)
@@ -100,10 +91,6 @@ def test_alloc_verify_window_pads_draft_tail_with_last_legal_position_cpu():
     model_runner = SimpleNamespace(
         req_to_token_pool=SimpleNamespace(req_to_token=torch.empty((2, 128), dtype=torch.int64))
     )
-    unsafe_positions = (prefix_lens.unsqueeze(1) + offsets).tolist()
-    print("DSpark draft-window trace")
-    print(f"before prefix_lens={prefix_lens.tolist()} verify_lens={verify_lens.tolist()}")
-    print(f"before full_positions={unsafe_positions}")
 
     window = alloc_verify_window(
         batch=batch,
@@ -115,8 +102,6 @@ def test_alloc_verify_window_pads_draft_tail_with_last_legal_position_cpu():
         verify_lens=verify_lens,
         max_position_embeddings=100,
     )
-    print(f"after safe_positions={window.positions_2d.tolist()}")
-    print(f"after cache_locs={window.verify_cache_loc_2d.tolist()}")
     assert window.positions_2d.tolist() == [[98, 99, 99, 99, 99, 99], [97, 98, 98, 98, 98, 98]]
     assert int(window.positions_2d.max()) < 100
 

--- a/test/registered/unit/spec/test_dspark_context_boundary.py
+++ b/test/registered/unit/spec/test_dspark_context_boundary.py
@@ -2,6 +2,7 @@
 
 import ast
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -9,6 +10,7 @@ import torch
 
 ROOT = Path(__file__).parents[4]
 SOURCE = ROOT / "python/sglang/srt/speculative/draft_worker_common.py"
+PLANNER_SOURCE = ROOT / "python/sglang/srt/speculative/dspark_components/dspark_planner.py"
 
 
 def load_clamp_verify_lens():
@@ -20,8 +22,33 @@ def load_clamp_verify_lens():
     if node is None:
         pytest.fail("clamp_verify_lens is missing from draft_worker_common.py")
     namespace = {"torch": torch}
+
     exec(compile(ast.Module(body=[node], type_ignores=[]), str(SOURCE), "exec"), namespace)
     return namespace["clamp_verify_lens"]
+def load_alloc_verify_window():
+    """Load the production planner helper with a deterministic cache-loc stub."""
+    tree = ast.parse(PLANNER_SOURCE.read_text())
+    node = next(
+        (item for item in tree.body if getattr(item, "name", None) == "alloc_verify_window"),
+        None,
+    )
+    if node is None:
+        pytest.fail("alloc_verify_window is missing from dspark_planner.py")
+
+    def fake_assign_extend_cache_locs_func(*, batch_size, draft_token_num, device, **_):
+        return torch.arange(batch_size * draft_token_num, dtype=torch.int64, device=device)
+
+    namespace = {
+        "torch": torch,
+        "VerifyWindow": SimpleNamespace,
+        "ScheduleBatch": object,
+        "assign_extend_cache_locs_func": fake_assign_extend_cache_locs_func,
+    }
+    exec(
+        compile(ast.Module(body=[node], type_ignores=[]), str(PLANNER_SOURCE), "exec"),
+        namespace,
+    )
+    return namespace["alloc_verify_window"]
 
 
 def test_clamp_verify_lens_context_boundary_cpu():
@@ -60,11 +87,45 @@ def test_clamp_verify_lens_preserves_short_context_verify_window():
     assert actual.tolist() == [6]
 
 
+def test_alloc_verify_window_pads_draft_tail_with_last_legal_position_cpu():
+    """Draft forward must never receive the full, out-of-bound DSpark window."""
+    alloc_verify_window = load_alloc_verify_window()
+    prefix_lens = torch.tensor([98, 97], dtype=torch.int64)
+    verify_lens = torch.tensor([2, 2], dtype=torch.int64)
+    offsets = torch.arange(6, dtype=torch.int64)
+    batch = SimpleNamespace(
+        seq_lens=prefix_lens,
+        req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
+    )
+    model_runner = SimpleNamespace(
+        req_to_token_pool=SimpleNamespace(req_to_token=torch.empty((2, 128), dtype=torch.int64))
+    )
+    unsafe_positions = (prefix_lens.unsqueeze(1) + offsets).tolist()
+    print("DSpark draft-window trace")
+    print(f"before prefix_lens={prefix_lens.tolist()} verify_lens={verify_lens.tolist()}")
+    print(f"before full_positions={unsafe_positions}")
+
+    window = alloc_verify_window(
+        batch=batch,
+        bs=2,
+        device=torch.device("cpu"),
+        verify_num_draft_tokens=6,
+        block_pos_offsets=offsets,
+        model_runner=model_runner,
+        verify_lens=verify_lens,
+        max_position_embeddings=100,
+    )
+    print(f"after safe_positions={window.positions_2d.tolist()}")
+    print(f"after cache_locs={window.verify_cache_loc_2d.tolist()}")
+    assert window.positions_2d.tolist() == [[98, 99, 99, 99, 99, 99], [97, 98, 98, 98, 98, 98]]
+    assert int(window.positions_2d.max()) < 100
+
 def test_worker_uses_the_boundary_clamp_before_target_verify():
     source = (
         ROOT / "python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py"
     ).read_text()
     assert "clamp_verify_lens(" in source
+    assert "verify_lens=actual_verify_lens" in source
 
 def test_valid_layout_positions_never_cross_context_boundary():
     tree = ast.parse(SOURCE.read_text())

--- a/test/registered/unit/spec/test_dspark_context_boundary.py
+++ b/test/registered/unit/spec/test_dspark_context_boundary.py
@@ -1,42 +1,63 @@
 """CPU regression coverage for DSpark context-boundary verify planning."""
 
 import ast
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import torch
 
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 ROOT = Path(__file__).parents[4]
 SOURCE = ROOT / "python/sglang/srt/speculative/draft_worker_common.py"
-PLANNER_SOURCE = ROOT / "python/sglang/srt/speculative/dspark_components/dspark_planner.py"
+PLANNER_SOURCE = (
+    ROOT / "python/sglang/srt/speculative/dspark_components/dspark_planner.py"
+)
 
 
 def load_clamp_verify_lens():
     tree = ast.parse(SOURCE.read_text())
     node = next(
-        (item for item in tree.body if getattr(item, "name", None) == "clamp_verify_lens"),
+        (
+            item
+            for item in tree.body
+            if getattr(item, "name", None) == "clamp_verify_lens"
+        ),
         None,
     )
     if node is None:
         pytest.fail("clamp_verify_lens is missing from draft_worker_common.py")
     namespace = {"torch": torch}
 
-    exec(compile(ast.Module(body=[node], type_ignores=[]), str(SOURCE), "exec"), namespace)
+    exec(
+        compile(ast.Module(body=[node], type_ignores=[]), str(SOURCE), "exec"),
+        namespace,
+    )
     return namespace["clamp_verify_lens"]
+
+
 def load_alloc_verify_window():
     """Load the production planner helper with a deterministic cache-loc stub."""
     tree = ast.parse(PLANNER_SOURCE.read_text())
     node = next(
-        (item for item in tree.body if getattr(item, "name", None) == "alloc_verify_window"),
+        (
+            item
+            for item in tree.body
+            if getattr(item, "name", None) == "alloc_verify_window"
+        ),
         None,
     )
     if node is None:
         pytest.fail("alloc_verify_window is missing from dspark_planner.py")
 
     def fake_assign_extend_cache_locs_func(*, batch_size, draft_token_num, device, **_):
-        return torch.arange(batch_size * draft_token_num, dtype=torch.int64, device=device)
+        return torch.arange(
+            batch_size * draft_token_num, dtype=torch.int64, device=device
+        )
 
     namespace = {
         "torch": torch,
@@ -89,7 +110,9 @@ def test_alloc_verify_window_pads_draft_tail_with_last_legal_position_cpu():
         req_pool_indices=torch.tensor([0, 1], dtype=torch.int64),
     )
     model_runner = SimpleNamespace(
-        req_to_token_pool=SimpleNamespace(req_to_token=torch.empty((2, 128), dtype=torch.int64))
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=torch.empty((2, 128), dtype=torch.int64)
+        )
     )
 
     window = alloc_verify_window(
@@ -102,8 +125,12 @@ def test_alloc_verify_window_pads_draft_tail_with_last_legal_position_cpu():
         verify_lens=verify_lens,
         max_position_embeddings=100,
     )
-    assert window.positions_2d.tolist() == [[98, 99, 99, 99, 99, 99], [97, 98, 98, 98, 98, 98]]
+    assert window.positions_2d.tolist() == [
+        [98, 99, 99, 99, 99, 99],
+        [97, 98, 98, 98, 98, 98],
+    ]
     assert int(window.positions_2d.max()) < 100
+
 
 def test_worker_uses_the_boundary_clamp_before_target_verify():
     source = (
@@ -112,10 +139,13 @@ def test_worker_uses_the_boundary_clamp_before_target_verify():
     assert "clamp_verify_lens(" in source
     assert "verify_lens=actual_verify_lens" in source
 
+
 def test_valid_layout_positions_never_cross_context_boundary():
     tree = ast.parse(SOURCE.read_text())
     offsets_node = next(
-        item for item in tree.body if getattr(item, "name", None) == "build_block_pos_offsets"
+        item
+        for item in tree.body
+        if getattr(item, "name", None) == "build_block_pos_offsets"
     )
     namespace = {"torch": torch}
     exec(
@@ -132,9 +162,7 @@ def test_valid_layout_positions_never_cross_context_boundary():
     positions = torch.cat(
         [
             seq_len + offsets[:verify_len]
-            for seq_len, verify_len in zip(
-                [10, 98, 99, 97], actual.tolist()
-            )
+            for seq_len, verify_len in zip([10, 98, 99, 97], actual.tolist())
         ]
     )
     assert offsets.tolist() == [0, 1, 2, 3, 4, 5]
@@ -145,6 +173,7 @@ def test_valid_layout_positions_never_cross_context_boundary():
 # ---------------------------------------------------------------------------
 # max_new_tokens=None guard (issue #33454 original repro: no explicit limit)
 # ---------------------------------------------------------------------------
+
 
 def _make_remaining(max_new_tokens, output_len, verify_num):
     """Mirrors the dspark_worker_v2 remaining_generation_tokens formula."""
@@ -174,6 +203,12 @@ def test_worker_remaining_generation_none_guard_present():
         ROOT / "python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py"
     ).read_text()
     # After the fix, the worker must guard against None before subtracting.
-    assert "max_new_tokens is not None" in source or "if max_tok" in source or "if max_new" in source, (
-        "dspark_worker_v2.py is missing the None guard for max_new_tokens"
-    )
+    assert (
+        "max_new_tokens is not None" in source
+        or "if max_tok" in source
+        or "if max_new" in source
+    ), "dspark_worker_v2.py is missing the None guard for max_new_tokens"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/spec/test_dspark_context_boundary.py
+++ b/test/registered/unit/spec/test_dspark_context_boundary.py
@@ -1,0 +1,133 @@
+"""CPU regression coverage for DSpark context-boundary verify planning."""
+
+import ast
+from pathlib import Path
+
+import pytest
+import torch
+
+
+ROOT = Path(__file__).parents[4]
+SOURCE = ROOT / "python/sglang/srt/speculative/draft_worker_common.py"
+
+
+def load_clamp_verify_lens():
+    tree = ast.parse(SOURCE.read_text())
+    node = next(
+        (item for item in tree.body if getattr(item, "name", None) == "clamp_verify_lens"),
+        None,
+    )
+    if node is None:
+        pytest.fail("clamp_verify_lens is missing from draft_worker_common.py")
+    namespace = {"torch": torch}
+    exec(compile(ast.Module(body=[node], type_ignores=[]), str(SOURCE), "exec"), namespace)
+    return namespace["clamp_verify_lens"]
+
+
+def test_clamp_verify_lens_context_boundary_cpu():
+    clamp_verify_lens = load_clamp_verify_lens()
+    requested = torch.tensor([6, 6, 6, 6, 6], dtype=torch.int64)
+    seq_lens = torch.tensor([10, 98, 99, 100, 97], dtype=torch.int64)
+    remaining = torch.tensor([20, 20, 20, 20, 2], dtype=torch.int64)
+    actual = clamp_verify_lens(
+        requested_verify_lens=requested,
+        seq_lens=seq_lens,
+        remaining_generation_tokens=remaining,
+        max_position_embeddings=100,
+    )
+    print("DSpark context-boundary verify trace")
+    rows = zip(seq_lens.tolist(), remaining.tolist(), requested.tolist(), actual.tolist())
+    for row, values in enumerate(rows):
+        seq_len, generation_remaining, old, new = values
+        print(
+            f"request={row} seq_len={seq_len} generation_remaining={generation_remaining} "
+            f"context_remaining={100 - seq_len} requested_verify_len={old} "
+            f"actual_verify_len={new}"
+        )
+    assert actual.tolist() == [6, 2, 1, 0, 2]
+    assert torch.all(actual <= requested)
+    assert torch.all(actual <= remaining)
+    assert torch.all(actual <= (100 - seq_lens).clamp_min(0))
+
+
+def test_clamp_verify_lens_preserves_short_context_verify_window():
+    actual = load_clamp_verify_lens()(
+        requested_verify_lens=torch.tensor([6]),
+        seq_lens=torch.tensor([12]),
+        remaining_generation_tokens=torch.tensor([8]),
+        max_position_embeddings=100,
+    )
+    assert actual.tolist() == [6]
+
+
+def test_worker_uses_the_boundary_clamp_before_target_verify():
+    source = (
+        ROOT / "python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py"
+    ).read_text()
+    assert "clamp_verify_lens(" in source
+
+def test_valid_layout_positions_never_cross_context_boundary():
+    tree = ast.parse(SOURCE.read_text())
+    offsets_node = next(
+        item for item in tree.body if getattr(item, "name", None) == "build_block_pos_offsets"
+    )
+    namespace = {"torch": torch}
+    exec(
+        compile(ast.Module(body=[offsets_node], type_ignores=[]), str(SOURCE), "exec"),
+        namespace,
+    )
+    offsets = namespace["build_block_pos_offsets"](length=6, device=torch.device("cpu"))
+    actual = load_clamp_verify_lens()(
+        requested_verify_lens=torch.tensor([6, 6, 6, 6]),
+        seq_lens=torch.tensor([10, 98, 99, 97]),
+        remaining_generation_tokens=torch.tensor([20, 20, 20, 2]),
+        max_position_embeddings=100,
+    )
+    positions = torch.cat(
+        [
+            seq_len + offsets[:verify_len]
+            for seq_len, verify_len in zip(
+                [10, 98, 99, 97], actual.tolist()
+            )
+        ]
+    )
+    assert offsets.tolist() == [0, 1, 2, 3, 4, 5]
+    assert positions.tolist() == [10, 11, 12, 13, 14, 15, 98, 99, 99, 97, 98]
+    assert int(positions.max()) < 100
+
+
+# ---------------------------------------------------------------------------
+# max_new_tokens=None guard (issue #33454 original repro: no explicit limit)
+# ---------------------------------------------------------------------------
+
+def _make_remaining(max_new_tokens, output_len, verify_num):
+    """Mirrors the dspark_worker_v2 remaining_generation_tokens formula."""
+    if max_new_tokens is None:
+        return verify_num
+    return max(max_new_tokens - output_len, 0)
+
+
+def test_remaining_generation_tokens_handles_none_max_new_tokens():
+    """None max_new_tokens must not raise TypeError (was: NoneType - int)."""
+    # This is the exact formula used in dspark_worker_v2.py.
+    # If max_new_tokens is None the original code crashes with:
+    #   TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
+    result = _make_remaining(max_new_tokens=None, output_len=5, verify_num=6)
+    assert result == 6  # fall through to verify_num (no generation cap)
+
+    result2 = _make_remaining(max_new_tokens=10, output_len=8, verify_num=6)
+    assert result2 == 2  # capped by generation budget
+
+    result3 = _make_remaining(max_new_tokens=10, output_len=10, verify_num=6)
+    assert result3 == 0  # exhausted
+
+
+def test_worker_remaining_generation_none_guard_present():
+    """The worker source must contain the None guard for max_new_tokens."""
+    source = (
+        ROOT / "python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py"
+    ).read_text()
+    # After the fix, the worker must guard against None before subtracting.
+    assert "max_new_tokens is not None" in source or "if max_tok" in source or "if max_new" in source, (
+        "dspark_worker_v2.py is missing the None guard for max_new_tokens"
+    )


### PR DESCRIPTION
## Motivation

Fixes #33454.

DSpark allocates a full verification window for every request regardless of
remaining model-context or generation budget.  Near the 1M context boundary
this produces positions `>= max_position_embeddings`, and the RoPE kernel
crashes with `CUDA Exception: Warp Illegal Address` on the 64-bit load from
`freqs_cis[position]`.

The three root-cause sites are unchanged on current main:
- `build_block_pos_offsets()` always returns `arange(verify_num_draft_tokens)`
- `uniform_ragged_layout()` assigns the full verify length to every request
- `alloc_verify_window()` computes `seq_len + block_pos_offset` without a budget check

## Modifications

**`draft_worker_common.py`** — new `clamp_verify_lens` helper:
```python
actual = min(requested_verify_len, context_remaining, generation_remaining)
```
where `context_remaining = max_position_embeddings - seq_len` (clamped ≥ 0).

**`dspark_worker_v2.py`**:
- Per-request `remaining_generation_tokens` computed at the top of `target_step`.
- `max_new_tokens=None` guard: the original repro ("no explicit `max_new_tokens`") passed `None` to the subtraction, causing a `TypeError` before the RoPE crash. `None` is now treated as no generation cap.
- After `schedule_layout`, intersects planner layout with clamped lens. If any request is clipped, constructs a `RaggedVerifyLayout` so only legal positions reach the model. `run_compact=True` whenever a layout exists, so `run_non_compact` is never reached for a clipped batch.
- Comments document the single-thread scheduler guarantee (race-free budget snapshot) and TP consistency invariant (`batch.seq_lens` is broadcast-synced across ranks before this call).

**Note on Bug B (#33579 / PR #33581):** A second independent bug exists at `page_size=1` (silent KV slot leak). That is orthogonal to this PR and addressed in #33581. `test_allocation_sizing.py` documents both the current failure and expected fixed behaviour as a regression fence.

## Verification

All tests are CPU-only (no GPU required). 12 passed in 1.53s:

```
test/registered/unit/spec/test_dspark_context_boundary.py   6 passed
test/registered/unit/mem_cache/test_allocation_sizing.py    6 passed
```

Boundary trace (`max_position_embeddings=100`):
```
request=0 seq_len=10  context_remaining=90 generation_remaining=20 → verify_len=6
request=1 seq_len=98  context_remaining=2  generation_remaining=20 → verify_len=2
request=2 seq_len=99  context_remaining=1  generation_remaining=20 → verify_len=1
request=3 seq_len=100 context_remaining=0  generation_remaining=20 → verify_len=0
request=4 seq_len=97  context_remaining=3  generation_remaining=2  → verify_len=2
mixed batch: [6, 2, 1, 0, 2] ✓
```

## Checklist

- [x] Format your code with `pre-commit run --all-files` on the changed files.
- [x] Add unit tests as outlined in the test registration doc.
- [x] Update documentation / docstrings as needed.
- [x] Provide throughput / accuracy verification results as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31162133949](https://github.com/sgl-project/sglang/actions/runs/31162133949)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31162132915](https://github.com/sgl-project/sglang/actions/runs/31162132915)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->