### PR TITLE
[Sampling] Add explicit bounded sampling-mask mode

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1828,7 +1828,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             output_token_logprobs_idx,
             output_top_logprobs_val,
             output_top_logprobs_idx,
-            output_token_sampling_mask_len,
+            output_token_sampling_mask_metadata,
             output_token_sampling_mask_idx,
             output_token_sampling_logprobs,
             output_topk_p,
@@ -1956,16 +1956,21 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             assert (
                 output_token_sampling_mask_idx is not None
             ), "sampling mask buffer disabled on decode side"
-            sampling_mask_len = int(output_token_sampling_mask_len[0].item())
+            sampling_mask_metadata = output_token_sampling_mask_metadata.tolist()
+            sampling_mask_len, sampling_mask_truncated = sampling_mask_metadata
             if sampling_mask_len < 0:
                 decode_req.req.output_token_sampling_mask.append(None)
                 decode_req.req.output_token_sampling_logprobs.append(None)
+                decode_req.req.output_token_sampling_mask_truncated.append(False)
             else:
                 decode_req.req.output_token_sampling_mask.append(
                     output_token_sampling_mask_idx[:sampling_mask_len].cpu().tolist()
                 )
                 decode_req.req.output_token_sampling_logprobs.append(
                     float(output_token_sampling_logprobs[0].item())
+                )
+                decode_req.req.output_token_sampling_mask_truncated.append(
+                    bool(sampling_mask_truncated)
                 )
 
         decode_req.kv_receiver.clear()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -696,6 +696,10 @@ class SchedulerDisaggregationPrefillMixin:
             batch=batch,
             logits_output=logits_output,
         )
+        if logits_output is not None and logits_output.sampling_mask_output is not None:
+            self.batch_result_processor.materialize_sampling_mask_output(
+                batch.reqs, logits_output
+            )
 
         def advance_logprob_pt(i: int, req: Req) -> None:
             nonlocal logprob_pt
@@ -715,6 +719,39 @@ class SchedulerDisaggregationPrefillMixin:
                 # Test hook: exercise the release/requeue retry path.
                 if req.pending_bootstrap and should_force_retry(req):
                     self.optimistic_release_and_requeue(req)
+                    advance_logprob_pt(i, req)
+                    continue
+
+                sampling_mask_finish_reason = None
+                if req.return_sampling_mask:
+                    assert logits_output is not None
+                    statuses = logits_output.next_token_sampling_mask_status
+                    status = None if statuses is None else statuses[i]
+                    sampling_mask_finish_reason = (
+                        self.batch_result_processor.get_sampling_mask_finish_reason(
+                            status=status
+                        )
+                    )
+                if sampling_mask_finish_reason is not None:
+                    self.clear_pending_chunk_send(req)
+                    prepare_abort(
+                        req,
+                        sampling_mask_finish_reason.message,
+                        status_code=sampling_mask_finish_reason.status_code,
+                    )
+                    req.time_stats.trace_ctx.abort(
+                        abort_info={"reason": sampling_mask_finish_reason.message}
+                    )
+                    req.disagg_kv_sender.abort()
+                    maybe_release_metadata_buffer(
+                        req, self.req_to_metadata_buffer_idx_allocator
+                    )
+                    req.pending_bootstrap = False
+                    if self.enable_hicache_storage:
+                        self.tree_cache.release_aborted_request(req.rid)
+                    release_kv_cache(req, self.tree_cache, is_insert=False)
+                    req.time_stats.set_completion_time()
+                    self.output_streamer.stream_output([req], req.return_logprob)
                     advance_logprob_pt(i, req)
                     continue
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -729,7 +729,8 @@ class SchedulerDisaggregationPrefillMixin:
                     status = None if statuses is None else statuses[i]
                     sampling_mask_finish_reason = (
                         self.batch_result_processor.get_sampling_mask_finish_reason(
-                            status=status
+                            status=status,
+                            mode=req.sampling_mask_mode,
                         )
                     )
                 if sampling_mask_finish_reason is not None:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -365,11 +365,12 @@ class MetadataBuffers:
             self.output_top_logprobs_idx = torch.zeros(
                 (size, max_top_logprobs_num), dtype=torch.int32, device=device
             )
-            self.output_token_sampling_mask_len = None
+            self.output_token_sampling_mask_metadata = None
             self.output_token_sampling_mask_idx = None
             self.output_token_sampling_logprobs = None
             if self.enable_sampling_mask:
