### PR TITLE
ci: publish nightly traces to S3 instead of the ci-data repo

### DIFF
--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -173,6 +173,9 @@ jobs:
   nightly-test-general-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-h200')
     runs-on: 8-gpu-h200
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -196,7 +199,7 @@ jobs:
         if: always()
         timeout-minutes: 300
         env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          TRACE_BASE_URL: https://sglang-ci-traces.s3.us-west-1.amazonaws.com/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-h200"
           IS_H200: "1"
@@ -204,14 +207,22 @@ jobs:
           cd test
           python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=18000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
 
-      - name: Publish traces to storage repo
+      - name: Configure AWS credentials
+        if: always()
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::324621154379:role/GitHubActionsSglangCI
+          aws-region: us-west-1
+
+      - name: Publish traces to S3
         if: always()
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          SGLANG_CI_TRACES_S3_BUCKET: sglang-ci-traces
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
+          python3 -m pip install -q boto3
           TRACE_ARGS=""
           for dir in test/performance_profiles_*/; do
             [ -d "$dir" ] && TRACE_ARGS="$TRACE_ARGS --traces-dir $dir"
@@ -289,6 +300,9 @@ jobs:
   nightly-test-general-8-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-general-8-gpu-b200')
     runs-on: 8-gpu-b200
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 2
@@ -310,21 +324,29 @@ jobs:
         if: always()
         timeout-minutes: 200
         env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          TRACE_BASE_URL: https://sglang-ci-traces.s3.us-west-1.amazonaws.com/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "8-gpu-b200"
         run: |
           cd test
           python3 run_suite.py --hw cuda --suite nightly-8-gpu-common --nightly --timeout-per-file=12000 --continue-on-error --auto-partition-id=${{ matrix.partition }} --auto-partition-size=4
 
-      - name: Publish traces to storage repo
+      - name: Configure AWS credentials
+        if: always()
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::324621154379:role/GitHubActionsSglangCI
+          aws-region: us-west-1
+
+      - name: Publish traces to S3
         if: always()
         continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          SGLANG_CI_TRACES_S3_BUCKET: sglang-ci-traces
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
+          python3 -m pip install -q boto3
           TRACE_ARGS=""
           for dir in test/performance_profiles_*/; do
             [ -d "$dir" ] && TRACE_ARGS="$TRACE_ARGS --traces-dir $dir"
@@ -390,6 +412,9 @@ jobs:
   nightly-test-text-perf-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-text-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -405,7 +430,7 @@ jobs:
       - name: Run performance test for text models
         timeout-minutes: 30
         env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          TRACE_BASE_URL: https://sglang-ci-traces.s3.us-west-1.amazonaws.com/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "2-gpu-h100"
         run: |
@@ -413,12 +438,20 @@ jobs:
           rm -rf performance_profiles_text_models/
           python3 run_suite.py --hw cuda --suite nightly-perf-text-2-gpu --nightly --continue-on-error --timeout-per-file 3600
 
-      - name: Publish traces to storage repo
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::324621154379:role/GitHubActionsSglangCI
+          aws-region: us-west-1
+
+      - name: Publish traces to S3
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          SGLANG_CI_TRACES_S3_BUCKET: sglang-ci-traces
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
+          python3 -m pip install -q boto3
           python3 scripts/ci/utils/publish_traces.py --traces-dir test/performance_profiles_text_models
 
       - uses: ./.github/actions/upload-cuda-coredumps
@@ -453,6 +486,9 @@ jobs:
   nightly-test-vlm-perf-2-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'nightly-test-vlm-perf-2-gpu-h100')
     runs-on: 2-gpu-h100
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -468,7 +504,7 @@ jobs:
       - name: Run perf test for VLM models (MMMU)
         timeout-minutes: 30
         env:
-          TRACE_BASE_URL: https://raw.githubusercontent.com/sglang-bot/sglang-ci-data/main/traces/${{ github.run_id }}
+          TRACE_BASE_URL: https://sglang-ci-traces.s3.us-west-1.amazonaws.com/traces/${{ github.run_id }}
           PERFETTO_RELAY_URL: ${{ vars.PERFETTO_RELAY_URL }}
           GPU_CONFIG: "2-gpu-h100"
         run: |
