### PR TITLE
[CI] Fetch full history in image builds so the version stamp is real

### DIFF
--- a/.github/workflows/_docker-build-and-publish.yml
+++ b/.github/workflows/_docker-build-and-publish.yml
@@ -63,6 +63,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
+          # This .git ships inside the image; without a reachable tag
+          # setuptools-scm stamps the build 0.0.0.
+          fetch-depth: 0
 
       - name: Compute Docker build metadata args
         run: |
@@ -184,6 +187,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref || github.ref }}
+          # This .git ships inside the image; without a reachable tag
+          # setuptools-scm stamps the build 0.0.0.
+          fetch-depth: 0
 
       - name: Compute Docker build metadata args
         run: |


### PR DESCRIPTION
Published images ship their `.git` — `.dockerignore` symlinks to `.gitignore`, which does not exclude it, and nothing removes it — while the build checks out with `actions/checkout@v4` defaults: depth 1, no tags. `python/tools/get_version_tag.py` then finds no `v*.*.*` tag and exits, so setuptools-scm falls back to `fallback_version` and the image reports `0.0.0`.

Since PEP 440 range matching reads the release segment, `0.0.0` sorts below every published advisory range, and vulnerability scanners flag the image for every historical CVE regardless of the commit it was actually built from.

Verified locally against this repo: `git clone --depth=1 --no-tags` reproduces it (script errors, setuptools-scm falls back to `0.0.0.dev0`), while full history resolves `v0.5.17-414-g0ee0215d0b`. `fetch-tags: true` alone is not enough — at depth 1 the merge-base fallback in the script still fails.

An earlier revision of this PR changed the Dockerfile clone instead. That path is unreachable: nothing sets `USE_LATEST_SGLANG=1` since #33738 moved the scheduled nightly to `BRANCH_TYPE=local`. Thanks @Kangyan-Zhou for catching it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34828982924](https://github.com/sgl-project/sglang/actions/runs/34828982924)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34828982745](https://github.com/sgl-project/sglang/actions/runs/34828982745)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->