### PR TITLE
fix: load Gemma-4 vision tower unquantized under compressed-tensors

### DIFF
--- a/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
+++ b/python/sglang/srt/hardware_backend/gpu/quantization/gptq_kernels.py
@@ -10,7 +10,6 @@ from sglang.srt.layers.moe.moe_runner.marlin import MarlinMoeQuantInfo
 from sglang.srt.layers.parameter import BasevLLMParameter, permute_param_layout_
 from sglang.srt.layers.quantization.marlin_utils import (
     apply_gptq_marlin_linear,
-    check_marlin_supports_shape,
     marlin_is_k_full,
     marlin_make_empty_g_idx,
     marlin_make_workspace,
@@ -18,6 +17,7 @@ from sglang.srt.layers.quantization.marlin_utils import (
     marlin_permute_scales,
     marlin_sort_g_idx,
     marlin_zero_points,
+    verify_marlin_supports_shape,
 )
 from sglang.srt.layers.quantization.utils import (
     get_scalar_types,
@@ -136,7 +136,7 @@ class GPTQMarlinLinearKernel:
         device = getattr(layer, "qweight").device
         c = self.kernel_config
 
-        check_marlin_supports_shape(
+        verify_marlin_supports_shape(
             c.partition_weight_shape[1],  # out_features
             c.partition_weight_shape[0],  # in_features
             c.full_weight_shape[0],  # in_features

--- a/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/schemes/compressed_tensors_wNa16.py
@@ -25,7 +25,6 @@ from sglang.srt.layers.quantization.compressed_tensors.schemes import (
 from sglang.srt.layers.quantization.marlin_utils import (
     MarlinLinearLayerConfig,
     apply_gptq_marlin_linear,
-    check_marlin_supports_shape,
     marlin_is_k_full,
     marlin_make_empty_g_idx,
     marlin_make_workspace,
@@ -33,6 +32,7 @@ from sglang.srt.layers.quantization.marlin_utils import (
     marlin_repeat_scales_on_all_ranks,
     marlin_sort_g_idx,
     marlin_zero_points,
+    verify_marlin_supports_shape,
 )
 from sglang.srt.layers.quantization.utils import (
     get_scalar_types,
@@ -218,7 +218,7 @@ class CompressedTensorsWNA16(CompressedTensorsLinearScheme):
         device = getattr(layer, self.w_q_name).device
         c = self.kernel_config
 
-        check_marlin_supports_shape(
+        verify_marlin_supports_shape(
             c.partition_weight_shape[1],  # out_features
             c.partition_weight_shape[0],  # in_features
             c.full_weight_shape[0],  # in_features

--- a/python/sglang/srt/models/gemma4_mm.py
+++ b/python/sglang/srt/models/gemma4_mm.py
@@ -173,6 +173,37 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
     embedding_padding_modules = []
     supports_lora = True
 
+    @staticmethod
+    def _vision_tower_quant_config(
+        quant_config: Optional[QuantizationConfig],
+    ) -> Optional[QuantizationConfig]:
+        """Quantization config for the Gemma-4 vision tower.
+
+        compressed-tensors Gemma-4 checkpoints exclude every vision-tower
+        linear through `ignore`, but the entries carry the `.linear` suffix of
+        the checkpoint's clip wrapper, which SGLang's fused `qkv_proj` /
+        `gate_up_proj` do not have, so the match fails and the vision tower
+        gets quantized anyway. Drop the config for the vision tower to honour
+        what the checkpoint asked for.
+
+        Other quantization methods are left alone: modelopt's NVFP4 Gemma-4
+        checkpoint already excludes `model.vision_tower*` by glob, and there is
+        no evidence to justify silently de-quantizing the vision tower on the
+        online fp8/awq/gptq paths.
+        """
+        from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+            CompressedTensorsConfig,
+        )
+
+        if not isinstance(quant_config, CompressedTensorsConfig):
+            return quant_config
+
+        logger.warning_once(
+            "Gemma-4 vision tower is loaded unquantized; the compressed-tensors "
+            "config does not apply to it."
+        )
+        return None
+
     def __init__(
         self,
         config: Gemma4Config,
@@ -191,9 +222,14 @@ class Gemma4ForConditionalGeneration(PreTrainedModel):
         # Vision/audio encoders + their projection embedders are only consumed
         # at the input-embedding stage, so they live on the first PP rank only.
         if self.pp_group.is_first_rank:
+            # NOTE: under compressed-tensors the vision tower loads unquantized,
+            # which is what the checkpoint's `ignore` list asks for; its entries
+            # just do not match SGLang's fused module names. See
+            # `_vision_tower_quant_config`.
+            vision_tower_quant_config = self._vision_tower_quant_config(quant_config)
             self.vision_tower = Gemma4VisionEncoder(
                 config=config.vision_config,
-                quant_config=quant_config,
+                quant_config=vision_tower_quant_config,
                 prefix=add_prefix("vision_tower", prefix),
             )
             self.embed_vision = Gemma4MultimodalEmbedder(

--- a/test/registered/unit/layers/quantization/test_marlin_shape_check.py
+++ b/test/registered/unit/layers/quantization/test_marlin_shape_check.py
@@ -1,0 +1,119 @@
+"""CPU regression test for the Marlin weight-shape check.
+
+Both `CompressedTensorsWNA16.process_weights_after_loading` and
+`GPTQMarlinLinearKernel.process_weights_after_loading` called
+`check_marlin_supports_shape`, which returns `(ok, err_msg)` and never raises,
+and dropped the result. An unsupported shape therefore sailed past the check
+and died later inside `gptq_marlin_repack` with a bare device-side assert
+instead of the actionable "not divisible by min_thread_n = 64" message. The AWQ
+Marlin scheme already uses the raising `verify_marlin_supports_shape`.
+
+These tests drive both checks with the Gemma-4 vision MLP shape from #28018
+(out_features = 2 * 4304 = 8608) and assert they now raise. They run on CPU:
+the call under test happens before any device work, which is stubbed out.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.quantization.compressed_tensors.schemes import (
+    compressed_tensors_wNa16 as wna16,
+)
+from sglang.srt.layers.quantization.marlin_utils import MarlinLinearLayerConfig
+from sglang.test.test_utils import CustomTestCase
+
+IN_FEATURES = 1152
+GEMMA4_VISION_GATE_UP_OUT = 2 * 4304  # 8608, 8608 % 64 == 32
+SUPPORTED_OUT = 8640  # the next multiple of 64
+GROUP_SIZE = 32
+
+
+def _gptq_kernels():
+    # Imported lazily: `hardware_backend...gptq_kernels` and the
+    # compressed-tensors schemes package import each other, so this has to come
+    # after the module-level import above.
+    from sglang.srt.hardware_backend.gpu.quantization import gptq_kernels
+
+    return gptq_kernels
+
+
+class _ReachedDeviceWork(Exception):
+    """Raised by the stub that stands in for the first post-check device call."""
+
+
+def _kernel_config(out_features: int) -> MarlinLinearLayerConfig:
+    return MarlinLinearLayerConfig(
+        full_weight_shape=(IN_FEATURES, out_features),
+        partition_weight_shape=(IN_FEATURES, out_features),
+        weight_type=wna16.WNA16_SUPPORTED_TYPES_MAP[4],
+        act_type=torch.bfloat16,
+        group_size=GROUP_SIZE,
+        zero_points=False,
+        has_g_idx=False,
+    )
+
+
+def _fake_layer(weight_name: str) -> torch.nn.Module:
+    layer = torch.nn.Module()
+    layer.register_parameter(
+        weight_name,
+        torch.nn.Parameter(torch.empty(0, dtype=torch.int32), requires_grad=False),
+    )
+    return layer
+
+
+def _process_wna16(out_features: int) -> None:
+    """Run the WNA16 path up to the first device-side call."""
+    scheme = wna16.CompressedTensorsWNA16.__new__(wna16.CompressedTensorsWNA16)
+    scheme.kernel_config = _kernel_config(out_features)
+    with mock.patch.object(
+        wna16, "marlin_make_workspace", side_effect=_ReachedDeviceWork
+    ):
+        scheme.process_weights_after_loading(_fake_layer("weight_packed"))
+
+
+def _process_gptq_marlin(out_features: int) -> None:
+    """Run the GPTQ-Marlin path up to the first device-side call."""
+    gptq_kernels = _gptq_kernels()
+    kernel = gptq_kernels.GPTQMarlinLinearKernel(quant_config=None)
+    kernel.kernel_config = _kernel_config(out_features)
+    with mock.patch.object(
+        gptq_kernels, "marlin_make_workspace", side_effect=_ReachedDeviceWork
+    ):
+        kernel.process_weights_after_loading(_fake_layer("qweight"))
+
+
+class TestMarlinShapeCheck(CustomTestCase):
+    def _assert_rejects(self, process):
+        with self.assertRaises(ValueError) as ctx:
+            process(GEMMA4_VISION_GATE_UP_OUT)
+        self.assertIn(str(GEMMA4_VISION_GATE_UP_OUT), str(ctx.exception))
+        self.assertIn("min_thread_n = 64", str(ctx.exception))
+
+    def _assert_accepts(self, process):
+        # Positive control: a divisible shape must get past the check, so the
+        # rejection tests are not just rejecting everything.
+        with self.assertRaises(_ReachedDeviceWork):
+            process(SUPPORTED_OUT)
+
+    def test_wna16_rejects_unsupported_out_features(self):
+        self._assert_rejects(_process_wna16)
+
+    def test_wna16_accepts_supported_out_features(self):
+        self._assert_accepts(_process_wna16)
+
+    def test_gptq_marlin_rejects_unsupported_out_features(self):
+        self._assert_rejects(_process_gptq_marlin)
+
+    def test_gptq_marlin_accepts_supported_out_features(self):
+        self._assert_accepts(_process_gptq_marlin)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_gemma4_tower_quantization.py
+++ b/test/registered/unit/models/test_gemma4_tower_quantization.py
@@ -1,0 +1,260 @@
+"""CPU regression test: the Gemma-4 vision tower must load unquantized.
+
+`google/gemma-4-31B-it-qat-w4a16-ct` lists every vision-tower linear in
+`quantization_config.ignore`, but the checkpoint wraps each tower `nn.Linear`
+in a clip module, so the entries carry a trailing `.linear`
+(`...mlp.gate_proj.linear`). SGLang keeps that suffix for the unfused clippable
+linears, but its fused `qkv_proj` / `gate_up_proj` do not have it, and the
+compressed-tensors fused mapping expands them to `...q_proj` / `...gate_proj`,
+which never match the `.linear` entries. Those two layers per block are
+therefore quantized, and the fused `gate_up_proj` (2 * 4304 = 8608) is not
+divisible by Marlin's min_thread_n = 64, so load crashes in
+`gptq_marlin_repack`.
+
+The model now drops a compressed-tensors config for the vision tower. These
+tests build the real vision-tower modules on CPU against a two-layer replica of
+the checkpoint's config -- the real vision geometry, and `ignore` entries in
+the checkpoint's own spelling -- and pin that contract. No weights are loaded
+and no kernels run.
+"""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+import os
+import socket
+import unittest
+from unittest import mock
+
+from transformers import Gemma4Config
+
+import sglang.srt.models.gemma4_mm as gemma4_mm
+import sglang.srt.models.gemma4_vision as gemma4_vision
+from sglang.srt.layers.linear import LinearBase
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
+from sglang.srt.models.gemma4_mm import Gemma4ForConditionalGeneration
+from sglang.test.test_utils import CustomTestCase
+
+# Real shapes from google/gemma-4-31B-it-qat-w4a16-ct's vision_config. The
+# intermediate_size is what makes the fused gate_up_proj 8608 wide.
+VISION_HIDDEN_SIZE = 1152
+VISION_INTERMEDIATE_SIZE = 4304
+VISION_LAYERS = 2
+
+# The checkpoint's ignore entries, in the checkpoint's own spelling: every
+# tower linear is listed with the trailing ".linear" of the clip wrapper.
+TOWER_IGNORE = ["model.vision_tower.patch_embedder.input_proj"] + [
+    f"model.vision_tower.encoder.layers.{i}.{sub}.linear"
+    for i in range(VISION_LAYERS)
+    for sub in (
+        "self_attn.q_proj",
+        "self_attn.k_proj",
+        "self_attn.v_proj",
+        "self_attn.o_proj",
+        "mlp.gate_proj",
+        "mlp.up_proj",
+        "mlp.down_proj",
+    )
+]
+IGNORE = TOWER_IGNORE + ["model.embed_vision.embedding_projection", "lm_head"]
+
+# group_0 targets "Linear", i.e. everything that is not ignored is quantized.
+W4A16_QUANT_CONFIG = {
+    "quant_method": "compressed-tensors",
+    "format": "pack-quantized",
+    "ignore": IGNORE,
+    "config_groups": {
+        "group_0": {
+            "format": "pack-quantized",
+            "targets": ["Linear"],
+            "input_activations": None,
+            "output_activations": None,
+            "weights": {
+                "num_bits": 4,
+                "type": "int",
+                "symmetric": True,
+                "strategy": "group",
+                "group_size": 32,
+                "dynamic": False,
+            },
+        }
+    },
+}
+
+
+def _gemma4_config() -> Gemma4Config:
+    """A Gemma-4 config with the real vision geometry and a stub text tower."""
+    text_config = {
+        "hidden_size": 128,
+        "intermediate_size": 256,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "vocab_size": 1024,
+    }
+    vision_config = {
+        "hidden_size": VISION_HIDDEN_SIZE,
+        "intermediate_size": VISION_INTERMEDIATE_SIZE,
+        "num_hidden_layers": VISION_LAYERS,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 16,
+        "head_dim": 72,
+        "patch_size": 16,
+    }
+    return Gemma4Config(text_config=text_config, vision_config=vision_config)
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _init_single_rank_cpu_parallelism() -> None:
+    """TP=PP=1 on gloo: the linear layers need the parallel groups to exist."""
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+        model_parallel_is_initialized,
+    )
+
+    if model_parallel_is_initialized():
+        return
+    # A free port, not a fixed one: CI may run several test files in parallel
+    # on the same host.
+    port = int(os.environ.get("SGLANG_TEST_MASTER_PORT") or _free_port())
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", str(port))
+    os.environ.setdefault("no_proxy", "127.0.0.1,localhost")
+    init_distributed_environment(
+        world_size=1,
+        rank=0,
+        local_rank=0,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="gloo",
+    )
+    initialize_model_parallel(tensor_model_parallel_size=1)
+
+
+class _StubMMConfig:
+    mm_attention_backend = "sdpa"
+    mm_enable_dp_encoder = False
+
+
+def _build_model(quant_config):
+    """Build the real vision tower through Gemma4ForConditionalGeneration.
+
+    The text model is stubbed out: it needs kernels that are not available on
+    CPU and it is not what these tests are about. Everything on the vision path
+    is the real thing.
+    """
+    with mock.patch.object(
+        CompressedTensorsConfig, "_check_scheme_supported", return_value=True
+    ), mock.patch.object(
+        gemma4_vision, "get_mm", lambda: _StubMMConfig()
+    ), mock.patch.object(
+        gemma4_mm, "Gemma4TextModel"
+    ), mock.patch.object(
+        gemma4_mm, "LogitsProcessor"
+    ), mock.patch.object(
+        Gemma4ForConditionalGeneration, "post_init"
+    ):
+        model = Gemma4ForConditionalGeneration(
+            config=_gemma4_config(), quant_config=quant_config, prefix=""
+        )
+        return model, gemma4_mm.Gemma4TextModel
+
+
+def _build_vision_tower(quant_config):
+    return _build_model(quant_config)[0].vision_tower
+
+
+def _linear_methods(module):
+    return {
+        name: type(layer.quant_method).__name__
+        for name, layer in module.named_modules()
+        if isinstance(layer, LinearBase)
+    }
+
+
+class TestGemma4TowerQuantization(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        _init_single_rank_cpu_parallelism()
+
+    def test_vision_tower_is_unquantized_under_w4a16(self):
+        quant_config = CompressedTensorsConfig.from_config(W4A16_QUANT_CONFIG)
+        tower = _build_vision_tower(quant_config)
+
+        methods = _linear_methods(tower)
+        self.assertTrue(methods, "no linear layers found in the vision tower")
+        quantized = {
+            name: method
+            for name, method in methods.items()
+            if method != UnquantizedLinearMethod.__name__
+        }
+        self.assertEqual(
+            quantized,
+            {},
+            "vision-tower linears must not be quantized",
+        )
+
+    def test_fused_gate_up_proj_is_the_marlin_unfriendly_shape(self):
+        # Pins why this matters: the layer that used to reach gptq_marlin_repack
+        # is 8608 wide, which is not divisible by Marlin's min_thread_n = 64.
+        tower = _build_vision_tower(None)
+        gate_up = tower.encoder.layers[0].mlp.gate_up.gate_up_proj
+        self.assertEqual(gate_up.output_size, 2 * VISION_INTERMEDIATE_SIZE)
+        self.assertEqual(gate_up.output_size % 64, 32)
+
+    def test_other_quant_methods_are_passed_through(self):
+        # Only compressed-tensors is dropped. Anything else keeps whatever
+        # behaviour it had; we have no checkpoint evidence to de-quantize it.
+        other = object()
+        self.assertIs(
+            Gemma4ForConditionalGeneration._vision_tower_quant_config(other), other
+        )
+        self.assertIsNone(
+            Gemma4ForConditionalGeneration._vision_tower_quant_config(None)
+        )
+
+    def test_language_model_still_gets_the_quant_config(self):
+        quant_config = CompressedTensorsConfig.from_config(W4A16_QUANT_CONFIG)
+        _, text_model_cls = _build_model(quant_config)
+
+        args, _ = text_model_cls.call_args
+        self.assertIs(args[1], quant_config)
+
+    def test_ignore_list_alone_does_not_save_the_tower(self):
+        # Negative control for the fix: the checkpoint's ignore entries do not
+        # match SGLang's module names, so passing the quant config down would
+        # quantize the tower. This is the behaviour the fix routes around.
+        from sglang.srt.layers.quantization.compressed_tensors.utils import (
+            should_ignore_layer,
+        )
+
+        packed = Gemma4ForConditionalGeneration.packed_modules_mapping
+        self.assertFalse(
+            should_ignore_layer(
+                "model.vision_tower.encoder.layers.0.mlp.gate_up_proj",
+                ignore=IGNORE,
+                fused_mapping=packed,
+            )
+        )
+        # ... while an entry without the clip wrapper does match.
+        self.assertTrue(
+            should_ignore_layer(
+                "model.embed_vision.embedding_projection",
+                ignore=IGNORE,
+                fused_mapping=packed,
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What

Addresses the Marlin shape-selection failure reported in #28018.

`google/gemma-4-31B-it-qat-w4a16-ct` ignores every vision-tower linear, but its clip
wrapper makes those `ignore` entries end in `.linear`. SGLang keeps that suffix on the
unfused clippable linears; the fused `qkv_proj` / `gate_up_proj` do not, so those two per
block miss the match and get quantized. `gate_up_proj` is `2 * 4304 = 8608`, not divisible
by Marlin's `min_thread_n = 64`, so load dies in `gptq_marlin_repack`.

So drop the compressed-tensors config for the vision tower, with a `warning_once`. Other
quant methods are untouched: the NVFP4 checkpoint already excludes `model.vision_tower*`
by glob, and I have nothing justifying de-quantizing online fp8/awq/gptq.

Second point: `CompressedTensorsWNA16` and `GPTQMarlinLinearKernel` both dropped the
return value of `check_marlin_supports_shape`, which never raises, so bad shapes hit the
kernel instead of the actionable `min_thread_n = 64` error. Both now use
`verify_marlin_supports_shape`, like `awq_marlin`. I left the repack kernel alone.

### Tests

CPU unit tests, each confirmed to fail when its own fix alone is reverted: one builds the
vision-tower modules against a two-layer replica of the checkpoint config and asserts
`UnquantizedLinearMethod`; two assert `n=8608` raises `ValueError` on each Marlin path.

End to end on one GB10, same command both sides: main dies in `gptq_marlin_repack`
(`size_n = 8608` vs `tile_n_size = 64`); patched loads the checkpoint and answers a
request.

Output quality not asserted; TP>1 and image input untested.

Happy to normalize `.linear` generically in compressed-tensors instead, if you prefer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31200478757](https://github.com/sgl-project/sglang/actions/runs/31200478757)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31200478387](https://github.com/sgl-project/sglang/actions/runs/31200478387)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->