### PR TITLE
Fix DeepSeek-V4 mHC combine allocating transients in the NCCL symmetric pool

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1664,10 +1664,19 @@ class DeepseekV4DecoderLayer(nn.Module):
         # output back into this buffer, so a symmetric input yields a symmetric
         # all-reduce input. Gated by is_allocation_symmetric() (mirrors the
         # TileLang path in _mhc_pre_impl / mhc_fused_post_pre).
+        # Compute the combine on the default allocator: the reduction's large
+        # intermediate ([m, hc_mult, k // hc_mult] product) must not allocate
+        # inside the NCCL symmetric pool, where transient allocations can
+        # alias in-flight symmetric all-reduce buffers and corrupt committed
+        # tokens (intermittent, batch-shape dependent; see #33800). Only the
+        # final y enters the pool, so the downstream all-reduce still sees a
+        # symmetric input.
+        y_tmp = (pre.squeeze(1).unsqueeze(-1) * x_flat.view(shape)).sum(dim=1).to(dtype)
         with use_symmetric_memory(
             get_tp_group(), disabled=not is_allocation_symmetric()
         ):
-            y = (pre.squeeze(1).unsqueeze(-1) * x_flat.view(shape)).sum(dim=1).to(dtype)
+            y = torch.empty_like(y_tmp)
+        y.copy_(y_tmp)
         return y, post.squeeze(1), comb.squeeze(1), False
 
     def hc_post(


### PR DESCRIPTION
## Motivation

Root cause of #33800 (DeepSeek-V4-Flash-0731 emitting corrupted output at DSpark draft depth 5 on SM120). The non-TileLang mHC combine fallback runs its y-combine reduction inside the `use_symmetric_memory` context, so the large intermediate (the `[m, hc_mult, k // hc_mult]` product) and the dtype cast allocate in the NCCL symmetric pool, not just the final `y`. Transients in that pool intermittently alias in-flight symmetric all-reduce buffers, and the corrupted values reach committed tokens. Depth 5 was never special to the code: its verify shape (m = bs x 6) just produced the pool occupancy pattern that made collisions land in output on our hardware. The same file already documents this exact hazard for the MoE path ("Only this final output enters the pool; intermediate buffers stay on the default allocator to bound pool occupancy") — this fallback predates that comment.

## Modification

Compute the reduction on the default allocator; allocate only the final `y` in the pool and copy in. The downstream all-reduce still sees a symmetric input. One hunk.

## Validation

On 4x RTX PRO 6000 Blackwell (SM120), tp4/dp4/ep4, DeepSeek-V4-Flash-0731 with DSPARK at depth 5, bursty 4-phase load:

- Unpatched: 22-39 corrupted requests per 1,000 in a 3-minute cold window (reproduced across 19 launches on two image generations).
- This change alone, same protocol: 323/323 clean, 0 corruption-band decode intervals (detector: any Decode-batch interval with accept length <= 2.0; dirty launches show 74-143, clean runs 0 across 5,700+ intervals).
- File-level A/B inside the #29927 patchset isolated the discriminant to this einsum: reverting only it reintroduces corruption; replacing only it (with #29927's `hc_combine` kernel) removes it.
- A stack carrying #29927's equivalent rewrite ran 12,334 requests / 5 cold launches at depth 5 with zero events.

#29927 replaces this einsum with a kernel and fixes the same hazard as a side effect on stacks that take it; this PR is the minimal fix for main as it stands today. Validated on SM120; the fallback also runs on other archs when the TileLang path is disabled, where the same allocation-context reasoning applies but we could not test.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31214370344](https://github.com/sgl-project/sglang/actions/runs/31214370344)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31214370112](https://github.com/sgl-project/sglang/actions/runs/31214370112)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->