### PR TITLE
[diffusion] Enable breakable CUDA graph for SANA (H200 1024px e2e -26%, bit-exact)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -136,7 +136,6 @@ from sglang.multimodal_gen.runtime.utils.torch_compile import (
     maybe_enable_inductor_compute_comm_overlap,
     resolve_torch_compile_mode,
 )
-from sglang.multimodal_gen.utils import dict_to_3d_list
 
 logger = init_logger(__name__)
 
@@ -978,7 +977,6 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
             {
                 # TODO: make sure on-device
                 "encoder_hidden_states_image": image_embeds,
-                "mask_strategy": dict_to_3d_list(None, t_max=50, l_max=60, h_max=24),
             },
         )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising_dmd.py
@@ -20,7 +20,6 @@ from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.precision import (
     autocast_context as precision_autocast_context,
 )
-from sglang.multimodal_gen.utils import dict_to_3d_list
 
 logger = init_logger(__name__)
 
@@ -91,7 +90,6 @@ class DmdDenoisingStage(DenoisingStage):
             self.transformer.forward,
             {
                 "encoder_hidden_states_image": image_embeds,
-                "mask_strategy": dict_to_3d_list(None, t_max=50, l_max=60, h_max=24),
             },
         )
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -133,6 +133,8 @@ DEFAULT_BCG_TEXT_BUCKETS = (64, 128, 256, 512, 1024)
 BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
     {
         "comfy-org/ideogram-4",
+        "efficient-large-model/sana1.5_1.6b_1024px_diffusers",
+        "sana1.5_1.6b_1024px_diffusers",
         "fal/ideogram-v4-fast",
         "fal/ideogram-v4-instant",
         "glm-image",
@@ -166,6 +168,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS = frozenset(
         "LTX2PipelineConfig",
         "MiniMaxH3PipelineConfig",
         "QwenImagePipelineConfig",
+        "SanaPipelineConfig",
         "ZImagePipelineConfig",
     }
 )
