### PR TITLE
Default the tool-call parser when dsv4/dsv32 encoding is used

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -265,6 +265,17 @@ class OpenAIServingChat(OpenAIServingBase):
             else None
         )
 
+        # The dsv4/dsv32 encoders are picked from the model architecture, not
+        # from --tool-call-parser, and they always render tools as DSML, so the
+        # model answers in DSML too. Pick the matching detector when no parser
+        # was configured, otherwise the DSML block is returned verbatim as
+        # content. An explicit --tool-call-parser still wins.
+        if self.tool_call_parser is None:
+            self.tool_call_parser = {
+                "dsv4": "deepseekv4",
+                "dsv32": "deepseekv32",
+            }.get(self.chat_encoding_spec)
+
         # Resolve the env-configured Inkling effort default once: the env var is
         # frozen for the server's lifetime, and a misconfigured value should
         # fail at boot, not 400 every request.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -26,7 +26,9 @@ from sglang.srt.entrypoints.openai.chat_encoding import (
 )
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
+    Function,
     MessageProcessingResult,
+    Tool,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
@@ -2971,6 +2973,84 @@ class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):
         )
 
         self.assertIsNone(tool_calls)
+
+
+class TestDsmlEncodingDefaultsToolCallParser(unittest.TestCase):
+    """DeepSeek-V4 / V3.2 ship no chat template, so the dsv4 / dsv32 encoder is
+    selected from the architecture and always renders tools as DSML. Launched
+    without --tool-call-parser the DSML reply came back verbatim as content
+    instead of tool_calls (issue #33163)."""
+
+    dsml_reply = (
+        "Let me look at the project.\n\n"
+        "<｜DSML｜tool_calls>\n"
+        '<｜DSML｜invoke name="List">\n'
+        '<｜DSML｜parameter name="path" string="true">D:/Project</｜DSML｜parameter>\n'
+        '<｜DSML｜parameter name="recursive" string="false">false</｜DSML｜parameter>\n'
+        "</｜DSML｜invoke>\n"
+        "</｜DSML｜tool_calls>"
+    )
+
+    def _make_chat(self, architecture, tool_call_parser=None):
+        tm = _MockTokenizerManager()
+        tm.server_args.tool_call_parser = tool_call_parser
+        tm.tokenizer.chat_template = None
+        tm.model_config.hf_config.architectures = [architecture]
+        return OpenAIServingChat(tm, _MockTemplateManager())
+
+    def test_dsv4_defaults_to_deepseekv4_parser(self):
+        chat = self._make_chat("DeepseekV4ForCausalLM")
+        self.assertEqual(chat.chat_encoding_spec, "dsv4")
+        self.assertEqual(chat.tool_call_parser, "deepseekv4")
+
+    def test_dsv32_defaults_to_deepseekv32_parser(self):
+        chat = self._make_chat("DeepseekV32ForCausalLM")
+        self.assertEqual(chat.chat_encoding_spec, "dsv32")
+        self.assertEqual(chat.tool_call_parser, "deepseekv32")
+
+    def test_explicit_parser_is_kept(self):
+        chat = self._make_chat("DeepseekV4ForCausalLM", tool_call_parser="hermes")
+        self.assertEqual(chat.tool_call_parser, "hermes")
+
+    def test_other_architecture_keeps_no_parser(self):
+        chat = self._make_chat("LlamaForCausalLM")
+        self.assertIsNone(chat.chat_encoding_spec)
+        self.assertIsNone(chat.tool_call_parser)
+
+    def test_dsml_reply_becomes_tool_calls(self):
+        chat = self._make_chat("DeepseekV4ForCausalLM")
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="List",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "path": {"type": "string"},
+                            "recursive": {"type": "boolean"},
+                        },
+                    },
+                ),
+            )
+        ]
+
+        tool_calls, text, finish_reason = chat._process_tool_calls(
+            text=self.dsml_reply,
+            tools=tools,
+            finish_reason={"type": "stop", "matched": None},
+            tool_choice="auto",
+        )
+
+        self.assertIsNotNone(tool_calls)
+        self.assertEqual(len(tool_calls), 1)
+        self.assertEqual(tool_calls[0].function.name, "List")
+        self.assertEqual(
+            json.loads(tool_calls[0].function.arguments),
+            {"path": "D:/Project", "recursive": False},
+        )
+        self.assertNotIn("DSML", text)
+        self.assertEqual(finish_reason["type"], "tool_calls")
 
 
 class TestNormalizeToolContent(unittest.TestCase):


### PR DESCRIPTION
Fixes #33163

DeepSeek-V4 ships no chat template, so `resolve_chat_encoding_spec()` picks the
`dsv4` encoder from `hf_config.architectures` and renders `request.tools` as a
DSML prompt no matter what. The decode half is not architecture-driven:
`OpenAIServingChat` only builds a `FunctionCallParser` when
`server_args.tool_call_parser` is set. A server launched without
`--tool-call-parser deepseekv4` therefore prompts the model in DSML and then
hands the `<｜DSML｜tool_calls>` block back to the client verbatim as
`message.content`.

The reporter's working config had `--tool-call-parser deepseekv4`; the config
they switched to does not. `--moe-runner-backend` is not involved: the DSML in
their screenshot is well formed and `DeepSeekV4Detector` parses it correctly,
both one-shot and streamed. Worth noting the cookbook config makes this easy to
hit, since `--moe-runner-backend flashinfer_mxfp4` lives in the deploy-matrix
cells while the parser flags live in a separate playground toggle list.

## Change

In `OpenAIServingChat.__init__`, when `chat_encoding_spec` resolved to `dsv4`
or `dsv32` and no `--tool-call-parser` was given, use the matching detector.
An explicit `--tool-call-parser` still wins. `dsv32` is included because
`resolve_chat_encoding_spec` reaches it under the same "DeepseekV3 arch, no
chat template" condition.

`--reasoning-parser` is deliberately left alone: defaulting it would move text
from `content` to `reasoning_content` and break clients that only read
`content`.

## Verification

CPU only, on 8x A40 (sm_86), so no DeepSeek-V4 end-to-end run.

- New `TestDsmlEncodingDefaultsToolCallParser` in
  `test/registered/unit/entrypoints/openai/test_serving_chat.py`. The last case
  feeds the DSML reply from the issue screenshot to `_process_tool_calls` and
  asserts it comes back as `tool_calls` with the DSML gone from the text.
  3 of 5 cases fail on the pre-fix code (`AssertionError: unexpectedly None`,
  `None != 'deepseekv4'`, `None != 'deepseekv32'`) and all 5 pass after.
- `test_serving_chat.py` 89 pass, `test_serving_completions.py` 15,
  `test_serving_responses.py` 17, `test_protocol.py` 32,
  `test/registered/unit/parser/` 303, `test/registered/unit/function_call/`
  387 (2 import errors from a missing `pytest` in my venv, not assertions).
- black / isort / ruff clean on both changed files.

Not verified: the fix on real DeepSeek-V4-Flash weights, and the reporter's
exact command line, which I inferred from the two configs in the issue. If they
did have `--tool-call-parser deepseekv4` set and trimmed it from the paste, this
is not their bug.

Thanks to @yiminghub2024 for the report and the screenshot, which is what ruled the
MoE runner backend out.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31340170272](https://github.com/sgl-project/sglang/actions/runs/31340170272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31340170122](https://github.com/sgl-project/sglang/actions/runs/31340170122)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->