### PR TITLE
[AMD] Fix weight checking for AITER-shuffled block FP8 weights

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -682,6 +682,7 @@ class Fp8LinearMethod(LinearMethodBase):
                 t = shuffle_weight(layer.weight, (16, 16))
                 layer.weight.copy_(t)
                 del t
+                layer.weight.is_shuffled = True
 
     def _process_mxfp8_linear_weight_scale(self, layer: Module) -> None:
         if not self.use_mxfp8:
@@ -1471,6 +1472,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight.data = shuffle_weight(
                     layer.w2_weight.contiguous(), (16, 16)
                 )
+                layer.w13_weight.is_shuffled = True
+                layer.w2_weight.is_shuffled = True
             return
         elif self.use_mxfp8:
             self._process_mxfp8_moe_weights(
@@ -1509,6 +1512,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight.data = shuffle_weight(
                     layer.w2_weight.contiguous(), (16, 16)
                 )
+                layer.w13_weight.is_shuffled = True
+                layer.w2_weight.is_shuffled = True
         elif _use_aiter:
             # Pre-shuffle weights
             t = shuffle_weight(layer.w13_weight, (16, 16))
@@ -1517,6 +1522,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             t = shuffle_weight(layer.w2_weight, (16, 16))
             layer.w2_weight.copy_(t)
             del t
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
         elif _is_cpu:
             assert (
                 _is_cpu_amx_available

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -54,6 +54,8 @@ class QuantizedWeight(NamedTuple):
 
 _NON_PERSISTENT_BUFFER_PATTERNS = (
     "cos_sin_cache",
+    "cos_cache",
+    "sin_cache",
     "inv_freq",
     "freqs_cis",
     "_weight_fp32",
@@ -203,12 +205,7 @@ class WeightChecker:
     def _model_state(self):
         model = self._get_model()
         yield from model.named_parameters()
-        for name, buffer in model.named_buffers():
-            module_name, _, buffer_name = name.rpartition(".")
-            owner = model.get_submodule(module_name) if module_name else model
-            if buffer_name in owner._non_persistent_buffers_set:
-                continue
-            yield name, buffer
+        yield from model.named_buffers()
 
 
 def _hash_tensor(t: torch.Tensor) -> str:

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -49,6 +49,7 @@ class CheckEntry(NamedTuple):
 class QuantizedWeight(NamedTuple):
     comparable_cls: type[ComparableWeight]
     scale_name: str
+    is_shuffled: bool = False
 
 
 _NON_PERSISTENT_BUFFER_PATTERNS = (
@@ -298,12 +299,14 @@ def _build_quantized_set(model) -> Dict[str, QuantizedWeight]:
         if comparable_cls is None:
             continue
         prefix = f"{module_name}." if module_name else ""
-        own = {name for name, _ in module.named_parameters(recurse=False)}
-        for name in own:
+        own = dict(module.named_parameters(recurse=False))
+        for name, parameter in own.items():
             scale = name.replace("weight", "weight_scale_inv")
             if name.endswith("weight") and scale in own:
                 quantized_set[prefix + name] = QuantizedWeight(
-                    comparable_cls, prefix + scale
+                    comparable_cls,
+                    prefix + scale,
+                    getattr(parameter, "is_shuffled", False),
                 )
     return quantized_set
 
@@ -327,7 +330,9 @@ def _build_check_entries(
             yield CheckEntry(
                 name,
                 name not in skip_compare_names,
-                qw.comparable_cls(tensor, raw[qw.scale_name]),
+                qw.comparable_cls(
+                    tensor, raw[qw.scale_name], is_shuffled=qw.is_shuffled
+                ),
             )
         else:
             should_compare = name not in skip_compare_names and (

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -202,7 +202,12 @@ class WeightChecker:
     def _model_state(self):
         model = self._get_model()
         yield from model.named_parameters()
-        yield from model.named_buffers()
+        for name, buffer in model.named_buffers():
+            module_name, _, buffer_name = name.rpartition(".")
+            owner = model.get_submodule(module_name) if module_name else model
+            if buffer_name in owner._non_persistent_buffers_set:
+                continue
+            yield name, buffer
 
 
 def _hash_tensor(t: torch.Tensor) -> str:

--- a/python/sglang/srt/utils/weight_checker_comparator.py
+++ b/python/sglang/srt/utils/weight_checker_comparator.py
@@ -45,15 +45,45 @@ class ComparableWeight:
         raise NotImplementedError
 
 
+def _unshuffle_aiter_fp8_weight(w_q: torch.Tensor) -> torch.Tensor:
+    """Undo AITER shuffle_weight with layout=(16, 16) for FP8 weights."""
+    if w_q.element_size() != 1:
+        raise ValueError("AITER FP8 unshuffle requires a one-byte element type")
+
+    shape = w_q.shape
+    n, k = shape[-2:]
+    if n % 16 != 0 or k % 32 != 0:
+        raise ValueError(
+            "AITER (16, 16) FP8 layout requires N % 16 == 0 and K % 32 == 0, "
+            f"got shape {tuple(shape)}"
+        )
+
+    return (
+        w_q.reshape(-1, n // 16, k // 32, 2, 16, 16)
+        .permute(0, 1, 4, 2, 3, 5)
+        .contiguous()
+        .reshape(shape)
+    )
+
+
 class Fp8BlockComparable(ComparableWeight):
     """Deepseek-style FP8 quantization."""
 
-    def __init__(self, w_q: torch.Tensor, w_s: torch.Tensor):
+    def __init__(
+        self,
+        w_q: torch.Tensor,
+        w_s: torch.Tensor,
+        is_shuffled: bool = False,
+    ):
         self.w_q = w_q
         self.w_s = w_s
+        self.is_shuffled = is_shuffled
 
     def __repr__(self) -> str:
-        return f"fp8_block(shape={tuple(self.w_q.shape)} dtype={self.w_q.dtype})"
+        return (
+            f"fp8_block(shape={tuple(self.w_q.shape)} dtype={self.w_q.dtype} "
+            f"is_shuffled={self.is_shuffled})"
+        )
 
     @staticmethod
     def _normalize_scale(w_q: torch.Tensor, w_s: torch.Tensor) -> torch.Tensor:
@@ -90,6 +120,8 @@ class Fp8BlockComparable(ComparableWeight):
         s, block_size = self._scale_and_block_size()
         for q, s_chunk in self._iter_quant_chunks(self.w_q, s, block_size[0]):
             q, s_chunk = q.cuda(), s_chunk.cuda()
+            if self.is_shuffled:
+                q = _unshuffle_aiter_fp8_weight(q)
             yield (
                 block_quant_dequant(q, s_chunk, block_size, dtype=torch.bfloat16),
                 block_quant_dequant(
@@ -99,7 +131,10 @@ class Fp8BlockComparable(ComparableWeight):
 
     def dequantize(self, dtype: torch.dtype = torch.bfloat16) -> torch.Tensor:
         s, block_size = self._scale_and_block_size()
-        return block_quant_dequant(self.w_q, s, block_size, dtype=dtype)
+        w_q = self.w_q
+        if self.is_shuffled:
+            w_q = _unshuffle_aiter_fp8_weight(w_q)
+        return block_quant_dequant(w_q, s, block_size, dtype=dtype)
 
 
 class RawComparable(ComparableWeight):

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -686,10 +686,10 @@ class TestCompare(_WeightCheckerTestBase):
         snapshot = {k: v.clone() for k, v in self.checker._snapshot_tensors.items()}
         self.checker._reset_tensors()
         with torch.no_grad():
-            for name, param in self.model.named_parameters():
-                param.data.copy_(snapshot[name].to(param.device))
-            for name, buffer in self.model.named_buffers():
-                buffer.data.copy_(snapshot[name].to(buffer.device))
+            for name, tensor in self.model.named_parameters():
+                tensor.data.copy_(snapshot[name].to(tensor.device))
+            for name, tensor in self.model.named_buffers():
+                tensor.data.copy_(snapshot[name].to(tensor.device))
         self.checker._compare()
 
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -25,6 +25,7 @@ from sglang.srt.layers.quantization.fp8_utils import (
     quant_weight_ue8m0,
     transform_scale_ue8m0,
 )
+from sglang.srt.utils import is_hip
 from sglang.srt.utils.weight_checker import (
     CheckEntry,
     ChecksumInfo,
@@ -43,9 +44,10 @@ from sglang.srt.utils.weight_checker_comparator import (
     RawComparable,
     _unshuffle_aiter_fp8_weight,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
 
 
@@ -84,18 +86,16 @@ def _assert_entries_close(
 
 
 def _build_fp8_quant_pair(device: str = "cuda"):
-    """Construct a real fp8-quantized weight + matching fp32 + ue8m0-packed scales.
+    """Construct a real fp8-quantized weight and matching fp32 scales.
 
-    Returns (qweight, sf_fp32, sf_packed_int32) so callers can pick which scale dtype
-    drives the _build_check_entries branch under test.
+    Returns (qweight, sf_fp32).
     """
     weight_bf16 = torch.randn((256, 128), dtype=torch.bfloat16, device=device)
     block_size = [128, 128]
     qweight, sf_fp32 = quant_weight_ue8m0(
         weight_dequant=weight_bf16, weight_block_size=block_size
     )
-    sf_packed_int32 = transform_scale_ue8m0(sf_fp32, mn=qweight.shape[-2])
-    return qweight, sf_fp32, sf_packed_int32
+    return qweight, sf_fp32
 
 
 # ---------------------------------------------------------------------------
@@ -171,9 +171,10 @@ class _TinyModel(nn.Module):
         self.register_buffer("running_mean", torch.zeros(4))
         # Buffer names that match weight_checker's hard-coded skip patterns.
         self.register_buffer("rotary_emb_cos_sin_cache", torch.full((8,), 3.14))
+        self.register_buffer("rotary_emb_cos_cache", torch.full((8,), 1.62))
+        self.register_buffer("rotary_emb_sin_cache", torch.full((8,), 0.58))
         self.register_buffer("rotary_emb_freqs_cis", torch.full((8,), 2.71))
         self.register_buffer("gate_proj_weight_fp32_cache", torch.full((8,), 1.41))
-        self.register_buffer("derived_cache", torch.full((8,), 0.42), persistent=False)
 
 
 class _FakeModelRunner:
@@ -327,7 +328,7 @@ class TestPostprocessTensors(CustomTestCase):
         )
 
     def test_skip_set_marks_quantized_entry_not_compared(self):
-        qweight, sf_fp32, _ = _build_fp8_quant_pair()
+        qweight, sf_fp32 = _build_fp8_quant_pair()
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_fp32}
         quantized_set = {
             "x.weight": QuantizedWeight(Fp8BlockComparable, "x.weight_scale_inv")
@@ -340,8 +341,10 @@ class TestPostprocessTensors(CustomTestCase):
 
     # --- fp8 quant pair (real dequant on real fp8 tensors) ---
 
+    @unittest.skipIf(is_hip(), "DeepGEMM is not supported on ROCm")
     def test_fp8_quant_pair_yields_lazy_pair(self):
-        qweight, sf_fp32, sf_packed_int32 = _build_fp8_quant_pair()
+        qweight, sf_fp32 = _build_fp8_quant_pair()
+        sf_packed_int32 = transform_scale_ue8m0(sf_fp32, mn=qweight.shape[-2])
         raw = {"x.weight": qweight, "x.weight_scale_inv": sf_packed_int32}
 
         ref = Fp8BlockComparable(qweight, sf_packed_int32)
@@ -370,7 +373,7 @@ class TestPostprocessTensors(CustomTestCase):
         )
 
     def test_fp8_quant_pair_yield_order_alongside_other_entries(self):
-        qweight, sf_fp32, _ = _build_fp8_quant_pair()
+        qweight, sf_fp32 = _build_fp8_quant_pair()
         bias = torch.ones(4, device="cuda")
         raw = {
             "x.weight": qweight,
@@ -597,15 +600,12 @@ class TestSnapshot(_WeightCheckerTestBase):
             "b",
             "running_mean",
             "rotary_emb_cos_sin_cache",
+            "rotary_emb_cos_cache",
+            "rotary_emb_sin_cache",
             "rotary_emb_freqs_cis",
             "gate_proj_weight_fp32_cache",
         }
         self.assertEqual(keys, expected)
-
-    def test_excludes_non_persistent_buffers(self):
-        self.assertIn("derived_cache", dict(self.model.named_buffers()))
-        self.checker._snapshot()
-        self.assertNotIn("derived_cache", self.checker._snapshot_tensors)
 
     def test_detaches_and_moves_to_cpu(self):
         self.checker._snapshot()
@@ -632,6 +632,16 @@ class TestResetTensors(_WeightCheckerTestBase):
         before = self.model.rotary_emb_cos_sin_cache.clone()
         self.checker._reset_tensors()
         torch.testing.assert_close(self.model.rotary_emb_cos_sin_cache, before)
+
+    def test_skips_cos_cache(self):
+        before = self.model.rotary_emb_cos_cache.clone()
+        self.checker._reset_tensors()
+        torch.testing.assert_close(self.model.rotary_emb_cos_cache, before)
+
+    def test_skips_sin_cache(self):
+        before = self.model.rotary_emb_sin_cache.clone()
+        self.checker._reset_tensors()
+        torch.testing.assert_close(self.model.rotary_emb_sin_cache, before)
 
     def test_skips_freqs_cis(self):
         before = self.model.rotary_emb_freqs_cis.clone()
@@ -676,8 +686,10 @@ class TestCompare(_WeightCheckerTestBase):
         snapshot = {k: v.clone() for k, v in self.checker._snapshot_tensors.items()}
         self.checker._reset_tensors()
         with torch.no_grad():
-            for name, tensor in self.checker._model_state():
-                tensor.data.copy_(snapshot[name].to(tensor.device))
+            for name, param in self.model.named_parameters():
+                param.data.copy_(snapshot[name].to(param.device))
+            for name, buffer in self.model.named_buffers():
+                buffer.data.copy_(snapshot[name].to(buffer.device))
         self.checker._compare()
 
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -109,8 +109,10 @@ class TestAiterFp8Layout(CustomTestCase):
     def _logical_and_shuffled():
         shape = (32, 64)
         n, k = shape[-2:]
-        logical = torch.arange(n * k, dtype=torch.float32).remainder(7).to(
-            torch.float8_e4m3fn
+        logical = (
+            torch.arange(n * k, dtype=torch.float32)
+            .remainder(7)
+            .to(torch.float8_e4m3fn)
         )
         logical = logical.reshape(shape)
         shuffled = (
@@ -123,9 +125,7 @@ class TestAiterFp8Layout(CustomTestCase):
 
     def test_unshuffle_round_trip(self):
         logical, shuffled = self._logical_and_shuffled()
-        torch.testing.assert_close(
-            _unshuffle_aiter_fp8_weight(shuffled), logical
-        )
+        torch.testing.assert_close(_unshuffle_aiter_fp8_weight(shuffled), logical)
 
     def test_iter_chunks_unshuffles_before_dequantization(self):
         logical, shuffled = self._logical_and_shuffled()
@@ -173,9 +173,7 @@ class _TinyModel(nn.Module):
         self.register_buffer("rotary_emb_cos_sin_cache", torch.full((8,), 3.14))
         self.register_buffer("rotary_emb_freqs_cis", torch.full((8,), 2.71))
         self.register_buffer("gate_proj_weight_fp32_cache", torch.full((8,), 1.41))
-        self.register_buffer(
-            "derived_cache", torch.full((8,), 0.42), persistent=False
-        )
+        self.register_buffer("derived_cache", torch.full((8,), 0.42), persistent=False)
 
 
 class _FakeModelRunner:

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -115,6 +115,9 @@ class _TinyModel(nn.Module):
         self.register_buffer("rotary_emb_cos_sin_cache", torch.full((8,), 3.14))
         self.register_buffer("rotary_emb_freqs_cis", torch.full((8,), 2.71))
         self.register_buffer("gate_proj_weight_fp32_cache", torch.full((8,), 1.41))
+        self.register_buffer(
+            "derived_cache", torch.full((8,), 0.42), persistent=False
+        )
 
 
 class _FakeModelRunner:
@@ -526,6 +529,11 @@ class TestSnapshot(_WeightCheckerTestBase):
         }
         self.assertEqual(keys, expected)
 
+    def test_excludes_non_persistent_buffers(self):
+        self.assertIn("derived_cache", dict(self.model.named_buffers()))
+        self.checker._snapshot()
+        self.assertNotIn("derived_cache", self.checker._snapshot_tensors)
+
     def test_detaches_and_moves_to_cpu(self):
         self.checker._snapshot()
         for tensor in self.checker._snapshot_tensors.values():
@@ -595,9 +603,7 @@ class TestCompare(_WeightCheckerTestBase):
         snapshot = {k: v.clone() for k, v in self.checker._snapshot_tensors.items()}
         self.checker._reset_tensors()
         with torch.no_grad():
-            for name, tensor in self.model.named_parameters():
-                tensor.data.copy_(snapshot[name].to(tensor.device))
-            for name, tensor in self.model.named_buffers():
+            for name, tensor in self.checker._model_state():
                 tensor.data.copy_(snapshot[name].to(tensor.device))
         self.checker._compare()
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -41,6 +41,7 @@ from sglang.srt.utils.weight_checker import (
 from sglang.srt.utils.weight_checker_comparator import (
     Fp8BlockComparable,
     RawComparable,
+    _unshuffle_aiter_fp8_weight,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -75,6 +76,7 @@ def _assert_entries_close(
             torch.testing.assert_close(
                 a_ref.w_s, e_ref.w_s, msg=f"[{i}] w_s {a_name!r}"
             )
+            assert a_ref.is_shuffled == e_ref.is_shuffled
         else:
             torch.testing.assert_close(
                 a_ref.tensor, e_ref.tensor, msg=f"[{i}] tensor {a_name!r}"
@@ -94,6 +96,62 @@ def _build_fp8_quant_pair(device: str = "cuda"):
     )
     sf_packed_int32 = transform_scale_ue8m0(sf_fp32, mn=qweight.shape[-2])
     return qweight, sf_fp32, sf_packed_int32
+
+
+# ---------------------------------------------------------------------------
+# AITER FP8 layout
+# ---------------------------------------------------------------------------
+
+
+class TestAiterFp8Layout(CustomTestCase):
+
+    @staticmethod
+    def _logical_and_shuffled():
+        shape = (32, 64)
+        n, k = shape[-2:]
+        logical = torch.arange(n * k, dtype=torch.float32).remainder(7).to(
+            torch.float8_e4m3fn
+        )
+        logical = logical.reshape(shape)
+        shuffled = (
+            logical.reshape(-1, n // 16, 16, k // 32, 2, 16)
+            .permute(0, 1, 3, 4, 2, 5)
+            .contiguous()
+            .reshape(shape)
+        )
+        return logical, shuffled
+
+    def test_unshuffle_round_trip(self):
+        logical, shuffled = self._logical_and_shuffled()
+        torch.testing.assert_close(
+            _unshuffle_aiter_fp8_weight(shuffled), logical
+        )
+
+    def test_iter_chunks_unshuffles_before_dequantization(self):
+        logical, shuffled = self._logical_and_shuffled()
+        scale = torch.ones((2, 4), dtype=torch.float32)
+        comparable = Fp8BlockComparable(shuffled, scale, is_shuffled=True)
+
+        with patch(
+            "sglang.srt.utils.weight_checker_comparator.block_quant_dequant",
+            side_effect=lambda weight, *_args, **_kwargs: weight,
+        ):
+            dequantized, _ = next(iter(comparable.iter_chunks()))
+
+        torch.testing.assert_close(dequantized.cpu(), logical)
+
+    def test_dequantize_unshuffles_before_checksum(self):
+        logical, shuffled = self._logical_and_shuffled()
+        scale = torch.ones((2, 4), dtype=torch.float32)
+        comparable = Fp8BlockComparable(shuffled, scale, is_shuffled=True)
+
+        with patch(
+            "sglang.srt.utils.weight_checker_comparator.block_quant_dequant",
+            side_effect=lambda weight, *_args, **_kwargs: weight,
+        ):
+            dequantized = comparable.dequantize()
+
+        torch.testing.assert_close(dequantized, logical)
 
 
 # ---------------------------------------------------------------------------
@@ -297,6 +355,22 @@ class TestPostprocessTensors(CustomTestCase):
             [("x.weight", True, ref)],
         )
 
+    def test_fp8_quant_pair_preserves_shuffled_flag(self):
+        qweight = torch.zeros((128, 128), dtype=torch.float8_e4m3fn)
+        scale = torch.ones((1, 1), dtype=torch.float32)
+        raw = {"x.weight": qweight, "x.weight_scale_inv": scale}
+        quantized_set = {
+            "x.weight": QuantizedWeight(
+                Fp8BlockComparable,
+                "x.weight_scale_inv",
+                is_shuffled=True,
+            )
+        }
+        _assert_entries_close(
+            _build_check_entries(raw, set(), quantized_set),
+            [("x.weight", True, Fp8BlockComparable(qweight, scale, True))],
+        )
+
     def test_fp8_quant_pair_yield_order_alongside_other_entries(self):
         qweight, sf_fp32, _ = _build_fp8_quant_pair()
         bias = torch.ones(4, device="cuda")
@@ -480,11 +554,12 @@ class TestBuildQuantizedSet(CustomTestCase):
         model.proj.register_parameter(
             "weight_scale_inv", nn.Parameter(torch.zeros(1, 1), requires_grad=False)
         )
+        model.proj.weight.is_shuffled = True
         self.assertEqual(
             _build_quantized_set(model),
             {
                 "proj.weight": QuantizedWeight(
-                    Fp8BlockComparable, "proj.weight_scale_inv"
+                    Fp8BlockComparable, "proj.weight_scale_inv", is_shuffled=True
                 )
             },
         )


### PR DESCRIPTION
## Motivation

AITER pre-shuffles block-FP8 weights on ROCm for optimized inference kernels. The weight checker was treating the shuffled physical layout as the original logical layout during dequantization, causing false weight-update mismatches even though inference was correct.

The checker also included buffers registered with `persistent=False`, such as derived rotary caches, in its snapshots.

## Modifications

- Mark dense and MoE block-FP8 parameters after AITER layout shuffling.
- Propagate the layout metadata into the weight checker.
- Restore the logical FP8 layout before checker dequantization, checksum, and ULP comparison.
- Exclude PyTorch non-persistent buffers from weight-checker model state.
- Add unit tests for AITER layout restoration, metadata propagation, and non-persistent buffers.

The layout conversion is only applied to weights explicitly marked as AITER-shuffled. NVIDIA and other unshuffled paths retain the existing behavior.

## Accuracy Tests

Validated on AMD MI355 with the Miles [DeepSeek V4 four-layer E2E test](https://github.com/radixark/miles/blob/main/tests/e2e/megatron/model_scripts/test_deepseek_v4_flash_4layer_ci.py).

Both rollout runs passed, and all checked FP8 weights reported `num_exceed=0`.

Weight-checker unit tests:
- New focused tests: 6 passed
- Runnable unit suite: 62 passed, 3 deselected because NVIDIA `deep_gemm` is unavailable in the ROCm container

This PR does not modify model forward computation or inference kernels.

## Speed Tests and Profiling

Not applicable. The only inference-path change is setting metadata during weight loading. Layout restoration runs exclusively when the weight checker is enabled and does not affect normal inference performance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31423591139](https://github.com/sgl-project/sglang/actions/runs/31423591139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31423591011](https://github.com/sgl-project/sglang/actions/runs/31423591011)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->