### PR TITLE
[Spec] Derive dsv4 target-verify extend lengths from the layout

### DIFF
--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -64,8 +64,8 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import (
-    RaggedVerifyLayout,
     RaggedVerifyMode,
+    VerifyExtendLengths,
     compute_ragged_extend_lengths,
     compute_target_verify_graph_key,
     read_ragged_verify_mode,
@@ -512,7 +512,6 @@ class DeepseekV4AttnBackend(
         super().__init__()
         self.model_runner = model_runner
         self.device = torch.device(model_runner.device)
-        self._uniform_layout_cache: dict = {}
         self.max_context_len = model_runner.model_config.context_len
         head_dim = model_runner.model_config.head_dim
         assert (
@@ -902,16 +901,18 @@ class DeepseekV4AttnBackend(
         ragged_layout: Optional[RaggedVerifyLayout] = None,
     ) -> DSV4Metadata:
         if ragged_layout is None:
-            ragged_layout = self._uniform_verify_layout(
-                bs=int(seq_lens.shape[0]),
+            lengths, extend_seq_lens = self._uniform_extend_lengths(
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
                 extend_len=self.speculative_num_draft_tokens,
             )
-        lengths = compute_ragged_extend_lengths(
-            seq_lens=seq_lens,
-            seq_lens_cpu=seq_lens_cpu,
-            ragged_layout=ragged_layout,
-        )
-        extend_seq_lens = ragged_layout.verify_lens
+        else:
+            lengths = compute_ragged_extend_lengths(
+                seq_lens=seq_lens,
+                seq_lens_cpu=seq_lens_cpu,
+                ragged_layout=ragged_layout,
+            )
+            extend_seq_lens = ragged_layout.verify_lens
         seq_lens = lengths.seq_lens_extended
         seq_lens_cpu = lengths.seq_lens_cpu_extended
         extend_seq_lens_cpu = lengths.extend_seq_lens_cpu
@@ -934,19 +935,25 @@ class DeepseekV4AttnBackend(
             online_c128_state_slot_offset=online_c128_state_slot_offset,
         )
 
-    def _uniform_verify_layout(self, *, bs: int, extend_len: int) -> RaggedVerifyLayout:
-        # Uniform verify / draft-block geometry as a trivial layout, cached per
-        # shape so the device tensors build once.
-        key = (bs, extend_len)
-        layout = self._uniform_layout_cache.get(key)
-        if layout is None:
-            layout = RaggedVerifyLayout.from_verify_lens(
-                verify_lens_cpu=[extend_len] * bs,
-                device=self.device,
-                grid=[bs * extend_len],
-            )
-            self._uniform_layout_cache[key] = layout
-        return layout
+    def _uniform_extend_lengths(
+        self, *, seq_lens: torch.Tensor, seq_lens_cpu: List[int], extend_len: int
+    ) -> Tuple[VerifyExtendLengths, torch.Tensor]:
+        # Uniform verify / draft-block geometry off the preallocated graph
+        # buffers. The returned slices are shared per backend instance;
+        # callers must not mutate them.
+        bs = int(seq_lens.shape[0])
+        extend_seq_lens = self.extend_seq_lens_buffer[:bs]
+        extend_seq_lens.fill_(extend_len)
+        extend_start_loc = self.extend_start_loc_buffer[:bs]
+        torch.arange(0, bs * extend_len, extend_len, out=extend_start_loc)
+        lengths = VerifyExtendLengths(
+            seq_lens_extended=seq_lens + extend_len,
+            seq_lens_cpu_extended=[x + extend_len for x in seq_lens_cpu],
+            extend_seq_lens_cpu=[extend_len] * bs,
+            num_tokens=extend_len * bs,
+            extend_start_loc=extend_start_loc,
+        )
+        return lengths, extend_seq_lens
 
     def init_forward_metadata_dspark_draft_block(
         self,
@@ -961,15 +968,11 @@ class DeepseekV4AttnBackend(
             seq_lens_cpu_list = seq_lens.tolist()
         else:
             seq_lens_cpu_list = [int(x) for x in seq_lens_cpu.tolist()]
-        layout = self._uniform_verify_layout(
-            bs=int(seq_lens.shape[0]), extend_len=block_size
-        )
-        lengths = compute_ragged_extend_lengths(
+        lengths, extend_seq_lens = self._uniform_extend_lengths(
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu_list,
-            ragged_layout=layout,
+            extend_len=block_size,
         )
-        extend_seq_lens = layout.verify_lens
         return self.init_forward_metadata_prefill(
             max_seq_len=max_seq_len,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -64,10 +64,10 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMo
 from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import (
+    RaggedVerifyLayout,
     RaggedVerifyMode,
     compute_ragged_extend_lengths,
     compute_target_verify_graph_key,
-    compute_uniform_extend_lengths,
     read_ragged_verify_mode,
     resolve_ragged_verify_layout,
 )
@@ -512,6 +512,7 @@ class DeepseekV4AttnBackend(
         super().__init__()
         self.model_runner = model_runner
         self.device = torch.device(model_runner.device)
+        self._uniform_layout_cache: dict = {}
         self.max_context_len = model_runner.model_config.context_len
         head_dim = model_runner.model_config.head_dim
         assert (
@@ -901,19 +902,16 @@ class DeepseekV4AttnBackend(
         ragged_layout: Optional[RaggedVerifyLayout] = None,
     ) -> DSV4Metadata:
         if ragged_layout is None:
-            lengths = compute_uniform_extend_lengths(
-                seq_lens=seq_lens,
-                seq_lens_cpu=seq_lens_cpu,
+            ragged_layout = self._uniform_verify_layout(
+                bs=int(seq_lens.shape[0]),
                 extend_len=self.speculative_num_draft_tokens,
             )
-            extend_seq_lens = self._move_to_device(lengths.extend_seq_lens_cpu)
-        else:
-            lengths = compute_ragged_extend_lengths(
-                seq_lens=seq_lens,
-                seq_lens_cpu=seq_lens_cpu,
-                ragged_layout=ragged_layout,
-            )
-            extend_seq_lens = ragged_layout.verify_lens
+        lengths = compute_ragged_extend_lengths(
+            seq_lens=seq_lens,
+            seq_lens_cpu=seq_lens_cpu,
+            ragged_layout=ragged_layout,
+        )
+        extend_seq_lens = ragged_layout.verify_lens
         seq_lens = lengths.seq_lens_extended
         seq_lens_cpu = lengths.seq_lens_cpu_extended
         extend_seq_lens_cpu = lengths.extend_seq_lens_cpu
@@ -936,6 +934,20 @@ class DeepseekV4AttnBackend(
             online_c128_state_slot_offset=online_c128_state_slot_offset,
         )
 
+    def _uniform_verify_layout(self, *, bs: int, extend_len: int) -> RaggedVerifyLayout:
+        # Uniform verify / draft-block geometry as a trivial layout, cached per
+        # shape so the device tensors build once.
+        key = (bs, extend_len)
+        layout = self._uniform_layout_cache.get(key)
+        if layout is None:
+            layout = RaggedVerifyLayout.from_verify_lens(
+                verify_lens_cpu=[extend_len] * bs,
+                device=self.device,
+                grid=[bs * extend_len],
+            )
+            self._uniform_layout_cache[key] = layout
+        return layout
+
     def init_forward_metadata_dspark_draft_block(
         self,
         max_seq_len: int,
@@ -949,12 +961,15 @@ class DeepseekV4AttnBackend(
             seq_lens_cpu_list = seq_lens.tolist()
         else:
             seq_lens_cpu_list = [int(x) for x in seq_lens_cpu.tolist()]
-        lengths = compute_uniform_extend_lengths(
+        layout = self._uniform_verify_layout(
+            bs=int(seq_lens.shape[0]), extend_len=block_size
+        )
+        lengths = compute_ragged_extend_lengths(
             seq_lens=seq_lens,
             seq_lens_cpu=seq_lens_cpu_list,
-            extend_len=block_size,
+            ragged_layout=layout,
         )
-        extend_seq_lens = self._move_to_device(lengths.extend_seq_lens_cpu)
+        extend_seq_lens = layout.verify_lens
         return self.init_forward_metadata_prefill(
             max_seq_len=max_seq_len,
             req_pool_indices=req_pool_indices,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -582,10 +582,6 @@ class DeepseekV4AttnBackend(
         self.is_draft_runner = model_runner.is_draft_worker
         self._verify_mask = None
 
-    def _move_to_device(self, x: List[int]) -> torch.Tensor:
-        pin_tensor = torch.tensor(x, dtype=torch.int32, pin_memory=True)
-        return pin_tensor.to(self.device, non_blocking=True)
-
     def _resolve_verify_layout(
         self,
         forward_batch: ForwardBatch,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -943,13 +943,7 @@ class DeepseekV4AttnBackend(
         extend_seq_lens = self.extend_seq_lens_buffer[:bs]
         extend_seq_lens.fill_(extend_len)
         extend_start_loc = self.extend_start_loc_buffer[:bs]
-        torch.arange(
-            0,
-            bs * extend_len,
-            extend_len,
-            out=extend_start_loc,
-            **self.cuda_int32_kwargs,
-        )
+        torch.arange(0, bs * extend_len, extend_len, out=extend_start_loc)
         lengths = VerifyExtendLengths(
             seq_lens_extended=seq_lens + extend_len,
             seq_lens_cpu_extended=[x + extend_len for x in seq_lens_cpu],

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -935,13 +935,21 @@ class DeepseekV4AttnBackend(
         self, *, seq_lens: torch.Tensor, seq_lens_cpu: List[int], extend_len: int
     ) -> Tuple[VerifyExtendLengths, torch.Tensor]:
         # Uniform verify / draft-block geometry off the preallocated graph
-        # buffers. The returned slices are shared per backend instance;
+        # buffers (allocated only under spec decoding; both callers are
+        # spec-only). The returned slices are shared per backend instance;
         # callers must not mutate them.
+        assert self.speculative_num_draft_tokens is not None
         bs = int(seq_lens.shape[0])
         extend_seq_lens = self.extend_seq_lens_buffer[:bs]
         extend_seq_lens.fill_(extend_len)
         extend_start_loc = self.extend_start_loc_buffer[:bs]
-        torch.arange(0, bs * extend_len, extend_len, out=extend_start_loc)
+        torch.arange(
+            0,
+            bs * extend_len,
+            extend_len,
+            out=extend_start_loc,
+            **self.cuda_int32_kwargs,
+        )
         lengths = VerifyExtendLengths(
             seq_lens_extended=seq_lens + extend_len,
             seq_lens_cpu_extended=[x + extend_len for x in seq_lens_cpu],

--- a/python/sglang/srt/speculative/ragged_verify.py
+++ b/python/sglang/srt/speculative/ragged_verify.py
@@ -277,27 +277,7 @@ class VerifyExtendLengths(msgspec.Struct, frozen=True):
     seq_lens_cpu_extended: List[int]
     extend_seq_lens_cpu: List[int]
     num_tokens: int
-    extend_start_loc: Optional[torch.Tensor]
-
-
-def compute_uniform_extend_lengths(
-    *,
-    seq_lens: torch.Tensor,
-    seq_lens_cpu: List[int],
-    extend_len: int,
-) -> VerifyExtendLengths:
-    batch_size = len(seq_lens_cpu)
-    seq_lens_extended = seq_lens + extend_len
-    seq_lens_cpu_extended = [x + extend_len for x in seq_lens_cpu]
-    extend_seq_lens_cpu = [extend_len] * batch_size
-    num_tokens = extend_len * batch_size
-    return VerifyExtendLengths(
-        seq_lens_extended=seq_lens_extended,
-        seq_lens_cpu_extended=seq_lens_cpu_extended,
-        extend_seq_lens_cpu=extend_seq_lens_cpu,
-        num_tokens=num_tokens,
-        extend_start_loc=None,
-    )
+    extend_start_loc: torch.Tensor
 
 
 def compute_ragged_extend_lengths(


### PR DESCRIPTION
Delete the uniform/ragged dual track for dsv4 verify extend lengths: `compute_uniform_extend_lengths` is removed, and the uniform target-verify and dspark draft-block paths derive their geometry from a per-shape cached trivial `RaggedVerifyLayout` through the same `compute_ragged_extend_lengths` path as ragged batches.

Behavior note: with a real `extend_start_loc` the uniform paths now take `ExpandPrefillCausally`'s vectorized device branch instead of the host-list branch (identical values; drops a per-step host list build + H2D copy). The kernel's host branch stays -- regular prefill batches without `extend_start_loc` still use it.

Stacks on #34038.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829000605](https://github.com/sgl-project/sglang/actions/runs/34829000605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829000378](https://github.com/sgl-project/sglang/actions/runs/34829000378)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->