-                self.output_token_sampling_mask_len = torch.zeros(
+                # Pad the metadata row to 64 bytes for RDMA.
+                self.output_token_sampling_mask_metadata = torch.zeros(
                     (size, 16), dtype=torch.int32, device=device
                 )
                 self.output_token_sampling_mask_idx = torch.zeros(
@@ -414,7 +415,7 @@ class MetadataBuffers:
         if self.enable_sampling_mask:
             bufs.extend(
                 [
-                    self.output_token_sampling_mask_len,
+                    self.output_token_sampling_mask_metadata,
                     self.output_token_sampling_mask_idx,
                     self.output_token_sampling_logprobs,
                 ]
@@ -435,11 +436,13 @@ class MetadataBuffers:
         return ptrs, data_lens, item_lens
 
     def get_buf(self, idx: int):
-        sampling_mask_len = None
+        sampling_mask_metadata = None
         sampling_mask_idx = None
         sampling_logprobs = None
         if self.enable_sampling_mask:
-            sampling_mask_len = self.output_token_sampling_mask_len[idx].clone()
+            sampling_mask_metadata = self.output_token_sampling_mask_metadata[
+                idx, :2
+            ].clone()
             sampling_mask_idx = self.output_token_sampling_mask_idx[idx].clone()
             sampling_logprobs = self.output_token_sampling_logprobs[idx].clone()
         return (
@@ -449,7 +452,7 @@ class MetadataBuffers:
             self.output_token_logprobs_idx[idx].clone(),
             self.output_top_logprobs_val[idx].clone(),
             self.output_top_logprobs_idx[idx].clone(),
-            sampling_mask_len,
+            sampling_mask_metadata,
             sampling_mask_idx,
             sampling_logprobs,
             self.output_topk_p[idx].clone(),
@@ -525,9 +528,16 @@ class MetadataBuffers:
                     "SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS > 0."
                 )
             # Sentinel -1: the decode side records None for this handoff token.
-            self.output_token_sampling_mask_len[req.metadata_buffer_index][0] = -1
+            sampling_mask_metadata = self.output_token_sampling_mask_metadata[
+                req.metadata_buffer_index
+            ]
+            # Slot 0 is the returned mask length (-1 means absent); slot 1 is
+            # whether the returned mask was truncated.
+            sampling_mask_metadata[0] = -1
+            sampling_mask_metadata[1] = 0
             sampling_masks = req.output_token_sampling_mask
             sampling_logprobs = req.output_token_sampling_logprobs
+            sampling_mask_truncated = req.output_token_sampling_mask_truncated
             if sampling_masks:
                 sampling_mask = sampling_masks[0]
                 sampling_logprob = sampling_logprobs[0] if sampling_logprobs else None
@@ -540,9 +550,7 @@ class MetadataBuffers:
                             f"metadata capacity {max_mask_len}. Increase "
                             "SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS."
                         )
-                    self.output_token_sampling_mask_len[req.metadata_buffer_index][
-                        0
-                    ] = mask_len
+                    sampling_mask_metadata[0] = mask_len
                     if mask_len:
                         self.output_token_sampling_mask_idx[
                             req.metadata_buffer_index, :mask_len
@@ -556,6 +564,7 @@ class MetadataBuffers:
                     self.output_token_sampling_logprobs[req.metadata_buffer_index][
                         0
                     ] = float(sampling_logprob)
+                    sampling_mask_metadata[1] = sampling_mask_truncated[0]
         # For PD + spec decode
         if req.hidden_states_tensor is not None:
             # speculative_eagle_topk should not be greater than 16 currently

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -800,6 +800,7 @@ class ChatCompletionRequest(BaseModel):
     return_token_ids: bool = False
     return_meta_info: bool = False
     return_sampling_mask: bool = False
+    sampling_mask_mode: Literal["exact", "bounded"] = "exact"
     reasoning_effort: ReasoningEffortType = Field(
         default=None,
         description="Constrains effort on reasoning for reasoning models. "

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1009,6 +1009,7 @@ class OpenAIServingChat(OpenAIServingBase):
             logprob_start_len=-1,
             top_logprobs_num=request.top_logprobs or 0,
             return_sampling_mask=request.return_sampling_mask,
+            sampling_mask_mode=request.sampling_mask_mode,
             stream=request.stream,
             return_text_in_logprobs=True,
             modalities=processed_messages.modalities,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -16,6 +16,7 @@
 import dataclasses
 import logging
 from contextlib import contextmanager
+from enum import IntEnum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
@@ -78,6 +79,30 @@ _UNQUANTIZED_LM_HEAD_METHODS = {
 _autotune_run_lm_head: Optional[bool] = None
 
 
+class SamplingMaskStatus(IntEnum):
+    """Ordered by severity so distributed MAX reaches one policy decision."""
+
+    OK = 0
+    TRUNCATED = 1
+    INVALID = 2
+
+
+@dataclasses.dataclass
+class SamplingMaskOutput:
+    """Tensor result for opted-in rows in batch order."""
+
+    token_ids: torch.Tensor
+    lengths: torch.Tensor
+    selected_logprobs: torch.Tensor
+    statuses: torch.Tensor
+
+    def map_device_tensors(self, fn) -> None:
+        self.token_ids = fn(self.token_ids)
+        self.lengths = fn(self.lengths)
+        self.selected_logprobs = fn(self.selected_logprobs)
+        self.statuses = fn(self.statuses)
+
+
 def get_in_autotune_dummy_run() -> bool:
     return _autotune_run_lm_head is not None
 
@@ -114,10 +139,12 @@ class LogitsProcessorOutput:
         List[Union[List[float], torch.Tensor]]
     ] = None
     next_token_token_ids_logprobs_idx: Optional[List] = None
-    # Sparse top-k/top-p/min-p support ids and selected-token logprob after
-    # truncation/renormalization. Only populated when requested.
+    # Post-filter support IDs, bounded by server capacity, and selected-token
+    # logprob over the full realized support.
+    sampling_mask_output: Optional[SamplingMaskOutput] = None
     next_token_sampling_mask_idx: Optional[List[Optional[List[int]]]] = None
     next_token_sampling_logprobs: Optional[List[Optional[float]]] = None
+    next_token_sampling_mask_status: Optional[List[Optional[int]]] = None
 
     ## Part 3: Prefill-only. This part will be assigned in python/sglang/srt/layers/logits_processor.py::LogitsProcessor
     # The logprobs of input tokens.        shape: [#token]

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -11,7 +11,11 @@ from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskOutput,
+    SamplingMaskStatus,
+)
 from sglang.srt.layers.logprob_processor import (
     OutputLogprobProcessor,
 )
@@ -68,12 +72,33 @@ _CUSTOM_SAMPLER_FACTORIES: Dict[str, Callable[[], "Sampler"]] = {}
 _BUILT_IN_SAMPLING_BACKENDS = {"flashinfer", "pytorch", "ascend"}
 
 
+class _SamplingMaskCapture(NamedTuple):
+    """Captured sampling support for opted-in rows."""
+
+    batch_indices: torch.Tensor
+    scores: torch.Tensor
+    token_ids: Optional[torch.Tensor]
+    selected_scores: Optional[torch.Tensor]
+    scores_are_logprobs: bool = False
+
+
+def _select_sampling_mask_rows(
+    tensor: torch.Tensor, batch_indices: torch.Tensor
+) -> torch.Tensor:
+    """Select opted-in rows, returning the input when every row opts in."""
+    if batch_indices.numel() == tensor.shape[0]:
+        return tensor
+    return tensor.index_select(0, batch_indices)
+
+
 class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
         self.tp_sync_group = get_tp_group().device_group
+        self.cp_sync_group = None
         if is_dp_attention_enabled():
             self.tp_sync_group = get_parallel().attn_tp_group.device_group
+            self.cp_sync_group = get_parallel().attn_cp_group.device_group
 
         self.rl_on_policy_target = get_exec().deterministic.rl_on_policy_target
         # In RL on-policy mode, deterministic inference is automatically enabled.
@@ -83,6 +108,7 @@ class Sampler(nn.Module):
         # In RL on-policy mode, we use log_softmax to compute logprobs to match the trainer.
         self.use_log_softmax_logprob = self.rl_on_policy_target is not None
         self.use_ascend_backend = get_exec().kernel.sampling_backend == "ascend"
+        self.sampling_mask_max_tokens = get_exec().features.sampling_mask_max_tokens
 
         self.output_logprob_processor = OutputLogprobProcessor()
 
@@ -125,7 +151,9 @@ class Sampler(nn.Module):
 
         # Preprocess logits (custom processors and NaN handling)
         logits = self._preprocess_logits(logits, sampling_info)
-        return_sampling_mask = any(sampling_info.return_sampling_masks or [])
+        sampling_mask_batch_indices = sampling_info.sampling_mask_batch_indices
+        return_sampling_mask = sampling_mask_batch_indices is not None
+        sampling_mask_data = None
 
         if sampling_info.is_all_greedy:
             if _use_aiter and not _disable_aiter_greedy_sample:
@@ -135,10 +163,6 @@ class Sampler(nn.Module):
                 _aiter_greedy_sample(batch_next_token_ids, logits)
             else:
                 batch_next_token_ids = torch.argmax(logits, -1)
-            if return_sampling_mask:
-                self._attach_greedy_sampling_mask_to_output(
-                    logits_output, sampling_info, batch_next_token_ids
-                )
             if return_logprob:
                 original_logprobs = logprobs = torch.nn.functional.log_softmax(
                     logits, dim=-1
@@ -186,6 +210,18 @@ class Sampler(nn.Module):
                     sampling_info,
                     positions,
                 )
+                if sampling_mask_batch_indices is not None:
+                    requested_logprobs = _select_sampling_mask_rows(
+                        logprobs_via_logsoftmax_kernel,
+                        sampling_mask_batch_indices,
+                    )
+                    sampling_mask_data = _SamplingMaskCapture(
+                        batch_indices=sampling_mask_batch_indices,
+                        scores=requested_logprobs,
+                        token_ids=None,
+                        selected_scores=None,
+                        scores_are_logprobs=True,
+                    )
                 if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
                     logprobs = logprobs_via_logsoftmax_kernel
             else:
@@ -211,19 +247,12 @@ class Sampler(nn.Module):
                 logits[:] = torch.softmax(logits, dim=-1)
                 probs = logits
 
-                batch_next_token_ids = self._sample_from_probs(
-                    probs, sampling_info, positions, simple_sampling_case
+                batch_next_token_ids, sampling_mask_data = self._sample_from_probs(
+                    probs,
+                    sampling_info,
+                    positions,
+                    simple_sampling_case,
                 )
-                if return_sampling_mask:
-                    sampling_mask_data = self._compute_sampling_mask_from_probs(
-                        probs, sampling_info
-                    )
-                    self._attach_sampling_mask_to_output(
-                        logits_output,
-                        sampling_info,
-                        batch_next_token_ids,
-                        sampling_mask_data,
-                    )
                 if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
                     logprobs = (
                         logprobs_via_logsoftmax_kernel
@@ -245,6 +274,29 @@ class Sampler(nn.Module):
 
         self._sync_token_ids_across_tp(batch_next_token_ids, sampling_info)
 
+        if (
+            sampling_mask_data is not None
+            and sampling_mask_data.token_ids is not None
+            and (SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars)
+        ):
+            # TP synchronization can change the token after PyTorch sampling.
+            sampling_mask_data = sampling_mask_data._replace(selected_scores=None)
+
+        if return_sampling_mask:
+            assert sampling_mask_batch_indices is not None
+            if sampling_info.is_all_greedy:
+                logits_output.sampling_mask_output = (
+                    self._build_greedy_sampling_mask_output(
+                        sampling_mask_batch_indices, batch_next_token_ids
+                    )
+                )
+            else:
+                assert sampling_mask_data is not None
+                logits_output.sampling_mask_output = self._build_sampling_mask_output(
+                    batch_next_token_ids,
+                    sampling_mask_data,
+                )
+
         return batch_next_token_ids
 
     def _sample_from_probs(
@@ -253,18 +305,31 @@ class Sampler(nn.Module):
         sampling_info: SamplingBatchInfo,
         positions: torch.Tensor,
         simple_sampling_case: bool,
-    ) -> torch.Tensor:
+    ) -> Tuple[torch.Tensor, Optional[_SamplingMaskCapture]]:
         """Sample from probability distribution (after softmax).
 
         Used for standard sampling with flashinfer/pytorch backends.
         Handles both simple (direct multinomial) and complex (top-k/top-p/min-p) cases.
+        Returns sampled token IDs and captured support data for requested rows,
+        or None when no rows request capture.
         """
+        sampling_mask_batch_indices = sampling_info.sampling_mask_batch_indices
+        sampling_mask_data = None
         if simple_sampling_case:
             batch_next_token_ids = sampling_from_probs_torch(
                 probs,
                 sampling_seed=sampling_info.sampling_seed,
                 positions=positions,
             )
+            if sampling_mask_batch_indices is not None:
+                sampling_mask_data = _SamplingMaskCapture(
+                    batch_indices=sampling_mask_batch_indices,
+                    scores=_select_sampling_mask_rows(
+                        probs, sampling_mask_batch_indices
+                    ),
+                    token_ids=None,
+                    selected_scores=None,
+                )
         else:
             backend = get_exec().kernel.sampling_backend
             if backend == "flashinfer":
@@ -277,6 +342,30 @@ class Sampler(nn.Module):
                     batch_next_token_ids = min_p_sampling_from_probs(
                         probs, sampling_info.min_ps
                     )
+                    if sampling_mask_batch_indices is not None:
+                        requested_probs = _select_sampling_mask_rows(
+                            probs, sampling_mask_batch_indices
+                        )
+                        requested_min_ps = _select_sampling_mask_rows(
+                            sampling_info.min_ps, sampling_mask_batch_indices
+                        )
+                        min_p_thresholds = (
+                            requested_probs.max(dim=-1).values * requested_min_ps
+                        )
+                        below_min_p = requested_probs < min_p_thresholds.view(-1, 1)
+                        if requested_probs is probs:
+                            # Do not change probabilities later used by return_logprob.
+                            requested_probs = requested_probs.masked_fill(
+                                below_min_p, 0
+                            )
+                        else:
+                            requested_probs.masked_fill_(below_min_p, 0)
+                        sampling_mask_data = _SamplingMaskCapture(
+                            batch_indices=sampling_mask_batch_indices,
+                            scores=requested_probs,
+                            token_ids=None,
+                            selected_scores=None,
+                        )
                 else:
                     batch_next_token_ids = top_k_top_p_sampling_from_probs(
                         probs.contiguous(),
@@ -284,9 +373,38 @@ class Sampler(nn.Module):
                         sampling_info.top_ps,
                         filter_apply_order="joint",
                     )
+                    if sampling_mask_batch_indices is not None:
+                        requested_probs = _select_sampling_mask_rows(
+                            probs, sampling_mask_batch_indices
+                        )
+                        filtered_probs = requested_probs
+                        if sampling_info.need_top_k_sampling:
+                            requested_top_ks = _select_sampling_mask_rows(
+                                sampling_info.top_ks, sampling_mask_batch_indices
+                            )
+                            filtered_probs = top_k_renorm_prob(
+                                requested_probs, requested_top_ks
+                            )
+                        if sampling_info.need_top_p_sampling:
+                            requested_top_ps = _select_sampling_mask_rows(
+                                sampling_info.top_ps, sampling_mask_batch_indices
+                            )
+                            top_p_probs = top_p_renorm_prob(
+                                requested_probs, requested_top_ps
+                            )
+                            if filtered_probs is requested_probs:
+                                filtered_probs = top_p_probs
+                            else:
+                                filtered_probs.masked_fill_(top_p_probs <= 0, 0)
+                        sampling_mask_data = _SamplingMaskCapture(
+                            batch_indices=sampling_mask_batch_indices,
+                            scores=filtered_probs,
+                            token_ids=None,
+                            selected_scores=None,
+                        )
             elif backend == "pytorch":
                 # A slower fallback implementation with torch native operations.
-                batch_next_token_ids = top_k_top_p_min_p_sampling_from_probs_torch(
+                sample_result = top_k_top_p_min_p_sampling_from_probs_torch(
                     probs,
                     sampling_info.top_ks,
                     sampling_info.top_ps,
@@ -294,124 +412,154 @@ class Sampler(nn.Module):
                     sampling_info.need_min_p_sampling,
                     sampling_info.sampling_seed,
                     positions,
+                    return_filtered_probs=sampling_mask_batch_indices is not None,
                 )
+                if sampling_mask_batch_indices is None:
+                    batch_next_token_ids = sample_result
+                else:
+                    (
+                        batch_next_token_ids,
+                        filtered_probs,
+                        token_ids,
+                        selected_weights,
+                    ) = sample_result
+                    sampling_mask_data = _SamplingMaskCapture(
+                        batch_indices=sampling_mask_batch_indices,
+                        scores=_select_sampling_mask_rows(
+                            filtered_probs, sampling_mask_batch_indices
+                        ),
+                        token_ids=_select_sampling_mask_rows(
+                            token_ids, sampling_mask_batch_indices
+                        ),
+                        selected_scores=_select_sampling_mask_rows(
+                            selected_weights, sampling_mask_batch_indices
+                        ),
+                    )
             else:
                 raise ValueError(f"Invalid sampling backend: {backend}")
-        return batch_next_token_ids
+        return batch_next_token_ids, sampling_mask_data
 
-    def _compute_sampling_mask_from_probs(
-        self, probs: torch.Tensor, sampling_info: SamplingBatchInfo
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Return sorted token ids, sorted probs, keep mask, and raw probs."""
-        vocab_size = probs.shape[-1]
-        max_top_k = sampling_info.sampling_mask_max_top_k
-        if 0 < max_top_k < vocab_size:
-            probs_sort, probs_idx = torch.topk(
-                probs,
-                k=max_top_k,
-                dim=-1,
-                largest=True,
-                sorted=True,
+    def _build_greedy_sampling_mask_output(
+        self,
+        batch_indices: torch.Tensor,
+        batch_next_token_ids: torch.Tensor,
+    ) -> SamplingMaskOutput:
+        token_ids = batch_next_token_ids.index_select(0, batch_indices).to(torch.int32)
+        num_requests = batch_indices.numel()
+        return SamplingMaskOutput(
+            token_ids=token_ids.view(-1, 1),
+            lengths=torch.ones(
+                num_requests, dtype=torch.int32, device=token_ids.device
+            ),
+            selected_logprobs=torch.zeros(
+                num_requests, dtype=torch.float32, device=token_ids.device
+            ),
+            statuses=torch.full(
+                (num_requests,),
+                SamplingMaskStatus.OK,
+                dtype=torch.int32,
+                device=token_ids.device,
+            ),
+        )
+
+    def _build_sampling_mask_output(
+        self,
+        batch_next_token_ids: torch.Tensor,
+        sampling_mask_data: _SamplingMaskCapture,
+    ) -> SamplingMaskOutput:
+        """Pack captured sampling support into a bounded tensor result."""
+        batch_indices = sampling_mask_data.batch_indices
+        scores = sampling_mask_data.scores
+        token_ids = sampling_mask_data.token_ids
+        selected_scores = sampling_mask_data.selected_scores
+        sampled_tokens = (
+            batch_next_token_ids.index_select(0, batch_indices).long().view(-1, 1)
+        )
+        sampled_tokens_int32 = sampled_tokens.to(torch.int32)
+
+        if selected_scores is None:
+            if token_ids is None:
+                selected_scores = torch.gather(scores, 1, sampled_tokens).squeeze(1)
+            else:
+                sampled_matches = token_ids == sampled_tokens_int32
+                selected_positions = sampled_matches.to(torch.int32).argmax(
+                    dim=-1, keepdim=True
+                )
+                selected_scores = torch.gather(scores, 1, selected_positions).squeeze(1)
+                selected_scores.masked_fill_(~sampled_matches.any(dim=-1), 0)
+
+        if sampling_mask_data.scores_are_logprobs:
+            assert token_ids is None
+            support = torch.isfinite(scores)
+            realized_lengths = torch.count_nonzero(support, dim=-1).to(torch.int32)
+            selected_logprobs = selected_scores.float() - torch.logsumexp(
+                scores.float(), dim=-1
             )
-            positions = torch.arange(max_top_k, device=probs.device).view(1, -1)
+            invalid = ~torch.isfinite(selected_logprobs)
         else:
-            probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
-            positions = torch.arange(vocab_size, device=probs.device).view(1, -1)
-        probs_sum = torch.cumsum(probs_sort, dim=-1)
+            support_mass = scores.sum(dim=-1, dtype=torch.float32)
+            realized_lengths = torch.count_nonzero(scores, dim=-1).to(torch.int32)
+            selected_scores = selected_scores.float()
+            selected_logprobs = torch.log(selected_scores / support_mass)
+            invalid = (
+                (selected_scores <= 0)
+                | (support_mass <= 0)
+                | ~torch.isfinite(selected_logprobs)
+            )
+        overflow = realized_lengths > self.sampling_mask_max_tokens
+        statuses = torch.where(
+            invalid,
+            SamplingMaskStatus.INVALID,
+            torch.where(
+                overflow,
+                SamplingMaskStatus.TRUNCATED,
+                SamplingMaskStatus.OK,
+            ),
+        ).to(torch.int32)
 
-        keep_mask = positions < sampling_info.top_ks.view(-1, 1)
-        keep_mask &= (probs_sum - probs_sort) <= sampling_info.top_ps.view(-1, 1)
+        # Scheduler control flow must agree across TP/CP replicas. MAX makes
+        # INVALID take precedence over TRUNCATED.
+        if dist.is_initialized():
+            if dist.get_world_size(self.tp_sync_group) > 1:
+                dist.all_reduce(
+                    statuses, op=dist.ReduceOp.MAX, group=self.tp_sync_group
+                )
+            if (
+                self.cp_sync_group is not None
+                and dist.get_world_size(self.cp_sync_group) > 1
+            ):
+                dist.all_reduce(
+                    statuses, op=dist.ReduceOp.MAX, group=self.cp_sync_group
+                )
 
-        if sampling_info.need_min_p_sampling:
-            min_p_thresholds = probs_sort[:, 0] * sampling_info.min_ps
-            keep_mask &= probs_sort >= min_p_thresholds.view(-1, 1)
+        successful = statuses != SamplingMaskStatus.INVALID
+        packed_size = min(self.sampling_mask_max_tokens, scores.shape[-1])
+        if token_ids is None:
+            _, packed_positions = torch.topk(
+                scores, k=packed_size, dim=-1, largest=True, sorted=True
+            )
+            packed_token_ids = packed_positions.to(torch.int32)
+        else:
+            # The PyTorch producer already orders weights and token IDs by probability.
+            packed_token_ids = token_ids[:, :packed_size].contiguous()
 
-        return probs_idx, probs_sort, keep_mask, probs
-
-    def _attach_greedy_sampling_mask_to_output(
-        self,
-        logits_output: LogitsProcessorOutput,
-        sampling_info: SamplingBatchInfo,
-        batch_next_token_ids: torch.Tensor,
-    ) -> None:
-        tokens = batch_next_token_ids.to(torch.int32).cpu().tolist()
-        masks = []
-        logprobs = []
-        for i, should_return in enumerate(sampling_info.return_sampling_masks or []):
-            if should_return:
-                masks.append([int(tokens[i])])
-                logprobs.append(0.0)
-            else:
-                masks.append(None)
-                logprobs.append(None)
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
-
-    def _attach_sampling_mask_to_output(
-        self,
-        logits_output: LogitsProcessorOutput,
-        sampling_info: SamplingBatchInfo,
-        batch_next_token_ids: torch.Tensor,
-        sampling_mask_data: Tuple[
-            torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
-        ],
-    ) -> None:
-        probs_idx, probs_sort, keep_mask, probs = sampling_mask_data
-        return_sampling_masks = sampling_info.return_sampling_masks or []
-        if not return_sampling_masks:
-            logits_output.next_token_sampling_mask_idx = []
-            logits_output.next_token_sampling_logprobs = []
-            return
-
-        sampled_tokens = batch_next_token_ids.view(-1, 1)
-        sampled_matches_all = probs_idx == sampled_tokens
-        sampled_in_idx = sampled_matches_all.any(dim=-1)
-
-        # The sampler is the source of truth for the rollout action space. If a
-        # backend/numeric edge chooses a token just outside the reconstructed
-        # prefix, include that sampled token so training can replay a support
-        # that contained the rollout action.
-        effective_keep_mask = keep_mask | sampled_matches_all
-        selected_raw_probs = torch.gather(probs, 1, sampled_tokens).squeeze(1)
-        support_mass = torch.where(
-            effective_keep_mask, probs_sort, torch.zeros_like(probs_sort)
-        ).sum(dim=-1)
-        support_mass = support_mass + torch.where(
-            sampled_in_idx, torch.zeros_like(selected_raw_probs), selected_raw_probs
-        )
-        selected_logprobs = torch.log(
-            selected_raw_probs.float()
-            / support_mass.float().clamp_min(torch.finfo(torch.float32).tiny)
+        # Keep the highest-weight prefix, replacing its final entry only when
+        # needed to retain the sampled token. Its logprob still uses the full
+        # realized support.
+        sampled_in_packed = (packed_token_ids == sampled_tokens_int32).any(dim=-1)
+        replace_last = successful & overflow & ~sampled_in_packed
+        packed_token_ids[:, -1] = torch.where(
+            replace_last,
+            sampled_tokens_int32.squeeze(1),
+            packed_token_ids[:, -1],
         )
 
-        flat_rows, flat_cols = effective_keep_mask.nonzero(as_tuple=True)
-        flat_ids = probs_idx[flat_rows, flat_cols].to(torch.int32)
-        mask_lengths = effective_keep_mask.sum(dim=-1, dtype=torch.int32)
-
-        flat_ids_cpu = flat_ids.cpu().tolist()
-        mask_lengths_cpu = mask_lengths.cpu().tolist()
-        sampled_in_idx_cpu = sampled_in_idx.cpu().tolist()
-        sampled_tokens_cpu = batch_next_token_ids.to(torch.int32).cpu().tolist()
-        selected_logprobs_cpu = selected_logprobs.cpu().tolist()
-
-        masks = []
-        logprobs = []
-        cursor = 0
-        for i, should_return in enumerate(return_sampling_masks):
-            mask_len = int(mask_lengths_cpu[i])
-            row_ids = flat_ids_cpu[cursor : cursor + mask_len]
-            cursor += mask_len
-            if not sampled_in_idx_cpu[i]:
-                row_ids.append(int(sampled_tokens_cpu[i]))
-            if should_return:
-                masks.append(row_ids)
-                logprobs.append(float(selected_logprobs_cpu[i]))
-            else:
-                masks.append(None)
-                logprobs.append(None)
-
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
+        return SamplingMaskOutput(
+            token_ids=packed_token_ids,
+            lengths=realized_lengths.clamp(max=self.sampling_mask_max_tokens),
+            selected_logprobs=selected_logprobs,
+            statuses=statuses,
+        )
 
     def _sample_from_logprobs(
         self,
@@ -572,11 +720,17 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     need_min_p_sampling: bool,
     sampling_seed: Optional[torch.Tensor],
     positions: torch.Tensor,
+    *,
+    return_filtered_probs: bool = False,
 ):
     """
     A top-k, top-p and min-p sampling implementation with native pytorch operations.
     When sampling_seed is not None, deterministic inference will be enabled, it will sample
     with the sampling_seed of each request.
+
+    By default, returns only sampled token IDs. With return_filtered_probs=True,
+    also returns the filtered weights, their token-ID permutation, and the
+    selected weights used by sampling-mask capture.
     """
     probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
     probs_sum = torch.cumsum(probs_sort, dim=-1)
@@ -601,14 +755,22 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
         # apply log to get logprobs. Therefore, we cannot use log_softmax directly.
         # For now, we use log to the modified probs to get logprobs, but for numerical
         # stability, we'd better come up with a solution to use log_softmax.
-        logprobs = probs_sort.to(torch.float64)  # Using float64 for numerical stability
-        del probs_sort
+        logprobs = probs_sort.to(
+            torch.float64, copy=return_filtered_probs
+        )  # Using float64 for numerical stability
+        if not return_filtered_probs:
+            del probs_sort
         logprobs.log_()
         sampled_index = multinomial_with_seed(logprobs, sampling_seed, positions)
+
+    if return_filtered_probs:
+        selected_weights = torch.gather(probs_sort, dim=1, index=sampled_index).view(-1)
 
     # int32 range is enough to represent the token ids
     probs_idx = probs_idx.to(torch.int32)
     batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
+    if return_filtered_probs:
+        return batch_next_token_ids, probs_sort, probs_idx, selected_weights
     return batch_next_token_ids
 
 

--- a/python/sglang/srt/managers/detokenizer_manager.py
+++ b/python/sglang/srt/managers/detokenizer_manager.py
@@ -474,6 +474,9 @@ class DetokenizerManager(MultiHttpWorkerDetokenizerMixin):
             output_token_entropy_val=recv_obj.output_token_entropy_val,
             output_token_sampling_mask=recv_obj.output_token_sampling_mask,
             output_token_sampling_logprobs=recv_obj.output_token_sampling_logprobs,
+            output_token_sampling_mask_truncated=(
+                recv_obj.output_token_sampling_mask_truncated
+            ),
             output_hidden_states=recv_obj.output_hidden_states,
             routed_experts=routed_experts,
             indexer_topk=indexer_topk,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -56,6 +56,7 @@ from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.schedule_batch import (
     Modality,
     ReturnHiddenStatesMode,
+    SamplingMaskMode,
     get_return_hidden_states_mode,
 )
 from sglang.srt.multimodal.mm_utils import has_valid_data
@@ -215,8 +216,13 @@ class GenerateReqInput:
     top_logprobs_num: Optional[Union[List[int], int]] = None
     # If return logprobs, the token ids to return logprob for.
     token_ids_logprob: Optional[Union[List[List[int]], List[int]]] = None
-    # Whether to return output-token sampling support and renormalized logprobs.
+    # Whether to return output-token sampling support and selected-token logprobs.
     return_sampling_mask: Optional[Union[List[bool], bool]] = None
+    # Whether returned sampling support must be exact or may be bounded by the
+    # server's sampling-mask capacity.
+    sampling_mask_mode: Optional[Union[List[SamplingMaskMode], SamplingMaskMode]] = (
+        field(default=None, kw_only=True)
+    )
     # Whether to detokenize tokens in text in the returned logprobs.
     return_text_in_logprobs: bool = False
     # Return prompt top logprobs as flat arrays plus shape metadata instead of
@@ -505,6 +511,10 @@ class GenerateReqInput:
                 )
             if value == "":
                 setattr(self, field_name, None)
+        if self.sampling_mask_mode is None:
+            self.sampling_mask_mode = "exact"
+        elif self.sampling_mask_mode not in ("exact", "bounded"):
+            raise ValueError("sampling_mask_mode must be 'exact' or 'bounded'.")
 
     def _normalize_batch_inputs(self):
         """Normalize inputs for a batch of examples, including parallel sampling expansion."""
@@ -710,6 +720,13 @@ class GenerateReqInput:
         self.return_sampling_mask = normalize_param(
             self.return_sampling_mask, False, "return_sampling_mask"
         )
+        self.sampling_mask_mode = normalize_param(
+            self.sampling_mask_mode,
+            "exact",
+            "sampling_mask_mode",
+        )
+        if any(mode not in ("exact", "bounded") for mode in self.sampling_mask_mode):
+            raise ValueError("sampling_mask_mode must be 'exact' or 'bounded'.")
 
         # Handle token_ids_logprob specially due to its nested structure
         if not self.token_ids_logprob:  # covers both None and []
@@ -871,6 +888,7 @@ class GenerateReqInput:
             top_logprobs_num=self.top_logprobs_num[i],
             token_ids_logprob=self.token_ids_logprob[i],
             return_sampling_mask=self.return_sampling_mask[i],
+            sampling_mask_mode=self.sampling_mask_mode[i],
             return_text_in_logprobs=self.return_text_in_logprobs,
             return_flat_raw_top_logprobs=self.return_flat_raw_top_logprobs,
             return_flat_raw_top_logprobs_b64=self.return_flat_raw_top_logprobs_b64,
@@ -1040,6 +1058,9 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
 
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
+
+    # Appended to preserve the positional wire layout used by the Rust server.
+    sampling_mask_mode: SamplingMaskMode = "exact"
 
     def wrap_pickle_fields(self):
         self.mm_inputs = wrap_as_pickle(self.mm_inputs)
@@ -1435,12 +1456,13 @@ class BatchTokenIDOutput(BaseBatchReq, kw_only=True):
     output_token_ids_logprobs_val: TokenIdsLogprobValues
     output_token_ids_logprobs_idx: TokenIdsLogprobIndices
     output_token_entropy_val: Optional[List[Optional[float]]]
-    # Per-request chunks of output-token sampling supports. None when no request
-    # in the batch asks for return_sampling_mask.
+    # Per-request chunks of post-filter token IDs; None if none were requested.
     output_token_sampling_mask: Optional[List[List]]
-    # Per-request chunks of selected-token logprobs renormalized over the
-    # corresponding sampling supports. None when sampling masks are not returned.
+    # Per-request chunks of selected-token logprobs over the full realized
+    # support.
     output_token_sampling_logprobs: Optional[List[List]]
+    # Per-request chunks of per-token truncation flags.
+    output_token_sampling_mask_truncated: Optional[List[List[bool]]]
 
     # Hidden states
     output_hidden_states: OutputHiddenStates
@@ -1533,6 +1555,7 @@ class BatchStrOutput(BaseBatchReq, kw_only=True):
     # None when sampling masks are not returned.
     output_token_sampling_mask: Optional[List[List]]
     output_token_sampling_logprobs: Optional[List[List]]
+    output_token_sampling_mask_truncated: Optional[List[List[bool]]]
 
     # Hidden states
     output_hidden_states: OutputHiddenStates

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -247,6 +247,12 @@ def _handle_output_by_index(output, i):
             output_token_sampling_logprobs=_extract_field_by_index(
                 output, "output_token_sampling_logprobs", i, check_length=False
             ),
+            output_token_sampling_mask_truncated=_extract_field_by_index(
+                output,
+                "output_token_sampling_mask_truncated",
+                i,
+                check_length=False,
+            ),
             output_hidden_states=_extract_field_by_index(
                 output, "output_hidden_states", i, check_length=False
             ),
@@ -363,6 +369,12 @@ def _handle_output_by_index(output, i):
             ),
             output_token_sampling_logprobs=_extract_field_by_index(
                 output, "output_token_sampling_logprobs", i, check_length=False
+            ),
+            output_token_sampling_mask_truncated=_extract_field_by_index(
+                output,
+                "output_token_sampling_mask_truncated",
+                i,
+                check_length=False,
             ),
             output_hidden_states=_extract_field_by_index(
                 output, "output_hidden_states", i, check_length=False

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -150,6 +150,7 @@ logger = logging.getLogger(__name__)
 
 
 ReturnHiddenStatesMode = Union[bool, Literal["last"]]
+SamplingMaskMode = Literal["exact", "bounded"]
 
 
 def get_return_hidden_states_mode(
@@ -849,6 +850,7 @@ class Req(ReqDllmMixin):
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
         cache_salt: Optional[str] = None,
+        sampling_mask_mode: SamplingMaskMode = "exact",
     ):
         # Input and output info
         self.rid = rid
@@ -1044,6 +1046,7 @@ class Req(ReqDllmMixin):
         self.temp_scaled_logprobs = False
         self.top_p_normalized_logprobs = False
         self.return_sampling_mask = return_sampling_mask
+        self.sampling_mask_mode = sampling_mask_mode
         self.return_flat_raw_top_logprobs = return_flat_raw_top_logprobs
 
         # Logprobs (return values)
@@ -1069,9 +1072,11 @@ class Req(ReqDllmMixin):
         if return_sampling_mask:
             self.output_token_sampling_mask = []
             self.output_token_sampling_logprobs = []
+            self.output_token_sampling_mask_truncated = []
         else:
             self.output_token_sampling_mask = None
             self.output_token_sampling_logprobs = None
+            self.output_token_sampling_mask_truncated = None
         self.hidden_states: List[List[float]] = []
         self.hidden_states_tensor = None  # Note: use tensor instead of list to transfer hidden_states when PD + MTP
         self.output_topk_p = None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2402,6 +2402,7 @@ class Scheduler(
                 top_logprobs_num=recv_req.top_logprobs_num,
                 token_ids_logprob=recv_req.token_ids_logprob,
                 return_sampling_mask=recv_req.return_sampling_mask,
+                sampling_mask_mode=recv_req.sampling_mask_mode,
                 return_flat_raw_top_logprobs=recv_req.return_flat_raw_top_logprobs,
                 stream=recv_req.stream,
                 lora_id=recv_req.lora_id,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -292,7 +292,6 @@ from sglang.srt.runtime_context import (
     publish,
 )
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
-from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.server_args import PortArgs, ServerArgs
 from sglang.srt.session.session_controller import SessionController
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
@@ -2534,19 +2533,6 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        uses_top_k_or_top_p_truncation = (
-            req.sampling_params.top_k != TOP_K_ALL or req.sampling_params.top_p < 1.0
-        )
-        if req.return_sampling_mask and not uses_top_k_or_top_p_truncation:
-            error_msg = (
-                "return_sampling_mask cannot return the full vocabulary; set "
-                "top_p < 1 or a finite top_k."
-            )
-            req.set_finish_with_abort(error_msg)
-            self.init_req_max_new_tokens(req)
-            self._add_request_to_queue(req)
-            return
-
         if req.return_sampling_mask and not self.spec_algorithm.is_none():
             # Spec workers do not emit one sampling support per accepted token, so
             # the returned mask would not align 1:1 with generated tokens. Reject
@@ -2559,12 +2545,14 @@ class Scheduler(
             self._add_request_to_queue(req)
             return
 
-        if req.return_sampling_mask and get_exec().kernel.sampling_backend == "ascend":
-            # The ascend backend samples from logits directly and never builds the
-            # top-k/top-p support, so it cannot produce a sampling mask.
+        sampling_backend = get_exec().kernel.sampling_backend
+        if req.return_sampling_mask and (
+            use_mlx() or sampling_backend not in {"flashinfer", "pytorch"}
+        ):
+            unsupported_backend = "mlx" if use_mlx() else sampling_backend
             error_msg = (
-                "return_sampling_mask is not supported with the ascend "
-                "sampling backend."
+                "return_sampling_mask is not supported with the "
+                f"{unsupported_backend} sampling backend."
             )
             req.set_finish_with_abort(error_msg)
             self.init_req_max_new_tokens(req)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Callable,
@@ -15,7 +16,10 @@ import torch
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskStatus,
+)
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_MATCHED_TOKEN,
@@ -223,6 +227,11 @@ class SchedulerBatchResultProcessor:
             # Move next_token_ids and logprobs to cpu
             next_token_ids = next_token_ids.tolist()
             self.move_logprobs_to_cpu(batch=batch, logits_output=logits_output)
+            if (
+                logits_output is not None
+                and logits_output.sampling_mask_output is not None
+            ):
+                self.materialize_sampling_mask_output(batch.reqs, logits_output)
 
             self._validate_pp_skip_output_comm(batch, result)
 
@@ -236,6 +245,19 @@ class SchedulerBatchResultProcessor:
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
+                should_commit_output = (
+                    not req.finished()
+                    and not req.is_retracted
+                    and req.inflight_middle_chunks <= 0
+                )
+                sampling_mask_finish_reason = None
+                if should_commit_output and req.return_sampling_mask:
+                    assert logits_output is not None
+                    statuses = logits_output.next_token_sampling_mask_status
+                    status = None if statuses is None else statuses[i]
+                    sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
+                        status=status
+                    )
                 if (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
@@ -248,9 +270,7 @@ class SchedulerBatchResultProcessor:
                         capture_hidden_mode=prefill_hidden_capture_mode,
                         extend_input_len=extend_input_len_per_req[i],
                         store=(
-                            not req.finished()
-                            and not req.is_retracted
-                            and req.inflight_middle_chunks <= 0
+                            should_commit_output and sampling_mask_finish_reason is None
                         ),
                     )
 
@@ -265,23 +285,30 @@ class SchedulerBatchResultProcessor:
                 if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
 
-                    # req output_ids are set here
-                    req.output_ids.append(next_token_id)
-
-                    self._maybe_update_reasoning_tokens(req, next_token_id)
-
-                    req.update_finish_state()
+                    if sampling_mask_finish_reason is not None:
+                        req.to_finish = sampling_mask_finish_reason
+                        req.update_finish_state(0)
+                    else:
+                        req.output_ids.append(next_token_id)
+                        self._maybe_update_reasoning_tokens(req, next_token_id)
+                        req.update_finish_state()
                     if req.finished():
-                        self._maybe_collect_routed_experts(req)
-                        self._maybe_collect_indexer_topk(req)
-                        release_kv_cache(req, self.tree_cache)
+                        if sampling_mask_finish_reason is None:
+                            self._maybe_collect_routed_experts(req)
+                            self._maybe_collect_indexer_topk(req)
+                        release_kv_cache(
+                            req,
+                            self.tree_cache,
+                            is_insert=sampling_mask_finish_reason is None,
+                        )
                         req.time_stats.set_completion_time()
                     elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                         maybe_cache_unfinished_req(req, self.tree_cache)
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
-                    self._maybe_collect_customized_info(i, req, logits_output)
+                    if sampling_mask_finish_reason is None:
+                        self._maybe_collect_customized_info(i, req, logits_output)
 
                     if batch.return_logprob:
                         logprob_pt = self._apply_prefill_logprobs(
@@ -292,7 +319,11 @@ class SchedulerBatchResultProcessor:
                             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
                             next_token_ids=next_token_ids,
                             logprob_pt=logprob_pt,
+                            store=sampling_mask_finish_reason is None,
                         )
+
+                    if sampling_mask_finish_reason is not None:
+                        continue
 
                     if req.return_sampling_mask:
                         self.add_sampling_mask_return_values(i, req, logits_output)
@@ -431,7 +462,9 @@ class SchedulerBatchResultProcessor:
         extend_logprob_start_len_per_req: Optional[List[int]],
         next_token_ids: List[int],
         logprob_pt: int,
+        store: bool = True,
     ) -> int:
+        """Advance the logprob cursor, optionally storing this request's values."""
         assert extend_logprob_start_len_per_req is not None
         assert extend_input_len_per_req is not None
         extend_logprob_start_len = extend_logprob_start_len_per_req[i]
@@ -443,7 +476,7 @@ class SchedulerBatchResultProcessor:
             extend_logprob_start_len,
         )
 
-        if req.return_logprob:
+        if store and req.return_logprob:
             self.logprob_result_processor.add_logprob_return_values(
                 i,
                 req,
@@ -821,6 +854,8 @@ class SchedulerBatchResultProcessor:
             result.next_token_ids,
             result.can_run_cuda_graph,
         )
+        if logits_output.sampling_mask_output is not None:
+            self.materialize_sampling_mask_output(batch.reqs, logits_output)
 
         next_token_ids, next_token_logprobs = self._normalize_decode_outputs(
             batch=batch,
@@ -859,12 +894,26 @@ class SchedulerBatchResultProcessor:
             next_token_id = next_token_ids[i]
             is_spec = not batch.spec_algorithm.is_none()
 
-            req.output_ids.extend(next_token_id)
-            new_accept_len = len(next_token_id)
-
-            self._maybe_update_reasoning_tokens(req, next_token_id)
             req.time_stats.set_last_decode_finish_time()
+            sampling_mask_finish_reason = None
+            if req.return_sampling_mask:
+                statuses = logits_output.next_token_sampling_mask_status
+                status = None if statuses is None else statuses[i]
+                sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
+                    status=status
+                )
+            if sampling_mask_finish_reason is not None:
+                req.to_finish = sampling_mask_finish_reason
+                new_accept_len = 0
+            else:
+                req.output_ids.extend(next_token_id)
+                new_accept_len = len(next_token_id)
+                self._maybe_update_reasoning_tokens(req, next_token_id)
             req.update_finish_state(new_accept_len)
+
+            if sampling_mask_finish_reason is not None:
+                self._handle_sampling_mask_abort(req)
+                continue
 
             self._handle_finish_state_updated_req(req, batch, result, i, logits_output)
 
@@ -1007,6 +1056,87 @@ class SchedulerBatchResultProcessor:
         req.output_token_sampling_logprobs.append(
             None if logprobs is None else logprobs[i]
         )
+
+    @staticmethod
+    def materialize_sampling_mask_output(
+        reqs: List[Req],
+        output: Optional[LogitsProcessorOutput],
+    ) -> None:
+        """Convert opted-in tensor rows to batch-aligned Python results."""
+        if output is None or output.sampling_mask_output is None:
+            return
+
+        sampling_output = output.sampling_mask_output
+        batch_indices = [i for i, req in enumerate(reqs) if req.return_sampling_mask]
+        lengths = sampling_output.lengths.tolist()
+        selected_logprobs = sampling_output.selected_logprobs.tolist()
+        statuses = sampling_output.statuses.tolist()
+        assert len(batch_indices) == len(lengths)
+
+        batch_size = len(reqs)
+        masks = [None] * batch_size
+        logprobs = [None] * batch_size
+        status_by_batch = [None] * batch_size
+        packed_width = sampling_output.token_ids.shape[1]
+        for row, batch_index in enumerate(batch_indices):
+            status = int(statuses[row])
+            length = int(lengths[row])
+            if status in (SamplingMaskStatus.OK, SamplingMaskStatus.TRUNCATED) and not (
+                0 <= length <= packed_width
+            ):
+                status = SamplingMaskStatus.INVALID
+            status_by_batch[batch_index] = status
+            if status in (SamplingMaskStatus.OK, SamplingMaskStatus.TRUNCATED):
+                masks[batch_index] = sampling_output.token_ids[row, :length].tolist()
+                logprobs[batch_index] = float(selected_logprobs[row])
+
+        output.next_token_sampling_mask_idx = masks
+        output.next_token_sampling_logprobs = logprobs
+        output.next_token_sampling_mask_status = status_by_batch
+        output.sampling_mask_output = None
+
+    def get_sampling_mask_finish_reason(
+        self,
+        *,
+        status: Optional[int],
+    ) -> Optional[FINISH_ABORT]:
+        if status == SamplingMaskStatus.OK:
+            return None
+        if status == SamplingMaskStatus.TRUNCATED:
+            return FINISH_ABORT(
+                "Sampling support exceeds --sampling-mask-max-tokens="
+                f"{self.server_args.sampling_mask_max_tokens}. Adjust top_k, "
+                "top_p, or min_p to reduce support, or increase the server limit.",
+                HTTPStatus.BAD_REQUEST,
+                "BadRequestError",
+            )
+        if status is None:
+            return FINISH_ABORT(
+                "The sampling backend did not return captured sampling support.",
+                HTTPStatus.INTERNAL_SERVER_ERROR,
+                "InternalServerError",
+            )
+        assert status == SamplingMaskStatus.INVALID
+        return FINISH_ABORT(
+            "The sampling backend selected a token outside its captured sampling "
+            "support.",
+            HTTPStatus.INTERNAL_SERVER_ERROR,
+            "InternalServerError",
+        )
+
+    def _handle_sampling_mask_abort(self, req: Req) -> None:
+        """Release a request whose sampled token must not be committed."""
+        if req.multimodal_inputs is not None and req.session is None:
+            req.multimodal_inputs.release_features()
+        if get_memory().enable_hisparse:
+            self.hisparse_coordinator.request_finished(req)
+        prepare_release = getattr(
+            self.model_worker, "prepare_for_kv_cache_release", None
+        )
+        if callable(prepare_release):
+            prepare_release(req)
+        release_kv_cache(req, self.tree_cache, is_insert=False)
+        req.time_stats.set_completion_time()
 
     def _handle_finish_state_updated_req(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -24,6 +24,7 @@ from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_MATCHED_TOKEN,
     Req,
+    SamplingMaskMode,
     ScheduleBatch,
     mamba_lazy_spec_in_window,
 )
@@ -256,7 +257,8 @@ class SchedulerBatchResultProcessor:
                     statuses = logits_output.next_token_sampling_mask_status
                     status = None if statuses is None else statuses[i]
                     sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
-                        status=status
+                        status=status,
+                        mode=req.sampling_mask_mode,
                     )
                 if (
                     batch.return_hidden_states
@@ -900,7 +902,8 @@ class SchedulerBatchResultProcessor:
                 statuses = logits_output.next_token_sampling_mask_status
                 status = None if statuses is None else statuses[i]
                 sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
-                    status=status
+                    status=status,
+                    mode=req.sampling_mask_mode,
                 )
             if sampling_mask_finish_reason is not None:
                 req.to_finish = sampling_mask_finish_reason
@@ -1052,9 +1055,13 @@ class SchedulerBatchResultProcessor:
         """Attach sparse sampling support metadata to the return values."""
         mask = output.next_token_sampling_mask_idx
         logprobs = output.next_token_sampling_logprobs
+        statuses = output.next_token_sampling_mask_status
         req.output_token_sampling_mask.append(None if mask is None else mask[i])
         req.output_token_sampling_logprobs.append(
             None if logprobs is None else logprobs[i]
+        )
+        req.output_token_sampling_mask_truncated.append(
+            statuses is not None and statuses[i] == SamplingMaskStatus.TRUNCATED
         )
 
     @staticmethod
@@ -1099,14 +1106,18 @@ class SchedulerBatchResultProcessor:
         self,
         *,
         status: Optional[int],
+        mode: SamplingMaskMode,
     ) -> Optional[FINISH_ABORT]:
         if status == SamplingMaskStatus.OK:
             return None
         if status == SamplingMaskStatus.TRUNCATED:
+            if mode == "bounded":
+                return None
             return FINISH_ABORT(
                 "Sampling support exceeds --sampling-mask-max-tokens="
                 f"{self.server_args.sampling_mask_max_tokens}. Adjust top_k, "
-                "top_p, or min_p to reduce support, or increase the server limit.",
+                "top_p, or min_p to reduce support, increase the server limit, "
+                "or set sampling_mask_mode='bounded' to return a truncated mask.",
                 HTTPStatus.BAD_REQUEST,
                 "BadRequestError",
             )

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -326,6 +326,7 @@ class _GenerationStreamAccumulator:
     output_token_ids_logprobs_idx: Optional[list] = None
     output_token_sampling_mask: Optional[list] = None
     output_token_sampling_logprobs: Optional[list] = None
+    output_token_sampling_mask_truncated: Optional[list] = None
     # Rust server mode: the Rust detokenizer reconstructs text/ids from the raw
     # output tokens itself and never consumes the scheduler's incremental-detok
     # offsets (decode_ids / read_offset), so that per-step bookkeeping is skipped.
@@ -358,6 +359,7 @@ class _GenerationStreamAccumulator:
         if self.return_sampling_mask:
             self.output_token_sampling_mask = []
             self.output_token_sampling_logprobs = []
+            self.output_token_sampling_mask_truncated = []
 
     def accept(self, *, req: Req) -> None:
         if req.finished():
@@ -557,10 +559,16 @@ class _GenerationStreamAccumulator:
                         send_output_sampling_mask_offset:sampling_mask_end
                     ]
                 )
+                self.output_token_sampling_mask_truncated.append(
+                    req.output_token_sampling_mask_truncated[
+                        send_output_sampling_mask_offset:sampling_mask_end
+                    ]
+                )
                 req.send_output_sampling_mask_offset = sampling_mask_end
             else:
                 self.output_token_sampling_mask.append([])
                 self.output_token_sampling_logprobs.append([])
+                self.output_token_sampling_mask_truncated.append([])
 
         if self.return_hidden_states:
             if req.return_hidden_states:
@@ -670,6 +678,9 @@ class _GenerationStreamAccumulator:
             output_token_entropy_val=None,
             output_token_sampling_mask=self.output_token_sampling_mask,
             output_token_sampling_logprobs=self.output_token_sampling_logprobs,
+            output_token_sampling_mask_truncated=(
+                self.output_token_sampling_mask_truncated
+            ),
             output_hidden_states=self.output_hidden_states,
             routed_experts=self.routed_experts,
             indexer_topk=self.indexer_topk,

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1020,11 +1020,15 @@ class SchedulerPPMixin:
             "next_token_ids": result.next_token_ids,
         }
 