@@ -476,12 +512,20 @@ jobs:
           rm -rf performance_profiles_vlms/
           python3 run_suite.py --hw cuda --suite nightly-perf-vlm-2-gpu --nightly --continue-on-error --timeout-per-file 3600
 
-      - name: Publish traces to storage repo
+      - name: Configure AWS credentials
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::324621154379:role/GitHubActionsSglangCI
+          aws-region: us-west-1
+
+      - name: Publish traces to S3
+        continue-on-error: true
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_PAT_FOR_NIGHTLY_CI_DATA }}
+          SGLANG_CI_TRACES_S3_BUCKET: sglang-ci-traces
           GITHUB_RUN_ID: ${{ github.run_id }}
-          GITHUB_RUN_NUMBER: ${{ github.run_number }}
         run: |
+          python3 -m pip install -q boto3
           python3 scripts/ci/utils/publish_traces.py --traces-dir test/performance_profiles_vlms
 
       - uses: ./.github/actions/upload-cuda-coredumps

--- a/scripts/ci/utils/diffusion/publish_comparison_results.py
+++ b/scripts/ci/utils/diffusion/publish_comparison_results.py
@@ -20,10 +20,10 @@ import time
 from datetime import datetime, timezone
 from pathlib import Path
 
-# Reuse GitHub API helpers from publish_traces.
+# Reuse GitHub API helpers from github_repo_upload.
 # Support both direct script execution and package-style imports.
 if __package__:
-    from ..publish_traces import (
+    from ..github_repo_upload import (
         create_blobs,
         create_commit,
         create_tree,
@@ -36,7 +36,7 @@ if __package__:
     )
 else:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from publish_traces import (
+    from github_repo_upload import (
         create_blobs,
         create_commit,
         create_tree,

--- a/scripts/ci/utils/diffusion/publish_diffusion_gt.py
+++ b/scripts/ci/utils/diffusion/publish_diffusion_gt.py
@@ -1,6 +1,6 @@
 """
 Publish diffusion CI ground-truth images to sgl-project/ci-data
-via the GitHub API (same pattern as publish_traces.py).
+via the GitHub API.
 """
 
 import argparse
@@ -11,10 +11,10 @@ import sys
 from pathlib import Path
 from urllib.error import HTTPError
 
-# Reuse GitHub API helpers from publish_traces.
+# Reuse GitHub API helpers from github_repo_upload.
 # Support both direct script execution and package-style imports.
 if __package__:
-    from ..publish_traces import (
+    from ..github_repo_upload import (
         create_blobs,
         create_commit,
         create_tree,
@@ -28,7 +28,7 @@ if __package__:
     )
 else:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from publish_traces import (
+    from github_repo_upload import (
         create_blobs,
         create_commit,
         create_tree,

--- a/scripts/ci/utils/github_repo_upload.py
+++ b/scripts/ci/utils/github_repo_upload.py
@@ -1,0 +1,296 @@
+"""GitHub API helpers for committing files into a storage repository.
+
+Used by the diffusion CI publishers to push images and comparison results into
+sgl-project/ci-data. Performance traces no longer go through here; they are
+uploaded to S3 by publish_traces.py.
+"""
+
+import base64
+import json
+import time
+import warnings
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+
+def is_rate_limit_error(e):
+    """Check if an exception is a GitHub rate limit error (not permission error)"""
+    if not isinstance(e, HTTPError):
+        return False
+    if e.code == 429:
+        return True
+    if e.code == 403:
+        # 403 can be rate limit OR permission error - check the message
+        error_body = getattr(e, "error_body", "")
+        if isinstance(error_body, str):
+            # Rate limit errors contain specific phrases
+            rate_limit_phrases = [
+                "rate limit",
+                "abuse detection",
+                "secondary rate limit",
+            ]
+            return any(phrase in error_body.lower() for phrase in rate_limit_phrases)
+    return False
+
+
+def is_permission_error(e):
+    """Check if an exception is a GitHub permission error"""
+    if not isinstance(e, HTTPError) or e.code != 403:
+        return False
+    error_body = getattr(e, "error_body", "")
+    if isinstance(error_body, str):
+        permission_phrases = [
+            "resource not accessible",
+            "must have push access",
+            "permission",
+            "denied",
+        ]
+        return any(phrase in error_body.lower() for phrase in permission_phrases)
+    return False
+
+
+def make_github_request(url, token, method="GET", data=None):
+    """Make authenticated request to GitHub API"""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {token}",
+        # "User-Agent": "sglang-ci",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    if data:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(data).encode("utf-8")
+
+    req = Request(url, data=data, headers=headers, method=method)
+
+    try:
+        with urlopen(req) as response:
+            return response.read().decode("utf-8")
+    except HTTPError as e:
+        print(f"GitHub API request failed: {e}")
+        try:
+            error_body = e.read().decode("utf-8")
+            print(f"Error response body: {error_body}")
+            e.error_body = error_body  # Attach for later inspection
+        except Exception:
+            e.error_body = ""
+        raise
+    except Exception as e:
+        print(f"GitHub API request failed with a non-HTTP error: {e}")
+        raise
+
+
+def verify_token_permissions(repo_owner, repo_name, token):
+    """Verify that the token has necessary permissions for the repository"""
+    print("Verifying token permissions...")
+
+    checks = [
+        (
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}",  # Check if we can access the repository
+            "Repository access verified",
+        ),
+        (
+            f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents",  # Check if we can read the repository contents
+            "Repository contents access verified",
+        ),
+    ]
+
+    for url, success_message in checks:
+        try:
+            response = make_github_request(url, token)
+            if success_message == "Repository access verified":
+                repo_data = json.loads(response)
+                print(f"{success_message}: {repo_data['full_name']}")
+            else:
+                print(success_message)
+        except Exception as e:
+            if is_rate_limit_error(e):
+                warnings.warn(
+                    "GitHub API rate limit exceeded during token verification."
+                )
+                return "rate_limited"
+            print(f"Failed to verify permissions for {url}: {e}")
+            return False
+
+    return True
+
+
+def get_branch_sha(repo_owner, repo_name, branch, token):
+    """Get SHA of the branch head"""
+    url = (
+        f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+    )
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["object"]["sha"]
+
+
+def get_tree_sha(repo_owner, repo_name, commit_sha, token):
+    """Get tree SHA from commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+    response = make_github_request(url, token)
+    data = json.loads(response)
+    return data["tree"]["sha"]
+
+
+def create_blob(repo_owner, repo_name, content, token, max_retries=3):
+    """Create a blob with file content"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/blobs"
+
+    # Encode content as base64 for GitHub API
+    content_b64 = base64.b64encode(content).decode("utf-8")
+
+    data = {"content": content_b64, "encoding": "base64"}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
+                print(
+                    f"Blob creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_blobs(repo_owner, repo_name, files, token):
+    """Create blobs for all files and return tree items with blob SHAs"""
+    tree_items = []
+    for i, (file_path, content) in enumerate(files):
+        # Create blob first to get SHA
+        blob_sha = create_blob(repo_owner, repo_name, content, token)
+        tree_items.append(
+            {
+                "path": file_path,
+                "mode": "100644",
+                "type": "blob",
+                "sha": blob_sha,
+            }
+        )
+        # Progress indicator for large uploads
+        if (i + 1) % 10 == 0 or (i + 1) == len(files):
+            print(f"Created {i + 1}/{len(files)} blobs...")
+    return tree_items
+
+
+def create_tree(repo_owner, repo_name, base_tree_sha, tree_items, token, max_retries=3):
+    """Create a new tree from pre-created blob SHAs"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/trees"
+
+    data = {"base_tree": base_tree_sha, "tree": tree_items}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            return json.loads(response)["sha"]
+        except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Tree creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def create_commit(
+    repo_owner, repo_name, tree_sha, parent_sha, message, token, max_retries=3
+):
+    """Create a new commit"""
+    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits"
+
+    data = {"tree": tree_sha, "parents": [parent_sha], "message": message}
+
+    for attempt in range(max_retries):
+        try:
+            response = make_github_request(url, token, method="POST", data=data)
+            commit_sha = json.loads(response)["sha"]
+
+            # Verify the commit was actually created
+            verify_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
+            verify_response = make_github_request(verify_url, token)
+            verify_data = json.loads(verify_response)
+            if verify_data["sha"] != commit_sha:
+                raise Exception(
+                    f"Commit verification failed: expected {commit_sha}, got {verify_data['sha']}"
+                )
+
+            return commit_sha
+        except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Commit creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+
+
+def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retries=3):
+    """Update branch reference to point to new commit"""
+    url = (
+        f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
+    )
+
+    data = {"sha": commit_sha}
+
+    for attempt in range(max_retries):
+        try:
+            make_github_request(url, token, method="PATCH", data=data)
+            return
+        except HTTPError as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
+            # Check if this is an "Object does not exist" error
+            is_object_not_exist = False
+            if hasattr(e, "error_body"):
+                try:
+                    error_data = json.loads(e.error_body)
+                    if "Object does not exist" in error_data.get("message", ""):
+                        is_object_not_exist = True
+                except Exception:
+                    pass
+
+            if is_object_not_exist and attempt < max_retries - 1:
+                # This might be a transient consistency issue - wait and retry
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed with 'Object does not exist' (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s for consistency..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise
+        except Exception as e:
+            # Don't retry on rate limit errors - fail fast
+            if is_rate_limit_error(e):
+                raise
+
+            if attempt < max_retries - 1:
+                wait_time = 2**attempt
+                print(
+                    f"Branch update failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
+                )
+                time.sleep(wait_time)
+            else:
+                raise

--- a/scripts/ci/utils/publish_traces.py
+++ b/scripts/ci/utils/publish_traces.py
@@ -1,305 +1,29 @@
 """
-Publish performance traces to GitHub repository
+Publish performance traces to S3
+
+Keys keep the layout the nightly report links expect:
+    s3://{bucket}/traces/{run_id}/{model}/{timestamp}/{file}.trace.json.gz
+
+so TRACE_BASE_URL only needs to point at the bucket instead of a raw
+githubusercontent URL. A lifecycle rule on the bucket expires traces after a
+month; nothing here deletes anything.
+
+Credentials come from the GitHub OIDC role assumed by
+aws-actions/configure-aws-credentials, so there are no static secrets.
 """
 
 import argparse
-import base64
-import json
 import os
 import sys
-import time
-import warnings
-from urllib.error import HTTPError
-from urllib.request import Request, urlopen
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+UPLOAD_CONCURRENCY = 8
 
 
-def is_rate_limit_error(e):
-    """Check if an exception is a GitHub rate limit error (not permission error)"""
-    if not isinstance(e, HTTPError):
-        return False
-    if e.code == 429:
-        return True
-    if e.code == 403:
-        # 403 can be rate limit OR permission error - check the message
-        error_body = getattr(e, "error_body", "")
-        if isinstance(error_body, str):
-            # Rate limit errors contain specific phrases
-            rate_limit_phrases = [
-                "rate limit",
-                "abuse detection",
-                "secondary rate limit",
-            ]
-            return any(phrase in error_body.lower() for phrase in rate_limit_phrases)
-    return False
+def collect_trace_files(source_dir, target_base_path):
+    """Return (key, local_path) pairs for the traces under source_dir.
 
-
-def is_permission_error(e):
-    """Check if an exception is a GitHub permission error"""
-    if not isinstance(e, HTTPError) or e.code != 403:
-        return False
-    error_body = getattr(e, "error_body", "")
-    if isinstance(error_body, str):
-        permission_phrases = [
-            "resource not accessible",
-            "must have push access",
-            "permission",
-            "denied",
-        ]
-        return any(phrase in error_body.lower() for phrase in permission_phrases)
-    return False
-
-
-def make_github_request(url, token, method="GET", data=None):
-    """Make authenticated request to GitHub API"""
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "Authorization": f"Bearer {token}",
-        # "User-Agent": "sglang-ci",
-        "X-GitHub-Api-Version": "2022-11-28",
-    }
-
-    if data:
-        headers["Content-Type"] = "application/json"
-        data = json.dumps(data).encode("utf-8")
-
-    req = Request(url, data=data, headers=headers, method=method)
-
-    try:
-        with urlopen(req) as response:
-            return response.read().decode("utf-8")
-    except HTTPError as e:
-        print(f"GitHub API request failed: {e}")
-        try:
-            error_body = e.read().decode("utf-8")
-            print(f"Error response body: {error_body}")
-            e.error_body = error_body  # Attach for later inspection
-        except Exception:
-            e.error_body = ""
-        raise
-    except Exception as e:
-        print(f"GitHub API request failed with a non-HTTP error: {e}")
-        raise
-
-
-def verify_token_permissions(repo_owner, repo_name, token):
-    """Verify that the token has necessary permissions for the repository"""
-    print("Verifying token permissions...")
-
-    checks = [
-        (
-            f"https://api.github.com/repos/{repo_owner}/{repo_name}",  # Check if we can access the repository
-            "Repository access verified",
-        ),
-        (
-            f"https://api.github.com/repos/{repo_owner}/{repo_name}/contents",  # Check if we can read the repository contents
-            "Repository contents access verified",
-        ),
-    ]
-
-    for url, success_message in checks:
-        try:
-            response = make_github_request(url, token)
-            if success_message == "Repository access verified":
-                repo_data = json.loads(response)
-                print(f"{success_message}: {repo_data['full_name']}")
-            else:
-                print(success_message)
-        except Exception as e:
-            if is_rate_limit_error(e):
-                warnings.warn(
-                    "GitHub API rate limit exceeded during token verification."
-                )
-                return "rate_limited"
-            print(f"Failed to verify permissions for {url}: {e}")
-            return False
-
-    return True
-
-
-def get_branch_sha(repo_owner, repo_name, branch, token):
-    """Get SHA of the branch head"""
-    url = (
-        f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
-    )
-    response = make_github_request(url, token)
-    data = json.loads(response)
-    return data["object"]["sha"]
-
-
-def get_tree_sha(repo_owner, repo_name, commit_sha, token):
-    """Get tree SHA from commit"""
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
-    response = make_github_request(url, token)
-    data = json.loads(response)
-    return data["tree"]["sha"]
-
-
-def create_blob(repo_owner, repo_name, content, token, max_retries=3):
-    """Create a blob with file content"""
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/blobs"
-
-    # Encode content as base64 for GitHub API
-    content_b64 = base64.b64encode(content).decode("utf-8")
-
-    data = {"content": content_b64, "encoding": "base64"}
-
-    for attempt in range(max_retries):
-        try:
-            response = make_github_request(url, token, method="POST", data=data)
-            return json.loads(response)["sha"]
-        except Exception as e:
-            # Don't retry on rate limit errors - fail fast
-            if is_rate_limit_error(e):
-                raise
-
-            if attempt < max_retries - 1:
-                wait_time = 2**attempt  # Exponential backoff: 1s, 2s, 4s
-                print(
-                    f"Blob creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-
-
-def create_blobs(repo_owner, repo_name, files, token):
-    """Create blobs for all files and return tree items with blob SHAs"""
-    tree_items = []
-    for i, (file_path, content) in enumerate(files):
-        # Create blob first to get SHA
-        blob_sha = create_blob(repo_owner, repo_name, content, token)
-        tree_items.append(
-            {
-                "path": file_path,
-                "mode": "100644",
-                "type": "blob",
-                "sha": blob_sha,
-            }
-        )
-        # Progress indicator for large uploads
-        if (i + 1) % 10 == 0 or (i + 1) == len(files):
-            print(f"Created {i + 1}/{len(files)} blobs...")
-    return tree_items
-
-
-def create_tree(repo_owner, repo_name, base_tree_sha, tree_items, token, max_retries=3):
-    """Create a new tree from pre-created blob SHAs"""
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/trees"
-
-    data = {"base_tree": base_tree_sha, "tree": tree_items}
-
-    for attempt in range(max_retries):
-        try:
-            response = make_github_request(url, token, method="POST", data=data)
-            return json.loads(response)["sha"]
-        except Exception as e:
-            # Don't retry on rate limit errors - fail fast
-            if is_rate_limit_error(e):
-                raise
-
-            if attempt < max_retries - 1:
-                wait_time = 2**attempt
-                print(
-                    f"Tree creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-
-
-def create_commit(
-    repo_owner, repo_name, tree_sha, parent_sha, message, token, max_retries=3
-):
-    """Create a new commit"""
-    url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits"
-
-    data = {"tree": tree_sha, "parents": [parent_sha], "message": message}
-
-    for attempt in range(max_retries):
-        try:
-            response = make_github_request(url, token, method="POST", data=data)
-            commit_sha = json.loads(response)["sha"]
-
-            # Verify the commit was actually created
-            verify_url = f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/commits/{commit_sha}"
-            verify_response = make_github_request(verify_url, token)
-            verify_data = json.loads(verify_response)
-            if verify_data["sha"] != commit_sha:
-                raise Exception(
-                    f"Commit verification failed: expected {commit_sha}, got {verify_data['sha']}"
-                )
-
-            return commit_sha
-        except Exception as e:
-            # Don't retry on rate limit errors - fail fast
-            if is_rate_limit_error(e):
-                raise
-
-            if attempt < max_retries - 1:
-                wait_time = 2**attempt
-                print(
-                    f"Commit creation failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-
-
-def update_branch_ref(repo_owner, repo_name, branch, commit_sha, token, max_retries=3):
-    """Update branch reference to point to new commit"""
-    url = (
-        f"https://api.github.com/repos/{repo_owner}/{repo_name}/git/refs/heads/{branch}"
-    )
-
-    data = {"sha": commit_sha}
-
-    for attempt in range(max_retries):
-        try:
-            make_github_request(url, token, method="PATCH", data=data)
-            return
-        except HTTPError as e:
-            # Don't retry on rate limit errors - fail fast
-            if is_rate_limit_error(e):
-                raise
-
-            # Check if this is an "Object does not exist" error
-            is_object_not_exist = False
-            if hasattr(e, "error_body"):
-                try:
-                    error_data = json.loads(e.error_body)
-                    if "Object does not exist" in error_data.get("message", ""):
-                        is_object_not_exist = True
-                except Exception:
-                    pass
-
-            if is_object_not_exist and attempt < max_retries - 1:
-                # This might be a transient consistency issue - wait and retry
-                wait_time = 2**attempt
-                print(
-                    f"Branch update failed with 'Object does not exist' (attempt {attempt + 1}/{max_retries}), waiting {wait_time}s for consistency..."
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-        except Exception as e:
-            # Don't retry on rate limit errors - fail fast
-            if is_rate_limit_error(e):
-                raise
-
-            if attempt < max_retries - 1:
-                wait_time = 2**attempt
-                print(
-                    f"Branch update failed (attempt {attempt + 1}/{max_retries}), retrying in {wait_time}s..."
-                )
-                time.sleep(wait_time)
-            else:
-                raise
-
-
-def copy_trace_files(source_dir, target_base_path):
-    """Copy trace files and return list of files to upload.
-
-    Only uploads traces from TP rank 0 to avoid duplicated data across tensor parallel ranks.
+    Only collects traces from TP rank 0 to avoid duplicated data across tensor parallel ranks.
     """
     files_to_upload = []
 
@@ -321,159 +45,51 @@ def copy_trace_files(source_dir, target_base_path):
                 rel_path = os.path.relpath(source_file, source_dir)
                 target_path = f"{target_base_path}/{rel_path}"
 
-                # Read file content
-                with open(source_file, "rb") as f:
-                    content = f.read()
-
-                files_to_upload.append((target_path, content))
+                files_to_upload.append((target_path, source_file))
 
     return files_to_upload
 
 
-def publish_traces(traces_dir, run_id, run_number):
-    """Publish traces from a single directory to GitHub repository in a single commit"""
-    target_base_path = f"traces/{run_id}"
-    files_to_upload = copy_trace_files(traces_dir, target_base_path)
+def upload_traces(files_to_upload, bucket):
+    """Upload the collected traces to S3, returning the number that succeeded."""
+    import boto3
 
-    if not files_to_upload:
-        print("No trace files found to upload")
-        return
+    s3 = boto3.client("s3")
 
-    print(f"Found {len(files_to_upload)} files to upload")
-    publish_traces_from_files(files_to_upload, run_id, run_number)
-
-
-def publish_traces_from_files(files_to_upload, run_id, run_number):
-    """Publish pre-collected trace files to GitHub repository in a single commit"""
-    # Get environment variables
-    token = os.getenv("GITHUB_TOKEN")
-    if not token:
-        print("Error: GITHUB_TOKEN environment variable not set")
-        sys.exit(1)
-
-    # Repository configuration
-    repo_owner = "sgl-project"
-    repo_name = "ci-data"
-    branch = "main"
-
-    # Verify token permissions before proceeding
-    permission_check = verify_token_permissions(repo_owner, repo_name, token)
-    if permission_check == "rate_limited":
-        warnings.warn(
-            "Skipping trace upload due to GitHub API rate limit. "
-            "This is expected during high CI activity and does not indicate a test failure."
-        )
-        return
-    elif not permission_check:
-        print(
-            "Token permission verification failed. Please check the token permissions."
-        )
-        sys.exit(1)
-
-    max_retries = 5
-    retry_delay = 5  # seconds
-
-    # Create blobs once before retry loop to avoid re-uploading on failures
-    try:
-        tree_items = create_blobs(repo_owner, repo_name, files_to_upload, token)
-    except Exception as e:
-        # Check for rate limit errors during blob creation
-        if is_rate_limit_error(e):
-            warnings.warn(
-                "GitHub API rate limit exceeded during blob creation. Skipping trace upload."
+    def put(item):
+        key, local_path = item
+        # Perfetto fetches the gzipped trace and inflates it itself, so serve the
+        # bytes as-is. Setting ContentEncoding here would make browsers
+        # transparently decompress and hand Perfetto a trace it cannot read.
+        with open(local_path, "rb") as f:
+            s3.put_object(
+                Bucket=bucket,
+                Key=key,
+                Body=f,
+                ContentType="application/gzip",
             )
-            return
-        # Check for permission errors - these should fail loudly
-        if is_permission_error(e):
-            print(
-                f"ERROR: Token does not have write permission to {repo_owner}/{repo_name}. "
-                "Please update the GH_PAT_FOR_NIGHTLY_CI_DATA secret with a token that has "
-                "'contents: write' permission for the repository."
-            )
-            sys.exit(1)
-        print(f"Failed to create blobs: {e}")
-        raise
+        return key
 
-    for attempt in range(max_retries):
-        try:
-            # Get current branch head
-            branch_sha = get_branch_sha(repo_owner, repo_name, branch, token)
-            print(f"Current branch head: {branch_sha}")
+    uploaded = 0
+    with ThreadPoolExecutor(max_workers=UPLOAD_CONCURRENCY) as pool:
+        futures = {pool.submit(put, item): item for item in files_to_upload}
+        for future in as_completed(futures):
+            key, local_path = futures[future]
+            try:
+                future.result()
+            except Exception as e:
+                print(f"Failed to upload {local_path} -> s3://{bucket}/{key}: {e}")
+                continue
+            uploaded += 1
+            if uploaded % 10 == 0 or uploaded == len(files_to_upload):
+                print(f"Uploaded {uploaded}/{len(files_to_upload)} traces...")
 
-            # Get current tree
-            tree_sha = get_tree_sha(repo_owner, repo_name, branch_sha, token)
-            print(f"Current tree SHA: {tree_sha}")
-
-            # Create new tree with pre-created blobs
-            new_tree_sha = create_tree(
-                repo_owner, repo_name, tree_sha, tree_items, token
-            )
-            print(f"Created new tree: {new_tree_sha}")
-
-            # Create commit
-            commit_message = f"Nightly traces for run {run_id} at {run_number} ({len(files_to_upload)} files)"
-            commit_sha = create_commit(
-                repo_owner,
-                repo_name,
-                new_tree_sha,
-                branch_sha,
-                commit_message,
-                token,
-            )
-            print(f"Created commit: {commit_sha}")
-
-            # Update branch reference
-            update_branch_ref(repo_owner, repo_name, branch, commit_sha, token)
-            print("Updated branch reference")
-
-            print("Successfully published all traces in a single commit")
-            return
-
-        except Exception as e:
-            # Check for retryable errors
-            is_retryable = False
-            error_type = "unknown"
-
-            if hasattr(e, "error_body"):
-                if "Update is not a fast forward" in e.error_body:
-                    is_retryable = True
-                    error_type = "fast-forward conflict"
-                elif "Object does not exist" in e.error_body:
-                    is_retryable = True
-                    error_type = "object consistency"
-
-            # Also retry on HTTP errors that might be transient
-            if isinstance(e, HTTPError) and e.code in [422, 500, 502, 503, 504]:
-                is_retryable = True
-                error_type = f"HTTP {e.code}"
-
-            # Check for rate limit errors (non-fatal - just warn and skip)
-            if is_rate_limit_error(e):
-                warnings.warn("GitHub API rate limit exceeded. Skipping trace upload.")
-                return
-
-            # Check for permission errors - these should fail loudly
-            if is_permission_error(e):
-                print(
-                    f"ERROR: Token does not have write permission to {repo_owner}/{repo_name}. "
-                    "Please update the GH_PAT_FOR_NIGHTLY_CI_DATA secret with a token that has "
-                    "'contents: write' permission for the repository."
-                )
-                sys.exit(1)
-
-            if is_retryable and attempt < max_retries - 1:
-                print(
-                    f"Attempt {attempt + 1}/{max_retries} failed ({error_type}). Retrying in {retry_delay} seconds..."
-                )
-                time.sleep(retry_delay)
-            else:
-                print(f"Failed to publish traces after {attempt + 1} attempts: {e}")
-                raise
+    return uploaded
 
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Publish performance traces to GitHub repository"
+        description="Publish performance traces to S3",
     )
     parser.add_argument(
         "--traces-dir",
@@ -485,23 +101,19 @@ def main():
     )
     args = parser.parse_args()
 
-    # Get environment variables
-    run_id = os.getenv("GITHUB_RUN_ID", "test")
-    run_number = os.getenv("GITHUB_RUN_NUMBER", "12345")
-
-    if not run_id or not run_number:
-        print(
-            "Error: GITHUB_RUN_ID and GITHUB_RUN_NUMBER environment variables must be set"
-        )
+    bucket = os.getenv("SGLANG_CI_TRACES_S3_BUCKET")
+    if not bucket:
+        print("Error: SGLANG_CI_TRACES_S3_BUCKET environment variable not set")
         sys.exit(1)
+
+    run_id = os.getenv("GITHUB_RUN_ID", "test")
 
     # Collect trace files from all directories
     target_base_path = f"traces/{run_id}"
     all_files = []
     for traces_dir in args.traces_dirs:
         print(f"Processing traces from directory: {traces_dir}")
-        files = copy_trace_files(traces_dir, target_base_path)
-        all_files.extend(files)
+        all_files.extend(collect_trace_files(traces_dir, target_base_path))
 
     if not all_files:
         print("No trace files found to upload across all directories")
@@ -509,8 +121,13 @@ def main():
 
     print(f"Found {len(all_files)} total files to upload")
 
-    # Publish all collected traces in a single commit
-    publish_traces_from_files(all_files, run_id, run_number)
+    uploaded = upload_traces(all_files, bucket)
+    print(
+        f"Published {uploaded}/{len(all_files)} traces to s3://{bucket}/{target_base_path}"
+    )
+
+    if uploaded != len(all_files):
+        sys.exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`sgl-project/ci-data` is at ~100 GB and stopped accepting pushes on 2026-07-21. The publish step is `continue-on-error`, so nightly traces have been silently dropped for ~3 weeks. This is the second storage repo we've filled — at ~371 MB/night any git repo dies in months.

## Fix

Traces go to S3 with a 30-day lifecycle rule, uploaded via GitHub OIDC (no static secrets). The key layout is unchanged, so only `TRACE_BASE_URL` moves.

Also fixes `TRACE_BASE_URL`, which still pointed at the retired `sglang-bot/sglang-ci-data` — every trace link in the nightly report has 404'd since the May repo switch.

`publish_traces.py`'s GitHub API helpers move to `github_repo_upload.py`; the diffusion publishers still import them and still write to ci-data.

## Before merging

The bucket, lifecycle rule, CORS and OIDC role need to exist. Both new steps are `continue-on-error`, so a misconfigured role degrades to "no traces" rather than a red nightly.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->