### PR TITLE
docs(cookbook): DeepSeek-V4-Flash-0731 — drop chunked-prefill/autotune flags on B300 low-latency

### DIFF
--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -620,7 +620,7 @@ sgl-eval run aime25 \\
 
     {
       match: { hw: "b300", variant: "flash-official", quant: "fp4", strategy: "low-latency", nodes: "single" },
-      verified: false,
+      verified: true,
       env: [],
       flags: [
         "--trust-remote-code",
@@ -628,8 +628,6 @@ sgl-eval run aime25 \\
         "--tp 4",
         "--moe-runner-backend flashinfer_mxfp4",
         "--speculative-algorithm DSPARK",
-        "--chunked-prefill-size 4096",
-        "--disable-flashinfer-autotune",
         "--swa-full-tokens-ratio 0.1",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",


### PR DESCRIPTION
Drops `--chunked-prefill-size 4096` and `--disable-flashinfer-autotune` from the **Flash Official (0731)** low-latency recipe on **B300** (`flash-official` / `fp4`), and marks the cell verified.

The cell has no benchmarks entry, so it keeps rendering pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31226045307](https://github.com/sgl-project/sglang/actions/runs/31226045307)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31226045117](https://github.com/sgl-project/sglang/actions/runs/31226045117)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->