-        if batch.return_logprob:
-            logprob_dict = get_logprob_dict_from_result(result)
+        has_sampling_mask_output = (
+            result.logits_output is not None
+            and result.logits_output.sampling_mask_output is not None
+        )
+        if batch.return_logprob or has_sampling_mask_output:
+            logits_output_dict = get_logprob_dict_from_result(result)
             tensor_dict = {
                 **tensor_dict,
-                **logprob_dict,
+                **logits_output_dict,
             }
         return tensor_dict
 
@@ -1144,7 +1148,10 @@ class SchedulerPPMixin:
         extend_input_len_per_req = None
         extend_logprob_start_len_per_req = None
 
-        if batch.return_logprob:
+        if (
+            batch.return_logprob
+            or pp_outputs.tensors.get("sampling_mask_token_ids") is not None
+        ):
             (
                 logits_output,
                 extend_input_len_per_req,
@@ -1266,7 +1273,17 @@ class SchedulerPPMixin:
                     target, mb_metadata[next_mb_id], next_pp_outputs
                 )
                 d2h_event = self.device_module.Event()
-                d2h_event.record(self.device_module.current_stream())
+                if (
+                    batch_result.logits_output is not None
+                    and batch_result.logits_output.sampling_mask_output is not None
+                ):
+                    batch_result.copy_done = d2h_event
+                    batch_result.copy_to_cpu(
+                        return_logprob=target.return_logprob,
+                        return_hidden_states=False,
+                    )
+                else:
+                    d2h_event.record(self.device_module.current_stream())
 
         if send_first:
             send_output_work = _do_send()

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -194,6 +194,7 @@ _INCREMENTAL_STREAMING_META_INFO_KEYS = (
     "output_token_ids_logprobs",
     "output_token_sampling_mask",
     "output_token_sampling_logprobs",
+    "output_token_sampling_mask_truncated",
 )
 
 
