### PR TITLE
feat(diffusion): add MiniMax H3 AdaLN cache

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -195,6 +195,7 @@ the cache stores the BF16 outputs of the original AdaLN linears.
 python -m sglang.multimodal_gen.tools.build_minimax_h3_adaln_cache \
   --transformer-path "$TRANSFORMER_PATH" \
   --model-variant fl2va \
+  --mode t2va \
   --num-inference-steps 50 \
   --flow-shift 12 \
   --audio-flow-shift 3 \
@@ -213,9 +214,10 @@ sglang serve \
 `$TRANSFORMER_PATH` is the `FL2VA/transformer` or `Ref2VA/transformer`
 directory in the normal SGLang/Hugging Face snapshot; the builder never
 downloads a second copy. A cache only covers the scheduler settings used to
-create it, including its step count, flow shifts, and condition noise values.
-SGLang rejects a request outside that coverage instead of silently changing
-conditioning. Cache mode supports the matching unquantized checkpoint only.
+create it, including its mode, step count, flow shifts, and condition noise
+values. SGLang rejects a request outside that coverage instead of silently
+changing conditioning. Cache mode supports the matching unquantized checkpoint
+only.
 
 ## 4. Generate video and audio
 

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -173,6 +173,50 @@ server environment.
 
 For MiniMax-H3, `--performance-mode speed` deliberately keeps the DiT eager. The current `torch.compile` path changes the model's numerical output, so it is not enabled implicitly by any recommended lossless preset. An explicit `--enable-torch-compile true` remains available for controlled experiments, but it should not be used to generate consistency ground truth.
 
