### PR TITLE
[HiSparse]: size DSV4 C4 device pool by request capacity

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -62,12 +62,17 @@ class NPUDeepSeekV4SingleKVPool(DeepSeekV4SingleKVPool):
         self.kernel_page_size = kernel_page_size
         super().__init__(*args, **kwargs)
 
+    def _init_layout_metadata(self) -> None:
+        if self.store_dtype != torch.bfloat16:
+            super()._init_layout_metadata()
+            return
+        self.kv_cache_total_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+
     def create_buffer(self, *, num_pages: int):
         # Non-bf16 store dtype (shouldn't happen here) falls back to base layout.
         if self.store_dtype != torch.bfloat16:
             return super().create_buffer(num_pages=num_pages)
-        kv_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-        self.kv_cache_total_dim = kv_dim
+        kv_dim = self.kv_cache_total_dim
         # GLOBAL kernel_page_size keeps cmp_kv.shape[1] == ori_kv.shape[1]; writes
         # are flat-indexed by loc, so page granularity affects shape not location.
         npu_num_pages = (self.size + self.kernel_page_size + 1) // self.kernel_page_size

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -68,9 +68,14 @@ class HiSparseCoordinator:
         self.is_dsv4_hisparse = isinstance(
             self.token_to_kv_pool_allocator, DeepSeekV4HiSparseTokenToKVPoolAllocator
         )
+        hisparse_c4_layout = None
         if self.is_dsv4_hisparse:
             self.mem_pool_device = self.token_to_kv_pool_allocator.hisparse_kvcache
+            hisparse_c4_layout = self.token_to_kv_pool_allocator.hisparse_c4_layout
             page_size = self.mem_pool_device.page_size
