### PR TITLE
[DSA] Remove the device-to-host syncs on the decode DP-divergent branch

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -791,7 +791,15 @@ class DeepseekSparseAttnBackend(
             # needs_cpu_seq_lens=False nulls the host mirror for spec-v2 relay
             # batches; graph replay uses the static page-table width, so only this
             # eager (e.g. over-capture-bs) fallback needs a length here.
-            max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num
+            #
+            # Use the static width rather than seq_lens.max().item(): that is a
+            # device-to-host sync, and this branch is entered per rank (an idle
+            # DP peer keeps its host mirror and takes the arm above), so under
+            # DP attention the ranks stop issuing the same collective sequence
+            # and the group deadlocks. Over-allocating columns is safe -- the
+            # page table is only indexed through top-k, which masks per row by
+            # cache_seqlens, so the extra columns are never selected.
+            max_seqlen_k = self.req_to_token.shape[1]
         # [b, max_seqlen_k]
         page_table = self.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, :max_seqlen_k
@@ -851,19 +859,19 @@ class DeepseekSparseAttnBackend(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
         elif forward_batch.forward_mode.is_draft_extend_v2():
-            if forward_batch.extend_prefix_lens_cpu is None:
-                assert forward_batch.extend_prefix_lens is not None
-                forward_batch.extend_prefix_lens_cpu = (
-                    forward_batch.extend_prefix_lens.cpu().tolist()
-                )
-            if forward_batch.seq_lens_cpu is None:
-                forward_batch.seq_lens_cpu = forward_batch.seq_lens.cpu()
-                forward_batch.seq_lens_sum = int(forward_batch.seq_lens_cpu.sum())
+            # No host mirrors are materialized here. Both would be D2H syncs on
+            # this same per-rank branch, so with only the max_seqlen_k fix above
+            # the DP group still deadlocks. Neither is read on this path:
+            # extend_prefix_lens_cpu and seq_lens_sum are consumed only inside
+            # the is_extend() arm below, and DRAFT_EXTEND_V2 is not is_extend()
+            # (include_draft_extend_v2 defaults to False). What this branch does
+            # need -- extend_seq_lens_cpu -- is already supplied by
+            # eagle_worker_common.prepare_for_draft_extend, on the same
+            # gpu_only branch and for this same reason.
             assert (
                 forward_batch.extend_seq_lens_cpu is not None
                 and forward_batch.extend_seq_lens is not None
-                and forward_batch.extend_prefix_lens_cpu is not None
-            ), "All of them must not be None"
+            ), "extend_seq_lens{,_cpu} must not be None for DRAFT_EXTEND_V2"
 
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
             assert forward_batch.extend_seq_lens is not None

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -796,7 +796,15 @@ class DeepseekSparseAttnBackend(
             # needs_cpu_seq_lens=False nulls the host mirror for spec-v2 relay
             # batches; graph replay uses the static page-table width, so only this
             # eager (e.g. over-capture-bs) fallback needs a length here.
-            max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num
+            #
+            # Use the static width rather than seq_lens.max().item(): that is a
+            # device-to-host sync, and this branch is entered per rank (an idle
+            # DP peer keeps its host mirror and takes the arm above), so under
+            # DP attention the ranks stop issuing the same collective sequence
+            # and the group deadlocks. Over-allocating columns is safe -- the
+            # page table is only indexed through top-k, which masks per row by
+            # cache_seqlens, so the extra columns are never selected.
+            max_seqlen_k = self.req_to_token.shape[1]
         # [b, max_seqlen_k]
         page_table = self.req_to_token_pool.req_to_token[
             forward_batch.req_pool_indices, :max_seqlen_k
@@ -856,19 +864,19 @@ class DeepseekSparseAttnBackend(
                 page_table, repeats=self.speculative_num_draft_tokens, dim=0
             )
         elif forward_batch.forward_mode.is_draft_extend_v2():
-            if forward_batch.extend_prefix_lens_cpu is None:
-                assert forward_batch.extend_prefix_lens is not None
-                forward_batch.extend_prefix_lens_cpu = (
-                    forward_batch.extend_prefix_lens.cpu().tolist()
-                )
-            if forward_batch.seq_lens_cpu is None:
-                forward_batch.seq_lens_cpu = forward_batch.seq_lens.cpu()
-                forward_batch.seq_lens_sum = int(forward_batch.seq_lens_cpu.sum())
+            # No host mirrors are materialized here. Both would be D2H syncs on
+            # this same per-rank branch, so with only the max_seqlen_k fix above
+            # the DP group still deadlocks. Neither is read on this path:
+            # extend_prefix_lens_cpu and seq_lens_sum are consumed only inside
+            # the is_extend() arm below, and DRAFT_EXTEND_V2 is not is_extend()
+            # (include_draft_extend_v2 defaults to False). What this branch does
+            # need -- extend_seq_lens_cpu -- is already supplied by
+            # eagle_worker_common.prepare_for_draft_extend, on the same
+            # gpu_only branch and for this same reason.
             assert (
                 forward_batch.extend_seq_lens_cpu is not None
                 and forward_batch.extend_seq_lens is not None
-                and forward_batch.extend_prefix_lens_cpu is not None
-            ), "All of them must not be None"
+            ), "extend_seq_lens{,_cpu} must not be None for DRAFT_EXTEND_V2"
 
             extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
             assert forward_batch.extend_seq_lens is not None


### PR DESCRIPTION
## Motivation

On the PD decode leg with DP attention and EAGLE MTP, the whole DP group
**hard-deadlocks on the first routed request** — no error, no traceback, the
group simply stops.

The cause is a blocking device-to-host sync sitting on a branch that only *some*
DP ranks enter:

```python
if forward_batch.seq_lens_cpu is not None:
    max_seqlen_k = int(forward_batch.seq_lens_cpu.max().item() + draft_token_num)
else:
    max_seqlen_k = int(forward_batch.seq_lens.max().item()) + draft_token_num  # <-- D2H sync
```

Which arm a rank takes is rank-dependent: `prepare_for_draft_extend` nulls the
host mirror only on its `gpu_only` path (`gpu_only = batch.seq_lens_cpu is None`),
so an idle DP peer keeps its mirror and takes the cheap arm while a busy rank
falls through to the sync. The ranks then stop issuing the same host-side
collective sequence, and the group deadlocks.

Worth noting that this backend **already declares it does not want that sync**:

```python
# Decode/verify/draft graph replay rebuilds metadata from static buffers
# (page-table width) and never reads seq_lens_cpu / seq_lens_sum; opt out of
# the D2H sync. The eager fallback derives lengths from GPU seq_lens.
needs_cpu_seq_lens: bool = False
```

The eager fallback contradicts that contract — it is exactly where the sync
crept back in.

## Modifications

**1. Use the static page-table width instead of the sync.**
`self.req_to_token.shape[1]` is the sync-free idiom this file already uses —
`_graph_page_table_width()` returns it, and the DSA graph path at
`dsa_backend.py` uses it directly for `max_seqlen_k` under
`dsa_drop_wide_page_table`. Over-allocating page-table columns is safe: the
table is only indexed *through* top-k, which masks per row by `cache_seqlens`,
so the extra columns score `-inf` and are never selected.

**2. Drop the two host mirrors materialized under `DRAFT_EXTEND_V2`.** These are
D2H syncs on the *same* divergent branch — with only change 1, the hang
persists. Neither value is read on this path:

- `extend_prefix_lens_cpu` — every consumer in this file (the `any(...)` prefix
  checks, `has_prefix_sharing`, the ragged-topk `_has_prefix`) sits inside the
  `elif forward_batch.forward_mode.is_extend():` arm, and `DRAFT_EXTEND_V2` is
  **not** `is_extend()` (`include_draft_extend_v2` defaults to `False`).
- `seq_lens_sum` — the one consumer, the `kv_cache_capacity` validation, is
  likewise inside the `is_extend()` arm. `DSAMetadata.seq_lens_sum` is stored
  but has no reader at all, so passing `None` changes nothing.

What this branch *does* need — `extend_seq_lens_cpu` — is already supplied by
`eagle_worker_common.prepare_for_draft_extend`, on the same `gpu_only` branch
and, per its own comment, for this same reason ("so backend `max()` reads from
list without a per-iter D2H sync"). The assert is narrowed to the two values
that are actually required here.

## Accuracy Tests

No change to which tokens are attended to. Verified directly rather than
argued — see below: every real top-k selection is bit-identical between the
narrow and the widened page table.

## Speed Tests and Profiling

This removes three D2H syncs from a per-iteration path, so it should be neutral
to slightly positive. The point is not the absolute duration — it is that the
call blocks *at all*, on a branch only some ranks take. For scale, on MI300X with
30 queued 4096² matmuls behind it, `.max().item()` blocks for **~0.5–3 ms**
(run to run) versus **~3 µs** for `.shape[1]`. How long it actually blocks in a
real server depends on what is queued at that moment. I have not measured
end-to-end serving throughput.

## Verification

**Reproduced and fixed** on 8× MI355X (gfx950), ROCm 7.2.0, GLM-5.2-FP8, PD
disaggregation, DP attention + EAGLE MTP: the first-request deadlock clears and
the group takes the same path on every rank. The defect was originally localised
with a `py-spy` dump that caught a busy rank blocked inside `dsa_backend` on
`.max().item()` while idle peers had already advanced into the next collective;
after the fix no rank appears in `dsa_backend` in a dump again. Change 2 was
forced by experiment, not by reading — with change 1 alone the hang persisted.

**Checked for this exact diff, on MI300X:**

- `.max().item()` measurably blocks on queued device work (~0.5–3 ms across
  runs) while `.shape[1]` does not (~3 µs) — i.e. the sync is real, which is what
  makes a per-rank branch desynchronizing.
- **Widening the page table does not change the result.** Comparing top-k over
  the narrow (`seq_lens.max()`) and widened (`req_to_token.shape[1]`) tables on
  identical logits with per-row `cache_seqlens` masking: every real selection
  and its score is identical, no real selection reaches the widened columns, and
  the surplus-slot count is unchanged.
  - One detail I got wrong on the first pass and want to state rather than hide:
    a row with `seq_len < topk` *does* return indices past its own `seq_len`,
    because top-k must return `topk` entries. Those slots carry `-inf` values and
    occur identically at **both** widths — they are a consequence of
    `seq_len < topk`, not of widening.
- `ForwardMode.DRAFT_EXTEND_V2.is_extend()` is `False` by default and `True`
  with `include_draft_extend_v2=True`, confirming the reachability argument
  above; and `DSAMetadata.seq_lens_sum` has no reader in this module.

**Not covered by that run:** that the DP group actually stops deadlocking, which
needs gfx950 + PD + DP attention + MTP. The cluster those runs were done on is
unreachable to me right now, so the gfx950 result above is from the original
investigation rather than from this branch. **Opening as a draft for that
reason** — I'll re-run it against this exact diff and mark it ready.

## Scope

This is deliberately **only** the host-sync half of the problem we hit on this
topology. A second, independent defect in the same file — the decode page table
being per-request while top-k is per-token under MTP — is *not* included here: it
overlaps with #32209, and I do not yet have a version of that convergence I trust
(porting #32209's trimming approach onto this path fails reproducibly at
concurrency 32 for reasons I have not identified). Keeping this PR to the one
defect it can fully justify.

## References

- #32722 `[RED regression] Test GLM-5.2 PD + DP attention + MTP` — a test for
  exactly this topology. Its existence is a good indication that no CI covers
  this combination today, which is how a deadlock like this reaches a release.
- #32209 and #32527 concern the *other* PD + DP-attention + MTP deadlock in this
  area (the per-rank draft-CUDA-graph decision). Different site, different cause;
  linking so the two are not confused.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32690310840](https://github.com/sgl-project/sglang/actions/runs/32690310840)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32690310410](https://github.com/sgl-project/sglang/actions/runs/32690310410)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32690310832](https://github.com/sgl-project/sglang/actions/runs/32690310832)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->