### PR TITLE
[Spec] Propagate state capture outputs in DFlash

### DIFF
--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -1891,4 +1891,6 @@ class DFlashWorkerV2(BaseSpecWorker):
             # The non-overlap (sync) scheduler path advances batch.seq_lens
             # from the result; overlap carries it via next_draft_input instead.
             new_seq_lens=new_seq_lens,
+            routed_experts_output=target_out.routed_experts_output,
+            indexer_topk_output=target_out.indexer_topk_output,
         )


### PR DESCRIPTION
## Summary

Propagate routed-expert and indexer state-capture outputs from the DFlash target verification forward into the scheduler's `GenerationBatchResult`.

## Root cause

With overlap scheduling, state capture returns deferred GPU-to-CPU copy handles. DFlash constructed a new generation result without forwarding those handles, so the scheduler never finalized the captured state. The host cache could consequently retain zero or stale entries even though the target forward produced valid state on GPU. Non-overlap scheduling was unaffected because it copies the captured state synchronously.

This change sends both capture handles through the existing generation-result path, where the normal result processor waits for the asynchronous copy and finalizes the host cache.

## Validation

- `pre-commit run --files python/sglang/srt/speculative/dflash_worker_v2.py`
- 4-GPU Blackwell integration probe with DFlash, overlap scheduling, overlap plan stream, top-p sampling, and routed-expert return enabled:
  - before: every decode routing row in a cold request remained zero
  - after: zero all-zero rows across four requests at `top_p=1.0` and `top_p=0.95`; expert IDs covered the expected model range

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31215817646](https://github.com/sgl-project/sglang/actions/runs/31215817646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31215817113](https://github.com/sgl-project/sglang/actions/runs/31215817113)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->