### PR TITLE
Fix int32 offset overflow in SM120 page-split kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/flash_mla_sm120.py
+++ b/python/sglang/kernels/ops/attention/flash_mla_sm120.py
@@ -315,7 +315,16 @@ def _page_split_kernel(
     are copied; untouched pages are skipped so the kernel no longer rewrites the
     entire KV pool every decode step.
     """
-    pid = tl.program_id(0)
+    # page_idx/sub are int32 (tl.program_id default); page_idx * src_stride0
+    # is therefore an int32 product. With today's byte strides that wraps at
+    # page_idx ~= 57,359 (dst side) -- reachable on large SM120 KV pools --
+    # and the wrapped, sign-extended offset lands the load/store ~2GiB
+    # outside the intended buffer: IMA if unmapped, silent stray write into
+    # adjacent GPU allocations if mapped. Promote to int64 before either
+    # product; the extra width costs nothing measurable (verified: <1%
+    # kernel-time delta across 128-14,340 pages, one widened scalar op
+    # amortized over a 37KB-per-page copy).
+    pid = tl.program_id(0).to(tl.int64)
     page_idx = pid // RATIO
     sub = pid % RATIO
 


### PR DESCRIPTION
Fixes #34025.

## Motivation

`page_idx`/`sub` in `_page_split_kernel` derive from `tl.program_id(0)`, int32 by default. `page_idx * src_stride0` (and the dst-side equivalent) is therefore an int32 product; with today's byte strides it wraps at page_idx ~= 57,359 (dst side wraps first), reachable on large SM120 KV pools (~3.67M tokens/rank at the pristine byte-offset stride). The wrapped, sign-extended offset lands the load/store ~2GiB outside the intended buffer: an illegal-memory-access crash if unmapped, or a silent stray write into adjacent GPU allocations (weights, KV, other scratch) if mapped — no error signal either way in the latter case.

## Modification

Promote `program_id` to int64 before either product; `page_idx` and `sub` inherit the width, so both offset computations are fixed at one line.

## Validation

On 4x RTX PRO 6000 Blackwell (SM120):

- Isolated the exact offset arithmetic in a standalone Triton kernel with the real dst-side stride constant (37,440 B). Unpatched wraps to the precise predicted negative value at page_idx=57,359/57,360 and is correct below the boundary; the int64 variant matches the true int64 product at every point including the boundary.
- Cost: <1% kernel-time delta (int64 vs int32 offset computation) across 128/2,048/14,340-page runs, replicating the real kernel's copy shape — one widened scalar op is noise next to the ~37KB-per-page memory copy per thread.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31216202015](https://github.com/sgl-project/sglang/actions/runs/31216202015)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31216201557](https://github.com/sgl-project/sglang/actions/runs/31216201557)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->