### PR TITLE
[AMD] Serve Kimi-K3 on gfx942: moonmath MLA multi-query verify, MXFP4 MoE, chunked prefix KV

### DIFF
--- a/docs/docs/advanced_features/attention_backend.mdx
+++ b/docs/docs/advanced_features/attention_backend.mdx
@@ -299,6 +299,15 @@ The support matrix is split into two parts: MHA (standard attention) and MLA (mu
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>❌</td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**Moonmath MLA (ROCm)**</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>1</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>❌</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>✅ (aiter)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>✅ (aiter)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>❌</td>
+    </tr>
   </tbody>
 </table>
 
@@ -692,6 +701,18 @@ python3 -m sglang.launch_server \
 python3 -m sglang.launch_server \
   --model meta-llama/Meta-Llama-3.1-8B-Instruct \
   --attention-backend wave
+```
+
+- Moonmath MLA (AMD ROCm, MI300X)
+  - Requires `pip install moonmath-attention` ([github.com/moonmath-ai/amd-kernels](https://github.com/moonmath-ai/amd-kernels))
+  - Pure decode A16W8 (bf16 Q / fp8 KV) for H≤16 on gfx942. Prefill and spec-verify fall back to aiter.
+```bash Command
+python3 -m sglang.launch_server \
+  --tp 4 \
+  --model moonshotai/Kimi-K2.7 \
+  --attention-backend moonmath_mla \
+  --kv-cache-dtype fp8_e4m3 \
+  --trust-remote-code
 ```
 
 - FlexAttention

--- a/docs/docs/advanced_features/attention_backend.mdx
+++ b/docs/docs/advanced_features/attention_backend.mdx
@@ -704,17 +704,17 @@ python3 -m sglang.launch_server \
 ```
 
 - Moonmath MLA (AMD ROCm, MI300X)
-  - Requires `pip install moonmath-attention` ([github.com/moonmath-ai/amd-kernels](https://github.com/moonmath-ai/amd-kernels))
-  - Pure decode A16W8 (bf16 Q / fp8 KV) for H≤16 on gfx942. Prefill and spec-verify fall back to aiter.
+  - Requires `moonmath-attention` from [github.com/moonmath-ai/amd-kernels](https://github.com/moonmath-ai/amd-kernels) (branch `mla-decode-a16w8-multiq`), and `--kv-cache-dtype fp8_e4m3`
+  - Serves absorbed MLA decode with A16W8 (bf16 Q / fp8 KV) at H≤16.
+  - Prefill falls back to aiter, with Q zero-padded to aiter's 16-head minimum at head counts it cannot serve (Kimi-K3 has 12 per rank at TP8).
 ```bash Command
 python3 -m sglang.launch_server \
-  --tp 4 \
-  --model moonshotai/Kimi-K2.7 \
+  --tp 8 \
+  --model deepseek-ai/DeepSeek-V3 \
   --attention-backend moonmath_mla \
   --kv-cache-dtype fp8_e4m3 \
   --trust-remote-code
 ```
-
 - FlexAttention
 ```bash Command
 python3 -m sglang.launch_server \

--- a/docs/docs/advanced_features/attention_backend.mdx
+++ b/docs/docs/advanced_features/attention_backend.mdx
@@ -705,7 +705,7 @@ python3 -m sglang.launch_server \
 
 - Moonmath MLA (AMD ROCm, MI300X)
   - Requires `moonmath-attention` from [github.com/moonmath-ai/amd-kernels](https://github.com/moonmath-ai/amd-kernels) (branch `mla-decode-a16w8-multiq`), and `--kv-cache-dtype fp8_e4m3`
-  - Serves absorbed MLA decode with A16W8 (bf16 Q / fp8 KV) at H≤16.
+  - Serves absorbed MLA with A16W8 (bf16 Q / fp8 KV) at H≤16: decode, plus the speculative verify pass through a multi-query draft window of 4..8 tokens, which aiter's asm MLA has no kernel for. Set `SGLANG_MOONMATH_MLA_MULTIQ_VERIFY=0` to force verify back to aiter.
   - Prefill falls back to aiter, with Q zero-padded to aiter's 16-head minimum at head counts it cannot serve (Kimi-K3 has 12 per rank at TP8).
 ```bash Command
 python3 -m sglang.launch_server \
@@ -715,6 +715,19 @@ python3 -m sglang.launch_server \
   --kv-cache-dtype fp8_e4m3 \
   --trust-remote-code
 ```
+  With speculative decoding, the draft window must land in 4..8 for the verify pass to take the multi-query kernel; a DSpark block size of 7 gives a window of 8. Kimi-K3 additionally needs `SGLANG_USE_AITER=1` for the gfx942 MXFP4 MoE route.
+```bash Command
+SGLANG_USE_AITER=1 python3 -m sglang.launch_server \
+  --tp 8 \
+  --model moonshotai/Kimi-K3 \
+  --attention-backend moonmath_mla \
+  --kv-cache-dtype fp8_e4m3 \
+  --speculative-algorithm DSPARK \
+  --speculative-draft-model-path RadixArk/Kimi-K3-DSpark \
+  --speculative-dspark-block-size 7 \
+  --trust-remote-code
+```
+
 - FlexAttention
 ```bash Command
 python3 -m sglang.launch_server \

--- a/python/sglang/kernels/ops/attention/verify_splitkv.py
+++ b/python/sglang/kernels/ops/attention/verify_splitkv.py
@@ -31,6 +31,8 @@ the caller falls back to ``extend_attention_fwd``. Supported case: causal
 sliding-window / logit-cap / xai-temperature. Correctness is never violated.
 """
 
+from functools import lru_cache
+
 import torch
 import triton
 import triton.language as tl
@@ -90,9 +92,58 @@ def block_config(head_dim):
 ADAPTIVE_SPLITS = True
 MAX_N_SPLITS = 16
 MIN_N_SPLITS = 4
+# MAX_N_SPLITS is a floor rather than a ceiling when the base grid cannot fill
+# the device -- see _cu_aware_max_splits. HARD_MAX bounds that raise, and the
+# workgroups-per-CU target is conservative enough to leave the tuned case at
+# exactly MAX_N_SPLITS.
+HARD_MAX_N_SPLITS = 128
+_WGS_PER_CU_TARGET = 4
+# att_out/att_lse are sized by max_bs for graph address stability, so n_splits
+# multiplies a max_bs-sized allocation even when only bs=1 is live. Bound it.
+_SPLIT_SCRATCH_BUDGET_BYTES = 512 << 20
 
 
-def choose_n_splits(avg_seqlen):
+@lru_cache(maxsize=8)
+def _device_cu_count(device_index):
+    return torch.cuda.get_device_properties(device_index).multi_processor_count
+
+
+def _cu_aware_max_splits(base_programs, device_index):
+    """Raise the split cap when the (bs, h_q) base grid cannot fill the device.
+
+    The stage1 grid is (bs, h_q, N_SPLITS), so bs*h_q fixes how many workgroups
+    exist before splitting. A per-TP-rank speculative draft shard is tiny, and
+    the flat cap then leaves most of the device idle. Scale the cap by the
+    shortfall instead; never below MAX_N_SPLITS, so shapes that already fill the
+    device keep their tuned value. Host-side property read only, so it stays
+    graph-capture safe.
+    """
+    n_cu = _device_cu_count(device_index)
+    if n_cu <= 0 or base_programs <= 0:
+        return MAX_N_SPLITS
+    want = triton.next_power_of_2(max(1, (_WGS_PER_CU_TARGET * n_cu) // base_programs))
+    return max(MAX_N_SPLITS, min(want, HARD_MAX_N_SPLITS))
+
+
+def _scratch_capped_splits(n_splits, max_bs, h_q, l_pad, v_head_dim):
+    """Largest power-of-two split count <= n_splits fitting the scratch budget.
+    Never below MAX_N_SPLITS: that is the pre-existing footprint, so this only
+    claws back what the CU-aware raise asked for."""
+    per_split = max_bs * h_q * l_pad * (v_head_dim + 1) * 4
+    if per_split <= 0:
+        return n_splits
+    while (
+        n_splits > MAX_N_SPLITS and n_splits * per_split > _SPLIT_SCRATCH_BUDGET_BYTES
+    ):
+        n_splits //= 2
+    return n_splits
+
+
+# `base_programs` (= bs * h_q) is the stage1 base grid before splitting. When it
+# cannot fill the device the cap is raised by the shortfall and the whole ladder
+# scales with it; passing None keeps the flat cap, i.e. exactly the behaviour
+# documented below.
+def choose_n_splits(avg_seqlen, base_programs=None, device_index=0):
     """Pick N_SPLITS (power of two, in [MIN_N_SPLITS, MAX_N_SPLITS]) from the
     average prefix length. Tuned by the real-shape sweep (head_dim=256, BS*H_Q
     =128 base programs on ~132 CUs):
@@ -106,6 +157,11 @@ def choose_n_splits(avg_seqlen):
     so it is HIP-graph-capture safe (no device->host sync)."""
     if not ADAPTIVE_SPLITS:
         return DEFAULT_N_SPLITS
+    max_splits = (
+        MAX_N_SPLITS
+        if base_programs is None
+        else _cu_aware_max_splits(base_programs, device_index)
+    )
     s = int(avg_seqlen)
     if s < 4096:
         n = 4
@@ -113,10 +169,15 @@ def choose_n_splits(avg_seqlen):
         n = 8
     else:
         n = 16
+    # The ladder was tuned at a base grid that already fills the device; when it
+    # does not, every rung is short by the same factor, not just the long one.
+    # boost == 1 whenever max_splits == MAX_N_SPLITS, so tuned shapes are
+    # bit-identical.
+    n *= max(1, max_splits // MAX_N_SPLITS)
     if n < MIN_N_SPLITS:
         n = MIN_N_SPLITS
-    if n > MAX_N_SPLITS:
-        n = MAX_N_SPLITS
+    if n > max_splits:
+        n = max_splits
     return n
 
 
@@ -823,12 +884,17 @@ def verify_splitkv_fwd(
     # mixed-length batches stay correct -- shorter seqs simply write fewer
     # active splits (the rest emit the -inf lse sentinel, ignored in stage2).
     avg_seqlen = kv_indices.shape[0] / max(1, bs)
-    n_splits = choose_n_splits(avg_seqlen)
+    n_splits = choose_n_splits(
+        avg_seqlen, base_programs=bs * h_q, device_index=q_extend.device.index or 0
+    )
 
     # Size scratch by the stable max_bs (backend passes req_to_token_pool size);
     # fall back to this call's bs if not provided / smaller.
     if max_bs is None or max_bs < bs:
         max_bs = bs
+    n_splits = _scratch_capped_splits(
+        n_splits, max_bs, h_q, triton.next_power_of_2(l_ext), v_head_dim
+    )
     vk = _get_vk(
         max_bs,
         h_q,

--- a/python/sglang/kernels/ops/attention/verify_splitkv.py
+++ b/python/sglang/kernels/ops/attention/verify_splitkv.py
@@ -369,6 +369,7 @@ def _verify_combine_stage2(
     V_HEAD_DIM: tl.constexpr,
     BLOCK_DMODEL: tl.constexpr,
     BLOCK_DV: tl.constexpr,
+    INTRA_BLOCK_CAUSAL: tl.constexpr,
 ):
     cur_batch = tl.program_id(0)
     cur_head = tl.program_id(1)
@@ -454,9 +455,12 @@ def _verify_combine_stage2(
 
     # scores[i,j] = q_i . k_j  (i query, j key)  -> [L_EXT, L_EXT]
     qk = tl.sum(q[:, None, :] * ke[None, :, :], 2) * sm_scale
-    # causal among drafts: query i sees key j iff j <= i, and both valid
-    causal = (offs_l[None, :] <= offs_l[:, None]) & mask_l[None, :] & mask_l[:, None]
-    qk = tl.where(causal, qk, float("-inf"))
+    # ENCODER_ONLY draft layers are bidirectional: every valid draft sees every
+    # other. Causal layers additionally require key j <= query i.
+    visible = mask_l[None, :] & mask_l[:, None]
+    if INTRA_BLOCK_CAUSAL:
+        visible = visible & (offs_l[None, :] <= offs_l[:, None])
+    qk = tl.where(visible, qk, float("-inf"))
     m_d = tl.max(qk, 1)  # [L_EXT]
     pd = tl.exp(qk - m_d[:, None])  # [L_EXT, L_EXT]
     denom_d = tl.sum(pd, 1)  # [L_EXT]
@@ -502,7 +506,10 @@ class VerifySplitKV:
         n_splits=DEFAULT_N_SPLITS,
         block_n=DEFAULT_BLOCK_N,
         num_warps=DEFAULT_NUM_WARPS,
+        intra_block_causal=True,
     ):
+        # A stage2 constexpr specialization, so it keys _VK_CACHE.
+        self.intra_block_causal = intra_block_causal
         self.h_q = h_q
         self.h_kv = h_kv
         self.group = h_q // h_kv
@@ -622,6 +629,7 @@ class VerifySplitKV:
             V_HEAD_DIM=self.v_head_dim,
             BLOCK_DMODEL=triton.next_power_of_2(self.head_dim),
             BLOCK_DV=triton.next_power_of_2(self.v_head_dim),
+            INTRA_BLOCK_CAUSAL=self.intra_block_causal,
             num_warps=1,
             num_stages=1,
         )
@@ -688,9 +696,26 @@ _VK_CACHE = {}
 
 
 def _get_vk(
-    max_bs, h_q, h_kv, head_dim, v_head_dim, l_ext, device, n_splits=DEFAULT_N_SPLITS
+    max_bs,
+    h_q,
+    h_kv,
+    head_dim,
+    v_head_dim,
+    l_ext,
+    device,
+    n_splits=DEFAULT_N_SPLITS,
+    intra_block_causal=True,
 ):
-    key = (h_q, h_kv, head_dim, v_head_dim, l_ext, str(device), n_splits)
+    key = (
+        h_q,
+        h_kv,
+        head_dim,
+        v_head_dim,
+        l_ext,
+        str(device),
+        n_splits,
+        intra_block_causal,
+    )
     vk = _VK_CACHE.get(key)
     if vk is None:
         block_n, num_warps = block_config(head_dim)
@@ -705,6 +730,7 @@ def _get_vk(
             n_splits=n_splits,
             block_n=block_n,
             num_warps=num_warps,
+            intra_block_causal=intra_block_causal,
         )
         _VK_CACHE[key] = vk
     else:
@@ -749,7 +775,7 @@ def can_handle(
         return False
     if xai_temperature_len is not None and xai_temperature_len > 0:
         return False
-    if not is_causal:
+    if not is_causal and custom_mask is not None:
         return False
     # q layout must be [tokens, H_Q, D]; head dims handled by power-of-2 pad.
     if q_extend.dim() != 3 or k_extend.dim() != 3 or v_extend.dim() != 3:
@@ -904,6 +930,7 @@ def verify_splitkv_fwd(
         l_ext,
         q_extend.device,
         n_splits=n_splits,
+        intra_block_causal=bool(is_causal),
     )
     vk(
         q_extend,

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -869,6 +869,12 @@ class Envs:
     # epilogue kernel. See kernels/ops/moe/moe_front.py. Default on.
     SGLANG_K3_FUSED_FRONT = EnvBool(True)
 
+    # Route TARGET_VERIFY through moonmath_attention's A16W8 multi-query MLA
+    # kernel (--attention-backend moonmath_mla). On by default: aiter's asm MLA
+    # has no kernel past qseqlen 4, so a larger draft window aborts without it.
+    # Set false to force the aiter path for A/B.
+    SGLANG_MOONMATH_MLA_MULTIQ_VERIFY = EnvBool(True)
+
     # sgl-kernel
     SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK = EnvBool(False)
 

--- a/python/sglang/srt/layers/activation.py
+++ b/python/sglang/srt/layers/activation.py
@@ -208,6 +208,33 @@ class SituAndMul(BaseFusedOp):
 
         return situ_and_mul(x, None, self.beta, self.linear_beta)
 
+    def forward_hip(self, x: torch.Tensor) -> torch.Tensor:
+        """ROCm cannot build the JIT kernel `forward_cuda` dispatches to.
+
+        `kernels/jit/csrc/kimi_k3/situ_and_mul.cuh` includes `<cuda_fp8.h>` and
+        uses `fp8_e4m3_t`, whose `DTypeTrait` is itself behind `#ifndef USE_ROCM`
+        -- so dropping the include only moves the failure to a missing trait.
+        Without this override `MultiPlatformOp` falls back to `forward_cuda` and
+        the build fails inside CUDA-graph capture, surfacing as
+        `Capture cuda graph failed: ninja exited with status 1` rather than as a
+        missing-kernel error.
+
+        The Triton twin SGLang already ships is arithmetically identical
+        (`_tl_tanh(x) = 2*sigmoid(2x)-1`) and stays a single fused elementwise
+        kernel, which is why it is preferred over `forward_native` -- that path
+        is ~8 separate elementwise kernels on fp32 upcasts, and this op runs once
+        per dense/shared-expert MLP per step.
+        """
+        from sglang.srt.layers.moe.fused_moe_triton.fused_marlin_moe import (
+            situ_and_mul as triton_situ_and_mul,
+        )
+
+        d = x.shape[-1] // 2
+        flat = x.reshape(-1, x.shape[-1])
+        out = torch.empty((flat.shape[0], d), dtype=x.dtype, device=x.device)
+        triton_situ_and_mul(out, flat, self.beta, self.linear_beta)
+        return out.reshape(*x.shape[:-1], d)
+
     def forward_cpu(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_native(x)
 

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -128,6 +128,8 @@ _AITER_PARTITION_SIZE_ROCM = 256
 
 
 class AiterAttnBackend(AttentionBackend):
+    skip_mla_head_count_assert: bool = False
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -290,7 +292,7 @@ class AiterAttnBackend(AttentionBackend):
             _valid_heads = self.num_head in (4, 8) or (
                 self.num_head % 16 == 0 and 16 <= self.num_head <= 128
             )
-            assert _valid_heads, (
+            assert _valid_heads or self.skip_mla_head_count_assert, (
                 f"Aiter MLA supports num_head of 4, 8, or multiples of 16 "
                 f"in [16, 128].\n"
                 f"Provided {self.num_head} number of heads.\n"

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -1901,6 +1901,57 @@ class AiterAttnBackend(AttentionBackend):
             and layer.qk_head_dim == layer.v_head_dim
         )
 
+    def _forward_extend_mha_chunk(
+        self,
+        *,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        qo_indptr: torch.Tensor,
+        max_q_len: int,
+    ):
+        """One slice of an AttnForwardMethod.MHA_CHUNKED_KV extend.
+
+        forward_normal_chunked_kv_core has already run kv_b_proj for this slice
+        alone -- either the new tokens or a single prefix chunk -- and merges the
+        per-slice LSEs itself, so we only attend the k/v we were handed. Falling
+        through to the unchunked path instead would re-gather and up-project the
+        whole prefix (~13.2 KiB/token/layer).
+        """
+        if forward_batch.attn_attend_prefix_cache:
+            chunk_idx = forward_batch.prefix_chunk_idx
+            assert chunk_idx >= 0
+            # The chunk lies entirely in the queries' past, so no causal mask.
+            kv_indptr = forward_batch.prefix_chunk_cu_seq_lens[chunk_idx]
+            max_kv_len = forward_batch.prefix_chunk_max_seq_lens[chunk_idx]
+            causal = False
+        else:
+            kv_indptr = qo_indptr
+            max_kv_len = max_q_len
+            causal = True
+
+        attn_out = flash_attn_varlen_func(
+            q,
+            k,
+            v,
+            qo_indptr,
+            kv_indptr,
+            max_q_len,
+            max_kv_len,
+            softmax_scale=layer.scaling,
+            causal=causal,
+            return_lse=forward_batch.mha_return_lse,
+        )
+        if not forward_batch.mha_return_lse:
+            return attn_out
+        # aiter returns the softmax lse heads-first [num_heads, num_tokens];
+        # merge_state sizes its grid off the output's token/head axes and so
+        # indexes [num_tokens, num_heads]. Transpose on the way out.
+        o, lse = attn_out
+        return o, lse.transpose(0, 1).contiguous()
+
     def forward_extend(
         self,
         q: torch.Tensor,
@@ -2023,6 +2074,19 @@ class AiterAttnBackend(AttentionBackend):
                 and not forward_batch.forward_mode.is_target_verify()
                 and not forward_batch.forward_mode.is_draft_extend_v2()
             ):
+                if forward_batch.attn_attend_prefix_cache is not None and any(
+                    forward_batch.extend_prefix_lens_cpu
+                ):  # MHA Chunk
+                    return self._forward_extend_mha_chunk(
+                        q=q,
+                        k=k,
+                        v=v,
+                        layer=layer,
+                        forward_batch=forward_batch,
+                        qo_indptr=qo_indptr,
+                        max_q_len=max_q_len,
+                    )
+
                 extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
                 if kv_indices.shape[0] == 0 or extend_no_prefix:
                     if _use_fp8_prefill_attn:

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -114,6 +114,15 @@ def create_aiter_backend(runner):
     return AiterAttnBackend(runner)
 
 
+@register_attention_backend("moonmath_mla")
+def create_moonmath_mla_backend(runner):
+    if not runner.use_mla_backend:
+        raise ValueError("moonmath_mla backend can only be used with MLA models.")
+    from sglang.srt.layers.attention.moonmath_mla_backend import MoonmathMLABackend
+
+    return MoonmathMLABackend(runner)
+
+
 @register_attention_backend("wave")
 def create_wave_backend(runner):
     from sglang.srt.layers.attention.wave_backend import WaveAttnBackend

--- a/python/sglang/srt/layers/attention/moonmath_mla_backend.py
+++ b/python/sglang/srt/layers/attention/moonmath_mla_backend.py
@@ -1,0 +1,120 @@
+"""Moonmath MLA decode backend for DeepSeek-V3 on CDNA3 (MI300X / gfx942).
+
+Subclasses AiterAttnBackend: decode with fp8 KV and H<=16 routes to the
+moonmath_attention A16W8 kernel (bf16 Q / fp8 KV, device-driven paged,
+cuda-graph-safe, reads sglang's existing fused-576 MLATokenToKVPool directly).
+Everything else (bf16 KV, H>16, prefill, spec-verify) falls back to aiter.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
+from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+KV_LORA_RANK = 512
+KV_CACHE_DIM = 576  # 512 latent + 64 rope
+
+
+class MoonmathMLABackend(AiterAttnBackend):
+    """MLA decode backend: A16W8 kernel for H<=16 fp8 KV, else aiter."""
+
+    def __init__(self, model_runner):
+        super().__init__(model_runner)
+        import moonmath_attention.mla as mla  # fail fast if missing
+
+        self._mla = mla
+        self._mla_ok = bool(self.use_mla)
+        self._disabled = os.environ.get("SGLANG_MOONMATH_MLA_DISABLE") == "1"
+        self._fp8_dtype = torch.float8_e4m3fnuz
+        self._fp8_kv = self._mla_ok and (self.kv_cache_dtype == self._fp8_dtype)
+
+        # Per-bs FIXED kv-split (frozen at first call / capture; reused on replay).
+        self._dec_parts: dict[int, int] = {}
+        model_config = getattr(model_runner, "model_config", None)
+        self._mla_max_ctx = (
+            model_config.context_len if model_config is not None else 131072
+        )
+        # int32 staging for device seq_lens (sglang gives int64 in eager mode).
+        self._mla_seqlen_i32 = torch.zeros(
+            8192, dtype=torch.int32, device=model_runner.device
+        )
+
+    # A16W8 kernel serves H<=16. H=128 (DSV3) falls back to aiter.
+    _A16W8_DECODE_MAX_HEADS = 16
+
+    def _decode_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+        return (
+            self._mla_ok
+            and not self._disabled
+            and self._fp8_kv
+            and q.dtype == torch.bfloat16
+            and layer.tp_q_head_num <= self._A16W8_DECODE_MAX_HEADS
+            and layer.qk_head_dim == KV_CACHE_DIM
+            and layer.v_head_dim == KV_LORA_RANK
+            and layer.tp_k_head_num == 1
+            and layer.logit_cap == 0
+            and fb.forward_mode.is_decode()
+            and fb.spec_info is None
+            and fb.batch_size <= self._mla_seqlen_i32.numel()
+            and self.forward_metadata is not None
+            and self.forward_metadata.kv_indices is not None
+            and self.forward_metadata.kv_indptr is not None
+        )
+
+    # ── decode ───────────────────────────────────────────────────────────────
+    def forward_decode(
+        self, q, k, v, layer, forward_batch, save_kv_cache=True, sinks=None
+    ):
+        if sinks is not None or not self._decode_eligible(q, layer, forward_batch):
+            return super().forward_decode(
+                q, k, v, layer, forward_batch, save_kv_cache, sinks
+            )
+
+        mla = self._mla
+        fb = forward_batch
+        B = fb.batch_size
+        H = layer.tp_q_head_num
+
+        if save_kv_cache and k is not None:
+            self.token_to_kv_pool.set_kv_buffer(layer, fb.out_cache_loc, k, v)
+
+        kv_pool = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        kv_indices = self.forward_metadata.kv_indices.to(torch.int32)
+        kv_indptr = self.forward_metadata.kv_indptr.to(torch.int32)
+        seq_lens = self._mla_seqlen_i32[:B]
+        seq_lens.copy_(fb.seq_lens)
+        k_descale = (
+            float(layer.k_scale) if getattr(layer, "k_scale", None) is not None else 1.0
+        )
+
+        parts = self._dec_parts.get(B)
+        if parts is None:
+            parts = mla.mla_decode_a16w8_plan_parts_capped(
+                B, H, self._mla_max_ctx, KV_LORA_RANK
+            )
+            self._dec_parts[B] = parts
+
+        q = q.reshape(B, H, layer.qk_head_dim)
+        q_lat = q[..., :KV_LORA_RANK].contiguous()
+        q_pe = q[..., KV_LORA_RANK:].contiguous()
+        out = torch.empty(B, H, KV_LORA_RANK, dtype=torch.bfloat16, device=q.device)
+        mla.mla_decode_a16w8_paged_dev(
+            q_lat,
+            q_pe,
+            kv_pool,
+            out,
+            seq_lens,
+            None,
+            kv_indices,
+            kv_indptr,
+            parts,
+            layer.scaling,
+            k_descale,
+            1.0,
+        )
+        return out.reshape(B, H * KV_LORA_RANK)

--- a/python/sglang/srt/layers/attention/moonmath_mla_backend.py
+++ b/python/sglang/srt/layers/attention/moonmath_mla_backend.py
@@ -1,14 +1,20 @@
 """Moonmath MLA attention backend for CDNA3 (gfx942).
 
-Subclasses AiterAttnBackend and takes over absorbed MLA decode with the
-moonmath_attention A16W8 kernel (bf16 Q / fp8 KV), which reads sglang's existing
+Subclasses AiterAttnBackend and takes over absorbed MLA with the
+moonmath_attention A16W8 kernels (bf16 Q / fp8 KV), which read sglang's existing
 fused-576 MLATokenToKVPool key buffer directly (page_size=1, device-driven,
-cuda-graph safe). H <= 16:
+cuda-graph safe). Two shapes, both H <= 16:
 
     decode        q_len 1     -> mla_decode_a16w8_paged_dev
+    TARGET_VERIFY q_len 4..8  -> mla_decode_a16w8_multiq_paged_dev
 
-Everything else -- prefill, spec-verify, bf16 KV, unsupported geometry -- falls
-back to AiterAttnBackend.
+Everything else -- prefill, bf16 KV, unsupported geometry -- falls back to
+AiterAttnBackend.
+
+The multi-query arm is what makes speculative decoding work here at all: aiter's
+asm MLA has no kernel past qseqlen 4, so a larger draft window aborts the
+process during cuda-graph capture. Q stays bf16 in both arms, so there is no
+query scale to calibrate and the verify logits are not perturbed.
 
 aiter's MLA kernels also require num_head in {4, 8} or a multiple of 16 in
 [16, 128], which excludes Kimi-K3's 12 heads at TP8. The moonmath kernels take H
@@ -23,6 +29,7 @@ import logging
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -43,12 +50,17 @@ _MAX_HEADS = 16
 # Narrowest head count aiter's asm MLA has a kernel for: its qh16 kernels bake
 # gqa=16 into the ISA, so a 12-head call has nothing to dispatch to.
 _AITER_MLA_MIN_HEADS = 16
+# Draft window the multi-query kernel is compiled for. Position t of the window
+# attends KV [0, S - q_len + t]. q_len 1 is a different CTA shape and is the
+# single-query decode kernel's job.
+_MULTIQ_MIN_QLEN = 4
+_MULTIQ_MAX_QLEN = 8
 
 _MAX_BATCH = 8192  # size of the staged int32 seq_lens buffer
 
 
 class MoonmathMLABackend(AiterAttnBackend):
-    """MLA decode via moonmath_attention; aiter for everything else."""
+    """MLA decode and spec-verify via moonmath_attention; aiter for the rest."""
 
     # This backend has its own MLA kernels, so aiter's head-count assert must not
     # reject it at construction.
@@ -64,6 +76,11 @@ class MoonmathMLABackend(AiterAttnBackend):
         self._enabled = (
             bool(self.use_mla) and self.kv_cache_dtype == torch.float8_e4m3fnuz
         )
+        self._multiq = (
+            self._enabled
+            and envs.SGLANG_MOONMATH_MLA_MULTIQ_VERIFY.get()
+            and hasattr(mla, "mla_decode_a16w8_multiq_paged_dev")
+        )
 
         # `parts` must not vary inside a captured graph, so the kv-split is
         # frozen per (arm, bs, H, q_len) at first call / capture and reused.
@@ -77,9 +94,11 @@ class MoonmathMLABackend(AiterAttnBackend):
             _MAX_BATCH, dtype=torch.int32, device=model_runner.device
         )
         self._logged_decode = False
+        self._logged_verify = False
         logger.info(
-            "moonmath_mla: enabled=%s num_head=%s kv_cache_dtype=%s",
+            "moonmath_mla: enabled=%s multiq_verify=%s num_head=%s kv_cache_dtype=%s",
             self._enabled,
+            self._multiq,
             self.num_head,
             self.kv_cache_dtype,
         )
@@ -90,10 +109,26 @@ class MoonmathMLABackend(AiterAttnBackend):
     # out-of-graph before every replay, which is where a device buffer that a
     # captured kernel reads must be refreshed.
     def _stage_seq_lens_i32(self, forward_batch: ForwardBatch) -> None:
-        if not self._enabled or not forward_batch.forward_mode.is_decode():
+        mode = forward_batch.forward_mode
+        # TARGET_VERIFY is an extend mode, not is_decode(), so it needs staging
+        # of its own or the window kernel reads the previous forward's values.
+        is_verify = self._multiq and mode.is_target_verify()
+        if not self._enabled or not (mode.is_decode() or is_verify):
             return
         bs = forward_batch.batch_size
-        if bs <= _MAX_BATCH:
+        if bs > _MAX_BATCH:
+            return
+        if is_verify:
+            # `fb.seq_lens` at TARGET_VERIFY EXCLUDES the draft tokens, but their
+            # KV is already written and the window kernel wants the TOTAL span:
+            # its position t sees the first `seq_lens[b] - q_len + t + 1` slots.
+            # Take the span from `kv_indptr`, which is what `kv_indices` was
+            # built against, so it is by construction the number of slots this
+            # request owns -- no assumption that every request drafted the same
+            # number of tokens. Device-side, so it stays graph-capture safe.
+            indptr = self.forward_metadata.kv_indptr
+            torch.sub(indptr[1 : bs + 1], indptr[:bs], out=self._seq_lens_i32[:bs])
+        else:
             self._seq_lens_i32[:bs].copy_(forward_batch.seq_lens)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
@@ -209,6 +244,80 @@ class MoonmathMLABackend(AiterAttnBackend):
         )
         return out.reshape(B, H * KV_LORA_RANK)
 
+    # ── TARGET_VERIFY: the multi-query draft window ──────────────────────────
+    def _verify_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+        """Falls back to aiter rather than raising: a mishandled shape here
+        surfaces as mis-accepted tokens, not as an exception."""
+        return (
+            self._multiq
+            and fb.forward_mode.is_target_verify()
+            and fb.spec_info is not None
+            and _MULTIQ_MIN_QLEN <= fb.spec_info.num_tokens_per_req <= _MULTIQ_MAX_QLEN
+            and self._shape_eligible(q, layer, fb)
+        )
+
+    def _forward_verify(self, q, k, v, layer, fb, save_kv_cache):
+        """TARGET_VERIFY through the A16W8 multi-query window, or None to fall back.
+
+        `seq_lens` is the TOTAL span including the draft tokens (staged in
+        `_stage_seq_lens_i32`) and the kernel applies end-aligned causal masking
+        inside the window, which is bitwise equal to per-position q_len=1 calls.
+        """
+        B, H = fb.batch_size, layer.tp_q_head_num
+        q_len = fb.spec_info.num_tokens_per_req
+        if q.shape[0] != B * q_len:
+            return None
+
+        if save_kv_cache and k is not None:
+            self.token_to_kv_pool.set_kv_buffer(layer, fb.out_cache_loc, k, v)
+
+        parts = self._cached_parts(
+            ("verify", B, H, q_len),
+            lambda: self._mla.mla_decode_a16w8_multiq_plan_parts_q(
+                B, self._plan_seq_len(B), q_len, H
+            ),
+        )
+        if not self._logged_verify:
+            self._logged_verify = True
+            logger.info(
+                "moonmath_mla: multi-query verify bs=%d q_len=%d H=%d parts=%d",
+                B,
+                q_len,
+                H,
+                parts,
+            )
+
+        q_lat, q_pe = self._split_q(q, B, q_len, H)
+        out = torch.empty(
+            B, q_len, H, KV_LORA_RANK, dtype=torch.bfloat16, device=q.device
+        )
+        kv_indices, kv_indptr = self._kv_indices_int32()
+        self._mla.mla_decode_a16w8_multiq_paged_dev(
+            q_lat,
+            q_pe,
+            self.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            out,
+            self._seq_lens_i32[:B],
+            None,
+            kv_indices,
+            kv_indptr,
+            parts,
+            layer.scaling,
+            1.0 if layer.k_scale is None else float(layer.k_scale),
+        )
+        return out.reshape(B * q_len, H * KV_LORA_RANK)
+
+    def forward_extend(
+        self, q, k, v, layer, forward_batch, save_kv_cache=True, sinks=None
+    ):
+        if sinks is None and self._verify_eligible(q, layer, forward_batch):
+            out = self._forward_verify(q, k, v, layer, forward_batch, save_kv_cache)
+            if out is not None:
+                return out
+        return super().forward_extend(
+            q, k, v, layer, forward_batch, save_kv_cache, sinks
+        )
+
     # ── prefill fallback: aiter asm-MLA head padding ─────────────────────────
     @staticmethod
     def _aiter_mla_needs_head_pad(num_head: int) -> bool:
@@ -226,8 +335,8 @@ class MoonmathMLABackend(AiterAttnBackend):
         """`mla_decode_fwd` with Q zero-padded up to aiter's 16-head minimum.
 
         Every aiter asm-MLA call this backend makes goes through here, so one
-        override covers prefill, TARGET_VERIFY, DRAFT_EXTEND_V2 and the shapes
-        the decode arm declines. Unconditional at the head counts
+        override covers prefill, DRAFT_EXTEND_V2 and the shapes the two moonmath
+        arms decline. Unconditional at the head counts
         `_aiter_mla_needs_head_pad` selects: there aiter aborts the process, so
         there is no prior behaviour to preserve.
 

--- a/python/sglang/srt/layers/attention/moonmath_mla_backend.py
+++ b/python/sglang/srt/layers/attention/moonmath_mla_backend.py
@@ -1,14 +1,25 @@
-"""Moonmath MLA decode backend for DeepSeek-V3 on CDNA3 (MI300X / gfx942).
+"""Moonmath MLA attention backend for CDNA3 (gfx942).
 
-Subclasses AiterAttnBackend: decode with fp8 KV and H<=16 routes to the
-moonmath_attention A16W8 kernel (bf16 Q / fp8 KV, device-driven paged,
-cuda-graph-safe, reads sglang's existing fused-576 MLATokenToKVPool directly).
-Everything else (bf16 KV, H>16, prefill, spec-verify) falls back to aiter.
+Subclasses AiterAttnBackend and takes over absorbed MLA decode with the
+moonmath_attention A16W8 kernel (bf16 Q / fp8 KV), which reads sglang's existing
+fused-576 MLATokenToKVPool key buffer directly (page_size=1, device-driven,
+cuda-graph safe). H <= 16:
+
+    decode        q_len 1     -> mla_decode_a16w8_paged_dev
+
+Everything else -- prefill, spec-verify, bf16 KV, unsupported geometry -- falls
+back to AiterAttnBackend.
+
+aiter's MLA kernels also require num_head in {4, 8} or a multiple of 16 in
+[16, 128], which excludes Kimi-K3's 12 heads at TP8. The moonmath kernels take H
+as a runtime parameter and mask the trailing rows of the 16-row MFMA tile, so
+H=12 runs natively; the inherited fallback paths keep aiter's limit, so Q is
+zero-padded to 16 heads for them (`_mla_decode_fwd_with_head_pad`).
 """
 
 from __future__ import annotations
 
-import os
+import logging
 
 import torch
 
@@ -16,105 +27,244 @@ from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
+try:  # pragma: no cover - AMD-only dependency, mirrors aiter_backend's guard
+    from aiter.mla import mla_decode_fwd
+except ImportError:  # pragma: no cover
+    mla_decode_fwd = None
+
+logger = logging.getLogger(__name__)
+
 KV_LORA_RANK = 512
 KV_CACHE_DIM = 576  # 512 latent + 64 rope
 
+# Both A16W8 kernels serve one 16-head TP shard (H is a runtime parameter that
+# masks the trailing rows of the single 16-row MFMA query tile).
+_MAX_HEADS = 16
+# Narrowest head count aiter's asm MLA has a kernel for: its qh16 kernels bake
+# gqa=16 into the ISA, so a 12-head call has nothing to dispatch to.
+_AITER_MLA_MIN_HEADS = 16
+
+_MAX_BATCH = 8192  # size of the staged int32 seq_lens buffer
+
 
 class MoonmathMLABackend(AiterAttnBackend):
-    """MLA decode backend: A16W8 kernel for H<=16 fp8 KV, else aiter."""
+    """MLA decode via moonmath_attention; aiter for everything else."""
+
+    # This backend has its own MLA kernels, so aiter's head-count assert must not
+    # reject it at construction.
+    skip_mla_head_count_assert = True
 
     def __init__(self, model_runner):
         super().__init__(model_runner)
-        import moonmath_attention.mla as mla  # fail fast if missing
+        import moonmath_attention.mla as mla  # fail fast if not installed
 
         self._mla = mla
-        self._mla_ok = bool(self.use_mla)
-        self._disabled = os.environ.get("SGLANG_MOONMATH_MLA_DISABLE") == "1"
-        self._fp8_dtype = torch.float8_e4m3fnuz
-        self._fp8_kv = self._mla_ok and (self.kv_cache_dtype == self._fp8_dtype)
-
-        # Per-bs FIXED kv-split (frozen at first call / capture; reused on replay).
-        self._dec_parts: dict[int, int] = {}
-        model_config = getattr(model_runner, "model_config", None)
-        self._mla_max_ctx = (
-            model_config.context_len if model_config is not None else 131072
-        )
-        # int32 staging for device seq_lens (sglang gives int64 in eager mode).
-        self._mla_seqlen_i32 = torch.zeros(
-            8192, dtype=torch.int32, device=model_runner.device
+        # The kernels take the fused-576 pool as fp8 e4m3fnuz at a per-tensor
+        # descale; a bf16 KV cache has no A16W8 arm and falls back to aiter.
+        self._enabled = (
+            bool(self.use_mla) and self.kv_cache_dtype == torch.float8_e4m3fnuz
         )
 
-    # A16W8 kernel serves H<=16. H=128 (DSV3) falls back to aiter.
-    _A16W8_DECODE_MAX_HEADS = 16
+        # `parts` must not vary inside a captured graph, so the kv-split is
+        # frozen per (arm, bs, H, q_len) at first call / capture and reused.
+        self._parts: dict[tuple, int] = {}
+        self._max_ctx = model_runner.model_config.context_len
+        # sum(seq_lens) can never exceed the pool, so slots // bs bounds the mean
+        # sequence length at that batch. See _plan_seq_len.
+        self._kv_pool_slots = int(self.token_to_kv_pool.size)
+        # int32 staging for device seq_lens (sglang carries int64 in eager mode).
+        self._seq_lens_i32 = torch.zeros(
+            _MAX_BATCH, dtype=torch.int32, device=model_runner.device
+        )
+        self._logged_decode = False
+        logger.info(
+            "moonmath_mla: enabled=%s num_head=%s kv_cache_dtype=%s",
+            self._enabled,
+            self.num_head,
+            self.kv_cache_dtype,
+        )
 
-    def _decode_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+    # ── metadata ─────────────────────────────────────────────────────────────
+    # The kernels want int32 device seq_lens; sglang carries int64. Stage it in
+    # the metadata hooks -- once per forward rather than once per MLA layer, and
+    # out-of-graph before every replay, which is where a device buffer that a
+    # captured kernel reads must be refreshed.
+    def _stage_seq_lens_i32(self, forward_batch: ForwardBatch) -> None:
+        if not self._enabled or not forward_batch.forward_mode.is_decode():
+            return
+        bs = forward_batch.batch_size
+        if bs <= _MAX_BATCH:
+            self._seq_lens_i32[:bs].copy_(forward_batch.seq_lens)
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        super().init_forward_metadata(forward_batch)
+        self._stage_seq_lens_i32(forward_batch)
+
+    def init_forward_metadata_out_graph(
+        self, forward_batch: ForwardBatch, in_capture: bool = False
+    ):
+        super().init_forward_metadata_out_graph(forward_batch, in_capture)
+        self._stage_seq_lens_i32(forward_batch)
+
+    # ── kv-split planning ────────────────────────────────────────────────────
+    def _plan_seq_len(self, bs: int) -> int:
+        """Sequence length the frozen kv-split is planned from.
+
+        `parts` must be constant inside a captured graph, but the optimal split
+        tracks the live sequence length, and planning from the context window
+        over-splits badly at batch. All requests' KV shares one pool, so
+        `slots // bs` is the mean length at that batch -- a better input, and a
+        safe one: every `parts >= 1` is numerically correct.
+        """
+        return max(1, min(self._max_ctx, self._kv_pool_slots // max(bs, 1)))
+
+    def _cached_parts(self, key: tuple, plan) -> int:
+        parts = self._parts.get(key)
+        if parts is None:
+            parts = plan()
+            self._parts[key] = parts
+        return parts
+
+    # ── shared eligibility ───────────────────────────────────────────────────
+    def _shape_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+        """Absorbed-MLA geometry the A16W8 kernels are compiled for."""
         return (
-            self._mla_ok
-            and not self._disabled
-            and self._fp8_kv
+            self._enabled
             and q.dtype == torch.bfloat16
-            and layer.tp_q_head_num <= self._A16W8_DECODE_MAX_HEADS
+            and 1 <= layer.tp_q_head_num <= _MAX_HEADS
             and layer.qk_head_dim == KV_CACHE_DIM
             and layer.v_head_dim == KV_LORA_RANK
             and layer.tp_k_head_num == 1
             and layer.logit_cap == 0
-            and fb.forward_mode.is_decode()
-            and fb.spec_info is None
-            and fb.batch_size <= self._mla_seqlen_i32.numel()
+            and 0 < fb.batch_size <= _MAX_BATCH
             and self.forward_metadata is not None
             and self.forward_metadata.kv_indices is not None
             and self.forward_metadata.kv_indptr is not None
         )
 
+    def _kv_indices_int32(self):
+        # Both are int32 already, so `.to` returns the argument. It must STAY
+        # free: a real cast allocates a fresh tensor per layer, and a captured
+        # graph holds the address it saw at capture time.
+        meta = self.forward_metadata
+        return meta.kv_indices.to(torch.int32), meta.kv_indptr.to(torch.int32)
+
+    def _split_q(self, q, *shape):
+        """`q` as the contiguous (latent, rope) pair the kernel ABI takes."""
+        q = q.reshape(*shape, KV_CACHE_DIM)
+        return q[..., :KV_LORA_RANK].contiguous(), q[..., KV_LORA_RANK:].contiguous()
+
     # ── decode ───────────────────────────────────────────────────────────────
+    def _decode_eligible(self, q, layer: RadixAttention, fb: ForwardBatch) -> bool:
+        return (
+            fb.forward_mode.is_decode()
+            and fb.spec_info is None
+            and self._shape_eligible(q, layer, fb)
+        )
+
     def forward_decode(
         self, q, k, v, layer, forward_batch, save_kv_cache=True, sinks=None
     ):
+        """Absorbed MLA decode.
+
+        `q` is the 576-wide `cat([q_nope_out, q_pe])` and `k` the 576-wide
+        `cat([k_nope, k_pe])`; both are split back into the 512-wide latent and
+        the 64-wide rope halves the kernel's ABI takes as separate pointers.
+        """
         if sinks is not None or not self._decode_eligible(q, layer, forward_batch):
             return super().forward_decode(
                 q, k, v, layer, forward_batch, save_kv_cache, sinks
             )
 
-        mla = self._mla
         fb = forward_batch
-        B = fb.batch_size
-        H = layer.tp_q_head_num
-
+        B, H = fb.batch_size, layer.tp_q_head_num
         if save_kv_cache and k is not None:
             self.token_to_kv_pool.set_kv_buffer(layer, fb.out_cache_loc, k, v)
 
-        kv_pool = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
-        kv_indices = self.forward_metadata.kv_indices.to(torch.int32)
-        kv_indptr = self.forward_metadata.kv_indptr.to(torch.int32)
-        seq_lens = self._mla_seqlen_i32[:B]
-        seq_lens.copy_(fb.seq_lens)
-        k_descale = (
-            float(layer.k_scale) if getattr(layer, "k_scale", None) is not None else 1.0
+        parts = self._cached_parts(
+            ("decode", B, H),
+            lambda: self._mla.mla_decode_a16w8_plan_parts_capped(
+                B, H, self._plan_seq_len(B), KV_LORA_RANK
+            ),
         )
+        if not self._logged_decode:
+            self._logged_decode = True
+            logger.info("moonmath_mla: decode bs=%d H=%d parts=%d", B, H, parts)
 
-        parts = self._dec_parts.get(B)
-        if parts is None:
-            parts = mla.mla_decode_a16w8_plan_parts_capped(
-                B, H, self._mla_max_ctx, KV_LORA_RANK
-            )
-            self._dec_parts[B] = parts
-
-        q = q.reshape(B, H, layer.qk_head_dim)
-        q_lat = q[..., :KV_LORA_RANK].contiguous()
-        q_pe = q[..., KV_LORA_RANK:].contiguous()
+        q_lat, q_pe = self._split_q(q, B, H)
         out = torch.empty(B, H, KV_LORA_RANK, dtype=torch.bfloat16, device=q.device)
-        mla.mla_decode_a16w8_paged_dev(
+        kv_indices, kv_indptr = self._kv_indices_int32()
+        self._mla.mla_decode_a16w8_paged_dev(
             q_lat,
             q_pe,
-            kv_pool,
+            self.token_to_kv_pool.get_key_buffer(layer.layer_id),
             out,
-            seq_lens,
+            self._seq_lens_i32[:B],
             None,
             kv_indices,
             kv_indptr,
             parts,
             layer.scaling,
-            k_descale,
-            1.0,
+            1.0 if layer.k_scale is None else float(layer.k_scale),
         )
         return out.reshape(B, H * KV_LORA_RANK)
+
+    # ── prefill fallback: aiter asm-MLA head padding ─────────────────────────
+    @staticmethod
+    def _aiter_mla_needs_head_pad(num_head: int) -> bool:
+        """Whether the base class's repeat-interleave cannot reach gqa 16.
+
+        `head_repeat_factor = 16 // num_head` only lands on 16 when
+        `16 % num_head == 0`. At 12 the factor is 1, so nothing is repeated and
+        the kernel sees gqa=12; same for 3, 5, 6, 7 and 9..15.
+        """
+        return 0 < num_head < _AITER_MLA_MIN_HEADS and (
+            _AITER_MLA_MIN_HEADS % num_head != 0
+        )
+
+    def _mla_decode_fwd_with_head_pad(self, q, k_buffer_flat, layer, **kwargs):
+        """`mla_decode_fwd` with Q zero-padded up to aiter's 16-head minimum.
+
+        Every aiter asm-MLA call this backend makes goes through here, so one
+        override covers prefill, TARGET_VERIFY, DRAFT_EXTEND_V2 and the shapes
+        the decode arm declines. Unconditional at the head counts
+        `_aiter_mla_needs_head_pad` selects: there aiter aborts the process, so
+        there is no prior behaviour to preserve.
+
+        The padded rows do compute something meaningless -- a zero query still
+        attends over the real K/V -- but it never reaches head h < H, because
+        MLA attention has no reduction across the head axis: QK, softmax and PV
+        are per (head, query position); the split-KV combine is launched on
+        `grid = (bs, nhead)` and indexes its partials by `cur_head`; and the
+        output write is one disjoint row per head. So `o[:, :H]` is
+        bit-identical to an unpadded call.
+
+        The pad is on the query side only. K/V are the shared 576-wide latent
+        rows (`tp_k_head_num == 1`), so there is nothing per-query-head to
+        widen -- and padding them would be wrong, injecting zero-score keys into
+        every real head's softmax denominator.
+        """
+        num_head = q.shape[1]
+        if not self._aiter_mla_needs_head_pad(num_head):
+            return super()._mla_decode_fwd_with_head_pad(
+                q, k_buffer_flat, layer, **kwargs
+            )
+        assert mla_decode_fwd is not None, "aiter.mla.mla_decode_fwd did not import"
+        assert num_head == layer.tp_q_head_num, (
+            f"head-pad: q has {num_head} heads but layer declares "
+            f"{layer.tp_q_head_num}; the output slice would be wrong."
+        )
+
+        # (0, 0) leaves qk_head_dim alone; (0, n) appends n zero heads. The pad
+        # is captured as kernels, so a replay re-zeroes it.
+        q_padded = torch.nn.functional.pad(
+            q, (0, 0, 0, _AITER_MLA_MIN_HEADS - num_head)
+        )
+        o = q.new_empty(
+            (q.shape[0], _AITER_MLA_MIN_HEADS, layer.v_head_dim),
+            dtype=self.input_dtype,
+        )
+        mla_decode_fwd(q_padded, k_buffer_flat, o, **kwargs)
+        # Not a strided view of the 16-head buffer: downstream is a transpose +
+        # BMM, and a kernel assuming contiguity would read the padded heads.
+        return o[:, :num_head, :].contiguous()

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -172,9 +172,9 @@ class TritonAttnBackend(AttentionBackend):
         self.speculative_num_steps = get_spec().speculative_num_steps
         self.topk = get_spec().speculative_eagle_topk or 0
         # Split-KV verify is bit-equivalent only for a pure-causal chain (topk==1)
-        # and is gfx95-only; else fall back to extend_attention_fwd.
+        # and is gfx95/gfx942-only; else fall back to extend_attention_fwd.
         self.use_verify_splitkv = (
-            is_gfx95_supported()
+            (is_gfx95_supported() or is_gfx942_supported())
             and envs.SGLANG_ENABLE_SPLITKV_VERIFY.get()
             and self.topk == 1
         )

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1395,7 +1395,10 @@ class TritonAttnBackend(AttentionBackend):
         if (
             self.use_verify_splitkv
             and score_mod is None
-            and forward_batch.forward_mode.is_target_verify()
+            and (
+                forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
             and self.verify_splitkv_fwd(
                 q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                 k.contiguous(),

--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -60,6 +60,8 @@ class AiterMoeQuantInfo(MoeQuantInfo):
     intermediate_pad: int = 0
     swiglu_limit: float = 0.0
     fused_moe_kwargs: Optional[dict[str, Any]] = None
+    mxfp4_triton: bool = False
+    ep_rank: int = 0
 
 
 @dataclass
@@ -148,6 +150,38 @@ class AiterRunnerCore(MoeRunnerCore):
                     )
                 )
             return AiterRunnerOutput(hidden_states=runner_input.hidden_states)
+
+        if quant_info.mxfp4_triton:
+            # aiter.fused_moe below has no gfx942 a4w4 path and aborts; its
+            # Triton MXFP4 GEMMs do run on CDNA3. Gated in the quant method.
+            from sglang.srt.layers.moe.moe_runner.aiter_mxfp4_triton import (
+                fused_moe_mxfp4_triton,
+            )
+
+            out = fused_moe_mxfp4_triton(
+                runner_input.hidden_states,
+                quant_info.w13_weight,
+                quant_info.w2_weight,
+                quant_info.w13_scale,
+                quant_info.w2_scale,
+                runner_input.topk_weights,
+                runner_input.topk_ids,
+                activation=self.config.activation,
+                situ_beta=(
+                    float(self.config.gemm1_alpha)
+                    if self.config.gemm1_alpha is not None
+                    else 4.0
+                ),
+                situ_linear_beta=(
+                    float(self.config.gemm1_clamp_limit)
+                    if self.config.gemm1_clamp_limit is not None
+                    else 25.0
+                ),
+                num_global_experts=self.config.num_experts,
+                ep_rank=quant_info.ep_rank,
+                apply_router_weight_on_input=quant_info.doweight_stage1,
+            )
+            return AiterRunnerOutput(hidden_states=out)
 
         from aiter.fused_moe import fused_moe
 

--- a/python/sglang/srt/layers/moe/moe_runner/aiter_mxfp4_triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter_mxfp4_triton.py
@@ -1,0 +1,355 @@
+# SPDX-License-Identifier: Apache-2.0
+"""gfx942 (CDNA3) route for MXFP4 MoE, through aiter's *Triton* kernels.
+
+Why this file exists
+--------------------
+`AiterRunnerCore.run` calls `aiter.fused_moe`, the FlyDSL/asm dispatcher.  On
+gfx942 that aborts inside the activation quantiser::
+
+    [AITER] csrc/kernels/quant_kernels.cu:1984
+    fused_dynamic_mx_quant_moe_sort_hip: not support output type: fp4x2
+
+i.e. aiter has no gfx942 a4w4 path.  But aiter *also* ships pure-Triton MXFP4
+MoE GEMMs (`aiter/ops/triton/moe/moe_op_mxfp4*.py`) built on `tl.dot_scaled`,
+which upcasts MXFP4 to bf16 in registers onto the bf16 MFMA that CDNA3 has had
+since day one.  This module routes gfx942 MXFP4 MoE to them.
+
+Two things the installed aiter build must carry:
+
+* `arch_info.is_fp4_avail()` must include `gfx942` (the allowlist was never a
+  capability probe).
+* `aiter/ops/triton/configs/moe/gfx942-MOE-MX_FP4.json` must exist.  Without it
+  `get_optimal_moe_config` warns and returns a 256x256x64 tile that does not
+  compile on CDNA3 (64 KB LDS vs CDNA4's 160 KB).
+
+Scope guard: everything here is behind `use_triton_mxfp4_moe()`, which is False
+on any arch but gfx942 and on any build where the Triton kernels do not import.
+No other MoE path changes.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+from typing import Optional, Tuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_ENV = "SGLANG_AITER_MXFP4_TRITON"
+
+
+@functools.lru_cache(maxsize=1)
+def _arch() -> str:
+    try:
+        name = torch.cuda.get_device_properties(0).gcnArchName
+    except Exception:  # noqa: BLE001
+        return ""
+    return name.split(":")[0]
+
+
+@functools.lru_cache(maxsize=1)
+def _kernels_importable() -> bool:
+    try:
+        import aiter.ops.triton.moe.moe_align_block_size  # noqa: F401
+        import aiter.ops.triton.moe.moe_op_mxfp4  # noqa: F401
+
+        # The SiTU variant lives here rather than in aiter: it is an ordinary
+        # Triton kernel needing only aiter's public helpers, so aiter requires
+        # no source modification. See mxfp4_situ_fused.py, which also carries
+        # the `N // 2` fix for the EP zero-fill bug still present upstream in
+        # aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py.
+        from sglang.srt.layers.moe.moe_runner import mxfp4_situ_fused  # noqa: F401
+
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("aiter Triton MXFP4 MoE kernels unavailable: %s", exc)
+        return False
+
+
+@functools.lru_cache(maxsize=1)
+def use_triton_mxfp4_moe() -> bool:
+    """True iff MXFP4 MoE should go through aiter's Triton kernels.
+
+    `SGLANG_AITER_MXFP4_TRITON=0/1` forces it either way; otherwise it is
+    auto-enabled only on gfx942, where the FlyDSL fp4x2 path does not exist.
+    """
+    forced = os.environ.get(_ENV)
+    if forced is not None:
+        return forced == "1"
+    return _arch() == "gfx942" and _kernels_importable()
+
+
+# --------------------------------------------------------------------------
+# global -> local expert id
+# --------------------------------------------------------------------------
+@functools.lru_cache(maxsize=8)
+def _global_to_local_table(
+    num_global: int, num_local: int, ep_rank: int, device: str
+) -> torch.Tensor:
+    """[num_global] int32: local id, or -1 if the expert is on another EP rank.
+
+    Same convention as sglang's own `StandardDispatcher.local_expert_mapping`.
+    """
+    t = torch.full((num_global,), -1, dtype=torch.int32, device=device)
+    lo = ep_rank * num_local
+    hi = min(lo + num_local, num_global)
+    if hi > lo:
+        t[lo:hi] = torch.arange(hi - lo, dtype=torch.int32, device=device)
+    return t
+
+
+@functools.lru_cache(maxsize=1)
+def _topk_reduce_kernel():
+    """Build the fused top-k reduce kernel once.
+
+    Cached, not defined inside `_topk_reduce`: a `@triton.jit` decorator inside
+    the caller would construct a fresh JITFunction on every MoE layer of every
+    forward, re-running the decorator's source inspection each time. Kept out of
+    module scope so importing this file does not hard-require triton.
+    """
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _kernel(
+        down_ptr, ids_ptr, out_ptr, H, TOPK: tl.constexpr, BLOCK_H: tl.constexpr
+    ):
+        t = tl.program_id(0)
+        offs = tl.program_id(1) * BLOCK_H + tl.arange(0, BLOCK_H)
+        hmask = offs < H
+        acc = tl.zeros([BLOCK_H], dtype=tl.float32)
+        for k in tl.static_range(TOPK):
+            lid = tl.load(ids_ptr + t * TOPK + k)
+            # mask the LOAD, not the result: `down` is `empty`, so an unowned
+            # row may hold NaN and `0 * NaN` would poison the sum.
+            v = tl.load(
+                down_ptr + (t * TOPK + k) * H + offs, mask=hmask & (lid >= 0), other=0.0
+            )
+            acc += v.to(tl.float32)
+        tl.store(out_ptr + t * H + offs, acc.to(out_ptr.dtype.element_ty), mask=hmask)
+
+    return _kernel
+
+
+def _topk_reduce(down: torch.Tensor, local_ids: torch.Tensor, H: int) -> torch.Tensor:
+    """Sum the top-k expert outputs for each token, skipping unowned rows.
+
+    Replaces this pair::
+
+        down = torch.zeros((T * topk, 1, H), ...)   # fill kernel
+        ...
+        return down.view(T, topk, H).sum(dim=1)     # reduce kernel
+
+    The `zeros` existed only so the reduce could safely read rows the GEMM never
+    wrote: rows whose expert lives on another EP rank are dropped by the align
+    step.  Masking those out of the load removes the need to pre-zero at all, so
+    `down` can be `empty` and the two kernels collapse into one.
+
+    The masked load is what makes `empty` safe -- an unwritten row may hold NaN,
+    and multiplying by a 0/1 mask after the fact would propagate it.
+    `tl.load(..., mask=..., other=0.0)` never materialises the value.
+    """
+    import triton
+
+    T, topk = local_ids.shape
+    out = torch.empty((T, H), dtype=down.dtype, device=down.device)
+    BLOCK_H = 512
+    _topk_reduce_kernel()[(T, triton.cdiv(H, BLOCK_H))](
+        down,
+        local_ids,
+        out,
+        H,
+        TOPK=topk,
+        BLOCK_H=BLOCK_H,
+        num_warps=4,
+    )
+    return out
+
+
+def _align(
+    local_ids: torch.Tensor, block_size: int, num_experts: int
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """`ignore_invalid_expert=True` DROPS the -1 rows rather than bucketing
+    them, so at EP16 the grouped GEMM stops padding 15/16 of the rows into
+    blocks that only write zeros. The caller must therefore not assume every
+    row of `down` is written -- see the `torch.empty` note in
+    fused_moe_mxfp4_triton."""
+    from sglang.srt.layers.moe.moe_runner.triton_utils.moe_align_block_size import (
+        moe_align_block_size,
+    )
+
+    return moe_align_block_size(
+        local_ids, block_size, num_experts, ignore_invalid_expert=True
+    )
+
+
+@functools.lru_cache(maxsize=8)
+def _unit_scales(num_experts: int, device: str) -> Tuple[torch.Tensor, torch.Tensor]:
+    """The Triton MXFP4 kernels carry a second fp32 scale on top of the e8m0
+    microscales.  MXFP4 checkpoints have none, so it is 1 -- cache it rather
+    than re-materialising two tensors every layer of every forward."""
+    return (
+        torch.ones(1, dtype=torch.float32, device=device),
+        torch.ones(num_experts, dtype=torch.float32, device=device),
+    )
+
+
+# --------------------------------------------------------------------------
+# the MoE itself
+# --------------------------------------------------------------------------
+def fused_moe_mxfp4_triton(
+    hidden_states: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w13_scale: torch.Tensor,
+    w2_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    *,
+    activation: str = "silu",
+    situ_beta: float = 4.0,
+    situ_linear_beta: float = 25.0,
+    num_global_experts: Optional[int] = None,
+    ep_rank: int = 0,
+    apply_router_weight_on_input: bool = False,
+) -> torch.Tensor:
+    """MXFP4 MoE = gate/up GEMM (fused activation) + down GEMM + top-k reduce.
+
+    Layout expected (exactly what `Mxfp4MoEMethod.create_weights` allocates,
+    minus aiter's `shuffle_weight` preshuffle, which the Triton kernels do not
+    consume):
+
+        w13_weight [E, 2*I, H/2] uint8   e2m1, first I rows gate, next I up
+        w13_scale  [E, 2*I, H/32] uint8  e8m0
+        w2_weight  [E, H,   I/2] uint8
+        w2_scale   [E, H,   I/32] uint8
+    """
+    import triton.language as tl  # noqa: F401  (torch_to_triton_dtype values)
+    from aiter.ops.triton.moe.moe_op_mxfp4 import fused_moe_mxfp4
+    from aiter.ops.triton.utils.moe_config_utils import get_optimal_moe_config
+    from aiter.ops.triton.utils.types import torch_to_triton_dtype
+
+    from sglang.srt.layers.moe.moe_runner.mxfp4_situ_fused import (
+        fused_moe_mxfp4_act,
+    )
+
+    assert activation in ("silu", "situ"), activation
+
+    w13 = w13_weight.view(torch.uint8)
+    w2 = w2_weight.view(torch.uint8)
+    E, N13, _ = w13.shape
+    H = w2.shape[1]
+    inter = N13 // 2
+    T = hidden_states.shape[0]
+    topk = topk_ids.shape[1]
+    dev = hidden_states.device
+    dt = hidden_states.dtype
+
+    # ---- int32 address guard -------------------------------------------
+    # The aiter Triton MoE kernels index their operands as
+    # `ptr + stride * offs_token[:, None]` with `offs_token` loaded as int32
+    # from sorted_token_ids, so the flat element offset must stay under 2^31.
+    # The binding term is the intermediate: (T * topk) rows x `inter` columns.
+    # Past that the kernel walks off the end of the buffer -- observed as
+    # "Memory access fault ... Write access to a read-only page". One unchunked
+    # long prefill is exactly that shape. Split the token dimension rather than
+    # patch the kernels; the
+    # expert weights and the routing are unaffected by the split.
+    max_rows = (2**31 - 1) // max(inter, H, hidden_states.shape[1])
+    max_T = max(1, max_rows // max(topk, 1))
+    if T > max_T:
+        chunks = [
+            fused_moe_mxfp4_triton(
+                hidden_states[i : i + max_T],
+                w13_weight,
+                w2_weight,
+                w13_scale,
+                w2_scale,
+                topk_weights[i : i + max_T],
+                topk_ids[i : i + max_T],
+                activation=activation,
+                situ_beta=situ_beta,
+                situ_linear_beta=situ_linear_beta,
+                num_global_experts=num_global_experts,
+                ep_rank=ep_rank,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+            )
+            for i in range(0, T, max_T)
+        ]
+        return torch.cat(chunks, dim=0)
+
+    config = get_optimal_moe_config(dt, use_mxfp4=True, M=T)
+    bm = config["BLOCK_SIZE_M"]
+
+    # global -> local ids; experts owned by another EP rank map to -1, which
+    # _align drops.
+    if num_global_experts is not None and num_global_experts != E:
+        table = _global_to_local_table(num_global_experts, E, ep_rank, str(dev))
+        local_ids = table[topk_ids.to(torch.long)]
+    else:
+        local_ids = topk_ids.to(torch.int32)
+
+    sorted_token_ids, expert_ids, num_tokens_post_padded = _align(local_ids, bm, E)
+
+    a_scale, b_scale = _unit_scales(E, str(dev))
+    ct = torch_to_triton_dtype[dt]
+
+    # ---- 1. gate/up GEMM, activation fused into the epilogue
+    inter_states = torch.empty((T * topk, inter), dtype=dt, device=dev)
+    fused_moe_mxfp4_act(
+        hidden_states,
+        w13,
+        inter_states,
+        a_scale,
+        b_scale,
+        None,
+        w13_scale,
+        topk_weights,
+        local_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        apply_router_weight_on_input,  # mul_routed_weight
+        topk,
+        False,  # swizzle_mx_a  -- preshuffled scales are CDNA4-only
+        False,  # swizzle_mx_b
+        config,
+        ct,
+        activation=activation,
+        situ_beta=situ_beta,
+        situ_linear_beta=situ_linear_beta,
+    )
+
+    # ---- 2. down GEMM; rows are already (token, expert) pairs -> top_k=1,
+    #         and the routed weight folds in here.
+    #
+    # `empty` is safe only because the fused reduce masks out the rows the
+    # align dropped (expert owned by another EP rank), which the GEMM never
+    # writes. A `.sum()` over them would read uninitialised memory.
+    down = torch.empty((T * topk, 1, H), dtype=dt, device=dev)
+    fused_moe_mxfp4(
+        inter_states,
+        w2,
+        down,
+        a_scale,
+        b_scale,
+        None,
+        w2_scale,
+        topk_weights,
+        local_ids,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        not apply_router_weight_on_input,  # mul_routed_weight
+        1,
+        False,
+        False,
+        config,
+        ct,
+    )
+
+    # ---- 3. top-k reduce (fused with the zero-fill step 2 used to need)
+    return _topk_reduce(down, local_ids, H)

--- a/python/sglang/srt/layers/moe/moe_runner/mxfp4_situ_fused.py
+++ b/python/sglang/srt/layers/moe/moe_runner/mxfp4_situ_fused.py
@@ -1,0 +1,535 @@
+# SPDX-License-Identifier: MIT
+# Copyright (C) 2024-2026, Advanced Micro Devices, Inc. All rights reserved.
+#
+# Derived from aiter (commit 9127c94a):
+#   aiter/ops/triton/moe/moe_op_mxfp4_silu_fused.py               (wrapper)
+#   aiter/ops/triton/_triton_kernels/moe/moe_op_mxfp4_silu_fused.py (kernel)
+#
+# CHANGE vs upstream: the fused epilogue gains a compile-time activation switch.
+#
+#   ACT_SITU = False  ->  SwiGLU, byte-identical to upstream:
+#                             out = silu(gate) * up
+#   ACT_SITU = True   ->  Kimi-K3's SituGLU (sglang SituAndMul, beta=4.0,
+#                         linear_beta=25.0):
+#                             gate_out = beta        * tanh(gate/beta) * sigmoid(gate)
+#                             up_out   = linear_beta * tanh(up/linear_beta)
+#                             out      = gate_out * up_out
+#
+# SiTU *is* SwiGLU with both branches soft-clipped by tanh; as beta -> inf it
+# degenerates to SwiGLU exactly.  Implemented with tanh(x) = 2*sigmoid(2x) - 1
+# so it reuses the same exp2-based sigmoid the SwiGLU epilogue already needs:
+# 3 exp2 + 3 reciprocal per output element instead of 1 + 1, on an epilogue
+# amortised over K=3584 -- i.e. off the critical path.  The GEMM loop, the
+# pointer arithmetic, the N-interleaving trick and the store are untouched.
+
+from typing import Any, Dict
+
+import torch
+import triton
+import triton.language as tl
+from aiter.ops.triton._triton_kernels.moe.moe_op_mxfp4_silu_fused import (
+    get_scaled_dot_format_string,
+)
+from aiter.ops.triton.utils._triton.kernel_repr import make_kernel_repr
+from aiter.ops.triton.utils._triton.moe_common import _write_zeros_to_output
+from aiter.ops.triton.utils._triton.pid_preprocessing import pid_grid, remap_xcd
+from aiter.ops.triton.utils.types import torch_to_triton_dtype
+
+LOG2E: tl.constexpr = 1.44269504089
+
+
+@triton.jit
+def _sigmoid_exp2(x):
+    """1/(1+e^-x) via exp2 -- same transform aiter's _silu_exp2 uses."""
+    return 1.0 / (1.0 + tl.exp2(-(x * 1.44269504089)))
+
+
+@triton.jit
+def _silu_exp2(x):
+    # verbatim from aiter/ops/triton/_triton_kernels/activation.py
+    return x / (1.0 + tl.exp2(-(x * 1.44269504089)))
+
+
+@triton.jit
+def _situ_and_mul(gate, up, BETA: tl.constexpr, LINEAR_BETA: tl.constexpr):
+    """Kimi-K3 SituGLU.
+
+    gate_out = BETA * tanh(gate/BETA) * sigmoid(gate)
+    up_out   = LINEAR_BETA * tanh(up/LINEAR_BETA)
+
+    tanh(x) = 2*sigmoid(2x) - 1, and sigmoid is the exp2 form above, so the
+    whole thing is 3 exp2 + 3 reciprocal + 5 multiplies.  The two 2/BETA
+    factors are folded into constants at compile time.
+    """
+    TWO_OVER_BETA: tl.constexpr = 2.0 / BETA
+    TWO_OVER_LBETA: tl.constexpr = 2.0 / LINEAR_BETA
+    # tanh(gate/BETA) = 2*sigmoid(2*gate/BETA) - 1
+    tanh_g = 2.0 * _sigmoid_exp2(gate * TWO_OVER_BETA) - 1.0
+    gate_out = (BETA * tanh_g) * _sigmoid_exp2(gate)
+    # tanh(up/LINEAR_BETA)
+    tanh_u = 2.0 * _sigmoid_exp2(up * TWO_OVER_LBETA) - 1.0
+    up_out = LINEAR_BETA * tanh_u
+    return gate_out * up_out
+
+
+_fused_moe_kernel_mxfp4_act_repr = make_kernel_repr(
+    "_fused_moe_kernel_mxfp4_act",
+    [
+        "A_DTYPE_FORMAT",
+        "B_DTYPE_FORMAT",
+        "BLOCK_SIZE_M",
+        "BLOCK_SIZE_N",
+        "BLOCK_SIZE_K",
+        "GROUP_SIZE_M",
+        "EVEN_K",
+        "MUL_ROUTED_WEIGHT",
+        "top_k",
+        "compute_type",
+        "SWIZZLE_MX_A",
+        "SWIZZLE_MX_B",
+        "ACT_SITU",
+    ],
+)
+
+
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % args["BLOCK_SIZE_K"] == 0,
+    }
+)
+@triton.jit(repr=_fused_moe_kernel_mxfp4_act_repr)
+def _fused_moe_kernel_mxfp4_act(
+    # Pointers to matrices
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    a_mx_scale_ptr,
+    b_mx_scale_ptr,
+    topk_weights_ptr,
+    sorted_token_ids_ptr,
+    expert_ids_ptr,
+    num_tokens_post_padded_ptr,
+    # Matrix dimensions
+    N,
+    K,
+    num_valid_tokens,
+    # Strides
+    stride_am,
+    stride_ak,
+    stride_be,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    stride_amxm,
+    stride_amxk,
+    stride_bmxe,
+    stride_bmxk,
+    stride_bmxn,
+    # Meta-parameters
+    A_DTYPE_FORMAT: tl.constexpr,
+    B_DTYPE_FORMAT: tl.constexpr,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    EVEN_K: tl.constexpr,
+    MUL_ROUTED_WEIGHT: tl.constexpr,
+    top_k: tl.constexpr,
+    compute_type: tl.constexpr,
+    SWIZZLE_MX_A: tl.constexpr,  # TODO add swizzle support
+    SWIZZLE_MX_B: tl.constexpr,  # TODO add swizzle support
+    ACT_SITU: tl.constexpr = False,
+    SITU_BETA: tl.constexpr = 4.0,
+    SITU_LINEAR_BETA: tl.constexpr = 25.0,
+):
+    """MoE GEMM with MXFP4 weights and a fused gated activation.
+
+    Identical to aiter's `_fused_moe_kernel_mxfp4_silu` except for the last
+    four lines of the epilogue (see ACT_SITU).
+    """
+    is_a_microscaled_format: tl.constexpr = a_mx_scale_ptr is not None
+    is_b_microscaled_format: tl.constexpr = b_mx_scale_ptr is not None
+    MX_PACK_DIVISOR: tl.constexpr = 32
+    if is_a_microscaled_format:
+        a_type: tl.constexpr = a_ptr.dtype.element_ty
+        tl.static_assert(
+            a_type == tl.uint8 or (a_type == tl.float8e4nv or a_type == tl.float8e5),
+            "mx_weight_ptr must be 1 byte",
+        )
+        tl.static_assert(
+            a_mx_scale_ptr.dtype.element_ty == tl.uint8, "a_mx_scale_ptr must be uint8"
+        )
+        tl.static_assert(
+            BLOCK_SIZE_K % MX_PACK_DIVISOR == 0,
+            "BLOCK_SIZE_K must be a multiple of MX_PACK_DIVISOR",
+        )
+    if is_b_microscaled_format:
+        b_type: tl.constexpr = b_ptr.dtype.element_ty
+        tl.static_assert(
+            b_type == tl.uint8 or (b_type == tl.float8e4nv or b_type == tl.float8e5),
+            "mx_weight_ptr must be 1 byte",
+        )
+        tl.static_assert(
+            b_mx_scale_ptr.dtype.element_ty == tl.uint8, "b_mx_scale_ptr must be uint8"
+        )
+        tl.static_assert(
+            BLOCK_SIZE_K % MX_PACK_DIVISOR == 0,
+            "BLOCK_SIZE_K must be a multiple of MX_PACK_DIVISOR",
+        )
+
+    # -----------------------------------------------------------
+    # Map program ids `pid` to the block of C it should compute.
+    # This is done in a grouped ordering to promote L2 data reuse.
+    pid = tl.program_id(axis=0)
+    num_tokens_post_padded = tl.load(num_tokens_post_padded_ptr)
+
+    num_pid_m = tl.cdiv(num_tokens_post_padded, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    NUM_XCDS: tl.constexpr = 8
+
+    GRID_MN = num_pid_n * num_pid_m
+    if pid < GRID_MN:
+        pid = remap_xcd(pid, GRID_MN, NUM_XCDS)
+    else:
+        return  # rest of the tiles are dummy paddings
+    pid_m, pid_n = pid_grid(pid, num_pid_m, num_pid_n, GROUP_SIZE_M)
+
+    # ----------------------------------------------------------
+    # Create pointers for the first blocks of A and B.
+    offs_token_id = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M).to(tl.int64)
+    offs_token = tl.load(sorted_token_ids_ptr + offs_token_id)
+    token_mask = offs_token < num_valid_tokens
+
+    BLOCK_SIZE_HALF: tl.constexpr = BLOCK_SIZE_N // 2
+
+    off_expert = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
+    if off_expert == -1:
+        # Write back zeros when the expert is not in this EP rank.
+        #
+        # BUGFIX vs upstream `moe_op_mxfp4_silu_fused.py`: this is a
+        # gate/up-FUSED kernel, so C has N//2 columns and the real store below
+        # writes BLOCK_SIZE_HALF of them at `pid_n * BLOCK_SIZE_HALF`.  Upstream
+        # passes the *unfused* N / BLOCK_SIZE_N here, so on the EP sentinel path
+        # it writes twice as many columns at twice the offset -- past the end of
+        # every row of C, corrupting the following rows.  Nothing exercised it
+        # until MXFP4 + EP>1 met on gfx942.  Only the zero-write is changed; the
+        # arithmetic epilogue is untouched.
+        _write_zeros_to_output(
+            c_ptr,
+            stride_cm,
+            stride_cn,
+            pid_n,
+            N // 2,
+            offs_token,
+            token_mask,
+            BLOCK_SIZE_M,
+            BLOCK_SIZE_HALF,
+            compute_type,
+        )
+        return
+
+    i = tl.arange(0, BLOCK_SIZE_N).to(tl.int64)
+    # [0, 0, 1, 1, ..., BLOCK_SIZE_HALF - 1, BLOCK_SIZE_HALF - 1]
+    i_floor = i // 2
+    offs_half = ((pid_n * (BLOCK_SIZE_N // 2) + i_floor) % (N // 2)).to(tl.int64)
+    # even lanes take a column from the FIRST half of N (gate), odd lanes from
+    # the SECOND half (up) -- so the reshape+split below needs no permute.
+    offs_b_n = ((offs_half + (i % 2) * (N // 2)) % N).to(tl.int64)
+
+    # Load a_scale, b_scale
+    a_scale = tl.load(a_scale_ptr)
+    b_scale = tl.load(b_scale_ptr + off_expert)
+    # Set offsets of B on dim N
+    offs_b_n = tl.max_contiguous(
+        tl.multiple_of(offs_b_n % N, BLOCK_SIZE_N), BLOCK_SIZE_N
+    )
+    # Load a_mx_scale
+    if is_a_microscaled_format:
+        A_PACK_DIVISOR: tl.constexpr = 2 if a_ptr.dtype.element_ty == tl.uint8 else 1
+        PACKED_BLOCK_K_A: tl.constexpr = BLOCK_SIZE_K // A_PACK_DIVISOR
+        MX_SCALE_BLOCK_K_A: tl.constexpr = BLOCK_SIZE_K // MX_PACK_DIVISOR
+
+        if SWIZZLE_MX_A:
+            tl.static_assert(BLOCK_SIZE_M % 128 == 0)
+            tl.static_assert(MX_SCALE_BLOCK_K_A % 4 == 0)
+            PACKED_MX_BLOCK_A: tl.constexpr = (MX_SCALE_BLOCK_K_A // 4) * 32 * 4 * 4
+            offs_inner = tl.arange(0, PACKED_MX_BLOCK_A)
+            offs_scale_m = (
+                pid_m * (BLOCK_SIZE_M // 128) + tl.arange(0, BLOCK_SIZE_M // 128)
+            ) % N
+            offs_scale_m = tl.max_contiguous(
+                tl.multiple_of(offs_scale_m, BLOCK_SIZE_M // 128), BLOCK_SIZE_M // 128
+            )
+
+            a_mx_scale_ptrs = (
+                a_mx_scale_ptr
+                + offs_scale_m.to(tl.int64)[:, None] * stride_amxm
+                + offs_inner[None, :]
+            )
+        else:
+            offs_scale_ak = tl.arange(0, MX_SCALE_BLOCK_K_A)
+            offs_scale_m = offs_token
+            a_mx_scale_ptrs = (
+                a_mx_scale_ptr
+                + offs_scale_ak.to(tl.int64)[None, :] * stride_amxk
+                + offs_scale_m.to(tl.int64)[:, None] // top_k * stride_amxm
+            )
+    else:
+        a_mx_scale_ptrs = None
+        A_PACK_DIVISOR: tl.constexpr = 1
+        MX_SCALE_BLOCK_K_A: tl.constexpr = 1
+        PACKED_BLOCK_K_A: tl.constexpr = BLOCK_SIZE_K
+    # Load b_mx_scale
+    if is_b_microscaled_format:
+        B_PACK_DIVISOR: tl.constexpr = 2 if b_ptr.dtype.element_ty == tl.uint8 else 1
+        PACKED_BLOCK_K_B: tl.constexpr = BLOCK_SIZE_K // B_PACK_DIVISOR
+        MX_SCALE_BLOCK_K_B: tl.constexpr = BLOCK_SIZE_K // MX_PACK_DIVISOR
+
+        b_mx_scale_ptr += off_expert * stride_bmxe
+
+        if SWIZZLE_MX_B:
+            tl.static_assert(BLOCK_SIZE_N % 128 == 0)
+            tl.static_assert(MX_SCALE_BLOCK_K_B % 4 == 0)
+            PACKED_MX_BLOCK_B: tl.constexpr = (MX_SCALE_BLOCK_K_B // 4) * 32 * 4 * 4
+            offs_inner = tl.arange(0, PACKED_MX_BLOCK_B)
+            offs_scale_n = (
+                pid_n * (BLOCK_SIZE_N // 128) + tl.arange(0, BLOCK_SIZE_N // 128)
+            ) % N
+            offs_scale_n = tl.max_contiguous(
+                tl.multiple_of(offs_scale_n, BLOCK_SIZE_N // 128), BLOCK_SIZE_N // 128
+            )
+
+            b_mx_scale_ptrs = (
+                b_mx_scale_ptr
+                + offs_scale_n.to(tl.int64)[:, None]
+                * PACKED_MX_BLOCK_B
+                * (K // MX_SCALE_BLOCK_K_B // (MX_PACK_DIVISOR // B_PACK_DIVISOR))
+                + offs_inner[None, :]
+            )
+        else:
+            offs_scale_bk = tl.arange(0, MX_SCALE_BLOCK_K_B)
+            offs_scale_n = offs_b_n
+            b_mx_scale_ptrs = (
+                b_mx_scale_ptr
+                + offs_scale_bk.to(tl.int64)[None, :] * stride_bmxk
+                + offs_scale_n.to(tl.int64)[:, None] * stride_bmxn
+            )
+    else:
+        b_mx_scale_ptrs = None
+        B_PACK_DIVISOR: tl.constexpr = 1
+        MX_SCALE_BLOCK_K_B: tl.constexpr = 1
+        PACKED_BLOCK_K_B: tl.constexpr = BLOCK_SIZE_K
+
+    offs_a_k = tl.arange(0, PACKED_BLOCK_K_A)
+    offs_b_k = tl.arange(0, PACKED_BLOCK_K_B)
+    a_ptrs = a_ptr + (
+        offs_token[:, None] // top_k * stride_am + offs_a_k[None, :] * stride_ak
+    )
+    b_ptrs = (
+        b_ptr
+        + off_expert * stride_be
+        + (offs_b_k[:, None] * stride_bk + offs_b_n[None, :] * stride_bn)
+    )
+
+    # -----------------------------------------------------------
+    # Iterate to compute a block of the C matrix.
+    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, PACKED_BLOCK_K_A)):
+        if EVEN_K:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None],
+                other=0.0,
+            )
+            b = tl.load(b_ptrs)
+        else:
+            a = tl.load(
+                a_ptrs,
+                mask=token_mask[:, None]
+                & (offs_a_k[None, :] < (K - k * PACKED_BLOCK_K_A)),
+                other=0.0,
+            )
+            b = tl.load(
+                b_ptrs,
+                mask=offs_b_k[:, None] < (K - k * PACKED_BLOCK_K_B),
+                other=0.0,
+            )
+        # We accumulate along the K dimension.
+        if is_a_microscaled_format or is_b_microscaled_format:
+            if is_a_microscaled_format:
+                mask_ak_scale = offs_scale_ak < (K - k * PACKED_BLOCK_K_A) // (
+                    MX_PACK_DIVISOR // A_PACK_DIVISOR
+                )
+                a_mx_scales = tl.load(
+                    a_mx_scale_ptrs, mask=mask_ak_scale[None, :], other=0.0
+                )
+            else:
+                a_mx_scales = None
+            mask_bk_scale = offs_scale_bk < (K - k * PACKED_BLOCK_K_B) // (
+                MX_PACK_DIVISOR // B_PACK_DIVISOR
+            )
+            b_mx_scales = tl.load(
+                b_mx_scale_ptrs, mask=mask_bk_scale[None, :], other=0.0
+            )
+
+            accumulator = tl.dot_scaled(
+                a,
+                a_mx_scales,
+                A_DTYPE_FORMAT,
+                b,
+                b_mx_scales,
+                B_DTYPE_FORMAT,
+                acc=accumulator,
+                fast_math=True,
+            )
+
+            if is_a_microscaled_format:
+                if SWIZZLE_MX_A:
+                    a_mx_scale_ptrs += MX_SCALE_BLOCK_K_A // 4 * stride_amxk
+                else:
+                    a_mx_scale_ptrs += MX_SCALE_BLOCK_K_A * stride_amxk
+            if SWIZZLE_MX_B:
+                b_mx_scale_ptrs += MX_SCALE_BLOCK_K_B // 4 * 512
+            else:
+                b_mx_scale_ptrs += MX_SCALE_BLOCK_K_B * stride_bmxk
+        # Advance the ptrs to the next K block.
+        a_ptrs += PACKED_BLOCK_K_A * stride_ak
+        b_ptrs += PACKED_BLOCK_K_B * stride_bk
+
+    # Multiply with the scalar weight
+    accumulator *= a_scale * b_scale
+    if MUL_ROUTED_WEIGHT:
+        moe_weight = tl.load(topk_weights_ptr + offs_token, mask=token_mask, other=0)
+        accumulator = accumulator * moe_weight[:, None]
+    accumulator = accumulator.to(compute_type)
+
+    gate_acc, up_acc = (
+        accumulator.to(tl.float32).reshape(BLOCK_SIZE_M, BLOCK_SIZE_HALF, 2).split()
+    )
+
+    # ------------------------- THE ONLY DIVERGENCE FROM UPSTREAM -------------
+    if ACT_SITU:
+        accumulator = _situ_and_mul(gate_acc, up_acc, SITU_BETA, SITU_LINEAR_BETA).to(
+            compute_type
+        )
+    else:
+        accumulator = (_silu_exp2(gate_acc) * up_acc).to(compute_type)
+    # -------------------------------------------------------------------------
+
+    # -----------------------------------------------------------
+    # Write back the block of the output
+    offs_cn = pid_n * BLOCK_SIZE_HALF + tl.arange(0, BLOCK_SIZE_HALF)
+    c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N // 2)
+    tl.store(c_ptrs, accumulator, mask=c_mask)
+
+
+def fused_moe_mxfp4_act(
+    A: torch.Tensor,
+    B: torch.Tensor,
+    C: torch.Tensor,
+    A_scale: torch.Tensor,
+    B_scale: torch.Tensor,
+    A_mx_scale: torch.Tensor,
+    B_mx_scale: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    sorted_token_ids: torch.Tensor,
+    expert_ids: torch.Tensor,
+    num_tokens_post_padded: torch.Tensor,
+    mul_routed_weight: bool,
+    top_k: int,
+    swizzle_mx_a: bool,
+    swizzle_mx_b: bool,
+    config: Dict[str, Any],
+    compute_type: tl.dtype,
+    activation: str = "silu",
+    situ_beta: float = 4.0,
+    situ_linear_beta: float = 25.0,
+) -> None:
+    """Drop-in replacement for aiter's `fused_moe_mxfp4_silu` with an extra
+    `activation` argument.
+
+    activation="silu"  -> upstream SwiGLU epilogue, byte-identical output.
+    activation="situ"  -> Kimi-K3 SituGLU (see module docstring).
+
+    swizzle_mx_a / swizzle_mx_b MUST be False on gfx942 -- preshuffled scale
+    layouts are not emulated off CDNA4.
+    """
+    assert activation in ("silu", "situ"), activation
+    assert topk_weights.stride(1) == 1
+    assert sorted_token_ids.stride(0) == 1
+
+    assert A_scale is not None
+    assert B_scale is not None
+    if A.dtype == torch.uint8:
+        assert A_mx_scale is not None, "A_mx_scale should exist when A is mxfp4"
+        A_mx_scale_strid_m, A_mx_scale_strid_k = A_mx_scale.stride()
+    else:
+        assert A_mx_scale is None, "A_mx_scale should not exist when A is not mxfp4"
+        A_mx_scale_strid_m, A_mx_scale_strid_k = None, None
+    # NOTE: Only supports B_mx_scale
+    assert B_mx_scale is not None
+
+    EM = sorted_token_ids.shape[0]
+    if A.shape[0] < config["BLOCK_SIZE_M"]:
+        # optimize for small batch_size (same heuristic as upstream)
+        EM = min(sorted_token_ids.shape[0], A.shape[0] * top_k * config["BLOCK_SIZE_M"])
+
+    A_tl_dtype = torch_to_triton_dtype[A.dtype]
+    A_DTYPE_FORMAT = get_scaled_dot_format_string(A_tl_dtype)
+    B_tl_dtype = torch_to_triton_dtype[B.dtype]
+    B_DTYPE_FORMAT = get_scaled_dot_format_string(B_tl_dtype)
+
+    grid = lambda META: (  # noqa: E731
+        triton.cdiv(EM, META["BLOCK_SIZE_M"])
+        * triton.cdiv(B.shape[1], META["BLOCK_SIZE_N"]),
+    )
+    _fused_moe_kernel_mxfp4_act[grid](
+        A,
+        B,
+        C,
+        A_scale,
+        B_scale,
+        A_mx_scale,
+        B_mx_scale,
+        topk_weights,
+        sorted_token_ids,
+        expert_ids,
+        num_tokens_post_padded,
+        B.shape[1],
+        A.shape[1],
+        topk_ids.numel(),
+        A.stride(0),
+        A.stride(1),
+        B.stride(0),
+        B.stride(2),
+        B.stride(1),
+        C.stride(0),
+        C.stride(1),
+        A_mx_scale_strid_m,
+        A_mx_scale_strid_k,
+        B_mx_scale.stride(0),
+        B_mx_scale.stride(2),
+        B_mx_scale.stride(1),
+        A_DTYPE_FORMAT=A_DTYPE_FORMAT,
+        B_DTYPE_FORMAT=B_DTYPE_FORMAT,
+        MUL_ROUTED_WEIGHT=mul_routed_weight,
+        top_k=top_k,
+        compute_type=compute_type,
+        SWIZZLE_MX_A=swizzle_mx_a,
+        SWIZZLE_MX_B=swizzle_mx_b,
+        ACT_SITU=(activation == "situ"),
+        SITU_BETA=situ_beta,
+        SITU_LINEAR_BETA=situ_linear_beta,
+        **config,
+    )
+
+
+def fused_moe_mxfp4_situ(*args, **kwargs) -> None:
+    """`fused_moe_mxfp4_act` with activation defaulted to SiTU."""
+    kwargs.setdefault("activation", "situ")
+    return fused_moe_mxfp4_act(*args, **kwargs)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -40,6 +40,7 @@ from sglang.srt.layers.amx_utils import (
 )
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.moe import MoeRunner, MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.aiter_mxfp4_triton import use_triton_mxfp4_moe
 from sglang.srt.layers.moe.moe_runner.triton import TritonMoeQuantInfo
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend, get_moe_runner_backend
 from sglang.srt.layers.quantization.base_config import (
@@ -871,6 +872,13 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         .contiguous()
                         .view(-1, n)
                     )
+
+            if use_triton_mxfp4_moe():
+                # The Triton kernels read the layout above; the preshuffle below
+                # is for the FlyDSL asm kernels.
+                layer.w13_weight.is_shuffled = False
+                layer.w2_weight.is_shuffled = False
+                return
 
             k3_situ_a8w4 = (
                 os.environ.get("AITER_SITUV2_A8W4", "0") == "1"
@@ -1714,6 +1722,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 quant_type=AiterQuantType.PER_1X32,
                 w13_scale=layer.w13_weight_scale,
                 w2_scale=layer.w2_weight_scale,
+                mxfp4_triton=use_triton_mxfp4_moe(),
+                ep_rank=layer.moe_ep_rank,
                 b13=layer.w13_weight_bias if self.with_bias else None,
                 b2=layer.w2_weight_bias if self.with_bias else None,
                 expert_mask=layer.dispatcher.expert_mask_gpu,

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -178,6 +178,16 @@ def handle_attention_aiter(attn, forward_batch):
         return AttnForwardMethod.MLA
 
 
+def handle_attention_moonmath_mla(attn, forward_batch):
+    # Same split as aiter (our backend subclasses AiterAttnBackend): pure prefill -> non-absorbed
+    # MHA (materialized K[192]/V[128]); decode + spec -> absorbed MLA (q[576] -> o[512] latent).
+    # Ineligible shapes fall back to aiter inside the backend's forward_decode / forward_extend.
+    if forward_batch.forward_mode.is_extend_without_speculative():
+        return AttnForwardMethod.MHA
+    else:
+        return AttnForwardMethod.MLA
+
+
 def handle_attention_dsa(attn, forward_batch):
     """
     Dispatch logic is centralized in DeepseekSparseAttnBackend.set_dsa_prefill_impl and executed
@@ -222,6 +232,7 @@ AttentionBackendRegistry.register("fa4", handle_attention_fa4)
 AttentionBackendRegistry.register("trtllm_mla", handle_attention_trtllm_mla)
 AttentionBackendRegistry.register("tokenspeed_mla", handle_attention_tokenspeed_mla)
 AttentionBackendRegistry.register("aiter", handle_attention_aiter)
+AttentionBackendRegistry.register("moonmath_mla", handle_attention_moonmath_mla)
 AttentionBackendRegistry.register("dsa", handle_attention_dsa)
 AttentionBackendRegistry.register(
     "nsa", handle_attention_dsa

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -173,6 +173,13 @@ def handle_attention_aiter(attn, forward_batch):
     if is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph():
         return AttnForwardMethod.MHA
     if forward_batch.forward_mode.is_extend_without_speculative():
+        sum_extend_prefix_lens = _get_sum_extend_prefix_lens(forward_batch)
+        if (
+            sum_extend_prefix_lens > 0
+            and not attn.disable_chunked_prefix_cache
+            and sum_extend_prefix_lens >= attn.chunked_prefix_cache_threshold
+        ):
+            return AttnForwardMethod.MHA_CHUNKED_KV
         return AttnForwardMethod.MHA
     else:
         return AttnForwardMethod.MLA

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -178,16 +178,6 @@ def handle_attention_aiter(attn, forward_batch):
         return AttnForwardMethod.MLA
 
 
-def handle_attention_moonmath_mla(attn, forward_batch):
-    # Same split as aiter (our backend subclasses AiterAttnBackend): pure prefill -> non-absorbed
-    # MHA (materialized K[192]/V[128]); decode + spec -> absorbed MLA (q[576] -> o[512] latent).
-    # Ineligible shapes fall back to aiter inside the backend's forward_decode / forward_extend.
-    if forward_batch.forward_mode.is_extend_without_speculative():
-        return AttnForwardMethod.MHA
-    else:
-        return AttnForwardMethod.MLA
-
-
 def handle_attention_dsa(attn, forward_batch):
     """
     Dispatch logic is centralized in DeepseekSparseAttnBackend.set_dsa_prefill_impl and executed
@@ -232,7 +222,7 @@ AttentionBackendRegistry.register("fa4", handle_attention_fa4)
 AttentionBackendRegistry.register("trtllm_mla", handle_attention_trtllm_mla)
 AttentionBackendRegistry.register("tokenspeed_mla", handle_attention_tokenspeed_mla)
 AttentionBackendRegistry.register("aiter", handle_attention_aiter)
-AttentionBackendRegistry.register("moonmath_mla", handle_attention_moonmath_mla)
+AttentionBackendRegistry.register("moonmath_mla", handle_attention_aiter)
 AttentionBackendRegistry.register("dsa", handle_attention_dsa)
 AttentionBackendRegistry.register(
     "nsa", handle_attention_dsa

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -50,6 +50,8 @@ if _is_cuda:
     from sglang.kernels.ops.attention.concat_mla import concat_mla_k
 elif _is_musa:
     from sgl_kernel import concat_mla_k
+else:
+    from sglang.srt.layers.attention.merge_state import merge_state as merge_state_v2
 
 if _use_aiter_gfx95:
     from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant

--- a/python/sglang/srt/models/kimi_k3_vl.py
+++ b/python/sglang/srt/models/kimi_k3_vl.py
@@ -40,8 +40,14 @@ from sglang.srt.utils import get_bool_env_var, is_hip, print_info_once
 _is_hip = is_hip()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
+aiter_conv2d = None
 if _use_aiter:
-    from aiter.ops.triton.conv.conv2d import conv2d as aiter_conv2d
+    try:
+        from aiter.ops.triton.conv.conv2d import conv2d as aiter_conv2d
+    except ImportError:
+        # Older aiter builds do not ship this op; the linear fallback below
+        # covers it, so it must not make the model unimportable.
+        pass
 
 _SM103_TRITON_MAX_SEQLEN = 1536
 _SM103_FA4_MIN_ATTENTION_WORK = 3_000_000
@@ -317,7 +323,7 @@ class MoonVision3dPatchEmbed(nn.Module):
     ) -> torch.Tensor:
         # MIOpen can overflow grid_size for some patch shapes. Prefer AITER's
         # Triton convolution on AMD, with an equivalent linear fallback.
-        if _use_aiter:
+        if aiter_conv2d is not None:
             x = aiter_conv2d(
                 x,
                 self.proj.weight,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -195,6 +195,7 @@ ATTENTION_BACKEND_CHOICES = [
     "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), Hopper (SM90) only, requires --page-size 64
     # AMD specific
     "aiter",
+    "moonmath_mla",
     "wave",
     # Other platforms
     "intel_amx",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -216,6 +216,8 @@ CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
     "cutlass_mla",
     "trtllm_mla",
     "tokenspeed_mla",
+    "aiter",
+    "moonmath_mla",
 ]
 
 DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [

--- a/test/registered/kernels/test_aiter_mha_chunked_kv.py
+++ b/test/registered/kernels/test_aiter_mha_chunked_kv.py
@@ -1,0 +1,172 @@
+"""Tests for AttnForwardMethod.MHA_CHUNKED_KV on the aiter (ROCm) backend.
+
+Chunked-prefix attention splits the cached prefix into chunks, attends each
+separately, and merges the per-chunk partial softmaxes. That is only correct if
+three things line up, and each has already been a bug:
+
+1. merge_state must be callable on ROCm. sgl_kernel exports a merge_state_v2
+   wrapper there but never registers the op, so the CUDA-gated import leaves the
+   name undefined and the chunked path dies with NameError.
+2. The lse layout must match. aiter's flash_attn_varlen_func returns the softmax
+   lse heads-first [num_heads, num_tokens]; merge_state sizes its grid off the
+   output's token/head axes and so indexes [num_tokens, num_heads].
+3. The causal flags must be right per slice: causal within the new tokens,
+   NON-causal against a prefix chunk (which lies entirely in the queries' past).
+   Getting this backwards produces plausible-but-wrong output, not a crash.
+
+The check is end-to-end on the math: chunk + merge must reproduce a single-shot
+attention over the whole context. Shapes are Kimi-K3-at-TP8 (12 heads, qk 192,
+v 128), which is where the gqa=12 path actually runs.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+NUM_HEADS = 12
+QK_HEAD_DIM = 192
+V_HEAD_DIM = 128
+NUM_Q_TOKENS = 512
+SOFTMAX_SCALE = 0.08
+# bf16 reassociation floor: splitting the KV stream reorders accumulation, which
+# shows up around 3e-3 regardless of implementation.
+REL_L2_TOL = 5e-3
+
+
+class TestAiterMHAChunkedKV(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("GPU required")
+        try:
+            from aiter import flash_attn_varlen_func
+        except ImportError:
+            raise unittest.SkipTest("aiter required (ROCm backend test)")
+        from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
+            merge_state_v2,
+        )
+
+        # staticmethod: a plain function assigned to a class attribute would be
+        # bound, and self would arrive as the first kernel argument.
+        cls.fa = staticmethod(flash_attn_varlen_func)
+        cls.merge = staticmethod(merge_state_v2)
+        cls.device = "cuda"
+
+    def _rand(self, *shape):
+        return torch.randn(*shape, device=self.device, dtype=torch.bfloat16)
+
+    def _cu_seqlens(self, total):
+        return torch.tensor([0, total], device=self.device, dtype=torch.int32)
+
+    def _attend(self, q, k, v, cu_q, cu_kv, max_q, max_kv, causal, return_lse):
+        """One slice, mirroring AiterAttnBackend._forward_extend_mha_chunk."""
+        out = self.fa(
+            q,
+            k,
+            v,
+            cu_q,
+            cu_kv,
+            max_q,
+            max_kv,
+            softmax_scale=SOFTMAX_SCALE,
+            causal=causal,
+            return_lse=return_lse,
+        )
+        if not return_lse:
+            return out
+        o, lse = out
+        # aiter is heads-first; merge_state wants [num_tokens, num_heads].
+        return o, lse.transpose(0, 1).contiguous()
+
+    def _chunked_attention(self, q, k_prefix, v_prefix, k_new, v_new, chunk_lens):
+        cu_q = self._cu_seqlens(NUM_Q_TOKENS)
+        # Phase 1: the new tokens, causal, seeding the accumulator.
+        acc_o, acc_lse = self._attend(
+            q, k_new, v_new, cu_q, cu_q, NUM_Q_TOKENS, NUM_Q_TOKENS, True, True
+        )
+        # Phase 2: one non-causal pass per prefix chunk, merged in.
+        offset = 0
+        for chunk_len in chunk_lens:
+            o, lse = self._attend(
+                q,
+                k_prefix[offset : offset + chunk_len],
+                v_prefix[offset : offset + chunk_len],
+                cu_q,
+                self._cu_seqlens(chunk_len),
+                NUM_Q_TOKENS,
+                chunk_len,
+                False,
+                True,
+            )
+            merged_o = torch.empty_like(acc_o)
+            merged_lse = torch.empty_like(acc_lse)
+            self.merge(o, lse, acc_o, acc_lse, merged_o, merged_lse)
+            acc_o, acc_lse = merged_o, merged_lse
+            offset += chunk_len
+        return acc_o
+
+    def _single_shot_attention(self, q, k_prefix, v_prefix, k_new, v_new):
+        """Reference: one causal pass over [prefix ; new tokens]."""
+        prefix_len = k_prefix.shape[0]
+        return self._attend(
+            q,
+            torch.cat([k_prefix, k_new]),
+            torch.cat([v_prefix, v_new]),
+            self._cu_seqlens(NUM_Q_TOKENS),
+            self._cu_seqlens(prefix_len + NUM_Q_TOKENS),
+            NUM_Q_TOKENS,
+            prefix_len + NUM_Q_TOKENS,
+            True,
+            False,
+        )
+
+    def _assert_matches_single_shot(self, chunk_lens):
+        torch.manual_seed(0)
+        prefix_len = sum(chunk_lens)
+        q = self._rand(NUM_Q_TOKENS, NUM_HEADS, QK_HEAD_DIM)
+        k_prefix = self._rand(prefix_len, NUM_HEADS, QK_HEAD_DIM)
+        v_prefix = self._rand(prefix_len, NUM_HEADS, V_HEAD_DIM)
+        k_new = self._rand(NUM_Q_TOKENS, NUM_HEADS, QK_HEAD_DIM)
+        v_new = self._rand(NUM_Q_TOKENS, NUM_HEADS, V_HEAD_DIM)
+
+        chunked = self._chunked_attention(
+            q, k_prefix, v_prefix, k_new, v_new, chunk_lens
+        )
+        reference = self._single_shot_attention(q, k_prefix, v_prefix, k_new, v_new)
+
+        self.assertTrue(torch.isfinite(chunked).all(), "chunked output has NaN/inf")
+        rel_l2 = (
+            (chunked.float() - reference.float()).norm() / reference.float().norm()
+        ).item()
+        self.assertLess(
+            rel_l2,
+            REL_L2_TOL,
+            f"chunks={chunk_lens}: rel L2 {rel_l2:.3e} exceeds {REL_L2_TOL:.0e}",
+        )
+
+    def test_multiple_chunks_match_single_shot(self):
+        """Merge math: iterated merges must equal one pass over the union.
+
+        Red if the merge is skipped/misordered, if the accumulator is not
+        threaded through the loop, if the per-slice causal flags are swapped, or
+        if the lse layout handed to merge_state stops matching what it indexes
+        (a layout flip corrupts the second and later merges).
+        """
+        self._assert_matches_single_shot([1024, 1024, 1024])
+
+    def test_uneven_final_chunk(self):
+        """Length arithmetic: the last chunk is shorter than the rest.
+
+        Red if a chunk's kv extent is taken from the chunk size rather than the
+        chunk's own length -- which the equal-length case cannot see.
+        """
+        self._assert_matches_single_shot([1024, 1024, 379])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
+++ b/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
@@ -1,0 +1,248 @@
+"""Unit tests for the moonmath MLA attention backend.
+
+Two layers of testing:
+  1. Eligibility: _decode_eligible() gate routing (no GPU, mocked kernel).
+  2. Correctness: real A16W8 kernel output vs fp32 reference on dequantized
+     fp8 KV (requires ROCm GPU + moonmath_attention installed).
+
+Requires: moonmath_attention installed (the backend imports it at __init__).
+Requires: AMD ROCm (torch.float8_e4m3fnuz is a ROCm-only dtype).
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+
+def _make_layer(
+    q_head_num=16,
+    qk_head_dim=576,
+    v_head_dim=512,
+    tp_k_head_num=1,
+    logit_cap=0,
+    scaling=0.0884,
+    k_scale=None,
+):
+    """Create a mock RadixAttention layer with MLA defaults."""
+    layer = MagicMock()
+    layer.tp_q_head_num = q_head_num
+    layer.qk_head_dim = qk_head_dim
+    layer.v_head_dim = v_head_dim
+    layer.tp_k_head_num = tp_k_head_num
+    layer.logit_cap = logit_cap
+    layer.scaling = scaling
+    layer.k_scale = k_scale
+    return layer
+
+
+def _make_fb(batch_size=4, forward_mode="decode", spec_info=None):
+    """Create a mock ForwardBatch."""
+    fb = MagicMock()
+    fb.batch_size = batch_size
+    fb.spec_info = spec_info
+    mode = MagicMock()
+    mode.is_decode.return_value = forward_mode == "decode"
+    mode.is_target_verify.return_value = forward_mode == "target_verify"
+    mode.is_extend.return_value = forward_mode == "extend"
+    fb.forward_mode = mode
+    return fb
+
+
+def _make_backend(kv_cache_dtype=None, use_mla=True):
+    """Create a MoonmathMLABackend with mocked dependencies."""
+    with patch(
+        "sglang.srt.layers.attention.aiter_backend.AiterAttnBackend.__init__"
+    ), patch("moonmath_attention.mla") as mock_mla:
+        mock_mla.mla_decode_a16w8_plan_parts_capped.return_value = 1
+        from sglang.srt.layers.attention.moonmath_mla_backend import (
+            MoonmathMLABackend,
+        )
+
+        runner = MagicMock()
+        runner.use_mla = use_mla
+        runner.device = torch.device("cuda")
+        runner.model_config.context_len = 131072
+
+        backend = MoonmathMLABackend.__new__(MoonmathMLABackend)
+        backend._mla = mock_mla
+        backend._mla_ok = use_mla
+        backend._disabled = False
+        backend._fp8_dtype = torch.float8_e4m3fnuz
+        backend._fp8_kv = use_mla and (kv_cache_dtype == torch.float8_e4m3fnuz)
+        backend._dec_parts = {}
+        backend._mla_max_ctx = 131072
+        backend._mla_seqlen_i32 = torch.zeros(8192, dtype=torch.int32, device="cpu")
+        backend.kv_cache_dtype = kv_cache_dtype
+        backend.forward_metadata = MagicMock()
+        backend.forward_metadata.kv_indices = torch.zeros(1, dtype=torch.int32)
+        backend.forward_metadata.kv_indptr = torch.zeros(1, dtype=torch.int32)
+        return backend
+
+
+class TestMoonmathMLAEligibility(unittest.TestCase):
+    """Test _decode_eligible gates correctly for all input combinations."""
+
+    def test_eligible_h16_fp8_decode(self):
+        """The supported case: H=16, fp8 KV, pure decode, MLA dims."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertTrue(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_h128(self):
+        """H=128 (DSV3) should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=128)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_bf16_kv(self):
+        """bf16 KV should fall back to aiter (A16W8 requires fp8 KV)."""
+        backend = _make_backend(kv_cache_dtype=torch.bfloat16)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_extend(self):
+        """Prefill/extend should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="extend")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_spec_verify(self):
+        """Spec-verify should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, spec_info=MagicMock())
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_disabled(self):
+        """SGLANG_MOONMATH_MLA_DISABLE=1 should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        backend._disabled = True
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_wrong_dims(self):
+        """Non-MLA dims (e.g. head_dim=128) should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=16, qk_head_dim=128, v_head_dim=128)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+    def test_reject_non_mla(self):
+        """Non-MLA model should fall back to aiter."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz, use_mla=False)
+        layer = _make_layer(q_head_num=16)
+        fb = _make_fb(batch_size=4, forward_mode="decode")
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+
+def _has_moonmath():
+    try:
+        import moonmath_attention.mla  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+class TestMoonmathMLAKernelCorrectness(unittest.TestCase):
+    """Correctness of the A16W8 decode kernel vs fp32 reference.
+
+    The kernel carries Q in bf16 and computes softmax in fp32.  The fp32
+    reference dequantizes the same fp8 KV bytes and runs the absorbed-MLA
+    decode math in full fp32.  Relative error must stay below 1e-2.
+    """
+
+    @unittest.skipUnless(
+        torch.cuda.is_available() and _has_moonmath(),
+        "Requires ROCm GPU and moonmath_attention",
+    )
+    def test_decode_matches_fp32_reference(self):
+        import math
+
+        import moonmath_attention.mla as mla
+
+        DEV = "cuda"
+        FP8 = torch.float8_e4m3fnuz
+        KV_LAT = 512
+        ROPE = 64
+        KV_DIM = KV_LAT + ROPE
+        H = 16
+        SCALE = 1.0 / math.sqrt(KV_DIM)
+
+        for B, S in [(1, 128), (2, 256)]:
+            with self.subTest(B=B, S=S):
+                torch.manual_seed(42 + B * 1000 + S)
+
+                q_lat = torch.randn(B, H, KV_LAT, dtype=torch.bfloat16, device=DEV)
+                q_pe = torch.randn(B, H, ROPE, dtype=torch.bfloat16, device=DEV)
+
+                num_slots = S * B + 1
+                kv_pool = torch.zeros(num_slots, 1, KV_DIM, dtype=FP8, device=DEV)
+                kv_indices = torch.zeros(S * B, dtype=torch.int32, device=DEV)
+                kv_indptr = torch.zeros(B + 1, dtype=torch.int32, device=DEV)
+                seq_lens = torch.full((B,), S, dtype=torch.int32, device=DEV)
+
+                c_refs, k_refs = [], []
+                for b in range(B):
+                    off = b * S
+                    slots = torch.arange(
+                        off + 1, off + S + 1, device=DEV, dtype=torch.int32
+                    )
+                    kv_indices[off : off + S] = slots
+                    kv_indptr[b + 1] = off + S
+                    c = torch.randn(S, KV_LAT, device=DEV)
+                    k = torch.randn(S, ROPE, device=DEV)
+                    kv_pool[slots.long(), 0, :KV_LAT] = c.to(FP8)
+                    kv_pool[slots.long(), 0, KV_LAT:] = k.to(FP8)
+                    c_refs.append(kv_pool[slots.long(), 0, :KV_LAT].float())
+                    k_refs.append(kv_pool[slots.long(), 0, KV_LAT:].float())
+
+                out = torch.empty(B, H, KV_LAT, dtype=torch.bfloat16, device=DEV)
+                parts = mla.mla_decode_a16w8_plan_parts_capped(B, H, S, KV_LAT)
+                mla.mla_decode_a16w8_paged_dev(
+                    q_lat,
+                    q_pe,
+                    kv_pool,
+                    out,
+                    seq_lens,
+                    None,
+                    kv_indices,
+                    kv_indptr,
+                    parts,
+                    SCALE,
+                    1.0,
+                    1.0,
+                )
+                torch.cuda.synchronize()
+
+                ref = torch.empty(B, H, KV_LAT, dtype=torch.float32, device=DEV)
+                for b in range(B):
+                    c, k = c_refs[b], k_refs[b]
+                    ql, qp = q_lat[b].float(), q_pe[b].float()
+                    scores = (ql @ c.t() + qp @ k.t()) * SCALE
+                    ref[b] = torch.softmax(scores, dim=-1) @ c
+
+                relerr = (out.float() - ref).abs().max().item() / ref.abs().max().item()
+                self.assertLess(relerr, 1e-2, f"B={B} S={S}: relerr={relerr:.3e}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
+++ b/test/registered/unit/layers/attention/test_moonmath_mla_backend.py
@@ -53,35 +53,41 @@ def _make_fb(batch_size=4, forward_mode="decode", spec_info=None):
     return fb
 
 
+def _fake_aiter_init(self, model_runner):
+    """Stand-in for AiterAttnBackend.__init__: set only what the subclass reads."""
+    self.use_mla = model_runner.use_mla
+    self.kv_cache_dtype = model_runner.kv_cache_dtype
+    self.num_head = model_runner.num_head
+    self.token_to_kv_pool = model_runner.token_to_kv_pool
+
+
 def _make_backend(kv_cache_dtype=None, use_mla=True):
-    """Create a MoonmathMLABackend with mocked dependencies."""
-    with patch(
-        "sglang.srt.layers.attention.aiter_backend.AiterAttnBackend.__init__"
-    ), patch("moonmath_attention.mla") as mock_mla:
+    """Construct a real MoonmathMLABackend with the aiter base __init__ stubbed.
+
+    The kernel selection under test is `__init__`'s own, not a copy of it: only
+    the base class and the moonmath_attention import are replaced.
+    """
+    from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
+    from sglang.srt.layers.attention.moonmath_mla_backend import MoonmathMLABackend
+
+    runner = MagicMock()
+    runner.use_mla = use_mla
+    runner.kv_cache_dtype = kv_cache_dtype
+    runner.num_head = 16
+    runner.device = "cpu"
+    runner.token_to_kv_pool.size = 8192
+    runner.model_config.context_len = 131072
+
+    with patch.object(AiterAttnBackend, "__init__", _fake_aiter_init), patch(
+        "moonmath_attention.mla"
+    ) as mock_mla:
         mock_mla.mla_decode_a16w8_plan_parts_capped.return_value = 1
-        from sglang.srt.layers.attention.moonmath_mla_backend import (
-            MoonmathMLABackend,
-        )
+        backend = MoonmathMLABackend(runner)
 
-        runner = MagicMock()
-        runner.use_mla = use_mla
-        runner.device = torch.device("cuda")
-        runner.model_config.context_len = 131072
-
-        backend = MoonmathMLABackend.__new__(MoonmathMLABackend)
-        backend._mla = mock_mla
-        backend._mla_ok = use_mla
-        backend._disabled = False
-        backend._fp8_dtype = torch.float8_e4m3fnuz
-        backend._fp8_kv = use_mla and (kv_cache_dtype == torch.float8_e4m3fnuz)
-        backend._dec_parts = {}
-        backend._mla_max_ctx = 131072
-        backend._mla_seqlen_i32 = torch.zeros(8192, dtype=torch.int32, device="cpu")
-        backend.kv_cache_dtype = kv_cache_dtype
-        backend.forward_metadata = MagicMock()
-        backend.forward_metadata.kv_indices = torch.zeros(1, dtype=torch.int32)
-        backend.forward_metadata.kv_indptr = torch.zeros(1, dtype=torch.int32)
-        return backend
+    backend.forward_metadata = MagicMock()
+    backend.forward_metadata.kv_indices = torch.zeros(1, dtype=torch.int32)
+    backend.forward_metadata.kv_indptr = torch.zeros(1, dtype=torch.int32)
+    return backend
 
 
 class TestMoonmathMLAEligibility(unittest.TestCase):
@@ -104,11 +110,12 @@ class TestMoonmathMLAEligibility(unittest.TestCase):
         self.assertFalse(backend._decode_eligible(q, layer, fb))
 
     def test_reject_bf16_kv(self):
-        """bf16 KV should fall back to aiter (A16W8 requires fp8 KV)."""
+        """The A16W8 kernels read an fp8 pool; a bf16 KV cache falls back."""
         backend = _make_backend(kv_cache_dtype=torch.bfloat16)
         layer = _make_layer(q_head_num=16)
         fb = _make_fb(batch_size=4, forward_mode="decode")
         q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._enabled)
         self.assertFalse(backend._decode_eligible(q, layer, fb))
 
     def test_reject_extend(self):
@@ -127,15 +134,6 @@ class TestMoonmathMLAEligibility(unittest.TestCase):
         q = torch.zeros(1, dtype=torch.bfloat16)
         self.assertFalse(backend._decode_eligible(q, layer, fb))
 
-    def test_reject_disabled(self):
-        """SGLANG_MOONMATH_MLA_DISABLE=1 should fall back to aiter."""
-        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
-        backend._disabled = True
-        layer = _make_layer(q_head_num=16)
-        fb = _make_fb(batch_size=4, forward_mode="decode")
-        q = torch.zeros(1, dtype=torch.bfloat16)
-        self.assertFalse(backend._decode_eligible(q, layer, fb))
-
     def test_reject_wrong_dims(self):
         """Non-MLA dims (e.g. head_dim=128) should fall back to aiter."""
         backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
@@ -151,6 +149,36 @@ class TestMoonmathMLAEligibility(unittest.TestCase):
         fb = _make_fb(batch_size=4, forward_mode="decode")
         q = torch.zeros(1, dtype=torch.bfloat16)
         self.assertFalse(backend._decode_eligible(q, layer, fb))
+
+
+class TestMoonmathMLAVerifyGate(unittest.TestCase):
+    """The multi-query window serves q_len 4..8 only; everything else falls back."""
+
+    def _fb(self, q_len):
+        spec = MagicMock()
+        spec.num_tokens_per_req = q_len
+        return _make_fb(batch_size=4, forward_mode="target_verify", spec_info=spec)
+
+    def test_window_accepted(self):
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=12)  # Kimi-K3 at TP8
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        for q_len in (4, 5, 6, 7, 8):
+            self.assertTrue(backend._verify_eligible(q, layer, self._fb(q_len)))
+
+    def test_window_bounds_rejected(self):
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=12)
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        for q_len in (1, 3, 9, 16):
+            self.assertFalse(backend._verify_eligible(q, layer, self._fb(q_len)))
+
+    def test_decode_gate_rejects_verify(self):
+        """The two arms are disjoint: verify never reaches forward_decode."""
+        backend = _make_backend(kv_cache_dtype=torch.float8_e4m3fnuz)
+        layer = _make_layer(q_head_num=12)
+        q = torch.zeros(1, dtype=torch.bfloat16)
+        self.assertFalse(backend._decode_eligible(q, layer, self._fb(8)))
 
 
 def _has_moonmath():


### PR DESCRIPTION
## Motivation

Kimi-K3 cannot be served on CDNA3 (MI300X / MI325X) today, and MLA models more
generally lose speculative decoding there. Four independent blockers, each of
which aborts or OOMs rather than degrading:

1. **`SituAndMul` does not build on ROCm.** `forward_cuda` JIT-builds
   `kimi_k3/situ_and_mul.cuh`, which includes `<cuda_fp8.h>` unguarded. Under
   hipcc the build fails *inside* CUDA-graph capture, so it surfaces only as
   `Capture cuda graph failed: ninja exited with status 1`.
2. **MXFP4 MoE aborts.** `aiter.fused_moe` has no gfx942 a4w4 path and dies in
   the activation quantiser with
   `fused_dynamic_mx_quant_moe_sort_hip: not support output type: fp4x2`.
3. **aiter's asm MLA has no kernel for 12 query heads** (Kimi-K3 at TP8 is
   96/8 = 12; aiter requires 4, 8, or a multiple of 16 in [16, 128]) and none
   past `qseqlen` 4, so a speculative draft window larger than 4 calls
   `abort()` during cuda-graph capture.
4. **Long-context prefill runs out of VRAM.** With a cached prefix the aiter MHA
   extend path re-gathers and up-projects the *entire* prefix through
   `kv_b_proj` in one shot. `AttnForwardMethod.MHA_CHUNKED_KV` already bounds
   this, but it was unreachable on ROCm: `maybe_disable_chunked_prefix_cache()`
   force-sets `disable_chunked_prefix_cache=True` for any backend absent from
   `CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS`.

This PR closes all four. It is stacked on #<PR1> (the single-query moonmath MLA
decode backend); the first commit here is that PR's commit rebased onto current
main.

## Modifications

**New attention backend — `--attention-backend moonmath_mla`**
(`layers/attention/moonmath_mla_backend.py`). Subclasses `AiterAttnBackend` and
takes over absorbed MLA with the [moonmath_attention](https://github.com/moonmath-ai/amd-kernels)
A16W8 kernels (bf16 Q / fp8 KV), which read SGLang's existing fused-576
`MLATokenToKVPool` key buffer directly — page_size 1, device-driven, cuda-graph
safe. Two shapes, both `H <= 16`:

| forward mode | kernel |
| --- | --- |
| decode, `q_len` 1 | `mla_decode_a16w8_paged_dev` |
| `TARGET_VERIFY`, `q_len` 4..8 | `mla_decode_a16w8_multiq_paged_dev` |

Everything else — prefill, bf16 KV, any unsupported geometry — falls through to
`AiterAttnBackend`, so the backend is a strict superset of aiter's behaviour.
The multi-query arm keeps the draft window resident per CTA and applies
end-aligned causal masking inside it, which is what makes speculative decoding
reachable at all past a window of 4. Q stays bf16 in both arms, so there is no
query scale to calibrate and the verify logits are not perturbed.

**Head padding for the fallback paths.** The paths this backend does not serve
itself still run aiter's kernel, so Q is zero-padded to aiter's 16-head minimum
for them. Unconditional at the head counts aiter has no kernel for, because
there the current behaviour is a process abort — there is no prior result to
preserve. The pad is on the query side only and MLA has no reduction across the
head axis, so the first `H` output rows are bit-identical to an unpadded call.
`AiterAttnBackend` gains one hook, `skip_mla_head_count_assert`, so a subclass
serving MLA with its own kernel is not rejected at construction.

**Kimi-K3 on gfx942.** A `SituAndMul.forward_hip` override onto the Triton twin
SGLang already ships (arithmetically identical, still one fused kernel), and a
gfx942 MXFP4 MoE route through aiter's *Triton* MXFP4 GEMMs
(`moe_runner/aiter_mxfp4_triton.py`), which lower `tl.dot_scaled` onto the bf16
MFMA CDNA3 has always had. `moe_runner/mxfp4_situ_fused.py` adds a SiTU variant
of aiter's fused SwiGLU epilogue so the routed experts keep their activation
fused into the GEMM. Both are behind `use_triton_mxfp4_moe()`, which is False on
every other arch and on any build where the Triton kernels do not import, so no
other MoE path changes.

**Split-KV verify on gfx942** (`kernels/ops/attention/verify_splitkv.py`,
`triton_backend.py`). Enabled on gfx942 as well as gfx95, and the split cap is
now CU-aware: `extend_attention_fwd` walks the prefix serially under a
`(bs, h_q, 1)` grid, so a per-TP-rank draft shard leaves most of the device
idle, and the flat `MAX_N_SPLITS = 16` was tuned at a base grid that already
fills the device. When the base grid underfills it, the cap is raised by the
shortfall — bounded at 128 splits, and bounded again by a scratch budget so a
large `max_bs` cannot balloon the stage-1 partials. **Shapes that already fill
the device keep their tuned value bit-identically** (`choose_n_splits` with no
`base_programs` is unchanged).

**Chunked prefix KV on the aiter / moonmath_mla backends.** Adds both to
`CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS`, returns
`MHA_CHUNKED_KV` from `handle_attention_aiter` once the cached prefix passes
`chunked_prefix_cache_threshold`, and implements
`AiterAttnBackend._forward_extend_mha_chunk()`. Two ROCm-specific fixes were
needed to make that path executable: `sgl_kernel` exports a `merge_state_v2`
wrapper on ROCm but never registers the op, so the CUDA-gated import left the
name undefined and the chunked path died with `NameError` (now uses
`merge_state`, which already dispatches to the Triton kernel on AMD); and
aiter's `flash_attn_varlen_func` returns the softmax LSE heads-first
`[num_heads, num_tokens]` while `merge_state` indexes `[num_tokens, num_heads]`.

**Environment surface: one new variable.**
`SGLANG_MOONMATH_MLA_MULTIQ_VERIFY` (default **on**) routes `TARGET_VERIFY`
through the multi-query kernel; set it to 0 to force the aiter path for A/B.

Serving Kimi-K3 with an fp8 KV cache and DSpark at block size 7 (verify window
8, exactly the multi-query kernel's range):

```bash
SGLANG_USE_AITER=1 python3 -m sglang.launch_server \
  --tp 8 --model moonshotai/Kimi-K3 \
  --attention-backend moonmath_mla --kv-cache-dtype fp8_e4m3 \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path RadixArk/Kimi-K3-DSpark \
  --speculative-dspark-block-size 7 --trust-remote-code
```

## Accuracy Tests

**MLA decode and multi-query verify vs an fp32 reference** — per-TP-rank shapes
on one MI300X, driving the backend's real `forward_decode` / `forward_extend`
(gates, seq_lens staging, kv-split planning and operand splitting included)
against an fp32 reference computed on the dequantized fp8 KV pool:

| case | shapes | rel L2 |
| --- | --- | --- |
| Kimi-K3 decode (H=12) | bs 1/4/16/32, S 2k–8k | 2.7e-3 |
| Kimi-K3 multi-query verify (H=12) | q_len 4,5,6,7,8 × bs 1/4/8/16 | 2.6e-3 |
| Kimi-K3 ragged verify (H=12) | spans `[4096, 517, 8192, 1031]`, `[2048, 2049, 33, 9000, 128, 4096]` | 2.7e-3 |
| DeepSeek-V3 decode + verify (H=16) | bs 8, S 4k | 2.7e-3 |

2.7e-3 is the fp8 KV quantization floor for these shapes, not kernel error — the
reference dequantizes the same fp8 bytes. The gates were separately checked to
decline (fall back to aiter) at `q_len` 3, `q_len` 9, `H = 32`, and with the
multi-query knob off. 20/20.

**Chunked prefix KV** — `test/registered/kernels/test_aiter_mha_chunked_kv.py`
asserts chunk + merge reproduces a single-shot attention over the whole context
at Kimi-K3-at-TP8 shapes, including an uneven final chunk. Tolerance 5e-3 is the
bf16 reassociation floor from splitting the KV stream.

**Unit tests** — `test/registered/unit/.../test_moonmath_mla_backend.py`, 13
tests: eligibility gating (head count, KV dtype, forward mode, MLA dims,
non-MLA), the multi-query window bounds, and A16W8 decode vs an fp32 reference
on GPU. All green.

## Speed Tests and Profiling

Split-KV verify on gfx942, MI300X, head_dim 64, h_q 8, h_kv 2, q_len 4, 250k
prefix: bf16 7.63 → 0.26 ms, fp8 9.30 → 0.23 ms. Accuracy against an exact fp32
reference is unchanged; the two paths differ only in reduction order.

Chunked prefix KV, 8× MI325X, Kimi-K3 TP8, 937k-token cold prefill:

| | before | after |
| --- | --- | --- |
| free VRAM at peak | 0.02 GiB | 17.90 GiB |
| transient | 19.3 GiB | 1.99 GiB |
| `kv_b_proj` GEMM M | 394564 | 32768 |

Peak becomes context-independent (237.86 GB at 400k vs 237.79 GB at 937k) for
+1% prefill latency, which is the per-chunk LSE merges. Without it the scheduler
aborted with `HSA_STATUS_ERROR_OUT_OF_RESOURCES` three times in 45 minutes at
347k–411k context.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

### Notes for reviewers

- The backend requires `moonmath-attention` (branch `mla-decode-a16w8-multiq`)
  and `--kv-cache-dtype fp8_e4m3`. It is opt-in via `--attention-backend`, and
  the import is at backend construction, so no other configuration is affected.
- All new gfx942 code is arch-gated or backend-gated; the diff removes only 9
  lines from existing files, each forced by a behaviour change
  (`choose_n_splits`' signature and cap, the aiter MLA head-count assert, the
  gfx95-only split-KV gate, and the `kimi_k3_vl` aiter conv2d import).
- Both new tests are registered for the AMD CI suite
  (`stage-b-test-1-gpu-small-amd`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31212470108](https://github.com/sgl-project/sglang/actions/runs/31212470108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31212471175](https://github.com/sgl-project/sglang/actions/runs/31212471175)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->