### PR TITLE
[Feature] Token-aware admission cap (--max-inflight-prefill-tokens)

### DIFF
--- a/python/sglang/srt/arg_groups/fields/schedule.py
+++ b/python/sglang/srt/arg_groups/fields/schedule.py
@@ -43,6 +43,13 @@ class Schedule(msgspec.Struct):
         Optional[int],
         "The maximum number of queued requests. This option is ignored when using disaggregation-mode.",
     ] = None
+    max_inflight_prefill_tokens: A[
+        Optional[int],
+        "Admission cap on the total prompt tokens of in-flight (not yet finished) requests. "
+        "A new request is rejected up front when it would push the in-flight total over this, "
+        "so a burst of long-context prompts sheds gracefully instead of over-committing prefill "
+        "memory. Unset (default) disables it.",
+    ] = None
     max_total_tokens: A[
         Optional[int],
         Arg(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -215,6 +215,9 @@ class ReqState:
     dispatched: bool = False
     last_completion_tokens: int = 1
     ttft_observed: bool = False
+    # Prompt tokens charged to the in-flight admission budget
+    # (max_inflight_prefill_tokens); summed over unfinished requests.
+    admitted_prefill_tokens: int = 0
 
     # For streaming output
     last_output_offset: int = 0
@@ -398,6 +401,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     ):
         # Parse args
         self.server_args = server_args
+        self.max_inflight_prefill_tokens = server_args.max_inflight_prefill_tokens
         self.startup_time: Optional[Dict[str, Any]] = None
         self._config_updates: List[Tuple[str, Dict[str, Any]]] = []
         self.elastic_worker_count = server_args.dp_size
@@ -1145,6 +1149,28 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         _max_req_len = self.context_len
         input_token_num = len(input_ids) if input_ids is not None else 0
         input_token_num += self.num_reserved_tokens
+
+        # Token-aware admission: reject up front when the prompt tokens already
+        # in flight plus this request would exceed the budget, so a burst of
+        # long-context prompts sheds gracefully instead of over-committing
+        # prefill memory (count-based caps cannot see prompt length). This is
+        # synchronous, so the sum and the charge are atomic against other
+        # in-flight requests; the charge is released when the request finishes.
+        if self.max_inflight_prefill_tokens is not None:
+            inflight = sum(
+                st.admitted_prefill_tokens
+                for st in self.rid_to_state.values()
+                if not st.finished
+            )
+            if inflight + input_token_num > self.max_inflight_prefill_tokens:
+                raise ValueError(
+                    f"Rejecting request: {inflight} prompt tokens already in flight "
+                    f"plus this request's {input_token_num} exceed "
+                    f"max_inflight_prefill_tokens ({self.max_inflight_prefill_tokens})."
+                )
+            cur_state = self.rid_to_state.get(getattr(obj, "rid", None))
+            if cur_state is not None:
+                cur_state.admitted_prefill_tokens = input_token_num
 
         # Validate input length
         if input_token_num >= self.context_len:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -234,6 +234,9 @@ class ReqState:
     time_stats: APIServerReqTimeStats
     last_completion_tokens: int = 1
     ttft_observed: bool = False
+    # Prompt tokens charged to the in-flight admission budget
+    # (max_inflight_prefill_tokens); summed over unfinished requests.
+    admitted_prefill_tokens: int = 0
 
     dispatched: bool = False
     abort_sent: bool = False
@@ -419,6 +422,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Parse args
         self.server_args = server_args
         assert_published(server_args, role="tokenizer")
+        self.max_inflight_prefill_tokens = server_args.max_inflight_prefill_tokens
         self.startup_time: Optional[Dict[str, Any]] = None
         self.elastic_worker_count = get_parallel().dp_size
         self.elastic_pending_ep_size = None
@@ -1176,6 +1180,28 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         _max_req_len = self.context_len
         input_token_num = len(input_ids) if input_ids is not None else 0
         input_token_num += self.num_reserved_tokens
+
+        # Token-aware admission: reject up front when the prompt tokens already
+        # in flight plus this request would exceed the budget, so a burst of
+        # long-context prompts sheds gracefully instead of over-committing
+        # prefill memory (count-based caps cannot see prompt length). This is
+        # synchronous, so the sum and the charge are atomic against other
+        # in-flight requests; the charge is released when the request finishes.
+        if self.max_inflight_prefill_tokens is not None:
+            inflight = sum(
+                st.admitted_prefill_tokens
+                for st in self.rid_to_state.values()
+                if not st.finished
+            )
+            if inflight + input_token_num > self.max_inflight_prefill_tokens:
+                raise ValueError(
+                    f"Rejecting request: {inflight} prompt tokens already in flight "
+                    f"plus this request's {input_token_num} exceed "
+                    f"max_inflight_prefill_tokens ({self.max_inflight_prefill_tokens})."
+                )
+            cur_state = self.rid_to_state.get(getattr(obj, "rid", None))
+            if cur_state is not None:
+                cur_state.admitted_prefill_tokens = input_token_num
 
         # Validate input length
         if input_token_num >= self.context_len:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -775,6 +775,14 @@ class ServerArgs:
         "The maximum number of queued requests. This option is ignored when using disaggregation-mode.",
         NS("schedule"),
     ] = None
