### PR TITLE
Fix Inkling tool name leaking into content without an opener

### DIFF
--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -961,18 +961,23 @@ class InklingDetector(BaseReasoningFormatDetector):
             reasoning_default="always",
         )
 
-        self._kind: str | None = None
+        # continue_final_message resumes inside an OPEN <|content_text|> block
+        # (see ServingChat._encode_messages), so its first run is visible text
+        # rather than a run that may still turn out to be a tool header.
+        self._kind: str | None = "content" if continue_final_message else None
         self._pending_header = ""
         self._pending_reasoning = ""
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         self._buffer = ""
-        self._kind = None
+        self._kind = "content" if self.continue_final_message else None
         self._pending_header = ""
         self._pending_reasoning = ""
         ret = self._parse_blocks(text)
         if self._kind == "reasoning" and not self.stream_reasoning:
             ret.reasoning_text += self._pending_reasoning
+        if self._kind is None:
+            ret.normal_text += self._pending_header
         self._kind = None
         self._pending_header = ""
         self._pending_reasoning = ""
@@ -996,11 +1001,16 @@ class InklingDetector(BaseReasoningFormatDetector):
         reasoning_text = ""
         if self._kind == "reasoning" and not self.stream_reasoning:
             reasoning_text = self._pending_reasoning
+        # Out-of-block text never met a control token that could reclassify it
+        # as a tool header, so it is visible text.
+        normal_text = self._pending_header if self._kind is None else ""
         self._buffer = ""
         self._pending_reasoning = ""
         self._pending_header = ""
         self._kind = None
-        return StreamingParseResult(reasoning_text=reasoning_text)
+        return StreamingParseResult(
+            normal_text=normal_text, reasoning_text=reasoning_text
+        )
 
     @staticmethod
     def _partial_control_length(text: str) -> int:
@@ -1017,7 +1027,6 @@ class InklingDetector(BaseReasoningFormatDetector):
     def _parse_blocks(self, text: str) -> StreamingParseResult:
         reasoning: list[str] = []
         content: list[str] = []
-        saw_control = False
         pos = 0
 
         def emit(text: str) -> None:
@@ -1030,21 +1039,26 @@ class InklingDetector(BaseReasoningFormatDetector):
                 content.append(text)
             elif self._kind == "tool":
                 content.append(text)
-            elif self._kind == "header":
+            else:
+                # An open header, or no open block at all: a turn whose first
+                # block is a tool call looks like the latter when the prompt
+                # already supplied the opener, so buffer either way and let the
+                # next control token settle it (flush_header).
                 self._pending_header += text
-            elif text:
-                # No open block — e.g. a continue_final_message stream resuming
-                # mid text block. Route to visible content, matching the
-                # no-control-token path below.
-                content.append(text)
 
         def flush_reasoning() -> None:
             if self._kind == "reasoning" and not self.stream_reasoning:
                 reasoning.append(self._pending_reasoning)
                 self._pending_reasoning = ""
 
+        def flush_header() -> None:
+            # The buffered run was not a tool header: after a real opener it is
+            # framing and dropped, with no open block it is visible text.
+            if self._kind is None:
+                content.append(self._pending_header)
+            self._pending_header = ""
+
         for match in _INKLING_CONTROL_RE.finditer(text):
-            saw_control = True
             emit(text[pos : match.start()])
 
             token = match.group(0)
@@ -1052,7 +1066,7 @@ class InklingDetector(BaseReasoningFormatDetector):
             if token == MESSAGE_MODEL:
                 if self._kind in (None, "header"):
                     flush_reasoning()
-                    self._pending_header = ""
+                    flush_header()
                     self._kind = "header"
                 else:
                     # Inside an open block a decoded <|message_model|> string
@@ -1064,7 +1078,7 @@ class InklingDetector(BaseReasoningFormatDetector):
                 # Preserve the tool-invocation framing (json and headerless raw
                 # text) in content so the tool-call detector receives it.
                 flush_reasoning()
-                if self._kind == "header":
+                if self._kind in (None, "header"):
                     content.extend((MESSAGE_MODEL, self._pending_header, token))
                     self._pending_header = ""
                 else:
@@ -1076,18 +1090,14 @@ class InklingDetector(BaseReasoningFormatDetector):
                     self._kind = None
             elif token in _INKLING_CONTENT_KINDS:
                 flush_reasoning()
-                self._pending_header = ""
+                flush_header()
                 self._kind = _INKLING_CONTENT_KINDS[token]
             elif token in _INKLING_END_TOKENS:
                 flush_reasoning()
