### PR TITLE
[HiCache] Support SWA host cache sizing and coexistence reclaim

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -125,6 +125,36 @@ def _split_hicache_size(
     )
 
 
+def _split_swa_hicache_size(
+    hicache_size: int,
+    kv_pools: tuple[Any, Any],
+    host_bytes_per_token: tuple[int, int],
+    swa_full_tokens_ratio: Optional[float] = None,
+) -> tuple[float, float]:
+    """Split HiCache bytes while preserving the requested token capacities."""
+    full_pool, swa_pool = kv_pools
+    ratio = (
+        swa_full_tokens_ratio
+        if swa_full_tokens_ratio is not None
+        else swa_pool.size / full_pool.size
+    )
+    full_bytes_per_token, swa_bytes_per_token = host_bytes_per_token
+    weighted_bytes_per_token = full_bytes_per_token + ratio * swa_bytes_per_token
+    full_host_size = hicache_size * full_bytes_per_token / weighted_bytes_per_token
+    return (full_host_size, hicache_size - full_host_size)
+
+
+def _get_host_bytes_per_token(
+    kv_pool: Any,
+    use_mla: bool,
+    mtp_draft_device_pools: tuple[Any, ...] = (),
+) -> int:
+    host_pool_cls = MLATokenToKVPoolHost if use_mla else get_mha_host_pool_cls(kv_pool)
+    return host_pool_cls.get_size_per_token_for_device_pool(
+        kv_pool, mtp_draft_device_pools=mtp_draft_device_pools
+    )
+
+
 def build_pool_entry(
     *,
     name: PoolName,
@@ -244,8 +274,14 @@ def build_hybrid_swa_stack(
 
     kv_host_size = swa_host_size = None
     if server_args.hicache_size > 0:
-        kv_host_size, swa_host_size = _split_hicache_size(
-            server_args.hicache_size, (full_kv_pool, swa_kv_pool)
+        kv_host_size, swa_host_size = _split_swa_hicache_size(
+            server_args.hicache_size,
+            (full_kv_pool, swa_kv_pool),
+            (
+                _get_host_bytes_per_token(full_kv_pool, use_mla),
+                _get_host_bytes_per_token(swa_kv_pool, use_mla, mtp_swa_device_pools),
+            ),
+            server_args.hicache_swa_full_tokens_ratio,
         )
 
     kv_host_pool = build_kv_host_pool(
@@ -729,6 +765,11 @@ def build_hybrid_mamba_swa_stack(
     storage_backend_extra_config: Optional[dict] = None,
     enable_storage_metrics: bool = False,
 ) -> tuple[HostPoolGroup, HybridCacheController]:
+    if server_args.hicache_swa_full_tokens_ratio is not None:
+        raise ValueError(
+            "--hicache-swa-full-tokens-ratio is not supported by the Mamba+SWA "
+            "cache stack."
+        )
     transfer_layer_num = len(
         full_layer_mapping | swa_layer_mapping | mamba_layer_mapping
     )

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -71,6 +71,20 @@ class MHATokenToKVPoolHost(HostKVCache):
     device_pool: MHATokenToKVPool | None = None
     mtp_draft_device_pools: tuple[MHATokenToKVPool, ...] = ()
 
+    @classmethod
+    def get_size_per_token_for_device_pool(
+        cls,
+        device_pool: MHATokenToKVPool,
+        mtp_draft_device_pools: Sequence[MHATokenToKVPool] = (),
+    ) -> int:
+        layer_num = device_pool.layer_num + len(mtp_draft_device_pools)
+        return (
+            (device_pool.head_dim + device_pool.v_head_dim)
+            * device_pool.head_num
+            * layer_num
+            * device_pool.store_dtype.itemsize
+        )
+
     def __init__(
         self,
         device_pool: MHATokenToKVPool,
@@ -151,7 +165,9 @@ class MHATokenToKVPoolHost(HostKVCache):
         self.head_num = self.device_pool.head_num
         self.head_dim = self.device_pool.head_dim
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
-        return self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
+        return self.get_size_per_token_for_device_pool(
+            self.device_pool, self.mtp_draft_device_pools
+        )
 
     def get_ksize_per_token(self):
         return self.get_size_per_token() // 2
@@ -1063,11 +1079,8 @@ class AsymmetricMHATokenToKVPoolHost(MHATokenToKVPoolHost):
         self.head_dim = self.device_pool.head_dim
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
         self.v_head_dim = self.device_pool.v_head_dim
-        return (
-            (self.head_dim + self.v_head_dim)
-            * self.head_num
-            * self.layer_num
-            * self.dtype.itemsize
+        return self.get_size_per_token_for_device_pool(
+            self.device_pool, self.mtp_draft_device_pools
         )
 
     def get_ksize_per_token(self):

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -52,6 +52,23 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
     device_pool: MLATokenToKVPool
     mtp_draft_device_pools: tuple[MLATokenToKVPool, ...] = ()
 
+    @classmethod
+    def get_size_per_token_for_device_pool(
+        cls,
+        device_pool: MLATokenToKVPool,
+        override_kv_cache_dim: Optional[int] = None,
+        mtp_draft_device_pools: Sequence[MLATokenToKVPool] = (),
+    ) -> int:
+        layer_num = device_pool.layer_num
+        if device_pool.layer_shard_enabled:
+            shard_size = device_pool.layer_shard_size
+            layer_num = (layer_num + shard_size - 1) // shard_size
+        layer_num += len(mtp_draft_device_pools)
+        kv_cache_dim = override_kv_cache_dim or (
+            device_pool.kv_lora_rank + device_pool.qk_rope_head_dim
+        )
+        return kv_cache_dim * device_pool.store_dtype.itemsize * layer_num
+
     def __init__(
         self,
         device_pool: MLATokenToKVPool,
@@ -130,7 +147,11 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         self.kv_cache_dim = self.override_kv_cache_dim or (
             self.kv_lora_rank + self.qk_rope_head_dim
         )
-        return self.kv_cache_dim * self.dtype.itemsize * self.layer_num
+        return self.get_size_per_token_for_device_pool(
+            self.device_pool,
+            self.override_kv_cache_dim,
+            self.mtp_draft_device_pools,
+        )
 
     def get_ksize_per_token(self):
         return self.get_size_per_token()

--- a/python/sglang/srt/mem_cache/unified_cache/components/README.md
+++ b/python/sglang/srt/mem_cache/unified_cache/components/README.md
@@ -290,6 +290,7 @@ Each component implements these hooks. See `tree_component.py` for the ABC and d
 | `evict_component(target=EvictLayer.DEVICE)` | Free this component's device, host, or both resources on a node being evicted. Internal device eviction tombstones (`value = None`); host eviction clears `host_value`. Returns `(device_freed, host_freed)`. | `_evict_component_and_detach_lru` | *abstract* |
 | `eviction_priority()` | Return cascade eviction priority (higher = evicted later). Leaf: all 0. Internal: Full(2) > SWA(1) > Mamba(0). When evicting, all components with ≤ priority on the same node are cascade-evicted. | `_cascade_evict` | `0` |
 | `evict_device_start()` / `evict_device_next_node()` / `evict_device_end()` | Step-wise device eviction walk the Controller drives: build the cursor/heap, return the next evictable leaf (freed values collected for the Controller to drain), clear the walk. Full: leaf-set heap. SWA/Mamba: component LRUs with internal tombstones and atomic leaf deletion. | `UnifiedRadixCache._evict_components` | *abstract* |
+| `reclaim_coexisting_host_values()` | Under write-back, reclaim host values whose device values remain resident before ordinary host eviction. Full walks its coexistence registry; SWA walks its device LRU. | `UnifiedTreeCore.drive_host_eviction` | no-op |
 | `drive_host_eviction()` | Drive host eviction for this component, collecting freed values for the Controller to drain. Full uses host leaves; SWA/Mamba use host LRUs. | `evict_host` | no-op |
 
 ### Lock Phase

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -227,6 +227,40 @@ class FullComponent(TreeComponent):
         self._evict_device_heap = []
         self._evict_device_last_node = None
 
+    def reclaim_coexisting_host_values(
+        self,
+        num_tokens: int,
+        tracker: dict[ComponentType, int],
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+    ) -> None:
+        """Reclaim Full host values, preserving imminent demotes first."""
+        ct = self.component_type
+        swept_ids: list[NodeId] = []
+        for spare_imminent_demotes in (True, False):
+            if tracker[ct] >= num_tokens:
+                break
+            for node in self.tree_core.full_host_duplicates.values():
+                if tracker[ct] >= num_tokens:
+                    break
+                cd = node.component_data[ct]
+                if cd.value is None or cd.host_value is None:
+                    swept_ids.append(node.id)
+                    continue
+                if (
+                    spare_imminent_demotes
+                    and node in self.tree_core.evictable_device_leaves
+                ):
+                    continue
+                if not self.tree_core._can_reclaim_host_duplicate(node, ct):
+                    continue
+                self.tree_core._release_host_duplicate(
+                    node, ct, tracker, device_frees, host_frees
+                )
+                swept_ids.append(node.id)
+        for node_id in swept_ids:
+            self.tree_core.full_host_duplicates.pop(node_id, None)
+
     def drive_host_eviction(
         self,
         num_tokens: int,

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -690,7 +690,7 @@ class MambaComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]
-            if cd.value is None:
+            if cd.value is None or cd.host_value is not None:
                 return None
             return [
                 PoolTransfer(

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -799,7 +799,7 @@ class SWAComponent(TreeComponent):
 
         if phase == CacheTransferPhase.BACKUP_HOST:
             cd = node.component_data[ct]
-            if cd.value is None:
+            if cd.value is None or cd.host_value is not None:
                 return None
             # cd.value already holds SWA-pool indices (translated at insert time).
             # Host pool indexing wants int64.
@@ -1034,6 +1034,31 @@ class SWAComponent(TreeComponent):
         # Buffer prefix that fell outside the anchor→leaf path.
         if pos > loaded_start:
             self._release_swa_host(host_indices[: pos - loaded_start], cache_actions)
+
+    def reclaim_coexisting_host_values(
+        self,
+        num_tokens: int,
+        tracker: dict[ComponentType, int],
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+    ) -> None:
+        """Reclaim SWA host values, preserving imminent demotes first."""
+        ct = self.component_type
+        lru = self.tree_core.lru_lists[ct]
+        for spare_imminent_demotes in (True, False):
+            if tracker[ct] >= num_tokens:
+                break
+            node = lru.get_lru_no_host_lock()
+            while tracker[ct] < num_tokens and node is not None:
+                next_node = lru.get_prev_no_host_lock(node)
+                if not (
+                    spare_imminent_demotes
+                    and node in self.tree_core.evictable_device_leaves
+                ) and self.tree_core._can_reclaim_host_duplicate(node, ct):
+                    self.tree_core._release_host_duplicate(
+                        node, ct, tracker, device_frees, host_frees
+                    )
+                node = next_node
 
     def drive_host_eviction(
         self,

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -678,6 +678,16 @@ class TreeComponent(ABC):
         """Post-transfer bookkeeping: store host indices, update LRU, etc."""
         pass
 
+    def reclaim_coexisting_host_values(
+        self,
+        num_tokens: int,
+        tracker: dict[ComponentType, int],
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+    ) -> None:
+        """Reclaim host values whose device values remain resident."""
+        return
+
     def drive_host_eviction(
         self,
         num_tokens: int,

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1072,7 +1072,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self._update_evictable_leaf_sets(new_node)
         self._update_evictable_leaf_sets(child)
         # Only the new fragment needs qualifying; the child keeps its id.
-        self._update_duplicate_tracking(new_node)
+        self._update_full_host_duplicate_tracking(new_node)
         return new_node, action
 
     def _add_new_node(
@@ -1109,7 +1109,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         self.component_evictable_size_[ct] += n
         self._update_evictable_leaf_sets(node)
         # A backuped node restored from fresh KV is a duplicate right away.
-        self._update_duplicate_tracking(node)
+        self._update_full_host_duplicate_tracking(node)
         if node.parent is not None:
             self._update_evictable_leaf_sets(node.parent)
         self._record_store_event(node, medium=StorageMedium.GPU)
@@ -1126,9 +1126,8 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         else:
             self.evictable_host_leaves.discard(node)
 
-    def _update_duplicate_tracking(self, node: UnifiedTreeNode) -> None:
-        """Register where duplicates are born (acks, split, unevict);
-        deregistration is lazy, so entries may be stale and re-checked live."""
+    def _update_full_host_duplicate_tracking(self, node: UnifiedTreeNode) -> None:
+        """Refresh Full's lazy host-duplicate registry."""
         if self._is_settled_full_host_duplicate(node):
             self.full_host_duplicates.setdefault(node.id, node)
         else:
@@ -1311,13 +1310,12 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     def drive_host_eviction(
         self, component_type: ComponentType, num_tokens: int
     ) -> DriveHostEvictionResult:
-        """Evict a component's host-side resources; no-op if absent. Under
-        write_back, FULL pressure reclaims redundant Full host copies first."""
+        """Evict a component's host-side resources; no-op if absent."""
         result = DriveHostEvictionResult()
         comp = self.components_by_type.get(component_type)
         if comp is not None:
-            if self.is_write_back and component_type == BASE_COMPONENT_TYPE:
-                self._reclaim_full_host_duplicates(
+            if self.is_write_back:
+                comp.reclaim_coexisting_host_values(
                     num_tokens,
                     result.tracker,
                     result.device_frees,
@@ -1341,42 +1339,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             self.node_by_id(tail_node_id), device_frees, host_frees
         )
 
-    def _reclaim_full_host_duplicates(
-        self,
-        num_tokens: int,
-        tracker: dict[ComponentType, int],
-        device_frees: dict[ComponentType, list[torch.Tensor]],
-        host_frees: dict[ComponentType, list[torch.Tensor]],
-    ) -> None:
-        """Reclaim Full host duplicates until num_tokens are freed; pass 1
-        spares evictable D-leaves (imminent free demotes), pass 2 takes them."""
-        swept_ids: list[NodeId] = []
-        for spare_imminent_demotes in (True, False):
-            if tracker[BASE_COMPONENT_TYPE] >= num_tokens:
-                break
-            for node in self.full_host_duplicates.values():
-                if tracker[BASE_COMPONENT_TYPE] >= num_tokens:
-                    break
-                cd = node.component_data[BASE_COMPONENT_TYPE]
-                if cd.value is None or cd.host_value is None:
-                    swept_ids.append(node.id)  # stale entry
-                    continue
-                if spare_imminent_demotes and node in self.evictable_device_leaves:
-                    continue
-                if not self._can_reclaim_full_host_duplicate(node):
-                    continue
-                self._release_full_host_duplicate(
-                    node, tracker, device_frees, host_frees
-                )
-                swept_ids.append(node.id)  # released -> no longer a duplicate
-        # Sweep after the walk: the dict must not be mutated mid-iteration.
-        for nid in swept_ids:
-            self.full_host_duplicates.pop(nid, None)
-
-    def _can_reclaim_full_host_duplicate(self, node: UnifiedTreeNode) -> bool:
-        """Full on both tiers, no in-flight DMA, no Full host lock; checked
-        live because tracking may be stale."""
-        cd = node.component_data[BASE_COMPONENT_TYPE]
+    def _can_reclaim_host_duplicate(
+        self, node: UnifiedTreeNode, component_type: ComponentType
+    ) -> bool:
+        cd = node.component_data[component_type]
         if node is self.root_node or cd.value is None or cd.host_value is None:
             return False
         if (
@@ -1386,27 +1352,30 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             return False
         return cd.host_lock_ref == 0
 
-    def _release_full_host_duplicate(
+    def _release_host_duplicate(
         self,
         node: UnifiedTreeNode,
+        component_type: ComponentType,
         tracker: dict[ComponentType, int],
         device_frees: dict[ComponentType, list[torch.Tensor]],
         host_frees: dict[ComponentType, list[torch.Tensor]],
     ) -> None:
-        """Free only the Full host layer; aux host slices stay under their own
-        pools' LRU (a host-only aux slice may be a sole copy)."""
-        assert self._can_reclaim_full_host_duplicate(node)
-        self._record_remove_event(node, medium=StorageMedium.CPU)
+        """Free one component's redundant host layer."""
+        assert self._can_reclaim_host_duplicate(node, component_type)
+        if component_type == BASE_COMPONENT_TYPE:
+            # BlockRemoved tracks Full host residency, not auxiliary slices.
+            self._record_remove_event(node, medium=StorageMedium.CPU)
         self._evict_component_and_detach_lru(
             node,
-            self.components_by_type[BASE_COMPONENT_TYPE],
+            self.components_by_type[component_type],
             target=EvictLayer.HOST,
             tracker=tracker,
             device_frees=device_frees,
             host_frees=host_frees,
         )
+        event = (node.id + 1) * len(ComponentType) + int(component_type)
         self.write_back_duplicate_reclaim_digest = (
-            self.write_back_duplicate_reclaim_digest * 1000003 + node.id + 1
+            self.write_back_duplicate_reclaim_digest * 1000003 + event
         ) & _RECLAIM_DIGEST_MASK
 
     def _evict_host_leaf(
@@ -1909,6 +1878,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 cache_actions=cache_actions,
             )
         assert not cache_actions  # BACKUP_HOST emits no actions
+        self._update_full_host_duplicate_tracking(node)
 
     def commit_load_back(
         self,
@@ -1961,7 +1931,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             if node.load_back_pending_id == anchor_node_id:
                 node.load_back_pending_id = None
                 # The loaded copies become tracked duplicates only now.
-                self._update_duplicate_tracking(node)
+                self._update_full_host_duplicate_tracking(node)
             node = node.parent
 
     def mark_write_through_pending(self, node_id: NodeId) -> None:
@@ -1977,7 +1947,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             if node.write_through_pending_id == ack_id:
                 node.write_through_pending_id = None
                 # The backed-up copy becomes a tracked duplicate only now.
-                self._update_duplicate_tracking(node)
+                self._update_full_host_duplicate_tracking(node)
             self._record_store_event(node, medium=StorageMedium.CPU)
 
     def set_component_device_value(

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -465,8 +465,8 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
         """Clear the in-flight H->D marks on the anchor's root path at ack time."""
         ...
 
-    # Order-sensitive digest of write_back duplicate-reclaim victim ids,
-    # cross-checked across TP ranks; cores that never reclaim keep 0.
+    # Order-sensitive digest of write_back duplicate-reclaim node/component
+    # events, cross-checked across TP ranks; cores that never reclaim keep 0.
     write_back_duplicate_reclaim_digest: int = 0
 
     @abstractmethod

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2613,6 +2613,12 @@ class ServerArgs:
         "The size of host KV cache memory pool in gigabytes, which will override the hicache_ratio if set.",
         NS("memory"),
     ] = 0
+    hicache_swa_full_tokens_ratio: A[
+        Optional[float],
+        "The ratio of SWA HiCache tokens to full HiCache tokens. If unset, "
+        "the ratio follows the device pools.",
+        NS("memory"),
+    ] = None
     hicache_write_policy: A[
         str,
         Arg(
@@ -7795,6 +7801,17 @@ class ServerArgs:
                 envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
 
     def _handle_cache_compatibility(self):
+        if self.hicache_swa_full_tokens_ratio is not None:
+            if not 0 < self.hicache_swa_full_tokens_ratio <= 1.0:
+                raise ValueError(
+                    "--hicache-swa-full-tokens-ratio should be in range (0, 1]."
+                )
+            if self.hicache_size <= 0:
+                raise ValueError(
+                    "--hicache-swa-full-tokens-ratio requires --hicache-size to be "
+                    "positive."
+                )
+
         if self.enable_hierarchical_cache and self.disable_radix_cache:
             raise ValueError(
                 "The arguments enable-hierarchical-cache and disable-radix-cache are mutually exclusive "

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -2787,7 +2787,7 @@ class UnifiedRadixCacheSuite:
                 if cd.value is not None and cd.host_value is None:
                     cd.host_value = cd.value.clone()
             # A real backup registers duplicate tracking at its ack.
-            cache.tree_core._update_duplicate_tracking(ancestor)
+            cache.tree_core._update_full_host_duplicate_tracking(ancestor)
 
     def _simulate_backup_tree(self, cache):
         """Backup all non-root nodes (simulates write-through)."""


### PR DESCRIPTION
## Summary

HiCache write-back can retain an SWA host value after the same component remains device-resident, exhausting the SWA host pool under pressure. This moves coexistence reclaim behind component hooks so Full and SWA reclaim their own redundant host values before ordinary eviction, and avoids backing up auxiliary values already present on host.

It also adds `--hicache-swa-full-tokens-ratio` and sizes Full/SWA host pools by bytes per token so the requested token-capacity ratio is preserved across MHA, MLA, and MTP draft pools.

## Test plan

- `pre-commit run --from-ref origin/main --to-ref HEAD` (passed)
- `python -m pytest -q test/registered/unit/mem_cache/test_mem_pool_host.py::TestHostKVCache::test_empty_free_keeps_release_list_empty test/registered/unit/mem_cache/test_hicache_dcp_host_pool.py::TestHostPoolSizingUnderDcp::test_non_dcp_pool_unchanged test/registered/unit/server_args/test_server_args.py::TestHiCacheArgs test/registered/unit/test_server_args_namespaces.py::TestServerArgsNamespaces::test_every_field_has_a_namespace` (5 passed, 5 subtests passed)
- `python -m pytest -q test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py::Test_FULL_SWA_ps1_sw4::test_has_swa_host_pool_flag_matches_attached_pool test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py::Test_FULL_SWA_ps1_sw4::test_hicache_write_back_leaf_backup test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py::Test_FULL_SWA_ps1_sw4::test_hicache_write_back_evict_drops_unbacked_leaf_when_host_full test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py::Test_FULL_SWA_ps1_sw4::test_evict_host_drains_freed_host_values_to_the_pools` (4 passed)

## Original commits

- `f4875f870`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31227661726](https://github.com/sgl-project/sglang/actions/runs/31227661726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31227661563](https://github.com/sgl-project/sglang/actions/runs/31227661563)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->