### PR TITLE
[Spec] Resolve the ragged-verify graph tier at a single point

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -34,7 +34,6 @@ from sglang.srt.runtime_context import get_schedule, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
 )
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
@@ -495,6 +494,7 @@ class FlashAttentionBackend(AttentionBackend):
                 encoder_lens=encoder_lens,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
                 seq_lens_cpu=seq_lens_cpu,
                 out_cache_loc=out_cache_loc,
             )
@@ -534,6 +534,7 @@ class FlashAttentionBackend(AttentionBackend):
                 encoder_lens=encoder_lens,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
                 seq_lens_cpu=(
                     forward_batch.seq_lens_cpu if self.needs_cpu_seq_lens else None
                 ),
@@ -2609,6 +2610,7 @@ class FlashAttentionBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
         out_cache_loc: Optional[torch.Tensor] = None,
+        ragged_verify_layout=None,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
@@ -2815,7 +2817,7 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = spec_info_ragged_verify_layout(spec_info)
+                ragged_layout = ragged_verify_layout
                 if ragged_layout is not None:
                     padded = ragged_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -2817,9 +2817,8 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = ragged_verify_layout
-                if ragged_layout is not None:
-                    padded = ragged_layout.padded_to_bucket(padded_bs=bs)
+                if ragged_verify_layout is not None:
+                    padded = ragged_verify_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(
                         seq_lens=seq_lens, layout=padded
                     )

--- a/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_mla_backend.py
@@ -37,7 +37,10 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.runtime_context import get_buffer
-from sglang.srt.speculative.ragged_verify import spec_info_ragged_verify_layout
+from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
+    resolve_ragged_verify_layout,
+)
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.speculative.spec_utils import (
     draft_kv_indices_buffer_width,
@@ -325,6 +328,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         seq_lens = forward_batch.seq_lens
         forward_mode = forward_batch.forward_mode
         spec_info = forward_batch.spec_info
+        ragged_layout = resolve_ragged_verify_layout(forward_batch)
 
         if in_capture:
             num_tokens = forward_batch.positions.numel()
@@ -365,7 +369,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                     backend="auto",
                 )
                 self.prefill_cuda_graph_metadata[
-                    self._verify_graph_key(bs, spec_info)
+                    self._verify_graph_key(bs, ragged_layout)
                 ] = prefill_wrapper
                 self.forward_metadata = PrefillMetadata(prefill_wrapper, False)
             else:
@@ -378,6 +382,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum=seq_lens_sum,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=ragged_layout,
                 seq_lens_cpu=seq_lens_cpu,
             )
         else:
@@ -388,6 +393,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum=forward_batch.seq_lens_sum,
                 forward_mode=forward_mode,
                 spec_info=spec_info,
+                ragged_verify_layout=ragged_layout,
                 seq_lens_cpu=forward_batch.seq_lens_cpu,
             )
 
@@ -470,13 +476,12 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         }
 
     @staticmethod
-    def _verify_graph_key(bs: int, spec_info: Optional[SpecInput]):
+    def _verify_graph_key(bs: int, ragged_layout: Optional[RaggedVerifyLayout]):
         """bs for uniform graphs; token tier for ragged (tiers share slot
         counts but each graph must replay its own recorded plan buffers)."""
-        layout = spec_info_ragged_verify_layout(spec_info)
-        if layout is None:
+        if ragged_layout is None:
             return bs
