### PR TITLE
[NPU] Add TeleChat4 support with fused mHC backends

### DIFF
--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -861,9 +861,14 @@ def mhc_pre(
                 hidden_block = 256
             elif hc_hidden_size == 28672:
                 hidden_block = 128
+            elif hc_hidden_size == 14336:
+                # 14336 = 4 * 3584 (telechat4). hidden_block=256 -> 14336/256=56.
+                # Caller must pass n_splits_pre dividing 56 so that
+                # (14336//n_splits_pre) % 256 == 0 (e.g. n_splits_pre=8 -> 1792).
+                hidden_block = 256
             else:
                 raise NotImplementedError(
-                    f"mhc_pre splitk kernel only supports hc_hidden_size in {{16384, 28672}}, "
+                    f"mhc_pre splitk kernel only supports hc_hidden_size in {{16384, 28672, 14336}}, "
                     f"got {hc_hidden_size}"
                 )
             kernel_0, _ = mhc_pre_gemm_sqrsum_splitk_kernel(

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1637,6 +1637,7 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
         "Qwen3_5ForConditionalGeneration",
         "NemotronHForCausalLM",
         "NemotronHPuzzleForCausalLM",
+        "TeleChat4ForCausalLM",
     }
 )
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -572,6 +572,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         "MistralLarge3ForCausalLM",
         "PixtralForConditionalGeneration",
         "HYV3ForCausalLM",
+        "TeleChat4ForCausalLM",
     ]:
         if server_args.speculative_draft_model_path is None:
             server_args.speculative_draft_model_path = server_args.model_path

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -52,6 +52,7 @@ from sglang.srt.configs.step3_vl import (
 )
 from sglang.srt.configs.step3p5 import Step3p5Config
 from sglang.srt.configs.step3p7 import Step3p7Config
+from sglang.srt.configs.telechat4 import TeleChat4Config
 from sglang.srt.configs.unlimited_ocr import UnlimitedVLConfig
 from sglang.srt.configs.zaya import ZayaConfig
 
@@ -99,6 +100,7 @@ __all__ = [
     "MiniMaxM3VLConfig",
     "Step3p7Config",
     "Qwen3ASRConfig",
+    "TeleChat4Config",
     "InklingAudioConfig",
     "InklingMMConfig",
     "InklingModelConfig",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -116,6 +116,7 @@ def is_deepseek_dsa(config) -> bool:
             "GlmMoeDsaForCausalLMNextN",
             "LongcatFlashForCausalLM",
             "LongcatFlashForCausalLMNextN",
+            "TeleChat4ForCausalLM",
         )
         and _hf_attr(config, "index_topk") is not None
     )
@@ -576,6 +577,12 @@ class ModelConfig:
         ]:
             self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
 
+        # TeleChat4 bundles a DeepSeek-V3-compatible MTP head (layer index ==
+        # num_hidden_layers); reuse DeepseekV3ForCausalLMNextN as the draft arch.
+        if is_draft_model and self.hf_config.architectures[0] == "TeleChat4ForCausalLM":
+            self.hf_config.architectures[0] = "DeepseekV3ForCausalLMNextN"
+            self.hf_config.num_nextn_predict_layers = 1
+
         if is_draft_model and self.hf_config.architectures[0] == "GlmMoeDsaForCausalLM":
             self.hf_config.architectures[0] = "GlmMoeDsaForCausalLMNextN"
 
@@ -836,6 +843,7 @@ class ModelConfig:
             or "MistralLarge3ForCausalLMEagle" in self.hf_config.architectures
             or "KimiK25ForConditionalGeneration" in self.hf_config.architectures
             or "Eagle3DeepseekV2ForCausalLM" in self.hf_config.architectures
+            or "TeleChat4ForCausalLM" in self.hf_config.architectures
         ):
             self.head_dim = 256
             self.attention_arch = AttentionArch.MLA

--- a/python/sglang/srt/configs/telechat4.py
+++ b/python/sglang/srt/configs/telechat4.py
@@ -1,0 +1,74 @@
+"""TeleChat4 model configuration."""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+from transformers import PretrainedConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(kw_only=True)
+class TeleChat4Config(PretrainedConfig):
+    architectures: List[str]
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    bos_token_id: int = 1
+    eos_token_id: int = 2
+    ep_size: int = 1
+    first_k_dense_replace: int = 0
+    hidden_act: str = "silu"
+    hidden_size: int = 3584
+
+    # DSA (Deep Sparse Attention) fields. Only present in DSA-enabled checkpoints;
+    # None for non-DSA models. is_deepseek_dsa() checks index_topk is not None.
+    index_head_dim: Optional[int] = None
+    index_n_heads: Optional[int] = None
+    index_topk: Optional[int] = None
+
+    initializer_range: float = 0.02
+    intermediate_size: int = 9216
+    kv_lora_rank: int = 512
+    max_position_embeddings: int = 262144
+    model_type: str = "telechat4"
+    moe_intermediate_size: int = 1024
+    moe_layer_freq: int = 1
+    n_group: int = 1
+    n_routed_experts: int = 64
+    n_shared_experts: int = 1
+    norm_topk_prob: bool = True
+
+    num_attention_heads: int = 32
+    num_experts_per_tok: int = 4
+    num_hidden_layers: int = 40
+    num_key_value_heads: int = 32
+
+    q_lora_rank: int = 768
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+
+    rms_norm_eps: float = 1e-6
+
+    rope_scaling: Dict[str, float] = field(default_factory=dict)
+    rope_theta: int = 10000
+
+    routed_scaling_factor: float = 2.0
+    scoring_func: str = "sigmoid"
+
+    tie_word_embeddings: bool = False
+
+    topk_group: int = 1
+    topk_method: str = "noaux_tc"
+
+    use_cache: bool = True
+    v_head_dim: int = 128
+    vocab_size: int = 131072
+
+    num_residual_streams: int = 4
+    mhc_sinkhorn_iterations: int = 20
+    mhc_init_gating_factor: float = 0.01
+    mhc_h_res_clamp_min: float = -30.0
+    mhc_h_res_clamp_max: float = 30.0
+
+    num_nextn_predict_layers: int = 0

--- a/python/sglang/srt/configs/telechat4.py
+++ b/python/sglang/srt/configs/telechat4.py
@@ -1,8 +1,8 @@
 """TeleChat4 model configuration."""
 
 import logging
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from dataclasses import dataclass
+from typing import ClassVar, Dict, List, Optional
 
 from transformers import PretrainedConfig
 
@@ -11,6 +11,8 @@ logger = logging.getLogger(__name__)
 
 @dataclass(kw_only=True)
 class TeleChat4Config(PretrainedConfig):
+    model_type: ClassVar[str] = "telechat4"
+
     architectures: List[str]
     attention_bias: bool = False
     attention_dropout: float = 0.0
@@ -31,7 +33,6 @@ class TeleChat4Config(PretrainedConfig):
     intermediate_size: int = 9216
     kv_lora_rank: int = 512
     max_position_embeddings: int = 262144
-    model_type: str = "telechat4"
     moe_intermediate_size: int = 1024
     moe_layer_freq: int = 1
     n_group: int = 1
@@ -50,7 +51,7 @@ class TeleChat4Config(PretrainedConfig):
 
     rms_norm_eps: float = 1e-6
 
-    rope_scaling: Dict[str, float] = field(default_factory=dict)
+    rope_parameters: Optional[Dict] = None
     rope_theta: int = 10000
 
     routed_scaling_factor: float = 2.0

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -42,6 +42,7 @@ from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.srt.function_call.qwen25_detector import Qwen25Detector
 from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.srt.function_call.telechat4_detector import TeleChat4Detector
 from sglang.srt.function_call.trinity_detector import TrinityDetector
 from sglang.srt.function_call.utils import (
     _get_tool_schema_defs,
@@ -85,6 +86,7 @@ class FunctionCallParser:
         "qwen3_coder": Qwen3CoderDetector,
         "step3": Step3Detector,
         "step3p5": Qwen3CoderDetector,
+        "telechat4": TeleChat4Detector,
         "minimax-m2": MinimaxM2Detector,
         "minimax-m3": MinimaxM3Detector,
         "trinity": TrinityDetector,

--- a/python/sglang/srt/function_call/telechat4_detector.py
+++ b/python/sglang/srt/function_call/telechat4_detector.py
@@ -1,0 +1,265 @@
+"""Tool call detector for TeleChat4 models.
+
+Supports two tool-call formats inside ``<tool_call>...</tool_call>`` blocks:
+
+1. **JSON** – ``<tool_call>{"name": "func", "arguments": {...}}</tool_call>``
+2. **Tag-based** – ``<tool_call>func<param_key>k1</param_key><param_value>v1
+   </param_value>...</tool_call>``
+
+Usage: ``--enable-auto-tool-choice --tool-call-parser telechat4``
+"""
+
+import ast
+import json
+import logging
+import re
+from typing import Any, Dict, List, Mapping, Sequence
+
+from sglang.srt.entrypoints.openai.protocol import Tool
+from sglang.srt.function_call.base_format_detector import BaseFormatDetector
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    StructureInfo,
+    ToolCallItem,
+    _GetInfoFunc,
+)
+
+logger = logging.getLogger(__name__)
+
+TOOL_START_TOKEN = "<tool_call>"
+TOOL_END_TOKEN = "</tool_call>"
+PARAM_KEY_START_TOKEN = "<param_key>"
+PARAM_KEY_END_TOKEN = "</param_key>"
+PARAM_VALUE_START_TOKEN = "<param_value>"
+PARAM_VALUE_END_TOKEN = "</param_value>"
+
+TOOL_CALL_REGEX = re.compile(
+    rf"{re.escape(TOOL_START_TOKEN)}(.*?){re.escape(TOOL_END_TOKEN)}",
+    re.DOTALL,
+)
+PARAM_REGEX = re.compile(
+    rf"{re.escape(PARAM_KEY_START_TOKEN)}(.*?){re.escape(PARAM_KEY_END_TOKEN)}"
+    rf"\s*{re.escape(PARAM_VALUE_START_TOKEN)}(.*?){re.escape(PARAM_VALUE_END_TOKEN)}",
+    re.DOTALL,
+)
+
+
+def _tool_parameters(tool: Tool) -> Mapping[str, Any]:
+    params = tool.function.parameters
+    if isinstance(params, Mapping):
+        return params
+    return {}
+
+
+def _iter_tool_names(tools: Sequence[Tool]) -> List[str]:
+    names = [t.function.name for t in tools if t.function.name]
+    return sorted(names, key=len, reverse=True)
+
+
+def _is_string_type(
+    tool_name: str, arg_name: str, tools: Sequence[Tool]
+) -> bool:
+    for tool in tools:
+        if tool.function.name != tool_name:
+            continue
+        properties = _tool_parameters(tool).get("properties", {})
+        if not isinstance(properties, Mapping):
+            return False
+        arg_schema = properties.get(arg_name, {})
+        if not isinstance(arg_schema, Mapping):
+            return False
+        arg_type = arg_schema.get("type")
+        if isinstance(arg_type, str):
+            return arg_type == "string"
+        if isinstance(arg_type, Sequence):
+            return "string" in arg_type
+        return False
+    return False
+
+
+def _deserialize(value: str) -> Any:
+    try:
+        return json.loads(value)
+    except Exception:
+        pass
+    try:
+        return ast.literal_eval(value)
+    except Exception:
+        pass
+    return value
+
+
+def _json_arguments(value: str) -> Dict[str, Any]:
+    parsed = _deserialize(value)
+    if not isinstance(parsed, Mapping):
+        return {}
+    arguments = parsed.get("arguments", parsed.get("parameters", parsed))
+    if isinstance(arguments, Mapping):
+        return dict(arguments)
+    return {}
+
+
+def _split_payload(
+    payload: str, tools: Sequence[Tool]
+) -> tuple[str, str, str]:
+    """Split payload into (tool_name, params_text, json_text).
+
+    Handles three formats:
+    1. Pure JSON: ``{"name": "func", "arguments": {...}}``
+    2. Tag-based: ``func<param_key>k1</param_key>...``
+    3. Name + JSON: ``func{...}``
+    """
+    payload = payload.strip()
+    param_pos = payload.find(PARAM_KEY_START_TOKEN)
+    if param_pos != -1:
+        return payload[:param_pos].strip(), payload[param_pos:], ""
+
+    # Pure JSON: extract tool name from the "name" field.
+    if payload.startswith("{"):
+        return "", "", payload
+
+    for tool_name in _iter_tool_names(tools):
+        if payload == tool_name:
+            return tool_name, "", ""
+        if payload.startswith(tool_name):
+            rest = payload[len(tool_name) :].strip()
+            if rest.startswith("{"):
+                return tool_name, "", rest
+
+    return payload, "", ""
+
+
+def _parse_payload(
+    payload: str, tools: Sequence[Tool]
+) -> tuple[str, Dict[str, Any]]:
+    tool_name, params_text, json_text = _split_payload(payload, tools)
+    arguments = _json_arguments(json_text) if json_text else {}
+
+    # Pure JSON format: extract tool name from the JSON object.
+    if not tool_name and json_text:
+        parsed = _deserialize(json_text)
+        if isinstance(parsed, Mapping):
+            tool_name = parsed.get("name", "") or ""
+
+    for key, value in PARAM_REGEX.findall(params_text):
+        arg_key = key.strip()
+        arg_val = value.strip()
+        if not _is_string_type(tool_name, arg_key, tools):
+            arg_val = _deserialize(arg_val)
+        arguments[arg_key] = arg_val
+
+    return tool_name, arguments
+
+
+def _partial_suffix_len(text: str, token: str) -> int:
+    max_len = min(len(text), len(token) - 1)
+    for size in range(max_len, 0, -1):
+        if token.startswith(text[-size:]):
+            return size
+    return 0
+
+
+class TeleChat4Detector(BaseFormatDetector):
+    """Detector for TeleChat4 tool call format.
+
+    Format::
+
+        <tool_call>{"name": "func", "arguments": {...}}</tool_call>
+
+    or::
+
+        <tool_call>func<param_key>k1</param_key><param_value>v1</param_value>
+        ...</tool_call>
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.bot_token = TOOL_START_TOKEN
+        self.eot_token = TOOL_END_TOKEN
+        self._buffer = ""
+
+    def has_tool_call(self, text: str) -> bool:
+        return self.bot_token in text
+
+    def detect_and_parse(
+        self, text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        idx = text.find(self.bot_token)
+        normal_text = text[:idx].strip() if idx != -1 else text
+        if self.bot_token not in text:
+            return StreamingParseResult(normal_text=normal_text, calls=[])
+
+        tool_indices = self._get_tool_indices(tools)
+        calls: List[ToolCallItem] = []
+
+        try:
+            for match in TOOL_CALL_REGEX.finditer(text):
+                tool_name, arguments = _parse_payload(match.group(1), tools)
+                if not tool_name or tool_name not in tool_indices:
+                    logger.warning(
+                        "TeleChat4Detector: unknown tool '%s'", tool_name
+                    )
+                    continue
+                calls.append(
+                    ToolCallItem(
+                        tool_index=tool_indices[tool_name],
+                        name=tool_name,
+                        parameters=json.dumps(arguments, ensure_ascii=False),
+                    )
+                )
+        except Exception:
+            logger.exception("TeleChat4Detector: failed to parse tool calls")
+            return StreamingParseResult(normal_text=text)
+
+        return StreamingParseResult(normal_text=normal_text, calls=calls)
+
+    def parse_streaming_increment(
+        self, new_text: str, tools: List[Tool]
+    ) -> StreamingParseResult:
+        self._buffer += new_text
+        content = ""
+        calls: List[ToolCallItem] = []
+        tool_indices = self._get_tool_indices(tools)
+
+        while True:
+            start_idx = self._buffer.find(self.bot_token)
+            if start_idx == -1:
+                partial_len = _partial_suffix_len(
+                    self._buffer, self.bot_token
+                )
+                if partial_len:
+                    content += self._buffer[:-partial_len]
+                    self._buffer = self._buffer[-partial_len:]
+                else:
+                    content += self._buffer
+                    self._buffer = ""
+                return StreamingParseResult(normal_text=content, calls=calls)
+
+            content += self._buffer[:start_idx]
+            self._buffer = self._buffer[start_idx:]
+            end_idx = self._buffer.find(self.eot_token)
+            if end_idx == -1:
+                return StreamingParseResult(normal_text=content, calls=calls)
+
+            end_pos = end_idx + len(self.eot_token)
+            tool_text = self._buffer[:end_pos]
+            extracted = self.detect_and_parse(tool_text, tools)
+
+            if not extracted.calls:
+                content += tool_text
+            else:
+                calls.extend(extracted.calls)
+
+            self._buffer = self._buffer[end_pos:]
+
+    def structure_info(self) -> _GetInfoFunc:
+        """Return function that creates StructureInfo for guided generation."""
+
+        def get_info(name: str) -> StructureInfo:
+            return StructureInfo(
+                begin=f'<tool_call>{{"name": "{name}", "arguments":',
+                end="}</tool_call>",
+                trigger="<tool_call>",
+            )
+
+        return get_info

--- a/python/sglang/srt/function_call/telechat4_detector.py
+++ b/python/sglang/srt/function_call/telechat4_detector.py
@@ -56,9 +56,7 @@ def _iter_tool_names(tools: Sequence[Tool]) -> List[str]:
     return sorted(names, key=len, reverse=True)
 
 
-def _is_string_type(
-    tool_name: str, arg_name: str, tools: Sequence[Tool]
-) -> bool:
+def _is_string_type(tool_name: str, arg_name: str, tools: Sequence[Tool]) -> bool:
     for tool in tools:
         if tool.function.name != tool_name:
             continue
@@ -99,9 +97,7 @@ def _json_arguments(value: str) -> Dict[str, Any]:
     return {}
 
 
-def _split_payload(
-    payload: str, tools: Sequence[Tool]
-) -> tuple[str, str, str]:
+def _split_payload(payload: str, tools: Sequence[Tool]) -> tuple[str, str, str]:
     """Split payload into (tool_name, params_text, json_text).
 
     Handles three formats:
