### PR TITLE
perf(unified-memory): batch lazy-compaction mapping lookup

### DIFF
--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -1635,18 +1635,10 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             src_pages_t = torch.tensor(srcs, dtype=torch.int64, device=self.device)
             dst_pages_t = torch.tensor(dsts, dtype=torch.int64, device=self.device)
             v_moveds_t = self.physical_to_virtual[src_pages_t]
-            invalid_mappings = v_moveds_t < 0
-            if bool(torch.any(invalid_mappings).item()):
-                invalid_index = int(torch.nonzero(invalid_mappings)[0, 0].item())
-                src = srcs[invalid_index]
-                raise AssertionError(
-                    f"MultiEndedAllocator({self.sub_pool_name!r})."
-                    f"_flush: topmost survivor p={src} has p2v=-1; "
-                    "this should be impossible (`_topmost_survivor` "
-                    "excludes `holes_cpu` and `_pending_reuse_pages_cpu`)."
-                    f" State: {self.allocator_state_str()}, "
-                    f"#pending_reuse={len(self._pending_reuse_pages_cpu)}"
-                )
+            torch._assert_async(
+                (v_moveds_t >= 0).all(),
+                "invalid p2v mapping in MultiEndedAllocator._flush",
+            )
             # Expand to token granularity (the move kernel is token-granular).
             if self.page_size == 1:
                 src_t, dst_t = src_pages_t, dst_pages_t

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -1427,16 +1427,17 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
     def _flush(self, *, urgent: bool) -> int:
         """One batched compaction pass; returns the number of survivor moves.
 
-        Pipeline (one D2H total, at step 3):
+        Pipeline (one free-list D2H plus one mapping D2H per committed move batch):
           1. `_drain_pending_reuse` — return read-settled prior srcs.
           2. sort the free list (or skip via env knob; either way ascending after).
-          3. `.tolist()` snapshot → `all_cpu`  *(the one sync)*.
+          3. `.tolist()` snapshot → `all_cpu`.
           4-5. `_absorb_boundary_holes` — retreat past boundary-contiguous holes;
                `holes_cpu` = interior holes. After this `_free_phys_pages==holes_cpu`.
           6. (urgent) `_settle_inflight_forward` — wait once so the walk is race-free.
           7. survivor walk — TWO-POINTER: move topmost live slot into the next hole,
              STOPPING when the pointers cross (band packed); batch into one
-             `move_kv_cache` + one v2p/p2v scatter at `_commit_move_batch`.
+             `move_kv_cache` + one v2p/p2v scatter at `_commit_move_batch`, which
+             gathers and validates all survivor virtual ids in one batch.
           8-9. exit: urgent → FULL-PACK reclaim (retreat past ALL holes, empty list);
                non-urgent → slice consumed dsts, merge freed srcs back.
 
@@ -1447,8 +1448,8 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             `_commit_move_batch` routes such srcs to `_pending_reuse`; urgent's
             settle makes them immediately reusable.
 
-        `_topmost_survivor` excludes all p2v=-1 pages, so a `v_moved < 0` in the
-        loop is a corrupt-state bug and raises.
+        `_topmost_survivor` excludes all p2v=-1 pages, so a negative virtual id in
+        the batched mapping lookup is a corrupt-state bug and raises.
         """
         if not self.lazy_compaction:
             return 0
@@ -1463,7 +1464,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             if not _SORT_FREE_LIST_AFTER_MERGE and self._free_phys_pages.numel() > 1:
                 self._free_phys_pages, _ = torch.sort(self._free_phys_pages)
 
-            all_cpu = self._free_phys_pages.tolist()  # the ONE D2H sync per flush
+            all_cpu = self._free_phys_pages.tolist()  # one batched D2H sync
 
             # `holes_cpu` = interior holes; `_free_phys_pages == holes_cpu` after.
             new_wm, holes_cpu = self._absorb_boundary_holes(all_cpu)
