### PR TITLE
[Spec] Make ForwardBatch the single channel for the ragged-verify layout

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -2099,6 +2099,7 @@ class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
         inner_fb = SimpleNamespace(
             batch_size=forward_batch.batch_size,
             forward_mode=ForwardMode.DECODE,
+            ragged_verify_layout=None,
             # Propagate the real runtime mode so inner backends can detect IDLE
             # and apply their idle substitution.
             actual_forward_mode=getattr(

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1680,6 +1680,7 @@ class DeepseekV4MultiStepBackend(DeepseekV4HipRadixBackend):
         inner_fb = SimpleNamespace(
             batch_size=forward_batch.batch_size,
             forward_mode=ForwardMode.DECODE,
+            ragged_verify_layout=None,
             # Propagate the real runtime mode so inner backends can detect IDLE
             # and apply their idle substitution.
             actual_forward_mode=getattr(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -31,7 +31,11 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import get_schedule, get_spec
-from sglang.srt.speculative.ragged_verify import build_ragged_target_verify_geometry
+from sglang.srt.speculative.ragged_verify import (
+    build_ragged_target_verify_geometry,
+    resolve_ragged_verify_layout,
+    spec_info_ragged_verify_layout,
+)
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
 from sglang.srt.utils import get_compiler_backend
@@ -787,9 +791,7 @@ class FlashAttentionBackend(AttentionBackend):
             self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
         elif forward_batch.forward_mode.is_target_verify():
             if self.topk <= 1:
-                ragged_layout = getattr(
-                    forward_batch.spec_info, "ragged_verify_layout", None
-                )
+                ragged_layout = resolve_ragged_verify_layout(forward_batch)
                 if ragged_layout is not None:
                     geometry = build_ragged_target_verify_geometry(
                         seq_lens=forward_batch.seq_lens, layout=ragged_layout
@@ -2820,7 +2822,7 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = getattr(spec_info, "ragged_verify_layout", None)
+                ragged_layout = spec_info_ragged_verify_layout(spec_info)
                 if ragged_layout is not None:
                     padded = ragged_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -34,7 +34,6 @@ from sglang.srt.runtime_context import get_schedule, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
 )
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
@@ -502,6 +501,7 @@ class FlashAttentionBackend(AttentionBackend):
                 encoder_lens=encoder_lens,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
                 seq_lens_cpu=seq_lens_cpu,
                 out_cache_loc=out_cache_loc,
             )
@@ -541,6 +541,7 @@ class FlashAttentionBackend(AttentionBackend):
                 encoder_lens=encoder_lens,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
                 seq_lens_cpu=(
                     forward_batch.seq_lens_cpu if self.needs_cpu_seq_lens else None
                 ),
@@ -2616,6 +2617,7 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: Optional[torch.Tensor] = None,
+        ragged_verify_layout=None,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
@@ -2822,7 +2824,7 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = spec_info_ragged_verify_layout(spec_info)
+                ragged_layout = ragged_verify_layout
                 if ragged_layout is not None:
                     padded = ragged_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2824,9 +2824,8 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = ragged_verify_layout
-                if ragged_layout is not None:
-                    padded = ragged_layout.padded_to_bucket(padded_bs=bs)
+                if ragged_verify_layout is not None:
+                    padded = ragged_verify_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(
                         seq_lens=seq_lens, layout=padded
                     )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -42,6 +42,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.runtime_context import get_buffer
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
@@ -706,8 +707,7 @@ class FlashInferAttnBackend(AttentionBackend):
         spec_info = forward_batch.spec_info
 
         if (
-            spec_info is not None
-            and spec_info.ragged_verify_layout is not None
+            resolve_ragged_verify_layout(forward_batch) is not None
             and forward_mode.is_target_verify()
         ):
             raise NotImplementedError(

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -37,6 +37,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.runtime_context import get_buffer
+from sglang.srt.speculative.ragged_verify import spec_info_ragged_verify_layout
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
@@ -472,7 +473,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
     def _verify_graph_key(bs: int, spec_info: Optional[SpecInput]):
         """bs for uniform graphs; token tier for ragged (tiers share slot
         counts but each graph must replay its own recorded plan buffers)."""
-        layout = spec_info.ragged_verify_layout if spec_info is not None else None
+        layout = spec_info_ragged_verify_layout(spec_info)
         if layout is None:
             return bs
         return ("ragged", layout.graph_num_tokens)

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -37,7 +37,10 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.runtime_context import get_buffer
-from sglang.srt.speculative.ragged_verify import spec_info_ragged_verify_layout
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    resolve_ragged_verify_layout,
+)
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
@@ -325,6 +328,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         seq_lens = forward_batch.seq_lens
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
+        ragged_layout = resolve_ragged_verify_layout(forward_batch)
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()
@@ -365,7 +369,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     backend="auto",
                 )
                 self.prefill_cuda_graph_metadata[
-                    self._verify_graph_key(bs, spec_info)
+                    self._verify_graph_key(bs, ragged_layout)
                 ] = prefill_wrapper
                 self.forward_metadata = PrefillMetadata(prefill_wrapper, False)
             else:
@@ -378,6 +382,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum=seq_lens_sum,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=ragged_layout,
                 seq_lens_cpu=seq_lens_cpu,
             )
         else:
@@ -388,6 +393,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum=forward_batch.seq_lens_sum,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=ragged_layout,
                 seq_lens_cpu=forward_batch.seq_lens_cpu,
             )
 
