### PR TITLE
[SM12x] Re-enable the FP8 wo_a GEMM on sm120/sm121

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -200,6 +200,20 @@ def _get_mhc_ops() -> MhcOps:
 logger = logging.getLogger(__name__)
 
 _FP8_WO_A_GEMM = envs.SGLANG_OPT_FP8_WO_A_GEMM.get()
+
+
+@functools.lru_cache(maxsize=1)
+def _wo_a_ue8m0_sm12x() -> bool:
+    """sm12x needs ue8m0 scales for wo_a; the global flag only covers sm100."""
+    if not _FP8_WO_A_GEMM:
+        return False
+    from sglang.srt.layers import deep_gemm_wrapper
+
+    if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+        return False
+    return deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and is_sm120_supported()
+
+
 _MHC_POST_MULT_VALUE = 2.0
 
 DEEPSEEK_V4_STACKED_PARAMS_MAPPING: List[Tuple[str, str, int]] = [
@@ -517,7 +531,7 @@ class MqaAttentionBase(nn.Module):
                 self.wo_a, "weight_scale_inv"
             ), "FP8 quant_config must create weight_scale_inv"
             self.wo_a.weight_scale_inv.format_ue8m0 = (
-                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0
+                deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or _wo_a_ue8m0_sm12x()
             )
         self.wo_b = RowParallelLinear(
             self.n_groups * self.o_lora_rank,
@@ -1324,8 +1338,9 @@ class MQALayer(MqaAttentionBase):
 
             T, G, D = o.shape
             R = self.o_lora_rank
-            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
-                # sm100 (Blackwell): ue8m0 scales via the dedicated JIT kernel.
+            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or _wo_a_ue8m0_sm12x():
+                # sm100 (Blackwell) and sm12x: ue8m0 scales via the dedicated
+                # JIT kernel.
                 o_fp8, o_s = sglang_per_token_group_quant_fp8_dsv4_wo_a(o)
                 recipe = (1, 1, 128)
             else:
@@ -2637,7 +2652,7 @@ class DeepseekV4ForCausalLM(nn.Module):
     def _setup_fp8_wo_a_scales(self, is_nextn: bool) -> None:
         from sglang.srt.layers import deep_gemm_wrapper
 
-        if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+        if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or _wo_a_ue8m0_sm12x():
             from deep_gemm import transform_sf_into_required_layout
 
         if is_nextn:
@@ -2654,7 +2669,7 @@ class DeepseekV4ForCausalLM(nn.Module):
             D = attn.wo_a.weight.shape[1]
 
             raw_scale = attn.wo_a.weight_scale_inv.data.view(G, R // 128, D // 128)
-            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0:
+            if deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or _wo_a_ue8m0_sm12x():
                 attn.wo_a.weight_scale_inv.data = transform_sf_into_required_layout(
                     raw_scale,
                     mn=R,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -5312,7 +5312,8 @@ class ServerArgs:
             if is_sm120_supported():
                 # SM120 lacks tcgen05/TMEM: disable features that depend on
                 # DeepGEMM or require >99KB SMEM (topk_v2).
-                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+                if not envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set():
+                    envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
                 envs.SGLANG_OPT_USE_TOPK_V2.set(False)
                 envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
                 envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
@@ -7762,7 +7763,7 @@ class ServerArgs:
             explicit = envs.SGLANG_OPT_FP8_WO_A_GEMM.is_set()
             supported = deep_gemm_wrapper.DEEPGEMM_SCALE_UE8M0 or (
                 deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM
-                and is_sm90_supported()
+                and (is_sm90_supported() or is_sm120_supported())
                 and explicit
             )
             if not supported and explicit:


### PR DESCRIPTION
## Motivation

On SM120/SM121 `server_args.py` disables a block of features with the rationale *"SM120 lacks tcgen05/TMEM: disable features that depend on DeepGEMM"*. For `wo_a` (the first stage of DeepSeek-V4's o-projection) the consequence is that the FP8 weights already present in the checkpoint are **dequantised to bf16 at load** and the projection then runs as a generic bf16 WMMA GEMM.

The hardware half of that rationale is correct — sm120/sm121 really have no tcgen05/TMEM (`grep tcgen05` hits only `impls/sm100_*.cuh`). The *implication* is what went stale: **DeepGEMM no longer requires tcgen05**. The installed package ships nine `impls/sm120_*.cuh` — `sm120_fp8_fp4_gemm_1d1d`, `sm120_bmk_bnk_mn`, `sm120_tf32_hc_prenorm_gemm`, `sm120_{fp8,fp4}_{paged_,}mqa_logits`, … — all built on the SM120 warp-level MMA path instead.

Measured on 2× DGX Spark (GB10 / sm_121, TP=2), `deepseek-ai/DeepSeek-V4-Flash-0731` + DSPARK, the bf16 fallback costs **48 calls/step at ~174 µs = 12.7 ms/step**, about 15% of the decode step.

## Modifications

Opt-in only; default behaviour on every arch is unchanged.

1. The SM120 feature-disable block honours an explicit `SGLANG_OPT_FP8_WO_A_GEMM=1` (`is_set()` guard).
2. The existing opt-in gate accepts sm12x via `is_sm120_supported()`.
3. `wo_a` takes the **whole** sm100 branch on sm12x: the dedicated ue8m0 activation quant, `transform_sf_into_required_layout` for the weight scales, and `recipe=(1, 1, 128)`.

Point 3 is not cosmetic. Two constraints were found by offline probing at the real shapes (T=6, G=4, D=4096, R=1024):

- **sm12x accepts only ue8m0 scales.** Every fp32-scale variant I tried (`fp8_einsum`, `fp8_gemm_nt` ×G, `m_grouped_fp8_gemm_nt_contiguous`) aborts with `cudaErrorLaunchFailure`; every ue8m0 variant works.
- **`recipe` must match the weight-scale layout.** The transformed `[G, R, D/128] int32` layout pairs with `(1, 1, 128)`; the untransformed `[G, R/128, D/128] fp32` layout pairs with `(1, 128, 128)`. Crossing them trips `Assertion (utils/layout.hpp:97): sf.size(-2) == ceil_div(mn, gran_mn)`.

Splitting the branch (ue8m0 weights + `(1,128,128)`) reproduces that assert, which is why sm12x reuses the sm100 branch intact rather than a hybrid.

Offline microbenchmark, exclusive GPU, same shapes:

| | µs/call |
| --- | ---: |
| bf16 einsum (current fallback) | 152–154 |
| `m_grouped_fp8_gemm_nt_contiguous` (ue8m0, M padded 6→128) | 73.4 |
| **dedicated quant + `fp8_einsum` + recipe (1,1,128)** | **26.0** |

The resulting kernel is `deep_gemm::sm120_fp8_fp4_gemm_1d1d_impl<0u, 6u, 4096u, 128u, 128u, 4u, …>` — the same instantiation vLLM launches for this projection on the same hardware.

## Accuracy Tests

GSM8K 5-shot, `--num-questions 200 --parallel 16`, 2× DGX Spark TP=2:

| | Accuracy | Invalid |
| --- | ---: | ---: |
| baseline | 0.970 | 0.000 |
| **this PR + #34019** | **0.980** | 0.000 |

An earlier n=1000 run on an older base gave 0.943 (baseline) vs 0.946 (this change). Note accuracy is **not** comparable across different `--num-questions` — the first 200 questions are easier than the first 1000 (same build: 0.970 @ n=200 vs 0.943 @ n=1000).

## Benchmarking and Profiling

`sglang.bench_one_batch_server`, bs=1, `SGLANG_SIMULATE_ACC_LEN=5` so the accept length is pinned and the comparison is pure step cost (`acc_length: 5.00` confirmed in both arms). Same container, same clocks (unlocked), RoCE/RDMA available to both.

| in / out | baseline | this PR + MHC default | |
| --- | ---: | ---: | ---: |
| 1024 / 512 | 58.48 tok/s | **72.67 tok/s** | +24.3% |
| 8192 / 1024 | 61.88 tok/s | **66.76 tok/s** | +7.9% |

Kernel-level attribution from a 20-step profile (same container, same conditions), which separates the two changes:

| kernel family | baseline | patched | attributable to |
| --- | ---: | ---: | --- |
| bf16 SM80-WMMA | 20.18 ms / 136 calls | **12.74 ms / 93 calls** | **this PR** (wo_a's 43 calls move out) |
| `deep_gemm sm120_fp8_fp4_gemm_1d1d` | 0 | **3.29 ms / 43 calls** | **this PR** |
| fp32 cuBLAS (`hc_pre`) | 9.54 ms / 93 calls | 0.86 ms / 8 calls | MHC default (separate PR) |
| decode step | 70.31 ms | **63.19 ms** | −10.1% |

Net for this PR alone: −7.45 ms of bf16 WMMA for +3.29 ms of FP8 GEMM ≈ **−4.2 ms/step**.

### Test environment caveat

DSPARK on sm120/sm121 **cannot boot on stock flashinfer today**: the draft's index width is
`ceil_align(swa_window + gamma, 64)`, which is 192 for every gamma in [1, 64], while
flashinfer 0.6.15.post1 only instantiates decode top-k widths `{128, 512, 1024}`. Both known
fixes are still open — flashinfer-ai/flashinfer#4309 (adds the 192 instantiation) and
sgl-project/sglang#33407 (dispatch fallback in SGLang). The numbers above were collected with
flashinfer#4309 carried as a local patch; `SGLANG_SM120_FLASHMLA_BACKEND=triton` is the only
stock alternative and it routes *all* sparse-MLA calls through Triton, which costs throughput
on the hot path (measured 4.8x slower end to end here), so it is not a usable baseline.

### On tests

No unit test is included. The change is arch-gated to sm120/sm121, and CI has no such runner,
so a test would not execute where the behaviour differs. Validation was done on hardware
instead: GSM8K for accuracy and a kernel-level profile (reported above) to confirm the intended
kernels actually run rather than inferring it from throughput. Happy to add a test if there is
a preferred pattern for arch-gated paths.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-tests).
- [x] Update documentation / docstrings / example tutorials as needed, see [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, see [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

---

### Open question for maintainers

The same SM120 block also force-disables `SGLANG_OPT_DEEPGEMM_HC_PRENORM` and pushes the DSA indexer onto the torch / TileLang paths (`SGLANG_FP8_PAGED_MQA_LOGITS_TORCH=True`, `SGLANG_OPT_USE_TILELANG_INDEXER=True`). DeepGEMM ships `sm120_tf32_hc_prenorm_gemm.cuh` and `sm120_{fp8,fp4}_{paged_,}mqa_logits.cuh` for exactly those. If the tcgen05 premise is stale for `wo_a`, those three deserve a re-audit too — happy to test them on this hardware. Tracking under #19637 rather than widening this PR.

Also note `deep_gemm_wrapper/configurer.py` gates on `sm_version == 120`, which misses sm_121 (GB10 reports 121), while `server_args.py` uses `is_sm120_supported()` which returns True there. The two disagree; this PR uses the helper consistently but does not change `configurer.py`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31215115097](https://github.com/sgl-project/sglang/actions/runs/31215115097)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31215114872](https://github.com/sgl-project/sglang/actions/runs/31215114872)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->