-                self._pending_header = ""
+                flush_header()
                 self._kind = None
 
-        tail = text[pos:]
-        if saw_control or self._kind is not None:
-            emit(tail)
-        else:
-            content.append(text)
+        emit(text[pos:])
 
         return StreamingParseResult(
             normal_text="".join(content),

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -265,6 +265,31 @@ class TestInklingDetector(CustomTestCase):
             content += detector.parse_streaming_increment(char).normal_text
         self.assertEqual(content, source)
 
+    def test_tool_header_without_opener_is_not_leaked_as_content(self):
+        """Bug regression: when a turn's first block is a tool call and the
+        <|message_model|> opener came from the prompt rather than the model, the
+        header ran with no open block and was routed to visible content, so the
+        caller got a stray assistant message holding just the tool name
+        alongside the parsed call."""
+        source = (
+            "weather<|content_invoke_tool_json|>"
+            '{"name":"weather","args":{"city":"SF"}}<|end_message|>'
+        )
+        framed = f"<|message_model|>{source}"
+
+        detector = InklingDetector()
+        self.assertEqual(detector.detect_and_parse(source).normal_text, framed)
+
+        for chunk_size in (1, 7):
+            detector = InklingDetector()
+            content = ""
+            for start in range(0, len(source), chunk_size):
+                content += detector.parse_streaming_increment(
+                    source[start : start + chunk_size]
+                ).normal_text
+            content += detector.finish().normal_text
+            self.assertEqual(content, framed, msg=f"chunk_size={chunk_size}")
+
     def test_raw_text_tool_framing_is_preserved_for_the_tool_parser(self):
         """The headerless <|content_invoke_tool_text|> block must survive into
         content so the tool-call detector can surface it, rather than being


### PR DESCRIPTION
Fixes #33181

`InklingDetector._parse_blocks` sent any text arriving with no open block
straight to visible content, and the `<|content_invoke_tool_json|>` /
`<|content_invoke_tool_text|>` branch only rebuilt the `<|message_model|>`
framing when `_kind == "header"`. When a turn's first block is a tool call and
the opener came from the prompt rather than the model, the tool name landed in
`content` before the marker arrived, so the caller got a stray assistant message
holding just the name next to the correctly parsed `tool_calls` entry.

Changes in `InklingDetector`:

- Out-of-block text now buffers into `_pending_header`, since at that position
  it can still turn out to be a tool header. A new `flush_header()` settles it
  at the next control token: dropped as framing after a real opener, appended to
  content when there was no open block. Buffering is what makes streaming work
  as well; reclassifying the preceding run only helps when the header and the
  marker arrive in the same increment, which they do not at token granularity.
- The invoke-tool branch reframes for `_kind in (None, "header")`.
- `detect_and_parse()` and `finish()` flush leftover out-of-block text into
  `normal_text`, so a generation truncated mid-header does not lose it.
- `_kind` starts as `"content"` under `continue_final_message`. That resume is
  rendered inside an open `<|content_text|>` block
  (`ServingChat._encode_messages`), so without this the new buffering would hold
  the whole continuation until the block closed.

One deliberate behavior change: streaming output containing zero Inkling control
tokens over the entire generation is now delivered at `finish()` rather than
incrementally, because out-of-block text has to be held until something proves
it is not a tool header. The text is preserved, just batched. Framed text and
`continue_final_message` continuations still stream per chunk.

Verified on CPU, parser level only, no GPU needed. The reporter's repro script
now shows empty visible content for all three inputs in both one-shot and
streamed modes. New regression test
`test_tool_header_without_opener_is_not_leaked_as_content` covers the one-shot
path and streaming at 1-char and 7-char chunks; it fails on the old parser and
passes on the new one. `test/registered/unit/parser/`,
`test/registered/unit/function_call/`, `test_serving_chat.py` and the constrained
grammar tests were run with and without the patch and show the same 7
environment-related pre-existing failures, plus the one new passing test.
ruff, black and isort are clean.

Not verified: no end-to-end run against real Inkling weights, and no live
`continue_final_message` request. The `_kind = "content"` initialization is
justified by reading `ServingChat._encode_messages` and checked at the parser
level only.

Thanks to @zolinthecow for the report, the exact line-level diagnosis and the
runnable repro script.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31340257997](https://github.com/sgl-project/sglang/actions/runs/31340257997)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31340257863](https://github.com/sgl-project/sglang/actions/runs/31340257863)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->