@@ -470,13 +476,12 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         }
 
     @staticmethod
-    def _verify_graph_key(bs: int, spec_info: Optional[SpecInput]):
+    def _verify_graph_key(bs: int, ragged_layout: Optional[RaggedVerifyLayout]):
         """bs for uniform graphs; token tier for ragged (tiers share slot
         counts but each graph must replay its own recorded plan buffers)."""
-        layout = spec_info_ragged_verify_layout(spec_info)
-        if layout is None:
+        if ragged_layout is None:
             return bs
-        return ("ragged", layout.graph_num_tokens)
+        return ("ragged", ragged_layout.graph_num_tokens)
 
     def _apply_cuda_graph_metadata(
         self,
@@ -486,6 +491,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         seq_lens_sum: int,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        ragged_verify_layout: Optional[RaggedVerifyLayout],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
         """Shared capture+replay body for the cuda-graph init path.
@@ -523,7 +529,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum,
                 prefix_lens=None,
                 prefill_wrapper_paged=self.prefill_cuda_graph_metadata[
-                    self._verify_graph_key(bs, spec_info)
+                    self._verify_graph_key(bs, ragged_verify_layout)
                 ],
                 use_ragged=False,
                 spec_info=spec_info,

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -27,10 +27,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_server_args
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
-from sglang.srt.speculative.ragged_verify import (
-    resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
-)
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
@@ -256,6 +253,7 @@ class MambaAttnBackendBase(AttentionBackend):
             forward_batch.req_pool_indices,
             forward_batch.forward_mode,
             forward_batch.spec_info,
+            resolve_ragged_verify_layout(forward_batch),
             forward_batch.seq_lens_cpu if not in_capture else None,
             num_padding=(
                 0 if in_capture else getattr(forward_batch, "num_padding", None)
@@ -489,13 +487,14 @@ class MambaAttnBackendBase(AttentionBackend):
         req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        ragged_verify_layout=None,
     ):
         if forward_mode.is_decode_or_idle():
             self.query_start_loc_list[bs - 1].copy_(
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
         elif forward_mode.is_target_verify():
-            ragged_layout = spec_info_ragged_verify_layout(spec_info)
+            ragged_layout = ragged_verify_layout
             if ragged_layout is not None:
                 # Ragged capture: qsl from the runner's synthetic layout.
                 self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
@@ -549,6 +548,7 @@ class MambaAttnBackendBase(AttentionBackend):
         req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        ragged_verify_layout,
         seq_lens_cpu: Optional[torch.Tensor],
         num_padding: Optional[int] = None,
         in_capture: bool = False,
@@ -669,7 +669,7 @@ class MambaAttnBackendBase(AttentionBackend):
                     bs - num_padding
                 )
         elif forward_mode.is_target_verify():
-            ragged_layout = spec_info_ragged_verify_layout(spec_info)
+            ragged_layout = ragged_verify_layout
             if ragged_layout is not None:
                 # Mamba kernels index dense [bs, N] scratch, so they need the
                 # capped variant (see padded_to_bucket). Padding rows carry
@@ -854,6 +854,7 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             forward_batch.req_pool_indices,
             forward_batch.forward_mode,
             forward_batch.spec_info,
+            resolve_ragged_verify_layout(forward_batch),
             forward_batch.seq_lens_cpu if not in_capture else None,
             num_padding=(
                 0 if in_capture else getattr(forward_batch, "num_padding", None)

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -27,6 +27,10 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_server_args
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.speculative.ragged_verify import (
+    resolve_ragged_verify_layout,
+    spec_info_ragged_verify_layout,
+)
 from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
@@ -179,7 +183,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 # skip mamba metadata.
                 query_start_loc = None
             elif forward_batch.forward_mode.is_target_verify():
-                ragged_layout = forward_batch.spec_info.ragged_verify_layout
+                ragged_layout = resolve_ragged_verify_layout(forward_batch)
                 if ragged_layout is not None:
                     # Compact ragged verify: variable per-request verify lens.
                     query_start_loc = ragged_layout.qo_indptr_device
@@ -491,9 +495,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
         elif forward_mode.is_target_verify():
-            ragged_layout = (
-                spec_info.ragged_verify_layout if spec_info is not None else None
-            )
+            ragged_layout = spec_info_ragged_verify_layout(spec_info)
             if ragged_layout is not None:
                 # Ragged capture: qsl from the runner's synthetic layout.
                 self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
@@ -667,9 +669,7 @@ class MambaAttnBackendBase(AttentionBackend):
                     bs - num_padding
                 )
         elif forward_mode.is_target_verify():
-            ragged_layout = (
-                spec_info.ragged_verify_layout if spec_info is not None else None
-            )
+            ragged_layout = spec_info_ragged_verify_layout(spec_info)
             if ragged_layout is not None:
                 # Mamba kernels index dense [bs, N] scratch, so they need the
                 # capped variant (see padded_to_bucket). Padding rows carry

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -25,7 +25,12 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_exec, get_memory, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_memory,
+    get_server_args,
+    get_spec,
+)
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.speculative.spec_info import SpecInput
@@ -42,6 +47,7 @@ class MambaAttnBackendBase(AttentionBackend):
         self.pad_slot_id = PAD_SLOT_ID
         self.device = model_runner.device
         self.topk = model_runner.server_args.speculative_eagle_topk or 0
+        self.num_draft_tokens = get_spec().speculative_num_draft_tokens
         self.is_draft_worker = model_runner.is_draft_worker
         self.req_to_token_pool: HybridReqToTokenPool = model_runner.req_to_token_pool
         self.token_to_kv_pool = model_runner.token_to_kv_pool
@@ -676,7 +682,7 @@ class MambaAttnBackendBase(AttentionBackend):
                 # mamba slot -1 and are skipped.
                 if ragged_verify_layout.bs != bs or ragged_verify_layout.cap is None:
                     ragged_verify_layout = ragged_verify_layout.padded_to_bucket(
-                        padded_bs=bs, cap=spec_info.draft_token_num
+                        padded_bs=bs, cap=self.num_draft_tokens
                     )
                 self.query_start_loc_list[bs - 1].copy_(
                     ragged_verify_layout.qo_indptr_device

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -494,10 +494,11 @@ class MambaAttnBackendBase(AttentionBackend):
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
         elif forward_mode.is_target_verify():
-            ragged_layout = ragged_verify_layout
-            if ragged_layout is not None:
+            if ragged_verify_layout is not None:
                 # Ragged capture: qsl from the runner's synthetic layout.
-                self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
+                self.query_start_loc_list[bs - 1].copy_(
+                    ragged_verify_layout.qo_indptr_device
+                )
             else:
                 self.query_start_loc_list[bs - 1].copy_(
                     self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
@@ -669,16 +670,17 @@ class MambaAttnBackendBase(AttentionBackend):
                     bs - num_padding
                 )
         elif forward_mode.is_target_verify():
-            ragged_layout = ragged_verify_layout
-            if ragged_layout is not None:
+            if ragged_verify_layout is not None:
                 # Mamba kernels index dense [bs, N] scratch, so they need the
                 # capped variant (see padded_to_bucket). Padding rows carry
                 # mamba slot -1 and are skipped.
-                if ragged_layout.bs != bs or ragged_layout.cap is None:
-                    ragged_layout = ragged_layout.padded_to_bucket(
+                if ragged_verify_layout.bs != bs or ragged_verify_layout.cap is None:
+                    ragged_verify_layout = ragged_verify_layout.padded_to_bucket(
                         padded_bs=bs, cap=spec_info.draft_token_num
                     )
-                self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
+                self.query_start_loc_list[bs - 1].copy_(
+                    ragged_verify_layout.qo_indptr_device
+                )
             elif num_padding == 0:
                 self.query_start_loc_list[bs - 1].copy_(
                     self.cached_cuda_graph_verify_query_start_loc[: bs + 1]

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -34,6 +34,7 @@ elif is_cpu():
 
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 
 
 class KDAKernelDispatcher:
@@ -731,7 +732,7 @@ class KDAAttnBackend(MambaAttnBackendBase):
         intermediate_state_indices = self.verify_intermediate_state_indices
 
         draft_token_num = forward_batch.spec_info.draft_token_num
-        ragged_layout = forward_batch.spec_info.ragged_verify_layout
+        ragged_layout = resolve_ragged_verify_layout(forward_batch)
         if self._can_run_dspark_cutedsl_mtp(
             layer=layer,
             mixed_qkv=mixed_qkv,

--- a/python/sglang/srt/layers/attention/tbo_backend.py
+++ b/python/sglang/srt/layers/attention/tbo_backend.py
@@ -233,6 +233,9 @@ def _build_tbo_child_replay_fb_view(
     return SimpleNamespace(
         batch_size=child_bs,
         forward_mode=fb_view.forward_mode,
+        # TBO is mutually exclusive with ragged verify; a parent layout would
+        # describe the full batch, not this child slice.
+        ragged_verify_layout=None,
         actual_forward_mode=getattr(
             fb_view, "actual_forward_mode", fb_view.forward_mode
         ),

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -41,6 +41,7 @@ from sglang.srt.runtime_context import get_buffer, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
+    spec_info_ragged_verify_layout,
 )
 from sglang.srt.utils import is_flashinfer_available
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
@@ -607,7 +608,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 : bs + 1
             ]
             metadata.is_ragged_verify = (
-                spec_info is not None and spec_info.ragged_verify_layout is not None
+                spec_info_ragged_verify_layout(spec_info) is not None
             )
             metadata.max_seq_len_q = (
                 self.speculative_num_draft_tokens
@@ -715,7 +716,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_target_verify():
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
-            if spec_info is not None and spec_info.ragged_verify_layout is not None:
+            if spec_info_ragged_verify_layout(spec_info) is not None:
                 # Ragged verify: the per-request k-extension is not a
                 # uniform scalar seqlen_offset, so the fused kernel cannot
                 # rebuild this metadata. It is written eagerly on every

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -41,7 +41,6 @@ from sglang.srt.runtime_context import get_buffer, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
 )
 from sglang.srt.utils import is_flashinfer_available
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
@@ -549,6 +548,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info,
         device: torch.device,
+        ragged_verify_layout=None,
     ) -> TRTLLMMHAMetadata:
         """Create TRTLLMMHAMetadata with pre-allocated buffer slice refs, stored in the dict."""
         metadata = TRTLLMMHAMetadata()
@@ -607,9 +607,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
                 : bs + 1
             ]
-            metadata.is_ragged_verify = (
-                spec_info_ragged_verify_layout(spec_info) is not None
-            )
+            metadata.is_ragged_verify = ragged_verify_layout is not None
             metadata.max_seq_len_q = (
                 self.speculative_num_draft_tokens
                 if metadata.is_ragged_verify
@@ -679,6 +677,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
+        ragged_verify_layout=None,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
@@ -716,7 +715,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_target_verify():
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
-            if spec_info_ragged_verify_layout(spec_info) is not None:
+            if ragged_verify_layout is not None:
                 # Ragged verify: the per-request k-extension is not a
                 # uniform scalar seqlen_offset, so the fused kernel cannot
                 # rebuild this metadata. It is written eagerly on every
@@ -847,7 +846,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if in_capture:
             num_tokens = forward_batch.positions.numel()
             self._build_cuda_graph_metadata(
-                bs, num_tokens, forward_mode, spec_info, forward_batch.seq_lens.device
+                bs,
+                num_tokens,
+                forward_mode,
+                spec_info,
+                forward_batch.seq_lens.device,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
             )
 
         if forward_mode.is_decode_or_idle():
@@ -921,6 +925,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             forward_mode=forward_batch.forward_mode,
             spec_info=forward_batch.spec_info,
             out_cache_loc=forward_batch.out_cache_loc,
+            ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -61,6 +61,7 @@ from sglang.srt.runtime_context import (
     get_schedule,
     get_spec,
 )
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import is_flashinfer_available, is_float4_e2m1fn_x2
 
 if is_flashinfer_available():
@@ -1289,7 +1290,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 max_seq_len = metadata.max_seq_len_k + (
                     0 if dcp_enabled else draft_token_num
                 )
-                ragged_layout = forward_batch.spec_info.ragged_verify_layout
+                ragged_layout = resolve_ragged_verify_layout(forward_batch)
                 if ragged_layout is None or dcp_enabled:
                     q = q.view(bs, -1, layer.tp_q_head_num, layer.head_dim)
                     needs_unpad = False

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -747,6 +747,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         *,
         capture_hidden_mode: Optional[CaptureHiddenMode] = None,
         return_hidden_states_before_norm: bool,
+        ragged_verify_layout: Optional[RaggedVerifyLayout] = None,
     ):
         # init_new must not mutate the input ScheduleBatch; per-forward
         # overrides go through explicit keyword arguments.
@@ -841,11 +842,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Compound (carry their own device tensors)
             sampling_info=batch.sampling_info,
             spec_info=batch.spec_info,
-            ragged_verify_layout=(
-                batch.spec_info.ragged_verify_layout
-                if batch.spec_info is not None
-                else None
-            ),
+            ragged_verify_layout=ragged_verify_layout,
         )
 
         ret._maybe_init_non_generation_fields(batch)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -506,8 +506,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     sampling_info: SamplingBatchInfo = None
     # Speculative decoding
     spec_info: Optional[SpecInput] = None
-    # Per-request target-verify geometry (ragged verify). Canonical read path:
-    # resolve_ragged_verify_layout(forward_batch).
+    # Per-request target-verify geometry; read via resolve_ragged_verify_layout().
     ragged_verify_layout: Optional[RaggedVerifyLayout] = None
 
     # === Derived from ScheduleBatch.reqs ===

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 
 # Warn-once flag for the deprecated skip_attn_backend_init kwarg; see
@@ -505,6 +506,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     sampling_info: SamplingBatchInfo = None
     # Speculative decoding
     spec_info: Optional[SpecInput] = None
+    # Per-request target-verify geometry (ragged verify). Canonical read path:
+    # resolve_ragged_verify_layout(forward_batch).
+    ragged_verify_layout: Optional[RaggedVerifyLayout] = None
 
     # === Derived from ScheduleBatch.reqs ===
     # For LoRA
@@ -837,6 +841,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Compound (carry their own device tensors)
             sampling_info=batch.sampling_info,
             spec_info=batch.spec_info,
+            ragged_verify_layout=(
+                batch.spec_info.ragged_verify_layout
+                if batch.spec_info is not None
+                else None
+            ),
         )
 
         ret._maybe_init_non_generation_fields(batch)
@@ -1660,6 +1669,7 @@ def build_inner_fb_view(
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
         out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
         spec_info=forward_batch.spec_info,
+        ragged_verify_layout=forward_batch.ragged_verify_layout,
     )
 
 

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -185,6 +185,7 @@ def _allocate_decode_buffers(
     return SimpleNamespace(
         input_ids=input_ids,
         input_embeds=input_embeds,
+        ragged_verify_layout=None,
         req_pool_indices=req_pool_indices,
         seq_lens=seq_lens,
         seq_lens_cpu=seq_lens_cpu,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -95,10 +95,7 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
-from sglang.srt.speculative.ragged_verify import (
-    resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
-)
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -915,7 +912,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
-            ragged_verify_layout=spec_info_ragged_verify_layout(spec_info),
+            # Algorithm-private field; only the dflash-family capture inputs
+            # carry a synthetic layout.
+            ragged_verify_layout=getattr(spec_info, "ragged_verify_layout", None),
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -95,7 +95,10 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
-from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
+from sglang.srt.speculative.ragged_verify import (
+    resolve_ragged_verify_layout,
+    spec_info_ragged_verify_layout,
+)
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -188,6 +191,7 @@ def build_replay_fb_view(
             else buffers.mamba_track_indices[:bs]
         ),
         spec_info=forward_batch.spec_info,
+        ragged_verify_layout=forward_batch.ragged_verify_layout,
     )
 
 
@@ -911,6 +915,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
+            ragged_verify_layout=spec_info_ragged_verify_layout(spec_info),
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -858,7 +858,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             global_dp_buffer_len = None
 
-        spec_info = self.get_spec_info(num_tokens)
+        capture_ragged_verify_layout = self._capture_ragged_verify_layout(num_tokens)
+        spec_info = self.get_spec_info(
+            num_tokens, ragged_verify_layout=capture_ragged_verify_layout
+        )
         self.capture_hidden_mode = get_required_capture_hidden_mode(
             self.capture_hidden_mode,
             spec_info,
@@ -912,9 +915,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
-            # Algorithm-private field; only the dflash-family capture inputs
-            # carry a synthetic layout.
-            ragged_verify_layout=getattr(spec_info, "ragged_verify_layout", None),
+            ragged_verify_layout=capture_ragged_verify_layout,
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,
@@ -1366,7 +1367,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             assert isinstance(output, PPProxyTensors)
             return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
 
-    def get_spec_info(self, num_tokens: int):
+    def get_spec_info(self, num_tokens: int, ragged_verify_layout=None):
         spec_info = None
         if (
             self.model_runner.spec_algorithm.is_eagle()
@@ -1429,7 +1430,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     if self.model_runner.is_draft_worker
                     else CaptureHiddenMode.FULL
                 ),
-                ragged_verify_layout=self._capture_ragged_verify_layout(num_tokens),
+                ragged_verify_layout=ragged_verify_layout,
             )
 
         elif self.model_runner.spec_algorithm.is_ngram():

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -74,6 +74,7 @@ class DFlashVerifyInput(SpecInput):
             target_worker.model_runner,
             capture_hidden_mode=self.capture_hidden_mode,
             return_hidden_states_before_norm=False,
+            ragged_verify_layout=self.ragged_verify_layout,
         )
 
         can_run_cuda_graph = bool(

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -42,6 +42,8 @@ class DFlashVerifyInput(SpecInput):
     # Shape info for padding (e.g., DP attention / CUDA graph).
     num_tokens_per_req: int = -1
 
+    # Seed for ForwardBatch.ragged_verify_layout (handed over in
+    # prepare_for_verify); set at construction, never reassigned after.
     ragged_verify_layout: Optional[RaggedVerifyLayout] = None
 
     def __post_init__(self):

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -574,6 +574,7 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         fb_view = SimpleNamespace(
             batch_size=bs,
             forward_mode=self.forward_mode,
+            ragged_verify_layout=None,
             input_ids=getattr(forward_batch, "input_ids", None),
             req_pool_indices=buffers.req_pool_indices,
             seq_lens=buffers.seq_lens,

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -335,6 +335,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         fb_view = SimpleNamespace(
             batch_size=bs,
             forward_mode=ForwardMode.DECODE,
+            ragged_verify_layout=None,
             input_ids=getattr(forward_batch, "input_ids", None),
             req_pool_indices=forward_batch.req_pool_indices[:bs],
             seq_lens=forward_batch.seq_lens[:bs],

--- a/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_draft_extend_cuda_graph_runner.py
@@ -480,6 +480,7 @@ class MultiLayerEagleDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         fb_view = SimpleNamespace(
             batch_size=bs,
             forward_mode=self.forward_mode,
+            ragged_verify_layout=None,
             input_ids=buffers.input_ids[:num_tokens],
             req_pool_indices=buffers.req_pool_indices,
             seq_lens=buffers.seq_lens,

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -219,7 +219,12 @@ def build_capture_verify_lens(
 def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
     """Layout riding the batch's spec input, or None. Tolerates the runner's
     ad-hoc replay batch views, which may not carry spec_info at all."""
-    spec_info = getattr(forward_batch, "spec_info", None)
+    return spec_info_ragged_verify_layout(getattr(forward_batch, "spec_info", None))
+
+
+def spec_info_ragged_verify_layout(spec_info) -> Optional[RaggedVerifyLayout]:
+    """Layout carried by a spec input, or None. For the cuda-graph init paths,
+    which receive spec_info directly rather than a ForwardBatch."""
     if spec_info is None:
         return None
     return spec_info.ragged_verify_layout

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -217,9 +217,10 @@ def build_capture_verify_lens(
 
 
 def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
-    """Layout riding the batch's spec input, or None. Tolerates the runner's
-    ad-hoc replay batch views, which may not carry spec_info at all."""
-    return spec_info_ragged_verify_layout(getattr(forward_batch, "spec_info", None))
+    """Canonical read of the batch's verify layout (ForwardBatch field).
+    Tolerates the runner's ad-hoc replay batch views, which may not carry
+    the field at all."""
+    return getattr(forward_batch, "ragged_verify_layout", None)
 
 
 def spec_info_ragged_verify_layout(spec_info) -> Optional[RaggedVerifyLayout]:

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -217,10 +217,8 @@ def build_capture_verify_lens(
 
 
 def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
-    """Canonical read of the batch's verify layout (ForwardBatch field).
-    Tolerates the runner's ad-hoc replay batch views, which may not carry
-    the field at all."""
-    return getattr(forward_batch, "ragged_verify_layout", None)
+    """Canonical read of the batch's verify layout (ForwardBatch field)."""
+    return forward_batch.ragged_verify_layout
 
 
 class RaggedTargetVerifyGeometry(msgspec.Struct):

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -223,14 +223,6 @@ def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
     return getattr(forward_batch, "ragged_verify_layout", None)
 
 
-def spec_info_ragged_verify_layout(spec_info) -> Optional[RaggedVerifyLayout]:
-    """Layout carried by a spec input, or None. For the cuda-graph init paths,
-    which receive spec_info directly rather than a ForwardBatch."""
-    if spec_info is None:
-        return None
-    return spec_info.ragged_verify_layout
-
-
 class RaggedTargetVerifyGeometry(msgspec.Struct):
     cache_seqlens_int32: torch.Tensor
     cu_seqlens_q: torch.Tensor

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -330,11 +330,10 @@ class SpecInput(ABC):
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
 
-    # DSA MTP IndexShare seed relay. Class-level defaults (not __init__
-    # assignments: dataclass subclasses run __post_init__ -> super().__init__
-    # *after* field assignment, so an init-time default would clobber a
-    # passed value) so scheduler/relay/attention code reads them uniformly
-    # on any SpecInput; only the EAGLE-family inputs override them.
+    # DSA MTP IndexShare seed relay: readable on any SpecInput; only the
+    # EAGLE-family inputs override them. Must stay class-level defaults, not
+    # __init__ assignments -- dataclass subclasses run __post_init__ ->
+    # super().__init__ after field assignment, which would clobber a passed value.
     dsa_topk_indices: Optional[torch.Tensor] = None
     future_dsa_topk_indices_available: bool = False
     dsa_seed_topk_capture: Optional[torch.Tensor] = None

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
     from sglang.srt.speculative.ngram_worker import NGRAMWorker
-    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
 class SpeculativeAlgorithm(Enum):
@@ -325,23 +324,17 @@ class SpecInputType(IntEnum):
 
 
 class SpecInput(ABC):
-    # Per-request verify lengths for the ragged-verify graphs (see
-    # sglang.srt.speculative.ragged_verify); verify inputs of algorithms with
-    # supports_ragged_verify() override it per step. Must stay a class-level
-    # default, not an __init__ assignment: dataclass subclasses declare it as
-    # a field and run __post_init__ -> super().__init__ *after* field
-    # assignment, so an init-time default would clobber the passed layout.
-    ragged_verify_layout: Optional[RaggedVerifyLayout] = None
-
     # Uniform per-request token width of this forward (and its logits-row
     # counterpart). Doubles as the DP-attention global_num_tokens multiplier
     # (ragged forwards carry 1 there). -1 = not set by this flow.
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
 
-    # DSA MTP IndexShare seed relay. Class-level defaults (same rationale as
-    # ragged_verify_layout) so scheduler/relay/attention code reads them
-    # uniformly on any SpecInput; only the EAGLE-family inputs override them.
+    # DSA MTP IndexShare seed relay. Class-level defaults (not __init__
+    # assignments: dataclass subclasses run __post_init__ -> super().__init__
+    # *after* field assignment, so an init-time default would clobber a
+    # passed value) so scheduler/relay/attention code reads them uniformly
+    # on any SpecInput; only the EAGLE-family inputs override them.
     dsa_topk_indices: Optional[torch.Tensor] = None
     future_dsa_topk_indices_available: bool = False
     dsa_seed_topk_capture: Optional[torch.Tensor] = None


### PR DESCRIPTION
Make `ForwardBatch` the single channel for the ragged-verify layout:

- Consolidate the three access idioms (resolver helper, direct `spec_info.ragged_verify_layout` reads, defensive `getattr`) behind `resolve_ragged_verify_layout`.
- Promote the layout to a first-class `ForwardBatch` field, populated at batch construction; backend cuda-graph helpers receive it as an explicit parameter resolved at their `ForwardBatch`-taking entry points, and the capture path threads one layout instance into both the capture spec input and the capture batch.
- Delete the `SpecInput` class-level carrier; the layout remains an algorithm-private field on the dflash-family verify inputs only.

No behavior change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31231115726](https://github.com/sgl-project/sglang/actions/runs/31231115726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31231115567](https://github.com/sgl-project/sglang/actions/runs/31231115567)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->