-        return ("ragged", layout.graph_num_tokens)
+        return ("ragged", ragged_layout.graph_num_tokens)
 
     def _apply_cuda_graph_metadata(
         self,
@@ -486,6 +491,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
         seq_lens_sum: int,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        ragged_verify_layout: Optional[RaggedVerifyLayout],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
         """Shared capture+replay body for the cuda-graph init path.
@@ -523,7 +529,7 @@ class FlashInferMLAAttnBackend(AttentionBackend):
                 seq_lens_sum,
                 prefix_lens=None,
                 prefill_wrapper_paged=self.prefill_cuda_graph_metadata[
-                    self._verify_graph_key(bs, spec_info)
+                    self._verify_graph_key(bs, ragged_verify_layout)
                 ],
                 use_ragged=False,
                 spec_info=spec_info,

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -27,10 +27,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import get_exec, get_memory, get_server_args
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
-from sglang.srt.speculative.ragged_verify import (
-    resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
-)
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
@@ -256,6 +253,7 @@ class MambaAttnBackendBase(AttentionBackend):
             forward_batch.req_pool_indices,
             forward_batch.forward_mode,
             forward_batch.spec_info,
+            resolve_ragged_verify_layout(forward_batch),
             forward_batch.seq_lens_cpu if not in_capture else None,
             num_padding=(
                 0 if in_capture else getattr(forward_batch, "num_padding", None)
@@ -489,13 +487,14 @@ class MambaAttnBackendBase(AttentionBackend):
         req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[Union[EagleDraftInput, EagleVerifyInput]],
+        ragged_verify_layout=None,
     ):
         if forward_mode.is_decode_or_idle():
             self.query_start_loc_list[bs - 1].copy_(
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
         elif forward_mode.is_target_verify():
-            ragged_layout = spec_info_ragged_verify_layout(spec_info)
+            ragged_layout = ragged_verify_layout
             if ragged_layout is not None:
                 # Ragged capture: qsl from the runner's synthetic layout.
                 self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
@@ -549,6 +548,7 @@ class MambaAttnBackendBase(AttentionBackend):
         req_pool_indices: torch.Tensor,
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
+        ragged_verify_layout,
         seq_lens_cpu: Optional[torch.Tensor],
         num_padding: Optional[int] = None,
         in_capture: bool = False,
@@ -669,7 +669,7 @@ class MambaAttnBackendBase(AttentionBackend):
                     bs - num_padding
                 )
         elif forward_mode.is_target_verify():
-            ragged_layout = spec_info_ragged_verify_layout(spec_info)
+            ragged_layout = ragged_verify_layout
             if ragged_layout is not None:
                 # Mamba kernels index dense [bs, N] scratch, so they need the
                 # capped variant (see padded_to_bucket). Padding rows carry
@@ -854,6 +854,7 @@ class Mamba2AttnBackend(MambaAttnBackendBase):
             forward_batch.req_pool_indices,
             forward_batch.forward_mode,
             forward_batch.spec_info,
+            resolve_ragged_verify_layout(forward_batch),
             forward_batch.seq_lens_cpu if not in_capture else None,
             num_padding=(
                 0 if in_capture else getattr(forward_batch, "num_padding", None)

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -494,10 +494,11 @@ class MambaAttnBackendBase(AttentionBackend):
                 self.cached_cuda_graph_decode_query_start_loc[: bs + 1]
             )
         elif forward_mode.is_target_verify():
-            ragged_layout = ragged_verify_layout
-            if ragged_layout is not None:
+            if ragged_verify_layout is not None:
                 # Ragged capture: qsl from the runner's synthetic layout.
-                self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
+                self.query_start_loc_list[bs - 1].copy_(
+                    ragged_verify_layout.qo_indptr_device
+                )
             else:
                 self.query_start_loc_list[bs - 1].copy_(
                     self.cached_cuda_graph_verify_query_start_loc[: bs + 1]
@@ -669,16 +670,17 @@ class MambaAttnBackendBase(AttentionBackend):
                     bs - num_padding
                 )
         elif forward_mode.is_target_verify():
-            ragged_layout = ragged_verify_layout
-            if ragged_layout is not None:
+            if ragged_verify_layout is not None:
                 # Mamba kernels index dense [bs, N] scratch, so they need the
                 # capped variant (see padded_to_bucket). Padding rows carry
                 # mamba slot -1 and are skipped.
-                if ragged_layout.bs != bs or ragged_layout.cap is None:
-                    ragged_layout = ragged_layout.padded_to_bucket(
+                if ragged_verify_layout.bs != bs or ragged_verify_layout.cap is None:
+                    ragged_verify_layout = ragged_verify_layout.padded_to_bucket(
                         padded_bs=bs, cap=spec_info.draft_token_num
                     )
-                self.query_start_loc_list[bs - 1].copy_(ragged_layout.qo_indptr_device)
+                self.query_start_loc_list[bs - 1].copy_(
+                    ragged_verify_layout.qo_indptr_device
+                )
             elif num_padding == 0:
                 self.query_start_loc_list[bs - 1].copy_(
                     self.cached_cuda_graph_verify_query_start_loc[: bs + 1]

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -41,7 +41,6 @@ from sglang.srt.runtime_context import get_buffer, get_spec
 from sglang.srt.speculative.ragged_verify import (
     build_ragged_target_verify_geometry,
     resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
 )
 from sglang.srt.utils import is_flashinfer_available
 from sglang.srt.utils.common import is_sm90_supported, is_sm120_supported
@@ -549,6 +548,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info,
         device: torch.device,
+        ragged_verify_layout=None,
     ) -> TRTLLMMHAMetadata:
         """Create TRTLLMMHAMetadata with pre-allocated buffer slice refs, stored in the dict."""
         metadata = TRTLLMMHAMetadata()
@@ -607,9 +607,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             metadata.cu_seqlens_k = self.target_verify_metadata["cu_seqlens_k"][
                 : bs + 1
             ]
-            metadata.is_ragged_verify = (
-                spec_info_ragged_verify_layout(spec_info) is not None
-            )
+            metadata.is_ragged_verify = ragged_verify_layout is not None
             metadata.max_seq_len_q = (
                 self.speculative_num_draft_tokens
                 if metadata.is_ragged_verify
@@ -679,6 +677,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         forward_mode: ForwardMode,
         spec_info: Optional[SpecInput],
         out_cache_loc: Optional[torch.Tensor] = None,
+        ragged_verify_layout=None,
     ):
         """Shared capture+replay body for the cuda-graph init path.
 
@@ -716,7 +715,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         elif forward_mode.is_target_verify():
             # Here we only support topk = 1 for now.
             metadata = self.target_verify_metadata[bs]
-            if spec_info_ragged_verify_layout(spec_info) is not None:
+            if ragged_verify_layout is not None:
                 # Ragged verify: the per-request k-extension is not a
                 # uniform scalar seqlen_offset, so the fused kernel cannot
                 # rebuild this metadata. It is written eagerly on every
@@ -847,7 +846,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if in_capture:
             num_tokens = forward_batch.positions.numel()
             self._build_cuda_graph_metadata(
-                bs, num_tokens, forward_mode, spec_info, forward_batch.seq_lens.device
+                bs,
+                num_tokens,
+                forward_mode,
+                spec_info,
+                forward_batch.seq_lens.device,
+                ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
             )
 
         if forward_mode.is_decode_or_idle():
@@ -921,6 +925,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             forward_mode=forward_batch.forward_mode,
             spec_info=forward_batch.spec_info,
             out_cache_loc=forward_batch.out_cache_loc,
+            ragged_verify_layout=resolve_ragged_verify_layout(forward_batch),
         )
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -747,6 +747,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         *,
         capture_hidden_mode: Optional[CaptureHiddenMode] = None,
         return_hidden_states_before_norm: bool,
