### PR TITLE
[diffusion] fix: stop RunAI Model Streamer's rank-discovery collective from firing on independent per-rank loads

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -34,31 +34,16 @@ logger = init_logger(__name__)
 
 
 def _disable_runai_streamer_rank_discovery_collective() -> None:
-    """Neutralize a RunAI Model Streamer bug: ``DistributedStreamer.stream_files()``
-    calls ``_distributedStreamerParams.set_params()`` before it even looks at the
-    caller's ``is_distributed`` flag, and ``set_params()`` unconditionally calls
-    ``find_local_ranks()`` the first time it runs for a given streamer instance.
-    ``find_local_ranks()`` issues a real collective (``dist.new_group`` +
-    ``dist.all_gather_object`` over the full world) whenever
-    ``torch.distributed.is_initialized()`` and world_size > 1 -- regardless of
-    ``is_distributed``, and even for the header-only metadata reads that pass
-    ``is_distributed=False`` explicitly. Its only purpose is to populate the
-    ``RUNAI_STREAMER_PROCESS_GROUP_SIZE`` env var for the library's own
-    distributed-streaming path, which this loader never opts into: every
-    ``stream_files()`` call below passes ``is_distributed=False`` because each
-    rank loads its own independent full copy of the checkpoint.
+    """RunAI Model Streamer's ``find_local_ranks()`` fires a full-world
+    collective on the first ``stream_files()`` of every streamer instance even
+    when the caller passes ``is_distributed=False`` — it only populates an env
+    var for the library's distributed-streaming path, which this loader never
+    uses (each rank loads its own full copy). Ranks reach it with divergent
+    timing, so it can fire out of lockstep and hang
+    (https://github.com/run-ai/runai-model-streamer/issues/84).
 
-    Left unpatched, the collective still fires once per component per rank (a
-    fresh ``SafetensorsStreamer()`` resets the cache each time), so any
-    per-rank divergence in load order or timing -- different layerwise-offload
-    memory state, warm vs. cold page cache -- can call it out of lockstep
-    across ranks and hang. Upstream:
-    https://github.com/run-ai/runai-model-streamer/issues/84.
-
-    Patch ``find_local_ranks`` to take the early-return path it already uses
-    for the single-process case, so it reports "1 process, no peers" without
-    ever touching ``torch.distributed``. Safe if upstream fixes this: the only
-    behavior given up is the collective this loader never wanted.
+    Patch it to the single-process early return it already has; the only
+    behavior lost is the collective this loader never wanted.
     """
     try:
         from runai_model_streamer.distributed_streamer.distributed_streamer import (
@@ -68,11 +53,9 @@ def _disable_runai_streamer_rank_discovery_collective() -> None:
         return
     if not hasattr(_distributedStreamerParams, "find_local_ranks"):
         logger.warning(
-            "runai_model_streamer._distributedStreamerParams.find_local_ranks "
-            "not found; skipping the rank-discovery-collective workaround. If "
-            "this version still runs a stream_files() collective regardless "
-            "of is_distributed, multi-rank diffusion weight loading may hang "
-            "-- see https://github.com/run-ai/runai-model-streamer/issues/84."
+            "runai_model_streamer find_local_ranks not found; skipping the "
+            "rank-discovery-collective workaround (multi-rank loads may hang, "
+            "see run-ai/runai-model-streamer#84)."
         )
         return
 

--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -32,6 +32,60 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 
+
+def _disable_runai_streamer_rank_discovery_collective() -> None:
+    """Neutralize a RunAI Model Streamer bug: ``DistributedStreamer.stream_files()``
+    calls ``_distributedStreamerParams.set_params()`` before it even looks at the
+    caller's ``is_distributed`` flag, and ``set_params()`` unconditionally calls
+    ``find_local_ranks()`` the first time it runs for a given streamer instance.
+    ``find_local_ranks()`` issues a real collective (``dist.new_group`` +
+    ``dist.all_gather_object`` over the full world) whenever
+    ``torch.distributed.is_initialized()`` and world_size > 1 -- regardless of
+    ``is_distributed``, and even for the header-only metadata reads that pass
+    ``is_distributed=False`` explicitly. Its only purpose is to populate the
+    ``RUNAI_STREAMER_PROCESS_GROUP_SIZE`` env var for the library's own
+    distributed-streaming path, which this loader never opts into: every
+    ``stream_files()`` call below passes ``is_distributed=False`` because each
+    rank loads its own independent full copy of the checkpoint.
+
+    Left unpatched, the collective still fires once per component per rank (a
+    fresh ``SafetensorsStreamer()`` resets the cache each time), so any
+    per-rank divergence in load order or timing -- different layerwise-offload
+    memory state, warm vs. cold page cache -- can call it out of lockstep
+    across ranks and hang. Upstream:
+    https://github.com/run-ai/runai-model-streamer/issues/84.
+
+    Patch ``find_local_ranks`` to take the early-return path it already uses
+    for the single-process case, so it reports "1 process, no peers" without
+    ever touching ``torch.distributed``. Safe if upstream fixes this: the only
+    behavior given up is the collective this loader never wanted.
+    """
+    try:
+        from runai_model_streamer.distributed_streamer.distributed_streamer import (
+            _distributedStreamerParams,
+        )
+    except ImportError:
+        return
+    if not hasattr(_distributedStreamerParams, "find_local_ranks"):
+        logger.warning(
+            "runai_model_streamer._distributedStreamerParams.find_local_ranks "
+            "not found; skipping the rank-discovery-collective workaround. If "
+            "this version still runs a stream_files() collective regardless "
+            "of is_distributed, multi-rank diffusion weight loading may hang "
+            "-- see https://github.com/run-ai/runai-model-streamer/issues/84."
+        )
+        return
+
+    def _find_local_ranks_no_collective(self):
+        rank = torch.distributed.get_rank() if torch.distributed.is_initialized() else 0
+        return 1, rank, [[rank]]
+
+    _distributedStreamerParams.find_local_ranks = _find_local_ranks_no_collective
+
+
+if HAS_RUNAI_MODEL_STREAMER:
+    _disable_runai_streamer_rank_discovery_collective()
+
 # use system-level temp directory for file locks, so that multiple users
 # can share the same lock without error.
 # lock files in the temp directory will be automatically deleted when the

--- a/python/sglang/multimodal_gen/test/unit/test_weight_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_weight_utils.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""_disable_runai_streamer_rank_discovery_collective: patches
+runai_model_streamer's find_local_ranks() to never touch torch.distributed,
+regardless of world size or initialization state.
+
+Context (see the docstring on the function under test): the unpatched
+find_local_ranks() issues a real dist.new_group()/all_gather_object()
+collective purely to populate a bookkeeping env var, unconditionally on the
+first stream_files() call of every DistributedStreamer instance -- even for
+this loader's calls, which always pass is_distributed=False. Divergent
+per-rank timing can call it out of lockstep and hang; this patch removes the
+collective entirely so that can't happen.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.multimodal_gen.runtime.loader.weight_utils import (
+    _disable_runai_streamer_rank_discovery_collective,
+)
+
+_DIST_STREAMER_MOD = "runai_model_streamer.distributed_streamer.distributed_streamer"
+
+
+class TestDisableRunaiStreamerRankDiscoveryCollective(unittest.TestCase):
+    def test_never_touches_torch_distributed_even_when_initialized(self):
+        from runai_model_streamer.distributed_streamer.distributed_streamer import (
+            _distributedStreamerParams,
+        )
+
+        _disable_runai_streamer_rank_discovery_collective()
+
+        with (
+            patch(f"{_DIST_STREAMER_MOD}.dist.is_initialized", return_value=True),
+            patch(f"{_DIST_STREAMER_MOD}.dist.get_world_size", return_value=2),
+            patch(f"{_DIST_STREAMER_MOD}.dist.get_rank", return_value=1),
+            patch(f"{_DIST_STREAMER_MOD}.dist.new_group") as mock_new_group,
+            patch(f"{_DIST_STREAMER_MOD}.dist.all_gather_object") as mock_all_gather,
+            patch(f"{_DIST_STREAMER_MOD}.dist.destroy_process_group") as mock_destroy,
+        ):
+            result = _distributedStreamerParams().find_local_ranks()
+
+        mock_new_group.assert_not_called()
+        mock_all_gather.assert_not_called()
+        mock_destroy.assert_not_called()
+        # rank is still reported correctly -- only the collective is gone
+        self.assertEqual(result, (1, 1, [[1]]))
+
+    def test_reports_rank_zero_when_not_distributed(self):
+        from runai_model_streamer.distributed_streamer.distributed_streamer import (
+            _distributedStreamerParams,
+        )
+
+        _disable_runai_streamer_rank_discovery_collective()
+
+        with patch(f"{_DIST_STREAMER_MOD}.dist.is_initialized", return_value=False):
+            result = _distributedStreamerParams().find_local_ranks()
+
+        self.assertEqual(result, (1, 0, [[0]]))
+
+    def test_idempotent_across_repeated_calls(self):
+        # Import-time application plus any re-import/re-entry must not stack
+        # wrappers or otherwise change behavior.
+        _disable_runai_streamer_rank_discovery_collective()
+        _disable_runai_streamer_rank_discovery_collective()
+
+        from runai_model_streamer.distributed_streamer.distributed_streamer import (
+            _distributedStreamerParams,
+        )
+
+        with (
+            patch(f"{_DIST_STREAMER_MOD}.dist.is_initialized", return_value=True),
+            patch(f"{_DIST_STREAMER_MOD}.dist.get_world_size", return_value=4),
+            patch(f"{_DIST_STREAMER_MOD}.dist.get_rank", return_value=3),
+            patch(f"{_DIST_STREAMER_MOD}.dist.new_group") as mock_new_group,
+        ):
+            result = _distributedStreamerParams().find_local_ranks()
+
+        mock_new_group.assert_not_called()
+        self.assertEqual(result, (1, 3, [[3]]))
+
+    def test_noop_when_library_missing_attribute(self):
+        # Defensive path: if a future runai_model_streamer release renames or
+        # removes find_local_ranks, patching must skip (with a warning) rather
+        # than crash import.
+        import sglang.multimodal_gen.runtime.loader.weight_utils as wu
+
+        class _StubParams:
+            pass
+
+        with patch(f"{_DIST_STREAMER_MOD}._distributedStreamerParams", _StubParams):
+            wu._disable_runai_streamer_rank_discovery_collective()  # must not raise
+
+        self.assertFalse(hasattr(_StubParams, "find_local_ranks"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_weight_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_weight_utils.py
@@ -1,16 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""_disable_runai_streamer_rank_discovery_collective: patches
-runai_model_streamer's find_local_ranks() to never touch torch.distributed,
-regardless of world size or initialization state.
-
-Context (see the docstring on the function under test): the unpatched
-find_local_ranks() issues a real dist.new_group()/all_gather_object()
-collective purely to populate a bookkeeping env var, unconditionally on the
-first stream_files() call of every DistributedStreamer instance -- even for
-this loader's calls, which always pass is_distributed=False. Divergent
-per-rank timing can call it out of lockstep and hang; this patch removes the
-collective entirely so that can't happen.
-"""
+"""The patched find_local_ranks() must never touch torch.distributed."""
 
 import unittest
 from unittest.mock import patch


### PR DESCRIPTION
## Problem

Multi-rank diffusion serving with layerwise offload + RunAI Model Streamer (`--layerwise-offload-components ..., use_runai_model_streamer=True`) can hang during weight loading. Observed on MiniMax-H3, 2×5090, TP=2: intermittent — most launches load fine, some hang indefinitely with zero I/O progress partway through a component's weights.

## Root cause

`runai_model_streamer`'s `DistributedStreamer.stream_files()` calls `_distributedStreamerParams.set_params()` **before it even inspects the caller's `is_distributed` argument**:

```python
def stream_files(self, file_stream_requests, credentials, device, is_distributed):
    self.params.set_params(file_stream_requests)      # <-- unconditional
    self.set_is_distributed(is_distributed, device)    # <-- checked only after
    ...
```

`set_params()` in turn unconditionally calls `find_local_ranks()` the first time it runs for a given streamer instance:

```python
def set_params(self, file_stream_requests):
    ...
    if self.num_processes_on_node is None:
        self.num_processes_on_node, self.my_global_rank, self.groups_by_ranks = self.find_local_ranks()
```

And `find_local_ranks()` issues a **real collective** whenever `torch.distributed.is_initialized()` and world_size > 1:

```python
sandbox_global_group = dist.new_group(ranks=list(range(world_size)), timeout=self.broadcast_timeout)
all_hostnames = [None] * world_size
dist.all_gather_object(all_hostnames, socket.gethostname(), group=sandbox_global_group)
dist.destroy_process_group(group=sandbox_global_group)
```

This runs **regardless of `is_distributed`** — even for the library's own internal header-only metadata reads, which explicitly pass `is_distributed=False`. Its only purpose is to populate `RUNAI_STREAMER_PROCESS_GROUP_SIZE`, a bookkeeping env var for the library's own distributed-streaming path.

sglang's diffusion weight loader never opts into that path — every `stream_files()` call in `weight_utils.py` passes `is_distributed=False` (each rank loads its own independent full copy of the checkpoint; there's no sharded/collaborative loading here). So this collective is pure overhead, and worse, a genuine hazard: it's re-issued once per component per rank (a fresh `SafetensorsStreamer()` resets the `num_processes_on_node` cache each time a component is loaded). Since sglang's layerwise offload determines per-rank memory-aware component load order independently on each rank, any divergence between ranks in load order or timing (different available memory, warm vs. cold page cache, ...) can call this ad-hoc `new_group()` out of lockstep across ranks — one rank's Nth `stream_files()` call rendezvousing with another rank's Mth — and hang.

