### PR TITLE
fix: guard set_embed_and_head against tied word embeddings

### DIFF
--- a/python/sglang/srt/models/apertus.py
+++ b/python/sglang/srt/models/apertus.py
@@ -638,8 +638,10 @@ class ApertusForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -3113,8 +3113,10 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -3174,8 +3174,10 @@ class DeepseekV4ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         # Hot weight reload (RL workflows). Use the device-agnostic module

--- a/python/sglang/srt/models/exaone4.py
+++ b/python/sglang/srt/models/exaone4.py
@@ -684,8 +684,10 @@ class Exaone4ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/exaone_moe.py
+++ b/python/sglang/srt/models/exaone_moe.py
@@ -746,8 +746,10 @@ class ExaoneMoEForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/falcon_h1.py
+++ b/python/sglang/srt/models/falcon_h1.py
@@ -499,8 +499,10 @@ class FalconH1ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/glm4.py
+++ b/python/sglang/srt/models/glm4.py
@@ -618,8 +618,10 @@ class Glm4ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/kimi_k25_eagle3.py
+++ b/python/sglang/srt/models/kimi_k25_eagle3.py
@@ -412,8 +412,10 @@ class Eagle3DeepseekV2ForCausalLM(nn.Module):
         torch.cuda.synchronize()
 
     def set_embed_and_head(self, embed: torch.Tensor, head: torch.Tensor) -> None:
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/llama.py
+++ b/python/sglang/srt/models/llama.py
@@ -849,8 +849,10 @@ class LlamaForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         if _is_xpu:

--- a/python/sglang/srt/models/mimo.py
+++ b/python/sglang/srt/models/mimo.py
@@ -146,8 +146,10 @@ class MiMoForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/nemotron_h.py
+++ b/python/sglang/srt/models/nemotron_h.py
@@ -1090,8 +1090,10 @@ class NemotronHForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/qwen2.py
+++ b/python/sglang/srt/models/qwen2.py
@@ -734,8 +734,10 @@ class Qwen2ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         current_platform.empty_cache()

--- a/python/sglang/srt/models/qwen3_5_text.py
+++ b/python/sglang/srt/models/qwen3_5_text.py
@@ -104,8 +104,10 @@ class Qwen3_5ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/python/sglang/srt/models/step3p5.py
+++ b/python/sglang/srt/models/step3p5.py
@@ -1028,8 +1028,10 @@ class Step3p5ForCausalLM(nn.Module):
         return self.model.embed_tokens.weight, self.lm_head.weight
 
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
         torch.cuda.empty_cache()

