### PR TITLE
[PD] Make the mooncake KV transfer wait on the prefill forward that wrote the pages

### DIFF
--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -32,6 +32,10 @@ class TransferKVChunk:
     # Set when the staging worker first counts this chunk toward the per-room
     # outstanding count; stays set across re-enqueue on a watermark defer.
     staging_counted: bool = False
+    # Completion event for the forward that wrote these KV pages. The transfer
+    # worker reads device memory outside the CUDA stream, so it has to wait on
+    # this before the RDMA read or it can observe half-written KV.
+    wait_event: Optional[object] = None
 
 
 def pack_list_of_buffers(buffers: List[bytes]) -> bytes:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1555,6 +1555,14 @@ class MooncakeKVManager(CommonKVManager):
                     self._staging_outstanding.pop(kv_chunk.room, None)
                     continue
 
+                # This worker reads device memory outside the CUDA stream, so
+                # without waiting here the read can race the prefill forward
+                # that is still writing these pages. Cleared afterwards so a
+                # chunk re-enqueued on a staging defer does not wait twice.
+                if kv_chunk.wait_event is not None:
+                    kv_chunk.wait_event.synchronize()
+                    kv_chunk.wait_event = None
+
                 # Count each chunk once; the flag survives re-enqueue on defer.
                 if not kv_chunk.staging_counted:
                     self._staging_outstanding[kv_chunk.room] += 1
@@ -2044,6 +2052,7 @@ class MooncakeKVManager(CommonKVManager):
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
+        wait_event: Optional[object] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -2083,6 +2092,7 @@ class MooncakeKVManager(CommonKVManager):
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=trace_ctx,
+                wait_event=wait_event,
             )
         )
 
@@ -2170,6 +2180,12 @@ class MooncakeKVSender(CommonKVSender):
         if should_skip:
             return
 