+        ragged_verify_layout: Optional[RaggedVerifyLayout] = None,
     ):
         # init_new must not mutate the input ScheduleBatch; per-forward
         # overrides go through explicit keyword arguments.
@@ -841,11 +842,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Compound (carry their own device tensors)
             sampling_info=batch.sampling_info,
             spec_info=batch.spec_info,
-            ragged_verify_layout=(
-                batch.spec_info.ragged_verify_layout
-                if batch.spec_info is not None
-                else None
-            ),
+            ragged_verify_layout=ragged_verify_layout,
         )
 
         ret._maybe_init_non_generation_fields(batch)

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import MultimodalInputs, ScheduleBatch
     from sglang.srt.model_executor.model_runner import ModelRunner
     from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
     from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 
 # Warn-once flag for the deprecated skip_attn_backend_init kwarg; see
@@ -505,6 +506,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     sampling_info: SamplingBatchInfo = None
     # Speculative decoding
     spec_info: Optional[SpecInput] = None
+    # Per-request target-verify geometry (ragged verify). Canonical read path:
+    # resolve_ragged_verify_layout(forward_batch).
+    ragged_verify_layout: Optional[RaggedVerifyLayout] = None
 
     # === Derived from ScheduleBatch.reqs ===
     # For LoRA
@@ -837,6 +841,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Compound (carry their own device tensors)
             sampling_info=batch.sampling_info,
             spec_info=batch.spec_info,