@@ -1487,7 +1488,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
 
             srcs: List[int] = []
             dsts: List[int] = []
-            v_moveds: List[int] = []
 
             # Flush-scoped accumulator for event-FIRED srcs. `_commit_move_batch`
             # appends here instead of catting onto `_free_phys_pages`; the merge is
@@ -1532,12 +1532,11 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                         # Commit accumulated moves, then wait the forward so the
                         # rest of the walk is race-free.
                         self._commit_move_batch(
-                            srcs, dsts, v_moveds, latest_event, released_fired
+                            srcs, dsts, latest_event, released_fired
                         )
                         n_moves += len(srcs)
                         srcs.clear()
                         dsts.clear()
-                        v_moveds.clear()
                         inflight = self._inflight_forward
                         if inflight is not None:
                             torch.cuda.current_stream().wait_event(inflight[0])
@@ -1568,22 +1567,8 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                     dst_cursor -= 1
                 n_dst_consumed += 1
 
-                v_moved = int(self.physical_to_virtual[src].item())
-                if v_moved < 0:
-                    # `_topmost_survivor` excludes all p2v=-1 pages — corrupt state.
-                    raise AssertionError(
-                        f"MultiEndedAllocator({self.sub_pool_name!r})."
-                        f"_flush: topmost survivor p={src} has p2v=-1; "
-                        "this should be impossible (`_topmost_survivor` "
-                        "excludes `holes_cpu` and `_pending_reuse_pages_cpu`)."
-                        f" State: {self.allocator_state_str()}, "
-                        f"#holes={len(holes_cpu)}, "
-                        f"#pending_reuse={len(self._pending_reuse_pages_cpu)}"
-                    )
-
                 srcs.append(src)
                 dsts.append(dst)
-                v_moveds.append(v_moved)
 
                 # Advance cursor strictly past the picked src.
                 if self.grow_direction == "up":
@@ -1594,7 +1579,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                 if move_cap is not None and len(srcs) >= move_cap:
                     break
 
-            self._commit_move_batch(srcs, dsts, v_moveds, latest_event, released_fired)
+            self._commit_move_batch(srcs, dsts, latest_event, released_fired)
             n_moves += len(srcs)
 
             if single_pass_absorb:
@@ -1635,12 +1620,12 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self,
         srcs: List[int],
         dsts: List[int],
-        v_moveds: List[int],
         latest_event: Optional[torch.cuda.Event],
         released_fired: List[torch.Tensor],
     ) -> None:
         """Issue ONE `move_kv_cache` + ONE bulk v2p/p2v remap for the accumulated
-        `(src, dst, v_moved)` triples. Fired srcs accumulate in `released_fired`
+        `(src, dst)` pairs. Survivor virtual ids are gathered from p2v in one
+        batch. Fired srcs accumulate in `released_fired`
         (merged by `_flush` AFTER its dst-slice, keeping the free list == holes_cpu);
         event-pending srcs route to `_pending_reuse` (read-race gating).
         """
@@ -1649,7 +1634,19 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         with record_function("MultiEndedAlloc._commit_move_batch"):
             src_pages_t = torch.tensor(srcs, dtype=torch.int64, device=self.device)
             dst_pages_t = torch.tensor(dsts, dtype=torch.int64, device=self.device)
-            v_moveds_t = torch.tensor(v_moveds, dtype=torch.int64, device=self.device)
+            v_moveds_t = self.physical_to_virtual[src_pages_t]
+            invalid_mappings = v_moveds_t < 0
+            if bool(torch.any(invalid_mappings).item()):
+                invalid_index = int(torch.nonzero(invalid_mappings)[0, 0].item())
+                src = srcs[invalid_index]
+                raise AssertionError(
+                    f"MultiEndedAllocator({self.sub_pool_name!r})."
+                    f"_flush: topmost survivor p={src} has p2v=-1; "
+                    "this should be impossible (`_topmost_survivor` "
+                    "excludes `holes_cpu` and `_pending_reuse_pages_cpu`)."
+                    f" State: {self.allocator_state_str()}, "
+                    f"#pending_reuse={len(self._pending_reuse_pages_cpu)}"
+                )
             # Expand to token granularity (the move kernel is token-granular).
             if self.page_size == 1:
                 src_t, dst_t = src_pages_t, dst_pages_t

