### PR TITLE
feat: load community EAGLE drafts without repackaging the checkpoint

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -86,6 +86,42 @@ class ModelImpl(str, Enum):
     MINDSPORE = "mindspore"
 
 
+# Community EAGLE / EAGLE3 drafts are published under the architecture of the
+# model they were trained against rather than under an Eagle-specific one:
+# yuhuili/EAGLE-LLaMA3.1-Instruct-8B and linborui/EAGLE-Llama-3.2-3B-Instruct
+# both report ["LlamaForCausalLM"], yuhuili/EAGLE-Qwen2-7B-Instruct reports
+# ["Qwen2ForCausalLM"]. Loaded as the base architecture they miss the Eagle
+# class whose load_weights() prepends "model." to their unprefixed checkpoint
+# keys. The repackaged lmsys/sglang-EAGLE-* checkpoints already name the Eagle
+# class and are unaffected.
+#
+# base architecture -> (EAGLE arch, EAGLE3 arch or None if the family has none)
+EAGLE_DRAFT_BASE_ARCHS = {
+    "LlamaForCausalLM": ("LlamaForCausalLMEagle", "LlamaForCausalLMEagle3"),
+    "Qwen2ForCausalLM": ("Qwen2ForCausalLMEagle", None),
+}
+
+
+def resolve_eagle_draft_arch(architecture: str, hf_config) -> Optional[str]:
+    """Eagle architecture for a draft published under its base architecture.
+
+    Returns None when ``architecture`` is not a known EAGLE base architecture,
+    or when the checkpoint is an EAGLE3 draft of a family that has no Eagle3
+    class; in both cases the caller leaves the architecture untouched.
+
+    EAGLE3 drafts are distinguished by carrying ``draft_vocab_size`` (the
+    reduced output vocabulary). Layer count is deliberately not used:
+    yuhuili/EAGLE3-Vicuna1.3-13B reports num_hidden_layers=40.
+    """
+    entry = EAGLE_DRAFT_BASE_ARCHS.get(architecture)
+    if entry is None:
+        return None
+    eagle_arch, eagle3_arch = entry
+    if getattr(hf_config, "draft_vocab_size", None) is not None:
+        return eagle3_arch
+    return eagle_arch
+
+
 def _hf_arch(config) -> Optional[str]:
     """First architecture from a HF config dict or PretrainedConfig (or None)."""
     archs = (
@@ -696,6 +732,19 @@ class ModelConfig:
         if is_draft_model and self.hf_config.architectures[0] == "HYV3ForCausalLM":
             self.hf_config.architectures[0] = "HYV3ForCausalLMNextN"
             self.hf_config.num_nextn_predict_layers = 1
+
+        if is_draft_model and self.speculative_algorithm in ("EAGLE", "EAGLE3"):
+            base_arch = self.hf_config.architectures[0]
+            eagle_arch = resolve_eagle_draft_arch(base_arch, self.hf_config)
+            if eagle_arch is not None:
+                logger.info(
+                    "Draft checkpoint reports architecture %s; loading it as %s "
+                    "for %s speculative decoding.",
+                    base_arch,
+                    eagle_arch,
+                    self.speculative_algorithm,
+                )
+                self.hf_config.architectures[0] = eagle_arch
 
     def _derive_hybrid_model(self):
         # Use self.context_len after it has been initialized to prevent using context_len which may be None.

--- a/test/registered/unit/configs/test_eagle_draft_arch.py
+++ b/test/registered/unit/configs/test_eagle_draft_arch.py
@@ -1,0 +1,87 @@
+"""Unit tests for EAGLE draft architecture resolution."""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.configs.model_config import (
+    EAGLE_DRAFT_BASE_ARCHS,
+    resolve_eagle_draft_arch,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _cfg(**kwargs):
+    return SimpleNamespace(**kwargs)
+
+
+class TestResolveEagleDraftArch(CustomTestCase):
+    def test_llama_draft_without_draft_vocab_is_eagle(self):
+        # yuhuili/EAGLE-LLaMA3.1-Instruct-8B, linborui/EAGLE-Llama-3.2-3B-Instruct
+        self.assertEqual(
+            resolve_eagle_draft_arch("LlamaForCausalLM", _cfg()),
+            "LlamaForCausalLMEagle",
+        )
+
+    def test_llama_draft_with_draft_vocab_is_eagle3(self):
+        # yuhuili/EAGLE3-LLaMA3.1-Instruct-8B reports draft_vocab_size=32000
+        self.assertEqual(
+            resolve_eagle_draft_arch("LlamaForCausalLM", _cfg(draft_vocab_size=32000)),
+            "LlamaForCausalLMEagle3",
+        )
+
+    def test_layer_count_is_not_used_to_classify(self):
+        # yuhuili/EAGLE3-Vicuna1.3-13B reports num_hidden_layers=40, so the
+        # draft is not identifiable by having a single decoder layer.
+        self.assertEqual(
+            resolve_eagle_draft_arch(
+                "LlamaForCausalLM", _cfg(num_hidden_layers=40, draft_vocab_size=32000)
+            ),
+            "LlamaForCausalLMEagle3",
+        )
+
+    def test_qwen2_draft_is_eagle(self):
+        # yuhuili/EAGLE-Qwen2-7B-Instruct
+        self.assertEqual(
+            resolve_eagle_draft_arch("Qwen2ForCausalLM", _cfg()),
+            "Qwen2ForCausalLMEagle",
+        )
+
+    def test_family_without_eagle3_class_is_left_alone(self):
+        # There is no Qwen2ForCausalLMEagle3 entry class to route to.
+        self.assertIsNone(
+            resolve_eagle_draft_arch("Qwen2ForCausalLM", _cfg(draft_vocab_size=32000))
+        )
+
+    def test_repackaged_checkpoints_are_untouched(self):
+        # lmsys/sglang-EAGLE-* already name the Eagle class.
+        for arch in ("LlamaForCausalLMEagle", "LlamaForCausalLMEagle3"):
+            with self.subTest(arch=arch):
+                self.assertIsNone(resolve_eagle_draft_arch(arch, _cfg()))
+
+    def test_unknown_architecture_is_untouched(self):
+        self.assertIsNone(resolve_eagle_draft_arch("DeepseekV3ForCausalLM", _cfg()))
+
+    def test_explicit_none_draft_vocab_counts_as_absent(self):
+        self.assertEqual(
+            resolve_eagle_draft_arch("LlamaForCausalLM", _cfg(draft_vocab_size=None)),
+            "LlamaForCausalLMEagle",
+        )
+
+    def test_mapping_targets_are_registered_entry_classes(self):
+        """Every architecture the table maps to must be loadable."""
+        from sglang.srt.models.registry import ModelRegistry
+
+        supported = set(ModelRegistry.get_supported_archs())
+        for base, (eagle_arch, eagle3_arch) in EAGLE_DRAFT_BASE_ARCHS.items():
+            for target in (eagle_arch, eagle3_arch):
+                if target is None:
+                    continue
+                with self.subTest(base=base, target=target):
+                    self.assertIn(target, supported)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Community EAGLE / EAGLE3 drafts are published under the architecture of the model they were trained against, not under an Eagle-specific one. Config values read from the Hub:

| checkpoint | `architectures` | `num_hidden_layers` | `draft_vocab_size` |
|---|---|---|---|
| `yuhuili/EAGLE-LLaMA3.1-Instruct-8B` | `["LlamaForCausalLM"]` | 1 | — |
| `linborui/EAGLE-Llama-3.2-3B-Instruct` | `["LlamaForCausalLM"]` | 1 | — |
| `yuhuili/EAGLE3-LLaMA3.1-Instruct-8B` | `["LlamaForCausalLM"]` | 1 | 32000 |
| `yuhuili/EAGLE3-Vicuna1.3-13B` | `["LlamaForCausalLM"]` | **40** | 32000 |
| `yuhuili/EAGLE-Qwen2-7B-Instruct` | `["Qwen2ForCausalLM"]` | 1 | — |

Loaded under the base architecture they miss `LlamaForCausalLMEagle` / `LlamaForCausalLMEagle3` / `Qwen2ForCausalLMEagle`, whose `load_weights()` is what prepends `"model."` to their unprefixed checkpoint keys.

The way around this today is a repackaged copy: `lmsys/sglang-EAGLE-LLaMA3-Instruct-8B` and `lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B` name the Eagle class directly in their config, and those are what the [speculative decoding docs](https://docs.sglang.ai/advanced_features/speculative_decoding) use. That works, but it means every newly trained draft needs a repackage before it can be served — which is friction for anyone training their own EAGLE head.

## Modifications

Resolve the Eagle architecture from the base architecture when the checkpoint is loaded as a draft **and** the selected algorithm is `EAGLE` or `EAGLE3` — in `_config_draft_model`, alongside the existing DeepSeek / GLM / MiMo / Ernie draft remaps.

```python
EAGLE_DRAFT_BASE_ARCHS = {
    "LlamaForCausalLM": ("LlamaForCausalLMEagle", "LlamaForCausalLMEagle3"),
    "Qwen2ForCausalLM": ("Qwen2ForCausalLMEagle", None),
}
```

Design notes:

- **EAGLE3 is identified by `draft_vocab_size`** (the reduced output vocabulary), not by layer count. `yuhuili/EAGLE3-Vicuna1.3-13B` reports `num_hidden_layers=40`, so "the draft has one decoder layer" is not a reliable signal.
- **A family with no Eagle3 class leaves an EAGLE3 checkpoint untouched** rather than routing it to something that cannot load it (Qwen2 has `Qwen2ForCausalLMEagle` but no Eagle3 counterpart).
- **Nothing that works today changes.** Checkpoints that already name an Eagle class do not match the table; other architectures and other algorithms do not enter the branch.
- **Mistral** has `mistral_eagle.py` and would be a one-line addition to the table. I left it out because I could not fetch a public Mistral EAGLE checkpoint's config to confirm the base architecture it reports — happy to add it if you know one.

With this, the original checkpoints work directly:

```bash
python3 -m sglang.launch_server \
    --model meta-llama/Llama-3.1-8B-Instruct \
    --speculative-algorithm EAGLE \
    --speculative-draft-model-path yuhuili/EAGLE-LLaMA3.1-Instruct-8B \
    --speculative-num-steps 3 --speculative-eagle-topk 4 \
    --speculative-num-draft-tokens 16
```

and log:

```
Draft checkpoint reports architecture LlamaForCausalLM; loading it as
LlamaForCausalLMEagle for EAGLE speculative decoding.
```

## Accuracy Test

Added `test/registered/unit/configs/test_eagle_draft_arch.py` covering every branch, following the `test_model_config.py` pattern of testing module-level helpers with `SimpleNamespace` configs. Cases, each anchored to a real checkpoint:

```
  [ok ] LlamaForCausalLM         -> LlamaForCausalLMEagle    yuhuili/EAGLE-LLaMA3.1-Instruct-8B
  [ok ] LlamaForCausalLM         -> LlamaForCausalLMEagle3   yuhuili/EAGLE3-LLaMA3.1-Instruct-8B
  [ok ] LlamaForCausalLM         -> LlamaForCausalLMEagle3   yuhuili/EAGLE3-Vicuna1.3-13B (40 layers)
  [ok ] Qwen2ForCausalLM         -> Qwen2ForCausalLMEagle    yuhuili/EAGLE-Qwen2-7B-Instruct
  [ok ] Qwen2ForCausalLM         -> None                     no Qwen2 Eagle3 class -> untouched
  [ok ] LlamaForCausalLMEagle    -> None                     lmsys repackaged -> untouched
  [ok ] LlamaForCausalLMEagle3   -> None                     lmsys repackaged -> untouched
  [ok ] DeepseekV3ForCausalLM    -> None                     unknown family -> untouched
  [ok ] LlamaForCausalLM         -> LlamaForCausalLMEagle    explicit None draft_vocab
```

The suite also asserts that every architecture the table maps to is a registered entry class (`ModelRegistry.get_supported_archs()`), so the table cannot drift away from the model registry.

Registered as `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`.

I do not have the hardware to run an end-to-end EAGLE accuracy comparison; the change is confined to architecture selection and does not alter any weight-loading or attention path, and the mapping targets are exactly the classes the repackaged checkpoints already select.

## Checklist

- [x] Format with `black` / `isort` / `ruff --select=F401,F821,UP037` / `codespell` per `.pre-commit-config.yaml`
- [x] Added unit tests under `test/registered/unit/`, registered for CI
- [x] No behaviour change for any checkpoint or algorithm that works today

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31160430392](https://github.com/sgl-project/sglang/actions/runs/31160430392)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31160429975](https://github.com/sgl-project/sglang/actions/runs/31160429975)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->