+            ragged_verify_layout=(
+                batch.spec_info.ragged_verify_layout
+                if batch.spec_info is not None
+                else None
+            ),
         )
 
         ret._maybe_init_non_generation_fields(batch)
@@ -1660,6 +1669,7 @@ def build_inner_fb_view(
         out_cache_loc=getattr(forward_batch, "out_cache_loc", None),
         out_cache_loc_dsv4=getattr(forward_batch, "out_cache_loc_dsv4", None),
         spec_info=forward_batch.spec_info,
+        ragged_verify_layout=forward_batch.ragged_verify_layout,
     )
 
 

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -95,10 +95,7 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
-from sglang.srt.speculative.ragged_verify import (
-    resolve_ragged_verify_layout,
-    spec_info_ragged_verify_layout,
-)
+from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -915,7 +912,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
-            ragged_verify_layout=spec_info_ragged_verify_layout(spec_info),
+            # Algorithm-private field; only the dflash-family capture inputs
+            # carry a synthetic layout.
+            ragged_verify_layout=getattr(spec_info, "ragged_verify_layout", None),
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -95,7 +95,10 @@ from sglang.srt.model_executor.runner_utils.deepep_adapter import (
 )
 from sglang.srt.multiplex.pdmux_context import get_current_stream_idx, get_stream_groups
 from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
-from sglang.srt.speculative.ragged_verify import resolve_ragged_verify_layout
+from sglang.srt.speculative.ragged_verify import (
+    resolve_ragged_verify_layout,
+    spec_info_ragged_verify_layout,
+)
 from sglang.srt.utils import (
     empty_context,
     get_available_gpu_memory,
@@ -188,6 +191,7 @@ def build_replay_fb_view(
             else buffers.mamba_track_indices[:bs]
         ),
         spec_info=forward_batch.spec_info,
+        ragged_verify_layout=forward_batch.ragged_verify_layout,
     )
 
 
@@ -911,6 +915,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
+            ragged_verify_layout=spec_info_ragged_verify_layout(spec_info),
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -858,7 +858,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         else:
             global_dp_buffer_len = None
 
-        spec_info = self.get_spec_info(num_tokens)
+        capture_ragged_verify_layout = self._capture_ragged_verify_layout(num_tokens)
+        spec_info = self.get_spec_info(
+            num_tokens, ragged_verify_layout=capture_ragged_verify_layout
+        )
         self.capture_hidden_mode = get_required_capture_hidden_mode(
             self.capture_hidden_mode,
             spec_info,
@@ -912,9 +915,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             mrope_positions=mrope_positions,
             spec_algorithm=self.model_runner.spec_algorithm,
             spec_info=spec_info,
-            # Algorithm-private field; only the dflash-family capture inputs
-            # carry a synthetic layout.
-            ragged_verify_layout=getattr(spec_info, "ragged_verify_layout", None),
+            ragged_verify_layout=capture_ragged_verify_layout,
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,
@@ -1366,7 +1367,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             assert isinstance(output, PPProxyTensors)
             return PPProxyTensors({k: v[: self.bs] for k, v in output.tensors.items()})
 
-    def get_spec_info(self, num_tokens: int):
+    def get_spec_info(self, num_tokens: int, ragged_verify_layout=None):
         spec_info = None
         if (
             self.model_runner.spec_algorithm.is_eagle()
@@ -1429,7 +1430,7 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     if self.model_runner.is_draft_worker
                     else CaptureHiddenMode.FULL
                 ),
-                ragged_verify_layout=self._capture_ragged_verify_layout(num_tokens),
+                ragged_verify_layout=ragged_verify_layout,
             )
 
         elif self.model_runner.spec_algorithm.is_ngram():

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -74,6 +74,7 @@ class DFlashVerifyInput(SpecInput):
             target_worker.model_runner,
             capture_hidden_mode=self.capture_hidden_mode,
             return_hidden_states_before_norm=False,