--- a/test/registered/unit/models/test_set_embed_and_head_tied_guard.py
+++ b/test/registered/unit/models/test_set_embed_and_head_tied_guard.py
@@ -1,0 +1,105 @@
+"""Guard `set_embed_and_head` against tied word embeddings.
+
+When `config.tie_word_embeddings` is set, model `__init__` aliases the head
+onto the embedding table:
+
+    if self.config.tie_word_embeddings:
+        self.lm_head = self.model.embed_tokens
+
+`self.lm_head` and `self.model.embed_tokens` are then the *same module*, so an
+unconditional
+
+    del self.model.embed_tokens.weight
+    del self.lm_head.weight
+
+deletes the same attribute twice and the second statement raises
+`AttributeError: 'VocabParallelEmbedding' object has no attribute 'weight'`.
+`set_embed_and_head` is on the EAGLE path (`EAGLEWorker.__init__` calls it on
+the draft model), so this fires whenever a draft checkpoint ties its
+embeddings -- e.g. `linborui/EAGLE-Llama-3.2-3B-Instruct`, which reports
+`tie_word_embeddings: true`.
+
+This is a source-level ratchet, in the style of the other `test_*_ratchet.py`
+files: it walks `python/sglang/srt/models/` and fails if any class that
+performs the aliasing also deletes both weights unconditionally. That keeps
+newly added models from reintroducing the pattern.
+"""
+
+import ast
+import pathlib
+import re
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_MODELS_DIR = _REPO_ROOT / "python" / "sglang" / "srt" / "models"
+
+# `self.lm_head = self.model.embed_tokens` under an `if ... tie_word_embeddings:`
+_ALIAS_RE = re.compile(
+    r"if\s+[^\n]*tie_word_embeddings\s*:\s*\n\s*self\.lm_head\s*=\s*self\.model\.embed_tokens"
+)
+
+
+class TestSetEmbedAndHeadTiedGuard(CustomTestCase):
+    def test_tied_embedding_delete_is_guarded(self):
+        offenders = []
+        for path in sorted(_MODELS_DIR.glob("*.py")):
+            offenders.extend(_find_unguarded(path))
+
+        self.assertFalse(
+            offenders,
+            msg=(
+                "`set_embed_and_head` deletes both `model.embed_tokens.weight` "
+                "and `lm_head.weight` unconditionally in a class that aliases "
+                "the two together when `tie_word_embeddings` is set. The second "
+                "`del` raises AttributeError for tied checkpoints. Guard it, as "
+                "`qwen3.py` and `qwen3_5_mtp.py` do:\n  " + "\n  ".join(offenders)
+            ),
+        )
+
+
+def _find_unguarded(path: pathlib.Path):
+    """Yield `<rel_path>:<lineno> <ClassName>` for each offending class."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    # Cheap pre-filter: most model files never define this method.
+    if "set_embed_and_head" not in source:
+        return []
+    try:
+        tree = ast.parse(source, filename=str(path))
+    except SyntaxError:
+        return []
+
+    found = []
+    for cls in [n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)]:
+        class_src = ast.get_source_segment(source, cls) or ""
+        if not _ALIAS_RE.search(class_src):
+            continue
+        for fn in cls.body:
+            if not (
+                isinstance(fn, ast.FunctionDef) and fn.name == "set_embed_and_head"
+            ):
+                continue
+            body = ast.get_source_segment(source, fn) or ""
+            if "del self.model.embed_tokens.weight" not in body:
+                continue
+            if "del self.lm_head.weight" not in body:
+                continue
+            # Any of the in-tree guards is accepted: a `hasattr` check, a
+            # `tie_word_embeddings` branch, or a try/except around the deletes.
+            if any(tok in body for tok in ("hasattr", "tie_word_embeddings", "try:")):
+                continue
+            rel = path.relative_to(_REPO_ROOT)
+            found.append(f"{rel}:{fn.lineno} {cls.name}")
+    return found
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

When `config.tie_word_embeddings` is set, model `__init__` aliases the head onto the embedding table:

```python
if self.config.tie_word_embeddings:
    self.lm_head = self.model.embed_tokens
```

`self.lm_head` and `self.model.embed_tokens` are then the **same module**, so `set_embed_and_head`'s two deletes target the same attribute:

```python
del self.model.embed_tokens.weight
del self.lm_head.weight              # AttributeError
```

```
AttributeError: 'VocabParallelEmbedding' object has no attribute 'weight'
```

`set_embed_and_head` is on the EAGLE path — `EAGLEWorker.__init__` calls it on the draft model — so this fires whenever a draft checkpoint ties its embeddings. [`linborui/EAGLE-Llama-3.2-3B-Instruct`](https://huggingface.co/linborui/EAGLE-Llama-3.2-3B-Instruct) reports `tie_word_embeddings: true` and hits it.

This has not shown up in CI because the repackaged drafts the [speculative decoding docs](https://docs.sglang.ai/advanced_features/speculative_decoding) use — `lmsys/sglang-EAGLE-LLaMA3-Instruct-8B`, `lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B` — all report `tie_word_embeddings: false`.

## Modifications

The fix already exists in the tree, in four places and three shapes:

| file | guard |
|---|---|
| `qwen3.py` | `if hasattr(self.model.embed_tokens, "weight"):` around each delete |
| `qwen3_5_mtp.py` | `if not self.config.tie_word_embeddings:` around the second delete |
| `ernie4_eagle.py` | same `tie_word_embeddings` branch |
| `glm4v.py` | re-aliases `lm_head = embed_tokens` afterwards |

14 other classes perform the same aliasing in `__init__` and still delete unconditionally. This PR applies `qwen3.py`'s `hasattr` form to those 14:

`apertus`, `deepseek_v2`, `deepseek_v4`, `exaone4`, `exaone_moe`, `falcon_h1`, `glm4`, `kimi_k25_eagle3`, `llama`, `mimo`, `nemotron_h`, `qwen2`, `qwen3_5_text`, `step3p5`

Behaviour is unchanged whenever the weights are present, which is every untied checkpoint. Each file gets the same 4-line change:

```diff
     def set_embed_and_head(self, embed, head):
-        del self.model.embed_tokens.weight
-        del self.lm_head.weight
+        if hasattr(self.model.embed_tokens, "weight"):
+            del self.model.embed_tokens.weight
+        if hasattr(self.lm_head, "weight"):
+            del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
```

I picked `hasattr` over the `tie_word_embeddings` branch because it needs no config attribute and also covers any other reason the weight may be absent; happy to switch to the `tie_word_embeddings` form if you prefer that as the canonical one.

## Accuracy Test

Reproduced against `main`'s own source — the function body is extracted from `python/sglang/srt/models/llama.py` rather than retyped, and executed against a minimal object graph that reproduces what `LlamaForCausalLM.__init__` builds:

```
=== main, LlamaForCausalLM.set_embed_and_head ===
    def set_embed_and_head(self, embed, head):
        del self.model.embed_tokens.weight
        del self.lm_head.weight
        ...

[ok   ] tie_word_embeddings=False        (lmsys/sglang-EAGLE-LLaMA3-Instruct-8B)
[RAISE] tie_word_embeddings=True         (linborui/EAGLE-Llama-3.2-3B-Instruct)
         AttributeError: 'Embedding' object has no attribute 'weight'
```

Added `test/registered/unit/models/test_set_embed_and_head_tied_guard.py`, a source-level ratchet in the style of the existing `test_*_ratchet.py` files, so a newly added model cannot reintroduce the pattern. It walks `python/sglang/srt/models/` and flags any class that aliases the two modules and still deletes both weights unconditionally.

On the pre-fix tree it fails and names all 14:

```
AssertionError: [...] is not false : `set_embed_and_head` deletes both
`model.embed_tokens.weight` and `lm_head.weight` unconditionally in a class
that aliases the two together when `tie_word_embeddings` is set. [...]
  python/sglang/srt/models/apertus.py:640 ApertusForCausalLM
  python/sglang/srt/models/deepseek_v2.py:3115 DeepseekV2ForCausalLM
  python/sglang/srt/models/deepseek_v4.py:3176 DeepseekV4ForCausalLM
  ...
  python/sglang/srt/models/step3p5.py:1030 Step3p5ForCausalLM
```

and after the fix:

```
test_tied_embedding_delete_is_guarded ... ok
Ran 1 test in 1.0s
OK
```

Registered as `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`; it imports nothing from `srt` and needs no GPU or weights.

## Checklist

- [x] Format with `black` / `isort` / `ruff --select=F401,F821,UP037` / `codespell` per `.pre-commit-config.yaml`
- [x] Added a unit test under `test/registered/unit/`, registered for CI
- [x] No behaviour change on any currently-working path

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31159125523](https://github.com/sgl-project/sglang/actions/runs/31159125523)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31159125512](https://github.com/sgl-project/sglang/actions/runs/31159125512)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->