--- a/test/registered/unit/mem_cache/test_multi_ended_allocator.py
+++ b/test/registered/unit/mem_cache/test_multi_ended_allocator.py
@@ -79,6 +79,24 @@ class _FakeKVCache:
         self.buf[dst_loc] = self.buf[src_loc].clone()
 
 
+class _RejectScalarIndexTensor:
+    """Tensor proxy that rejects one-row-at-a-time mapping lookups."""
+
+    def __init__(self, tensor: torch.Tensor):
+        self.tensor = tensor
+
+    def __getattr__(self, name):
+        return getattr(self.tensor, name)
+
+    def __getitem__(self, index):
+        if isinstance(index, int):
+            raise AssertionError("physical_to_virtual was read one row at a time")
+        return self.tensor[index]
+
+    def __setitem__(self, index, value):
+        self.tensor[index] = value
+
+
 class TestUnifiedKVPoolViews(unittest.TestCase):
     def test_min_slot_index_and_disjoint_bytes(self):
         full = _make_mha_spec("full", "up", layer_num=4)
@@ -2048,6 +2066,27 @@ class TestLazyCompaction(unittest.TestCase):
             if p == -1:
                 continue  # freed
             self.assertEqual(int(fa.physical_to_virtual[p].item()), v)
+
+    def test_lazy_flush_gathers_survivor_mappings_as_one_batch(self):
+        """Compaction must not synchronize once per relocated survivor."""
+        _pool, fa, kv = self._make_full(lazy=True)
+        values = fa.alloc(12)
+        self._stamp_kv(kv, fa, values)
+        fa.free(values[1:5].clone())
+
+        physical_to_virtual = fa.physical_to_virtual
+        fa.physical_to_virtual = _RejectScalarIndexTensor(physical_to_virtual)
+        try:
+            self.assertEqual(fa._flush(urgent=True), 4)
+        finally:
+            fa.physical_to_virtual = physical_to_virtual
+
+        for virtual in values.tolist():
+            physical = int(fa.virtual_to_physical[virtual].item())
+            if physical == -1:
+                continue
+            self.assertEqual(int(fa.physical_to_virtual[physical].item()), virtual)
+            self.assertEqual(int(kv.buf[physical].item()), virtual)
 
     def _replay_sequence(self, ops, lazy: bool):
         """Run a given alloc/free op trace under eager OR lazy mode and


### PR DESCRIPTION
## Motivation

Unified-memory lazy compaction reads `physical_to_virtual[src].item()` for every relocated survivor. 
Each scalar read synchronizes the GPU and CPU, making compaction a major bottleneck under memory pressure. 
Batching these lookups improved unified-memory throughput by 20.4% to 128.2% across Qwen3.5-0.8B, 4B, and 9B in eviction-heavy benchmarks.

## Modifications

- Gather all survivor virtual IDs with one indexed tensor operation per move batch.
- Keep the invalid-mapping assertion with one check per batch.
- Add a regression test that rejects per-row mapping reads and verifies the
  virtual/physical mappings and relocated cache data.

## Accuracy Tests

| Test | Result |
|---|---:|
| Complete allocator test file | **66 passed** |
| Eviction/replay parity | **80/80 exact matches** |
| Test-only diff applied to upstream base | **1 failed** (expected) |
| New regression test with this patch | **1 passed** |

The parity test compared output IDs, logprob token IDs, and logprob values between upstream unified memory and this patch after eviction. Maximum logprob difference was 0.0.

<details>
<summary>Test commands</summary>

```bash
PYTHONPATH=python:test python -m pytest -q \
  test/registered/unit/mem_cache/test_multi_ended_allocator.py \
  -k lazy_flush_gathers_survivor_mappings_as_one_batch

PYTHONPATH=python:test python -m pytest -q \
  test/registered/unit/mem_cache/test_multi_ended_allocator.py
```

To reproduce the failure, apply only the test-file diff to the upstream base.
The regression test fails at the per-row mapping lookup; it passes after the
production-file diff is applied.

</details>

## Speed Tests and Profiling

### Environment

- GPU: NVIDIA GeForce RTX 5090, 32,607 MiB; driver 610.62
- Models: `Qwen/Qwen3.5-0.8B`, `Qwen/Qwen3.5-4B`, and  `Qwen/Qwen3.5-9B`, bfloat16

The three variants differ only as follows:

| Configuration | Source revision | Server option |
|---|---|---|
| Static memory | `52afe87a08c6` (upstream base) | `--enable-unified-memory` disabled |
| Unified memory (upstream) | `52afe87a08c6` | `--enable-unified-memory` |
| Unified memory + batched mapping (this PR) | this PR  | `--enable-unified-memory` |

Each run used 80 prefix groups, four measured rounds, 1,024 input tokens, four
output tokens, concurrency 16, and two priming passes. A fresh server was used
for every variant and repetition. Results are medians of three runs.

<details>
<summary>Reproduction commands and workload</summary>

### Server

Create isolated source trees for the exact revisions:

```bash
git fetch upstream main
git worktree add ../sglang-upstream-base \
  52afe87a08c6aa049c52f9507b4f0ca26cecb562

git fetch https://github.com/seokwoosong/sglang.git \
  perf/unified-compaction-batch-mapping
git worktree add ../sglang-unified-batched-mapping \
  66535cef39775b13a589668fc1429d57e8f8ff03
```

Use `../sglang-upstream-base` for Static memory and Unified memory (upstream).
Use `../sglang-unified-batched-mapping` for Unified memory + batched mapping
(this PR).

Start a fresh server for every variant, memory fraction, and repetition. 

```bash
PYTHONPATH=<SOURCE_TREE>/python python -m sglang.launch_server \
  --model-path <MODEL> \
  --host 127.0.0.1 --port 30000 --tp 1 --dtype bfloat16 \
  --page-size 1 \
  --attention-backend triton \
  --linear-attn-backend triton \
  --mamba-backend triton \
  --mamba-radix-cache-strategy extra_buffer \
  --max-total-tokens 60000 \
  --max-running-requests 16 \
  --chunked-prefill-size 4096 \
  --context-length 65536 \
  --cuda-graph-backend-decode disabled \
  --cuda-graph-backend-prefill disabled \
  --enable-metrics \
  --mem-fraction-static <MEMORY_FRACTION> \
  [--enable-unified-memory]
```

Stop the server after each run so that every measurement starts from a fresh allocator and radix cache.

Use these model-specific memory fractions:
| Model | Memory fractions |
|---|---|
| `Qwen/Qwen3.5-0.8B` | 0.30, 0.15 |
| `Qwen/Qwen3.5-4B` | 0.55, 0.40 |
| `Qwen/Qwen3.5-9B` | 0.85, 0.75 |

Each pair above leaves a valid cache pool and still causes L1 eviction.

### Workload reproduction

The workload is deterministic and uses token IDs directly through `/generate`:

1. Initialize `random.Random(42)`.
2. Create 80 groups. Each group has a 972-token shared prefix
   (`int(1024 * 0.95)`) consisting of token `1000 + group_id`, followed by 971
   values from `rng.randrange(2000, 200000)`.
3. Prime the radix cache twice. In each pass, submit every prefix sequentially
   with `temperature=0`, `max_new_tokens=1`, and `ignore_eos=true`.
4. Build four measured rounds. In each round, visit groups in reverse order
   (`79` through `0`) and append 52 new values from
   `rng.randrange(2000, 200000)` to the group's prefix. This produces 320
   measured requests of exactly 1,024 input tokens each.
5. Submit all measured requests through the streaming `/generate` endpoint,
   limiting in-flight requests with `asyncio.Semaphore(16)`. Use
   `temperature=0`, `max_new_tokens=4`, and `ignore_eos=true`.
6. Measure wall-clock time immediately around the 320-request
   `asyncio.gather()`. Compute total token throughput as
   `sum(prompt_tokens + completion_tokens) / measured_seconds` using the token
   counts returned by the server.
7. Read `/metrics` immediately before and after the measured phase. Reject the
   run if a request failed or if `sglang:evicted_tokens_total` did not increase.

Run three repetitions at each memory fraction. 
Rotate server order to reduce thermal and order bias:

- repetition 1: Static memory, Unified memory (upstream), Unified memory + batched mapping
- repetition 2: Unified memory (upstream), Unified memory + batched mapping, Static memory
- repetition 3: Unified memory + batched mapping, Static memory, Unified memory (upstream)

Report the median of the three runs. Across the three models, the matrix
contains 54 clean runs and 17,280 measured requests in total.

</details>

### Results

| Model | GPU memory fraction | Static memory | Unified memory (upstream) | This PR | Improvement |
|---|---:|---:|---:|---:|---:|
| Qwen3.5-0.8B | 0.30 | 88,366 tok/s | 50,938 tok/s | 97,612 tok/s | +91.6% |
| Qwen3.5-0.8B | 0.15 | 82,397 tok/s | 31,320 tok/s | 71,467 tok/s | +128.2% |
| Qwen3.5-4B | 0.55 | 19,253 tok/s | 13,501 tok/s | 18,404 tok/s | +36.3% |
| Qwen3.5-4B | 0.40 | 17,390 tok/s | 12,311 tok/s | 16,961 tok/s | +37.8% |
| Qwen3.5-9B | 0.85 | 10,650 tok/s | 8,612 tok/s | 10,372 tok/s | +20.4% |
| Qwen3.5-9B | 0.75 | 10,155 tok/s | 8,276 tok/s | 10,226 tok/s | +23.6% |

All 54 runs and 17,280 measured requests passed. L1 eviction occurred in every run. 
Upstream unified memory and this PR evicted exactly the same number of tokens in every repetition for five of the six rows; 0.8B/0.30 is an end-to-end comparison with scheduling-dependent eviction. 
The maximum throughput range across the three repetitions of any 4B or 9B variant was 1.04%.

### Profiler

At 0.8B/0.15, both traces contained the same 51 `_flush` calls and 18 move-batch commits:

| Metric inside `_flush` | Upstream | This PR | Change |
|---|---:|---:|---:|
| `aten::item` calls | 32,646 | 18 | -99.9% |
| `_flush` CPU duration | 1,060.4 ms | 68.0 ms | -93.6% |

The remaining 18 scalar reads are the intentional invalid-mapping check, once per committed move batch.

<details>
<summary>Profiler reproduction</summary>

Use memory fraction 0.15 and the same priming procedure, but run one measured round (80 requests). 
Immediately before the measured phase, start the built-in
profiler:

```bash
curl -X POST http://127.0.0.1:30000/start_profile \
  -H 'Content-Type: application/json' \
  -d '{
    "output_dir": "/tmp/sglang-compaction-profile",
    "num_steps": 64,
    "activities": ["CPU", "GPU"],
    "with_stack": false,
    "record_shapes": false
  }'
```

Count `aten::item` events whose timestamps and thread IDs fall inside a
`MultiEndedAlloc._flush` event, and sum the durations of those `_flush` events.

</details>

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is required.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32574983465](https://github.com/sgl-project/sglang/actions/runs/32574983465)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32574983384](https://github.com/sgl-project/sglang/actions/runs/32574983384)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32574983448](https://github.com/sgl-project/sglang/actions/runs/32574983448)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->