### PR TITLE
Limit prefill delayer debug logs to rank zero

### DIFF
--- a/python/sglang/srt/managers/prefill_delayer.py
+++ b/python/sglang/srt/managers/prefill_delayer.py
@@ -52,9 +52,11 @@ class PrefillDelayer:
         metrics_collector: Optional["SchedulerMetricsCollector"] = None,
         device: Optional["torch.device"] = "cpu",
         device_group=None,
+        debug_log_enabled: bool = True,
     ):
         self._max_delay_passes = max_delay_passes
         self._token_usage_low_watermark = token_usage_low_watermark
+        self._debug_log_enabled = _DEBUG_LOG and debug_log_enabled
         # Queue-based trigger is opt-in: activates only when queue_min_ratio
         # is explicitly set. Additive with the slot-based trigger.
         self._queue_min_ratio = server_args.prefill_delayer_queue_min_ratio
@@ -358,6 +360,7 @@ class PrefillDelayerSinglePassExecutor:
             actual_execution=actual_prefill,
             output=self._result,
             metrics_collector=self._prefill_delayer._metrics_collector,
+            debug_log_enabled=self._prefill_delayer._debug_log_enabled,
         )
 
     def negotiate_should_allow_prefill(
@@ -384,8 +387,10 @@ def _record_single_pass_result(
     actual_execution: bool,
     output: _NegotiateOutput,
     metrics_collector: Optional["SchedulerMetricsCollector"],
+    *,
+    debug_log_enabled: bool,
 ) -> None:
-    if _DEBUG_LOG:
+    if debug_log_enabled:
         if output.output_allow and (output.output_reason == "wait_timeout"):
             logger.info(
                 f"PrefillDelayer timeout thus not forbid prefill "

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1211,6 +1211,7 @@ class Scheduler(
                     max_delay_passes=get_schedule().prefill_delayer_max_delay_passes,
                     token_usage_low_watermark=get_schedule().prefill_delayer_token_usage_low_watermark,
                     device=self.tp_group.device,
+                    debug_log_enabled=self.ps.attn_tp_rank == 0,
                 )
 
         # NOTE: preemption is enabled by default for priority scheduling.


### PR DESCRIPTION
## Motivation

Attention tensor-parallel ranks can emit duplicate prefill-delayer debug diagnostics. Limit these logs to rank zero while leaving scheduling decisions and metrics unchanged.

## Modifications

Pass a per-instance debug-log flag into the prefill delayer and enable it only on attention TP rank zero. The environment flag remains the global opt-in.

## Test plan

- `pytest -q test/registered/scheduler/test_prefill_delayer.py::TestPrefillDelayerNegotiate` — passed
- `pre-commit run --from-ref main --to-ref HEAD` — passed
- `python -m py_compile python/sglang/srt/managers/prefill_delayer.py python/sglang/srt/managers/scheduler.py` — passed
- GPU/runtime tests were not run because this is a logging-only change.

## Accuracy Tests

Not applicable; this does not affect model outputs.

## Speed Tests and Profiling

Not applicable; this only suppresses duplicate debug logs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Original commits

- `468938be2`

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31213906561](https://github.com/sgl-project/sglang/actions/runs/31213906561)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31214215151](https://github.com/sgl-project/sglang/actions/runs/31214215151)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->