### PR TITLE
Fix/hicache sidecar ok pure mla

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -776,7 +776,13 @@ class HybridCacheController(BaseHiCacheController):
         if not self.backup_skip:
             super()._page_backup(operation)
         else:
-            sidecar_ok = bool(backup_transfers)
+            # Vacuously successful: when there are no rank-sharded sidecars
+            # (e.g. pure-MLA DSV4 where every pool is replicated), the
+            # follower rank has nothing to write — TP0 already persisted all
+            # replicated pools. Reporting failure here (completed_tokens=0)
+            # would prevent restore from ever triggering on follower ranks,
+            # causing NaN on DSpark speculative hits.
+            sidecar_ok = True
             if sidecar_ok:
                 for transfer in backup_transfers:
                     result = results.get(transfer.name)

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -783,21 +783,20 @@ class HybridCacheController(BaseHiCacheController):
             # would prevent restore from ever triggering on follower ranks,
             # causing NaN on DSpark speculative hits.
             sidecar_ok = True
-            if sidecar_ok:
-                for transfer in backup_transfers:
-                    result = results.get(transfer.name)
-                    if result is None:
-                        result = results.get(transfer.name.value)
-                    expected = len(transfer.keys or [])
-                    if expected == 0 and transfer.host_indices is not None:
-                        expected = int(transfer.host_indices.numel())
-                    if (
-                        not isinstance(result, (list, tuple))
-                        or len(result) != expected
-                        or not all(bool(ok) for ok in result)
-                    ):
-                        sidecar_ok = False
-                        break
+            for transfer in backup_transfers:
+                result = results.get(transfer.name)
+                if result is None:
+                    result = results.get(transfer.name.value)
+                expected = len(transfer.keys or [])
+                if expected == 0 and transfer.host_indices is not None:
+                    expected = int(transfer.host_indices.numel())
+                if (
+                    not isinstance(result, (list, tuple))
+                    or len(result) != expected
+                    or not all(bool(ok) for ok in result)
+                ):
+                    sidecar_ok = False
+                    break
             operation.completed_tokens = (
                 len(operation.hash_value) * self.page_size if sidecar_ok else 0
             )

