### PR TITLE
[ROCm] Fix HiCache host-pool allocator: hipHostRegister's device pointer is not the host VA

### DIFF
--- a/python/sglang/srt/mem_cache/pool_host/common.py
+++ b/python/sglang/srt/mem_cache/pool_host/common.py
@@ -8,8 +8,11 @@ from collections import defaultdict
 import torch
 
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap
+from sglang.srt.utils import is_hip
 
 logger = logging.getLogger(__name__)
+
+_is_hip = is_hip()
 
 
 class HostTensorAllocator:
@@ -174,10 +177,28 @@ def alloc_with_pin_memory(
     return buffer
 
 
+# On ROCm, hipHostRegister maps the pages at a device address that DIFFERS from
+# the host VA -- you are expected to obtain it with hipHostGetDevicePointer. But
+# the host pools store host data_ptr()s in a device-side pointer table that a
+# kernel dereferences (e.g. DSAIndexerPoolHost.index_k_data_ptrs), so a host VA
+# has to be directly dereferenceable from the device. hipHostMalloc, which torch
+# uses for pin_memory=True, returns memory whose device pointer IS the host
+# pointer -- the same property "npu" and "musa" rely on below.
+#
+# ROCm reports its device as "cuda", so it cannot simply be given its own key
+# the way "npu" and "musa" are. The default is switched as well, not just the
+# "cuda" entry: two call sites key this table with a torch.device object rather
+# than a string (memory_pool_host.py, `self.gpu_device = device_buffers[0].device`
+# and `= state_tensor.device`), and torch.device("cuda:0") is not dict-key-equal
+# to "cuda", so those pools always resolve through the default.
+_ALLOC_MEMORY_FUNCS = {
+    "npu": alloc_with_pin_memory,
+    "musa": alloc_with_pin_memory,
+}
+if _is_hip:
+    _ALLOC_MEMORY_FUNCS["cuda"] = alloc_with_pin_memory
+
 ALLOC_MEMORY_FUNCS = defaultdict(
-    lambda: alloc_with_host_register,
-    {
-        "npu": alloc_with_pin_memory,
-        "musa": alloc_with_pin_memory,
-    },
+    lambda: alloc_with_pin_memory if _is_hip else alloc_with_host_register,
+    _ALLOC_MEMORY_FUNCS,
 )


### PR DESCRIPTION
## Motivation

On ROCm, the first HiCache write-back aborts the process:

```
Memory access fault by GPU node-2 (Agent handle: 0x...) on address 0x7d3bee790000.
Reason: Unknown.
```

The fault address is exactly the **host** pointer of a HiCache host buffer.

`ALLOC_MEMORY_FUNCS` defaults to `alloc_with_host_register`, which allocates an
anonymous `mmap` and page-locks it with `cudaHostRegister`. The host pools then
store the resulting **host VAs** in a device-side pointer table that a GPU kernel
dereferences — e.g. `DSAIndexerPoolHost.init_kv_buffer` builds
`index_k_data_ptrs` from `data_ptr()` and hands it to
`transfer_kv_all_layer_mla(dst_layers=...)`.

That is only correct if a host VA is directly dereferenceable from the device.
On CUDA it is: `cudaHostRegister` maps the pages at the *same* address in the
device address space. On ROCm it is not — `hipHostRegister` maps them at a
*different* device address, which you are expected to obtain via
`hipHostGetDevicePointer`. So the kernel receives an address that is not mapped
on the device.

Measured on MI355X / gfx950 / ROCm 7.2.0, 8 MiB buffer:

| strategy | host | devPtr | same |
|---|---|---|---|
| `pin_memory` | `0x7d7c2f600000` | `0x7d7c2f600000` | **True** |
| `mmap` + `hipHostRegister` | `0x7d3bee790000` | `0x7d3bede00000` | False |
| ” + `hipHostRegisterMapped` | `0x7d3bed600000` | `0x7d3becc00000` | False |
| ” + `Portable\|Mapped` | `0x7d3bec400000` | `0x7d3a97600000` | False |
| ” `MAP_PRIVATE` | `0x7d3a96e00000` | `0x7d3a96400000` | False |

Every `hipHostRegister` variant differs; only `pin_memory` matches. gfx950
reports `xnack-`, so there is no page-migration path that could paper over it.

## Modifications

Route HIP to `alloc_with_pin_memory` — torch `pin_memory=True`, `hipHostMalloc`
underneath — which returns memory whose device pointer **is** the host pointer.
This is the property the existing `"npu"` and `"musa"` entries already rely on,
and this change is the HIP counterpart of #23361.

Two details are worth flagging, because they are why this is not the same
one-line edit #23361 was:

1. **ROCm reports its device as `"cuda"`**, so HIP has no key of its own to add.
2. **The default has to change too, not just the `"cuda"` entry.** Two call sites
   key this table with a `torch.device` object rather than a string —
   `memory_pool_host.py`, `self.gpu_device = device_buffers[0].device` and
   `= state_tensor.device`. `torch.device("cuda:0")` is not dict-key-equal to
   `"cuda"` (different hash), so those pools always resolve through the
   `defaultdict` default. Adding only a `"cuda"` key would silently miss them.

Cost on ROCm: the hugepage path in `alloc_mmap` (`SGLANG_HUGEPAGE_SIZE`) is
bypassed. With that env var unset — the default — `alloc_mmap` takes its
plain-page branch anyway, so both allocators hand out 4 KiB pages.

This fixes the allocator, not the design: the pointer tables still hold raw host
pointers, and remain correct only because `pin_memory` happens to return matching
addresses. Translating every host pointer through `hipHostGetDevicePointer` is
the more thorough shape, but it touches roughly ten call sites in
`memory_pool_host.py`; I'd rather do that as a separate change if maintainers
prefer it.

## Accuracy Tests

No model-output change — this only selects which host allocator HiCache uses on
ROCm. On CUDA and every non-HIP platform the dispatch table is byte-for-byte
unchanged in behaviour.

## Speed Tests and Profiling

Not applicable: this is a startup-time allocation path, not a per-request one,
and on the default configuration both allocators produce 4 KiB pages.

## Verification

**Reproduced and fixed (MI355X / gfx950, ROCm 7.2.0):** a standalone repro of
the HiCache write-back kernel — 78 layers, 7.33 GB host indexer buffer, page
ranges head / tail / last — faults on *every* `mmap`+`hipHostRegister` variant and
is clean on all page ranges with `pin_memory`. In a full server, GLM-5.2 with DSA
and the hierarchical cache goes from aborting on the first write-back to serving.

**Negative control (MI300X / gfx942, ROCm 7.2.0), re-measured for this PR:**

```
device: AMD Instinct MI300X gcn=gfx942:sramecc+:xnack-
  [pin_memory]                 host=0x7baddb600000  devPtr=0x7baddb600000  same=True
  [mmap + hipHostRegister]     host=0x7baddae00000  devPtr=0x7baddae00000  same=True
  [  + hipHostRegisterMapped]  host=0x7badda600000  devPtr=0x7badda600000  same=True
  [  + Portable|Mapped]        host=0x7baddae00000  devPtr=0x7baddae00000  same=True
```

MI300X returns matching addresses for every strategy, so it does **not** exhibit
the fault. The identity is a property of that driver, not of the API — the
`hipHostRegister` contract is that you call `hipHostGetDevicePointer` — and
gfx950 already breaks it on the same ROCm release. Comparing `data_ptr()` against
`hipHostGetDevicePointer` is the cheap way to tell whether a given arch is
affected; worth running before assuming either outcome on a new one.

**What this PR's exact diff was checked against, on MI300X:** the patched module
was loaded alongside stock and compared on dispatch for five string keys plus a
`torch.device` key, on a real 8 MiB allocation with its device pointer measured,
and on the module's exported names. Dispatch resolves to `alloc_with_pin_memory`
on HIP for every key including the `torch.device` one; the allocation is pinned
with `devPtr == host`; nothing is removed from the module.

**Not yet run on gfx950:** I no longer have MI355X access as of this writing, so
the table at the top is from the original investigation rather than from this
branch. Opening as a **draft** for that reason — I'll re-run the write-back repro
against this exact diff on gfx950 and mark it ready. Happy to have it run on an
AMD CI lane instead if one is available.

## References

- #23361 `[MUSA][19/N] Support HiCache with pin_memory allocator` — same
  one-line dispatch override, same underlying reason (host VA is not the device
  VA on that platform). This change is its HIP counterpart.
- #32503 and #32792 (Intel XPU HiCache) touch the same dict; happy to rebase
  around whichever lands first.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32690307809](https://github.com/sgl-project/sglang/actions/runs/32690307809)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32690307379](https://github.com/sgl-project/sglang/actions/runs/32690307379)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32690307716](https://github.com/sgl-project/sglang/actions/runs/32690307716)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->