+    max_inflight_prefill_tokens: A[
+        Optional[int],
+        "Admission cap on the total prompt tokens of in-flight (not yet finished) requests. "
+        "A new request is rejected up front when it would push the in-flight total over this, "
+        "so a burst of long-context prompts sheds gracefully instead of over-committing prefill "
+        "memory. Unset (default) disables it.",
+        NS("schedule"),
+    ] = None
     max_total_tokens: A[
         Optional[int],
         Arg(


### PR DESCRIPTION
The admission knobs we have today (`--max-running-requests`, `--max-queued-requests`) are count-based. They can't tell a 4k prompt from a 500k one. So when a burst of long-context requests lands, the server admits them by count, over-commits prefill memory, and OOM-crashes instead of shedding. On a GLM-5.2-FP8 tp8/dp8 run, 8 concurrent 500k-token prompts take the whole server down (every request net-fails).

This adds a token-aware bound: `--max-inflight-prefill-tokens N`. The tokenizer manager sits in front of the workers (one per server, before requests are dispatched to the DP ranks), so it's the right place to bound total work before anything is scheduled. A new request is rejected up front when the prompt tokens already in flight plus this request would exceed `N`.

The one subtle part is the accounting. The charge is recorded on the request's `ReqState` inside `_validate_one_request`, which runs synchronously (no `await`), so the read of the in-flight total and the charge are atomic against other in-flight requests. That matters under a concurrent burst: if you compute the in-flight total lazily, 8 requests that arrive together all read an empty total and all get admitted (I hit exactly this and watched it still OOM). Charging synchronously fixes it. The charge is released for free when the request finishes and leaves `rid_to_state`, so there's no separate counter to leak on aborts or disconnects.

Default is unset, which is a no-op: the `is not None` guard short-circuits, zero overhead. When set, the only added cost is an int sum over in-flight requests at admission time.

Validation (GLM-5.2-FP8, tp8/dp8, dp-attention, `--mem-fraction-static 0.55`):

- Without the cap: 8x500k over-admits and OOM-crashes the server, 24/24 requests net-fail.
- With `--max-inflight-prefill-tokens 500000`: 4x500k and 8x500k come back as clean 503 rejects, 0 net-fail, server stays healthy (health 200 and no OOM in the log across the whole sequence).
- Safe load unaffected: 50 concurrent 4k prompts (206k tokens, under budget) all served, 0 rejects, ttft p50 ~21 ms.

I logged the per-request admission decision to confirm the accounting: the first 500k request is admitted at inflight=0 and charged ~507k, and every following one sees inflight=~507k and is rejected, so there's no over-admission and no double count.

The budget is sized to what the server can actually serve at once. Set it to the total prefill tokens your memory headroom allows in flight; unset leaves behavior exactly as before.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34603903664](https://github.com/sgl-project/sglang/actions/runs/34603903664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34603903198](https://github.com/sgl-project/sglang/actions/runs/34603903198)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34603903763](https://github.com/sgl-project/sglang/actions/runs/34603903763)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->