### PR TITLE
[ROCm] Fix gfx942 LDS overflow in DSA bf16 decode under dp-attention

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -847,8 +847,9 @@ def sparse_mla_fwd_decode_partial(
 
     head_kv = heads // kv_group
     padded_H = max(tilelang.math.next_power_of_2(head_kv), 16)
-    REPLICATE_H = (head_kv // 64) if head_kv > 64 else 1
-    H_per_block = padded_H if REPLICATE_H == 1 else 64
+    _hb_cap = 16 if (_is_hip and not _is_gfx95_supported) else 64
+    REPLICATE_H = (head_kv // _hb_cap) if head_kv > _hb_cap else 1
+    H_per_block = padded_H if REPLICATE_H == 1 else _hb_cap
     N_GROUPS = topk // (block_I * inner_iter)
     BI = block_I
     D = dim
@@ -901,7 +902,7 @@ def sparse_mla_fwd_decode_partial(
             b_i, g_i = 0, 0
             s_i = bx if REPLICATE_H == 1 else (bx // REPLICATE_H)
             group_i = by
-            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64
+            H0 = 0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * H_per_block
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_buf)


### PR DESCRIPTION
On gfx942 (CDNA3, MI325X) the DSA bf16 decode kernel overflows the 64 KB per-block LDS limit under dp-attention. `sparse_mla_fwd_decode_partial` sizes its shared buffers by heads-per-block. With dp-attention each rank runs all 64 heads, so `H_per_block = 64` and `Q_buf` alone is 64 x 512 x 2 B = 64 KB, which hits the LDS ceiling before the other shared buffers are even counted, so the kernel can't launch. At TP4 the attention is sharded to 16 heads/rank and it fits.

The kernel already knows how to split heads across blocks (`REPLICATE_H`), it just only turns it on for `head_kv > 64` (the 128-head case) and hardcodes a 64-head stride. This caps the per-block head count at 16 on gfx942 so dp-attention decode fits (about 55 KB, the same footprint TP4 already runs). The cap is gated on `_is_hip and not _is_gfx95_supported`, and only the bf16 decode kernel (`sparse_mla_fwd_decode_partial`) is touched, so gfx950 and the TP-sharded paths are unchanged. The `H0` head-slice offset in that kernel is updated to use `H_per_block` instead of the hardcoded 64 so the smaller stride is honored.

I validated this on a real gfx942 box (8x MI325X, GLM-5.2-FP8, tp4/dp4). Stock first: the dp-attention launch dies in decode CUDA-graph capture with `Requested dynamic shared memory 115200 exceeds device limit 65536 for main_kernel`, so the server never comes up. With the patch, decode capture completes 52/52 including bs=8, the exact batch the stock run died on, and the server serves. A planted needle `ORCA-58231` at depth 0.70 comes back correct at 32k (29,363 prompt tokens) and 131k (121,615), matching a TP4 reference on the same box: same retrieved answer, identical tokenization. No regression off the dp path either. TP4 with the patch present serves the same needles and the fix is inert there (at 16 heads/rank, `16 > 16` is false so H_per_block stays 16, the same as stock), and gfx950 is unchanged at the code level since `_is_gfx95_supported` is true there so `_hb_cap` stays 64.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31201007500](https://github.com/sgl-project/sglang/actions/runs/31201007500)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #32114014783](https://github.com/sgl-project/sglang/actions/runs/32114014783)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->