### PR TITLE
Fix DSpark compact confidence path locked to checkpoint-native gamma

### DIFF
--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -744,10 +744,19 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         if confidence_head is None:
             return None
         bs = int(anchor_tokens.shape[0])
-        x_post_hc = x_post_hc.view(bs, self.gamma, -1)
+        # The runtime draft window can differ from the checkpoint-native
+        # dspark_block_size (self.gamma): --speculative-dspark-block-size
+        # overrides it everywhere on the static verify path, but this
+        # confidence path (compact / cap-accept mode) still viewed by the
+        # NATIVE gamma, so any configured gamma != native fails decode-graph
+        # capture with a shape error. Derive the window from the tensor
+        # instead so compact mode can run at any configured depth.
+        x_post_hc = x_post_hc.view(bs, -1, x_post_hc.shape[-1])
+        runtime_gamma = x_post_hc.shape[1]
         if confidence_head.with_markov:
             prev_seq = torch.cat(
-                [anchor_tokens.view(-1, 1), sampled_tokens[:, : self.gamma - 1]], dim=1
+                [anchor_tokens.view(-1, 1), sampled_tokens[:, : runtime_gamma - 1]],
+                dim=1,
             )
             markov_embed_stack = self.markov_head.get_prev_embeddings(prev_seq)
         else:


### PR DESCRIPTION
Fixes #34023.

## Motivation

The compact/confidence verify path (cap-accept / compact mode) views its post-hc-combine tensor by `self.gamma`, the checkpoint's native `dspark_block_size`, instead of the runtime draft window. Every other consumer of the draft window honors `--speculative-dspark-block-size`; this one silently ignores it, so compact mode only ever works at the checkpoint-native depth and fails decode-graph capture with a shape error at any other configured gamma.

For DeepSeek-V4-Flash-0731 the native depth is 5, which is also the one depth that corrupts output on SM120 (#33800, #34021) — so before this fix compact mode was only testable at the one depth known to be broken there, and never validated at any other depth on any hardware. The two bugs were masking each other.

## Modification

Derive the window from the tensor shape instead of the checkpoint field. Two hunks, same function.

## Validation

On 4x RTX PRO 6000 Blackwell (SM120), composed config (compact mode + gamma 7 + SPS cost table): corruption screen 11,611 requests over 5 cold launches, zero events. Decode-graph capture succeeds at every configured gamma we've tried (4, 6, 7); previously only 5 (native) worked at all.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31215588581](https://github.com/sgl-project/sglang/actions/runs/31215588581)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31215588439](https://github.com/sgl-project/sglang/actions/runs/31215588439)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->