+            ragged_verify_layout=self.ragged_verify_layout,
         )
 
         can_run_cuda_graph = bool(

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -217,9 +217,10 @@ def build_capture_verify_lens(
 
 
 def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
-    """Layout riding the batch's spec input, or None. Tolerates the runner's
-    ad-hoc replay batch views, which may not carry spec_info at all."""
-    return spec_info_ragged_verify_layout(getattr(forward_batch, "spec_info", None))
+    """Canonical read of the batch's verify layout (ForwardBatch field).
+    Tolerates the runner's ad-hoc replay batch views, which may not carry
+    the field at all."""
+    return getattr(forward_batch, "ragged_verify_layout", None)
 
 
 def spec_info_ragged_verify_layout(spec_info) -> Optional[RaggedVerifyLayout]:

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -223,14 +223,6 @@ def resolve_ragged_verify_layout(forward_batch) -> Optional[RaggedVerifyLayout]:
     return getattr(forward_batch, "ragged_verify_layout", None)
 
 
-def spec_info_ragged_verify_layout(spec_info) -> Optional[RaggedVerifyLayout]:
-    """Layout carried by a spec input, or None. For the cuda-graph init paths,
-    which receive spec_info directly rather than a ForwardBatch."""
-    if spec_info is None:
-        return None
-    return spec_info.ragged_verify_layout
-
-
 class RaggedTargetVerifyGeometry(msgspec.Struct):
     cache_seqlens_int32: torch.Tensor
     cu_seqlens_q: torch.Tensor

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
     from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
     from sglang.srt.speculative.ngram_worker import NGRAMWorker
-    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 
 class SpeculativeAlgorithm(Enum):
@@ -325,23 +324,17 @@ class SpecInputType(IntEnum):
 
 
 class SpecInput(ABC):
-    # Per-request verify lengths for the ragged-verify graphs (see
-    # sglang.srt.speculative.ragged_verify); verify inputs of algorithms with
-    # supports_ragged_verify() override it per step. Must stay a class-level
-    # default, not an __init__ assignment: dataclass subclasses declare it as
-    # a field and run __post_init__ -> super().__init__ *after* field
-    # assignment, so an init-time default would clobber the passed layout.
-    ragged_verify_layout: Optional[RaggedVerifyLayout] = None
-
     # Uniform per-request token width of this forward (and its logits-row
     # counterpart). Doubles as the DP-attention global_num_tokens multiplier
     # (ragged forwards carry 1 there). -1 = not set by this flow.
     num_tokens_per_req: int = -1
     num_tokens_for_logprob_per_req: int = -1
 
-    # DSA MTP IndexShare seed relay. Class-level defaults (same rationale as
-    # ragged_verify_layout) so scheduler/relay/attention code reads them
-    # uniformly on any SpecInput; only the EAGLE-family inputs override them.
+    # DSA MTP IndexShare seed relay. Class-level defaults (not __init__
+    # assignments: dataclass subclasses run __post_init__ -> super().__init__
+    # *after* field assignment, so an init-time default would clobber a
+    # passed value) so scheduler/relay/attention code reads them uniformly
+    # on any SpecInput; only the EAGLE-family inputs override them.
     dsa_topk_indices: Optional[torch.Tensor] = None
     future_dsa_topk_indices_available: bool = False
     dsa_seed_topk_capture: Optional[torch.Tensor] = None


### PR DESCRIPTION
The graph tier (token-source selection, floor, round-up-to-grid) was derived independently in `_ragged_verify_layout` and `_budget_aligned_to_graph_tier`, kept consistent by comment; the decode graph runner re-derived it a third time at replay and asserted it matched the layout. Extract `_resolve_verify_tier` as the single derivation point (returning a `VerifyTierResolution`), and make the runner read the tier off the layout instead of recomputing it. No behavior change. Stacks on #34031.