### PR TITLE
docker: pin Kimi images to SGLang commit

### DIFF
--- a/docker/kimi_k3/kimi_k3_cu12.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu12.Dockerfile
@@ -61,10 +61,12 @@ RUN set -eu; \
 # --- 1. Kimi-K3 SGLang code (replaces the base's stock sglang, editable) ---
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
+ARG SGLANG_COMMIT="25035bff8d34f3fcce2c1a2a5b1fe610225e84ed"
 RUN rm -rf /sgl-workspace/sglang && \
-    git clone --branch main \
+    git clone --no-checkout \
       https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
     cd /sgl-workspace/sglang && \
+    git checkout --detach "${SGLANG_COMMIT}" && \
     rm -rf .git && \
     test ! -e .git && \
     pip install -e python --no-deps && \

--- a/docker/kimi_k3/kimi_k3_cu13.Dockerfile
+++ b/docker/kimi_k3/kimi_k3_cu13.Dockerfile
@@ -52,10 +52,12 @@ ARG TORCH_CUDA_ARCH_LIST="9.0;10.0a;10.3a"
 # --- 1. Kimi-K3 SGLang code (replaces the base's stock sglang, editable) ---
 # Keep the installed extension modules, but discard Rust and pip build
 # artifacts that are not used at runtime.
+ARG SGLANG_COMMIT="25035bff8d34f3fcce2c1a2a5b1fe610225e84ed"
 RUN rm -rf /sgl-workspace/sglang && \
-    git clone --branch main \
+    git clone --no-checkout \
       https://github.com/sgl-project/sglang.git /sgl-workspace/sglang && \
     cd /sgl-workspace/sglang && \
+    git checkout --detach "${SGLANG_COMMIT}" && \
     rm -rf .git && \
     test ! -e .git && \
     pip install -e python --no-deps && \


### PR DESCRIPTION
## Motivation

Pin the SGLang source used by the Kimi CUDA 12 and CUDA 13 images to a known revision so image builds remain reproducible instead of following `main`.

## Modifications

- Add an overridable `SGLANG_COMMIT` build argument defaulting to `25035bff8d34f3fcce2c1a2a5b1fe610225e84ed`.
- Clone without checking out `main`, then check out the pinned commit in detached-HEAD mode before removing `.git`.
- Apply the same source pinning flow to both Kimi Dockerfiles.

## Accuracy Tests

Not applicable; this changes only the source revision selected during image builds.

## Speed Tests and Profiling

Not applicable; this does not change inference code or runtime behavior.

## Validation

- `git diff --check`
- Static assertions that both Dockerfiles contain the requested SHA and detached checkout, and no longer clone `--branch main`
- Repository pre-commit hooks passed during commit
- Full Docker image builds were not run because Docker/Buildx is unavailable in the local environment

## Checklist

- [x] Format checks passed through pre-commit.
- [x] Unit tests are not applicable to this Dockerfile-only source pin.
- [x] Documentation updates are not required.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Followed the existing Dockerfile style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31220814548](https://github.com/sgl-project/sglang/actions/runs/31220814548)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31220813764](https://github.com/sgl-project/sglang/actions/runs/31220813764)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->