### PR TITLE
Keep chunked prefix bookkeeping when the radix insert is skipped

### DIFF
--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -96,7 +96,10 @@ def free_swa_out_of_window_slots(
 
 
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
-    if getattr(req, "skip_radix_cache_insert", False):
+    # A chunk cache inserts nothing here; cache_unfinished_req only records
+    # prefix_indices, which the next chunk of the same request needs in order to
+    # extend its existing pages instead of allocating the whole sequence again.
+    if getattr(req, "skip_radix_cache_insert", False) and tree_cache.is_tree_cache():
         return
 
     tree_cache.cache_unfinished_req(req, **kwargs)


### PR DESCRIPTION
## Problem

A request whose `bootstrap_host` is `FAKE_BOOTSTRAP_HOST` gets
`skip_radix_cache_insert = True` (`managers/schedule_batch.py`). That flag makes
`maybe_cache_unfinished_req` return before calling `cache_unfinished_req`:

```python
def maybe_cache_unfinished_req(req, tree_cache, **kwargs):
    if getattr(req, "skip_radix_cache_insert", False):
        return
    tree_cache.cache_unfinished_req(req, **kwargs)
```

That is correct for a radix cache, where `cache_unfinished_req` inserts into the
tree. It is wrong for a chunk cache, where the same method inserts nothing and
only records `prefix_indices`:

```python
def cache_unfinished_req(self, req: Req, chunked=False):
    kv_indices = self.req_to_token_pool.req_to_token[
        req.req_pool_idx, : req.extend_range.end
    ]
    req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
```

`prefix_indices` is what lets the next chunk of the same request extend its
existing pages. Without it the request restarts from `prefix=0` and allocates the
whole sequence a second time; the pages from the first chunk are never referenced
again and never freed.

## Reproduction

Prefill server with `--disable-radix-cache` (so the tree cache is a chunk cache)
and a client using `--fake-prefill`, at a concurrency high enough that a batch
fills `--chunked-prefill-size` and truncates a request.

Instrumenting the allocator and `release_kv_cache`, one request out of 66 fails to
balance:

```
rid=8b167b62
  alloc  prefix=0  seq=64     ->  1 page  =   64
  alloc  prefix=0  seq=4096   -> 64 pages = 4096      (prefix should have been 64)
  free   committed=4096       ->            4096
  leaked                                       64
```

The pool loses one page per truncated request. Over a few hundred requests it
reaches `available=0` and the next prefill raises
`RuntimeError: Prefill out of memory`.

Concurrency 8 and below never triggers it: a batch never fills the chunk budget,
so no request is truncated.

## Fix

Skip only when the cache actually inserts. `is_tree_cache()` already exists on
`BasePrefixCache`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31185825920](https://github.com/sgl-project/sglang/actions/runs/31185825920)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31185826006](https://github.com/sgl-project/sglang/actions/runs/31185826006)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->