@@ -254,6 +255,9 @@ class ReqState:
     output_token_ids_logprobs_idx: List = dataclasses.field(default_factory=list)
     output_token_sampling_mask: List = dataclasses.field(default_factory=list)
     output_token_sampling_logprobs: List = dataclasses.field(default_factory=list)
+    output_token_sampling_mask_truncated: List[bool] = dataclasses.field(
+        default_factory=list
+    )
 
     # Cached flat-format prompt top logprob fields; rebuilt only when more
     # prefill chunks arrive, so streaming decode chunks reuse the payload.
@@ -1412,6 +1416,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 top_logprobs_num=obj.top_logprobs_num,
                 token_ids_logprob=obj.token_ids_logprob,
                 return_sampling_mask=obj.return_sampling_mask,
+                sampling_mask_mode=obj.sampling_mask_mode,
                 return_flat_raw_top_logprobs=obj.return_flat_raw_top_logprobs,
                 stream=obj.stream,
                 rid=obj.rid,
@@ -2277,6 +2282,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         state.output_token_sampling_logprobs.extend(
                             output_sampling_logprobs[i]
                         )
+                    output_sampling_mask_truncated = (
+                        recv_obj.output_token_sampling_mask_truncated
+                    )
+                    if output_sampling_mask_truncated is not None:
+                        state.output_token_sampling_mask_truncated.extend(
+                            output_sampling_mask_truncated[i]
+                        )
                     meta_info["output_token_sampling_mask"] = (
                         state.output_token_sampling_mask
                     )
