### PR TITLE
[Docker] Drop gnuplot from the dev image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -499,7 +499,6 @@ RUN --mount=type=cache,target=/var/cache/apt,id=framework-apt \
     less \
     rdma-core \
     openssh-server \
-    gnuplot \
     infiniband-diags \
     perftest \
     ibverbs-providers \

--- a/docs/cookbook/base/benchmarks/autoregressive_model_benchmark.mdx
+++ b/docs/cookbook/base/benchmarks/autoregressive_model_benchmark.mdx
@@ -243,7 +243,7 @@ Used to simulate multi-LoRA serving scenarios.
 Tools for deep performance analysis.
 
 - `--profile`: Enables Torch Profiler (Requires `SGLANG_TORCH_PROFILER_DIR` env var on server).
-- `--plot-throughput`: Generates throughput/concurrency plots (requires `termplotlib` and `gnuplot`).
+- `--plot-throughput`: Generates throughput/concurrency plots. `termplotlib` ships in the Docker image; `gnuplot` does not — install it with `apt-get update && apt-get install -y gnuplot`.
 - `--profile-activities`: Activities to profile (CPU, GPU, CUDA_PROFILER).
 - `--profile-num-steps`: Number of steps to profile.
 - `--profile-by-stage` / `--profile-stages`: Profile specific processing stages.

--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -1222,7 +1222,18 @@ def calculate_metrics(
                 )
                 fig.show()
             else:
-                print("tip: install termplotlib and gnuplot to plot the metrics")
+                missing = [
+                    name
+                    for name, present in (
+                        (
+                            "termplotlib",
+                            importlib.util.find_spec("termplotlib") is not None,
+                        ),
+                        ("gnuplot", shutil.which("gnuplot") is not None),
+                    )
+                    if not present
+                ]
+                print(f"tip: install {' and '.join(missing)} to plot the metrics")
 
     itls = retokenized_itls if use_retokenized_itl else itls
     metrics = BenchmarkMetrics(
@@ -2481,7 +2492,7 @@ def cli_main():
     parser.add_argument(
         "--plot-throughput",
         action="store_true",
-        help="Plot throughput and concurrent requests over time. Requires termplotlib and gnuplot.",
+        help="Plot throughput and concurrent requests over time. Requires termplotlib and gnuplot; gnuplot is not preinstalled in the Docker image.",
     )
     # TODO unify all these
     parser.add_argument(


### PR DESCRIPTION
gnuplot is only used by `--plot-throughput` in `python/sglang/benchmark/serving.py`, to draw a terminal ASCII chart. Nothing in CI uses that flag, and it is soft-detected via `shutil.which`, so the benchmark degrades to a one-line tip when it is absent — the throughput numbers are computed outside that guard and are unaffected.

Installing it also pulls in `gnuplot-qt` and `gnuplot-data`, dragging a Qt stack into a headless image, and it accounts for three CVE findings whose fixes ship only through Ubuntu Pro `esm-apps`, so they cannot be applied from the public archive at all.

The tip now names only what is actually missing rather than always naming both, since `termplotlib` stays preinstalled and only gnuplot goes away. Docs and the `--plot-throughput` help updated to match.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828985416](https://github.com/sgl-project/sglang/actions/runs/34828985416)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828985021](https://github.com/sgl-project/sglang/actions/runs/34828985021)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34828985280](https://github.com/sgl-project/sglang/actions/runs/34828985280)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->