### PR TITLE
fix(qwen3-vl): honor enable_precise_embedding_interpolation on the default ViT path

### DIFF
--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -551,12 +551,8 @@ class Qwen3VLMoeVisionModel(nn.Module, RotaryPosMixin):
 
         outputs = []
         for t, h, w in grid_thw:
-            h_idxs = torch.linspace(
-                0, num_grid_per_side - 1, h, dtype=torch.float32, device=self.device
-            )
-            w_idxs = torch.linspace(
-                0, num_grid_per_side - 1, w, dtype=torch.float32, device=self.device
-            )
+            h_idxs = self._torch_interp_indices(h, self.device)
+            w_idxs = self._torch_interp_indices(w, self.device)
 
             h_floor = h_idxs.to(torch.long)
             w_floor = w_idxs.to(torch.long)

--- a/test/registered/unit/models/test_qwen3_vl_pos_embed_interp.py
+++ b/test/registered/unit/models/test_qwen3_vl_pos_embed_interp.py
@@ -1,0 +1,102 @@
+"""Qwen3-VL ViT position-embedding interpolation must be consistent across paths.
+
+`fast_pos_embed_interpolate()` (used by the CUDA-graph ViT path) honors
+`enable_precise_embedding_interpolation` via `_get_interpolation_indices()`.
+`fast_pos_embed_interpolate_from_list()` (used by the default eager path)
+hardcoded `torch.linspace(...)`, i.e. it always behaved as
+`align_corners=True`, so the flag had no effect on the default path.
+
+These tests pin both paths to the same coordinates for both flag values.
+
+Destination in-tree:
+    test/registered/unit/models/test_qwen3_vl_pos_embed_interp.py
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.models.qwen3_vl import Qwen3VLMoeVisionModel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+NUM_GRID_PER_SIDE = 8
+MERGE = 2
+HIDDEN = 4
+
+# Grid sizes deliberately != NUM_GRID_PER_SIDE: at h == num_grid_per_side the two
+# coordinate formulas coincide, so that case cannot discriminate.
+GRIDS = [(1, 4, 6), (1, 6, 10), (1, 12, 4), (2, 4, 4)]
+
+
+def _make_vision_model(align_corners: bool) -> Qwen3VLMoeVisionModel:
+    """Build only the attributes the two interpolation paths touch.
+
+    `__init__` needs a full vision config plus a global exec context, neither of
+    which is required here:
+      from_list path -> device, dtype, num_grid_per_side, pos_embed, spatial_merge_size
+      interpolate path -> pos_embed, num_grid_per_side, align_corners, spatial_merge_size
+    """
+    model = object.__new__(Qwen3VLMoeVisionModel)
+    torch.nn.Module.__init__(
+        model
+    )  # set up _modules/_parameters for attribute assignment
+    model.num_grid_per_side = NUM_GRID_PER_SIDE
+    model.spatial_merge_size = MERGE
+    model.align_corners = align_corners
+    # device/dtype are read-only properties over patch_embed.proj.weight
+    model.patch_embed = SimpleNamespace(
+        proj=SimpleNamespace(weight=torch.zeros(1, dtype=torch.float32))
+    )
+    embed = torch.nn.Embedding(NUM_GRID_PER_SIDE * NUM_GRID_PER_SIDE, HIDDEN)
+    torch.nn.init.normal_(embed.weight, std=1.0)
+    model.pos_embed = embed.to(torch.float32)
+    return model
+
+
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("grid", GRIDS)
+def test_from_list_matches_reference_path(align_corners, grid):
+    """Both interpolation paths must agree, for either flag value."""
+    model = _make_vision_model(align_corners)
+    t, h, w = grid
+
+    from_list = model.fast_pos_embed_interpolate_from_list([[t, h, w]])
+    reference = model.fast_pos_embed_interpolate(
+        torch.tensor([[t, h, w]], dtype=torch.int32)
+    )
+
+    assert from_list.shape == reference.shape
+    torch.testing.assert_close(from_list, reference, rtol=1e-5, atol=1e-5)
+
+
+@pytest.mark.parametrize("dim_size", [4, 6, 10, 12])
+def test_indices_helpers_agree(dim_size):
+    """The torch helper must match the numpy helper it documents itself against."""
+    for align_corners in (False, True):
+        model = _make_vision_model(align_corners)
+        torch_idx = model._torch_interp_indices(dim_size, torch.device("cpu"))
+        numpy_idx = torch.from_numpy(model._get_interpolation_indices(dim_size))
+        torch.testing.assert_close(torch_idx, numpy_idx, rtol=1e-6, atol=1e-6)
+
+
+def test_flag_actually_changes_from_list_output():
+    """The flag must be observable on the default (from_list) path.
+
+    Before the fix this failed: from_list ignored the flag, so both outputs were
+    identical and the flag was a silent no-op on the default code path.
+    """
+    t, h, w = 1, 4, 6
+    model_off = _make_vision_model(align_corners=False)
+    model_on = _make_vision_model(align_corners=True)
+    # identical weights; the flag is the only difference
+    model_on.pos_embed.load_state_dict(model_off.pos_embed.state_dict())
+
+    off = model_off.fast_pos_embed_interpolate_from_list([[t, h, w]])
+    on = model_on.fast_pos_embed_interpolate_from_list([[t, h, w]])
+
+    assert not torch.allclose(
+        off, on, rtol=1e-5, atol=1e-5
+    ), "align_corners had no effect on fast_pos_embed_interpolate_from_list"


### PR DESCRIPTION
## Motivation

`enable_precise_embedding_interpolation` (`align_corners`) has **no effect on the
default Qwen3-VL ViT path**. Both branches of the eager forward interpolate the ViT
absolute position-embedding grid with `linspace` coordinates unconditionally, while
the CUDA-graph path honors the flag — and it even carries the exact guard the eager
path is missing.

Current `main`, `python/sglang/srt/models/qwen3_vl.py`:

```python
# eager path (default: SGLANG_VIT_ENABLE_CUDA_GRAPH is off)
903:  pos_embeds = self.fast_pos_embed_interpolate_vectorized(grid_thw_list)  # linspace
905:  pos_embeds = self.fast_pos_embed_interpolate_from_list(grid_thw_list)   # linspace

# CUDA-graph path
1085: if self.align_corners and self._use_vectorized_pos_embed(len(grid_thw_list)):
          # The vectorized implementation uses linspace coordinates. In graph mode
          # the legacy fallback honors enable_precise_embedding_interpolation, so
          # only use the vectorized path when the active graph interpolation mode
          # is also linspace; otherwise image count would change the output.
1090:     pos_embeds = self.fast_pos_embed_interpolate_vectorized(grid_thw_list)
1092: else:
          pos_embeds = self.fast_pos_embed_interpolate(grid_thw)               # honors flag
```

`fast_pos_embed_interpolate_from_list()` hardcodes the coordinates:

```python
547: def fast_pos_embed_interpolate_from_list(self, grid_thw):
554:     h_idxs = torch.linspace(0, num_grid_per_side - 1, h, ...)   # == align_corners=True
557:     w_idxs = torch.linspace(0, num_grid_per_side - 1, w, ...)
```

whereas the flag-honoring helpers pick half-pixel centers by default:

```python
461: def _get_interpolation_indices(self, dim_size):        # numpy, used by the graph path
467:     if self.align_corners:
468:         indices = np.linspace(0, self.num_grid_per_side - 1, dim_size, ...)
471:     else:
472:         indices = (np.arange(dim_size) + 0.5) * (self.num_grid_per_side / dim_size) - 0.5
475:         indices = np.clip(indices, 0, self.num_grid_per_side - 1)

531: def _torch_interp_indices(self, dim_size, device):     # torch mirror, currently unused
541:     # align_corners=False  (match _get_interpolation_indices)
```

`_torch_interp_indices()` already exists and documents itself as matching
`_get_interpolation_indices()`, but nothing calls it — this PR wires it up.

Two more signals that all paths were meant to agree:

- `_use_vectorized_pos_embed()` docstring: *"Both give the same result."*
- `fast_pos_embed_interpolate_vectorized()` docstring: *"Same result as the loop version."*

Both statements hold between the two `linspace` implementations, but not against
`fast_pos_embed_interpolate()` at the default flag value.

## Secondary: the flag-honoring path is unreachable on a default Hopper setup

`fast_pos_embed_interpolate()` is only reached through the ViT CUDA-graph path, and
that path aborts with the default vision attention backend. On H200, sglang
`0.0.0.dev1+ga14971730.d20260731`, `Qwen3.5-35B-A3B-FP8`, TP1, `attention_backend=fa3`,
`mm_attention_backend=None`, setting `SGLANG_VIT_ENABLE_CUDA_GRAPH=1` takes the
scheduler down on the first image request:

```
File "python/sglang/srt/models/qwen3_vl.py", line 1032, in forward_with_cuda_graph
    return self.graph_runners.run(
File "python/sglang/srt/multimodal/vit_cuda_graph_runner.py", line 200, in _create_graph
    raise RuntimeError("Not supported ViT attention backend")
[...] SIGQUIT received. signum=None [...] It usually means one child failed.
[...] "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
```

So in practice every request takes the eager path, and
`enable_precise_embedding_interpolation` cannot be made to take effect at all.
Arguably the runner should fall back to eager (or fail at startup) instead of
`SIGQUIT`-ing on the first request, but that is a separate change and not part of
this PR.

## Modifications

- `fast_pos_embed_interpolate_from_list()`: use `_torch_interp_indices()` instead of
  hardcoded `torch.linspace(...)`, so the default path honors the flag.
- New unit test pinning both interpolation paths to the same coordinates for both
  flag values, plus a test asserting the flag is observable on the default path.
  Registered with `register_cpu_ci` (no GPU, no weights needed).

## Alternatives

The asymmetry can be resolved in either direction and I have no strong preference —
happy to switch:

1. **This PR**: make the eager path honor the flag (default becomes half-pixel
   centers, matching `_get_interpolation_indices`' documented default).
2. Make the graph path use `linspace` unconditionally too, and document that
   `enable_precise_embedding_interpolation` no longer applies to Qwen3-VL.

Option 1 changes default numerics for Qwen3-VL/Qwen3.5/Moss-VL, which is why I am
flagging it explicitly rather than presenting it as a pure no-op cleanup. Note that
`fast_pos_embed_interpolate_vectorized()` is also `linspace`-only; it is gated behind
`SGLANG_VIT_ENABLE_VECTORIZED_POS_EMBED` and `num_images >= N`, so it is untouched
here, but it has the same inconsistency and should follow whichever direction is
chosen.

## Testing

```
pytest test/registered/unit/models/test_qwen3_vl_pos_embed_interp.py -v
```

The tests construct only the attributes the two paths touch, so they need no model
weights, no GPU, and no vision config.

Before this change, `test_from_list_matches_reference_path[grid...-False]` and
`test_flag_actually_changes_from_list_output` fail; after it, all 13 pass.

## Not claimed

I am **not** claiming a quality regression from this. I measured a ~4 point
field-accuracy difference between sglang `0.5.9` and `20260731` nightly on an
internal document-extraction task, but a controlled experiment ruled this
interpolation path out as its cause, and that dataset is too small (17 documents)
to support a magnitude claim anyway. This PR is a consistency fix only.

## Checklist

- [x] Format your code with `pre-commit run --files ...`
- [x] Add unit tests

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31206271570](https://github.com/sgl-project/sglang/actions/runs/31206271570)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31206270548](https://github.com/sgl-project/sglang/actions/runs/31206270548)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->