### PR TITLE
[Spec] Resolve the ragged-verify graph tier at a single point

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1209,8 +1209,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         raw_bs = forward_batch.batch_size
 
         if is_ragged:
-            # The layout is the single source of the tier; it is constructed
-            # on this runner's capture grid.
+            # The layout tier is always on this runner's capture grid, so no
+            # re-round or assert here: the planner rounds on
+            # ragged_capture_num_tokens, which returns this runner's
+            # capture_num_tokens (same source), and verify_layout_grid's
+            # [total] escape branches only fire with ragged_verify_mode off,
+            # where this branch is unreachable.
             raw_num_token = graph_size_key = ragged_layout.graph_num_tokens
             bs = self._ragged_capture_slots(graph_size_key)
             assert bs >= raw_bs, (

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1209,12 +1209,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         raw_bs = forward_batch.batch_size
 
         if is_ragged:
-            raw_num_token = ragged_layout.graph_num_tokens
-            graph_size_key = self._ragged_graph_num_tokens(raw_num_token)
-            assert graph_size_key == ragged_layout.graph_num_tokens, (
-                f"ragged verify tier mismatch: runner tier {graph_size_key} != "
-                f"layout graph_num_tokens {ragged_layout.graph_num_tokens}"
-            )
+            # The layout is the single source of the tier; it is constructed
+            # on this runner's capture grid.
+            raw_num_token = graph_size_key = ragged_layout.graph_num_tokens
             bs = self._ragged_capture_slots(graph_size_key)
             assert bs >= raw_bs, (
                 f"ragged capture slots {bs} (tier {graph_size_key}) < raw_bs "
@@ -1296,11 +1293,6 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         self._replay_graph_key = self._make_graph_key(
             graph_size_key, stream_idx, variant_label
         )
-
-    def _ragged_graph_num_tokens(self, total_verify_tokens: int) -> int:
-        from sglang.srt.speculative.ragged_verify import round_up_grid
-
-        return round_up_grid(total_verify_tokens, self.capture_num_tokens)
 
     def execute(
         self,

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -67,6 +67,14 @@ class VerifyWindow(msgspec.Struct, frozen=True):
     verify_cache_loc_2d: torch.Tensor
 
 
+class VerifyTierResolution(msgspec.Struct, frozen=True):
+    tier_num_reqs: int
+    tier_num_tokens: Optional[int]
+    graph_num_tokens_floor: int
+    # None when the floor is empty or no ragged capture grid exists.
+    graph_num_tokens: Optional[int]
+
+
 class DSparkVerifyPlanner:
     def __init__(
         self,
@@ -471,41 +479,23 @@ class DSparkVerifyPlanner:
                 )
             return None
         bs = int(verify_lens.shape[0])
-        tier_num_reqs = bs if global_num_reqs is None else global_num_reqs
-        if dp_tier_num_tokens is not None:
-            assert global_num_reqs is not None, (
-                "dp tier agreement requires the dp-global request count; "
-                "keying the tier off the local bs diverges across ranks"
-            )
-            tier_num_tokens = dp_tier_num_tokens
-        elif self._dynamic_graph_tier and budget is not None:
-            tier_num_tokens = local_verify_tier_num_tokens(
-                bs=tier_num_reqs,
-                verify_token_budget=budget,
-                verify_num_draft_tokens=self.verify_num_draft_tokens,
-                min_verify_len=self._schedule_cfg.min_verify_len,
-            )
-        else:
-            tier_num_tokens = None
+        tier = self._resolve_verify_tier(
+            num_reqs=bs,
+            global_num_reqs=global_num_reqs,
+            dp_tier_num_tokens=dp_tier_num_tokens,
+            budget=budget,
+        )
         if ragged_layout_exceeds_captured_grid(
-            num_reqs=tier_num_reqs,
+            num_reqs=tier.tier_num_reqs,
             verify_num_draft_tokens=self.verify_num_draft_tokens,
             model_runner=self.model_runner,
-            tier_tokens_hint=tier_num_tokens,
+            tier_tokens_hint=tier.tier_num_tokens,
         ):
             return None
-        graph_num_tokens_floor = verify_layout_graph_num_tokens_floor(
-            num_reqs=tier_num_reqs,
-            ragged_verify_mode=self._ragged_verify_mode,
-            verify_num_draft_tokens=self.verify_num_draft_tokens,
-            model_runner=self.model_runner,
-            tier_num_tokens=tier_num_tokens,
-        )
-        capture_num_tokens = ragged_capture_num_tokens(model_runner=self.model_runner)
-        if graph_num_tokens_floor > 0 and capture_num_tokens is not None:
-            graph_num_tokens = round_up_grid(graph_num_tokens_floor, capture_num_tokens)
+        graph_num_tokens_floor = tier.graph_num_tokens_floor
+        if tier.graph_num_tokens is not None:
             return RaggedVerifyLayout.from_verify_lens_device(
-                verify_lens=verify_lens, graph_num_tokens=graph_num_tokens
+                verify_lens=verify_lens, graph_num_tokens=tier.graph_num_tokens
             )
         verify_lens_cpu = verify_lens.to("cpu").tolist()
         grid = verify_layout_grid(
@@ -539,14 +529,40 @@ class DSparkVerifyPlanner:
         # it does not touch the layout's own tier computation.
         if not self._align_verify_tokens_to_graph_tier or budget is None:
             return budget
-        tier_num_reqs = (
-            int(req_pool_indices.shape[0])
-            if global_num_reqs is None
-            else global_num_reqs
+        tier = self._resolve_verify_tier(
+            num_reqs=int(req_pool_indices.shape[0]),
+            global_num_reqs=global_num_reqs,
+            dp_tier_num_tokens=dp_tier_num_tokens,
+            budget=budget,
         )
+        if tier.graph_num_tokens is None:
+            return budget
+        return graph_tier_fill_budget(
+            graph_num_tokens=tier.graph_num_tokens,
+            bs=int(req_pool_indices.shape[0]),
+            verify_num_draft_tokens=self.verify_num_draft_tokens,
+            min_verify_len=self._schedule_cfg.min_verify_len,
+        )
+
+    def _resolve_verify_tier(
+        self,
+        *,
+        num_reqs: int,
+        global_num_reqs: Optional[int],
+        dp_tier_num_tokens: Optional[int],
+        budget: Optional[int],
+    ) -> VerifyTierResolution:
+        """Single source for the ragged verify graph tier. Token sources, in
+        priority order: the DP-gathered cross-rank tier, the local
+        budget-derived tier (dynamic), or the full-block floor (None)."""
+        tier_num_reqs = num_reqs if global_num_reqs is None else global_num_reqs
         if dp_tier_num_tokens is not None:
+            assert global_num_reqs is not None, (
+                "dp tier agreement requires the dp-global request count; "
+                "keying the tier off the local bs diverges across ranks"
+            )
             tier_num_tokens = dp_tier_num_tokens
-        elif self._dynamic_graph_tier:
+        elif self._dynamic_graph_tier and budget is not None:
             tier_num_tokens = local_verify_tier_num_tokens(
                 bs=tier_num_reqs,
                 verify_token_budget=budget,
@@ -563,14 +579,16 @@ class DSparkVerifyPlanner:
             tier_num_tokens=tier_num_tokens,
         )
         capture_num_tokens = ragged_capture_num_tokens(model_runner=self.model_runner)
-        if graph_num_tokens_floor <= 0 or capture_num_tokens is None:
-            return budget
-        graph_num_tokens = round_up_grid(graph_num_tokens_floor, capture_num_tokens)
-        return graph_tier_fill_budget(
+        graph_num_tokens = (
+            round_up_grid(graph_num_tokens_floor, capture_num_tokens)
+            if graph_num_tokens_floor > 0 and capture_num_tokens is not None
+            else None
+        )
+        return VerifyTierResolution(
+            tier_num_reqs=tier_num_reqs,
+            tier_num_tokens=tier_num_tokens,
+            graph_num_tokens_floor=graph_num_tokens_floor,
             graph_num_tokens=graph_num_tokens,
-            bs=int(req_pool_indices.shape[0]),
-            verify_num_draft_tokens=self.verify_num_draft_tokens,
-            min_verify_len=self._schedule_cfg.min_verify_len,
         )
 
     def _schedule_verify_lens(


### PR DESCRIPTION
The graph tier (token-source selection, floor, round-up-to-grid) was derived independently in `_ragged_verify_layout` and `_budget_aligned_to_graph_tier`, kept consistent by comment; the decode graph runner re-derived it a third time at replay and asserted it matched the layout. Extract `_resolve_verify_tier` as the single derivation point (returning a `VerifyTierResolution`), and make the runner read the tier off the layout instead of recomputing it. No behavior change. Stacks on #34031.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828988770](https://github.com/sgl-project/sglang/actions/runs/34828988770)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828988502](https://github.com/sgl-project/sglang/actions/runs/34828988502)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->