@@ -2285,6 +2297,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     )
                     meta_info["output_token_sampling_mask_length"] = len(
                         state.output_token_sampling_mask
+                    )
+                    meta_info["output_token_sampling_mask_truncated"] = (
+                        state.output_token_sampling_mask_truncated
                     )
 
             if not isinstance(recv_obj, BatchEmbeddingOutput):

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -11,7 +11,10 @@ import torch
 
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.eplb.expert_distribution import ExpertDistributionMetrics
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskOutput,
+)
 from sglang.srt.managers import io_struct
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
@@ -162,7 +165,13 @@ class GenerationBatchResult:
         # Sub-objects only declare their device fields; the single copy+safety
         # primitive (_async_d2h: pinned D2H + record_stream) is injected here so
         # all device->host copying and lifetime safety lives in one place.
+        sampling_mask_output = (
+            self.logits_output.sampling_mask_output
+            if self.logits_output is not None
+            else None
+        )
         for holder in (
+            sampling_mask_output,
             self.routed_experts_output,
             self.indexer_topk_output,
             self.expert_distribution_metrics,
@@ -224,9 +233,11 @@ def validate_input_length(
 
 
 def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
+    """Build the tensor payload needed to reconstruct PP output processing state."""
 
     logits_output = result.logits_output
     assert logits_output is not None
+    sampling_mask_output = logits_output.sampling_mask_output
 
     return {
         "extend_input_len_per_req": result.extend_input_len_per_req,
@@ -236,8 +247,20 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
         "next_token_top_logprobs_idx": result.logits_output.next_token_top_logprobs_idx,
         "next_token_token_ids_logprobs_val": result.logits_output.next_token_token_ids_logprobs_val,
         "next_token_token_ids_logprobs_idx": result.logits_output.next_token_token_ids_logprobs_idx,
-        "next_token_sampling_mask_idx": result.logits_output.next_token_sampling_mask_idx,
-        "next_token_sampling_logprobs": result.logits_output.next_token_sampling_logprobs,
+        "sampling_mask_token_ids": (
+            None if sampling_mask_output is None else sampling_mask_output.token_ids
+        ),
+        "sampling_mask_lengths": (
+            None if sampling_mask_output is None else sampling_mask_output.lengths
+        ),
+        "sampling_mask_selected_logprobs": (
+            None
+            if sampling_mask_output is None
+            else sampling_mask_output.selected_logprobs
+        ),
+        "sampling_mask_statuses": (
+            None if sampling_mask_output is None else sampling_mask_output.statuses
+        ),
         "input_token_logprobs": result.logits_output.input_token_logprobs,
         "input_top_logprobs_val": result.logits_output.input_top_logprobs_val,
         "input_top_logprobs_idx": result.logits_output.input_top_logprobs_idx,
@@ -249,6 +272,15 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
 def get_logprob_from_pp_outputs(
     next_pp_outputs: PPProxyTensors,
 ) -> tuple[LogitsProcessorOutput, list[int], list[int]]:
+    """Reconstruct output processing state received from the last PP stage."""
+    sampling_mask_output = None
+    if next_pp_outputs["sampling_mask_token_ids"] is not None:
+        sampling_mask_output = SamplingMaskOutput(
+            token_ids=next_pp_outputs["sampling_mask_token_ids"],
+            lengths=next_pp_outputs["sampling_mask_lengths"],
+            selected_logprobs=next_pp_outputs["sampling_mask_selected_logprobs"],
+            statuses=next_pp_outputs["sampling_mask_statuses"],
+        )
     logits_output = LogitsProcessorOutput(
         # Do not send logits and hidden states because they are large
         next_token_logits=None,
@@ -262,8 +294,7 @@ def get_logprob_from_pp_outputs(
         next_token_token_ids_logprobs_idx=next_pp_outputs[
             "next_token_token_ids_logprobs_idx"
         ],
-        next_token_sampling_mask_idx=next_pp_outputs["next_token_sampling_mask_idx"],
-        next_token_sampling_logprobs=next_pp_outputs["next_token_sampling_logprobs"],
+        sampling_mask_output=sampling_mask_output,
         input_token_logprobs=next_pp_outputs["input_token_logprobs"],
         input_top_logprobs_val=next_pp_outputs["input_top_logprobs_val"],
         input_top_logprobs_idx=next_pp_outputs["input_top_logprobs_idx"],

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -473,6 +473,19 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
             )
             return
 
+        if not is_insert:
+            # The protected prefix is owned by the cache. Release every KV slot
+            # owned by the request, including slots without a committed token id.
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, req.cache_protected_len : kv_len_to_handle
+            ]
+            self.token_to_kv_pool_allocator.free_segment(
+                kv_indices, start_pos=req.cache_protected_len
+            )
+            if req.last_node is not None:
+                self.dec_lock_ref(req.last_node)
+            return
+
         token_ids = (req.origin_input_ids + req.output_ids)[:kv_len_to_handle]
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, : len(token_ids)
@@ -488,14 +501,11 @@ class RadixCache(KVCacheEventMixin, BasePrefixCache):
         values = kv_indices[:key_len].to(dtype=torch.int64, copy=True)
 
         # Radix Cache takes one ref in memory pool
-        if is_insert:
-            priority = getattr(req, "priority", 0) or 0
-            result = self.insert(
-                InsertParams(key=radix_key, value=values, priority=priority)
-            )
-            freed_end = result.prefix_len
-        else:
-            freed_end = key_len
+        priority = getattr(req, "priority", 0) or 0
+        result = self.insert(
+            InsertParams(key=radix_key, value=values, priority=priority)
+        )
+        freed_end = result.prefix_len
 
         # duplicates / uninserted range, then the unaligned tail
         self.token_to_kv_pool_allocator.free_segments(

--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -73,9 +73,10 @@ class SamplingBatchInfo:
     # Used for deterministic sampling
     sampling_seed: Optional[torch.Tensor] = None
 
-    # Per-request flag for returning sparse sampling support metadata.
+    # CPU request flags and their derived device indices. The flags make batch
+    # filtering cheap; the indices keep sampler work limited to opted-in rows.
     return_sampling_masks: Optional[List[bool]] = None
-    sampling_mask_max_top_k: int = 0
+    sampling_mask_batch_indices: Optional[torch.Tensor] = None
 
     # Device
     device: str = "cuda"
@@ -145,9 +146,8 @@ class SamplingBatchInfo:
             and any(r.custom_logit_processor for r in reqs)  # check the flag first.
         )  # then check the requests.
         return_sampling_masks = [r.return_sampling_mask for r in reqs]
-        sampling_mask_max_top_k = max(
-            (r.sampling_params.top_k for r in reqs if r.return_sampling_mask),
-            default=0,
+        sampling_mask_batch_indices = cls._make_sampling_mask_batch_indices(
+            return_sampling_masks, device
         )
 
         if has_custom_logit_processor:
@@ -214,7 +214,7 @@ class SamplingBatchInfo:
             device=device,
             logit_bias=logit_bias,
             return_sampling_masks=return_sampling_masks,
-            sampling_mask_max_top_k=sampling_mask_max_top_k,
+            sampling_mask_batch_indices=sampling_mask_batch_indices,
         )
         ret.adjusted_from_schedule_batch(batch, vocab_size)
         return ret
@@ -232,6 +232,22 @@ class SamplingBatchInfo:
         self, keep_indices: List[int], keep_indices_device: torch.Tensor
     ):
         pass
+
+    @staticmethod
+    def _make_sampling_mask_batch_indices(
+        return_sampling_masks: List[bool], device: str
+    ) -> Optional[torch.Tensor]:
+        """Build device row indices for requests that return sampling masks."""
+        indices = [
+            i for i, should_return in enumerate(return_sampling_masks) if should_return
+        ]
+        if not indices:
+            return None
+        return torch.tensor(
+            indices,
+            dtype=torch.long,
+            pin_memory=is_pin_memory_available(device),
+        ).to(device, non_blocking=True)
 
     def __len__(self):
         return len(self.temperatures)
@@ -322,6 +338,12 @@ class SamplingBatchInfo:
             self.return_sampling_masks = [
                 self.return_sampling_masks[i] for i in keep_indices
             ]
+            if self.sampling_mask_batch_indices is not None:
+                self.sampling_mask_batch_indices = (
+                    self._make_sampling_mask_batch_indices(
+                        self.return_sampling_masks, self.device
+                    )
+                )
 
         self.adjusted_filter_batch(keep_indices, keep_indices_device)
 
@@ -420,12 +442,23 @@ class SamplingBatchInfo:
             self.return_sampling_masks is not None
             or other.return_sampling_masks is not None
         ):
+            if other.sampling_mask_batch_indices is not None:
+                other_sampling_mask_batch_indices = (
+                    other.sampling_mask_batch_indices + self_len
+                )
+                self.sampling_mask_batch_indices = (
+                    other_sampling_mask_batch_indices
+                    if self.sampling_mask_batch_indices is None
+                    else torch.cat(
+                        [
+                            self.sampling_mask_batch_indices,
+                            other_sampling_mask_batch_indices,
+                        ]
+                    )
+                )
             self.return_sampling_masks = (
                 self.return_sampling_masks or [False] * self_len
             ) + (other.return_sampling_masks or [False] * other_len)
-            self.sampling_mask_max_top_k = max(
-                self.sampling_mask_max_top_k, other.sampling_mask_max_top_k
-            )
 
         # Note: because the __len()__ operator is defined on the temperatures tensor,
         # please make sure any merge operation with len(self) or len(other) is done before

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3508,7 +3508,8 @@ class ServerArgs:
     sampling_mask_max_tokens: A[
         int,
         "The maximum number of token IDs in a returned sampling mask. Requests "
-        "are aborted if their realized sampling support exceeds this limit.",
+        "using sampling_mask_mode='exact' abort if their realized support "
+        "exceeds this limit; 'bounded' requests return a truncated mask.",
         NS("exec.features"),
     ] = 4096
     disable_outlines_disk_cache: A[

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3505,6 +3505,12 @@ class ServerArgs:
         "Enable returning indexer topk indices of layers with indexer with responses.",
         NS("exec.features"),
     ] = False
+    sampling_mask_max_tokens: A[
+        int,
+        "The maximum number of token IDs in a returned sampling mask. Requests "
+        "are aborted if their realized sampling support exceeds this limit.",
+        NS("exec.features"),
+    ] = 4096
     disable_outlines_disk_cache: A[
         bool,
         "Disable disk cache of outlines to avoid possible crashes related to file system or high concurrency.",
@@ -8515,6 +8521,21 @@ class ServerArgs:
             )
 
     def _handle_other_validations(self):
+        if self.sampling_mask_max_tokens <= 0:
+            raise ValueError(
+                "--sampling-mask-max-tokens must be positive "
+                f"(got {self.sampling_mask_max_tokens})."
+            )
+        if self.disaggregation_mode != "null":
+            disagg_sampling_mask_capacity = (
+                envs.SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS.get()
+            )
+            if disagg_sampling_mask_capacity > 0:
+                self.sampling_mask_max_tokens = min(
+                    self.sampling_mask_max_tokens,
+                    disagg_sampling_mask_capacity,
+                )
+
         if self.default_chat_template_kwargs is not None and not isinstance(
             self.default_chat_template_kwargs, dict
         ):

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -303,6 +303,7 @@ class Session:
             top_logprobs_num=req.top_logprobs_num,
             token_ids_logprob=req.token_ids_logprob,
             return_sampling_mask=req.return_sampling_mask,
+            sampling_mask_mode=req.sampling_mask_mode,
             vocab_size=vocab_size,
             eos_token_ids=eos_token_ids,
             require_reasoning=req.require_reasoning,

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -20,10 +20,13 @@ _MAX_NEW_TOKENS = 4
 _TOP_P = 0.99
 _TOP_P_SMALL = 1e-5
 _TOP_K = 10
+_SAMPLING_MASK_MAX_TOKENS = 16
 _SAMPLING_SEED = 1234
 _SERVER_ARGS = (
     "--mem-fraction-static",
     "0.7",
+    "--sampling-mask-max-tokens",
+    str(_SAMPLING_MASK_MAX_TOKENS),
 )
 
 
@@ -41,7 +44,8 @@ class SamplingMaskTestMixin:
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        if hasattr(cls, "process") and cls.process:
+            kill_process_tree(cls.process.pid)
 
     def _post_generate(
         self,
@@ -95,12 +99,10 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 "ignore_eos": True,
             }
         )
-        # The mask keeps at most top_k tokens, plus possibly the actually
-        # sampled token when the sampling kernel picks one just outside the
-        # mask's topk reconstruction (fp cumsum divergence); see
-        # Sampler._attach_sampling_mask_to_output.
+        # SGLang's sampling primitives retain ties at their threshold, so
+        # top-k can realize more than k support entries.
         for sampling_mask in top_p_sampling_masks:
-            self.assertLessEqual(len(sampling_mask), _TOP_K + 1)
+            self.assertLessEqual(len(sampling_mask), _SAMPLING_MASK_MAX_TOKENS)
 
         top_k_sampling_masks = self._generate_sampling_masks(
             {
@@ -111,7 +113,8 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_sampling_masks:
-            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
+            self.assertGreaterEqual(len(sampling_mask), _TOP_K)
+            self.assertLessEqual(len(sampling_mask), _SAMPLING_MASK_MAX_TOKENS)
 
         top_k_top_p_one_sampling_masks = self._generate_sampling_masks(
             {
@@ -123,15 +126,17 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_top_p_one_sampling_masks:
-            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
+            self.assertGreaterEqual(len(sampling_mask), _TOP_K)
+            self.assertLessEqual(len(sampling_mask), _SAMPLING_MASK_MAX_TOKENS)
 
     def test_sampling_mask_matches_topk_logprobs(self):
-        """Check the returned mask and its renormalized logprobs.
+        """Check an uncapped mask and its selected-token logprobs.
 
         We get the per-token full-vocab logprobs via ``return_logprob`` with
-        ``top_logprobs_num == top_k``, which covers every token the mask can
-        contain. With ``temperature=1.0`` these are the sampler's distribution,
-        so ``p = exp(logprob)`` are the exact probabilities. For each token, we check:
+        ``top_logprobs_num == sampling_mask_max_tokens``, which covers every token
+        in this mask because ``top_k`` is below the cap. With ``temperature=1.0``
+        these are the sampler's distribution, so ``p = exp(logprob)`` are the
+        exact probabilities. For each token, we check:
 
         1. the returned mask matches the nucleus reconstructed from those probs,
         2. sampling_logprob == log(p[sampled] / sum(p[t] for t in mask)).
@@ -146,7 +151,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 "ignore_eos": True,
             },
             return_logprob=True,
-            top_logprobs_num=top_k,
+            top_logprobs_num=_SAMPLING_MASK_MAX_TOKENS,
         )
         self.assertEqual(response.status_code, 200, response.text)
 
@@ -168,17 +173,24 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 int(tid): math.exp(logprob) for logprob, tid, _ in step_top_logprobs
             }
 
-            reconstructed = []
+            ranked = [
+                (math.exp(logprob), int(tid)) for logprob, tid, _ in step_top_logprobs
+            ]
+            top_k_threshold = ranked[top_k - 1][0]
             mass_before = 0.0
-            for logprob, tid, _ in step_top_logprobs:
+            top_p_threshold = ranked[-1][0]
+            for prob, _ in ranked:
                 if mass_before <= top_p:
-                    reconstructed.append(int(tid))
-                mass_before += math.exp(logprob)
-            if output_id not in reconstructed:
-                reconstructed.append(output_id)
+                    top_p_threshold = prob
+                mass_before += prob
+            reconstructed = {
+                tid
+                for prob, tid in ranked
+                if prob >= top_k_threshold and prob >= top_p_threshold
+            }
             # ``<= 1``: fp32 (server) and fp64 (here) cumsums may split on the
             # single token straddling the top_p cut.
-            self.assertLessEqual(len(set(mask) ^ set(reconstructed)), 1)
+            self.assertLessEqual(len(set(mask) ^ reconstructed), 1)
 
             support_mass = sum(probs[tid] for tid in mask)
             expected_logprob = math.log(probs[output_id] / support_mass)
@@ -224,19 +236,31 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
         for output_id, sampling_mask in zip(output_ids, sampling_masks):
             self.assertIn(output_id, sampling_mask)
 
-    def test_generate_rejects_full_vocabulary_sampling_mask(self):
+    def test_top_p_only_support_above_capacity_is_rejected(self):
+        sampling_params = {
+            "temperature": 1.0,
+            "top_p": _TOP_P,
+            "max_new_tokens": _MAX_NEW_TOKENS,
+            "ignore_eos": True,
+        }
+
+        response = self._post_generate(sampling_params)
+        self.assertEqual(response.status_code, 400, response.text)
+        self.assertIn("sampling-mask-max-tokens", response.text)
+
+    def test_support_above_capacity_is_rejected(self):
+        sampling_params = {
+            "temperature": 1.0,
+            "top_k": _SAMPLING_MASK_MAX_TOKENS + 1,
+            "max_new_tokens": _MAX_NEW_TOKENS,
+            "ignore_eos": True,
+        }
+
         response = self._post_generate(
-            {
-                "temperature": 1.0,
-                "top_p": 1.0,
-                "max_new_tokens": _MAX_NEW_TOKENS,
-                "ignore_eos": True,
-            }
+            sampling_params,
         )
         self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn(
-            "return_sampling_mask cannot return the full vocabulary", response.text
-        )
+        self.assertIn("sampling-mask-max-tokens", response.text)
 
 
 class TestSamplingMaskDeterministic(SamplingMaskTestMixin, CustomTestCase):

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -51,6 +51,7 @@ class SamplingMaskTestMixin:
         self,
         sampling_params,
         return_sampling_mask=True,
+        sampling_mask_mode=None,
         return_logprob=False,
         top_logprobs_num=0,
     ):
@@ -59,6 +60,8 @@ class SamplingMaskTestMixin:
             "sampling_params": sampling_params,
             "return_sampling_mask": return_sampling_mask,
         }
+        if sampling_mask_mode is not None:
+            payload["sampling_mask_mode"] = sampling_mask_mode
         if return_logprob:
             payload["return_logprob"] = True
             payload["top_logprobs_num"] = top_logprobs_num
@@ -72,6 +75,7 @@ class SamplingMaskTestMixin:
         meta_info = output["meta_info"]
         output_ids = output["output_ids"]
         sampling_masks = meta_info["output_token_sampling_mask"]
+        sampling_masks_truncated = meta_info["output_token_sampling_mask_truncated"]
 
         self.assertEqual(len(output_ids), _MAX_NEW_TOKENS)
         self.assertEqual(meta_info["completion_tokens"], len(output_ids))
@@ -79,6 +83,7 @@ class SamplingMaskTestMixin:
             meta_info["output_token_sampling_mask_length"], len(output_ids)
         )
         self.assertEqual(len(sampling_masks), len(output_ids))
+        self.assertEqual(sampling_masks_truncated, [False] * len(output_ids))
         for output_id, sampling_mask in zip(output_ids, sampling_masks):
             self.assertIn(output_id, sampling_mask)
         return sampling_masks
@@ -196,47 +201,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             expected_logprob = math.log(probs[output_id] / support_mass)
             self.assertAlmostEqual(mask_logprob, expected_logprob, delta=1e-2)
 
-    def test_generate_returns_top_p_only_sampling_mask(self):
-        self._generate_sampling_masks(
-            {
-                "temperature": 1.0,
-                "top_p": _TOP_P_SMALL,
-                "max_new_tokens": _MAX_NEW_TOKENS,
-                "ignore_eos": True,
-            }
-        )
-
-    def test_chat_completions_returns_top_p_only_sampling_mask(self):
-        response = requests.post(
-            self.base_url + "/v1/chat/completions",
-            json={
-                "model": self.model,
-                "messages": [{"role": "user", "content": "Name a capital city."}],
-                "temperature": 1.0,
-                "top_p": _TOP_P_SMALL,
-                "max_tokens": _MAX_NEW_TOKENS,
-                "ignore_eos": True,
-                "return_sampling_mask": True,
-                "return_meta_info": True,
-                "return_token_ids": True,
-            },
-            timeout=60,
-        )
-        self.assertEqual(response.status_code, 200, response.text)
-
-        choice = response.json()["choices"][0]
-        output_ids = choice["token_ids"]
-        meta_info = choice["meta_info"]
-        sampling_masks = meta_info["output_token_sampling_mask"]
-        sampling_logprobs = meta_info["output_token_sampling_logprobs"]
-
-        self.assertEqual(len(output_ids), _MAX_NEW_TOKENS)
-        self.assertEqual(len(sampling_masks), len(output_ids))
-        self.assertEqual(len(sampling_logprobs), len(output_ids))
-        for output_id, sampling_mask in zip(output_ids, sampling_masks):
-            self.assertIn(output_id, sampling_mask)
-
-    def test_top_p_only_support_above_capacity_is_rejected(self):
+    def test_top_p_only_support_uses_runtime_capacity(self):
         sampling_params = {
             "temperature": 1.0,
             "top_p": _TOP_P,
@@ -244,11 +209,27 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             "ignore_eos": True,
         }
 
-        response = self._post_generate(sampling_params)
-        self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn("sampling-mask-max-tokens", response.text)
+        exact_response = self._post_generate(sampling_params)
+        self.assertEqual(exact_response.status_code, 400, exact_response.text)
+        self.assertIn("sampling_mask_mode='bounded'", exact_response.text)
 
-    def test_support_above_capacity_is_rejected(self):
+        bounded_response = self._post_generate(
+            sampling_params, sampling_mask_mode="bounded"
+        )
+        self.assertEqual(bounded_response.status_code, 200, bounded_response.text)
+        output = bounded_response.json()
+        meta_info = output["meta_info"]
+        self.assertEqual(
+            meta_info["output_token_sampling_mask_truncated"],
+            [True] * len(output["output_ids"]),
+        )
+        for output_id, sampling_mask in zip(
+            output["output_ids"], meta_info["output_token_sampling_mask"]
+        ):
+            self.assertEqual(len(sampling_mask), _SAMPLING_MASK_MAX_TOKENS)
+            self.assertIn(output_id, sampling_mask)
+
+    def test_generate_requires_bounded_mode_to_truncate_sampling_mask(self):
         sampling_params = {
             "temperature": 1.0,
             "top_k": _SAMPLING_MASK_MAX_TOKENS + 1,
@@ -256,11 +237,39 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             "ignore_eos": True,
         }
 
-        response = self._post_generate(
+        exact_response = self._post_generate(sampling_params)
+        self.assertEqual(exact_response.status_code, 400, exact_response.text)
+        self.assertIn("sampling_mask_mode='bounded'", exact_response.text)
+
+        bounded_response = self._post_generate(
             sampling_params,
+            sampling_mask_mode="bounded",
+        )
+        self.assertEqual(bounded_response.status_code, 200, bounded_response.text)
+        output = bounded_response.json()
+        meta_info = output["meta_info"]
+        self.assertEqual(
+            meta_info["output_token_sampling_mask_truncated"],
+            [True] * len(output["output_ids"]),
+        )
+        for output_id, sampling_mask in zip(
+            output["output_ids"],
+            meta_info["output_token_sampling_mask"],
+        ):
+            self.assertEqual(len(sampling_mask), _SAMPLING_MASK_MAX_TOKENS)
+            self.assertIn(output_id, sampling_mask)
+
+    def test_generate_rejects_unknown_sampling_mask_mode(self):
+        response = self._post_generate(
+            {
+                "temperature": 1.0,
+                "top_k": _TOP_K,
+                "max_new_tokens": _MAX_NEW_TOKENS,
+            },
+            sampling_mask_mode="unknown",
         )
         self.assertEqual(response.status_code, 400, response.text)
-        self.assertIn("sampling-mask-max-tokens", response.text)
+        self.assertIn("sampling_mask_mode", response.text)
 
 
 class TestSamplingMaskDeterministic(SamplingMaskTestMixin, CustomTestCase):

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -38,6 +38,7 @@ from sglang.srt.speculative.eagle_disaggregation import (
     build_eagle_disagg_draft_input,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
@@ -254,26 +255,26 @@ class TestMooncakePPStaging(unittest.TestCase):
         )
 
 
-class TestEagleDsaSeedTransfer(unittest.TestCase):
-    @staticmethod
-    def _make_req(seed, metadata_buffer_index=0):
-        return SimpleNamespace(
-            metadata_buffer_index=metadata_buffer_index,
-            output_ids=[101],
-            cached_tokens=0,
-            cached_tokens_device=0,
-            cached_tokens_host=0,
-            cached_tokens_storage=0,
-            multimodal_inputs=None,
-            return_logprob=False,
-            return_sampling_mask=False,
-            hidden_states_tensor=torch.tensor([1.0, 2.0]),
-            output_topk_p=torch.tensor([1.0]),
-            output_topk_index=torch.tensor([7]),
-            output_dsa_topk_indices=seed,
-            bootstrap_room=9,
-        )
+def _make_metadata_req(seed, metadata_buffer_index=0):
+    return SimpleNamespace(
+        metadata_buffer_index=metadata_buffer_index,
+        output_ids=[101],
+        cached_tokens=0,
+        cached_tokens_device=0,
+        cached_tokens_host=0,
+        cached_tokens_storage=0,
+        multimodal_inputs=None,
+        return_logprob=False,
+        return_sampling_mask=False,
+        hidden_states_tensor=torch.tensor([1.0, 2.0]),
+        output_topk_p=torch.tensor([1.0]),
+        output_topk_index=torch.tensor([7]),
+        output_dsa_topk_indices=seed,
+        bootstrap_room=9,
+    )
 
+
+class TestEagleDsaSeedTransfer(CustomTestCase):
     def test_metadata_buffer_copies_seed_and_uses_invalid_sentinel(self):
         buffers = MetadataBuffers(
             size=2,
@@ -282,8 +283,8 @@ class TestEagleDsaSeedTransfer(unittest.TestCase):
             output_dsa_topk_indices_dim=3,
         )
         seed = torch.tensor([4, 5, 6], dtype=torch.int32)
-        buffers.set_buf(self._make_req(seed))
-        buffers.set_buf(self._make_req(None, metadata_buffer_index=1))
+        buffers.set_buf(_make_metadata_req(seed))
+        buffers.set_buf(_make_metadata_req(None, metadata_buffer_index=1))
 
         self.assertTrue(torch.equal(buffers.output_dsa_topk_indices[0], seed))
         self.assertEqual(buffers.output_dsa_topk_indices[1].tolist(), [-1, -1, -1])
@@ -298,7 +299,7 @@ class TestEagleDsaSeedTransfer(unittest.TestCase):
             torch.tensor([4, 5, 6], dtype=torch.int32),
         )
         batch = SimpleNamespace(
-            reqs=[self._make_req(seed) for seed in seeds],
+            reqs=[_make_metadata_req(seed) for seed in seeds],
             device="cpu",
             enable_overlap=False,
         )
@@ -340,7 +341,7 @@ class TestEagleDsaSeedTransfer(unittest.TestCase):
             dtype=torch.int32,
         )
         batch = SimpleNamespace(
-            reqs=[self._make_req(seed) for seed in wire_positions],
+            reqs=[_make_metadata_req(seed) for seed in wire_positions],
             device="cpu",
             enable_overlap=False,
             req_pool_indices=torch.tensor([3, 1], dtype=torch.int64),
@@ -391,6 +392,33 @@ class TestEagleDsaSeedTransfer(unittest.TestCase):
         )
         self.assertEqual(future_map.dsa_topk_indices_buf.shape, (4, 3))
         self.assertEqual(future_map.dsa_topk_indices_buf.dtype, torch.int32)
+
+
+class TestSamplingMaskMetadataTransfer(CustomTestCase):
+    def test_metadata_preserves_truncation(self):
+        buffers = MetadataBuffers(
+            size=1,
+            hidden_size=2,
+            hidden_states_dtype=torch.float32,
+            max_sampling_mask_tokens=3,
+        )
+        req = _make_metadata_req(None)
+        req.return_sampling_mask = True
+        req.output_token_sampling_mask = [[4, 7, 9]]
+        req.output_token_sampling_logprobs = [-1.25]
+        req.output_token_sampling_mask_truncated = [True]
+
+        buffers.set_buf(req)
+
+        metadata = buffers.output_token_sampling_mask_metadata[0]
+        self.assertEqual(int(metadata[0]), 3)
+        self.assertEqual(int(metadata[1]), 1)
+        self.assertEqual(
+            buffers.output_token_sampling_mask_idx[0, :3].tolist(), [4, 7, 9]
+        )
+        self.assertAlmostEqual(
+            float(buffers.output_token_sampling_logprobs[0, 0]), -1.25
+        )
 
 
 class TestDSV4C128StateIndices(unittest.TestCase):

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -161,6 +161,7 @@ class TestChatCompletionRequest(unittest.TestCase):
         self.assertEqual(request.temperature, None)  # default
         self.assertFalse(request.stream)  # default
         self.assertFalse(request.return_sampling_mask)
+        self.assertEqual(request.sampling_mask_mode, "exact")
         self.assertEqual(request.tool_choice, "none")  # default when no tools
 
     def test_image_content_hash_validation(self):

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -282,11 +282,13 @@ class ServingChatTestCase(unittest.TestCase):
             )
 
             self.basic_req.return_sampling_mask = True
+            self.basic_req.sampling_mask_mode = "bounded"
             self.basic_req.return_meta_info = True
             adapted, processed = self.chat._convert_to_internal_request(self.basic_req)
             self.assertIsInstance(adapted, GenerateReqInput)
             self.assertFalse(adapted.stream)
             self.assertTrue(adapted.return_sampling_mask)
+            self.assertEqual(adapted.sampling_mask_mode, "bounded")
             self.assertEqual(adapted.session_id, "session-1")
             self.assertEqual(processed, self.basic_req)
 

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock, patch
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler_components.batch_result_processor import (
     SchedulerBatchResultProcessor,
 )