+            if hisparse_c4_layout is not None:
+                self.top_k = hisparse_c4_layout.top_k
+                self.device_buffer_size = hisparse_c4_layout.device_buffer_size
             num_host_pages = (
                 self.token_to_kv_pool_allocator.size_full // self.compress_ratio
                 + page_size
@@ -106,16 +111,20 @@ class HiSparseCoordinator:
             self.item_size_bytes = self.mem_pool_host.token_stride_size
         self.page_size = self.mem_pool_device.page_size
 
-        max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
-        max_context_len = req_to_token_pool.max_context_len
-        max_compressed_context_len = (
-            max_context_len + self.compress_ratio - 1
-        ) // self.compress_ratio
-
-        # to have an extra page for new tokens
-        self.padded_buffer_size = (
-            self.device_buffer_size + self.mem_pool_device.page_size
-        )
+        if hisparse_c4_layout is not None:
+            max_num_req_slots = hisparse_c4_layout.req_slot_count
+            max_compressed_context_len = hisparse_c4_layout.compressed_context_len
+            self.padded_buffer_size = hisparse_c4_layout.padded_per_req
+        else:
+            max_num_req_slots = req_to_token_pool.req_to_token.shape[0]
+            max_context_len = req_to_token_pool.max_context_len
+            max_compressed_context_len = (
+                max_context_len + self.compress_ratio - 1
+            ) // self.compress_ratio
+            # Keep one extra page for new tokens in generic DSA HiSparse.
+            self.padded_buffer_size = (
+                self.device_buffer_size + self.mem_pool_device.page_size
+            )
 
         self.req_to_device_buffer = torch.zeros(
             (max_num_req_slots, self.padded_buffer_size),

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -288,6 +288,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.hisparse_kvcache = logical_attn_allocator._kvcache.c4_kv_pool
         self._size_full = logical_attn_allocator.size_full
         self._size_hisparse = self.hisparse_kvcache.size
+        self.hisparse_c4_layout = self.hisparse_kvcache.hisparse_c4_layout
 
         self.dtype = self.hisparse_kvcache.dtype
         self.device = self.hisparse_kvcache.device

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from contextlib import nullcontext
-from typing import List, Literal, NamedTuple, Optional, Tuple
+from typing import TYPE_CHECKING, List, Literal, NamedTuple, Optional, Tuple
 
 import torch
 
@@ -25,6 +25,9 @@ from sglang.srt.runtime_context import get_exec, get_server_args, get_spec
 from sglang.srt.utils import ceil_div, is_hip
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.hisparse_c4_sizing import HiSparseC4Layout
 
 _is_hip = is_hip()
 
@@ -79,7 +82,20 @@ class DeepSeekV4SingleKVPool(KVCache):
         self.quantize_block_size = 64
         self.rope_storage_dtype = torch.bfloat16
         self.k_with_scale_buffer_dtype = torch.int8
+        self._init_layout_metadata()
         self._create_buffers()
+
+    def _init_layout_metadata(self) -> None:
+        bytes_per_token = self.get_bytes_per_token()
+        self.kv_cache_total_dim = bytes_per_token
+        bytes_per_page_non_padded = self.page_size * bytes_per_token
+        self.bytes_per_page_padded = ceil_div(bytes_per_page_non_padded, 576) * 576
+
+        assert bytes_per_token == 448 + 64 * 2 + 8, (
+            "DSV4 KV layout: qk_nope_head_dim FP8 (448) + qk_rope_head_dim BF16 "
+            "(64*2) + nope FP8 scales + scale_pad = 584 bytes/token"
+        )
+        assert self.store_dtype == torch.uint8
 
     def _create_buffers(self):
         with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
@@ -105,17 +121,6 @@ class DeepSeekV4SingleKVPool(KVCache):
         return dim_per_token
 
     def create_buffer(self, *, num_pages: int):
-        bytes_per_token = self.get_bytes_per_token()
-        self.kv_cache_total_dim = bytes_per_token
-        bytes_per_page_non_padded = self.page_size * bytes_per_token
-        self.bytes_per_page_padded = ceil_div(bytes_per_page_non_padded, 576) * 576
-
-        assert bytes_per_token == 448 + 64 * 2 + 8, (
-            "DSV4 KV layout: qk_nope_head_dim FP8 (448) + qk_rope_head_dim BF16 "
-            "(64*2) + nope FP8 scales + scale_pad = 584 bytes/token"
-        )
-        assert self.store_dtype == torch.uint8
-
         return torch.zeros(
             num_pages,
             self.bytes_per_page_padded,
@@ -181,6 +186,7 @@ class HiSparseC4DevicePool(DeepSeekV4SingleKVPool):
         start_layer: int | None = None,
         end_layer: int | None = None,
     ):
+        self.hisparse_c4_layout: Optional[HiSparseC4Layout] = None
         super().__init__(
             size,
             page_size,
@@ -480,6 +486,7 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         enable_hisparse: bool = False,
         online_mtp_max_draft_tokens: int = 0,
         num_req_slots: Optional[int] = None,
+        hisparse_c4_layout: Optional[HiSparseC4Layout] = None,
     ):
         super().__init__(
             swa_size,
@@ -564,6 +571,16 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         c128_layer_num = sum(1 for r in stage_ratios if r == 128)
         c4_page_size = page_size // 4
         c128_page_size = page_size // 128
+        self.hisparse_c4_layout = hisparse_c4_layout
+        if hisparse_c4_layout is not None:
+            assert self.num_req_slots == hisparse_c4_layout.req_slot_count, (
+                "DSV4 HiSparse req-slot mismatch: "
+                f"pool={self.num_req_slots}, layout={hisparse_c4_layout.req_slot_count}"
+            )
+            assert c4_size == hisparse_c4_layout.c4_device_slot_capacity, (
+                "DSV4 HiSparse C4 capacity mismatch: "
+                f"pool={c4_size}, layout={hisparse_c4_layout.c4_device_slot_capacity}"
+            )
 
         from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
             is_unified_kv_triton,
@@ -622,6 +639,8 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
                 global_page_size=page_size,
                 cls=c4_kv_pool_type,
             )
+            if hisparse_c4_layout is not None:
+                self.c4_kv_pool.hisparse_c4_layout = hisparse_c4_layout
 
             self.c128_kv_pool = self._make_kv_pool(
                 size=c128_size,

--- a/python/sglang/srt/mem_cache/hisparse_c4_sizing.py
+++ b/python/sglang/srt/mem_cache/hisparse_c4_sizing.py
@@ -1,0 +1,138 @@
+"""Request-level C4 sizing for DSV4 HiSparse PD decode."""
+
+from __future__ import annotations
+
+import msgspec
+
+from sglang.srt.utils.common import ceil_div
+
+
+class HiSparseC4PersistentBytes(msgspec.Struct, frozen=True):
+    """Persistent GPU memory charged before sizing token pools."""
+
+    c4_kv: int
+    c4_data_ptrs: int
+    allocator_free_pages: int
+    logical_mapping_tail: int
+    req_to_token: int
+    coordinator_host_pool_ptrs: int
+    coordinator: int
+
+    @property
+    def total(self) -> int:
+        return (
+            self.c4_kv
+            + self.c4_data_ptrs
+            + self.allocator_free_pages
+            + self.logical_mapping_tail
+            + self.req_to_token
+            + self.coordinator_host_pool_ptrs
+            + self.coordinator
+        )
+
+
+class HiSparseC4Layout(msgspec.Struct, frozen=True):
+    """Final request-indexed C4 contract shared by pool consumers."""
+
+    max_running_requests: int
+    pd_extra_slots: int
+    req_slot_count: int
+    context_len: int
+    compressed_context_len: int
+    c4_page_size: int
+    device_buffer_size: int
+    padded_per_req: int
+    top_k: int
+    local_c4_layers: int
+    c4_device_slot_capacity: int
+    persistent_bytes: HiSparseC4PersistentBytes
+
+    @property
+    def resident_request_capacity(self) -> int:
+        """C4 buffers cover every request-table row, including the reserve row."""
+        return self.req_slot_count
+
+
+class HiSparseC4Geometry(msgspec.Struct, frozen=True):
+    """Static geometry resolved before max-running-request finalization."""
+
+    context_len: int
+    compressed_context_len: int
+    c4_page_size: int
+    device_buffer_size: int
+    padded_per_req: int
+    top_k: int
+    local_c4_layers: int
+    pd_extra_slots: int
+    coordinator_instances: int
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        context_len: int,
+        c4_page_size: int,
+        device_buffer_size: int,
+        top_k: int,
+        local_c4_layers: int,
+        pd_extra_slots: int,
+        coordinator_instances: int,
+    ) -> HiSparseC4Geometry:
+        return cls(
+            context_len=context_len,
+            compressed_context_len=ceil_div(context_len, 4),
+            c4_page_size=c4_page_size,
+            device_buffer_size=device_buffer_size,
+            padded_per_req=device_buffer_size + c4_page_size,
+            top_k=top_k,
+            local_c4_layers=local_c4_layers,
+            pd_extra_slots=pd_extra_slots,
+            coordinator_instances=coordinator_instances,
+        )
+
+    def finalize(self, max_running_requests: int) -> HiSparseC4Layout:
+        assert max_running_requests > 0, "max_running_requests must be positive"
+        req_slot_count = max_running_requests + self.pd_extra_slots + 1
+        c4_device_slot_capacity = req_slot_count * self.padded_per_req
+        alloc_pages = c4_device_slot_capacity // self.c4_page_size
+        physical_pages = (
+            c4_device_slot_capacity + self.c4_page_size + 1
+        ) // self.c4_page_size
+        kv_page_stride_bytes = ceil_div(self.c4_page_size * 584, 576) * 576
+        persistent_bytes = HiSparseC4PersistentBytes(
+            c4_kv=self.local_c4_layers * physical_pages * kv_page_stride_bytes,
+            c4_data_ptrs=self.local_c4_layers * 8,
+            allocator_free_pages=alloc_pages * 8,
+            logical_mapping_tail=(self.c4_page_size + 1) * 8,
+            req_to_token=req_slot_count * self.context_len * 4,
+            coordinator_host_pool_ptrs=(
+                self.coordinator_instances * self.local_c4_layers * 16
+            ),
+            coordinator=self.coordinator_instances
+            * self._coordinator_bytes(req_slot_count),
+        )
+        return HiSparseC4Layout(
+            max_running_requests=max_running_requests,
+            pd_extra_slots=self.pd_extra_slots,
+            req_slot_count=req_slot_count,
+            context_len=self.context_len,
+            compressed_context_len=self.compressed_context_len,
+            c4_page_size=self.c4_page_size,
+            device_buffer_size=self.device_buffer_size,
+            padded_per_req=self.padded_per_req,
+            top_k=self.top_k,
+            local_c4_layers=self.local_c4_layers,
+            c4_device_slot_capacity=c4_device_slot_capacity,
+            persistent_bytes=persistent_bytes,
+        )
+
+    def _coordinator_bytes(self, req_slot_count: int) -> int:
+        return (
+            8 * req_slot_count * self.padded_per_req
+            + 8 * req_slot_count * (self.compressed_context_len + self.c4_page_size)
+            + 8 * self.local_c4_layers * req_slot_count * self.padded_per_req
+            + 2 * self.local_c4_layers * req_slot_count * self.device_buffer_size
+            + 6 * self.device_buffer_size
+            + 8 * req_slot_count * self.top_k
+            + 4
+        )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -124,6 +124,7 @@ MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_BUFFER = 1
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+    from sglang.srt.mem_cache.hisparse_c4_sizing import HiSparseC4Layout
     from sglang.srt.mem_cache.unified_memory_pool import (
         UnifiedKVPool,
         UnifiedPoolBundle,
@@ -134,9 +135,7 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
         SpecAuxHiddenStateConfig,
     )
-    from sglang.srt.model_executor.pool_configurator import (
-        MemoryPoolConfig,
-    )
+    from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 
 
 class KVCacheConfigResult(msgspec.Struct, frozen=True, kw_only=True):
@@ -169,6 +168,7 @@ class _PoolSizes(msgspec.Struct, frozen=True, kw_only=True):
     c128_state_pool_size: int
     c4_state_dtype: Optional[torch.dtype]
     c128_state_dtype: Optional[torch.dtype]
+    hisparse_c4_layout: Optional[HiSparseC4Layout]
 
 
 @dataclass(slots=True, kw_only=True)
@@ -334,6 +334,9 @@ class KVCacheConfigurator:
             c128_state_pool_size=c128_state_pool_size,
             c4_state_dtype=c4_state_dtype,
             c128_state_dtype=c128_state_dtype,
+            hisparse_c4_layout=(
+                None if self.is_draft_worker else config.hisparse_c4_layout
+            ),
         )
 
     def _init_pools(
@@ -863,6 +866,7 @@ class KVCacheConfigurator:
                 c128_state_pool_size=sizes.c128_state_pool_size,
                 c4_state_dtype=sizes.c4_state_dtype,
                 c128_state_dtype=sizes.c128_state_dtype,
+                hisparse_c4_layout=sizes.hisparse_c4_layout,
                 req_to_token_pool=req_to_token_pool,
             )
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
@@ -954,6 +958,7 @@ class KVCacheConfigurator:
         c128_state_pool_size: int,
         c4_state_dtype: Optional[torch.dtype],
         c128_state_dtype: Optional[torch.dtype],
+        hisparse_c4_layout: Optional[HiSparseC4Layout],
         req_to_token_pool: ReqToTokenPool,
     ) -> KVCache:
         swa_page_size = get_schedule().page_size
