### PR TITLE
fix(sm120): widen unsupported topk so DSpark verify reaches decode-dsv4

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -526,6 +526,53 @@ def _flash_mla_flashinfer(
         else extra_indices
     )
 
+    # FlashInfer instantiates decode-dsv4 only for a fixed (num_heads, topk)
+    # table. Normal decode always arrives with an instantiated topk, but
+    # DSpark's draft attention does not (topk=192 on DeepSeek-V4-Flash), and an
+    # unlisted shape falls through to the prefill orchestrator, whose first
+    # check is `num_tokens > 64`. Speculative verify submits
+    # batch * (gamma + 1) tokens, so that check can never pass and the server
+    # dies during CUDA graph capture.
+    #
+    # Widen the index to the next instantiated width and bound the real length
+    # with topk_length, which the kernel already honours. This must happen
+    # before num_splits is computed below, so the scratch buffers are sized for
+    # the width FlashInfer will actually see.
+    if B <= _FI_DECODE_MAX_TOKENS:
+        from flashinfer.mla._sparse_mla_sm120 import (
+            _DECODE_DSV4_DISPATCH as _FI_DSV4_TABLE,
+        )
+
+        _topk_real = idx.shape[-1]
+        if (H, _topk_real) not in _FI_DSV4_TABLE:
+            _target = next(
+                (
+                    width
+                    for width in sorted(
+                        w for heads, w in _FI_DSV4_TABLE if heads == H
+                    )
+                    if width > _topk_real
+                ),
+                None,
+            )
+            if _target is not None:
+                if topk_length is None:
+                    topk_length = torch.full(
+                        (idx.shape[0],),
+                        _topk_real,
+                        dtype=torch.int32,
+                        device=idx.device,
+                    )
+                idx = torch.cat(
+                    [
+                        idx,
+                        idx[..., :1].expand(
+                            *idx.shape[:-1], _target - _topk_real
+                        ),
+                    ],
+                    dim=-1,
+                ).contiguous()
+
     output = torch.empty(B, H, head_dim_v, dtype=torch.bfloat16, device=dev)
     out_lse = torch.empty(B, H, dtype=torch.float32, device=dev)
 


### PR DESCRIPTION
Fixes #33985.

## Problem

DSpark speculative decoding cannot start on SM120. Every launch dies during
CUDA graph capture:

```
tvm.error.InternalError: Check failed: num_tokens > 64 (50 vs. 64) :
  Decode (num_tokens <= 64) must go through sparse_mla_sm120_decode_dsv3_2
  or sparse_mla_sm120_decode_dsv4; got num_tokens=50
```

FlashInfer instantiates `sparse_mla_sm120_decode_dsv4` only for a fixed
`(num_heads, topk)` table. Instrumenting `_flash_mla_flashinfer` over a full
startup shows the split cleanly:

| topk | `_decode_dsv4_dispatchable` | calls |
|-----:|---|------:|
| 128  | True  | 4644 |
| **192** | **False** | **4** |

Normal decode always arrives with `topk=128`. DSpark's draft attention arrives
with `topk=192`, which has no instantiation, so the call falls through to the
prefill orchestrator whose first check is `num_tokens > 64`. Speculative verify
submits `batch * (gamma + 1)` tokens, which is below 64 by construction, so
that check can never pass.

Every other dispatch input is already correct: `model_type=_MODEL_TYPE_DSV4`,
`d_qk=512`, `kv_pbs=64` after the existing page-split, `num_heads=64`.

## Fix

Pad the sparse index to the next instantiated width and bound the real length
with `topk_length`, which the kernel already accepts and the non-speculative
path already uses.

The widening is placed before `num_splits` is computed, so the `mid_out` /
`mid_lse` scratch buffers are sized for the width FlashInfer actually sees.
Placing it after would size the scratch for the unpadded width and the kernel
would run past it.

## Correctness

Speculative decoding must not change what the attention computes. To show the
padding is never consumed, the same five deterministic fixtures were run twice
with only the padding *value* changed -- first index of the row vs last index:

| fixture | tokens | content sha256 |
|---|---|---|
| code | 400/400 | identical |
| prose | 400/400 | identical |
| list | 400/400 | identical |
| json | 148/148 | identical |
| reason | 260/260 | identical |

Byte-identical in every case, which is only possible if `topk_length` bounds
the read. If the padding were consumed, two different pad values would produce
two different attention results.

## Measurements

4x RTX PRO 6000 Blackwell (SM120), PCIe-only, DeepSeek-V4-Flash-0731, TP4,
FP8 E4M3 KV cache, gamma 5 (the checkpoint's own `dspark_block_size`):

| Metric | before | after |
|---|---:|---:|
| single-stream decode, natural text | 80.8 tok/s | **223.7 tok/s** |
| aggregate decode, 1 concurrent | 80.9 tok/s | 264.6 tok/s |
| aggregate decode, 4 concurrent | 258.8 tok/s | 286.5 tok/s |
| aggregate decode, 10 concurrent | 429.2 tok/s | 465.2 tok/s |
| acceptance rate | n/a | 0.62 (accept len 4.10) |

Health, exact model id, deterministic completion, streaming with usage and
`[DONE]`, separated reasoning, forced tool call with exact JSON arguments, and
a 65,536-token fixture with exact usage all pass with DSpark enabled.

## Notes

- Ladder size is not the variable: `--cuda-graph-max-bs-decode` of 1, 2 and 10
  all fail identically before this change, only with different token counts.
- The cleaner long-term fix is to instantiate `decode-dsv4` for `topk=192` in
  FlashInfer. This change makes SGLang resilient to the gap in the meantime,
  and stays a no-op whenever the shape is already instantiated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31173089654](https://github.com/sgl-project/sglang/actions/runs/31173089654)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31173089435](https://github.com/sgl-project/sglang/actions/runs/31173089435)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->