@@ -129,9 +125,7 @@ def _split_payload(
     return payload, "", ""
 
 
-def _parse_payload(
-    payload: str, tools: Sequence[Tool]
-) -> tuple[str, Dict[str, Any]]:
+def _parse_payload(payload: str, tools: Sequence[Tool]) -> tuple[str, Dict[str, Any]]:
     tool_name, params_text, json_text = _split_payload(payload, tools)
     arguments = _json_arguments(json_text) if json_text else {}
 
@@ -181,9 +175,7 @@ class TeleChat4Detector(BaseFormatDetector):
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
 
-    def detect_and_parse(
-        self, text: str, tools: List[Tool]
-    ) -> StreamingParseResult:
+    def detect_and_parse(self, text: str, tools: List[Tool]) -> StreamingParseResult:
         idx = text.find(self.bot_token)
         normal_text = text[:idx].strip() if idx != -1 else text
         if self.bot_token not in text:
@@ -196,9 +188,7 @@ class TeleChat4Detector(BaseFormatDetector):
             for match in TOOL_CALL_REGEX.finditer(text):
                 tool_name, arguments = _parse_payload(match.group(1), tools)
                 if not tool_name or tool_name not in tool_indices:
-                    logger.warning(
-                        "TeleChat4Detector: unknown tool '%s'", tool_name
-                    )
+                    logger.warning("TeleChat4Detector: unknown tool '%s'", tool_name)
                     continue
                 calls.append(
                     ToolCallItem(
@@ -224,9 +214,7 @@ class TeleChat4Detector(BaseFormatDetector):
         while True:
             start_idx = self._buffer.find(self.bot_token)
             if start_idx == -1:
-                partial_len = _partial_suffix_len(
-                    self._buffer, self.bot_token
-                )
+                partial_len = _partial_suffix_len(self._buffer, self.bot_token)
                 if partial_len:
                     content += self._buffer[:-partial_len]
                     self._buffer = self._buffer[-partial_len:]

--- a/python/sglang/srt/hardware_backend/npu/moe/topk.py
+++ b/python/sglang/srt/hardware_backend/npu/moe/topk.py
@@ -42,6 +42,8 @@ def fused_topk_npu(
     use_grouped_topk = topk_config.use_grouped_topk
     renormalize = topk_config.renormalize
     correction_bias = topk_config.correction_bias
+    num_fused_shared_experts = topk_config.num_fused_shared_experts
+    routed_topk = topk_config.top_k - num_fused_shared_experts
 
     # sqrtsoftplus (DSV4 noaux_tc): top-k over (scores + bias); weights from
     # un-biased scores. The custom op fuses softplus/sqrt/topk/gather/norm/cast.
@@ -53,7 +55,7 @@ def fused_topk_npu(
         )
         topk_weights, topk_ids, _ = torch.ops.custom.npu_moe_gating_top_k(
             x=router_logits.to(torch.float32),
-            k=topk_config.top_k,
+            k=routed_topk,
             bias=(
                 correction_bias.to(torch.float32)
                 if correction_bias is not None
@@ -70,15 +72,11 @@ def fused_topk_npu(
     elif not use_grouped_topk and correction_bias is None:
         topk_weights, topk_ids, _ = torch.ops.npu.npu_moe_gating_top_k_softmax(
             router_logits,
-            k=topk_config.top_k,
+            k=routed_topk,
         )
 
         if renormalize:
-            topk_weights = l1_norm(
-                topk_weights
-                if topk_config.num_fused_shared_experts == 0
-                else topk_weights[:, :-1]
-            )
+            topk_weights = l1_norm(topk_weights)
         topk_weights = topk_weights.to(torch.float32)
 
     # Support grouped top-k or correction bias or sigmoid or routed_scaling_factor
@@ -89,7 +87,7 @@ def fused_topk_npu(
     ):
         topk_weights, topk_ids, _ = torch.ops.npu.npu_moe_gating_top_k(
             router_logits.to(torch.float32),
-            k=topk_config.top_k,
+            k=routed_topk,
             bias=(
                 correction_bias.to(torch.float32)
                 if correction_bias is not None
@@ -128,5 +126,24 @@ def fused_topk_npu(
         topk_ids = topk_ids_logical_to_physical(topk_ids, expert_location_dispatch_info)
     get_global_expert_distribution_recorder().on_select_experts(topk_ids=topk_ids)
     capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
+
+    if num_fused_shared_experts > 0:
+        num_tokens, num_routed_experts = router_logits.shape
+        shared_ids = torch.arange(
+            num_routed_experts,
+            num_routed_experts + num_fused_shared_experts,
+            dtype=topk_ids.dtype,
+            device=topk_ids.device,
+        ).expand(num_tokens, -1)
+        scale = topk_config.routed_scaling_factor or 1.0
+        shared_weights = topk_weights.sum(dim=-1, keepdim=True) / scale
+        if num_fused_shared_experts > 1:
+            shared_weights = shared_weights.expand(-1, num_fused_shared_experts)
+        if topk_config.fused_shared_experts_scaling_factor is not None:
+            shared_weights = (
+                shared_weights * topk_config.fused_shared_experts_scaling_factor
+            )
+        topk_ids = torch.cat((topk_ids, shared_ids), dim=-1)
+        topk_weights = torch.cat((topk_weights, shared_weights), dim=-1)
 
     return StandardTopKOutput(topk_weights, topk_ids, router_logits)

--- a/python/sglang/srt/layers/telechat4_mhc_torch.py
+++ b/python/sglang/srt/layers/telechat4_mhc_torch.py
@@ -16,9 +16,7 @@ def telechat4_mhc_pre_torch(
     num_streams = residual.shape[-2]
     residual_fp32 = residual.float()
     residual_flat = residual_fp32.flatten(-2)
-    inv_rms = torch.rsqrt(
-        residual_flat.square().mean(dim=-1, keepdim=True) + rms_eps
-    )
+    inv_rms = torch.rsqrt(residual_flat.square().mean(dim=-1, keepdim=True) + rms_eps)
     mixes = F.linear(residual_flat, fn.float()) * inv_rms
     pre_logits, post_logits, comb_logits = torch.split(
         mixes,
@@ -27,33 +25,23 @@ def telechat4_mhc_pre_torch(
     )
 
     pre_mix = (
-        torch.sigmoid(
-            pre_logits * hc_scale[0] + hc_base[:num_streams]
-        )
-        + hc_pre_eps
+        torch.sigmoid(pre_logits * hc_scale[0] + hc_base[:num_streams]) + hc_pre_eps
     )
     post_mix = (
         torch.sigmoid(
-            post_logits * hc_scale[1]
-            + hc_base[num_streams : 2 * num_streams]
+            post_logits * hc_scale[1] + hc_base[num_streams : 2 * num_streams]
         )
         * hc_post_mult_value
     )
-    comb_mix = (
-        comb_logits * hc_scale[2] + hc_base[2 * num_streams :]
-    ).view(-1, num_streams, num_streams)
+    comb_mix = (comb_logits * hc_scale[2] + hc_base[2 * num_streams :]).view(
+        -1, num_streams, num_streams
+    )
     comb_mix = torch.exp(comb_mix - comb_mix.amax(dim=-1, keepdim=True))
     comb_mix = comb_mix / comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps
-    comb_mix = comb_mix / (
-        comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps
-    )
+    comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
     for _ in range(sinkhorn_repeat - 1):
-        comb_mix = comb_mix / (
-            comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps
-        )
-        comb_mix = comb_mix / (
-            comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps
-        )
+        comb_mix = comb_mix / (comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps)
+        comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps)
 
     layer_input = (pre_mix.unsqueeze(-1) * residual_fp32).sum(dim=-2)
     return post_mix.unsqueeze(-1), comb_mix, layer_input.to(torch.bfloat16)
@@ -66,7 +54,5 @@ def telechat4_mhc_post_torch(
     comb_mix: torch.Tensor,
 ) -> torch.Tensor:
     output = post_mix.squeeze(-1).unsqueeze(-1) * x.float().unsqueeze(-2)
-    output += (
-        comb_mix.unsqueeze(-1) * residual.float().unsqueeze(-2)
-    ).sum(dim=-3)
+    output += (comb_mix.unsqueeze(-1) * residual.float().unsqueeze(-2)).sum(dim=-3)
     return output.to(torch.bfloat16)

--- a/python/sglang/srt/layers/telechat4_mhc_torch.py
+++ b/python/sglang/srt/layers/telechat4_mhc_torch.py
@@ -1,0 +1,72 @@
+import torch
+import torch.nn.functional as F
+
+
+def telechat4_mhc_pre_torch(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    num_streams = residual.shape[-2]
+    residual_fp32 = residual.float()
+    residual_flat = residual_fp32.flatten(-2)
+    inv_rms = torch.rsqrt(
+        residual_flat.square().mean(dim=-1, keepdim=True) + rms_eps
+    )
+    mixes = F.linear(residual_flat, fn.float()) * inv_rms
+    pre_logits, post_logits, comb_logits = torch.split(
+        mixes,
+        [num_streams, num_streams, num_streams * num_streams],
+        dim=-1,
+    )
+
+    pre_mix = (
+        torch.sigmoid(
+            pre_logits * hc_scale[0] + hc_base[:num_streams]
+        )
+        + hc_pre_eps
+    )
+    post_mix = (
+        torch.sigmoid(
+            post_logits * hc_scale[1]
+            + hc_base[num_streams : 2 * num_streams]
+        )
+        * hc_post_mult_value
+    )
+    comb_mix = (
+        comb_logits * hc_scale[2] + hc_base[2 * num_streams :]
+    ).view(-1, num_streams, num_streams)
+    comb_mix = torch.exp(comb_mix - comb_mix.amax(dim=-1, keepdim=True))
+    comb_mix = comb_mix / comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps
+    comb_mix = comb_mix / (
+        comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps
+    )
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (
+            comb_mix.sum(dim=-1, keepdim=True) + hc_sinkhorn_eps
+        )
+        comb_mix = comb_mix / (
+            comb_mix.sum(dim=-2, keepdim=True) + hc_sinkhorn_eps
+        )
+
+    layer_input = (pre_mix.unsqueeze(-1) * residual_fp32).sum(dim=-2)
+    return post_mix.unsqueeze(-1), comb_mix, layer_input.to(torch.bfloat16)
+
+
+def telechat4_mhc_post_torch(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_mix: torch.Tensor,
+) -> torch.Tensor:
+    output = post_mix.squeeze(-1).unsqueeze(-1) * x.float().unsqueeze(-2)
+    output += (
+        comb_mix.unsqueeze(-1) * residual.float().unsqueeze(-2)
+    ).sum(dim=-3)
+    return output.to(torch.bfloat16)

--- a/python/sglang/srt/layers/telechat4_mhc_triton.py
+++ b/python/sglang/srt/layers/telechat4_mhc_triton.py
@@ -1,0 +1,485 @@
+"""Triton Ascend kernels for TeleChat4's 3584-wide mHC layers."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+import triton.runtime.driver as driver
+
+MHC_STREAMS = 4
+MHC_HIDDEN_SIZE = 3584
+MHC_FLAT_SIZE = MHC_STREAMS * MHC_HIDDEN_SIZE
+MHC_OUTPUT_SIZE = MHC_STREAMS * (MHC_STREAMS + 2)
+MHC_PADDED_OUTPUT_SIZE = 32
+
+
+@triton.jit
+def _telechat4_mhc_pre_gemm_kernel(
+    residual_ptr,
+    fn_ptr,
+    partial_logits_ptr,
+    partial_sqrsum_ptr,
+    num_tokens,
+    SPLIT_K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    K: tl.constexpr,
+    N: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+    num_m_blocks = tl.cdiv(num_tokens, BLOCK_M)
+    num_tasks = num_m_blocks * SPLIT_K
+    split_size: tl.constexpr = K // SPLIT_K
+
+    offs_m_base = tl.arange(0, BLOCK_M)
+    offs_n = tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    for task_id in range(pid, num_tasks, num_programs):
+        split_id = task_id % SPLIT_K
+        block_m_id = task_id // SPLIT_K
+        offs_m = block_m_id * BLOCK_M + offs_m_base
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        sqrsum = tl.zeros((BLOCK_M,), dtype=tl.float32)
+
+        for k_offset in range(0, split_size, BLOCK_K):
+            offs_k_global = split_id * split_size + k_offset + offs_k
+            residual = tl.load(
+                residual_ptr
+                + offs_m[:, None] * K
+                + offs_k_global[None, :],
+                mask=(offs_m[:, None] < num_tokens)
+                & (offs_k_global[None, :] < K),
+                other=0.0,
+            )
+            fn = tl.load(
+                fn_ptr + offs_n[None, :] * K + offs_k_global[:, None],
+                mask=(offs_n[None, :] < N) & (offs_k_global[:, None] < K),
+                other=0.0,
+            )
+            acc += tl.dot(residual, fn)
+            residual_fp32 = residual.to(tl.float32)
+            sqrsum += tl.sum(residual_fp32 * residual_fp32, axis=1)
+
+        logits_offsets = (
+            split_id * num_tokens * BLOCK_N
+            + offs_m[:, None] * BLOCK_N
+            + offs_n[None, :]
+        )
+        tl.store(
+            partial_logits_ptr + logits_offsets,
+            acc,
+            mask=offs_m[:, None] < num_tokens,
+        )
+        tl.store(
+            partial_sqrsum_ptr + split_id * num_tokens + offs_m,
+            sqrsum,
+            mask=offs_m < num_tokens,
+        )
+
+
+@triton.jit
+def _telechat4_mhc_pre_finalize_kernel(
+    residual_ptr,
+    partial_logits_ptr,
+    partial_sqrsum_ptr,
+    hc_scale_ptr,
+    hc_base_ptr,
+    post_mix_ptr,
+    comb_mix_ptr,
+    layer_input_ptr,
+    num_tokens,
+    rms_eps,
+    hc_pre_eps,
+    hc_sinkhorn_eps,
+    hc_post_mult_value,
+    SPLIT_K: tl.constexpr,
+    SINKHORN_REPEAT: tl.constexpr,
+    STREAMS: tl.constexpr,
+    HIDDEN_SIZE: tl.constexpr,
+    FLAT_SIZE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    POST_LAYOUT: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+    split_offsets = tl.arange(0, SPLIT_K)
+    stream_offsets = tl.arange(0, STREAMS)
+    comb_offsets = tl.arange(0, STREAMS * STREAMS)
+    hidden_offsets = tl.arange(0, BLOCK_H)
+
+    for token_id in range(pid, num_tokens, num_programs):
+        partial_sqrsum = tl.load(
+            partial_sqrsum_ptr + split_offsets * num_tokens + token_id
+        )
+        inv_rms = tl.rsqrt(tl.sum(partial_sqrsum, axis=0) / FLAT_SIZE + rms_eps)
+
+        pre_partial_offsets = (
+            split_offsets[:, None] * num_tokens * BLOCK_N
+            + token_id * BLOCK_N
+            + stream_offsets[None, :]
+        )
+        pre_logits = tl.sum(
+            tl.load(partial_logits_ptr + pre_partial_offsets), axis=0
+        ) * inv_rms
+        pre_scale = tl.load(hc_scale_ptr)
+        pre_base = tl.load(hc_base_ptr + stream_offsets)
+        pre_mix = tl.sigmoid(pre_logits * pre_scale + pre_base) + hc_pre_eps
+
+        post_partial_offsets = pre_partial_offsets + STREAMS
+        post_logits = tl.sum(
+            tl.load(partial_logits_ptr + post_partial_offsets), axis=0
+        ) * inv_rms
+        post_scale = tl.load(hc_scale_ptr + 1)
+        post_base = tl.load(hc_base_ptr + STREAMS + stream_offsets)
+        post_mix = (
+            tl.sigmoid(post_logits * post_scale + post_base)
+            * hc_post_mult_value
+        )
+
+        comb_partial_offsets = (
+            split_offsets[:, None] * num_tokens * BLOCK_N
+            + token_id * BLOCK_N
+            + 2 * STREAMS
+            + comb_offsets[None, :]
+        )
+        comb_logits = tl.sum(
+            tl.load(partial_logits_ptr + comb_partial_offsets), axis=0
+        ) * inv_rms
+        comb_scale = tl.load(hc_scale_ptr + 2)
+        comb_base = tl.load(hc_base_ptr + 2 * STREAMS + comb_offsets)
+        comb_mix = tl.reshape(
+            comb_logits * comb_scale + comb_base,
+            (STREAMS, STREAMS),
+        )
+
+        row_max = tl.max(comb_mix, axis=1)
+        comb_mix = tl.exp(comb_mix - row_max[:, None])
+        row_sum = tl.sum(comb_mix, axis=1)
+        comb_mix = comb_mix / row_sum[:, None] + hc_sinkhorn_eps
+        col_sum = tl.sum(comb_mix, axis=0)
+        comb_mix = comb_mix / (col_sum[None, :] + hc_sinkhorn_eps)
+        for _ in range(SINKHORN_REPEAT - 1):
+            row_sum = tl.sum(comb_mix, axis=1)
+            comb_mix = comb_mix / (row_sum[:, None] + hc_sinkhorn_eps)
+            col_sum = tl.sum(comb_mix, axis=0)
+            comb_mix = comb_mix / (col_sum[None, :] + hc_sinkhorn_eps)
+
+        residual_offsets = (
+            token_id * FLAT_SIZE
+            + stream_offsets[:, None] * HIDDEN_SIZE
+            + hidden_offsets[None, :]
+        )
+        residual = tl.load(
+            residual_ptr + residual_offsets,
+            mask=hidden_offsets[None, :] < HIDDEN_SIZE,
+            other=0.0,
+        ).to(tl.float32)
+        layer_input = tl.sum(residual * pre_mix[:, None], axis=0)
+
+        tl.store(
+            post_mix_ptr + token_id * STREAMS + stream_offsets,
+            post_mix,
+        )
+        if POST_LAYOUT:
+            comb_output_offsets = (
+                (comb_offsets % STREAMS) * STREAMS + comb_offsets // STREAMS
+            )
+        else:
+            comb_output_offsets = comb_offsets
+        tl.store(
+            comb_mix_ptr
+            + token_id * STREAMS * STREAMS
+            + comb_output_offsets,
+            tl.reshape(comb_mix, (STREAMS * STREAMS,)),
+        )
+        tl.store(
+            layer_input_ptr + token_id * HIDDEN_SIZE + hidden_offsets,
+            layer_input,
+            mask=hidden_offsets < HIDDEN_SIZE,
+        )
+
+
+@triton.jit
+def _telechat4_mhc_post_kernel(
+    x_ptr,
+    residual_ptr,
+    post_mix_ptr,
+    comb_mix_ptr,
+    output_ptr,
+    num_tokens,
+    STREAMS: tl.constexpr,
+    FLAT_SIZE: tl.constexpr,
+    HIDDEN_SIZE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+    num_tasks = num_tokens * STREAMS
+    hidden_offsets = tl.arange(0, BLOCK_H)
+    old_stream_offsets = tl.arange(0, STREAMS)
+
+    for task_id in range(pid, num_tasks, num_programs):
+        token_id = task_id // STREAMS
+        new_stream_id = task_id % STREAMS
+        hidden_mask = hidden_offsets < HIDDEN_SIZE
+        x = tl.load(
+            x_ptr + token_id * HIDDEN_SIZE + hidden_offsets,
+            mask=hidden_mask,
+            other=0.0,
+        ).to(tl.float32)
+        post_mix = tl.load(
+            post_mix_ptr + token_id * STREAMS + new_stream_id
+        )
+        residual_offsets = (
+            token_id * FLAT_SIZE
+            + old_stream_offsets[:, None] * HIDDEN_SIZE
+            + hidden_offsets[None, :]
+        )
+        residual = tl.load(
+            residual_ptr + residual_offsets,
+            mask=hidden_mask[None, :],
+            other=0.0,
+        ).to(tl.float32)
+        comb_offsets = (
+            token_id * STREAMS * STREAMS
+            + old_stream_offsets * STREAMS
+            + new_stream_id
+        )
+        comb_mix = tl.load(comb_mix_ptr + comb_offsets)
+        output = post_mix * x + tl.sum(residual * comb_mix[:, None], axis=0)
+        tl.store(
+            output_ptr
+            + token_id * FLAT_SIZE
+            + new_stream_id * HIDDEN_SIZE
+            + hidden_offsets,
+            output,
+            mask=hidden_mask,
+        )
+
+
+def _validate_pre_inputs(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+) -> None:
+    if residual.shape[-2:] != (MHC_STREAMS, MHC_HIDDEN_SIZE):
+        raise ValueError(
+            "TeleChat4 Triton mHC requires residual[..., 4, 3584], "
+            f"got {tuple(residual.shape)}"
+        )
+    if residual.dtype != torch.bfloat16 or fn.dtype != torch.bfloat16:
+        raise TypeError("TeleChat4 Triton mHC requires BF16 residual and fn")
+    if fn.shape != (MHC_OUTPUT_SIZE, MHC_FLAT_SIZE):
+        raise ValueError(
+            f"TeleChat4 Triton mHC requires fn[24, 14336], got {tuple(fn.shape)}"
+        )
+    if hc_scale.shape != (3,) or hc_scale.dtype != torch.float32:
+        raise ValueError("TeleChat4 Triton mHC requires FP32 hc_scale[3]")
+    if hc_base.shape != (MHC_OUTPUT_SIZE,) or hc_base.dtype != torch.float32:
+        raise ValueError("TeleChat4 Triton mHC requires FP32 hc_base[24]")
+    if not all(t.is_contiguous() for t in (residual, fn, hc_scale, hc_base)):
+        raise ValueError("TeleChat4 Triton mHC inputs must be contiguous")
+
+
+def _telechat4_mhc_pre_split(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    split_k: int = 8,
+    direct_post_layout: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if split_k not in (1, 2, 4, 8, 16):
+        raise ValueError(f"split_k must be one of 1, 2, 4, 8, 16, got {split_k}")
+    if MHC_FLAT_SIZE % split_k != 0:
+        raise ValueError(f"split_k={split_k} does not divide {MHC_FLAT_SIZE}")
+
+    num_tokens = residual.numel() // MHC_FLAT_SIZE
+    residual_flat = residual.view(num_tokens, MHC_FLAT_SIZE)
+    partial_logits = torch.empty(
+        split_k,
+        num_tokens,
+        MHC_PADDED_OUTPUT_SIZE,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    partial_sqrsum = torch.empty(
+        split_k, num_tokens, dtype=torch.float32, device=residual.device
+    )
+    post_mix = torch.empty(
+        num_tokens,
+        MHC_STREAMS,
+        1,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb_post_layout = torch.empty(
+        num_tokens,
+        MHC_STREAMS,
+        MHC_STREAMS,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    layer_input = torch.empty(
+        num_tokens,
+        MHC_HIDDEN_SIZE,
+        dtype=torch.bfloat16,
+        device=residual.device,
+    )
+
+    num_aicore = driver.active.utils.get_device_properties(
+        residual.device.index or 0
+    )["num_aicore"]
+    block_m = 16
+    num_tasks = triton.cdiv(num_tokens, block_m) * split_k
+    _telechat4_mhc_pre_gemm_kernel[(min(num_tasks, num_aicore),)](
+        residual_flat,
+        fn,
+        partial_logits,
+        partial_sqrsum,
+        num_tokens,
+        SPLIT_K=split_k,
+        BLOCK_M=block_m,
+        BLOCK_N=MHC_PADDED_OUTPUT_SIZE,
+        BLOCK_K=128,
+        K=MHC_FLAT_SIZE,
+        N=MHC_OUTPUT_SIZE,
+        num_stages=2,
+    )
+
+    num_vectorcore = driver.active.utils.get_device_properties(
+        residual.device.index or 0
+    )["num_vectorcore"]
+    _telechat4_mhc_pre_finalize_kernel[(min(num_tokens, num_vectorcore),)](
+        residual_flat,
+        partial_logits,
+        partial_sqrsum,
+        hc_scale,
+        hc_base,
+        post_mix,
+        comb_post_layout,
+        layer_input,
+        num_tokens,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        SPLIT_K=split_k,
+        SINKHORN_REPEAT=sinkhorn_repeat,
+        STREAMS=MHC_STREAMS,
+        HIDDEN_SIZE=MHC_HIDDEN_SIZE,
+        FLAT_SIZE=MHC_FLAT_SIZE,
+        BLOCK_H=4096,
+        BLOCK_N=MHC_PADDED_OUTPUT_SIZE,
+        POST_LAYOUT=direct_post_layout,
+        num_stages=1,
+    )
+    comb_mix = (
+        comb_post_layout.transpose(-1, -2)
+        if direct_post_layout
+        else comb_post_layout
+    )
+    return post_mix, comb_mix, layer_input
+
+
+def telechat4_mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    split_k: int = 8,
+    implementation: str = "auto",
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Run TeleChat4 mHC pre-mixing with split-K Ascend Triton kernels."""
+    _validate_pre_inputs(residual, fn, hc_scale, hc_base)
+    if implementation not in ("auto", "split", "split_direct"):
+        raise ValueError(
+            "implementation must be 'auto', 'split', or 'split_direct', "
+            f"got {implementation!r}"
+        )
+
+    if implementation == "auto":
+        from sglang.srt.runtime_context import get_forward
+
+        direct_post_layout = bool(get_forward().is_extend_in_batch)
+    else:
+        direct_post_layout = implementation == "split_direct"
+    return _telechat4_mhc_pre_split(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        split_k,
+        direct_post_layout,
+    )
+
+
+def telechat4_mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_mix: torch.Tensor,
+    comb_mix: torch.Tensor,
+) -> torch.Tensor:
+    """Run the 3584-wide TeleChat4 mHC post-mixing kernel on Ascend."""
+    if x.ndim != 2 or x.shape[1] != MHC_HIDDEN_SIZE:
+        raise ValueError(f"expected x[num_tokens, 3584], got {tuple(x.shape)}")
+    if residual.shape != (x.shape[0], MHC_STREAMS, MHC_HIDDEN_SIZE):
+        raise ValueError(
+            f"expected residual[{x.shape[0]}, 4, 3584], got {tuple(residual.shape)}"
+        )
+    if post_mix.shape not in (
+        (x.shape[0], MHC_STREAMS),
+        (x.shape[0], MHC_STREAMS, 1),
+    ):
+        raise ValueError(f"unexpected post_mix shape {tuple(post_mix.shape)}")
+    if comb_mix.shape != (x.shape[0], MHC_STREAMS, MHC_STREAMS):
+        raise ValueError(f"unexpected comb_mix shape {tuple(comb_mix.shape)}")
+    if x.dtype != torch.bfloat16 or residual.dtype != torch.bfloat16:
+        raise TypeError("TeleChat4 Triton mHC post requires BF16 x and residual")
+    if post_mix.dtype != torch.float32 or comb_mix.dtype != torch.float32:
+        raise TypeError("TeleChat4 Triton mHC post requires FP32 mixing coefficients")
+    if not all(t.is_contiguous() for t in (x, residual, post_mix, comb_mix)):
+        raise ValueError("TeleChat4 Triton mHC post inputs must be contiguous")
+
+    output = torch.empty(
+        residual.shape, device=residual.device, dtype=residual.dtype
+    )
+    num_tokens = x.shape[0]
+    num_vectorcore = driver.active.utils.get_device_properties(x.device.index or 0)[
+        "num_vectorcore"
+    ]
+    _telechat4_mhc_post_kernel[(min(num_tokens * MHC_STREAMS, num_vectorcore),)](
+        x,
+        residual,
+        post_mix,
+        comb_mix,
+        output,
+        num_tokens,
+        STREAMS=MHC_STREAMS,
+        FLAT_SIZE=MHC_FLAT_SIZE,
+        HIDDEN_SIZE=MHC_HIDDEN_SIZE,
+        BLOCK_H=4096,
+        num_stages=1,
+    )
+    return output

--- a/python/sglang/srt/layers/telechat4_mhc_triton.py
+++ b/python/sglang/srt/layers/telechat4_mhc_triton.py
@@ -48,11 +48,8 @@ def _telechat4_mhc_pre_gemm_kernel(
         for k_offset in range(0, split_size, BLOCK_K):
             offs_k_global = split_id * split_size + k_offset + offs_k
             residual = tl.load(
-                residual_ptr
-                + offs_m[:, None] * K
-                + offs_k_global[None, :],
-                mask=(offs_m[:, None] < num_tokens)
-                & (offs_k_global[None, :] < K),
+                residual_ptr + offs_m[:, None] * K + offs_k_global[None, :],
+                mask=(offs_m[:, None] < num_tokens) & (offs_k_global[None, :] < K),
                 other=0.0,
             )
             fn = tl.load(
@@ -123,23 +120,20 @@ def _telechat4_mhc_pre_finalize_kernel(
             + token_id * BLOCK_N
             + stream_offsets[None, :]
         )
-        pre_logits = tl.sum(
-            tl.load(partial_logits_ptr + pre_partial_offsets), axis=0
-        ) * inv_rms
+        pre_logits = (
+            tl.sum(tl.load(partial_logits_ptr + pre_partial_offsets), axis=0) * inv_rms
+        )
         pre_scale = tl.load(hc_scale_ptr)
         pre_base = tl.load(hc_base_ptr + stream_offsets)
         pre_mix = tl.sigmoid(pre_logits * pre_scale + pre_base) + hc_pre_eps
 
         post_partial_offsets = pre_partial_offsets + STREAMS
-        post_logits = tl.sum(
-            tl.load(partial_logits_ptr + post_partial_offsets), axis=0
-        ) * inv_rms
+        post_logits = (
+            tl.sum(tl.load(partial_logits_ptr + post_partial_offsets), axis=0) * inv_rms
+        )
         post_scale = tl.load(hc_scale_ptr + 1)
         post_base = tl.load(hc_base_ptr + STREAMS + stream_offsets)
-        post_mix = (
-            tl.sigmoid(post_logits * post_scale + post_base)
-            * hc_post_mult_value
-        )
+        post_mix = tl.sigmoid(post_logits * post_scale + post_base) * hc_post_mult_value
 
         comb_partial_offsets = (
             split_offsets[:, None] * num_tokens * BLOCK_N
@@ -147,9 +141,9 @@ def _telechat4_mhc_pre_finalize_kernel(
             + 2 * STREAMS
             + comb_offsets[None, :]
         )
-        comb_logits = tl.sum(
-            tl.load(partial_logits_ptr + comb_partial_offsets), axis=0
-        ) * inv_rms
+        comb_logits = (
+            tl.sum(tl.load(partial_logits_ptr + comb_partial_offsets), axis=0) * inv_rms
+        )
         comb_scale = tl.load(hc_scale_ptr + 2)
         comb_base = tl.load(hc_base_ptr + 2 * STREAMS + comb_offsets)
         comb_mix = tl.reshape(
@@ -187,14 +181,12 @@ def _telechat4_mhc_pre_finalize_kernel(
         )
         if POST_LAYOUT:
             comb_output_offsets = (
-                (comb_offsets % STREAMS) * STREAMS + comb_offsets // STREAMS
-            )
+                comb_offsets % STREAMS
+            ) * STREAMS + comb_offsets // STREAMS
         else:
             comb_output_offsets = comb_offsets
         tl.store(
-            comb_mix_ptr
-            + token_id * STREAMS * STREAMS
-            + comb_output_offsets,
+            comb_mix_ptr + token_id * STREAMS * STREAMS + comb_output_offsets,
             tl.reshape(comb_mix, (STREAMS * STREAMS,)),
         )
         tl.store(
@@ -232,9 +224,7 @@ def _telechat4_mhc_post_kernel(
             mask=hidden_mask,
             other=0.0,
         ).to(tl.float32)
-        post_mix = tl.load(
-            post_mix_ptr + token_id * STREAMS + new_stream_id
-        )
+        post_mix = tl.load(post_mix_ptr + token_id * STREAMS + new_stream_id)
         residual_offsets = (
             token_id * FLAT_SIZE
             + old_stream_offsets[:, None] * HIDDEN_SIZE
@@ -246,9 +236,7 @@ def _telechat4_mhc_post_kernel(
             other=0.0,
         ).to(tl.float32)
         comb_offsets = (
-            token_id * STREAMS * STREAMS
-            + old_stream_offsets * STREAMS
-            + new_stream_id
+            token_id * STREAMS * STREAMS + old_stream_offsets * STREAMS + new_stream_id
         )
         comb_mix = tl.load(comb_mix_ptr + comb_offsets)
         output = post_mix * x + tl.sum(residual * comb_mix[:, None], axis=0)
@@ -338,9 +326,9 @@ def _telechat4_mhc_pre_split(
         device=residual.device,
     )
 
-    num_aicore = driver.active.utils.get_device_properties(
-        residual.device.index or 0
-    )["num_aicore"]
+    num_aicore = driver.active.utils.get_device_properties(residual.device.index or 0)[
+        "num_aicore"
+    ]
     block_m = 16
     num_tasks = triton.cdiv(num_tokens, block_m) * split_k
     _telechat4_mhc_pre_gemm_kernel[(min(num_tasks, num_aicore),)](
@@ -386,9 +374,7 @@ def _telechat4_mhc_pre_split(
         num_stages=1,
     )
     comb_mix = (
-        comb_post_layout.transpose(-1, -2)
-        if direct_post_layout
-        else comb_post_layout
+        comb_post_layout.transpose(-1, -2) if direct_post_layout else comb_post_layout
     )
     return post_mix, comb_mix, layer_input
 
@@ -462,9 +448,7 @@ def telechat4_mhc_post(
     if not all(t.is_contiguous() for t in (x, residual, post_mix, comb_mix)):
         raise ValueError("TeleChat4 Triton mHC post inputs must be contiguous")
 
-    output = torch.empty(
-        residual.shape, device=residual.device, dtype=residual.dtype
-    )
+    output = torch.empty(residual.shape, device=residual.device, dtype=residual.dtype)
     num_tokens = x.shape[0]
     num_vectorcore = driver.active.utils.get_device_properties(x.device.index or 0)[
         "num_vectorcore"

--- a/python/sglang/srt/models/telechat4.py
+++ b/python/sglang/srt/models/telechat4.py
@@ -1,0 +1,993 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""TeleChat4 model for SGLang.
+
+Adapts the TeleChat4 architecture (MLA attention + MoE + mHC residual streams)
+on top of sglang's DeepSeek-V2 building blocks.  The mHC module uses sglang's
+fused TileLang kernels (``mhc_pre`` / ``mhc_post``) for performance.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Iterable, List, Optional, Tuple
+
+import torch
+from torch import nn
+
+import sglang.srt.models.deepseek_v2 as deepseek_v2
+from sglang.srt.configs.telechat4 import TeleChat4Config
+from sglang.srt.configs.model_config import is_deepseek_dsa
+from sglang.srt.distributed import get_pp_group
+from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
+from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
+    DeepseekV2WeightLoaderMixin,
+)
+from sglang.srt.runtime_context import get_forward, get_parallel
+from sglang.srt.server_args import get_global_server_args
+from sglang.srt.utils import add_prefix, make_layers
+from sglang.srt.utils.custom_op import register_custom_op
+
+# Register mhc_pre / mhc_post as torch custom ops with fake (meta) implementations
+# so that torch.compile can trace through the mHC module. Without registration,
+# dynamo tries to execute the real kernel with FakeTensors and fails because the
+# TVM/TileLang C-extension calls attempt to access the data pointer of FakeTensors.
+from sglang.kernels.ops.layernorm.mhc import mhc_pre as _mhc_pre_orig
+from sglang.kernels.ops.layernorm.mhc import mhc_post as _mhc_post_orig
+
+
+def _mhc_pre_fake(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int,
+    n_splits_pre: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fake (meta) implementation of mhc_pre for torch.compile tracing."""
+    num_tokens, hc_mult, hidden_size = residual.shape
+    post_mix = torch.empty(
+        num_tokens, hc_mult, 1, dtype=torch.float32, device=residual.device
+    )
+    comb_mix = torch.empty(
+        num_tokens, hc_mult, hc_mult, dtype=torch.float32, device=residual.device
+    )
+    layer_input = torch.empty(
+        num_tokens, hidden_size, dtype=torch.bfloat16, device=residual.device
+    )
+    return (post_mix, comb_mix, layer_input)
+
+
+@register_custom_op(
+    op_name="telechat4_mhc_pre",
+    mutates_args=[],
+    fake_impl=_mhc_pre_fake,
+)
+def mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int,
+    n_splits_pre: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    return _mhc_pre_orig(
+        residual=residual,
+        fn=fn,
+        hc_scale=hc_scale,
+        hc_base=hc_base,
+        rms_eps=rms_eps,
+        hc_pre_eps=hc_pre_eps,
+        hc_sinkhorn_eps=hc_sinkhorn_eps,
+        hc_post_mult_value=hc_post_mult_value,
+        sinkhorn_repeat=sinkhorn_repeat,
+        n_splits=n_splits,
+        n_splits_pre=n_splits_pre,
+    )
+
+
+@register_custom_op(
+    op_name="telechat4_mhc_post",
+    mutates_args=[],
+    out_shape="residual",
+)
+def mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    return _mhc_post_orig(x, residual, post_layer_mix, comb_res_mix)
+
+
+logger = logging.getLogger(__name__)
+
+
+class mHCModule(nn.Module):
+    """mHC (Manifold-constrained Hyper-Connection) module.
+
+    Backed by sglang's fused TileLang kernels (``mhc_pre`` / ``mhc_post``).
+    The fp32 op operands (``fn`` / ``hc_scale`` / ``hc_base``) are materialised
+    once in :meth:`finalize` after weight loading.
+    """
+
+    def __init__(self, config, layer_number: int):
+        super().__init__()
+        self.config = config
+        self.layer_number = layer_number
+        self.n = config.num_residual_streams
+        self.hidden_size = config.hidden_size
+        self.sinkhorn_iterations = config.mhc_sinkhorn_iterations
+
+        # mHC kernel hyper-parameters
+        self.norm_eps = 1e-6
+        self.pre_eps = 1e-6
+        self.post_mult_value = 2.0
+        self.sinkhorn_eps = 1e-6
+        # splitk GEMM parallelism. hc_hidden_size = n * hidden_size = 4 * 3584
+        # = 14336. 14336 / n_splits_pre must be divisible by hidden_block(256).
+        self.n_splits_pre = 8
+
+        out_features = self.n * self.n + 2 * self.n
+        self.mapping_proj = nn.Linear(
+            self.n * self.hidden_size, out_features, bias=False
+        )
+
+        init_alpha = config.mhc_init_gating_factor
+        self.alpha_pre = nn.Parameter(torch.full((1,), init_alpha))
+        self.alpha_post = nn.Parameter(torch.full((1,), init_alpha))
+        self.alpha_res = nn.Parameter(torch.full((1,), init_alpha))
+
+        self.bias = nn.Parameter(torch.zeros(out_features))
+
+        # fp32 op operands, filled by finalize() after weight loading.
+        self.register_buffer(
+            "fn",
+            torch.zeros(out_features, self.n * self.hidden_size),
+            persistent=False,
+        )
+        self.register_buffer("hc_scale", torch.zeros(3), persistent=False)
+        self.register_buffer(
+            "hc_base", torch.zeros(out_features), persistent=False
+        )
+        self._finalized = False
+
+    @torch.no_grad()
+    def finalize(self) -> None:
+        """Build the fp32 op operands from the loaded parameters."""
+        self.fn = self.mapping_proj.weight.detach().to(
+            torch.float32
+        ).contiguous()
+        self.hc_scale = (
+            torch.cat([self.alpha_pre, self.alpha_post, self.alpha_res])
+            .detach()
+            .to(torch.float32)
+            .contiguous()
+        )
+        self.hc_base = self.bias.detach().to(torch.float32).contiguous()
+        self._finalized = True
+
+    def forward(self, hidden_states: torch.Tensor):
+        """Compute mHC pre-mixing: aggregate n-stream -> 1-stream.
+
+        Args:
+            hidden_states: [S, B, n*C] n-stream hidden states.
+        Returns:
+            aggregated: [S, B, C] single-stream input for the sub-layer.
+            comb_mix: [S*B, n*n] residual mixing matrix.
+            post_mix: [S*B, n] stream expansion weights.
+        """
+        S, B, _ = hidden_states.shape
+        n = self.n
+        C = self.hidden_size
+
+        if not self._finalized:
+            self.finalize()
+
+        # Flatten to [S*B, n, C] and ensure bf16 (kernel requirement).
+        residual = hidden_states.reshape(S * B, n, C)
+        if residual.dtype != torch.bfloat16:
+            residual = residual.to(torch.bfloat16)
+
+        num_tokens = residual.shape[0]
+        if num_tokens == 0:
+            layer_input = torch.empty(
+                0, C, dtype=torch.bfloat16, device=residual.device
+            )
+            post_mix = torch.empty(
+                0, n, dtype=torch.float32, device=residual.device
+            )
+            comb_mix = torch.empty(
+                0, n * n, dtype=torch.float32, device=residual.device
+            )
+        else:
+            post_mix, comb_mix, layer_input = mhc_pre(
+                residual=residual,
+                fn=self.fn,
+                hc_scale=self.hc_scale,
+                hc_base=self.hc_base,
+                rms_eps=self.norm_eps,
+                hc_pre_eps=self.pre_eps,
+                hc_sinkhorn_eps=self.sinkhorn_eps,
+                hc_post_mult_value=self.post_mult_value,
+                sinkhorn_repeat=self.sinkhorn_iterations,
+                n_splits=1,
+                n_splits_pre=self.n_splits_pre,
+            )
+
+        aggregated = layer_input.view(S, B, C)
+        comb_mix = comb_mix.transpose(-1, -2).contiguous()
+        return aggregated, comb_mix, post_mix
+
+    def fused_h_res_h_post_bda_inference(
+        self,
+        h_res: torch.Tensor,
+        original_residual: torch.Tensor,
+        h_post: torch.Tensor,
+        layer_output_with_bias,
+    ) -> torch.Tensor:
+        """Fused residual mixing + post expansion + bias-dropout-add.
+
+        Args:
+            h_res: comb_mix [S*B, n*n] from forward().
+            original_residual: [S, B, n*C] - n-stream input before aggregation.
+            h_post: post_mix [S*B, n] from forward().
+            layer_output_with_bias: (x [S, B, C], bias None).
+        Returns:
+            output: [S, B, n*C] - updated n-stream residual.
+        """
+        x, _ = layer_output_with_bias
+
+        S, B, _ = x.shape
+        n = self.n
+        C = self.hidden_size
+
+        x_flat = x.reshape(S * B, C)
+        if x_flat.dtype != torch.bfloat16:
+            x_flat = x_flat.to(torch.bfloat16)
+        residual_flat = original_residual.reshape(S * B, n, C)
+        if residual_flat.dtype != torch.bfloat16:
+            residual_flat = residual_flat.to(torch.bfloat16)
+
+        # comb_mix is stored flattened [S*B, n*n]; view as 3D for mhc_post.
+        comb_res_mix = h_res.view(S * B, n, n)
+
+        if x_flat.shape[0] == 0:
+            out = torch.empty_like(residual_flat)
+        else:
+            out = mhc_post(x_flat, residual_flat, h_post, comb_res_mix)
+
+        return out.view(S, B, n * C)
+
+
+def input_expand(x: torch.Tensor, n: int) -> torch.Tensor:
+    s, b, C = x.shape
+    expanded = x.unsqueeze(2).expand(s, b, n, C).contiguous()
+    return expanded.view(s, b, n * C)
+
+
+def output_contract(x: torch.Tensor, n: int) -> torch.Tensor:
+    s, b, nC = x.shape
+    C = nC // n
+    x_streams = x.view(s, b, n, C)
+    contracted = x_streams.mean(dim=2)
+    return contracted
+
+
+def _get_llama_4_scaling(
+    original_max_position_embeddings: int, scaling_beta: float, positions: torch.Tensor
+) -> torch.Tensor:
+    scaling = 1 + scaling_beta * torch.log(
+        1 + torch.floor(positions / original_max_position_embeddings)
+    )
+    return scaling[..., None, None]
+
+
+class TeleChat4DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        config: TeleChat4Config,
+        layer_id: int,
+        quant_config: Optional["QuantizationConfig"] = None,
+        moe_quant_config_override: Optional["QuantizationConfig"] = None,
+        is_nextn: bool = False,
+        prefix: str = "",
+        alt_stream: Optional[torch.cuda.Stream] = None,
+        dsa_enable_prefill_cp: bool = False,
+        mla_enable_prefill_cp: bool = False,
+    ) -> None:
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.config = config
+
+        if hasattr(config, "rope_parameters"):
+            rope_theta = config.rope_parameters["rope_theta"]
+            rope_type = config.rope_parameters.get("rope_type")
+            rope_scaling = config.rope_parameters if rope_type != "default" else None
+        else:
+            rope_theta = config.rope_theta
+            rope_scaling = config.rope_scaling
+        max_position_embeddings = config.max_position_embeddings
+
+        self.dsa_enable_prefill_cp = dsa_enable_prefill_cp
+        self.mla_enable_prefill_cp = mla_enable_prefill_cp
+        self.layer_id = layer_id
+        self.is_nextn = is_nextn
+
+        mtp_start_layer_idx = config.num_hidden_layers
+        self.is_mtp_layer = layer_id >= mtp_start_layer_idx
+
+        qk_nope_head_dim = getattr(config, "qk_nope_head_dim", 0)
+        qk_rope_head_dim = getattr(config, "qk_rope_head_dim", 0)
+        v_head_dim = getattr(config, "v_head_dim", 0)
+        kv_lora_rank = getattr(config, "kv_lora_rank", 0)
+        is_v32 = hasattr(config, "index_topk")
+        use_mha = config.model_type == "deepseek" or all(
+            dim == 0 for dim in (qk_nope_head_dim, qk_rope_head_dim)
+        )
+        self.use_mha = use_mha
+
+        from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+        self.self_attn = DeepseekV2AttentionMLA(
+            config=config,
+            hidden_size=self.hidden_size,
+            num_heads=config.num_attention_heads,
+            qk_nope_head_dim=qk_nope_head_dim,
+            qk_rope_head_dim=qk_rope_head_dim,
+            v_head_dim=v_head_dim,
+            q_lora_rank=(
+                config.q_lora_rank if hasattr(config, "q_lora_rank") else None
+            ),
+            kv_lora_rank=kv_lora_rank,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            max_position_embeddings=max_position_embeddings,
+            quant_config=quant_config,
+            layer_id=layer_id,
+            prefix=add_prefix("self_attn", prefix),
+            alt_stream=alt_stream,
+            is_nextn=is_nextn,
+            dsa_enable_prefill_cp=dsa_enable_prefill_cp,
+            mla_enable_prefill_cp=mla_enable_prefill_cp,
+        )
+
+        moe_layer_freq = getattr(config, "moe_layer_freq", 1)
+        if (
+            config.n_routed_experts is not None
+            and layer_id >= config.first_k_dense_replace
+            and layer_id % moe_layer_freq == 0
+        ):
+            self.mlp = deepseek_v2.DeepseekV2MoE(
+                config=config,
+                layer_id=self.layer_id,
+                quant_config=moe_quant_config_override or quant_config,
+                prefix=add_prefix("mlp", prefix),
+                alt_stream=alt_stream,
+                is_nextn=is_nextn,
+                is_deepseek_v4=False,
+                dsa_enable_prefill_cp=dsa_enable_prefill_cp,
+                mla_enable_prefill_cp=mla_enable_prefill_cp,
+            )
+        else:
+            from sglang.srt.layers.communicator import enable_moe_dense_fully_dp
+
+            if enable_moe_dense_fully_dp():
+                mlp_tp_rank, mlp_tp_size = 0, 1
+            else:
+                mlp_tp_rank, mlp_tp_size = None, None
+            self.mlp = deepseek_v2.DeepseekV2MLP(
+                hidden_size=config.hidden_size,
+                intermediate_size=config.intermediate_size,
+                hidden_act=config.hidden_act,
+                quant_config=quant_config,
+                prefix=add_prefix("mlp", prefix),
+                tp_rank=mlp_tp_rank,
+                tp_size=mlp_tp_size,
+                swiglu_limit=getattr(config, "swiglu_limit", None),
+            )
+
+        self.input_layernorm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
+
+        self.n = getattr(config, "num_residual_streams", 1)
+        self.enable_mhc = self.n > 1
+        if self.enable_mhc and not self.is_mtp_layer:
+            self.attn_hc = mHCModule(config, config.num_hidden_layers)
+            self.ffn_hc = mHCModule(config, config.num_hidden_layers)
+
+        from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
+
+        self.is_layer_sparse = self._is_layer_sparse(layer_id, is_nextn=is_nextn)
+        is_previous_layer_sparse = self._is_layer_sparse(layer_id - 1, is_nextn=False)
+        is_next_layer_sparse = self._is_layer_sparse(layer_id + 1, is_nextn=False)
+
+        self.layer_scatter_modes = LayerScatterModes.init_new(
+            layer_id=layer_id,
+            num_layers=1 if is_nextn else config.num_hidden_layers,
+            is_layer_sparse=self.is_layer_sparse,
+            is_previous_layer_sparse=is_previous_layer_sparse,
+            is_next_layer_sparse=is_next_layer_sparse,
+        )
+
+        self.layer_communicator = LayerCommunicator(
+            layer_scatter_modes=self.layer_scatter_modes,
+            input_layernorm=self.input_layernorm,
+            post_attention_layernorm=self.post_attention_layernorm,
+            allow_reduce_scatter=True,
+            is_last_layer=is_nextn or (layer_id == config.num_hidden_layers - 1),
+            qkv_latent_func=self.self_attn.prepare_qkv_latent,
+        )
+
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator,
+        gemm_output_zero_allocator=None,
+        llama_4_scaling: Optional[torch.Tensor] = None,
+        prev_topk_indices: Optional[torch.Tensor] = None,
+        captured_last_layer_outputs: Optional[List[torch.Tensor]] = None,
+        next_full_attention_layer_id: Optional[int] = None,
+    ) -> torch.Tensor:
+        if self.enable_mhc and not self.is_mtp_layer:
+            S = hidden_states.shape[0]
+            B = hidden_states.shape[1]
+            C = self.hidden_size
+
+            origin_hidden_states = hidden_states
+            aggregated_hidden_states, attention_res_weights, attention_post_weights = self.attn_hc(origin_hidden_states)
+
+            hidden_states = aggregated_hidden_states.reshape(-1, C)
+
+            # Use prepare_attn to set up attn_inputs_ (needed by MLA attention)
+            hidden_states, residual = (
+                self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                    hidden_states,
+                    None,
+                    forward_batch,
+                )
+            )
+
+            attn_kwargs = {
+                "positions": positions,
+                "hidden_states": hidden_states,
+                "forward_batch": forward_batch,
+                "zero_allocator": zero_allocator,
+                "layer_scatter_modes": self.layer_scatter_modes,
+                "llama_4_scaling": llama_4_scaling,
+            }
+            hidden_states = self.self_attn(**attn_kwargs)
+            if isinstance(hidden_states, tuple):
+                hidden_states, topk_indices = hidden_states
+            else:
+                topk_indices = None
+
+            from sglang.srt.layers.communicator import get_attn_tp_context
+            get_attn_tp_context().clear_attn_inputs()
+
+            hidden_states = hidden_states.reshape(S, B, C)
+
+            if (
+                isinstance(self.self_attn, deepseek_v2.DeepseekV2AttentionMLA)
+                and hidden_states.dtype == torch.float16
+            ):
+                hidden_states *= 1.0 / self.routed_scaling_factor
+
+            hidden_states = self.attn_hc.fused_h_res_h_post_bda_inference(
+                h_res=attention_res_weights,
+                original_residual=origin_hidden_states,
+                h_post=attention_post_weights,
+                layer_output_with_bias=(hidden_states, None),
+            )
+
+            origin_hidden_states = hidden_states
+            aggregated_hidden_states, mlp_res_weights, mlp_post_weights = self.ffn_hc(origin_hidden_states)
+
+            hidden_states = aggregated_hidden_states.reshape(-1, C)
+            hidden_states = self.post_attention_layernorm(hidden_states)
+
+            with get_forward().scoped(
+                fuse_mlp_allreduce=False,
+                mlp_reduce_scatter=False,
+            ):
+                hidden_states = self.mlp(
+                    hidden_states,
+                    forward_batch,
+                    gemm_output_zero_allocator,
+                )
+
+            hidden_states = hidden_states.reshape(S, B, C)
+
+            if isinstance(self.mlp, deepseek_v2.DeepseekV2MLP) and hidden_states.dtype == torch.float16:
+                hidden_states *= 1.0 / self.routed_scaling_factor
+
+            hidden_states = self.ffn_hc.fused_h_res_h_post_bda_inference(
+                h_res=mlp_res_weights,
+                original_residual=origin_hidden_states,
+                h_post=mlp_post_weights,
+                layer_output_with_bias=(hidden_states, None),
+            )
+
+            return hidden_states, None, topk_indices
+
+        hidden_states, residual = (
+            self.layer_communicator.prepare_attn_and_capture_last_layer_outputs(
+                hidden_states,
+                residual,
+                forward_batch,
+                captured_last_layer_outputs=captured_last_layer_outputs,
+            )
+        )
+
+        attn_kwargs = {
+            "positions": positions,
+            "hidden_states": hidden_states,
+            "forward_batch": forward_batch,
+            "zero_allocator": zero_allocator,
+            "layer_scatter_modes": self.layer_scatter_modes,
+        }
+        if not self.use_mha:
+            attn_kwargs["llama_4_scaling"] = llama_4_scaling
+        attn_output = self.self_attn(**attn_kwargs)
+        if isinstance(attn_output, tuple):
+            attn_output, topk_indices = attn_output
+        else:
+            topk_indices = None
+
+        hidden_states = attn_output
+
+        from sglang.srt.layers.communicator import get_attn_tp_context
+        get_attn_tp_context().clear_attn_inputs()
+
+        if (
+            isinstance(self.self_attn, deepseek_v2.DeepseekV2AttentionMLA)
+            and hidden_states.dtype == torch.float16
+        ):
+            hidden_states *= 1.0 / self.routed_scaling_factor
+            if self.layer_id == 0:
+                residual *= 1.0 / self.routed_scaling_factor
+
+        hidden_states, residual = self.layer_communicator.prepare_mlp(
+            hidden_states, residual, forward_batch
+        )
+
+        fuse_mlp_allreduce = (
+            self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
+                forward_batch
+            )
+        )
+        mlp_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(
+            forward_batch
+        )
+
+        with get_forward().scoped(
+            fuse_mlp_allreduce=fuse_mlp_allreduce,
+            mlp_reduce_scatter=mlp_reduce_scatter,
+        ):
+            hidden_states = self.mlp(
+                hidden_states,
+                forward_batch,
+                gemm_output_zero_allocator,
+            )
+
+        if (
+            not (self.dsa_enable_prefill_cp or self.mla_enable_prefill_cp)
+            and fuse_mlp_allreduce
+        ):
+            hidden_states._sglang_needs_allreduce_fusion = True
+
+        if not fuse_mlp_allreduce:
+            hidden_states, residual = self.layer_communicator.postprocess_layer(
+                hidden_states, residual, forward_batch
+            )
+
+        if isinstance(self.mlp, deepseek_v2.DeepseekV2MLP) and hidden_states.dtype == torch.float16:
+            hidden_states *= 1.0 / self.routed_scaling_factor
+
+        return hidden_states, residual, topk_indices
+
+    def _is_layer_sparse(self, layer_id: int, is_nextn: bool) -> bool:
+        return is_nextn or (
+            self.config.n_routed_experts is not None
+            and layer_id >= self.config.first_k_dense_replace
+            and layer_id % self.config.moe_layer_freq == 0
+        )
+
+    def op_comm_prepare_attn(
+        self,
+        state,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+        residual: Optional[torch.Tensor],
+        zero_allocator,
+        tbo_subbatch_index: Optional[int] = None,
+    ):
+        state.hidden_states_after_comm_pre_attn, state.residual_after_input_ln = (
+            self.layer_communicator.prepare_attn(hidden_states, residual, forward_batch)
+        )
+        state.update(
+            dict(
+                forward_batch=forward_batch,
+                positions=positions,
+                zero_allocator=zero_allocator,
+                tbo_subbatch_index=tbo_subbatch_index,
+            )
+        )
+
+    def op_comm_prepare_mlp(self, state):
+        state.hidden_states_mlp_input, state.residual_after_comm_pre_mlp = (
+            self.layer_communicator.prepare_mlp(
+                state.pop("hidden_states_after_attn"),
+                state.pop("residual_after_input_ln"),
+                state.forward_batch,
+            )
+        )
+
+    def op_comm_postprocess_layer(self, state):
+        hidden_states, residual = self.layer_communicator.postprocess_layer(
+            state.pop("hidden_states_mlp_output"),
+            state.pop("residual_after_comm_pre_mlp"),
+            state.forward_batch,
+        )
+
+        output = dict(
+            positions=state.positions,
+            hidden_states=hidden_states,
+            residual=residual,
+            forward_batch=state.forward_batch,
+            zero_allocator=state.zero_allocator,
+            tbo_subbatch_index=state.tbo_subbatch_index,
+        )
+
+        state.clear(
+            expect_keys={
+                "positions",
+                "forward_batch",
+                "zero_allocator",
+                "tbo_subbatch_index",
+            }
+        )
+        return output
+
+
+class TeleChat4Model(nn.Module):
+    def __init__(
+        self,
+        config: TeleChat4Config,
+        quant_config: Optional["QuantizationConfig"] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.config = config
+        self.pp_group = get_pp_group()
+
+        if self.pp_group.is_first_rank:
+            self.embed_tokens = VocabParallelEmbedding(
+                config.vocab_size,
+                config.hidden_size,
+                quant_config=quant_config,
+                prefix=add_prefix("embed_tokens", prefix),
+            )
+        else:
+            self.embed_tokens = PPMissingLayer()
+
+        dsa_enable_prefill_cp = False
+        mla_enable_prefill_cp = False
+
+        self.layers, self.start_layer, self.end_layer = make_layers(
+            config.num_hidden_layers,
+            lambda idx, prefix: TeleChat4DecoderLayer(
+                config,
+                layer_id=idx,
+                quant_config=quant_config,
+                prefix=prefix,
+                dsa_enable_prefill_cp=dsa_enable_prefill_cp,
+                mla_enable_prefill_cp=mla_enable_prefill_cp,
+            ),
+            pp_rank=self.pp_group.rank_in_group,
+            pp_size=self.pp_group.world_size,
+            prefix=add_prefix("layers", prefix),
+        )
+
+        if self.pp_group.is_last_rank:
+            self.norm = RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        else:
+            self.norm = PPMissingLayer()
+
+        self.num_residual_streams = getattr(config, "num_residual_streams", 1)
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: Optional[torch.Tensor],
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        if self.pp_group.is_first_rank:
+            if input_embeds is not None:
+                hidden_states = input_embeds
+            else:
+                if input_ids is None:
+                    raise ValueError(
+                        "Either input_ids or inputs_embeds must be provided "
+                        "to TeleChat4Model.forward"
+                    )
+                hidden_states = self.embed_input_ids(input_ids)
+        else:
+            assert pp_proxy_tensors is not None
+            hidden_states = pp_proxy_tensors.inputs_embeds
+
+        n_streams = self.num_residual_streams
+        if n_streams > 1:
+            S = hidden_states.shape[0]
+            C = hidden_states.shape[1]
+            hidden_states = hidden_states.reshape(S, 1, C)
+            hidden_states = input_expand(hidden_states, n_streams)
+
+        residual = None
+        topk_indices = None
+
+        from sglang.srt.utils import BumpAllocator
+
+        device = hidden_states.device
+        total_num_layers = self.end_layer - self.start_layer
+        zero_allocator = BumpAllocator(
+            buffer_size=total_num_layers * 2 * (2 if forward_batch.can_run_tbo else 1),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        for layer in self.layers:
+            if isinstance(layer, PPMissingLayer):
+                continue
+            hidden_states, residual, topk_indices = layer(
+                positions=positions,
+                hidden_states=hidden_states,
+                forward_batch=forward_batch,
+                residual=residual,
+                zero_allocator=zero_allocator,
+            )
+
+        if not self.pp_group.is_last_rank:
+            return hidden_states
+
+        if n_streams > 1:
+            hidden_states = output_contract(hidden_states, n_streams)
+            hidden_states = hidden_states.reshape(S, C)
+
+        hidden_states = self.norm(hidden_states)
+        return hidden_states
+
+
+class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
+    packed_modules_mapping = {
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def __init__(
+        self,
+        config: TeleChat4Config,
+        quant_config: Optional["QuantizationConfig"] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+
+        self.pp_group = get_pp_group()
+        self.config = config
+        self.tp_size = get_parallel().tp_size
+        self.quant_config = quant_config
+
+        # Fuse q_a_proj and kv_a_proj_with_mqa along output dimension when
+        # q_lora_rank is not None (matches DeepseekV2ForCausalLM behaviour).
+        self.fuse_qkv_a_proj = (
+            hasattr(config, "q_lora_rank") and config.q_lora_rank is not None
+        )
+        if self.fuse_qkv_a_proj:
+            self.packed_modules_mapping["fused_qkv_a_proj_with_mqa"] = [
+                "q_a_proj",
+                "kv_a_proj_with_mqa",
+            ]
+
+        from sglang.srt.layers.quantization.base_config import QuantizationConfig
+
+        if quant_config is not None:
+            quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
+
+        self.num_fused_shared_experts = 0
+        self.use_dsa = is_deepseek_dsa(config)
+
+        self.model = TeleChat4Model(
+            config, quant_config, prefix=add_prefix("model", prefix)
+        )
+
+        for layer in self.model.layers:
+            if hasattr(layer, "mlp") and hasattr(layer.mlp, "num_fused_shared_experts"):
+                self.num_fused_shared_experts = layer.mlp.num_fused_shared_experts
+                break
+
+        if self.pp_group.is_last_rank:
+            if self.pp_group.world_size == 1 and config.tie_word_embeddings:
+                self.lm_head = self.model.embed_tokens
+            else:
+                self.lm_head = ParallelLMHead(
+                    config.vocab_size,
+                    config.hidden_size,
+                    quant_config=quant_config,
+                    prefix=add_prefix("lm_head", prefix),
+                    use_attn_tp_group=get_global_server_args().enable_dp_lm_head,
+                )
+        else:
+            self.lm_head = PPMissingLayer()
+
+        from sglang.srt.layers.logits_processor import LogitsProcessor
+
+        self.logits_processor = LogitsProcessor(config)
+
+        self.capture_aux_hidden_states = False
+
+    @property
+    def start_layer(self):
+        return self.model.start_layer
+
+    @property
+    def end_layer(self):
+        return self.model.end_layer
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: torch.Tensor = None,
+        pp_proxy_tensors: Optional[PPProxyTensors] = None,
+    ) -> torch.Tensor:
+        from sglang.srt.layers.communicator import get_attn_tp_context
+
+        with get_attn_tp_context().maybe_input_scattered(forward_batch):
+            hidden_states = self.model(
+                input_ids, positions, forward_batch, input_embeds, pp_proxy_tensors
+            )
+
+        if self.pp_group.is_last_rank:
+            return self.logits_processor(
+                input_ids, hidden_states, self.lm_head, forward_batch, None
+            )
+        else:
+            return hidden_states
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]], is_nextn=False):
+        processed_weights = []
+        hc_weights = []
+
+        for name, loaded_weight in weights:
+            if "rotary_emb.inv_freq" in name:
+                continue
+
+            if "indexer.k_norm_bias" in name:
+                name = name.replace("indexer.k_norm_bias", "indexer.k_norm.bias")
+
+            if "attn_hc.mapping_weight" in name:
+                name = name.replace(
+                    "attn_hc.mapping_weight", "attn_hc.mapping_proj.weight"
+                )
+            if "ffn_hc.mapping_weight" in name:
+                name = name.replace(
+                    "ffn_hc.mapping_weight", "ffn_hc.mapping_proj.weight"
+                )
+
+            # Skip split bias parameters; the checkpoint stores a merged bias.
+            skip_patterns = [
+                "attn_hc.bias_pre",
+                "attn_hc.bias_post",
+                "attn_hc.bias_res",
+                "ffn_hc.bias_pre",
+                "ffn_hc.bias_post",
+                "ffn_hc.bias_res",
+            ]
+            if any(p in name for p in skip_patterns):
+                continue
+
+            if "attn_hc" in name or "ffn_hc" in name:
+                hc_weights.append((name, loaded_weight))
+            else:
+                processed_weights.append((name, loaded_weight))
+
+        params_dict = dict(self.named_parameters())
+        from sglang.srt.model_loader.weight_utils import default_weight_loader
+
+        for name, loaded_weight in hc_weights:
+            param = None
+            target_name = name
+
+            if name in params_dict:
+                param = params_dict[name]
+            elif f"model.{name}" in params_dict:
+                param = params_dict[f"model.{name}"]
+                target_name = f"model.{name}"
+            elif name.startswith("model.") and name[6:] in params_dict:
+                param = params_dict[name[6:]]
+                target_name = name[6:]
+
+            if param is None:
+                logger.warning("Skip %s, not found in params_dict", name)
+                continue
+
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            try:
+                weight_loader(param, loaded_weight)
+            except Exception as e:
+                logger.warning(
+                    "Failed to load %s -> %s: %s", name, target_name, e
+                )
+
+        self.do_load_weights(processed_weights, is_nextn)
+
+        # Build fp32 op operands (fn / hc_scale / hc_base) for every mHC module
+        # so that the fused mhc_pre / mhc_post kernels can run without per-step
+        # parameter materialisation.
+        for m in self.modules():
+            if isinstance(m, mHCModule):
+                m.finalize()
+
+    def get_embed_and_head(self):
+        return self.model.embed_tokens.weight, self.lm_head.weight
+
+    def set_embed_and_head(self, embed, head):
+        del self.model.embed_tokens.weight
+        del self.lm_head.weight
+        self.model.embed_tokens.weight = embed
+        self.lm_head.weight = head
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+
+    @classmethod
+    def get_model_config_for_expert_location(cls, config):
+        return ModelConfigForExpertLocation(
+            num_layers=config.num_hidden_layers,
+            num_logical_experts=config.n_routed_experts,
+            num_groups=config.n_group,
+        )
+
+
+EntryClass = [TeleChat4ForCausalLM]

--- a/python/sglang/srt/models/telechat4.py
+++ b/python/sglang/srt/models/telechat4.py
@@ -30,11 +30,19 @@ import torch
 from torch import nn
 
 import sglang.srt.models.deepseek_v2 as deepseek_v2
-from sglang.srt.configs.telechat4 import TeleChat4Config
+
+# Register mhc_pre / mhc_post as torch custom ops with fake (meta) implementations
+# so that torch.compile can trace through the mHC module. Without registration,
+# dynamo tries to execute the real kernel with FakeTensors and fails because the
+# TVM/TileLang C-extension calls attempt to access the data pointer of FakeTensors.
+from sglang.kernels.ops.layernorm.mhc import mhc_post as _mhc_post_orig
+from sglang.kernels.ops.layernorm.mhc import mhc_pre as _mhc_pre_orig
 from sglang.srt.configs.model_config import is_deepseek_dsa
+from sglang.srt.configs.telechat4 import TeleChat4Config
 from sglang.srt.distributed import get_pp_group
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.utils import PPMissingLayer
 from sglang.srt.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -49,18 +57,9 @@ from sglang.srt.server_args import get_global_server_args
 from sglang.srt.utils import add_prefix, is_npu, make_layers
 from sglang.srt.utils.custom_op import register_custom_op
 
-# Register mhc_pre / mhc_post as torch custom ops with fake (meta) implementations
-# so that torch.compile can trace through the mHC module. Without registration,
-# dynamo tries to execute the real kernel with FakeTensors and fails because the
-# TVM/TileLang C-extension calls attempt to access the data pointer of FakeTensors.
-from sglang.kernels.ops.layernorm.mhc import mhc_pre as _mhc_pre_orig
-from sglang.kernels.ops.layernorm.mhc import mhc_post as _mhc_post_orig
-
 logger = logging.getLogger(__name__)
 
-_NPU_MHC_BACKEND = os.environ.get(
-    "SGLANG_TECHAT4_MHC_BACKEND", "auto"
-).lower()
+_NPU_MHC_BACKEND = os.environ.get("SGLANG_TECHAT4_MHC_BACKEND", "auto").lower()
 if _NPU_MHC_BACKEND not in ("auto", "ascendc", "triton", "torch"):
     raise ValueError(
         "SGLANG_TELECHAT4_MHC_BACKEND must be 'auto', 'ascendc', 'triton', "
@@ -74,9 +73,7 @@ def _load_ascendc_mhc() -> bool:
         import sgl_kernel_npu  # noqa: F401
     except ImportError:
         return False
-    return hasattr(torch.ops.npu, "hc_pre") and hasattr(
-        torch.ops.npu, "hc_post"
-    )
+    return hasattr(torch.ops.npu, "hc_pre") and hasattr(torch.ops.npu, "hc_post")
 
 
 @lru_cache(maxsize=1)
@@ -239,9 +236,7 @@ def mhc_post(
                 telechat4_mhc_post_torch,
             )
 
-            return telechat4_mhc_post_torch(
-                x, residual, post_layer_mix, comb_res_mix
-            )
+            return telechat4_mhc_post_torch(x, residual, post_layer_mix, comb_res_mix)
 
         from sglang.srt.layers.telechat4_mhc_triton import telechat4_mhc_post
 
@@ -293,20 +288,14 @@ class mHCModule(nn.Module):
             persistent=False,
         )
         self.register_buffer("hc_scale", torch.zeros(3), persistent=False)
-        self.register_buffer(
-            "hc_base", torch.zeros(out_features), persistent=False
-        )
+        self.register_buffer("hc_base", torch.zeros(out_features), persistent=False)
         self._finalized = False
 
     @torch.no_grad()
     def finalize(self) -> None:
         """Build the fused-kernel operands from the loaded parameters."""
         npu_backend = _get_npu_mhc_backend() if is_npu() else None
-        fn_dtype = (
-            torch.bfloat16
-            if npu_backend == "triton"
-            else torch.float32
-        )
+        fn_dtype = torch.bfloat16 if npu_backend == "triton" else torch.float32
         self.fn = self.mapping_proj.weight.detach().to(fn_dtype).contiguous()
         self.hc_scale = (
             torch.cat([self.alpha_pre, self.alpha_post, self.alpha_res])
@@ -344,9 +333,7 @@ class mHCModule(nn.Module):
             layer_input = torch.empty(
                 0, C, dtype=torch.bfloat16, device=residual.device
             )
-            post_mix = torch.empty(
-                0, n, dtype=torch.float32, device=residual.device
-            )
+            post_mix = torch.empty(0, n, dtype=torch.float32, device=residual.device)
             comb_mix = torch.empty(
                 0, n * n, dtype=torch.float32, device=residual.device
             )
@@ -438,8 +425,8 @@ class TeleChat4DecoderLayer(nn.Module):
         self,
         config: TeleChat4Config,
         layer_id: int,
-        quant_config: Optional["QuantizationConfig"] = None,
-        moe_quant_config_override: Optional["QuantizationConfig"] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        moe_quant_config_override: Optional[QuantizationConfig] = None,
         is_nextn: bool = False,
         prefix: str = "",
         alt_stream: Optional[torch.cuda.Stream] = None,
@@ -478,6 +465,7 @@ class TeleChat4DecoderLayer(nn.Module):
         self.use_mha = use_mha
 
         from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
+
         self.self_attn = DeepseekV2AttentionMLA(
             config=config,
             hidden_size=self.hidden_size,
@@ -590,7 +578,9 @@ class TeleChat4DecoderLayer(nn.Module):
             C = self.hidden_size
 
             origin_hidden_states = hidden_states
-            aggregated_hidden_states, attention_res_weights, attention_post_weights = self.attn_hc(origin_hidden_states)
+            aggregated_hidden_states, attention_res_weights, attention_post_weights = (
+                self.attn_hc(origin_hidden_states)
+            )
 
             hidden_states = aggregated_hidden_states.reshape(-1, C)
 
@@ -618,6 +608,7 @@ class TeleChat4DecoderLayer(nn.Module):
                 topk_indices = None
 
             from sglang.srt.layers.communicator import get_attn_tp_context
+
             get_attn_tp_context().clear_attn_inputs()
 
             hidden_states = hidden_states.reshape(S, B, C)
@@ -636,7 +627,9 @@ class TeleChat4DecoderLayer(nn.Module):
             )
 
             origin_hidden_states = hidden_states
-            aggregated_hidden_states, mlp_res_weights, mlp_post_weights = self.ffn_hc(origin_hidden_states)
+            aggregated_hidden_states, mlp_res_weights, mlp_post_weights = self.ffn_hc(
+                origin_hidden_states
+            )
 
             hidden_states = aggregated_hidden_states.reshape(-1, C)
             hidden_states = self.post_attention_layernorm(hidden_states)
@@ -653,7 +646,10 @@ class TeleChat4DecoderLayer(nn.Module):
 
             hidden_states = hidden_states.reshape(S, B, C)
 
-            if isinstance(self.mlp, deepseek_v2.DeepseekV2MLP) and hidden_states.dtype == torch.float16:
+            if (
+                isinstance(self.mlp, deepseek_v2.DeepseekV2MLP)
+                and hidden_states.dtype == torch.float16
+            ):
                 hidden_states *= 1.0 / self.routed_scaling_factor
 
             hidden_states = self.ffn_hc.fused_h_res_h_post_bda_inference(
@@ -692,6 +688,7 @@ class TeleChat4DecoderLayer(nn.Module):
         hidden_states = attn_output
 
         from sglang.srt.layers.communicator import get_attn_tp_context
+
         get_attn_tp_context().clear_attn_inputs()
 
         if (
@@ -736,7 +733,10 @@ class TeleChat4DecoderLayer(nn.Module):
                 hidden_states, residual, forward_batch
             )
 
-        if isinstance(self.mlp, deepseek_v2.DeepseekV2MLP) and hidden_states.dtype == torch.float16:
+        if (
+            isinstance(self.mlp, deepseek_v2.DeepseekV2MLP)
+            and hidden_states.dtype == torch.float16
+        ):
             hidden_states *= 1.0 / self.routed_scaling_factor
 
         return hidden_states, residual, topk_indices
@@ -810,7 +810,7 @@ class TeleChat4Model(nn.Module):
     def __init__(
         self,
         config: TeleChat4Config,
-        quant_config: Optional["QuantizationConfig"] = None,
+        quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -929,7 +929,7 @@ class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
     def __init__(
         self,
         config: TeleChat4Config,
-        quant_config: Optional["QuantizationConfig"] = None,
+        quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -949,8 +949,6 @@ class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
                 "q_a_proj",
                 "kv_a_proj_with_mqa",
             ]
-
-        from sglang.srt.layers.quantization.base_config import QuantizationConfig
 
         if quant_config is not None:
             quant_config.update_packed_modules_mapping(self.packed_modules_mapping)
@@ -1079,9 +1077,7 @@ class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             try:
                 weight_loader(param, loaded_weight)
             except Exception as e:
-                logger.warning(
-                    "Failed to load %s -> %s: %s", name, target_name, e
-                )
+                logger.warning("Failed to load %s -> %s: %s", name, target_name, e)
 
         self.do_load_weights(processed_weights, is_nextn)
 

--- a/python/sglang/srt/models/telechat4.py
+++ b/python/sglang/srt/models/telechat4.py
@@ -22,6 +22,8 @@ from __future__ import annotations
 
 import logging
 import os
+from functools import lru_cache
+from importlib.util import find_spec
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -54,14 +56,48 @@ from sglang.srt.utils.custom_op import register_custom_op
 from sglang.kernels.ops.layernorm.mhc import mhc_pre as _mhc_pre_orig
 from sglang.kernels.ops.layernorm.mhc import mhc_post as _mhc_post_orig
 
+logger = logging.getLogger(__name__)
+
 _NPU_MHC_BACKEND = os.environ.get(
-    "SGLANG_TELECHAT4_MHC_BACKEND", "triton"
+    "SGLANG_TECHAT4_MHC_BACKEND", "auto"
 ).lower()
-if _NPU_MHC_BACKEND not in ("triton", "torch"):
+if _NPU_MHC_BACKEND not in ("auto", "ascendc", "triton", "torch"):
     raise ValueError(
-        "SGLANG_TELECHAT4_MHC_BACKEND must be 'triton' or 'torch', "
+        "SGLANG_TELECHAT4_MHC_BACKEND must be 'auto', 'ascendc', 'triton', "
+        "or 'torch', "
         f"got {_NPU_MHC_BACKEND!r}"
     )
+
+
+def _load_ascendc_mhc() -> bool:
+    try:
+        import sgl_kernel_npu  # noqa: F401
+    except ImportError:
+        return False
+    return hasattr(torch.ops.npu, "hc_pre") and hasattr(
+        torch.ops.npu, "hc_post"
+    )
+
+
+@lru_cache(maxsize=1)
+def _get_npu_mhc_backend() -> str:
+    if _NPU_MHC_BACKEND == "ascendc":
+        if not _load_ascendc_mhc():
+            raise RuntimeError(
+                "The AscendC TeleChat4 mHC backend requires hc_pre and hc_post "
+                "from sgl-kernel-npu."
+            )
+        backend = "ascendc"
+    elif _NPU_MHC_BACKEND != "auto":
+        backend = _NPU_MHC_BACKEND
+    elif _load_ascendc_mhc():
+        backend = "ascendc"
+    elif find_spec("triton") is not None:
+        backend = "triton"
+    else:
+        backend = "torch"
+    logger.info("TeleChat4 NPU mHC backend: %s", backend)
+    return backend
 
 
 def _mhc_pre_fake(
@@ -110,7 +146,30 @@ def mhc_pre(
     n_splits_pre: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     if is_npu():
-        if _NPU_MHC_BACKEND == "torch":
+        backend = _get_npu_mhc_backend()
+        if backend == "ascendc":
+            if hc_sinkhorn_eps != hc_pre_eps:
+                raise ValueError(
+                    "The AscendC hc_pre kernel uses one epsilon for pre and "
+                    "Sinkhorn."
+                )
+            if hc_post_mult_value != 2.0:
+                raise ValueError(
+                    "The AscendC hc_pre kernel requires post multiplier 2.0."
+                )
+            layer_input, post_mix, comb_mix = torch.ops.npu.hc_pre(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                hc_mult=residual.shape[-2],
+                hc_sinkhorn_iters=sinkhorn_repeat,
+                norm_eps=rms_eps,
+                hc_eps=hc_pre_eps,
+            )
+            return post_mix.unsqueeze(-1), comb_mix, layer_input
+
+        if backend == "torch":
             from sglang.srt.layers.telechat4_mhc_torch import (
                 telechat4_mhc_pre_torch,
             )
@@ -169,7 +228,13 @@ def mhc_post(
     comb_res_mix: torch.Tensor,
 ) -> torch.Tensor:
     if is_npu():
-        if _NPU_MHC_BACKEND == "torch":
+        backend = _get_npu_mhc_backend()
+        if backend == "ascendc":
+            return torch.ops.npu.hc_post(
+                x, residual, post_layer_mix.squeeze(-1), comb_res_mix
+            )
+
+        if backend == "torch":
             from sglang.srt.layers.telechat4_mhc_torch import (
                 telechat4_mhc_post_torch,
             )
@@ -183,9 +248,6 @@ def mhc_post(
         return telechat4_mhc_post(x, residual, post_layer_mix, comb_res_mix)
 
     return _mhc_post_orig(x, residual, post_layer_mix, comb_res_mix)
-
-
-logger = logging.getLogger(__name__)
 
 
 class mHCModule(nn.Module):
@@ -239,9 +301,10 @@ class mHCModule(nn.Module):
     @torch.no_grad()
     def finalize(self) -> None:
         """Build the fused-kernel operands from the loaded parameters."""
+        npu_backend = _get_npu_mhc_backend() if is_npu() else None
         fn_dtype = (
             torch.bfloat16
-            if is_npu() and _NPU_MHC_BACKEND == "triton"
+            if npu_backend == "triton"
             else torch.float32
         )
         self.fn = self.mapping_proj.weight.detach().to(fn_dtype).contiguous()

--- a/python/sglang/srt/models/telechat4.py
+++ b/python/sglang/srt/models/telechat4.py
@@ -14,13 +14,14 @@
 """TeleChat4 model for SGLang.
 
 Adapts the TeleChat4 architecture (MLA attention + MoE + mHC residual streams)
-on top of sglang's DeepSeek-V2 building blocks.  The mHC module uses sglang's
-fused TileLang kernels (``mhc_pre`` / ``mhc_post``) for performance.
+on top of sglang's DeepSeek-V2 building blocks. The mHC module uses dedicated
+fused kernels for the model's 3584-wide residual streams.
 """
 
 from __future__ import annotations
 
 import logging
+import os
 from typing import Iterable, List, Optional, Tuple
 
 import torch
@@ -43,7 +44,7 @@ from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
 )
 from sglang.srt.runtime_context import get_forward, get_parallel
 from sglang.srt.server_args import get_global_server_args
-from sglang.srt.utils import add_prefix, make_layers
+from sglang.srt.utils import add_prefix, is_npu, make_layers
 from sglang.srt.utils.custom_op import register_custom_op
 
 # Register mhc_pre / mhc_post as torch custom ops with fake (meta) implementations
@@ -52,6 +53,15 @@ from sglang.srt.utils.custom_op import register_custom_op
 # TVM/TileLang C-extension calls attempt to access the data pointer of FakeTensors.
 from sglang.kernels.ops.layernorm.mhc import mhc_pre as _mhc_pre_orig
 from sglang.kernels.ops.layernorm.mhc import mhc_post as _mhc_post_orig
+
+_NPU_MHC_BACKEND = os.environ.get(
+    "SGLANG_TELECHAT4_MHC_BACKEND", "triton"
+).lower()
+if _NPU_MHC_BACKEND not in ("triton", "torch"):
+    raise ValueError(
+        "SGLANG_TELECHAT4_MHC_BACKEND must be 'triton' or 'torch', "
+        f"got {_NPU_MHC_BACKEND!r}"
+    )
 
 
 def _mhc_pre_fake(
@@ -99,6 +109,39 @@ def mhc_pre(
     n_splits: int,
     n_splits_pre: int,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    if is_npu():
+        if _NPU_MHC_BACKEND == "torch":
+            from sglang.srt.layers.telechat4_mhc_torch import (
+                telechat4_mhc_pre_torch,
+            )
+
+            return telechat4_mhc_pre_torch(
+                residual,
+                fn,
+                hc_scale,
+                hc_base,
+                rms_eps,
+                hc_pre_eps,
+                hc_sinkhorn_eps,
+                hc_post_mult_value,
+                sinkhorn_repeat,
+            )
+
+        from sglang.srt.layers.telechat4_mhc_triton import telechat4_mhc_pre
+
+        return telechat4_mhc_pre(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            split_k=n_splits_pre,
+        )
+
     return _mhc_pre_orig(
         residual=residual,
         fn=fn,
@@ -125,6 +168,20 @@ def mhc_post(
     post_layer_mix: torch.Tensor,
     comb_res_mix: torch.Tensor,
 ) -> torch.Tensor:
+    if is_npu():
+        if _NPU_MHC_BACKEND == "torch":
+            from sglang.srt.layers.telechat4_mhc_torch import (
+                telechat4_mhc_post_torch,
+            )
+
+            return telechat4_mhc_post_torch(
+                x, residual, post_layer_mix, comb_res_mix
+            )
+
+        from sglang.srt.layers.telechat4_mhc_triton import telechat4_mhc_post
+
+        return telechat4_mhc_post(x, residual, post_layer_mix, comb_res_mix)
+
     return _mhc_post_orig(x, residual, post_layer_mix, comb_res_mix)
 
 
@@ -134,9 +191,8 @@ logger = logging.getLogger(__name__)
 class mHCModule(nn.Module):
     """mHC (Manifold-constrained Hyper-Connection) module.
 
-    Backed by sglang's fused TileLang kernels (``mhc_pre`` / ``mhc_post``).
-    The fp32 op operands (``fn`` / ``hc_scale`` / ``hc_base``) are materialised
-    once in :meth:`finalize` after weight loading.
+    Backed by platform-specific fused kernels. The kernel operands are
+    materialised once in :meth:`finalize` after weight loading.
     """
 
     def __init__(self, config, layer_number: int):
@@ -168,7 +224,7 @@ class mHCModule(nn.Module):
 
         self.bias = nn.Parameter(torch.zeros(out_features))
 
-        # fp32 op operands, filled by finalize() after weight loading.
+        # Kernel operands, filled by finalize() after weight loading.
         self.register_buffer(
             "fn",
             torch.zeros(out_features, self.n * self.hidden_size),
@@ -182,10 +238,13 @@ class mHCModule(nn.Module):
 
     @torch.no_grad()
     def finalize(self) -> None:
-        """Build the fp32 op operands from the loaded parameters."""
-        self.fn = self.mapping_proj.weight.detach().to(
-            torch.float32
-        ).contiguous()
+        """Build the fused-kernel operands from the loaded parameters."""
+        fn_dtype = (
+            torch.bfloat16
+            if is_npu() and _NPU_MHC_BACKEND == "triton"
+            else torch.float32
+        )
+        self.fn = self.mapping_proj.weight.detach().to(fn_dtype).contiguous()
         self.hc_scale = (
             torch.cat([self.alpha_pre, self.alpha_post, self.alpha_res])
             .detach()
@@ -328,7 +387,7 @@ class TeleChat4DecoderLayer(nn.Module):
         self.hidden_size = config.hidden_size
         self.config = config
 
-        if hasattr(config, "rope_parameters"):
+        if getattr(config, "rope_parameters", None) is not None:
             rope_theta = config.rope_parameters["rope_theta"]
             rope_type = config.rope_parameters.get("rope_type")
             rope_scaling = config.rope_parameters if rope_type != "default" else None
@@ -963,9 +1022,8 @@ class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
 
         self.do_load_weights(processed_weights, is_nextn)
 
-        # Build fp32 op operands (fn / hc_scale / hc_base) for every mHC module
-        # so that the fused mhc_pre / mhc_post kernels can run without per-step
-        # parameter materialisation.
+        # Build mHC kernel operands once so forward does not materialise
+        # parameters on every step.
         for m in self.modules():
             if isinstance(m, mHCModule):
                 m.finalize()
@@ -978,8 +1036,12 @@ class TeleChat4ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        if is_npu():
+            torch.npu.empty_cache()
+            torch.npu.synchronize()
+        else:
+            torch.cuda.empty_cache()
+            torch.cuda.synchronize()
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -1143,6 +1143,45 @@ class _PoolsideV1Detector(Qwen3Detector):
         self.reasoning_default = "explicit_enable_thinking"
 
 
+class TeleChat4Detector(BaseReasoningFormatDetector):
+    """Detector for TeleChat4 models.
+
+    TeleChat4 models use <think> and </think> as reasoning markers.
+    The chat template injects these markers into the prompt via ``enable_thinking`` parameter.
+
+    When ``enable_thinking=True``:
+      The model generates reasoning content followed by </think> and then the answer.
+      Format: "reasoning content</think>answer"
+
+    When ``enable_thinking=False``:
+      The model generates the answer directly without any markers.
+      Format: "answer"
+
+    ``force_nonempty_content=True`` acts as a safety net: if the model omits
+    the ``</think>`` close tag, the accumulated reasoning is reclassified as
+    normal text so the answer is never lost in the text field.
+    """
+
+    def __init__(
+        self,
+        stream_reasoning: bool = True,
+        force_reasoning: bool = False,
+        continue_final_message: bool = False,
+        previous_content: str = "",
+        force_nonempty_content: bool = True,
+    ):
+        super().__init__(
+            "<think>",
+            "</think>",
+            force_reasoning=force_reasoning,
+            stream_reasoning=stream_reasoning,
+            continue_final_message=continue_final_message,
+            previous_content=previous_content,
+            reasoning_default="enable_thinking",
+            force_nonempty_content=force_nonempty_content,
+        )
+
+
 class Apertus2509Detector(BaseReasoningFormatDetector):
     """
     Detector for Apertus 2509 models
@@ -1651,6 +1690,7 @@ class ReasoningParser:
         "gemma4": Gemma4Detector,
         "inkling": InklingDetector,
         "cohere_command4": CohereCommand4Detector,
+        "telechat": TeleChat4Detector,
     }
 
     def __init__(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5293,16 +5293,14 @@ class ServerArgs:
                 envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
                 envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
                 envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
-                
+
         elif model_arch in ["TeleChat4ForCausalLM"]:
-            # TeleChat4 uses the TileLang mhc_pre/mhc_post kernels (sglang.kernels.ops.layernorm.mhc)
-            # for its mHC module. The DeepGEMM tf32_hc_prenorm_gemm path is a raw C
-            # extension that torch.compile (fullgraph=True, used by tc_piecewise prefill
-            # backend) cannot trace, raising:
+            # The DeepGEMM tf32_hc_prenorm_gemm path is a raw C extension that
+            # torch.compile (fullgraph=True, used by tc_piecewise prefill backend)
+            # cannot trace, raising:
             #   torch._dynamo.exc.Unsupported: Dynamo does not know how to trace
             #   method `__call__` of class `Function`
-            # Disable it so mhc_pre falls through to the TileLang splitk path which
-            # already supports telechat4's hc_hidden_size=14336 (4 * 3584).
+            # TeleChat4 selects its platform-specific 3584-wide mHC path directly.
             envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
 
         elif model_arch in ["GptOssForCausalLM"]:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5294,15 +5294,6 @@ class ServerArgs:
                 envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
                 envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
 
-        elif model_arch in ["TeleChat4ForCausalLM"]:
-            # The DeepGEMM tf32_hc_prenorm_gemm path is a raw C extension that
-            # torch.compile (fullgraph=True, used by tc_piecewise prefill backend)
-            # cannot trace, raising:
-            #   torch._dynamo.exc.Unsupported: Dynamo does not know how to trace
-            #   method `__call__` of class `Function`
-            # TeleChat4 selects its platform-specific 3584-wide mHC path directly.
-            envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
-
         elif model_arch in ["GptOssForCausalLM"]:
             # Attention backend selection + XPU dtype validation moved to the
             # override registry (arg_groups/overrides.py: _gpt_oss_overrides).

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5086,6 +5086,7 @@ class ServerArgs:
             "PixtralForConditionalGeneration",
             "GlmMoeDsaForCausalLM",
             "LongcatFlashForCausalLM",
+            "TeleChat4ForCausalLM",
         ]:
             # Set attention backend for DeepSeek
             if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
@@ -5292,6 +5293,17 @@ class ServerArgs:
                 envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
                 envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
                 envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
+                
+        elif model_arch in ["TeleChat4ForCausalLM"]:
+            # TeleChat4 uses the TileLang mhc_pre/mhc_post kernels (sglang.kernels.ops.layernorm.mhc)
+            # for its mHC module. The DeepGEMM tf32_hc_prenorm_gemm path is a raw C
+            # extension that torch.compile (fullgraph=True, used by tc_piecewise prefill
+            # backend) cannot trace, raising:
+            #   torch._dynamo.exc.Unsupported: Dynamo does not know how to trace
+            #   method `__call__` of class `Function`
+            # Disable it so mhc_pre falls through to the TileLang splitk path which
+            # already supports telechat4's hc_hidden_size=14336 (4 * 3584).
+            envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
 
         elif model_arch in ["GptOssForCausalLM"]:
             # Attention backend selection + XPU dtype validation moved to the
@@ -7703,6 +7715,7 @@ class ServerArgs:
                         "MistralLarge3ForCausalLM",
                         "PixtralForConditionalGeneration",
                         "GlmMoeDsaForCausalLM",
+                        "TeleChat4ForCausalLM",
                     ]
                 except Exception:
                     pass

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -62,6 +62,7 @@ from sglang.srt.configs import (
     Step3p5Config,
     Step3p7Config,
     Step3VLConfig,
+    TeleChat4Config,
 )
 from sglang.srt.configs.deepseek_ocr import DeepseekVLV2Config
 from sglang.srt.configs.internvl import InternVLChatConfig
@@ -126,6 +127,7 @@ _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
         InklingVisionConfig,
         InklingMMConfig,
         MiniMaxM3VLConfig,
+        TeleChat4Config,
     ]
 }
 

--- a/test/registered/unit/configs/test_telechat4_config.py
+++ b/test/registered/unit/configs/test_telechat4_config.py
@@ -1,0 +1,31 @@
+from transformers import AutoConfig
+
+import sglang.srt.utils.hf_transformers.common  # noqa: F401
+from sglang.srt.configs.telechat4 import TeleChat4Config
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def test_telechat4_native_config_registration_and_legacy_rope_scaling():
+    config = AutoConfig.for_model(
+        "telechat4",
+        architectures=["TeleChat4ForCausalLM"],
+        rope_scaling={
+            "beta_fast": 32,
+            "beta_slow": 1,
+            "factor": 64,
+            "mscale": 1.0,
+            "mscale_all_dim": 1.0,
+            "original_max_position_embeddings": 4096,
+            "type": "rope",
+        },
+        rope_theta=10000,
+    )
+
+    assert isinstance(config, TeleChat4Config)
+    assert config.architectures == ["TeleChat4ForCausalLM"]
+    assert config.model_type == "telechat4"
+    assert config.rope_parameters["factor"] == 64
+    assert config.rope_parameters["rope_theta"] == 10000
+    assert config.rope_parameters["rope_type"] == "rope"

--- a/test/registered/unit/npu/test_npu_topk_shared_expert.py
+++ b/test/registered/unit/npu/test_npu_topk_shared_expert.py
@@ -1,0 +1,102 @@
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(torch, "npu") or not torch.npu.is_available(),
+    reason="Ascend NPU is required",
+)
+
+
+def test_telechat4_shared_expert_topk():
+    import custom_ops  # noqa: F401
+    import sgl_kernel_npu  # noqa: F401
+    import torch_npu  # noqa: F401
+
+    from sglang.srt.hardware_backend.npu.moe.topk import fused_topk_npu
+    from sglang.srt.layers.moe.topk import TopKConfig
+
+    torch.manual_seed(1)
+    hidden_states = torch.randn(8, 3584, dtype=torch.bfloat16, device="npu")
+    router_logits = torch.randn(8, 64, dtype=torch.float32, device="npu")
+    correction_bias = torch.randn(64, dtype=torch.float32, device="npu") * 0.1
+    config = TopKConfig(
+        top_k=5,
+        use_grouped_topk=True,
+        renormalize=True,
+        topk_group=1,
+        num_expert_group=1,
+        num_fused_shared_experts=1,
+        correction_bias=correction_bias,
+        scoring_func="sigmoid",
+        routed_scaling_factor=2.0,
+    )
+
+    output = fused_topk_npu(hidden_states, router_logits, config)
+    torch.npu.synchronize()
+
+    scores = router_logits.sigmoid()
+    reference_ids = (scores + correction_bias).topk(4, dim=-1).indices
+    reference_weights = scores.gather(1, reference_ids)
+    reference_weights /= reference_weights.sum(dim=-1, keepdim=True)
+
+    assert output.topk_ids.shape == (8, 5)
+    assert output.topk_weights.shape == (8, 5)
+    assert torch.all(output.topk_ids[:, -1] == 64)
+    assert torch.allclose(
+        output.topk_weights[:, -1],
+        torch.full((8,), 0.5, dtype=torch.float32, device="npu"),
+    )
+    for actual, expected in zip(
+        output.topk_ids[:, :4].cpu().tolist(), reference_ids.cpu().tolist()
+    ):
+        assert set(actual) == set(expected)
+    assert torch.allclose(
+        output.topk_weights[:, :4].sort(dim=-1).values,
+        reference_weights.sort(dim=-1).values,
+        atol=1e-6,
+        rtol=1e-6,
+    )
+
+
+def test_softmax_shared_expert_keeps_all_routed_weights():
+    import torch_npu  # noqa: F401
+
+    from sglang.srt.hardware_backend.npu.moe.topk import fused_topk_npu
+    from sglang.srt.layers.moe.topk import TopKConfig
+
+    torch.manual_seed(2)
+    hidden_states = torch.randn(4, 32, dtype=torch.bfloat16, device="npu")
+    router_logits = torch.randn(4, 8, dtype=torch.float32, device="npu")
+    config = TopKConfig(
+        top_k=3,
+        renormalize=True,
+        num_fused_shared_experts=1,
+        scoring_func="softmax",
+        routed_scaling_factor=2.0,
+    )
+
+    output = fused_topk_npu(hidden_states, router_logits, config)
+    torch.npu.synchronize()
+
+    reference_weights, reference_ids = router_logits.softmax(dim=-1).topk(2, dim=-1)
+    reference_weights /= reference_weights.sum(dim=-1, keepdim=True)
+
+    assert output.topk_ids.shape == (4, 3)
+    assert torch.all(output.topk_ids[:, -1] == 8)
+    assert torch.allclose(
+        output.topk_weights[:, :2].sum(dim=-1), torch.ones(4, device="npu")
+    )
+    assert torch.allclose(
+        output.topk_weights[:, -1], torch.full((4,), 0.5, device="npu")
+    )
+    for actual, expected in zip(
+        output.topk_ids[:, :2].cpu().tolist(), reference_ids.cpu().tolist()
+    ):
+        assert set(actual) == set(expected)
+    assert torch.allclose(
+        output.topk_weights[:, :2].sort(dim=-1).values,
+        reference_weights.sort(dim=-1).values,
+        atol=1e-6,
+        rtol=1e-6,
+    )

--- a/test/registered/unit/npu/test_npu_topk_shared_expert.py
+++ b/test/registered/unit/npu/test_npu_topk_shared_expert.py
@@ -1,6 +1,9 @@
 import pytest
 import torch
 
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=5, suite="stage-a-unit-test-npu")
 
 pytestmark = pytest.mark.skipif(
     not hasattr(torch, "npu") or not torch.npu.is_available(),

--- a/test/srt/models/test_telechat4_mhc_triton_npu.py
+++ b/test/srt/models/test_telechat4_mhc_triton_npu.py
@@ -163,3 +163,81 @@ def test_telechat4_mhc_auto_layout_only_for_eager_extend():
         eager_extend_comb.transpose(-1, -2).contiguous().data_ptr()
         == eager_extend_comb.data_ptr()
     )
+
+
+def test_telechat4_mhc_ascendc_dispatch_matches_torch(monkeypatch, request):
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        pytest.skip("Ascend NPU is required")
+
+    try:
+        import sgl_kernel_npu  # noqa: F401
+    except ImportError:
+        pytest.skip("sgl-kernel-npu is required")
+    if not hasattr(torch.ops.npu, "hc_pre") or not hasattr(
+        torch.ops.npu, "hc_post"
+    ):
+        pytest.skip("sgl-kernel-npu was built without mHC operators")
+
+    from sglang.srt.models import telechat4 as telechat4_model
+
+    monkeypatch.setattr(telechat4_model, "_NPU_MHC_BACKEND", "ascendc")
+    telechat4_model._get_npu_mhc_backend.cache_clear()
+    request.addfinalizer(telechat4_model._get_npu_mhc_backend.cache_clear)
+    assert telechat4_model._get_npu_mhc_backend() == "ascendc"
+
+    torch.manual_seed(20260807)
+    num_tokens = 8
+    residual = torch.randn(
+        num_tokens,
+        MHC_STREAMS,
+        MHC_HIDDEN_SIZE,
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+    fn = (
+        torch.randn(
+            MHC_OUTPUT_SIZE,
+            MHC_FLAT_SIZE,
+            device="npu",
+            dtype=torch.float32,
+        )
+        / MHC_FLAT_SIZE**0.5
+    ).contiguous()
+    hc_scale = torch.tensor([0.8, 1.1, 0.7], device="npu")
+    hc_base = torch.randn(MHC_OUTPUT_SIZE, device="npu") * 0.1
+
+    actual_pre = telechat4_model.mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        1e-6,
+        1e-6,
+        1e-6,
+        2.0,
+        20,
+        1,
+        8,
+    )
+    expected_pre = telechat4_mhc_pre_torch(
+        residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
+    )
+    for actual, expected in zip(actual_pre, expected_pre):
+        torch.testing.assert_close(actual, expected, atol=0.03125, rtol=5e-3)
+
+    x = torch.randn(
+        num_tokens,
+        MHC_HIDDEN_SIZE,
+        device="npu",
+        dtype=torch.bfloat16,
+    )
+    comb_for_post = actual_pre[1].transpose(-1, -2).contiguous()
+    actual_post = telechat4_model.mhc_post(
+        x, residual, actual_pre[0], comb_for_post
+    )
+    expected_post = telechat4_mhc_post_torch(
+        x, residual, actual_pre[0], comb_for_post
+    )
+    torch.testing.assert_close(
+        actual_post, expected_post, atol=0.03125, rtol=5e-3
+    )

--- a/test/srt/models/test_telechat4_mhc_triton_npu.py
+++ b/test/srt/models/test_telechat4_mhc_triton_npu.py
@@ -1,0 +1,165 @@
+import pytest
+import torch
+
+from sglang.srt.layers.telechat4_mhc_triton import (
+    MHC_FLAT_SIZE,
+    MHC_HIDDEN_SIZE,
+    MHC_OUTPUT_SIZE,
+    MHC_STREAMS,
+    telechat4_mhc_post,
+    telechat4_mhc_pre,
+)
+from sglang.srt.layers.telechat4_mhc_torch import (
+    telechat4_mhc_post_torch,
+    telechat4_mhc_pre_torch,
+)
+from sglang.srt.runtime_context import get_forward
+
+
+def _torch_pre(residual, fn, hc_scale, hc_base, sinkhorn_repeat=20):
+    residual_fp32 = residual.float()
+    residual_flat = residual_fp32.reshape(-1, MHC_FLAT_SIZE)
+    inv_rms = torch.rsqrt(
+        residual_flat.square().mean(dim=-1, keepdim=True) + 1e-6
+    )
+    mixes = torch.nn.functional.linear(residual_flat, fn.float()) * inv_rms
+    pre_logits, post_logits, comb_logits = torch.split(mixes, [4, 4, 16], dim=-1)
+    pre_mix = torch.sigmoid(pre_logits * hc_scale[0] + hc_base[:4]) + 1e-6
+    post_mix = torch.sigmoid(post_logits * hc_scale[1] + hc_base[4:8]) * 2.0
+    comb_mix = (comb_logits * hc_scale[2] + hc_base[8:]).reshape(-1, 4, 4)
+    comb_mix = torch.exp(comb_mix - comb_mix.amax(dim=-1, keepdim=True))
+    comb_mix = comb_mix / comb_mix.sum(dim=-1, keepdim=True) + 1e-6
+    comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + 1e-6)
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (comb_mix.sum(dim=-1, keepdim=True) + 1e-6)
+        comb_mix = comb_mix / (comb_mix.sum(dim=-2, keepdim=True) + 1e-6)
+    layer_input = (pre_mix.unsqueeze(-1) * residual_fp32).sum(dim=1)
+    return post_mix.unsqueeze(-1), comb_mix, layer_input.to(torch.bfloat16)
+
+
+def _torch_post(x, residual, post_mix, comb_mix):
+    output = post_mix.squeeze(-1).unsqueeze(-1) * x.float().unsqueeze(1)
+    output += (comb_mix.unsqueeze(-1) * residual.float().unsqueeze(2)).sum(dim=1)
+    return output.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("implementation", ["split", "split_direct"])
+@pytest.mark.parametrize("num_tokens", [1, 16, 64, 128, 256, 512, 1024])
+def test_telechat4_mhc_triton_matches_torch(num_tokens, implementation):
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        pytest.skip("Ascend NPU is required")
+
+    torch.manual_seed(0)
+    residual = (
+        torch.randn(
+            num_tokens,
+            MHC_STREAMS,
+            MHC_HIDDEN_SIZE,
+            device="npu",
+            dtype=torch.bfloat16,
+        )
+        * 0.1
+    )
+    fn = (
+        torch.randn(
+            MHC_OUTPUT_SIZE,
+            MHC_FLAT_SIZE,
+            device="npu",
+            dtype=torch.bfloat16,
+        )
+        * 0.01
+    ).contiguous()
+    hc_scale = torch.tensor([0.5, 0.25, 0.25], device="npu", dtype=torch.float32)
+    hc_base = torch.randn(MHC_OUTPUT_SIZE, device="npu", dtype=torch.float32) * 0.01
+
+    expected_pre = _torch_pre(residual, fn, hc_scale, hc_base)
+    actual_pre = telechat4_mhc_pre(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        1e-6,
+        1e-6,
+        1e-6,
+        2.0,
+        20,
+        implementation=implementation,
+    )
+    fallback_pre = telechat4_mhc_pre_torch(
+        residual, fn.float(), hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
+    )
+    torch.testing.assert_close(actual_pre[0], expected_pre[0], atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(actual_pre[1], expected_pre[1], atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(actual_pre[2], expected_pre[2], atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(fallback_pre[0], expected_pre[0], atol=0, rtol=0)
+    torch.testing.assert_close(fallback_pre[1], expected_pre[1], atol=0, rtol=0)
+    torch.testing.assert_close(fallback_pre[2], expected_pre[2], atol=0, rtol=0)
+
+    x = (
+        torch.randn(
+            num_tokens,
+            MHC_HIDDEN_SIZE,
+            device="npu",
+            dtype=torch.bfloat16,
+        )
+        * 0.1
+    )
+    post_mix, comb_mix, _ = actual_pre
+    comb_mix_for_post = comb_mix.transpose(-1, -2).contiguous()
+    if implementation == "split":
+        assert comb_mix.is_contiguous()
+        assert comb_mix_for_post.data_ptr() != comb_mix.data_ptr()
+    else:
+        assert not comb_mix.is_contiguous()
+        assert comb_mix_for_post.data_ptr() == comb_mix.data_ptr()
+    expected_post = _torch_post(x, residual, post_mix, comb_mix_for_post)
+    actual_post = telechat4_mhc_post(x, residual, post_mix, comb_mix_for_post)
+    fallback_comb_mix = fallback_pre[1].transpose(-1, -2).contiguous()
+    fallback_expected_post = _torch_post(
+        x, residual, fallback_pre[0], fallback_comb_mix
+    )
+    fallback_post = telechat4_mhc_post_torch(
+        x, residual, fallback_pre[0], fallback_comb_mix
+    )
+    torch.testing.assert_close(actual_post, expected_post, atol=2e-3, rtol=2e-3)
+    torch.testing.assert_close(fallback_post, fallback_expected_post, atol=0, rtol=0)
+
+
+def test_telechat4_mhc_triton_rejects_other_hidden_sizes():
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        pytest.skip("Ascend NPU is required")
+
+    residual = torch.empty(1, 4, 4096, device="npu", dtype=torch.bfloat16)
+    fn = torch.empty(24, 16384, device="npu", dtype=torch.bfloat16)
+    hc_scale = torch.empty(3, device="npu", dtype=torch.float32)
+    hc_base = torch.empty(24, device="npu", dtype=torch.float32)
+    with pytest.raises(ValueError, match="3584"):
+        telechat4_mhc_pre(
+            residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
+        )
+
+
+def test_telechat4_mhc_auto_layout_only_for_eager_extend():
+    if not hasattr(torch, "npu") or not torch.npu.is_available():
+        pytest.skip("Ascend NPU is required")
+
+    residual = torch.zeros(1, 4, 3584, device="npu", dtype=torch.bfloat16)
+    fn = torch.zeros(24, 14336, device="npu", dtype=torch.bfloat16)
+    hc_scale = torch.ones(3, device="npu", dtype=torch.float32)
+    hc_base = torch.zeros(24, device="npu", dtype=torch.float32)
+
+    with get_forward().scoped(is_extend_in_batch=False):
+        graph_comb = telechat4_mhc_pre(
+            residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
+        )[1]
+    with get_forward().scoped(is_extend_in_batch=True):
+        eager_extend_comb = telechat4_mhc_pre(
+            residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
+        )[1]
+
+    assert graph_comb.is_contiguous()
+    assert not eager_extend_comb.is_contiguous()
+    assert (
+        eager_extend_comb.transpose(-1, -2).contiguous().data_ptr()
+        == eager_extend_comb.data_ptr()
+    )

--- a/test/srt/models/test_telechat4_mhc_triton_npu.py
+++ b/test/srt/models/test_telechat4_mhc_triton_npu.py
@@ -1,6 +1,10 @@
 import pytest
 import torch
 
+from sglang.srt.layers.telechat4_mhc_torch import (
+    telechat4_mhc_post_torch,
+    telechat4_mhc_pre_torch,
+)
 from sglang.srt.layers.telechat4_mhc_triton import (
     MHC_FLAT_SIZE,
     MHC_HIDDEN_SIZE,
@@ -9,19 +13,13 @@ from sglang.srt.layers.telechat4_mhc_triton import (
     telechat4_mhc_post,
     telechat4_mhc_pre,
 )
-from sglang.srt.layers.telechat4_mhc_torch import (
-    telechat4_mhc_post_torch,
-    telechat4_mhc_pre_torch,
-)
 from sglang.srt.runtime_context import get_forward
 
 
 def _torch_pre(residual, fn, hc_scale, hc_base, sinkhorn_repeat=20):
     residual_fp32 = residual.float()
     residual_flat = residual_fp32.reshape(-1, MHC_FLAT_SIZE)
-    inv_rms = torch.rsqrt(
-        residual_flat.square().mean(dim=-1, keepdim=True) + 1e-6
-    )
+    inv_rms = torch.rsqrt(residual_flat.square().mean(dim=-1, keepdim=True) + 1e-6)
     mixes = torch.nn.functional.linear(residual_flat, fn.float()) * inv_rms
     pre_logits, post_logits, comb_logits = torch.split(mixes, [4, 4, 16], dim=-1)
     pre_mix = torch.sigmoid(pre_logits * hc_scale[0] + hc_base[:4]) + 1e-6
@@ -134,9 +132,7 @@ def test_telechat4_mhc_triton_rejects_other_hidden_sizes():
     hc_scale = torch.empty(3, device="npu", dtype=torch.float32)
     hc_base = torch.empty(24, device="npu", dtype=torch.float32)
     with pytest.raises(ValueError, match="3584"):
-        telechat4_mhc_pre(
-            residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20
-        )
+        telechat4_mhc_pre(residual, fn, hc_scale, hc_base, 1e-6, 1e-6, 1e-6, 2.0, 20)
 
 
 def test_telechat4_mhc_auto_layout_only_for_eager_extend():
@@ -173,9 +169,7 @@ def test_telechat4_mhc_ascendc_dispatch_matches_torch(monkeypatch, request):
         import sgl_kernel_npu  # noqa: F401
     except ImportError:
         pytest.skip("sgl-kernel-npu is required")
-    if not hasattr(torch.ops.npu, "hc_pre") or not hasattr(
-        torch.ops.npu, "hc_post"
-    ):
+    if not hasattr(torch.ops.npu, "hc_pre") or not hasattr(torch.ops.npu, "hc_post"):
         pytest.skip("sgl-kernel-npu was built without mHC operators")
 
     from sglang.srt.models import telechat4 as telechat4_model
@@ -232,12 +226,6 @@ def test_telechat4_mhc_ascendc_dispatch_matches_torch(monkeypatch, request):
         dtype=torch.bfloat16,
     )
     comb_for_post = actual_pre[1].transpose(-1, -2).contiguous()
-    actual_post = telechat4_model.mhc_post(
-        x, residual, actual_pre[0], comb_for_post
-    )
-    expected_post = telechat4_mhc_post_torch(
-        x, residual, actual_pre[0], comb_for_post
-    )
-    torch.testing.assert_close(
-        actual_post, expected_post, atol=0.03125, rtol=5e-3
-    )
+    actual_post = telechat4_model.mhc_post(x, residual, actual_pre[0], comb_for_post)
+    expected_post = telechat4_mhc_post_torch(x, residual, actual_pre[0], comb_for_post)
+    torch.testing.assert_close(actual_post, expected_post, atol=0.03125, rtol=5e-3)


### PR DESCRIPTION
## Motivation

TeleChat4-29B uses four mHC residual streams with `hidden_size=3584`. On Ascend NPU, the previous Torch decomposition generated many eager operators, synchronization points, and intermediate tensors. The generic CUDA mHC path is not an NPU implementation.

This PR adds native TeleChat4 registration and explicit NPU mHC backends while preserving the existing CUDA path. The AscendC backend depends on [sgl-project/sgl-kernel-npu#670](https://github.com/sgl-project/sgl-kernel-npu/pull/670). If that package is unavailable, `auto` falls back to Triton and then Torch.

## Modifications

- Register `TeleChat4Config`, `TeleChat4ForCausalLM`, the TeleChat4 tool parser, and reasoning parser.
- Accept released checkpoints with native `model_type: telechat4` and convert legacy `rope_scaling` fields to the Transformers v5 `rope_parameters` representation.
- Add `SGLANG_TELECHAT4_MHC_BACKEND=auto|ascendc|triton|torch`; `auto` resolves as AscendC -> Triton -> Torch on NPU.
- Keep the NPU Triton prefill implementation as two kernels (split-K GEMM and finalize). Finalize writes the HcPost physical layout directly, removing an extra transpose copy.
- Append shared-expert indices after routed top-k indices on NPU and add focused coverage for the fused path.
- Leave CUDA dispatch on the existing `sglang.kernels.ops.layernorm.mhc` implementation.

### Checkpoint configuration

The checkpoint `config.json` must identify the native class:

```json
{
  "architectures": ["TeleChat4ForCausalLM"],
  "model_type": "telechat4"
}
```

The released legacy `rope_scaling` dictionary is supported. No `--json-model-override-args` is required with this configuration.

### Build and source setup

This setup reuses the existing Torch, torch-npu, and CANN installation; it does not reinstall them.

```bash
export SGLANG_SRC=/path/to/sglang
export SGL_KERNEL_NPU_SRC=/path/to/sgl-kernel-npu

source /usr/local/Ascend/ascend-toolkit/set_env.sh

cd "$SGL_KERNEL_NPU_SRC"
./build.sh -a kernels

source "$SGL_KERNEL_NPU_SRC/python/sgl_kernel_npu/sgl_kernel_npu/vendors/aie_ascendc/bin/set_env.bash"
export PYTHONPATH="$SGLANG_SRC/python:$SGL_KERNEL_NPU_SRC/python/sgl_kernel_npu:${PYTHONPATH:-}"

python3 - <<'PY'
import torch
import torch_npu
import sgl_kernel_npu

print("NPU available:", torch.npu.is_available())
print("hc_pre:", hasattr(torch.ops.npu, "hc_pre"))
print("hc_post:", hasattr(torch.ops.npu, "hc_post"))
PY
```

### Minimal TP=2 smoke launch

```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1
export SGLANG_TELECHAT4_MHC_BACKEND=auto

python3 -m sglang.launch_server \
  --model-path /path/to/TeleChat4-29B \
  --tp-size 2 \
  --device npu \
  --attention-backend ascend \
  --dtype bfloat16 \
  --moe-a2a-backend none \
  --cuda-graph-backend-decode disabled \
  --cuda-graph-backend-prefill disabled \
  --disable-overlap-schedule \
  --disable-radix-cache \
  --disable-shared-experts-fusion \
  --context-length 2048 \
  --chunked-prefill-size 1024 \
  --max-prefill-tokens 2048 \
  --max-running-requests 1 \
  --mem-fraction-static 0.7 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 30000
```

### NEXTN throughput launch

Graph capture, RadixCache, and overlap scheduling remain enabled by omitting their disable flags.

```bash
export ASCEND_RT_VISIBLE_DEVICES=0,1
export SGLANG_TELECHAT4_MHC_BACKEND=auto

python3 -m sglang.launch_server \
  --model-path /path/to/TeleChat4-29B \
  --tp-size 2 \
  --device npu \
  --attention-backend ascend \
  --dtype bfloat16 \
  --moe-a2a-backend none \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --disable-shared-experts-fusion \
  --context-length 131072 \
  --chunked-prefill-size 1024 \
  --max-prefill-tokens 8192 \
  --max-running-requests 16 \
  --mem-fraction-static 0.7 \
  --trust-remote-code \
  --host 0.0.0.0 \
  --port 30000
```

## Accuracy Tests

- Native checkpoint config loaded as `TeleChat4Config` / `TeleChat4ForCausalLM` with `json_model_override_args='{}'`; TP=2 BF16 weight loading and API dialogue smoke completed.
- `pytest -q test/registered/unit/configs/test_telechat4_config.py`: **1 passed**.
- `pytest -q test/srt/models/test_telechat4_mhc_triton_npu.py test/registered/unit/npu/test_npu_topk_shared_expert.py`: **19 passed** on Ascend 910B3.
- Coordinated kernel tests in sgl-kernel-npu: **4 passed** at 1, 8, and 129 tokens, including 3584 shape validation.

Full GSM8K: 1319 questions, dataset SHA256 `fb581f0270b25988e071316835842a1c8449f4e27af6fc0f539ef270b987f9ff`, 5-shot, temperature 0, TP=2, BF16, concurrency 16, NEXTN steps=3, four draft tokens, Graph/Radix/overlap enabled.

| Backend | Accuracy | Invalid |
| --- | ---: | ---: |
| AscendC | 85.2% | 0.2% |
| Triton split-direct | 85.0% | 0.2% |
| Torch fallback | 84.9% | 0.3% |

## Speed Tests and Profiling

| Backend | End-to-end latency | Output throughput |
| --- | ---: | ---: |
| AscendC | 497.391 s | 291.248 token/s |
| Triton split-direct | 525.785 s | 277.691 token/s |
| Torch fallback | 1358.826 s | 107.135 token/s |

Triton and Torch were a same-container/card A/B and had nearly identical NEXTN acceptance (2.9299 / 64.33% vs. 2.9241 / 64.16%). Triton is **2.592x** the Torch fallback throughput. The AscendC result came from the existing 0721 integration container, so its 4.882% lead over Triton also includes container/framework differences and is not attributed solely to the mHC kernel.

At 512 tokens, `msprof op` measured AscendC HcPre at **135.1-136.3 us** and HcPost at **48.8-49.3 us**. Reproducible kernel microbenchmarks are included in the dependent kernel PR.

## Checklist

- [x] Format Python/C++ and pass all applicable pre-commit checks.
- [x] Add CPU and NPU unit tests and register them with SGLang CI.
- [x] Document checkpoint, build, environment, and launch requirements in this PR.
- [x] Provide accuracy, end-to-end speed, kernel correctness, and `msprof` results.
- [x] Follow the existing SGLang CUDA/NPU backend boundaries.