Upstream: https://github.com/run-ai/runai-model-streamer/issues/84 frames the distributed-streamer feature as a bandwidth-sharing optimization, not something every caller must accept collateral collective traffic for.

## Fix

`find_local_ranks()` already has an early-return path for the genuinely-single-process case (`if not dist.is_initialized(): return 1, 0, [[0]]`). Since this loader never wants the distributed-streaming feature, patch `find_local_ranks` (defensively, guarded by `hasattr` so a future upstream rename/removal degrades to a logged no-op rather than a crash) to always take that path, reporting "1 process, no peers" without ever touching `torch.distributed`. No upstream env var gates this specific call, so there's no cleaner opt-out available from the caller side.

## Validation

- New unit tests (`test_weight_utils.py`) confirm the patched `find_local_ranks` never calls `dist.new_group`/`all_gather_object`/`destroy_process_group` even when `torch.distributed.is_initialized()` is mocked True with world_size > 1, is idempotent across repeated application, and degrades safely if the target attribute is absent.
- GPU validation on 2×5090 (MiniMax-H3, TP=2, `--layerwise-offload-components dit,text_encoder,vae`, RunAI streamer): with the fix, both ranks stream all components (including the 61.7 GiB transformer) in lockstep — e.g. rank0/rank1 finished the transformer stream within 0.2s of each other (18.07s vs 18.26s @ 3.4 GiB/s) — full load-through-warmup-through-ready in ~3.5 minutes, ready to serve, with no hang across repeated launches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31183663792](https://github.com/sgl-project/sglang/actions/runs/31183663792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31183663781](https://github.com/sgl-project/sglang/actions/runs/31183663781)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->