@@ -131,6 +132,7 @@ class TestPrefillHiddenStateOffsets(CustomTestCase):
                     logits_output=SimpleNamespace(
                         hidden_states=hidden_states,
                         customized_info=None,
+                        sampling_mask_output=None,
                     ),
                     next_token_ids=torch.tensor([0, 1]),
                     extend_input_len_per_req=[2, 3],
@@ -158,6 +160,52 @@ class TestPrefillHiddenStateOffsets(CustomTestCase):
                 self.assertEqual(last.hidden_states, [[22.0]])
 
 
+class TestPrefillSkippedOutput(CustomTestCase):
+    def test_sampling_mask_middle_chunk_does_not_require_logits_output(self):
+        """A non-token-producing PP chunk may omit its logits output."""
+        req = _PrefillReq(
+            rid="middle",
+            inflight_middle_chunks=1,
+            return_hidden_states=False,
+        )
+        req.return_sampling_mask = True
+        batch = SimpleNamespace(
+            reqs=[req],
+            return_logprob=False,
+            return_hidden_states=False,
+            return_hidden_states_mode=CaptureHiddenMode.NULL,
+            spec_info=None,
+            prefill_stats=None,
+            dp_cooperation_info=None,
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=None,
+            next_token_ids=torch.zeros(1, dtype=torch.int64),
+            extend_input_len_per_req=None,
+            extend_logprob_start_len_per_req=None,
+            grammar_advanced=False,
+            can_run_cuda_graph=False,
+            skipped_output_comm=True,
+        )
+        processor = _make_processor()
+
+        with patch.object(
+            envs.SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM,
+            "get",
+            return_value=True,
+        ):
+            processor.process_batch_result_prefill(batch, result)
+
+        self.assertEqual(req.inflight_middle_chunks, 0)
+        self.assertEqual(req.output_ids, [])
+        processor.output_streamer.stream_output.assert_called_once_with(
+            [req], False, req
+        )
+
+
 class TestDecodeHiddenStateRetention(CustomTestCase):
     def test_last_mode_multi_step_storage_stays_bounded(self):
         processor = _make_processor()
@@ -176,7 +224,10 @@ class TestDecodeHiddenStateRetention(CustomTestCase):
                 copy_done=None,
                 routed_experts_output=None,
                 indexer_topk_output=None,
-                logits_output=SimpleNamespace(hidden_states=hidden_states),
+                logits_output=SimpleNamespace(
+                    hidden_states=hidden_states,
+                    sampling_mask_output=None,
+                ),
                 next_token_ids=None,
                 can_run_cuda_graph=False,
                 num_correct_drafts=0,

--- a/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
+++ b/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
@@ -76,7 +76,11 @@ def _make_result():
         copy_done=None,
         routed_experts_output=None,
         indexer_topk_output=None,
-        logits_output=SimpleNamespace(hidden_states=None, customized_info=None),
+        logits_output=SimpleNamespace(
+            hidden_states=None,
+            customized_info=None,
+            sampling_mask_output=None,
+        ),
         next_token_ids=[4],
         can_run_cuda_graph=False,
         num_correct_drafts=0,

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -575,6 +575,7 @@ def _make_batch_token_id_output(**overrides) -> BatchTokenIDOutput:
         output_token_entropy_val=None,
         output_token_sampling_mask=None,
         output_token_sampling_logprobs=None,
+        output_token_sampling_mask_truncated=None,
         output_hidden_states=None,
         routed_experts=None,
         indexer_topk=None,

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -767,6 +767,25 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(req[0].routed_dp_rank, 3)
         self.assertEqual(req[1].routed_dp_rank, 3)
 
+    def test_sampling_mask_mode_defaults_and_propagates(self):
+        single = GenerateReqInput(
+            text="Hello", sampling_params={}, return_sampling_mask=True
+        )
+        single.normalize_batch_and_arguments()
+        self.assertEqual(single.sampling_mask_mode, "exact")
+
+        batch = GenerateReqInput(
+            text=["Hello", "World"],
+            sampling_params=[{}, {}],
+            return_sampling_mask=[True, True],
+            sampling_mask_mode=["exact", "bounded"],
+        )
+        batch.normalize_batch_and_arguments()
+        self.assertEqual(
+            [batch[i].sampling_mask_mode for i in range(2)],
+            ["exact", "bounded"],
+        )
+
 
 class TestEmbeddingReqInputGetItem(CustomTestCase):
     """Test EmbeddingReqInput.__getitem__."""

--- a/test/registered/unit/managers/test_multi_tokenizer_mixin.py
+++ b/test/registered/unit/managers/test_multi_tokenizer_mixin.py
@@ -70,6 +70,7 @@ def _make_batch_str_output() -> BatchStrOutput:
         output_token_entropy_val=[0.0, 0.0],
         output_token_sampling_mask=[[], []],
         output_token_sampling_logprobs=[[], []],
+        output_token_sampling_mask_truncated=[[True], [False]],
         output_hidden_states=[None, None],
         routed_experts=[None, None],
         indexer_topk=[None, None],
@@ -91,6 +92,7 @@ class TestMultiTokenizerMixin(unittest.TestCase):
             single_output.cached_tokens_details,
             [{"device": 1, "host": 3}],
         )
+        self.assertEqual(single_output.output_token_sampling_mask_truncated, [[False]])
 
     def test_get_tokenizer_worker_class_uses_default(self):
         self.assertIs(get_tokenizer_worker_class(DefaultServerArgs()), TokenizerWorker)

--- a/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
+++ b/test/registered/unit/mem_cache/test_decode_radix_lock_ref.py
@@ -39,6 +39,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixCache, RadixKey
 from sglang.srt.utils.common import Range
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_cache_with_pools(page_size=1):
@@ -92,7 +93,7 @@ def _make_req(fill_ids, req_pool_idx=0, cache_protected_len=0, last_node=None):
     return MockReq(fill_ids, req_pool_idx, cache_protected_len, last_node)
 
 
-class TestDecodeLockRefScenarios(unittest.TestCase):
+class TestDecodeLockRefScenarios(CustomTestCase):
     """Test lock_ref balance across decode transfer scenarios."""
 
     def _populate_prefix(self, cache, prefix_ids, prefix_values):
@@ -201,7 +202,10 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
         self.assertEqual(cache.evictable_size(), len(full_ids))
 
     def test_incremental_transfer_failure(self):
-        """Scenario 3: prefix match > 0, transfer fails.
+        """Scenario 3: prefix match > 0, transfer fails after KV commit.
+
+        The final committed KV slot has no corresponding output token. Cleanup
+        must preserve the matched prefix and release the full request-owned suffix.
 
         Flow: inc_lock_ref(pop_preallocated)
               -> dec_lock_ref(cache_finished_req via release_kv_cache is_insert=False)
@@ -233,12 +237,20 @@ class TestDecodeLockRefScenarios(unittest.TestCase):
             cache_protected_len=prefix_len,
             last_node=matched_node,
         )
+        req.output_ids = array("q")
 
         # Transfer fails -> cache_finished_req with is_insert=False
         # This frees delta tokens and dec_lock_ref on last_node
+        cache.token_to_kv_pool_allocator.reset_mock()
         cache.cache_finished_req(
             req, is_insert=False, kv_len_to_handle=req.kv_committed_len
         )
+
+        free_call = cache.token_to_kv_pool_allocator.free_segment.call_args
+        torch.testing.assert_close(
+            free_call.args[0], torch.tensor(full_vals[prefix_len:])
+        )
+        self.assertEqual(free_call.kwargs["start_pos"], prefix_len)
 
         # The prefix node should be unlocked (back to evictable)
         self.assertEqual(cache.root_node.lock_ref, 1)

--- a/test/registered/unit/sampling/test_sampler_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampler_sampling_mask.py
@@ -1,0 +1,359 @@
+"""Unit tests for sampling-support capture and overflow policy."""
+
+import math
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskStatus,
+)
+from sglang.srt.layers.sampler import (
+    Sampler,
+    _SamplingMaskCapture,
+    top_k_top_p_min_p_sampling_from_probs_torch,
+)
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.utils import (
+    GenerationBatchResult,
+    get_logprob_dict_from_result,
+    get_logprob_from_pp_outputs,
+)
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.sampling.sampling_params import TOP_K_ALL
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSamplingMaskCapture(CustomTestCase):
+    def setUp(self):
+        self.sampler = Sampler.__new__(Sampler)
+        torch.nn.Module.__init__(self.sampler)
+        self.sampler.sampling_mask_max_tokens = 3
+        self.sampler.tp_sync_group = None
+        self.sampler.cp_sync_group = None
+
+    def _capture(
+        self,
+        weights,
+        sampled_tokens,
+        token_ids=None,
+        batch_indices=None,
+        selected_weights=None,
+    ):
+        if batch_indices is None:
+            batch_indices = torch.arange(weights.shape[0])
+        return self.sampler._build_sampling_mask_output(
+            torch.tensor(sampled_tokens),
+            _SamplingMaskCapture(
+                batch_indices=batch_indices,
+                scores=weights,
+                token_ids=token_ids,
+                selected_scores=selected_weights,
+            ),
+        )
+
+    def test_returns_complete_support_and_selected_logprob(self):
+        output = self._capture(torch.tensor([[0.4, 0.3, 0.2, 0.0]]), sampled_tokens=[1])
+
+        length = int(output.lengths[0])
+        self.assertEqual(output.statuses.tolist(), [SamplingMaskStatus.OK])
+        self.assertEqual(set(output.token_ids[0, :length].tolist()), {0, 1, 2})
+        self.assertAlmostEqual(
+            float(output.selected_logprobs[0]), math.log(0.3 / 0.9), places=6
+        )
+
+    def test_support_above_cap_is_truncated_and_keeps_sampled_token(self):
+        output = self._capture(torch.tensor([[0.4, 0.3, 0.2, 0.1]]), sampled_tokens=[3])
+
+        self.assertEqual(output.statuses.tolist(), [SamplingMaskStatus.TRUNCATED])
+        self.assertEqual(output.lengths.tolist(), [3])
+        self.assertEqual(set(output.token_ids[0].tolist()), {0, 1, 3})
+        self.assertAlmostEqual(float(output.selected_logprobs[0]), math.log(0.1))
+        self.assertNotAlmostEqual(
+            float(output.selected_logprobs[0]), math.log(0.1 / 0.8)
+        )
+
+    def test_scheduler_rejects_overflow(self):
+        output = self._capture(torch.tensor([[0.4, 0.3, 0.2, 0.1]]), sampled_tokens=[3])
+        materialized = LogitsProcessorOutput(
+            next_token_logits=None, sampling_mask_output=output
+        )
+        SchedulerBatchResultProcessor.materialize_sampling_mask_output(
+            [SimpleNamespace(return_sampling_mask=True)], materialized
+        )
+
+        processor = SchedulerBatchResultProcessor.__new__(SchedulerBatchResultProcessor)
+        object.__setattr__(
+            processor,
+            "server_args",
+            SimpleNamespace(sampling_mask_max_tokens=3),
+        )
+        finish_reason = processor.get_sampling_mask_finish_reason(
+            status=materialized.next_token_sampling_mask_status[0]
+        )
+        self.assertEqual(finish_reason.status_code, 400)
+        self.assertIn("sampling-mask-max-tokens", finish_reason.message)
+
+    def test_sampled_token_is_not_added_to_support(self):
+        output = self._capture(torch.tensor([[0.6, 0.4, 0.0]]), sampled_tokens=[2])
+
+        self.assertEqual(output.statuses.tolist(), [SamplingMaskStatus.INVALID])
+
+    def test_token_id_mapping_uses_sampler_order(self):
+        output = self._capture(
+            weights=torch.tensor([[0.7, 0.3, 0.0, 0.0]]),
+            token_ids=torch.tensor([[3, 1, 2, 0]], dtype=torch.int32),
+            sampled_tokens=[1],
+            selected_weights=torch.tensor([0.3]),
+        )
+
+        length = int(output.lengths[0])
+        self.assertEqual(set(output.token_ids[0, :length].tolist()), {1, 3})
+        self.assertAlmostEqual(float(output.selected_logprobs[0]), math.log(0.3))
+
+    def test_selected_logprob_follows_synchronized_token(self):
+        """A post-sampling token sync must also update the selected logprob."""
+        self.sampler.rl_on_policy_target = None
+        self.sampler.use_log_softmax_logprob = False
+        self.sampler.enable_deterministic = False
+        self.sampler.use_ascend_backend = False
+        logits_output = LogitsProcessorOutput(
+            next_token_logits=torch.tensor([[2.0, 1.0, 0.0]])
+        )
+        sampling_info = SimpleNamespace(
+            has_custom_logit_processor=False,
+            sampling_mask_batch_indices=torch.tensor([0]),
+            is_all_greedy=False,
+            need_top_p_sampling=False,
+            need_top_k_sampling=False,
+            need_min_p_sampling=False,
+            temperatures=torch.ones(1, 1),
+            grammars=None,
+        )
+        captured = _SamplingMaskCapture(
+            batch_indices=torch.tensor([0]),
+            scores=torch.tensor([[0.5, 0.3, 0.2]]),
+            token_ids=torch.tensor([[0, 2, 1]], dtype=torch.int32),
+            selected_scores=torch.tensor([0.3]),
+        )
+
+        def sync_to_token_one(token_ids, _):
+            token_ids.fill_(1)
+
+        with (
+            patch.object(
+                self.sampler,
+                "_sample_from_probs",
+                return_value=(torch.tensor([2]), captured),
+            ),
+            patch.object(
+                self.sampler,
+                "_sync_token_ids_across_tp",
+                side_effect=sync_to_token_one,
+            ),
+            patch("sglang.srt.layers.sampler.SYNC_TOKEN_IDS_ACROSS_TP", True),
+        ):
+            sampled_tokens = self.sampler.forward(
+                logits_output,
+                sampling_info,
+                return_logprob=False,
+                top_logprobs_nums=[0],
+                token_ids_logprobs=[None],
+                positions=torch.tensor([0]),
+            )
+
+        output = logits_output.sampling_mask_output
+        self.assertEqual(sampled_tokens.tolist(), [1])
+        self.assertEqual(output.statuses.tolist(), [SamplingMaskStatus.OK])
+        self.assertAlmostEqual(float(output.selected_logprobs[0]), math.log(0.2))
+
+    def test_min_p_capture_filters_without_mutating_sampler_probs(self):
+        renormalized_probs = torch.tensor([[0.6, 0.3, 0.1]])
+        sampling_info = SimpleNamespace(
+            sampling_seed=None,
+            sampling_mask_batch_indices=torch.tensor([0]),
+            need_min_p_sampling=True,
+            top_ks=torch.tensor([3]),
+            top_ps=torch.tensor([1.0]),
+            min_ps=torch.tensor([0.5]),
+        )
+        with (
+            patch(
+                "sglang.srt.layers.sampler.get_exec",
+                return_value=SimpleNamespace(
+                    kernel=SimpleNamespace(sampling_backend="flashinfer")
+                ),
+            ),
+            patch(
+                "sglang.srt.layers.sampler.top_k_renorm_prob",
+                return_value=renormalized_probs,
+            ),
+            patch(
+                "sglang.srt.layers.sampler.top_p_renorm_prob",
+                side_effect=lambda probs, _: probs,
+            ),
+            patch(
+                "sglang.srt.layers.sampler.min_p_sampling_from_probs",
+                return_value=torch.tensor([0]),
+            ),
+        ):
+            _, sampling_mask_data = self.sampler._sample_from_probs(
+                torch.tensor([[0.6, 0.3, 0.1]]),
+                sampling_info,
+                positions=torch.tensor([0]),
+                simple_sampling_case=False,
+            )
+
+        self.assertTrue(
+            torch.equal(sampling_mask_data.scores, torch.tensor([[0.6, 0.3, 0.0]]))
+        )
+        self.assertTrue(
+            torch.equal(renormalized_probs, torch.tensor([[0.6, 0.3, 0.1]]))
+        )
+
+    def test_logprob_sampling_capture_uses_producer_distribution(self):
+        self.sampler.rl_on_policy_target = "test"
+        self.sampler.use_log_softmax_logprob = True
+        self.sampler.enable_deterministic = True
+        self.sampler.use_ascend_backend = False
+        logits = torch.tensor([[2.0, 1.0, 0.0], [0.0, 1.0, 2.0]])
+        logits_output = LogitsProcessorOutput(next_token_logits=logits.clone())
+        sampling_info = SimpleNamespace(
+            has_custom_logit_processor=False,
+            sampling_mask_batch_indices=torch.tensor([1]),
+            is_all_greedy=False,
+            need_top_p_sampling=False,
+            need_top_k_sampling=False,
+            need_min_p_sampling=False,
+            temperatures=torch.ones(2, 1),
+            sampling_seed=torch.tensor([1, 2]),
+            grammars=None,
+        )
+
+        with patch.object(
+            self.sampler,
+            "_sample_from_logprobs",
+            return_value=torch.tensor([0, 1]),
+        ):
+            self.sampler.forward(
+                logits_output,
+                sampling_info,
+                return_logprob=False,
+                top_logprobs_nums=[0, 0],
+                token_ids_logprobs=[None, None],
+                positions=torch.tensor([0, 0]),
+            )
+
+        output = logits_output.sampling_mask_output
+        self.assertEqual(output.token_ids.shape[0], 1)
+        self.assertEqual(output.statuses.tolist(), [SamplingMaskStatus.OK])
+        producer_logprobs = torch.log_softmax(logits.bfloat16(), dim=-1)
+        producer_weights = producer_logprobs[1].float().exp()
+        self.assertAlmostEqual(
+            float(output.selected_logprobs[0]),
+            float(torch.log(producer_weights[1] / producer_weights.sum())),
+            places=6,
+        )
+
+    def test_greedy_support_is_singleton(self):
+        output = self.sampler._build_greedy_sampling_mask_output(
+            torch.tensor([0, 2]), torch.tensor([4, 5, 6])
+        )
+
+        self.assertEqual(output.token_ids.tolist(), [[4], [6]])
+        self.assertEqual(output.lengths.tolist(), [1, 1])
+        self.assertEqual(output.selected_logprobs.tolist(), [0.0, 0.0])
+
+    def test_materialization_preserves_batch_rows(self):
+        sampling_output = self._capture(
+            weights=torch.tensor(
+                [
+                    [0.6, 0.4, 0.0, 0.0],
+                    [0.4, 0.3, 0.2, 0.1],
+                ]
+            ),
+            sampled_tokens=[1, 9, 0],
+            batch_indices=torch.tensor([0, 2]),
+        )
+        output = LogitsProcessorOutput(
+            next_token_logits=None, sampling_mask_output=sampling_output
+        )
+
+        SchedulerBatchResultProcessor.materialize_sampling_mask_output(
+            [
+                SimpleNamespace(return_sampling_mask=True),
+                SimpleNamespace(return_sampling_mask=False),
+                SimpleNamespace(return_sampling_mask=True),
+            ],
+            output,
+        )
+
+        self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {0, 1})
+        self.assertIsNone(output.next_token_sampling_mask_idx[1])
+        self.assertEqual(set(output.next_token_sampling_mask_idx[2]), {0, 1, 2})
+        self.assertEqual(
+            output.next_token_sampling_mask_status,
+            [SamplingMaskStatus.OK, None, SamplingMaskStatus.TRUNCATED],
+        )
+        self.assertIsNone(output.sampling_mask_output)
+
+    def test_pipeline_parallel_round_trip_preserves_tensor_output(self):
+        sampling_output = self._capture(
+            weights=torch.tensor([[0.6, 0.4, 0.0]]), sampled_tokens=[0]
+        )
+        result = GenerationBatchResult(
+            logits_output=LogitsProcessorOutput(
+                next_token_logits=None, sampling_mask_output=sampling_output
+            )
+        )
+
+        received, _, _ = get_logprob_from_pp_outputs(
+            PPProxyTensors(get_logprob_dict_from_result(result))
+        )
+
+        self.assertIsNotNone(received.sampling_mask_output)
+        self.assertTrue(
+            torch.equal(
+                received.sampling_mask_output.token_ids, sampling_output.token_ids
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                received.sampling_mask_output.statuses, sampling_output.statuses
+            )
+        )
+
+    def test_pytorch_capture_uses_filtered_support_with_and_without_top_k(self):
+        for top_k, top_p in ((2, 0.5), (TOP_K_ALL, 0.49)):
+            with self.subTest(top_k=top_k, top_p=top_p):
+                probs = torch.tensor([[0.30, 0.20, 0.18, 0.17, 0.15]])
+                (
+                    _,
+                    filtered,
+                    token_ids,
+                    _,
+                ) = top_k_top_p_min_p_sampling_from_probs_torch(
+                    probs,
+                    top_ks=torch.tensor([top_k]),
+                    top_ps=torch.tensor([top_p]),
+                    min_ps=torch.tensor([0.0]),
+                    need_min_p_sampling=False,
+                    sampling_seed=None,
+                    positions=torch.tensor([0]),
+                    return_filtered_probs=True,
+                )
+
+                kept_ids = token_ids[filtered > 0].tolist()
+                self.assertEqual(set(kept_ids), {0, 1})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/sampling/test_sampler_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampler_sampling_mask.py
@@ -81,7 +81,7 @@ class TestSamplingMaskCapture(CustomTestCase):
             float(output.selected_logprobs[0]), math.log(0.1 / 0.8)
         )
 