@@ -1032,6 +1037,7 @@ class KVCacheConfigurator:
             online_mtp_max_draft_tokens=(
                 self.server_args.max_speculative_num_draft_tokens or 0
             ),
+            hisparse_c4_layout=hisparse_c4_layout,
         )
         return token_to_kv_pool
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -30,8 +30,15 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.environ import envs
-from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
+from sglang.srt.mem_cache.allocation_sizing import (
+    get_alloc_len_per_decode,
+    get_req_to_token_extra_context_len,
+)
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import get_compress_state_ring_size
+from sglang.srt.mem_cache.hisparse_c4_sizing import (
+    HiSparseC4Geometry,
+    HiSparseC4Layout,
+)
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.common import (
@@ -56,6 +63,7 @@ class MemoryPoolConfig:
     c128_max_total_num_tokens: int = 0
     c4_state_pool_size: int = 0
     c128_state_pool_size: int = 0
+    hisparse_c4_layout: Optional[HiSparseC4Layout] = None
 
     mem_fraction_static: Optional[float] = None
 
@@ -647,12 +655,44 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.disaggregation_decode_extra_slots = (
             kvc.server_args.disaggregation_decode_extra_slots or 0
         )
+        self.hisparse_c4_geometry: Optional[HiSparseC4Geometry] = None
+        self._reserved_hisparse_c4_layout: Optional[HiSparseC4Layout] = None
         if kvc.server_args.enable_hisparse:
             from sglang.srt.mem_cache.sparsity import parse_hisparse_config
 
-            self.c4_shrink_factor = parse_hisparse_config(
-                kvc.server_args
-            ).host_to_device_ratio
+            hisparse_config = parse_hisparse_config(kvc.server_args)
+            self.c4_shrink_factor = hisparse_config.host_to_device_ratio
+            if self.disaggregation_mode == "decode":
+                req_to_token_context_len = (
+                    self.context_len
+                    + get_req_to_token_extra_context_len(kvc.server_args)
+                )
+                model_top_k = getattr(
+                    kvc.model_config.hf_text_config, "index_topk", None
+                )
+                top_k = hisparse_config.top_k if model_top_k is None else model_top_k
+                if (
+                    kvc.server_args.enable_multi_layer_eagle
+                    and kvc.spec_algorithm.is_eagle()
+                ):
+                    coordinator_instances = 1 + kvc.server_args.speculative_num_steps
+                elif (
+                    kvc.spec_algorithm.is_eagle()
+                    or kvc.spec_algorithm.is_standalone()
+                    or kvc.spec_algorithm.is_dflash()
+                ):
+                    coordinator_instances = 2
+                else:
+                    coordinator_instances = 1
+                self.hisparse_c4_geometry = HiSparseC4Geometry.create(
+                    context_len=req_to_token_context_len,
+                    c4_page_size=kvc.page_size // 4,
+                    device_buffer_size=hisparse_config.device_buffer_size,
+                    top_k=top_k,
+                    local_c4_layers=sum(1 for r in self.compression_ratios if r == 4),
+                    pd_extra_slots=self.disaggregation_decode_extra_slots,
+                    coordinator_instances=coordinator_instances,
+                )
         else:
             self.c4_shrink_factor = 1
         assert self.c4_shrink_factor >= 1
@@ -734,7 +774,9 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         # full-token capacity here.
         c128_state_ratio = 0
 
-        c4_frac = 1 / (4 * self.c4_shrink_factor)
+        request_level_c4 = self.hisparse_c4_geometry is not None
+        c4_frac = 0 if request_level_c4 else 1 / (4 * self.c4_shrink_factor)
+        hisparse_logical_mapping_bytes = 2 if request_level_c4 else 0
         return (
             self.swa_ratio * kv_bytes * self.num_layers_total
             + c4_frac * kv_bytes * self.num_layers_ca4
@@ -746,15 +788,26 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             * c4_state_ratio
             * c4_indexer_state_bytes
             * self.num_layers_ca4
+            + hisparse_logical_mapping_bytes
         )
 
-    def _compute_dsv4_sizes(self, full_token: int, page_size: int) -> _DSV4PoolSizes:
+    def _compute_dsv4_sizes(
+        self,
+        full_token: int,
+        page_size: int,
+        *,
+        hisparse_c4_size: Optional[int] = None,
+    ) -> _DSV4PoolSizes:
         full_token = full_token // page_size * page_size
         swa_tokens = int(full_token * self.swa_ratio) // page_size * page_size
         return _DSV4PoolSizes(
             full_max_total_num_tokens=full_token,
             swa_max_total_num_tokens=swa_tokens,
-            c4_max_total_num_tokens=full_token // (4 * self.c4_shrink_factor),
+            c4_max_total_num_tokens=(
+                hisparse_c4_size
+                if hisparse_c4_size is not None
+                else full_token // (4 * self.c4_shrink_factor)
+            ),
             c128_max_total_num_tokens=full_token // 128,
             c4_state_pool_size=swa_tokens // self.swa_page_size * self.c4_ring_size,
             c128_state_pool_size=0,
@@ -790,15 +843,47 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
     def _get_c128_state_fixed_bytes_for_token_capacity(
         self, token_capacity: int
     ) -> int:
+        return self._get_c128_state_fixed_bytes(
+            self._get_reserved_max_running_requests(token_capacity)
+        )
+
+    def _get_reserved_max_running_requests(self, token_capacity: int) -> int:
         if self.requested_max_running_requests_per_worker is not None:
-            return self._get_c128_state_fixed_bytes(
-                self.requested_max_running_requests_per_worker
-            )
+            return self.requested_max_running_requests_per_worker
 
         estimated = int(token_capacity / self.context_len * 512)
         estimated = max(min(estimated, 4096), 2048)
-        max_running_requests = min(estimated, token_capacity // 2)
-        return self._get_c128_state_fixed_bytes(max_running_requests)
+        return min(estimated, token_capacity // 2)
+
+    def _reserve_hisparse_c4_layout(
+        self, token_capacity: int
+    ) -> Optional[HiSparseC4Layout]:
+        if self.hisparse_c4_geometry is None:
+            return None
+        if self._reserved_hisparse_c4_layout is None:
+            max_running_requests = max(
+                1,
+                self._get_reserved_max_running_requests(token_capacity),
+            )
+            self._reserved_hisparse_c4_layout = self.hisparse_c4_geometry.finalize(
+                max_running_requests
+            )
+        return self._reserved_hisparse_c4_layout
+
+    @staticmethod
+    def _hisparse_audit_log(layout: HiSparseC4Layout) -> str:
+        audit = layout.persistent_bytes
+        return (
+            f"mode=pd_decode, M={layout.max_running_requests}, "
+            f"N={layout.req_slot_count}, "
+            f"R={layout.resident_request_capacity}, "
+            f"c4_kv={audit.c4_kv}, c4_data_ptrs={audit.c4_data_ptrs}, "
+            f"allocator_free_pages={audit.allocator_free_pages}, "
+            f"logical_mapping_tail={audit.logical_mapping_tail}, "
+            f"req_to_token={audit.req_to_token}, "
+            f"coordinator_host_pool_ptrs={audit.coordinator_host_pool_ptrs}, "
+            f"coordinator={audit.coordinator}, total={audit.total}"
+        )
 
     def _to_config(self, sizes: _DSV4PoolSizes) -> MemoryPoolConfig:
         full = sizes.full_max_total_num_tokens
@@ -829,6 +914,20 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             config.c128_state_pool_size = num_req_slots
         else:
             config.c128_state_pool_size = num_req_slots * self.c128_ring_size
+        if self.hisparse_c4_geometry is not None:
+            layout = self.hisparse_c4_geometry.finalize(config.max_running_requests)
+            config.hisparse_c4_layout = layout
+            config.c4_max_total_num_tokens = layout.c4_device_slot_capacity
+            logger.info(
+                "DSV4 HiSparse C4 finalized: reserve_M=%d, %s, c4_slots=%d",
+                (
+                    self._reserved_hisparse_c4_layout.max_running_requests
+                    if self._reserved_hisparse_c4_layout is not None
+                    else layout.max_running_requests
+                ),
+                self._hisparse_audit_log(layout),
+                layout.c4_device_slot_capacity,
+            )
         return config
 
     def calculate_pool_sizes(
@@ -838,25 +937,42 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
             page_size % 128 == 0
         ), "page_size must be multiple of 128 for compressed attention"
 
-        if self.requested_max_running_requests_per_worker is not None:
-            c128_state_fixed_bytes = self._get_c128_state_fixed_bytes(
-                self.requested_max_running_requests_per_worker
-            )
-        else:
-            full_token = int(available_bytes / self.bytes_per_full_token)
-            c128_state_fixed_bytes = (
-                self._get_c128_state_fixed_bytes_for_token_capacity(full_token)
+        provisional_full_token = int(available_bytes / self.bytes_per_full_token)
+        c128_state_fixed_bytes = self._get_c128_state_fixed_bytes_for_token_capacity(
+            provisional_full_token
+        )
+        hisparse_layout = self._reserve_hisparse_c4_layout(provisional_full_token)
+        hisparse_fixed_bytes = (
+            hisparse_layout.persistent_bytes.total if hisparse_layout is not None else 0
+        )
+        persistent_fixed_bytes = c128_state_fixed_bytes + hisparse_fixed_bytes
+        if hisparse_layout is not None and available_bytes <= persistent_fixed_bytes:
+            raise RuntimeError(
+                "DSV4 persistent request footprint leaves no token budget: "
+                f"available_bytes={available_bytes}, "
+                f"c128_state={c128_state_fixed_bytes}, "
+                f"hisparse=({self._hisparse_audit_log(hisparse_layout)})"
             )
 
-        available_bytes_for_tokens = max(available_bytes - c128_state_fixed_bytes, 0)
+        available_bytes_for_tokens = max(available_bytes - persistent_fixed_bytes, 0)
         full_token = int(available_bytes_for_tokens / self.bytes_per_full_token)
 
-        sizes = self._compute_dsv4_sizes(full_token, page_size)
+        sizes = self._compute_dsv4_sizes(
+            full_token,
+            page_size,
+            hisparse_c4_size=(
+                hisparse_layout.c4_device_slot_capacity
+                if hisparse_layout is not None
+                else None
+            ),
+        )
         logger.info(
             f"DSV4 memory calculation: "
             f"bytes_per_full_token={self.bytes_per_full_token:.2f}, "
             f"available_bytes={available_bytes / (1 << 30):.2f} GB, "
             f"c128_state_fixed={c128_state_fixed_bytes / (1 << 30):.2f} GB, "
+            f"hisparse_persistent_fixed={hisparse_fixed_bytes / (1 << 30):.2f} GB, "
+            f"remaining_token_budget={available_bytes_for_tokens / (1 << 30):.2f} GB, "
             f"full_token={sizes.full_max_total_num_tokens}"
         )
         return self._to_config(sizes)
@@ -867,7 +983,16 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         assert (
             page_size % 128 == 0
         ), "page_size must be multiple of 128 for compressed attention"
-        sizes = self._compute_dsv4_sizes(max_total_num_tokens, page_size)
+        hisparse_layout = self._reserve_hisparse_c4_layout(max_total_num_tokens)
+        sizes = self._compute_dsv4_sizes(
+            max_total_num_tokens,
+            page_size,
+            hisparse_c4_size=(
+                hisparse_layout.c4_device_slot_capacity
+                if hisparse_layout is not None
+                else None
+            ),
+        )
         return self._to_config(sizes)
 
 

--- a/test/registered/unit/model_executor/test_dsv4_hisparse_c4_capacity.py
+++ b/test/registered/unit/model_executor/test_dsv4_hisparse_c4_capacity.py
@@ -1,0 +1,269 @@
+"""CPU unit tests for DSV4 HiSparse request-level C4 sizing."""
+
+import json
+import unittest
+from dataclasses import dataclass
+
+from sglang.srt.mem_cache.hisparse_c4_sizing import HiSparseC4Geometry
+from sglang.srt.model_executor.pool_configurator import (
+    DSV4PoolConfigurator,
+    MemoryPoolConfig,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+@dataclass(frozen=True, slots=True)
+class _TextConfig:
+    index_topk: int | None = 512
+
+
+@dataclass(frozen=True, slots=True)
+class _HFConfig:
+    architectures: tuple[str, ...] = ("DeepseekV4ForCausalLM",)
+
+
+@dataclass(frozen=True, slots=True)
+class _ModelConfig:
+    context_len: int = 8192
+    compress_ratios: tuple[int, ...] = (4, 128, 4, 128)
+    qk_nope_head_dim: int = 448
+    qk_rope_head_dim: int = 64
+    index_head_dim: int = 128
+    window_size: int = 256
+    hf_config: _HFConfig = _HFConfig()
+    hf_text_config: _TextConfig = _TextConfig()
+
+
+@dataclass(frozen=True, slots=True)
+class _LayerInfo:
+    start_layer: int = 0
+    end_layer: int = 4
+
+
+@dataclass(frozen=True, slots=True)
+class _ParallelState:
+    attn_dp_size: int = 1
+    pp_size: int = 1
+
+
+@dataclass(frozen=True, slots=True)
+class _PPGroup:
+    rank_in_group: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class _KVConfiguratorFixture:
+    model_config: _ModelConfig
+    server_args: ServerArgs
+    layer_info: _LayerInfo
+    ps: _ParallelState
+    kv_cache_dtype_str: str = "auto"
+    pp_group: _PPGroup = _PPGroup()
+    spec_algorithm: SpeculativeAlgorithm = SpeculativeAlgorithm.NONE
+    page_size: int = 256
+
+
+def _make_configurator(
+    *,
+    enable_hisparse: bool = True,
+    disaggregation_mode: str = "decode",
+    max_running_requests: int = 64,
+    dp_size: int = 1,
+    extra_slots: int = 0,
+    host_to_device_ratio: int = 15,
+    model_top_k: int | None = 512,
+) -> DSV4PoolConfigurator:
+    server_args = ServerArgs(
+        model_path="dummy",
+        enable_hisparse=enable_hisparse,
+        disaggregation_mode=disaggregation_mode,
+        disaggregation_decode_extra_slots=extra_slots,
+        max_running_requests=max_running_requests,
+        page_size=256,
+        swa_full_tokens_ratio=0.01,
+        hisparse_config=json.dumps(
+            {
+                "top_k": 64,
+                "device_buffer_size": 2048,
+                "host_to_device_ratio": host_to_device_ratio,
+            }
+        ),
+    )
+    fixture = _KVConfiguratorFixture(
+        model_config=_ModelConfig(hf_text_config=_TextConfig(model_top_k)),
+        server_args=server_args,
+        layer_info=_LayerInfo(),
+        ps=_ParallelState(attn_dp_size=dp_size),
+    )
+    return DSV4PoolConfigurator(fixture)
+
+
+class TestHiSparseC4Geometry(CustomTestCase):
+    def test_request_capacity_includes_the_reserve_row(self):
+        for max_running_requests, extra_slots, expected_slots, expected_capacity in (
+            (64, 0, 65, 137280),
+            (32, 64, 97, 204864),
+        ):
+            with self.subTest(
+                max_running_requests=max_running_requests,
+                extra_slots=extra_slots,
+            ):
+                layout = HiSparseC4Geometry.create(
+                    context_len=262144,
+                    c4_page_size=64,
+                    device_buffer_size=2048,
+                    top_k=512,
+                    local_c4_layers=2,
+                    pd_extra_slots=extra_slots,
+                    coordinator_instances=1,
+                ).finalize(max_running_requests)
+
+                self.assertEqual(layout.req_slot_count, expected_slots)
+                self.assertEqual(layout.resident_request_capacity, expected_slots)
+                self.assertEqual(
+                    layout.c4_device_slot_capacity,
+                    expected_capacity,
+                )
+
+    def test_persistent_budget_matches_allocated_tensor_shapes(self):
+        layout = HiSparseC4Geometry.create(
+            context_len=1028,
+            c4_page_size=64,
+            device_buffer_size=128,
+            top_k=32,
+            local_c4_layers=2,
+            pd_extra_slots=0,
+            coordinator_instances=2,
+        ).finalize(3)
+        persistent = layout.persistent_bytes
+
+        self.assertEqual(persistent.c4_kv, 2 * 13 * 37440)
+        self.assertEqual(persistent.allocator_free_pages, 12 * 8)
+        self.assertEqual(persistent.req_to_token, 4 * 1028 * 4)
+        self.assertEqual(persistent.coordinator_host_pool_ptrs, 2 * 2 * 16)
+        self.assertEqual(persistent.coordinator, 2 * 32548)
+
+    def test_device_buffer_size_keeps_existing_non_aligned_behavior(self):
+        layout = HiSparseC4Geometry.create(
+            context_len=1028,
+            c4_page_size=64,
+            device_buffer_size=130,
+            top_k=32,
+            local_c4_layers=2,
+            pd_extra_slots=0,
+            coordinator_instances=1,
+        ).finalize(3)
+
+        self.assertEqual(layout.padded_per_req, 194)
+        self.assertEqual(layout.c4_device_slot_capacity, 776)
+
+
+class TestDSV4HiSparsePoolConfigurator(CustomTestCase):
+    def test_request_level_sizing_is_scoped_to_hisparse_pd_decode(self):
+        for mode, enabled, shrink_factor in (
+            ("null", True, 15),
+            ("prefill", True, 15),
+            ("decode", False, 1),
+        ):
+            with self.subTest(mode=mode, enabled=enabled):
+                configurator = _make_configurator(
+                    enable_hisparse=enabled,
+                    disaggregation_mode=mode,
+                )
+                config = configurator.calculate_pool_sizes(2_000_000_000, 256)
+                config.max_running_requests = 64
+                configurator.finalize_with_max_running_requests(config)
+
+                self.assertIsNone(config.hisparse_c4_layout)
+                self.assertEqual(
+                    config.c4_max_total_num_tokens,
+                    config.full_max_total_num_tokens // (4 * shrink_factor),
+                )
+
+    def test_finalized_layout_uses_per_dp_request_capacity(self):
+        configurator = _make_configurator(
+            max_running_requests=96,
+            dp_size=3,
+            extra_slots=64,
+            model_top_k=777,
+        )
+        config = configurator.calculate_pool_sizes(20_000_000_000, 256)
+        config.max_running_requests = 32
+
+        configurator.finalize_with_max_running_requests(config)
+
+        layout = config.hisparse_c4_layout
+        self.assertEqual(layout.req_slot_count, 97)
+        self.assertEqual(layout.c4_device_slot_capacity, 204864)
+        self.assertEqual(layout.top_k, 777)
+        self.assertEqual(config.c4_max_total_num_tokens, 204864)
+
+    def test_fixed_hisparse_footprint_is_removed_from_token_budget(self):
+        configurator = _make_configurator(max_running_requests=64)
+        layout = configurator.hisparse_c4_geometry.finalize(64)
+        available_bytes = 20_000_000_000
+
+        config = configurator.calculate_pool_sizes(available_bytes, 256)
+
+        c128_bytes = configurator._get_c128_state_fixed_bytes(64)
+        expected = int(
+            (available_bytes - c128_bytes - layout.persistent_bytes.total)
+            / configurator.bytes_per_full_token
+        )
+        self.assertEqual(config.max_total_num_tokens, expected // 256 * 256)
+
+    def test_insufficient_budget_reports_persistent_components(self):
+        configurator = _make_configurator(max_running_requests=64)
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "c4_kv=.*req_to_token=.*coordinator=.*total=",
+        ):
+            configurator.calculate_pool_sizes(1, 256)
+
+    def test_draft_pool_sizes_do_not_take_target_layout_ownership(self):
+        from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+
+        config = MemoryPoolConfig(
+            max_total_num_tokens=4096,
+            full_max_total_num_tokens=4096,
+            swa_max_total_num_tokens=256,
+            c4_max_total_num_tokens=137280,
+            c128_max_total_num_tokens=32,
+            c4_state_pool_size=64,
+            c128_state_pool_size=128,
+            hisparse_c4_layout=HiSparseC4Geometry.create(
+                context_len=1028,
+                c4_page_size=64,
+                device_buffer_size=2048,
+                top_k=512,
+                local_c4_layers=2,
+                pd_extra_slots=0,
+                coordinator_instances=1,
+            ).finalize(64),
+        )
+
+        class _DraftFixture:
+            is_hybrid_swa = True
+            is_draft_worker = True
+            loc_space_scale = 1
+            model_config = _ModelConfig(
+                hf_config=_HFConfig(("DeepseekV4ForCausalLMNextN",))
+            )
+
+        sizes = KVCacheConfigurator._derive_pool_sizes(_DraftFixture(), config=config)
+
+        self.assertIsNone(sizes.hisparse_c4_layout)
+        self.assertEqual(sizes.c4_max_total_num_tokens, 0)
+        self.assertEqual(sizes.c128_max_total_num_tokens, 0)
+        self.assertEqual(sizes.c4_state_pool_size, 0)
+        self.assertEqual(sizes.c128_state_pool_size, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

<!-- Local validation metadata: branch dsv4-hisparse-request-level-c4; base origin/main@3ed2a0adf3; latest commit 73562503dae6c76b71c9a71ada9d3d3c61f04b77. -->

## Motivation

DSV4 HiSparse currently derives the C4 device-pool capacity from the total logical token capacity and `host_to_device_ratio`. This charges C4 device storage into the per-full-token byte coefficient (`BPF`):

```text
BPF = Base_BPF + (C4_layers * C4_bytes) / (4 * host_to_device_ratio)
Full = available_bytes / BPF
C4_device_pool = Full / (4 * host_to_device_ratio)
```

The device pool is used as a fixed per-request decode buffer, so modeling it as token-proportional storage creates a circular dependency. Increasing `host_to_device_ratio` first increases `Full`, then increases the derived C4 pool again and consumes part of the memory that the ratio was intended to release.

This PR decouples the fixed C4 device footprint from the logical full-token capacity. It is limited to request-level C4 capacity estimation, layout finalization, pool construction, and unit coverage. It does not change decode admission, host-backed logical-capacity limits, C4 transfer page IDs, or the HiSparse attention/top-k algorithm.

## Modifications

### Request-level C4 sizing

The new layout uses request capacity rather than full-token capacity:

```text
Q = device_buffer_size + c4_page_size
N = M + E + 1                 # request-table rows; row 0 is the dummy row
R = N                         # C4 capacity slots, including one reserve slot
C4_device_pool = R * Q
```

`M` is the final per-worker maximum running-request count and `E` is the per-worker PD decode extra-slot reservation. The extra request-sized C4 slot is retained as a conservative reserve. The allocator's physical page-0 sentinel is accounted for separately by the KV-pool allocation.

The estimator now has two phases:

1. Build a conservative request-level layout from provisional request capacity and charge its persistent bytes before calculating token pools.
2. Resolve the final `max_running_requests`, finalize one immutable `HiSparseC4Layout`, and pass it to the KV pool, allocator, and coordinator.

The fixed-footprint accounting includes:

- physical C4 KV pages, allocator dummy-page overhead, and page-stride padding;
- allocator free-page metadata and the logical-mapping tail;
- `ReqToTokenPool` request rows;
- coordinator request/device/host metadata and top-k scratch buffers;
- C128 request-state bytes from the existing DSV4 request-level path.

The logical full-to-C4 mapping remains token-proportional and is charged in the per-token coefficient. The C4 device KV term is removed from that coefficient.

### Capacity observations

The following startup logs show the old ratio-based behavior and the new request-level behavior under an approximately 19 GB available budget:

```text
# Ordinary decode
bytes_per_full_token=4168.57, available_bytes=18.91 GB,
c128_state_fixed=0.65 GB, remaining_token_budget=18.26 GB,
full_token=4701952

# host_to_device_ratio=5
bytes_per_full_token=1715.77, available_bytes=18.94 GB,
c128_state_fixed=0.65 GB, full_token=11444992

# host_to_device_ratio=15
bytes_per_full_token=1306.97, available_bytes=18.94 GB,
c128_state_fixed=0.65 GB, full_token=15024896

# host_to_device_ratio=25
bytes_per_full_token=1225.21, available_bytes=18.94 GB,
c128_state_fixed=0.65 GB, full_token=16027392

# Request-level HiSparse C4
bytes_per_full_token=1104.57, available_bytes=18.91 GB,
c128_state_fixed=0.65 GB, hisparse_persistent_fixed=1.69 GB,
remaining_token_budget=16.56 GB, full_token=16098304
```

For the previous estimator, the C4 contribution was:

```text
C4_device_BPF = (21 C4 layers * 584 bytes) / (4 * ratio)
               = 3066 / ratio bytes

ratio=1   -> 3066.00 B
ratio=5   ->  613.20 B
ratio=15  ->  204.40 B
ratio=25  ->  122.64 B
request-level -> 0 B token coefficient + 2 B logical mapping
```

The request-level estimator reserves the physical C4 footprint explicitly (`1.69 GB` in the example) and reduces the token coefficient to `1104.57 B`.

### Scope and dependency boundary

During validation, we also identified a related decode-admission issue: once C4 pages are fixed per request, admission must use logical capacity rather than treating exhaustion of the fixed C4 pool as a per-token allocation budget. This issue is addressed by the separate upstream [#30909](https://github.com/sgl-project/sglang/pull/30909), so this PR intentionally submits only the request-level C4 sizing and layout changes and does not duplicate the admission fix. The two changes can be reviewed independently, but deployments should include the admission fix in the serving baseline.

### Unit tests and validation

Added unit coverage for:

- `N=M+E+1` request-table capacity and the matching request-sized C4 reserve;
- physical C4 page and allocator metadata accounting;
- non-page-aligned `device_buffer_size` preserving the existing assertion;
- model `index_topk` overriding generic HiSparse `top_k`;
- DP-local request capacity and PD extra slots;
- fixed-footprint subtraction from the full-token budget;
- insufficient persistent-budget diagnostics;
- draft workers not taking ownership of the target HiSparse layout.

Validation on the clean latest-main worktree:

```text
pre-commit on changed files: PASS
py_compile: PASS
ruff check: PASS for new/changed code
ruff format: PASS
git diff --check: PASS
focused capacity tests: PASS (8 tests, 5 subtests)
```

## Accuracy Tests

This PR changes memory sizing and pool layout only. It does not change model forward computation, attention kernels, token selection, or sampling logic. The following are observed DSV4 PD-prefill plus D-decode HiSparse results from the current serving setup; they are reference measurements, not a claim that this capacity change fixes all HiSparse accuracy behavior.

| Benchmark | Mode | Result |
| --- | --- | --- |
| `sgl-eval gsm8k` | HiSparse PD | `96.97%` |
| `sgl-eval gpqa` | HiSparse PD | `87.02%` |
| `swe-bench-verified` | **non-think** HiSparse PD | `75.0`|

The SWE-Bench result is explicitly from non-think mode and is not directly comparable to prior think-mode long-output observations.

## Speed Tests and Profiling

No isolated speedup claim is made by this PR. The request-level sizing changes startup memory accounting and available token capacity; it does not modify the decode kernel or transfer implementation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31168060091](https://github.com/sgl-project/sglang/actions/runs/31168060091)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31168059814](https://github.com/sgl-project/sglang/actions/runs/31168059814)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->