### PR TITLE
[Fix] Normalize array function call outputs in Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -929,10 +929,18 @@ class OpenAIServingResponses(OpenAIServingChat):
                 ],
             }
         if msg_type == "function_call_output":
+            output = message.get("output", "")
+            if isinstance(output, list):
+                output = [
+                    cls._normalize_response_content_part_for_chat(part)
+                    for part in output
+                ]
+            else:
+                output = cls._normalize_response_content_part_for_chat(output)
             return {
                 "role": "tool",
                 "tool_call_id": message.get("call_id"),
-                "content": message.get("output", ""),
+                "content": output,
             }
         # Reasoning items render as {role: assistant, reasoning_content};
         # empty ones drop instead of injecting an empty assistant block.

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -118,6 +118,39 @@ class InputMessageConstructionTestCase(unittest.TestCase):
             ],
         )
 
+    def test_function_call_output_parts_normalized_for_chat_templates(self):
+        serving = make_serving()
+        request = ResponsesRequest(
+            model="x",
+            input=[
+                {
+                    "type": "function_call_output",
+                    "call_id": "call_abc",
+                    "output": [
+                        {"type": "input_text", "text": "First result"},
+                        {"type": "input_text", "text": "Second result"},
+                    ],
+                }
+            ],
+            store=False,
+        )
+
+        messages = serving._construct_input_messages(request)
+
+        self.assertEqual(
+            messages,
+            [
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_abc",
+                    "content": [
+                        {"type": "text", "text": "First result"},
+                        {"type": "text", "text": "Second result"},
+                    ],
+                }
+            ],
+        )
+
     def test_previous_response_id_input_list_does_not_call_copy_module(self):
         serving = make_serving()
         serving.use_harmony = True


### PR DESCRIPTION
## Summary

- normalize each content part when `function_call_output.output` is a list
- preserve the existing scalar output behavior
- add regression coverage through the full `ResponsesRequest` to chat-message conversion path

## Why

The Responses API accepts function call output as a list of content parts. SGLang previously forwarded that list without converting Responses content types such as `input_text` into their chat-completions equivalents. The resulting tool message failed downstream validation with HTTP 400.

Fixes #33867


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31179418165](https://github.com/sgl-project/sglang/actions/runs/31179418165)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31179417996](https://github.com/sgl-project/sglang/actions/runs/31179417996)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->