-    def test_scheduler_rejects_overflow(self):
+    def test_scheduler_applies_exact_and_bounded_overflow_policy(self):
         output = self._capture(torch.tensor([[0.4, 0.3, 0.2, 0.1]]), sampled_tokens=[3])
         materialized = LogitsProcessorOutput(
             next_token_logits=None, sampling_mask_output=output
@@ -97,10 +97,30 @@ class TestSamplingMaskCapture(CustomTestCase):
             SimpleNamespace(sampling_mask_max_tokens=3),
         )
         finish_reason = processor.get_sampling_mask_finish_reason(
-            status=materialized.next_token_sampling_mask_status[0]
+            status=materialized.next_token_sampling_mask_status[0], mode="exact"
         )
         self.assertEqual(finish_reason.status_code, 400)
-        self.assertIn("sampling-mask-max-tokens", finish_reason.message)
+        self.assertIn("sampling_mask_mode='bounded'", finish_reason.message)
+
+        bounded_req = SimpleNamespace(
+            return_sampling_mask=True,
+            sampling_mask_mode="bounded",
+            output_token_sampling_mask=[],
+            output_token_sampling_logprobs=[],
+            output_token_sampling_mask_truncated=[],
+        )
+        self.assertIsNone(
+            processor.get_sampling_mask_finish_reason(
+                status=materialized.next_token_sampling_mask_status[0], mode="bounded"
+            )
+        )
+        processor.add_sampling_mask_return_values(0, bounded_req, materialized)
+
+        self.assertEqual(bounded_req.output_token_sampling_mask_truncated, [True])
+        self.assertEqual(set(bounded_req.output_token_sampling_mask[0]), {0, 1, 3})
+        self.assertAlmostEqual(
+            bounded_req.output_token_sampling_logprobs[0], math.log(0.1)
+        )
 
     def test_sampled_token_is_not_added_to_support(self):
         output = self._capture(torch.tensor([[0.6, 0.4, 0.0]]), sampled_tokens=[2])

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -102,6 +102,38 @@ class TestSamplingBatchInfoLen(CustomTestCase):
         self.assertEqual(len(info), 5)
 
 
+class TestSamplingMaskBatchIndices(CustomTestCase):
+
+    def test_filter_rebuilds_row_indices(self):
+        info = _make_info(
+            batch_size=4,
+            return_sampling_masks=[False, True, False, True],
+            sampling_mask_batch_indices=torch.tensor([1, 3]),
+        )
+
+        info.filter_batch([1, 2, 3], torch.tensor([1, 2, 3]))
+
+        self.assertEqual(info.return_sampling_masks, [True, False, True])
+        self.assertEqual(info.sampling_mask_batch_indices.tolist(), [0, 2])
+
+    def test_merge_offsets_rhs_row_indices(self):
+        lhs = _make_info(
+            batch_size=2,
+            return_sampling_masks=[False, True],
+            sampling_mask_batch_indices=torch.tensor([1]),
+        )
+        rhs = _make_info(
+            batch_size=3,
+            return_sampling_masks=[True, False, True],
+            sampling_mask_batch_indices=torch.tensor([0, 2]),
+        )
+
+        lhs.merge_batch(rhs)
+
+        self.assertEqual(lhs.return_sampling_masks, [False, True, True, False, True])
+        self.assertEqual(lhs.sampling_mask_batch_indices.tolist(), [1, 2, 4])
+
+
 class TestMergeCustomLogitProcessor(CustomTestCase):
 
     def test_both_none_returns_none(self):


### PR DESCRIPTION
## Why

#27408 added SGLang's native sampling-mask response, but reconstructed support after sampling and used finite `top_k` as its safety bound. #33593, now merged in `main`, made top-p-only requests valid and exposed sampling masks through the OpenAI chat extension. The remaining contract must therefore be general: top-p/min-p support is data-dependent, and SGLang's threshold primitives retain every token tied at the cutoff, so even finite top-k does not bound realized support.

This PR makes the response describe the distribution that actually sampled the token, then bounds only its transport. This is a general serving contract, not an RL-only path.

## Contract

For the post-filter weights `w` used to sample token `y`, let `S = {i | w[i] > 0}` and `C = --sampling-mask-max-tokens`:

- sampling itself is unchanged;
- if `|S| <= C`, the returned token IDs are the complete support `S`;
- exact mode is the default, so `|S| > C` aborts before `y` is committed;
- `sampling_mask_mode="bounded"` opts into at most `C` IDs and reports `output_token_sampling_mask_truncated=true`;
- bounded mode keeps the highest-weight prefix and retains `y` by replacing its final entry when necessary;
- the selected-token logprob is always `log(w[y] / sum(w))` over the full realized support, never over the truncated return;
- missing or internally inconsistent producer output is an internal error, not truncation.

The cap changes metadata only. It never changes the sampling distribution.

## Design

- Capture the producer's representation. PyTorch reuses its filtered weights and token permutation; FlashInfer uses SGLang's existing top-k/top-p renormalization primitives and min-p predicate; deterministic logprob sampling and greedy sampling use their native representations.
- Keep internal results tensor-backed. `SamplingMaskOutput` is a dataclass following the existing result-holder `map_device_tensors`/async-D2H path; `_SamplingMaskCapture` is a sampler-private `NamedTuple`.
- Maintain opted-in device row indices in `SamplingBatchInfo`, including filter/merge, so mixed batches restrict dense work and transfer to requested rows.
- Emit factual `OK`, `TRUNCATED`, or `INVALID` status in the sampler, reach TP/CP consensus through the existing process groups, and apply exact/bounded policy in the scheduler.
- Propagate the per-token truncation bit through streaming, multi-tokenizer output, sessions, PP, and PD disaggregation. PD reuses its existing 64-byte padded metadata row; the first two slots carry returned length and truncation.
- Reuse the OpenAI chat sampling-mask path merged in #33593 and forward its `sampling_mask_mode` into the existing native request field.
- Abort exact overflow before committing the sampled token and release every request-owned KV slot, including overlap-allocated slots without a committed token ID.

## Internal API changes

- Private `Sampler._sample_from_probs` now returns sampled IDs plus optional producer capture data.
- `top_k_top_p_min_p_sampling_from_probs_torch` keeps its existing token-only behavior by default; a keyword-only opt-in returns already-computed filtered data for capture.
- Private `_attach_*` helpers became `_build_*` because they now return a tensor holder. The post-hoc `_compute_sampling_mask_from_probs` reconstruction was removed because it was not the producer's source of truth.
- Request fields are placed so existing positional constructors and the tokenized Rust wire layout do not shift.
- The PD field changed from `output_token_sampling_mask_len` to `output_token_sampling_mask_metadata` because the same padded row now carries length and truncation. No layout class, one-use global size constant, or additional RDMA buffer is introduced.
- Existing PP `get_logprob_*` helper names remain unchanged; only their logits-output payload is widened.
- Existing optional backend KV-release hooks are used at the release site; no new base-worker lifecycle interface is added.

No public sampling function is removed or renamed.

## Performance

- Feature-off requests add Python flag/tuple plumbing only: no new tensor operation, dense allocation, D2H copy, PP tensor, or TP/CP collective.
- Opted-in rows require dense `O(R * V)` support work because current sampling primitives produce dense weights. Packing transfers `4 * R * C + 12 * R` bytes. A fixed cap avoids a GPU-to-CPU synchronization to discover a data-dependent width; finite top-k is not a valid bound because cutoff ties are retained.
- On one H200 at `V=128256`, `C=4096`, measured opt-in operator overhead was approximately 0.28-0.72 ms across FlashInfer joint, min-p, and PyTorch paths.
- Dense temporary storage scaled with opted-in rows: approximately 1.7 MB at `R=1`, 54 MB at `R=32`, and 107 MB at `R=64`. Bounded D2H payload p50 was approximately 53-55 us from `R=1` through `R=64` (16 KB to 1.05 MB).
- Same-node TP2/4/8 status consensus measured approximately 20-42 us across 1-1024 rows.

## Validation

- 295 focused tests passed, 2 skipped, with 75 subtests on one H200 using `lmsysorg/sglang:nightly-dev-cu13-20260817-d91c3682` and the rebased PR source.
- Seven end-to-end H200 serving contracts passed on the rebased tree: finite support/logprob consistency, exact overflow abort, bounded truncation signal, top-p-only policy, OpenAI chat bounded-mode propagation, invalid-mode rejection, and deterministic sampling preservation.
- A 4,927-check H200 operator matrix passed against independent support and selected-logprob oracles, including uniform cutoff ties and min-p input isolation.
- One-node H200 TP2/4/8 collective probes passed.
- Repository-native `pre-commit run --all-files` passed on current `main`, including registered-test validation, lint-checker tests, Rust formatting, and workspace clippy. `git diff --check` passed.

The existing CUDA/AMD end-to-end sampling-mask test remains registered in its current CI suites.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32076643369](https://github.com/sgl-project/sglang/actions/runs/32076643369)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32076642814](https://github.com/sgl-project/sglang/actions/runs/32076642814)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->