### PR TITLE
Don't select Marlin kernels on ROCm

### DIFF
--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -86,6 +86,11 @@ def query_marlin_supported_quant_types(
     include_fp_type: bool = True,
     device_capability: Optional[int] = None,
 ):
+    # The Marlin kernels are written in PTX, so a ROCm device reporting its gfx
+    # arch as e.g. (11, 5) must not be mistaken for an Ampere+ CUDA device.
+    if not _is_cuda:
+        return []
+
     if device_capability is None:
         major, minor = get_device_capability()
         capability = major * 10 + minor

--- a/test/registered/unit/layers/quantization/test_marlin_utils_platform.py
+++ b/test/registered/unit/layers/quantization/test_marlin_utils_platform.py
@@ -1,0 +1,45 @@
+"""Unit tests for the Marlin platform gate — CPU-only, no model loading."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization.marlin_utils import check_marlin_supported
+from sglang.srt.layers.quantization.utils import get_scalar_types
+from sglang.test.test_utils import CustomTestCase
+
+_MODULE = "sglang.srt.layers.quantization.marlin_utils"
+_GET_CAP = f"{_MODULE}.get_device_capability"
+_IS_CUDA = f"{_MODULE}._is_cuda"
+
+_, scalar_types = get_scalar_types()
+
+
+class TestMarlinSupportedPlatform(CustomTestCase):
+    """Regression for #33015: Marlin selected on ROCm.
+
+    The Marlin kernels are PTX-only, but support was decided from
+    `get_device_capability()` alone. On ROCm that returns the gfx arch, so
+    gfx1150 reads back as (11, 5) -> 115 >= 80 and a GPTQ/AutoRound model got
+    routed into `gptq_marlin_repack`, which then failed to compile under hipcc
+    with "use of undeclared identifier '__cvta_generic_to_shared'".
+    """
+
+    def test_not_supported_on_rocm(self):
+        with patch(_IS_CUDA, False), patch(_GET_CAP, return_value=(11, 5)):
+            self.assertFalse(
+                check_marlin_supported(scalar_types.uint4b8, group_size=128)
+            )
+
+    def test_supported_on_ampere(self):
+        with patch(_IS_CUDA, True), patch(_GET_CAP, return_value=(8, 6)):
+            self.assertTrue(
+                check_marlin_supported(scalar_types.uint4b8, group_size=128)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #33015

`query_marlin_supported_quant_types()` decided Marlin support from `get_device_capability()` alone.
On ROCm that returns the gfx arch, so gfx1150 comes back as `(11, 5)` -> `115 >= 80` and Marlin is
declared supported. The Marlin kernels are PTX-only (`marlin.cuh` uses `__cvta_generic_to_shared`
and `cp.async` inline asm, no HIP path), so an int4 AutoRound checkpoint got routed into
`gptq_marlin_repack` and hipcc failed with `use of undeclared identifier '__cvta_generic_to_shared'`.

Return `[]` when not on CUDA. The module already computes `_is_cuda` at import and already uses it
to gate the `gptq_marlin_gemm` import, so the platform fact was there, the support check just did
not read it. This also funnels every caller (`gptq`, `awq`, `auto_round`, `moe_wna16` via
`is_gptq_marlin_compatible`), since they all reach it through `check_marlin_supported`.

Verified on 8x A40 (sm_86, CUDA 12.6). I have no AMD hardware, so I did not run hipcc or reproduce
the compile error itself. What I reproduced is the decision that causes it: with
`marlin_utils._is_cuda` patched False and `get_device_capability` patched to `(11, 5)`,
`check_marlin_supported(uint4b8, 128)` returned `True` before this change and returns `False`
after. Added `test/registered/unit/layers/quantization/test_marlin_utils_platform.py` (CPU-only)
covering both that case and the sm_86 case, so the guard cannot silently disable Marlin on CUDA.
It fails before the change and passes after.

Two things a ROCm user will still hit, both out of scope here and neither introduced by this patch:

- `auto_round.py:412` returns `GPTQMarlinMoEMethod(quant_args_marlin)` on the non-Marlin branch,
  where `quant_args_marlin` was never assigned. Any GPTQ MoE model that fails the Marlin check
  raises `UnboundLocalError` there, on ROCm or on a pre-Ampere CUDA GPU. The model in the issue is
  MoE, so it will hit this.
- There is no non-Marlin GPTQ MoE path at all, `GPTQConfig.get_quant_method` raises "GPTQ Method
  does not support MoE, please use gptq_marlin".

So this stops sglang from claiming a kernel it cannot build, it does not make that checkpoint serve
on gfx1150.

Thanks to @alex-mashin for the report, the full hipcc output and the `arch_11.5` JIT cache path in
it are what pinned this down.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31340139181](https://github.com/sgl-project/sglang/actions/runs/31340139181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31340139108](https://github.com/sgl-project/sglang/actions/runs/31340139108)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->