@@ -560,7 +563,7 @@ class ServerArgs(DisaggServerArgsMixin):
 
         logger.warning(
             "[Diffusion BCG] disabled for %s: only Ideogram-4, Lightricks/LTX-2, MiniMax-H3, "
-            "Qwen/Qwen-Image, Qwen/Qwen-Image-2512, "
+            "Qwen/Qwen-Image, Qwen/Qwen-Image-2512, SANA1.5, "
             "Tongyi-MAI/Z-Image/Z-Image-Turbo, and zai-org/GLM-Image are "
             "currently supported.",
             pipeline_config_name,


### PR DESCRIPTION
## Motivation

SANA1.5-1.6B at 1024x1024 is the most launch/CPU-bound model in the diffusion tree: a
steady eager denoise step issues ~2,000 CUDA kernels and keeps the GPU only ~30% busy
(torch.profiler, H200; ~23.4 ms GPU busy inside a ~80 ms profiled step window). This is
exactly the workload breakable CUDA graph (BCG, #27436) was built for, and the same
situation LTX-2 was in before #33885. `--enable-breakable-cuda-graph` currently
silently no-ops for SANA.

Two gaps blocked BCG on SANA:

1. **Allowlist** (`server_args.py`): `SanaPipelineConfig` / the SANA1.5 model id were
   not on `BREAKABLE_CUDA_GRAPH_SUPPORTED_{PIPELINE_CONFIGS,MODEL_IDS}`, so the flag was
   silently dropped.
2. **Dead `mask_strategy` payload poisons the BCG signature path**
   (`denoising.py` / `denoising_dmd.py`): `predict_noise` builds
   `dict_to_3d_list(None, t_max=50, l_max=60, h_max=24)` — a 72,000-element nested list
   of `None` — on **every DiT forward** and passes it as a `mask_strategy` kwarg.
   No in-tree DiT consumes this kwarg (grep over `runtime/models/dits/` finds zero
   consumers; the sliding-tile attention backend loads its mask strategy from
   `mask_strategy_file_path` on its own). The 15 DiT classes whose `forward` takes
   `**kwargs` (SANA, Wan, HunyuanVideo, LTX-2, Z-Image, ERNIE, Krea2, Helios, ...)
   silently swallow it. Building the list costs ~1.1 ms CPU per call in eager mode, and
   under BCG the runner's signature/flatten pass walks all 72k leaves on every call,
   which made BCG replay *slower* than eager (denoise 2.63 s vs 0.67 s). This PR removes
   the payload.

With both fixed, warmup captures one graph per text bucket (5 buckets, **1 segment
each** — SANA's linear-attention forward is fully capturable, no attention break
points) and serving replays with zero signature misses.

## Benchmark

H200, `Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers`, 1024x1024, default 20
steps, seed 42, eager (`--enable-torch-compile=false`, production default), single GPU.
9 back-to-back requests in one warmed process, drop-first median (protocol of #33885):

| arm | wall / req | e2e (total_duration) | denoise |
|---|---|---|---|
| eager (main 5ca734fc3d) | 1.028 s | 0.821 s | 699.2 ms |
| eager + dead-payload removal | ~1.03 s (noise band) | — | 685.1 ms (-2.0%) |
| **eager + BCG (this PR)** | **0.781 s (-24.0%)** | **0.608 s (-25.9%)** | **408.1 ms (-41.6%)** |

Reproduce:

```bash
sglang generate --backend=sglang \
  --model-path=Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
  --prompt="A cup of coffee on a wooden table in a sunlit cafe" \
  --width=1024 --height=1024 --seed=42 --num-gpus=1 \
  --enable-torch-compile=false --warmup-mode request \
  --enable-breakable-cuda-graph --warmup-resolutions 1024x1024 --save-output
```

## Serving mode: prompt-length matrix (does a different prompt length re-capture?)

**No — capture happens only at warmup; serving never captures.** SANA encodes prompts
with Gemma2 at variable length (tokenizer cap 300); warmup captures **one graph per text
bucket** (default buckets 64/128/256/512/1024, `1 segment, 5 tensor inputs` each) and
serving pads each prompt up to the nearest bucket and replays. Since the tokenizer cap
(300) is below the largest default bucket (1024), the over-bucket fallback is unreachable
in the default config.

Real HTTP server (`serve` entrypoint, `POST /v1/images/generations`), H200 x1, 1024x1024,
20 steps, seed 42, 4 requests/tier, medians:

| prompt tier | eager denoise (s) | BCG denoise (s) | delta | capture evidence |
|---|---|---|---|---|
| short (5 words, ~7 tok) | 0.663 | 0.395 | **-40.4%** | pads to bucket 64 -> replay |
| medium (33 words, ~45 tok) | 0.684 | 0.394 | **-42.3%** | pads to bucket 64 -> replay |
| long (126 words, 152 tok) | 0.657 | 0.404 | **-38.5%** | pads to bucket 256 -> replay |
| xlong (281 words, 300-tok cap) | 0.651 | 0.420 | **-35.5%** | pads to bucket 512 -> replay |

Server-log evidence: exactly 5 graphs captured, all before "The server is fired up";
serving-phase captures = **0** after 16 requests; misses/warnings = **0**; all 16 BCG
images **md5-identical** to the eager server's (same seed).

Fallback path exercised explicitly with `--bcg-text-buckets 64 128` (max bucket below the
152/300-token prompts): those prompts log
`[Diffusion BCG] text length 152 exceeds max bucket 128; not padding ... Raise --bcg-text-buckets.`
once per forward and run eager — still **0 serving captures** and still md5-identical
(the negative CFG branch, ~40 tok, keeps replaying bucket 64, so the tier lands between
full-replay and full-eager: 0.48 s vs 0.39/0.66 s).

Profiler comparison (5 profiled timesteps; eager span is inflated by profiler overhead —
steady-state numbers are in the table):

![sana serving profiler](https://github.com/BBuf/sglang/releases/download/assets-bcg-serving/sana_bcg_vs_eager_timeline.png)

eager: GPU busy 28.5%, 8,412 runtime launches; BCG: GPU busy 93.3%, 132 launches.

<details>
<summary>Serving commands</summary>

```bash
# server (eager arm; BCG arm adds --enable-breakable-cuda-graph;
# fallback demo adds --bcg-text-buckets 64 128)
python3 -m sglang.multimodal_gen.runtime.entrypoints.cli.main serve \
  --model-path Efficient-Large-Model/SANA1.5_1.6B_1024px_diffusers \
  --num-gpus 1 --host 127.0.0.1 --port 31100 --warmup-resolutions 1024x1024

# client: POST /v1/images/generations {"prompt", "size": "1024x1024", "seed": 42};
# 4 prompt tiers x 4 requests (5 / 33 / 126 / 281 words)
```
</details>

## Correctness

- **Bit-exact**: all 27 outputs (9 requests x 3 arms: main-eager / fixed-eager / BCG)
  share a single md5 (`0e0b6e045e0abdcf...`). BCG replays the captured eager kernel
  stream, and the payload removal deletes a value nothing reads.
- **No silent fallback**: 5 captured signatures, `[Diffusion BCG] ... MISSED` count = 0
  over all serving requests.
- **Unit tests**: `test_diffusion_bcg_padding.py` + `test_cfg_parallel_warmup.py`
  (55 passed).

## Profiler evidence

| | eager | BCG |
|---|---|---|
| GPU busy in steady step | ~26-33% | **~94%** |
| step wall (profiled) | ~80 ms | ~4.5 ms (replay-issue steps) |
| CUDA kernels / step | ~2,017 | same kernels, replayed as graphs |

(3-step torch.profiler windows per arm, same analysis pipeline as #33885.)

## Notes

- The dead-payload removal also shaves ~1.1 ms CPU per `predict_noise` call from every
  eager model that goes through the generic denoising stage (visible as denoise
  699.2 -> 685.1 ms on SANA; within noise on GPU-bound models), and shrinks the BCG
  signature key for every current and future BCG model.
- Only the validated SANA1.5-1.6B id is added to the model allowlist, mirroring how
  #33885 added only `Lightricks/LTX-2`.
- `mask_strategy` plumbing for the sliding-tile-attention backend is untouched: the
  backend reads `attention_backend_config.mask_strategy_file_path` itself
  (`sliding_tile_attn.py:123-132`).

## Benchmark configuration

All numbers are eager mode (`--enable-torch-compile=false`), the production default
path; BCG composes with eager (it captures the eager stream). Driver: 9 back-to-back
`DiffGenerator.generate` calls in one warmed process with per-request perf dumps,
same protocol as #33885 (reproduce command above).


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31188139541](https://github.com/sgl-project/sglang/actions/runs/31188139541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31188139159](https://github.com/sgl-project/sglang/actions/runs/31188139159)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