--- a/test/registered/unit/mem_cache/test_hybrid_cache_controller_page_backup.py
+++ b/test/registered/unit/mem_cache/test_hybrid_cache_controller_page_backup.py
@@ -1,0 +1,107 @@
+"""Unit tests for HybridCacheController._page_backup sidecar_ok logic.
+
+Regression tests for issue #33656: when a pure-MLA model (e.g. DSV4) runs
+with TP>1, follower ranks have no rank-sharded sidecars to back up.
+Pre-fix, ``sidecar_ok = bool(backup_transfers)`` evaluated to ``False``
+when ``backup_transfers`` was empty, yielding ``completed_tokens=0`` and
+preventing L3 restore from ever triggering on follower ranks — causing
+NaN on DSpark speculative hits.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.mem_cache.hicache_storage import PoolName, PoolTransfer
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
+    HybridCacheController,
+    StorageOperation,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _indices(start: int, end: int) -> torch.Tensor:
+    return torch.arange(start, end, dtype=torch.int64)
+
+
+class TestPageBackupSidecarOk(unittest.TestCase):
+    """Guard the sidecar_ok default and validation loop in _page_backup."""
+
+    def _make_controller(self, *, backup_skip: bool) -> HybridCacheController:
+        ctrl = HybridCacheController.__new__(HybridCacheController)
+        ctrl.backup_skip = backup_skip
+        ctrl.page_size = 1
+        ctrl.storage_backend_type = "mooncake"
+        ctrl.mem_pool_host = SimpleNamespace(entry_map={})
+        ctrl.storage_backend = mock.Mock()
+        return ctrl
+
+    def _make_operation(self, *, pool_transfers=None, num_pages=4):
+        return StorageOperation(
+            host_indices=_indices(0, num_pages),
+            token_ids=list(range(num_pages)),
+            hash_value=[f"h{i}" for i in range(num_pages)],
+            pool_transfers=pool_transfers,
+        )
+
+    def test_pure_mla_follower_reports_success_with_no_sidecars(self):
+        """Follower rank with all-replicated pools (empty backup_transfers)
+        must report completed_tokens > 0 — TP0 already persisted everything.
+
+        Pre-fix: sidecar_ok = bool([]) = False -> completed_tokens = 0 (bug).
+        Post-fix: sidecar_ok = True -> completed_tokens = full.
+        """
+        ctrl = self._make_controller(backup_skip=True)
+        op = self._make_operation(pool_transfers=[])
+
+        ctrl._page_backup(op)
+
+        self.assertEqual(op.completed_tokens, len(op.hash_value) * ctrl.page_size)
+
+    def test_follower_sidecar_write_failure_reports_zero(self):
+        """When rank-sharded sidecar writes fail, completed_tokens must be 0
+        so the corrupted backup is not considered restorable."""
+        ctrl = self._make_controller(backup_skip=True)
+        transfer = PoolTransfer(
+            name=PoolName.MAMBA,
+            host_indices=_indices(0, 4),
+            keys=None,
+            indices_from_pool=None,
+        )
+        op = self._make_operation(pool_transfers=[transfer])
+
+        ctrl.storage_backend.batch_set_v2.return_value = {
+            PoolName.MAMBA: [True, False, True, True]
+        }
+
+        ctrl._page_backup(op)
+
+        self.assertEqual(op.completed_tokens, 0)
+
+    def test_follower_sidecar_write_success_reports_full(self):
+        """When rank-sharded sidecar writes succeed, completed_tokens must
+        equal the full page count."""
+        ctrl = self._make_controller(backup_skip=True)
+        transfer = PoolTransfer(
+            name=PoolName.MAMBA,
+            host_indices=_indices(0, 4),
+            keys=None,
+            indices_from_pool=None,
+        )
+        op = self._make_operation(pool_transfers=[transfer])
+
+        ctrl.storage_backend.batch_set_v2.return_value = {
+            PoolName.MAMBA: [True, True, True, True]
+        }
+
+        ctrl._page_backup(op)
+
+        self.assertEqual(op.completed_tokens, len(op.hash_value) * ctrl.page_size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When a pure-MLA model (e.g. DeepSeek-V4) runs with TP>1, follower TP ranks have no rank-sharded sidecars to back up — all pools are replicated and TP0 handles the writes. The `else` branch of `_page_backup` set `sidecar_ok = bool(backup_transfers)`, which evaluated to `False` when `backup_transfers` was empty, yielding `completed_tokens=0`. This prevented L3 restore from ever triggering on follower ranks, causing **NaN on DSpark speculative hits** (issue #33656).

## Modifications

**`python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py`** — `_page_backup()` method, `else` branch (`backup_skip=True`, i.e. follower TP ranks):

Changed `sidecar_ok = bool(backup_transfers)` to `sidecar_ok = True`. When there are no rank-sharded sidecars, the follower rank's backup is vacuously successful — TP0 already persisted all replicated pools. The validation loop still runs for non-empty `backup_transfers` and can set `sidecar_ok=False` on real failures.

```python
# Before (buggy):
sidecar_ok = bool(backup_transfers)  # empty → False → completed_tokens=0 → no restore → NaN

# After (fixed):
sidecar_ok = True  # vacuously successful; validation loop still runs and can set False
```

**`test/registered/unit/mem_cache/test_hybrid_cache_controller_page_backup.py`** — 3 new unit tests:

1. `test_pure_mla_follower_reports_success_with_no_sidecars` — Bug regression: follower rank with empty `backup_transfers` → `completed_tokens > 0` (fails pre-fix, passes post-fix)
2. `test_follower_sidecar_write_failure_reports_zero` — Negative: non-empty `backup_transfers` with failed writes → `completed_tokens = 0`
3. `test_follower_sidecar_write_success_reports_full` — Positive: non-empty `backup_transfers` with successful writes → `completed_tokens = full`

Registered as `base-a-test-cpu` (est_time=3s). All tests pass locally on CPU.

## Accuracy Tests

N/A — this change does not affect model outputs. It fixes the HiCache L3 backup/restore coordination path for pure-MLA models (DSV4 etc.) under TP>1.

## Speed Tests and Profiling

N/A — no inference speed impact. The fix eliminates spurious backup-failure reporting on follower ranks when all pools are already replicated.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Related #33656

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31193950878](https://github.com/sgl-project/sglang/actions/runs/31193950878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31193947131](https://github.com/sgl-project/sglang/actions/runs/31193947131)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->