### PR TITLE
scheduler: bound consecutive prefills to protect decode

### DIFF
--- a/python/sglang/srt/managers/consecutive_prefill_limiter.py
+++ b/python/sglang/srt/managers/consecutive_prefill_limiter.py
@@ -1,0 +1,28 @@
+class ConsecutivePrefillLimiter:
+    """Reserve a decode turn after a bounded run of prefill batches.
+
+    The scheduler normally prioritizes prefill whenever one is available. This
+    opt-in limiter preserves that default at a limit of zero, while allowing a
+    runnable decode batch to make progress after a configured number of
+    consecutive prefill batches.
+    """
+
+    def __init__(self, max_consecutive_prefill_batches: int):
+        if max_consecutive_prefill_batches < 0:
+            raise ValueError("max_consecutive_prefill_batches must be non-negative")
+        self._limit = max_consecutive_prefill_batches
+        self._consecutive_prefill_batches = 0
+
+    def should_force_decode(self, *, has_runnable_decode: bool) -> bool:
+        return (
+            has_runnable_decode
+            and self._limit > 0
+            and self._consecutive_prefill_batches >= self._limit
+        )
+
+    def on_prefill(self) -> None:
+        if self._limit > 0:
+            self._consecutive_prefill_batches += 1
+
+    def on_decode(self) -> None:
+        self._consecutive_prefill_batches = 0

--- a/python/sglang/srt/managers/consecutive_prefill_limiter.py
+++ b/python/sglang/srt/managers/consecutive_prefill_limiter.py
@@ -22,7 +22,9 @@ class ConsecutivePrefillLimiter:
 
     def on_prefill(self) -> None:
         if self._limit > 0:
-            self._consecutive_prefill_batches += 1
+            self._consecutive_prefill_batches = min(
+                self._consecutive_prefill_batches + 1, self._limit
+            )
 
     def on_decode(self) -> None:
         self._consecutive_prefill_batches = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3065,6 +3065,7 @@ class Scheduler(
             prefill_plan = self.get_new_batch_prefill(running_batch)
             new_batch = prefill_plan.batch_to_run
             running_batch = prefill_plan.running_batch
+        selected_prefill = new_batch is not None
 
         need_mlp_sync = self.require_mlp_sync
         if (
@@ -3081,7 +3082,7 @@ class Scheduler(
 
         if new_batch is not None:
             # Run prefill first if possible
-            if self.dllm_config is None:
+            if self.dllm_config is None and selected_prefill:
                 self.consecutive_prefill_limiter.on_prefill()
             ret = new_batch
         else:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -104,6 +104,9 @@ from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 from sglang.srt.layers.quantization.unquant import initialize_bf16_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
+from sglang.srt.managers.consecutive_prefill_limiter import (
+    ConsecutivePrefillLimiter,
+)
 from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
 from sglang.srt.managers.io_struct import (
@@ -1025,6 +1028,9 @@ class Scheduler(
             self.min_free_slots_delayer = MinFreeSlotsDelayer(
                 min_free_slots=min_free_slots
             )
+        self.consecutive_prefill_limiter = ConsecutivePrefillLimiter(
+            get_schedule().max_consecutive_prefill_batches
+        )
         if not get_parallel().pp_max_micro_batch_size:
             get_context().override(
                 "scheduler.pp_max_micro_batch_size_default",
@@ -3049,6 +3055,12 @@ class Scheduler(
 
         if self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
+        elif self.consecutive_prefill_limiter.should_force_decode(
+            has_runnable_decode=(
+                not running_batch.is_empty() and not running_batch.is_prefill_only
+            )
+        ):
+            new_batch = None
         else:
             prefill_plan = self.get_new_batch_prefill(running_batch)
             new_batch = prefill_plan.batch_to_run
@@ -3069,12 +3081,16 @@ class Scheduler(
 
         if new_batch is not None:
             # Run prefill first if possible
+            if self.dllm_config is None:
+                self.consecutive_prefill_limiter.on_prefill()
             ret = new_batch
         else:
             # Run decode (skip for prefill-only batches)
             if not running_batch.is_empty() and not running_batch.is_prefill_only:
                 running_batch = self.update_running_batch(running_batch)
                 ret = running_batch if not running_batch.is_empty() else None
+                if ret is not None:
+                    self.consecutive_prefill_limiter.on_decode()
             else:
                 ret = None
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -770,6 +770,11 @@ class ServerArgs:
     max_running_requests: A[
         Optional[int], "The maximum number of running requests.", NS("schedule")
     ] = None
+    max_consecutive_prefill_batches: A[
+        int,
+        "Run at most N consecutive prefill batches before scheduling one runnable decode batch. Set to 0 to preserve prefill-first scheduling.",
+        NS("schedule"),
+    ] = 0
     max_queued_requests: A[
         Optional[int],
         "The maximum number of queued requests. This option is ignored when using disaggregation-mode.",
@@ -8768,6 +8773,10 @@ class ServerArgs:
             assert (
                 self.tp_size * self.pp_size
             ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+
+        assert (
+            self.max_consecutive_prefill_batches >= 0
+        ), "--max-consecutive-prefill-batches must be non-negative"
 
         assert (
             self.pp_max_micro_batch_size is None or self.pp_max_micro_batch_size >= 1

--- a/test/registered/scheduler/test_consecutive_prefill_limiter.py
+++ b/test/registered/scheduler/test_consecutive_prefill_limiter.py
@@ -1,0 +1,124 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.srt.managers.consecutive_prefill_limiter import (
+    ConsecutivePrefillLimiter,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestConsecutivePrefillLimiter(unittest.TestCase):
+    def test_default_preserves_prefill_first_scheduling(self):
+        limiter = ConsecutivePrefillLimiter(0)
+
+        for _ in range(4):
+            limiter.on_prefill()
+
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+
+    def test_reserves_decode_after_limit(self):
+        limiter = ConsecutivePrefillLimiter(2)
+
+        limiter.on_prefill()
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+        limiter.on_prefill()
+        self.assertTrue(limiter.should_force_decode(has_runnable_decode=True))
+
+    def test_does_not_force_decode_when_none_is_runnable(self):
+        limiter = ConsecutivePrefillLimiter(1)
+        limiter.on_prefill()
+
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=False))
+        self.assertTrue(limiter.should_force_decode(has_runnable_decode=True))
+
+    def test_decode_resets_the_prefill_run(self):
+        limiter = ConsecutivePrefillLimiter(1)
+        limiter.on_prefill()
+        self.assertTrue(limiter.should_force_decode(has_runnable_decode=True))
+
+        limiter.on_decode()
+
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+
+    def test_rejects_negative_limit(self):
+        with self.assertRaisesRegex(ValueError, "must be non-negative"):
+            ConsecutivePrefillLimiter(-1)
+
+
+class _Batch:
+    def __init__(self, *, empty=False, prefill_only=False):
+        self._empty = empty
+        self.is_prefill_only = prefill_only
+        self.batch_is_full = False
+
+    def is_empty(self):
+        return self._empty
+
+
+def _make_scheduler(limiter, prefill_plan):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.process_pending_chunked_abort = Mock()
+    scheduler.enable_fpm = False
+    scheduler._abort_on_waiting_timeout = Mock()
+    scheduler._abort_on_running_timeout = Mock()
+    scheduler.dllm_config = None
+    scheduler.chunked_req = None
+    scheduler.enable_hisparse = False
+    scheduler.get_new_batch_prefill = Mock(return_value=prefill_plan)
+    scheduler.require_mlp_sync = False
+    scheduler.dp_attn_adapter = SimpleNamespace(
+        maybe_prepare_mlp_sync_batch=lambda batch, need_sync: batch
+    )
+    scheduler.ngram_embedding_manager = SimpleNamespace(
+        prepare_for_forward=lambda batch, chunked_req: batch
+    )
+    scheduler.update_running_batch = Mock()
+    scheduler.consecutive_prefill_limiter = limiter
+    return scheduler
+
+
+class TestSchedulerConsecutivePrefillLimiter(unittest.TestCase):
+    @patch("sglang.srt.managers.scheduler.set_schedule_time_batch")
+    def test_default_still_selects_prefill(self, _set_schedule_time_batch):
+        running_batch = _Batch()
+        prefill_batch = _Batch()
+        scheduler = _make_scheduler(
+            ConsecutivePrefillLimiter(0),
+            SimpleNamespace(batch_to_run=prefill_batch, running_batch=running_batch),
+        )
+
+        plan = Scheduler.get_next_batch_to_run(scheduler, running_batch, None)
+
+        self.assertIs(plan.batch_to_run, prefill_batch)
+        scheduler.get_new_batch_prefill.assert_called_once_with(running_batch)
+        scheduler.update_running_batch.assert_not_called()
+
+    @patch("sglang.srt.managers.scheduler.set_schedule_time_batch")
+    def test_limit_skips_new_prefill_for_a_decode_turn(self, _set_schedule_time_batch):
+        running_batch = _Batch()
+        limiter = ConsecutivePrefillLimiter(1)
+        limiter.on_prefill()
+        scheduler = _make_scheduler(
+            limiter,
+            SimpleNamespace(batch_to_run=_Batch(), running_batch=running_batch),
+        )
+        scheduler.update_running_batch.return_value = running_batch
+
+        plan = Scheduler.get_next_batch_to_run(scheduler, running_batch, None)
+
+        self.assertIs(plan.batch_to_run, running_batch)
+        scheduler.get_new_batch_prefill.assert_not_called()
+        scheduler.update_running_batch.assert_called_once_with(running_batch)
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/scheduler/test_consecutive_prefill_limiter.py
+++ b/test/registered/scheduler/test_consecutive_prefill_limiter.py
@@ -48,6 +48,14 @@ class TestConsecutivePrefillLimiter(unittest.TestCase):
 
         self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
 
+    def test_prefill_count_saturates_at_limit(self):
+        limiter = ConsecutivePrefillLimiter(2)
+
+        for _ in range(4):
+            limiter.on_prefill()
+
+        self.assertEqual(limiter._consecutive_prefill_batches, 2)
+
     def test_rejects_negative_limit(self):
         with self.assertRaisesRegex(ValueError, "must be non-negative"):
             ConsecutivePrefillLimiter(-1)
@@ -118,6 +126,35 @@ class TestSchedulerConsecutivePrefillLimiter(unittest.TestCase):
         scheduler.get_new_batch_prefill.assert_not_called()
         scheduler.update_running_batch.assert_called_once_with(running_batch)
         self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+
+    @patch(
+        "sglang.srt.managers.scheduler.get_spec",
+        return_value=SimpleNamespace(speculative_skip_dp_mlp_sync=False),
+    )
+    @patch("sglang.srt.managers.scheduler.set_schedule_time_batch")
+    def test_dp_sync_idle_batch_does_not_count_as_prefill(
+        self, _set_schedule_time_batch, _get_spec
+    ):
+        running_batch = _Batch()
+        limiter = ConsecutivePrefillLimiter(2)
+        scheduler = _make_scheduler(
+            limiter,
+            SimpleNamespace(batch_to_run=None, running_batch=running_batch),
+        )
+        scheduler.require_mlp_sync = True
+        scheduler.spec_algorithm = SimpleNamespace(is_none=lambda: False)
+        idle_batch = _Batch(empty=True)
+        scheduler.dp_attn_adapter = SimpleNamespace(
+            maybe_prepare_mlp_sync_batch=lambda batch, need_sync=None: (
+                idle_batch if batch is None else batch
+            )
+        )
+
+        for _ in range(2):
+            Scheduler.get_next_batch_to_run(scheduler, running_batch, None)
+
+        self.assertFalse(limiter.should_force_decode(has_runnable_decode=True))
+        self.assertEqual(limiter._consecutive_prefill_batches, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`Scheduler.get_next_batch_to_run()` currently gives every eligible new prefill batch priority over the running decode batch. Under an ongoing prompt-heavy arrival stream, a new prefill remains eligible on every scheduling pass, so the fallback decode path may not run for an unbounded time.

This is not only a tail-latency problem. A request that has completed prefill still needs a decode step before it can emit its first token, and in-flight streams need later decode steps for every subsequent token. Starving decode therefore raises both TTFT and inter-token latency, increases request residence time, and can self-amplify concurrency until aggregate decode throughput collapses.

The production report in #32549 measured this effect under sustained chunked-prefill traffic with speculative decoding: 250+ active streams received roughly one decode batch every 24 seconds, even though KV-cache usage remained low and the engine was otherwise healthy. The strict prefill-first decision is the common cause; the report reproduced it with both DSPARK and EAGLE.

Existing controls do not bound this starvation:

- `--num-continuous-decode-steps` applies only after decode has already been selected.
- Smaller prefill chunks reduce the duration of one prefill turn, but do not change its priority over decode.
- Mixing prefill and decode is not the safe path for the affected speculative configurations.

## Solution

Add the opt-in scheduler control:

```text
--max-consecutive-prefill-batches N
```

- `N = 0` is the default and preserves current prefill-first scheduling.
- With `N > 0`, after `N` locally selected non-DLMM prefills, if decode work is runnable, the next selection skips new-prefill admission and uses the existing running-batch decode path.
- A nonempty decode turn resets the counter. If no decode is runnable, prefills continue; the limiter never idles a worker merely to satisfy the bound.

This creates a bounded-fairness guarantee without redesigning the scheduler: when both kinds of work are available, at most `N` eligible local prefill selections occur between decode turns. It deliberately does not mix prefill and decode batches, so EAGLE/DSPARK retain the existing speculative scheduling model. Chunked-prefill continuations are counted intentionally: exempting them would leave the same starvation path open for long prompts.

DLMM scheduling is untouched. In DP attention, the limiter counts a locally selected prefill before synchronization, not a synchronization-generated idle batch from another rank.

## Why this shape

A default flip to decode-first or a proportional token-budget scheduler is a larger policy change with broad throughput consequences. This narrow, default-off control fixes the concrete failure mode while leaving current deployments unchanged and giving operators an explicit TTFT/ITL-versus-prefill-throughput tradeoff to tune.

## Tests and validation

Added registered CPU coverage for:

- default prefill-first selection at `0`
- the forced-decode boundary and reset after a running decode
- no forced decode when none is runnable
- DP-attention synchronization idle batches not advancing the local counter
- saturation and invalid negative values

Local validation passed: `py_compile`, isolated limiter behavior, the registered-test manifest check, and `git diff --check`. The complete registered test could not run in this checkout because its existing SGLang virtual environment lacks `pybase64`; upstream CI remains the required full validation.

Fixes #32549.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31236186479](https://github.com/sgl-project/sglang/actions/runs/31236186479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31236186380](https://github.com/sgl-project/sglang/actions/runs/31236186380)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