+        # Pages handed over before their forward is known to have completed
+        # carry a completion event; the transfer worker waits on it before it
+        # reads them. Same handoff as MoriKVSender.send().
+        wait_event = getattr(self, "_early_send_wait_event", None)
+        self._early_send_wait_event = None
+
         if not is_last_chunk:
             self.kv_mgr.add_transfer_request(
                 self.bootstrap_room,
@@ -2178,6 +2194,7 @@ class MooncakeKVSender(CommonKVSender):
                 False,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         else:
             self.kv_mgr.add_transfer_request(
@@ -2189,6 +2206,7 @@ class MooncakeKVSender(CommonKVSender):
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         self._record_transfer_indices(kv_indices, state_indices)
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1626,6 +1626,14 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
 
+                # This worker reads device memory outside the CUDA stream, so
+                # without waiting here the read can race the prefill forward
+                # that is still writing these pages. Cleared afterwards so a
+                # chunk re-enqueued on a staging defer does not wait twice.
+                if kv_chunk.wait_event is not None:
+                    kv_chunk.wait_event.synchronize()
+                    kv_chunk.wait_event = None
+
                 if (
                     self.enable_staging
                     and staging_strategy is None
@@ -2145,6 +2153,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
+        wait_event: Optional[object] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
         assert not is_last_chunk or (is_last_chunk and aux_index is not None)
@@ -2184,6 +2193,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=trace_ctx,
+                wait_event=wait_event,
             )
         )
 
@@ -2298,6 +2308,12 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         if should_skip:
             return
 
+        # Pages handed over before their forward is known to have completed
+        # carry a completion event; the transfer worker waits on it before it
+        # reads them. Same handoff as MoriKVSender.send().
+        wait_event = getattr(self, "_early_send_wait_event", None)
+        self._early_send_wait_event = None
+
         if not is_last_chunk:
             self.kv_mgr.add_transfer_request(
                 self.bootstrap_room,
@@ -2306,6 +2322,7 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
                 False,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         else:
             self.kv_mgr.add_transfer_request(
@@ -2317,6 +2334,7 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
+                wait_event=wait_event,
             )
         self._record_transfer_indices(kv_indices, state_indices)
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -809,6 +809,14 @@ class SchedulerDisaggregationPrefillMixin:
                     assert (
                         req.metadata_buffer_index >= 0
                     ), f"Req {req.rid} does not have metadata buffer allocated"
+                    # Under overlap scheduling this chunk is handed over while
+                    # its own forward may still be running on forward_stream,
+                    # and the transfer worker reads device memory outside the
+                    # CUDA stream. Gate that read on this chunk's writes, the
+                    # same way the early-send path below does.
+                    ev = torch.cuda.Event()
+                    ev.record(self.forward_stream)
+                    req.disagg_kv_sender._early_send_wait_event = ev
                     self.send_kv_chunk(req, last_chunk=False, end_idx=req.tmp_end_idx)
                 req.time_stats.set_last_chunked_prefill_finish_time()
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -819,6 +819,14 @@ class SchedulerDisaggregationPrefillMixin:
                     assert (
                         req.metadata_buffer_index >= 0
                     ), f"Req {req.rid} does not have metadata buffer allocated"
+                    # Under overlap scheduling this chunk is handed over while
+                    # its own forward may still be running on forward_stream,
+                    # and the transfer worker reads device memory outside the
+                    # CUDA stream. Gate that read on this chunk's writes, the
+                    # same way the early-send path below does.
+                    ev = torch.cuda.Event()
+                    ev.record(self.forward_stream)
+                    req.disagg_kv_sender._early_send_wait_event = ev
                     self.send_kv_chunk(req, last_chunk=False, end_idx=req.tmp_end_idx)
                 req.time_stats.set_last_chunked_prefill_finish_time()
 


### PR DESCRIPTION
## Motivation

**This is a silent correctness bug: no crash, no traceback, no log line — the
output is simply partially wrong.**

With chunked prefill over the mooncake KV transport, every prefill chunk except
the last can be RDMA-read while the forward that writes those pages is still
running, so the decode leg receives half-written KV. On GLM-5.2 DSA, a
needle-in-a-haystack read returns the first digits of the needle and then
degenerates:

```
want = 2183762
got  = '2183</think>2183</think>218</think>218</think> the'
```

The corruption boundary lands exactly on the prefill chunk boundary — a needle
placed in the *final* chunk is retrieved correctly — and the same model, same
backends and same chunk size in an aggregated single-node server passes 9/9.
That A/B is what localises it to the transport rather than to the model.

### Root cause

`prefill.py` already records a completion event as the barrier
(`req.disagg_kv_sender._early_send_wait_event`), and the comment there says
exactly what it is for. But **only `mori/conn.py` ever reads it.** On current
`main`:

- `disaggregation/mooncake/conn.py` — `wait_event` occurs **0 times**
- `disaggregation/mori/conn.py` — `wait_event` occurs **6 times**

So on mooncake that barrier has never taken effect.

There is a second, transport-independent half. The overlap-scheduling path that
hands over non-final chunks — `process_batch_result_disagg_prefill`, the
`send_kv_chunk(req, last_chunk=False, end_idx=req.tmp_end_idx)` call — does not
record an event **at all**, for any transport. Only the radix early-send path
does.

The final chunk is always correct regardless, because it goes through the
sampling path, which has a real `copy_done.synchronize()`.

This is not DSA-specific: any PD deployment running chunked prefill over
mooncake with overlap scheduling is affected. DSA's sparse retrieval only makes
it conspicuous ("retrieved half the digits") where a dense model shows a quiet
quality drop.

## Modifications

Mirror what `mori` already does, in three places:

- `disaggregation/common/utils.py` — `TransferKVChunk` gains a `wait_event`
  field so the barrier travels with the work item. It defaults to `None`, so
  every existing construction site is unaffected.
- `disaggregation/mooncake/conn.py` — `send()` picks the event up off the
  sender and clears it (so the next chunk cannot inherit a stale barrier),
  `add_transfer_request()` forwards it, and `transfer_worker` synchronizes on it
  **before** it reads device memory, clearing it afterwards so a chunk
  re-enqueued on a staging defer does not wait twice.
- `disaggregation/prefill.py` — the overlap non-final-chunk send records an
  event on `forward_stream`.

**Note the cross-transport effect of that last one.** `prefill.py` is
transport-agnostic, so recording the event there also closes the same gap for
`mori`, which reads the field but was never handed one on this path. The other
transports (`nixl`, `ascend`, `fake`, `base`) do not read `_early_send_wait_event`
and none of their senders uses `__slots__`, so setting the attribute is inert
for them.

## Accuracy Tests

The fix *is* an accuracy fix. On 2× 8× MI325X (gfx942), ROCm 7.2.0,
GLM-5.2-FP8 1P1D over mooncake RDMA, overlap scheduling on,
`--chunked-prefill-size 131072`, `--enable-dp-attention`:

| test | before | after |
|---|---|---|
| needle retrieval | 5/9 | **9/9** |
| 29k depth sweep | 4/9 | **9/9** |

The logs confirm the previously-failing prompt is still really split into 4
chunks afterwards — so this is a barrier, not an accidental disabling of
chunking.

## Speed Tests and Profiling

**Not measured, and I want to flag it rather than bury it.** The added
`synchronize()` sits on the transfer worker, on the hot chunk path, and trades
some transfer/compute overlap for correctness. I do not have a prefill-throughput
before/after number for it.

Two things bound the concern: the wait is on an event recorded on
`forward_stream` for work the transfer is *already* logically dependent on, and
`mori` has been carrying the identical `synchronize()` on its own chunk path.
But that is an argument, not a measurement. If a maintainer would like the number
before this merges, say so and I will get it — see the verification note below
on hardware.

## Verification

**Reproduced and fixed** on 2× 8× MI325X (gfx942), ROCm 7.2.0, sglang v0.5.16,
GLM-5.2-FP8 1P1D over mooncake RDMA — the numbers in the accuracy table above.

**Checked for this exact diff, on a single MI300X node:** the plumbing and the
barrier semantics, against real CUDA events —

- `TransferKVChunk.wait_event` exists, defaults to `None` when omitted (so
  existing construction sites keep working), and accepts an event.
- `send()` forwards the event to `add_transfer_request()` on **both** the
  last-chunk and non-last-chunk arms, and clears the sender's copy afterwards;
  with no event recorded it forwards `None` and does not raise.
- `add_transfer_request(wait_event=...)` defaults to `None`, so existing callers
  are unaffected.
- The wait is a **real** barrier, not a no-op: the event is pending immediately
  after `record()`, `synchronize()` measurably blocks, and a read issued
  afterwards on a *different* stream observes the writer's results.

**Not covered by that run, and therefore still open:** whether the corruption is
gone end-to-end, which needs a 2-node PD pair, and the throughput cost above. The
multi-node cluster those were originally measured on is unreachable to me right
now, so the accuracy table is from the original investigation rather than from
this branch. **Opening as a draft for that reason** — I will re-run both against
this exact diff and mark it ready, and I'm happy for it to go through a PD CI
lane instead if one exists.

## References

- #25583 `[Bug] Long text response error on GLM-5-FP8 with NSA backend` — the
  same corruption shape, but reported on an *aggregated* server with no PD and no
  mooncake, so a shared root cause is not established. It was auto-closed
  inactive with no follow-up. The aggregated-vs-PD A/B above is the evidence that
  issue was missing; linking it in case it is in fact the same thing seen from the
  other side.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32690308003](https://github.com/sgl-project/sglang/actions/runs/32690308003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32690307834](https://github.com/sgl-project/sglang/actions/runs/32690307834)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32690307931](https://github.com/sgl-project/sglang/actions/runs/32690307931)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->