+### Advanced: precomputed AdaLN cache
+
+The [model card](https://huggingface.co/MiniMaxAI/MiniMax-H3) notes that about
+13B H3 parameters are AdaLN branches whose outputs can be precomputed for
+inference. The public base checkpoint contains the original branches, not a
+ready-to-use cache. SGLang therefore keeps the standard path as the default.
+
+<Warning>
+This is an experimental deployment path. It is intentionally disabled unless
+you provide an explicitly generated cache; end-to-end numerical and peak-memory
+validation remains required before using it in production.
+</Warning>
+
+When an inference-only deployment has a fixed sampling schedule, build a cache
+from the already materialized transformer directory on CUDA, then pass it to
+the usual `sglang serve` command. This does not alter the denoising formula:
+the cache stores the BF16 outputs of the original AdaLN linears.
+
+```bash Command
+python -m sglang.multimodal_gen.tools.build_minimax_h3_adaln_cache \
+  --transformer-path "$TRANSFORMER_PATH" \
+  --model-variant fl2va \
+  --num-inference-steps 50 \
+  --flow-shift 12 \
+  --audio-flow-shift 3 \
+  --output /models/minimax-h3-fl2va-adaln-50step.safetensors
+
+sglang serve \
+  --model-path MiniMaxAI/MiniMax-H3 \
+  --model-variant fl2va \
+  --minimax-h3-adaln-cache-path /models/minimax-h3-fl2va-adaln-50step.safetensors \
+  --num-gpus 4 \
+  --tp-size 2 \
+  --ulysses-degree 2 \
+  --port 30010
+```
+
+`$TRANSFORMER_PATH` is the `FL2VA/transformer` or `Ref2VA/transformer`
+directory in the normal SGLang/Hugging Face snapshot; the builder never
+downloads a second copy. A cache only covers the scheduler settings used to
+create it, including its step count, flow shifts, and condition noise values.
+SGLang rejects a request outside that coverage instead of silently changing
+conditioning. Cache mode supports the matching unquantized checkpoint only.
+
 ## 4. Generate video and audio
 
 MiniMax-H3 uses the asynchronous OpenAI-compatible video endpoint. Choose a

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -76,6 +76,7 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 
 - `--model-path {MODEL}`: model path or Hugging Face model ID
 - `--model-variant {NAME}`: semantic checkpoint variant to load when one model repository contains multiple weight partitions. The pipeline maps this stable name to the repository layout before loading; for example, MiniMax-H3 accepts `fl2va` and `ref2va`. This is a server/load-time choice, unlike a request's `task`.
+- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose BF16 timestep embeddings are included in the cache. It requires unquantized weights and the matching model variant.
 - `--model-subfolder {PATH}`: advanced direct override for a component subfolder inside the model repository. Prefer `--model-variant` when the pipeline exposes semantic routing. If both are supplied, they must resolve to the same weight partition.
 - `--lora-path {PATH}` and `--lora-nickname {NAME}`: load a LoRA adapter
 - `--lora-merge-mode {auto|merge|dynamic}`: choose how LoRA is applied. `auto` statically merges regular weights and uses dynamic LoRA for FSDP-sharded weights to avoid full-gather peaks.

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -76,7 +76,7 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 
 - `--model-path {MODEL}`: model path or Hugging Face model ID
 - `--model-variant {NAME}`: semantic checkpoint variant to load when one model repository contains multiple weight partitions. The pipeline maps this stable name to the repository layout before loading; for example, MiniMax-H3 accepts `fl2va` and `ref2va`. This is a server/load-time choice, unlike a request's `task`.
-- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose BF16 timestep embeddings are included in the cache. It requires unquantized weights and the matching model variant.
+- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose exact FP32 timestep plan is included in the cache. It requires unquantized weights and the matching model variant.
 - `--model-subfolder {PATH}`: advanced direct override for a component subfolder inside the model repository. Prefer `--model-variant` when the pipeline exposes semantic routing. If both are supplied, they must resolve to the same weight partition.
 - `--lora-path {PATH}` and `--lora-nickname {NAME}`: load a LoRA adapter
 - `--lora-merge-mode {auto|merge|dynamic}`: choose how LoRA is applied. `auto` statically merges regular weights and uses dynamic LoRA for FSDP-sharded weights to avoid full-gather peaks.

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any
 
@@ -37,6 +38,10 @@ from sglang.srt.utils import is_npu
 _is_npu = is_npu()
 
 logger = init_logger(__name__)
+
+
+def _minimax_h3_adaln_cache_key_filter(name: str) -> bool:
+    return ".adaln_proj.linear." not in name
 
 
 def _default_quantized_attention_backend(
@@ -187,6 +192,22 @@ class TransformerLoader(ComponentLoader):
             "hf_config": config,
             "quant_config": quant_spec.runtime_quant_config,
         }
+        checkpoint_key_filter: Callable[[str], bool] | None = None
+        adaln_cache_path = component_server_args.minimax_h3_adaln_cache_path
+        if adaln_cache_path is not None:
+            if cls_name != "MiniMaxH3DiTModel":
+                raise ValueError(
+                    "--minimax-h3-adaln-cache-path is only supported by MiniMax H3"
+                )
+            if component_server_args.model_variant not in ("fl2va", "ref2va"):
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache requires --model-variant fl2va or ref2va"
+                )
+            init_params["adaln_cache_path"] = adaln_cache_path
+            init_params["adaln_cache_model_variant"] = (
+                component_server_args.model_variant
+            )
+            checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
         if (
             init_params["quant_config"] is None
             and component_server_args.transformer_weights_path is not None
@@ -238,6 +259,7 @@ class TransformerLoader(ComponentLoader):
                 output_dtype=None,
                 strict=False,
                 weight_load_plan=weight_load_plan,
+                checkpoint_key_filter=checkpoint_key_filter,
             )
 
         # post-hooks (e.g., patch scales (nunchaku))

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -178,6 +178,7 @@ def maybe_load_fsdp_model(
     pin_cpu_memory: bool = True,
     strict: bool = True,
     weight_load_plan: WeightLoadPlan | None = None,
+    checkpoint_key_filter: Callable[[str], bool] | None = None,
 ) -> torch.nn.Module:
     """Load a model with optional FSDP (Fully Sharded Data Parallel) support.
 
@@ -285,6 +286,7 @@ def maybe_load_fsdp_model(
         use_fsdp
         and weight_dir_list
         and preprocess_loaded_state_dict is None
+        and checkpoint_key_filter is None
         and not is_bnb_quantized
     ):
         preconverted_state_dict = (
@@ -298,6 +300,7 @@ def maybe_load_fsdp_model(
         not use_fsdp
         and weight_dir_list
         and preprocess_loaded_state_dict is None
+        and checkpoint_key_filter is None
         and not is_bnb_quantized
     ):
         preconverted_state_dict = (
@@ -309,7 +312,10 @@ def maybe_load_fsdp_model(
         )
 
     if preconverted_state_dict is None:
-        weight_iterator = safetensors_weights_iterator(weight_dir_list)
+        weight_iterator = safetensors_weights_iterator(
+            weight_dir_list,
+            key_filter=checkpoint_key_filter,
+        )
         if preprocess_loaded_state_dict is not None:
             weight_iterator = preprocess_loaded_state_dict(weight_iterator)
         if is_bnb_quantized:

--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -191,6 +191,10 @@ def safetensors_weights_iterator(
         use_runai_model_streamer = (
             HAS_RUNAI_MODEL_STREAMER and envs.SGLANG_USE_RUNAI_MODEL_STREAMER
         )
+    if key_filter is not None:
+        # streamer filters after materializing all tensors, so it cannot skip
+        # a checkpoint partition at load time
+        use_runai_model_streamer = False
 
     # Validate files before loading
     corrupted_files, duplicate_files_by_key = _scan_safetensors_files(hf_weights_files)

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -790,10 +790,11 @@ class MiniMaxH3AdalnProj(nn.Module):
 
 
 class MiniMaxH3AdalnCache(nn.Module):
-    """Precomputed AdaLN outputs for a fixed set of BF16 timestep embeddings."""
+    """Precomputed AdaLN outputs for fixed FP32 timestep plans."""
 
-    _FORMAT_VERSION = "1"
-    adaln_inputs: torch.Tensor
+    _FORMAT_VERSION = "2"
+    plan_timesteps: torch.Tensor
+    plan_lengths: torch.Tensor
     block_params: torch.Tensor
     final_params: torch.Tensor
 
@@ -809,7 +810,6 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.model_variant = model_variant
         self.num_layers = arch.num_layers
         self.hidden_size = arch.hidden_size
-        self.time_embed_dim = arch.time_embed_dim
 
     def load(self, device: torch.device) -> None:
         if not os.path.isfile(self.path):
@@ -827,53 +827,68 @@ class MiniMaxH3AdalnCache(nn.Module):
                     "MiniMax H3 AdaLN cache model_variant does not match the loaded "
                     f"variant ({cache_variant!r} != {self.model_variant!r})"
                 )
-            adaln_inputs = cache_file.get_tensor("adaln_inputs")
+            plan_timesteps = cache_file.get_tensor("plan_timesteps")
+            plan_lengths = cache_file.get_tensor("plan_lengths")
             block_params = cache_file.get_tensor("block_params")
             final_params = cache_file.get_tensor("final_params")
 
         expected_block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * self.hidden_size
         expected_final_width = 2 * self.hidden_size
         if (
-            adaln_inputs.dtype != _BF16_DTYPE
-            or adaln_inputs.ndim != 2
-            or adaln_inputs.shape[1] != self.time_embed_dim
+            plan_timesteps.dtype != _FP32_DTYPE
+            or plan_timesteps.ndim != 2
+            or plan_lengths.dtype != torch.int64
+            or plan_lengths.shape != (plan_timesteps.shape[0],)
+            or (plan_lengths < 1).any()
+            or (plan_lengths > plan_timesteps.shape[1]).any()
         ):
-            raise ValueError("MiniMax H3 AdaLN cache has invalid adaln_inputs")
+            raise ValueError("MiniMax H3 AdaLN cache has invalid timestep plans")
         if block_params.dtype != _BF16_DTYPE or block_params.shape != (
-            adaln_inputs.shape[0],
+            plan_timesteps.shape[0],
+            plan_timesteps.shape[1],
             self.num_layers,
             expected_block_width,
         ):
             raise ValueError("MiniMax H3 AdaLN cache has invalid block_params")
         if final_params.dtype != _BF16_DTYPE or final_params.shape != (
-            adaln_inputs.shape[0],
+            plan_timesteps.shape[0],
+            plan_timesteps.shape[1],
             expected_final_width,
         ):
             raise ValueError("MiniMax H3 AdaLN cache has invalid final_params")
 
-        self.register_buffer("adaln_inputs", adaln_inputs.to(device))
+        self.register_buffer("plan_timesteps", plan_timesteps.to(device))
+        self.register_buffer("plan_lengths", plan_lengths.to(device))
         self.register_buffer("block_params", block_params.to(device))
         self.register_buffer("final_params", final_params.to(device))
 
-    def lookup(self, adaln_input: torch.Tensor) -> torch.Tensor:
-        matches = (
-            self.adaln_inputs.unsqueeze(0).eq(adaln_input.unsqueeze(1)).all(dim=-1)
-        )
-        if not bool(matches.any(dim=1).all()):
+    def lookup(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
+        num_timesteps = unique_timesteps.shape[0]
+        matches = self.plan_lengths.eq(num_timesteps) & self.plan_timesteps[
+            :, :num_timesteps
+        ].eq(unique_timesteps).all(dim=-1)
+        if not bool(matches.any()):
             raise ValueError(
-                "MiniMax H3 AdaLN cache does not cover the request timestep embedding"
+                "MiniMax H3 AdaLN cache does not cover the request timestep plan"
             )
-        return matches.to(torch.int64).argmax(dim=1)
+        return matches.to(torch.int64).argmax()
 
     def block(
-        self, index: int, cache_indices: torch.Tensor
+        self,
+        index: int,
+        cache_plan_index: torch.Tensor,
+        num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
-        params = self.block_params.index_select(0, cache_indices)[:, index]
+        params = self.block_params[cache_plan_index, :num_timesteps, index]
         params = params.view(-1, 6, self.hidden_size)
         return tuple(params.unbind(dim=1))
 
-    def final(self, cache_indices: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        params = self.final_params.index_select(0, cache_indices)
+    def final(
+        self,
+        cache_plan_index: torch.Tensor,
+        num_timesteps: int,
+    ) -> tuple[torch.Tensor, ...]:
+        params = self.final_params[cache_plan_index, :num_timesteps]
         return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
 
 
@@ -1740,11 +1755,17 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         hidden = decoder_input
         cu_seqlens = cu_seqlens.to(device)
         block_adaln_params = None
-        adaln_cache_indices = None
+        adaln_cache_plan_index = None
         if self.adaln_cache is not None:
-            adaln_cache_indices = self.adaln_cache.lookup(adaln_input)
+            adaln_cache_plan_index = self.adaln_cache.lookup(
+                unique_timesteps.view(-1).to(device)
+            )
             block_adaln_params = tuple(
-                self.adaln_cache.block(index, adaln_cache_indices)
+                self.adaln_cache.block(
+                    index,
+                    adaln_cache_plan_index,
+                    adaln_input.shape[0],
+                )
                 for index in range(len(self.blocks))
             )
         elif self._can_batch_block_adaln():
@@ -1779,8 +1800,11 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             inverse_indices=block_inverse,
             adaln_params=(
                 None
-                if adaln_cache_indices is None
-                else self.adaln_cache.final(adaln_cache_indices)
+                if adaln_cache_plan_index is None
+                else self.adaln_cache.final(
+                    adaln_cache_plan_index,
+                    adaln_input.shape[0],
+                )
             ),
         )
         if sp_ws > 1:

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -880,7 +880,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
         params = self.block_params[cache_plan_index, :num_timesteps, index]
-        params = params.view(-1, 6, self.hidden_size)
+        params = params.reshape(-1, 6, self.hidden_size)
         return tuple(params.unbind(dim=1))
 
     def final(
@@ -889,7 +889,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
         params = self.final_params[cache_plan_index, :num_timesteps]
-        return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
+        return tuple(params.reshape(-1, 2, self.hidden_size).unbind(dim=1))
 
 
 class MiniMaxH3TokenRefinerBlock(nn.Module):

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -8,10 +8,12 @@ contract accepts packed inference keyword arguments and returns packed logits.
 from __future__ import annotations
 
 import math
+import os
 from typing import Any
 
 import torch
 import torch.nn as nn
+from safetensors.torch import safe_open
 
 from sglang.kernels.ops.activation.activation import (
     silu_and_mul_with_activation_rounding_,
@@ -787,6 +789,94 @@ class MiniMaxH3AdalnProj(nn.Module):
         return self.split_output(x)
 
 
+class MiniMaxH3AdalnCache(nn.Module):
+    """Precomputed AdaLN outputs for a fixed set of BF16 timestep embeddings."""
+
+    _FORMAT_VERSION = "1"
+    adaln_inputs: torch.Tensor
+    block_params: torch.Tensor
+    final_params: torch.Tensor
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        path: str,
+        model_variant: str | None,
+    ) -> None:
+        super().__init__()
+        self.path = path
+        self.model_variant = model_variant
+        self.num_layers = arch.num_layers
+        self.hidden_size = arch.hidden_size
+        self.time_embed_dim = arch.time_embed_dim
+
+    def load(self, device: torch.device) -> None:
+        if not os.path.isfile(self.path):
+            raise ValueError(f"MiniMax H3 AdaLN cache does not exist: {self.path}")
+
+        with safe_open(self.path, framework="pt", device="cpu") as cache_file:
+            metadata = cache_file.metadata() or {}
+            if metadata.get("format_version") != self._FORMAT_VERSION:
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache has an unsupported or missing format_version"
+                )
+            cache_variant = metadata.get("model_variant")
+            if self.model_variant is not None and cache_variant != self.model_variant:
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache model_variant does not match the loaded "
+                    f"variant ({cache_variant!r} != {self.model_variant!r})"
+                )
+            adaln_inputs = cache_file.get_tensor("adaln_inputs")
+            block_params = cache_file.get_tensor("block_params")
+            final_params = cache_file.get_tensor("final_params")
+
+        expected_block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * self.hidden_size
+        expected_final_width = 2 * self.hidden_size
+        if (
+            adaln_inputs.dtype != _BF16_DTYPE
+            or adaln_inputs.ndim != 2
+            or adaln_inputs.shape[1] != self.time_embed_dim
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid adaln_inputs")
+        if block_params.dtype != _BF16_DTYPE or block_params.shape != (
+            adaln_inputs.shape[0],
+            self.num_layers,
+            expected_block_width,
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid block_params")
+        if final_params.dtype != _BF16_DTYPE or final_params.shape != (
+            adaln_inputs.shape[0],
+            expected_final_width,
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid final_params")
+
+        self.register_buffer("adaln_inputs", adaln_inputs.to(device))
+        self.register_buffer("block_params", block_params.to(device))
+        self.register_buffer("final_params", final_params.to(device))
+
+    def lookup(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        matches = (
+            self.adaln_inputs.unsqueeze(0).eq(adaln_input.unsqueeze(1)).all(dim=-1)
+        )
+        if not bool(matches.any(dim=1).all()):
+            raise ValueError(
+                "MiniMax H3 AdaLN cache does not cover the request timestep embedding"
+            )
+        return matches.to(torch.int64).argmax(dim=1)
+
+    def block(
+        self, index: int, cache_indices: torch.Tensor
+    ) -> tuple[torch.Tensor, ...]:
+        params = self.block_params.index_select(0, cache_indices)[:, index]
+        params = params.view(-1, 6, self.hidden_size)
+        return tuple(params.unbind(dim=1))
+
+    def final(self, cache_indices: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        params = self.final_params.index_select(0, cache_indices)
+        return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
+
+
 class MiniMaxH3TokenRefinerBlock(nn.Module):
     """Standard pre-norm transformer block without AdaLN or RoPE."""
 
@@ -875,6 +965,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        use_adaln_cache: bool = False,
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
@@ -885,13 +976,17 @@ class MiniMaxH3DiTBlock(nn.Module):
             prefix=f"{prefix}.attn",
         )
         self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
-        self.adaln_proj = MiniMaxH3AdalnProj(
-            arch,
-            arch.adaln_out_features,
-            quant_config,
-            prefix=f"{prefix}.adaln_proj",
-            expand_ratio=6,
-            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+        self.adaln_proj = (
+            None
+            if use_adaln_cache
+            else MiniMaxH3AdalnProj(
+                arch,
+                arch.adaln_out_features,
+                quant_config,
+                prefix=f"{prefix}.adaln_proj",
+                expand_ratio=6,
+                modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+            )
         )
 
     def forward(
@@ -915,6 +1010,8 @@ class MiniMaxH3DiTBlock(nn.Module):
         norm2 -> scale/shift -> MLP -> gated residual.
         """
         if adaln_params is None:
+            if self.adaln_proj is None:
+                raise ValueError("MiniMax H3 AdaLN cache parameters are required")
             adaln_params = self.adaln_proj(adaln_input)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
 
@@ -951,6 +1048,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        use_adaln_cache: bool = False,
     ) -> None:
         super().__init__()
         video_patch_dim = (
@@ -960,13 +1058,17 @@ class MiniMaxH3FinalLayer(nn.Module):
             * arch.patch_size[2]
         )
         self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
-        self.adaln_proj = MiniMaxH3AdalnProj(
-            arch,
-            arch.final_adaln_out_features,
-            quant_config,
-            prefix=f"{prefix}.adaln_proj",
-            expand_ratio=2,
-            modality_num=1,
+        self.adaln_proj = (
+            None
+            if use_adaln_cache
+            else MiniMaxH3AdalnProj(
+                arch,
+                arch.final_adaln_out_features,
+                quant_config,
+                prefix=f"{prefix}.adaln_proj",
+                expand_ratio=2,
+                modality_num=1,
+            )
         )
         self.video_out = ColumnParallelLinear(
             arch.hidden_size,
@@ -993,6 +1095,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         *,
         adaln_input: torch.Tensor,
         inverse_indices: torch.Tensor,
+        adaln_params: tuple[torch.Tensor, ...] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Project all rows into TP-local video/audio output shards.
 
@@ -1001,7 +1104,11 @@ class MiniMaxH3FinalLayer(nn.Module):
         The model gathers output columns only after selecting live media rows,
         preserving the GEMM shape while reducing collective payload.
         """
-        shift, scale = self.adaln_proj(adaln_input)
+        if adaln_params is None:
+            if self.adaln_proj is None:
+                raise ValueError("MiniMax H3 AdaLN cache parameters are required")
+            adaln_params = self.adaln_proj(adaln_input)
+        shift, scale = adaln_params
         h = self.norm(x)
         h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
         # Preserve full precision through both final output projections.
@@ -1023,7 +1130,8 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
 
     def _can_batch_block_adaln(self) -> bool:
         return (
-            get_tp_world_size() > 1
+            self.adaln_cache is None
+            and get_tp_world_size() > 1
             and not torch.compiler.is_compiling()
             and not envs.SGLANG_CACHE_DIT_ENABLED
             and not hasattr(self, "_sglang_cache_dit_adapter")
@@ -1097,8 +1205,14 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         config: MiniMaxH3DiTConfig,
         hf_config: dict[str, Any],
         quant_config: QuantizationConfig | None = None,
+        adaln_cache_path: str | None = None,
+        adaln_cache_model_variant: str | None = None,
     ) -> None:
         super().__init__(config=config, hf_config=hf_config)
+        if adaln_cache_path is not None and quant_config is not None:
+            raise ValueError(
+                "MiniMax H3 AdaLN cache is only compatible with unquantized weights"
+            )
         arch = config.arch_config
         self.arch = arch
         self.hidden_size = arch.hidden_size
@@ -1160,6 +1274,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
                     arch,
                     quant_config,
                     prefix=f"blocks.{index}",
+                    use_adaln_cache=adaln_cache_path is not None,
                 )
                 for index in range(arch.num_layers)
             ]
@@ -1169,6 +1284,16 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             arch,
             quant_config,
             prefix="final_layer",
+            use_adaln_cache=adaln_cache_path is not None,
+        )
+        self.adaln_cache = (
+            None
+            if adaln_cache_path is None
+            else MiniMaxH3AdalnCache(
+                arch,
+                path=adaln_cache_path,
+                model_variant=adaln_cache_model_variant,
+            )
         )
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()
@@ -1203,6 +1328,8 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             raise ValueError(
                 f"rope.inv_freq must stay fp32 after load, got {rope_inv_freq.dtype}."
             )
+        if self.adaln_cache is not None:
+            self.adaln_cache.load(self.video_patch_proj.weight.device)
 
     @staticmethod
     def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
@@ -1613,7 +1740,14 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         hidden = decoder_input
         cu_seqlens = cu_seqlens.to(device)
         block_adaln_params = None
-        if self._can_batch_block_adaln():
+        adaln_cache_indices = None
+        if self.adaln_cache is not None:
+            adaln_cache_indices = self.adaln_cache.lookup(adaln_input)
+            block_adaln_params = tuple(
+                self.adaln_cache.block(index, adaln_cache_indices)
+                for index in range(len(self.blocks))
+            )
+        elif self._can_batch_block_adaln():
             local_adaln = torch.stack(
                 [block.adaln_proj.project_local(adaln_input) for block in self.blocks]
             )
@@ -1643,6 +1777,11 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             hidden,
             adaln_input=adaln_input,
             inverse_indices=block_inverse,
+            adaln_params=(
+                None
+                if adaln_cache_indices is None
+                else self.adaln_cache.final(adaln_cache_indices)
+            ),
         )
         if sp_ws > 1:
             from sglang.multimodal_gen.runtime.distributed.parallel_state import (

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -266,6 +266,8 @@ class ServerArgs(DisaggServerArgsMixin):
 
     # path to pre-quantized transformer weights (single .safetensors or directory).
     transformer_weights_path: str | None = None
+    # path to precomputed MiniMax H3 AdaLN outputs for inference-only serving.
+    minimax_h3_adaln_cache_path: str | None = None
     # Per-component transformer weight overrides (key = model_index.json component name).
     # Pipelines use this when a checkpoint ships separate quantized weights for
     # secondary DiT components; the generic loader consumes it without model-specific
@@ -1336,6 +1338,16 @@ class ServerArgs(DisaggServerArgsMixin):
                 "Semantic checkpoint variant to serve. Models with partitioned "
                 "checkpoints use this value to select the compatible weights "
                 "without exposing repository subfolder layout."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-cache-path",
+            type=str,
+            default=ServerArgs.minimax_h3_adaln_cache_path,
+            help=(
+                "Path to a precomputed MiniMax H3 AdaLN cache. This only "
+                "supports the matching unquantized H3 checkpoint and rejects "
+                "requests whose timestep embeddings are not present in the cache."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
+    MiniMaxH3DiTArchConfig,
+)
+from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
+    MiniMaxH3AdalnCache,
+)
+
+
+def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
+    arch = MiniMaxH3DiTArchConfig(
+        num_layers=2,
+        hidden_size=4,
+        time_embed_dim=3,
+    )
+    cache_path = tmp_path / "adaln.safetensors"
+    adaln_inputs = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).bfloat16()
+    block_params = (
+        torch.arange(2 * 2 * 72, dtype=torch.float32).reshape(2, 2, 72).bfloat16()
+    )
+    final_params = torch.arange(16, dtype=torch.float32).reshape(2, 8).bfloat16()
+    save_file(
+        {
+            "adaln_inputs": adaln_inputs,
+            "block_params": block_params,
+            "final_params": final_params,
+        },
+        cache_path,
+        metadata={"format_version": "1", "model_variant": "fl2va"},
+    )
+
+    cache = MiniMaxH3AdalnCache(
+        arch,
+        path=str(cache_path),
+        model_variant="fl2va",
+    )
+    cache.load(torch.device("cpu"))
+
+    cache_indices = cache.lookup(adaln_inputs.flip(0))
+    block = cache.block(1, cache_indices)
+    final = cache.final(cache_indices)
+
+    assert torch.equal(torch.cat(block, dim=-1), block_params.flip(0)[:, 1])
+    assert torch.equal(torch.cat(final, dim=-1), final_params.flip(0))

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -18,19 +18,23 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
         time_embed_dim=3,
     )
     cache_path = tmp_path / "adaln.safetensors"
-    adaln_inputs = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).bfloat16()
+    plan_timesteps = torch.tensor([[0.0, 0.0], [1.0, 2.0]])
+    plan_lengths = torch.tensor([1, 2], dtype=torch.int64)
     block_params = (
-        torch.arange(2 * 2 * 72, dtype=torch.float32).reshape(2, 2, 72).bfloat16()
+        torch.arange(2 * 2 * 2 * 72, dtype=torch.float32)
+        .reshape(2, 2, 2, 72)
+        .bfloat16()
     )
-    final_params = torch.arange(16, dtype=torch.float32).reshape(2, 8).bfloat16()
+    final_params = torch.arange(32, dtype=torch.float32).reshape(2, 2, 8).bfloat16()
     save_file(
         {
-            "adaln_inputs": adaln_inputs,
+            "plan_timesteps": plan_timesteps,
+            "plan_lengths": plan_lengths,
             "block_params": block_params,
             "final_params": final_params,
         },
         cache_path,
-        metadata={"format_version": "1", "model_variant": "fl2va"},
+        metadata={"format_version": "2", "model_variant": "fl2va"},
     )
 
     cache = MiniMaxH3AdalnCache(
@@ -40,9 +44,9 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
     )
     cache.load(torch.device("cpu"))
 
-    cache_indices = cache.lookup(adaln_inputs.flip(0))
-    block = cache.block(1, cache_indices)
-    final = cache.final(cache_indices)
+    cache_plan_index = cache.lookup(plan_timesteps[1])
+    block = cache.block(1, cache_plan_index, 2)
+    final = cache.final(cache_plan_index, 2)
 
-    assert torch.equal(torch.cat(block, dim=-1), block_params.flip(0)[:, 1])
-    assert torch.equal(torch.cat(final, dim=-1), final_params.flip(0))
+    assert torch.equal(torch.cat(block, dim=-1), block_params[1, :, 1])
+    assert torch.equal(torch.cat(final, dim=-1), final_params[1])

--- a/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
@@ -23,11 +23,24 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.m
 )
 
 _HIDDEN_SIZE = 5376
-_TIME_EMBED_DIM = 2688
 _TIMESTEP_INPUT_DIM = 256
 _NUM_BLOCKS = 50
 _BLOCK_PARAM_WIDTH = 18 * _HIDDEN_SIZE
 _FINAL_PARAM_WIDTH = 2 * _HIDDEN_SIZE
+_CACHE_MODES = {
+    "t2va": ("video", "audio"),
+    "fl2va": ("video", "audio", "image"),
+    "ref2va-image": ("video", "audio", "image"),
+    "ref2va-audio": ("video", "audio", "audio_ref"),
+    "ref2va-mixed": ("video", "audio", "image", "audio_ref"),
+}
+_MODE_VARIANTS = {
+    "t2va": "fl2va",
+    "fl2va": "fl2va",
+    "ref2va-image": "ref2va",
+    "ref2va-audio": "ref2va",
+    "ref2va-mixed": "ref2va",
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -37,6 +50,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--transformer-path", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--model-variant", choices=("fl2va", "ref2va"), required=True)
+    parser.add_argument("--mode", choices=tuple(_CACHE_MODES), default="t2va")
     parser.add_argument("--num-inference-steps", type=int, default=50)
     parser.add_argument("--flow-shift", type=float, default=12.0)
     parser.add_argument("--audio-flow-shift", type=float, default=3.0)
@@ -54,15 +68,15 @@ def _parse_args() -> argparse.Namespace:
         "--timesteps",
         type=float,
         nargs="+",
-        help="Override the scheduler-derived timestep coverage.",
+        help="Override the scheduler-derived timestep plan.",
     )
     parser.add_argument("--device", default="cuda")
     return parser.parse_args()
 
 
-def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
+def _cache_timestep_plans(args: argparse.Namespace) -> list[torch.Tensor]:
     if args.timesteps is not None:
-        return torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)
+        return [torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)]
 
     video_sigmas = minimax_h3_time_shift_sigmas(
         num_steps=args.num_inference_steps,
@@ -72,19 +86,31 @@ def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
         num_steps=args.num_inference_steps,
         shift_scale=args.audio_flow_shift,
     )
-    candidates = []
+    fields = _CACHE_MODES[args.mode]
+    plans = []
     for video_sigma, audio_sigma in zip(video_sigmas[:-1], audio_sigmas[:-1]):
         video_timestep = 1.0 - video_sigma
         audio_timestep = 1.0 - audio_sigma
-        candidates.extend(
-            (
-                video_timestep,
-                audio_timestep,
-                max(video_timestep, args.imgvid_cond_noise_aug),
-                max(audio_timestep, args.audio_cond_noise_aug),
-            )
+        candidates = {
+            "video": video_timestep,
+            "audio": audio_timestep,
+            "image": max(video_timestep, args.imgvid_cond_noise_aug),
+            "audio_ref": max(audio_timestep, args.audio_cond_noise_aug),
+        }
+        plans.append(
+            torch.tensor(
+                [candidates[field] for field in fields], dtype=torch.float32
+            ).unique(sorted=True)
         )
-    return torch.tensor(candidates, dtype=torch.float32).unique(sorted=True)
+
+    deduplicated = []
+    seen = set()
+    for plan in plans:
+        key = tuple(plan.tolist())
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(plan)
+    return deduplicated
 
 
 def _time_embed(
@@ -125,6 +151,9 @@ def main() -> None:
     args = _parse_args()
     if args.num_inference_steps < 2 and args.timesteps is None:
         raise ValueError("--num-inference-steps must be at least 2")
+    mode_variant = _MODE_VARIANTS[args.mode]
+    if args.model_variant != mode_variant:
+        raise ValueError(f"--mode {args.mode} requires {mode_variant}")
     device = torch.device(args.device)
     if device.type != "cuda" or not torch.cuda.is_available():
         raise ValueError("MiniMax H3 AdaLN cache must be built on CUDA")
@@ -133,17 +162,18 @@ def main() -> None:
     with index_path.open() as f:
         weight_map = json.load(f)["weight_map"]
 
-    timesteps = _cache_timesteps(args)
-    if timesteps.numel() == 0:
-        raise ValueError("AdaLN cache must cover at least one timestep")
-    adaln_inputs = torch.empty(
-        (timesteps.numel(), _TIME_EMBED_DIM), dtype=torch.bfloat16
-    )
+    plans = _cache_timestep_plans(args)
+    if not plans or any(plan.numel() == 0 for plan in plans):
+        raise ValueError("AdaLN cache must cover at least one timestep plan")
+    max_plan_length = max(plan.numel() for plan in plans)
+    plan_timesteps = torch.zeros((len(plans), max_plan_length), dtype=torch.float32)
+    plan_lengths = torch.tensor([plan.numel() for plan in plans], dtype=torch.int64)
     block_params = torch.empty(
-        (timesteps.numel(), _NUM_BLOCKS, _BLOCK_PARAM_WIDTH), dtype=torch.bfloat16
+        (len(plans), max_plan_length, _NUM_BLOCKS, _BLOCK_PARAM_WIDTH),
+        dtype=torch.bfloat16,
     )
     final_params = torch.empty(
-        (timesteps.numel(), _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
+        (len(plans), max_plan_length, _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
     )
 
     with ExitStack() as stack:
@@ -171,60 +201,64 @@ def main() -> None:
                 ("proj_out", "bias"),
             )
         }
-        adaln_input = F.silu(_time_embed(timesteps.to(device), **time_kwargs)).to(
-            torch.bfloat16
-        )
-        adaln_inputs.copy_(adaln_input.cpu())
+        adaln_inputs = []
+        for plan_index, plan in enumerate(plans):
+            plan_length = plan.numel()
+            plan_timesteps[plan_index, :plan_length].copy_(plan)
+            adaln_inputs.append(
+                F.silu(_time_embed(plan.to(device), **time_kwargs)).to(torch.bfloat16)
+            )
 
         for index in range(_NUM_BLOCKS):
             prefix = f"blocks.{index}.adaln_proj.linear"
-            block_params[:, index].copy_(
-                F.linear(
-                    adaln_input,
-                    _load_tensor(
-                        f"{prefix}.weight",
-                        weight_map=weight_map,
-                        files=files,
-                        device=device,
-                    ),
-                    _load_tensor(
-                        f"{prefix}.bias",
-                        weight_map=weight_map,
-                        files=files,
-                        device=device,
-                    ),
-                ).cpu()
+            weight = _load_tensor(
+                f"{prefix}.weight",
+                weight_map=weight_map,
+                files=files,
+                device=device,
             )
+            bias = _load_tensor(
+                f"{prefix}.bias",
+                weight_map=weight_map,
+                files=files,
+                device=device,
+            )
+            for plan_index, adaln_input in enumerate(adaln_inputs):
+                plan_length = adaln_input.shape[0]
+                block_params[plan_index, :plan_length, index].copy_(
+                    F.linear(adaln_input, weight, bias).cpu()
+                )
 
         prefix = "final_layer.adaln_proj.linear"
-        final_params.copy_(
-            F.linear(
-                adaln_input,
-                _load_tensor(
-                    f"{prefix}.weight",
-                    weight_map=weight_map,
-                    files=files,
-                    device=device,
-                ),
-                _load_tensor(
-                    f"{prefix}.bias",
-                    weight_map=weight_map,
-                    files=files,
-                    device=device,
-                ),
-            ).cpu()
+        weight = _load_tensor(
+            f"{prefix}.weight",
+            weight_map=weight_map,
+            files=files,
+            device=device,
         )
+        bias = _load_tensor(
+            f"{prefix}.bias",
+            weight_map=weight_map,
+            files=files,
+            device=device,
+        )
+        for plan_index, adaln_input in enumerate(adaln_inputs):
+            plan_length = adaln_input.shape[0]
+            final_params[plan_index, :plan_length].copy_(
+                F.linear(adaln_input, weight, bias).cpu()
+            )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     save_file(
         {
-            "adaln_inputs": adaln_inputs,
+            "plan_timesteps": plan_timesteps,
+            "plan_lengths": plan_lengths,
             "block_params": block_params,
             "final_params": final_params,
         },
         str(args.output),
         metadata={
-            "format_version": "1",
+            "format_version": "2",
             "model_variant": args.model_variant,
         },
     )

--- a/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build an inference-only AdaLN cache from a local MiniMax H3 transformer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import safe_open, save_file
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.denoise_loop import (
+    MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    MINIMAX_H3_IMGVID_COND_TIMESTEP,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.time_request import (
+    minimax_h3_time_shift_sigmas,
+)
+
+_HIDDEN_SIZE = 5376
+_TIME_EMBED_DIM = 2688
+_TIMESTEP_INPUT_DIM = 256
+_NUM_BLOCKS = 50
+_BLOCK_PARAM_WIDTH = 18 * _HIDDEN_SIZE
+_FINAL_PARAM_WIDTH = 2 * _HIDDEN_SIZE
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a MiniMax H3 inference-only AdaLN cache from local weights."
+    )
+    parser.add_argument("--transformer-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--model-variant", choices=("fl2va", "ref2va"), required=True)
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--flow-shift", type=float, default=12.0)
+    parser.add_argument("--audio-flow-shift", type=float, default=3.0)
+    parser.add_argument(
+        "--imgvid-cond-noise-aug",
+        type=float,
+        default=MINIMAX_H3_IMGVID_COND_TIMESTEP,
+    )
+    parser.add_argument(
+        "--audio-cond-noise-aug",
+        type=float,
+        default=MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    )
+    parser.add_argument(
+        "--timesteps",
+        type=float,
+        nargs="+",
+        help="Override the scheduler-derived timestep coverage.",
+    )
+    parser.add_argument("--device", default="cuda")
+    return parser.parse_args()
+
+
+def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
+    if args.timesteps is not None:
+        return torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)
+
+    video_sigmas = minimax_h3_time_shift_sigmas(
+        num_steps=args.num_inference_steps,
+        shift_scale=args.flow_shift,
+    )
+    audio_sigmas = minimax_h3_time_shift_sigmas(
+        num_steps=args.num_inference_steps,
+        shift_scale=args.audio_flow_shift,
+    )
+    candidates = []
+    for video_sigma, audio_sigma in zip(video_sigmas[:-1], audio_sigmas[:-1]):
+        video_timestep = 1.0 - video_sigma
+        audio_timestep = 1.0 - audio_sigma
+        candidates.extend(
+            (
+                video_timestep,
+                audio_timestep,
+                max(video_timestep, args.imgvid_cond_noise_aug),
+                max(audio_timestep, args.audio_cond_noise_aug),
+            )
+        )
+    return torch.tensor(candidates, dtype=torch.float32).unique(sorted=True)
+
+
+def _time_embed(
+    timesteps: torch.Tensor,
+    *,
+    proj_in_weight: torch.Tensor,
+    proj_in_bias: torch.Tensor,
+    proj_out_weight: torch.Tensor,
+    proj_out_bias: torch.Tensor,
+) -> torch.Tensor:
+    half = _TIMESTEP_INPUT_DIM // 2
+    freqs = torch.exp(
+        -math.log(10000.0)
+        * torch.arange(half, dtype=torch.float32, device=timesteps.device)
+        / half
+    )
+    args = timesteps[:, None] * freqs[None]
+    t_freq = torch.cat((torch.cos(args), torch.sin(args)), dim=-1)
+    return F.linear(
+        F.silu(F.linear(t_freq, proj_in_weight, proj_in_bias)),
+        proj_out_weight,
+        proj_out_bias,
+    )
+
+
+def _load_tensor(
+    name: str,
+    *,
+    weight_map: dict[str, str],
+    files: dict[str, Any],
+    device: torch.device,
+) -> torch.Tensor:
+    tensor_file = files[weight_map[name]]
+    return tensor_file.get_tensor(name).to(device)
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.num_inference_steps < 2 and args.timesteps is None:
+        raise ValueError("--num-inference-steps must be at least 2")
+    device = torch.device(args.device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        raise ValueError("MiniMax H3 AdaLN cache must be built on CUDA")
+
+    index_path = args.transformer_path / "model.safetensors.index.json"
+    with index_path.open() as f:
+        weight_map = json.load(f)["weight_map"]
+
+    timesteps = _cache_timesteps(args)
+    if timesteps.numel() == 0:
+        raise ValueError("AdaLN cache must cover at least one timestep")
+    adaln_inputs = torch.empty(
+        (timesteps.numel(), _TIME_EMBED_DIM), dtype=torch.bfloat16
+    )
+    block_params = torch.empty(
+        (timesteps.numel(), _NUM_BLOCKS, _BLOCK_PARAM_WIDTH), dtype=torch.bfloat16
+    )
+    final_params = torch.empty(
+        (timesteps.numel(), _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
+    )
+
+    with ExitStack() as stack:
+        files = {
+            filename: stack.enter_context(
+                safe_open(
+                    str(args.transformer_path / filename),
+                    framework="pt",
+                    device="cpu",
+                )
+            )
+            for filename in set(weight_map.values())
+        }
+        time_kwargs = {
+            f"{module}_{name}": _load_tensor(
+                f"time_embedder.{module}.{name}",
+                weight_map=weight_map,
+                files=files,
+                device=device,
+            )
+            for module, name in (
+                ("proj_in", "weight"),
+                ("proj_in", "bias"),
+                ("proj_out", "weight"),
+                ("proj_out", "bias"),
+            )
+        }
+        adaln_input = F.silu(_time_embed(timesteps.to(device), **time_kwargs)).to(
+            torch.bfloat16
+        )
+        adaln_inputs.copy_(adaln_input.cpu())
+
+        for index in range(_NUM_BLOCKS):
+            prefix = f"blocks.{index}.adaln_proj.linear"
+            block_params[:, index].copy_(
+                F.linear(
+                    adaln_input,
+                    _load_tensor(
+                        f"{prefix}.weight",
+                        weight_map=weight_map,
+                        files=files,
+                        device=device,
+                    ),
+                    _load_tensor(
+                        f"{prefix}.bias",
+                        weight_map=weight_map,
+                        files=files,
+                        device=device,
+                    ),
+                ).cpu()
+            )
+
+        prefix = "final_layer.adaln_proj.linear"
+        final_params.copy_(
+            F.linear(
+                adaln_input,
+                _load_tensor(
+                    f"{prefix}.weight",
+                    weight_map=weight_map,
+                    files=files,
+                    device=device,
+                ),
+                _load_tensor(
+                    f"{prefix}.bias",
+                    weight_map=weight_map,
+                    files=files,
+                    device=device,
+                ),
+            ).cpu()
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "adaln_inputs": adaln_inputs,
+            "block_params": block_params,
+            "final_params": final_params,
+        },
+        str(args.output),
+        metadata={
+            "format_version": "1",
+            "model_variant": args.model_variant,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add an explicit MiniMax H3 AdaLN sidecar-cache format and CUDA builder
- skip original AdaLN checkpoint keys only when a matching cache is selected
- reject timestep embeddings absent from the cache rather than changing the inference path
- document the opt-in CLI and cookbook workflow

## Motivation

The MiniMax H3 model card notes that its AdaLN branches can be precomputed for inference-only serving. The public checkpoint ships those original branches, not a cache artifact, so this keeps the existing path as the default and makes cache use explicit.

## Status

Draft: remote end-to-end numerical and peak-memory validation are pending.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31182344526](https://github.com/sgl-project/sglang/actions/runs/31182344526)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31182344502](https://github.com/sgl-project/sglang/actions/runs/31182344502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->