### PR TITLE
[CI] Organize weekly CUDA tests the same way as nightly

### DIFF
--- a/.github/workflows/_scheduled-test-stage.yml
+++ b/.github/workflows/_scheduled-test-stage.yml
@@ -1,19 +1,24 @@
-# Reusable workflow for one nightly CUDA runner_config. The caller
-# (nightly-test-nvidia.yml) supplies only the runner_config and its partition
-# layout; everything about the machine -- runs-on label, install script,
-# install timeout, rdma devices, Grace-Blackwell flag -- is resolved from
-# scripts/ci/runner_configs.yml, and the test list comes from the
-# `nightly-test-{runner_config}` suite in the registry.
+# Reusable workflow for one scheduled CUDA (stage, runner_config) pair. The
+# caller -- nightly-test-nvidia.yml or weekly-test-nvidia.yml -- supplies the
+# stage and runner_config plus a partition layout; everything about the machine
+# (runs-on label, install script, install timeout, rdma devices,
+# Grace-Blackwell flag) is resolved from scripts/ci/runner_configs.yml, and the
+# test list comes from the `{stage}-test-{runner_config}` suite in the registry.
 #
-# Consequence: adding or moving a nightly test is a registry edit only. A test
-# reaches a machine by declaring `runner_config=`, never by a workflow change.
-name: Nightly Test Stage (Nvidia)
+# Consequence: adding or moving a scheduled test is a registry edit only. A
+# test reaches a machine by declaring `runner_config=`, never by a workflow
+# change.
+name: Scheduled Test Stage (Nvidia)
 
 on:
   workflow_call:
     inputs:
+      stage:
+        description: 'Suite stage, e.g. nightly or weekly. Combined with runner_config into the suite name {stage}-test-{runner_config}.'
+        required: true
+        type: string
       runner_config:
-        description: 'Key in scripts/ci/runner_configs.yml. Also selects the suite: nightly-test-{runner_config}.'
+        description: 'Key in scripts/ci/runner_configs.yml. Resolves the runs-on label, install script, install timeout and rdma devices.'
         required: true
         type: string
       runs_on:
@@ -57,10 +62,11 @@ env:
   SGLANG_CUDA_COREDUMP: "1"
   HF_HUB_DOWNLOAD_TIMEOUT: 300
   HF_HUB_ETAG_TIMEOUT: 300
-  # Nightly runs the full jit_kernel parameter grids. This used to be set per
-  # job on the kernel-only jobs; it is a property of running nightly, not of a
-  # particular machine, so it lives at the workflow level now. Only
-  # sglang.kernels.jit reads it (see should_run_full_tests).
+  # Scheduled runs use the full jit_kernel parameter grids. This used to be set
+  # per job on the kernel-only nightly jobs; it is a property of running on a
+  # schedule rather than per-commit, not of a particular machine, so it lives at
+  # the workflow level. Only sglang.kernels.jit reads it (see
+  # should_run_full_tests), so callers with no kernel tests are unaffected.
   SGLANG_JIT_KERNEL_RUN_FULL_TESTS: "1"
   SGLANG_JIT_DEEPGEMM_FAST_WARMUP: true
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
@@ -115,7 +121,7 @@ jobs:
         run: |
           cd test
           python3 run_suite.py --hw cuda \
-            --suite nightly-test-${{ inputs.runner_config }} \
+            --suite ${{ inputs.stage }}-test-${{ inputs.runner_config }} \
             --continue-on-error \
             --timeout-from-est-time \
             --auto-partition-id ${{ matrix.partition }} \

--- a/.github/workflows/nightly-test-nvidia.yml
+++ b/.github/workflows/nightly-test-nvidia.yml
@@ -57,8 +57,9 @@ jobs:
   # type the pool can give us at once.
   nightly-1-gpu-large:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '1-gpu-large')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 1-gpu-large
       runs_on: 1-gpu-h100
       partition_ids: '[0, 1]'
@@ -70,8 +71,9 @@ jobs:
 
   nightly-2-gpu-large:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '2-gpu-large')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 2-gpu-large
       runs_on: 2-gpu-h100
       # Two 2h tests (VLM eval + VLM perf) dominate; 3 partitions splits them
@@ -85,8 +87,9 @@ jobs:
 
   nightly-4-gpu-h100:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '4-gpu-h100')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 4-gpu-h100
       runs_on: 4-gpu-h100
       run_timeout_minutes: 120
@@ -95,8 +98,9 @@ jobs:
 
   nightly-4-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '4-gpu-b200')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 4-gpu-b200
       runs_on: 4-gpu-b200
       run_timeout_minutes: 300
@@ -105,8 +109,9 @@ jobs:
 
   nightly-4-gpu-gb300:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '4-gpu-gb300')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 4-gpu-gb300
       # Nightly keeps its own GB300 pool, separate from the per-commit
       # `4-gpu-gb300` label used by base-c.
@@ -120,8 +125,9 @@ jobs:
 
   nightly-8-gpu-h200:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '8-gpu-h200')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 8-gpu-h200
       runs_on: 8-gpu-h200
       partition_ids: '[0, 1, 2, 3]'
@@ -134,8 +140,9 @@ jobs:
 
   nightly-8-gpu-b200:
     if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '8-gpu-b200')
-    uses: ./.github/workflows/_nightly-test-stage.yml
+    uses: ./.github/workflows/_scheduled-test-stage.yml
     with:
+      stage: nightly
       runner_config: 8-gpu-b200
       runs_on: 8-gpu-b200
       partition_ids: '[0, 1, 2, 3]'

--- a/.github/workflows/weekly-test-nvidia.yml
+++ b/.github/workflows/weekly-test-nvidia.yml
@@ -1,3 +1,7 @@
+# Weekly CUDA tests. Same organisation as nightly: the suite is
+# `weekly-test-{runner_config}` and the job body lives in the shared
+# _scheduled-test-stage.yml, so a test joins the weekly run by declaring
+# `stage="weekly"` plus a runner_config, with no workflow edit.
 name: Weekly Test (Nvidia)
 
 on:
@@ -5,46 +9,25 @@ on:
     - cron: '0 0 * * 0'  # Run every Sunday at midnight UTC
   workflow_dispatch:
     inputs:
-      job_filter:
-        description: 'Select which job to run (leave empty or "all" to run all jobs)'
+      runner_filter:
+        description: 'Select which runner_config to run (leave empty or "all" to run all)'
         required: false
         type: choice
         default: 'all'
         options:
           - 'all'
-          - 'weekly-test-8-gpu-h200'
+          - '8-gpu-h200'
 
 concurrency:
   group: weekly-test-nvidia-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  SGLANG_IS_IN_CI: true
-  SGLANG_ENABLE_ASYNC_ASSERT: true
-  HF_HUB_DOWNLOAD_TIMEOUT: 300
-  HF_HUB_ETAG_TIMEOUT: 300
-
 jobs:
-  # Weekly tests - 8 GPU H200
-  weekly-test-8-gpu-h200:
-    if: github.repository == 'sgl-project/sglang' && (inputs.job_filter == '' || inputs.job_filter == 'all' || inputs.job_filter == 'weekly-test-8-gpu-h200')
-    runs-on: 8-gpu-h200
-    timeout-minutes: 120
-    env:
-      RUNNER_LABELS: 8-gpu-h200
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/cuda/ci_install_dependency.sh
-
-      - name: Run weekly 8-GPU H200 tests
-        timeout-minutes: 120
-        env:
-          GPU_CONFIG: "8-gpu-h200"
-          IS_H200: "1"
-        run: |
-          cd test
-          python3 run_suite.py --hw cuda --suite weekly-8-gpu-h200 --nightly --continue-on-error --timeout-per-file 7200
+  weekly-8-gpu-h200:
+    if: github.repository == 'sgl-project/sglang' && (inputs.runner_filter == '' || inputs.runner_filter == 'all' || inputs.runner_filter == '8-gpu-h200')
+    uses: ./.github/workflows/_scheduled-test-stage.yml
+    with:
+      stage: weekly
+      runner_config: 8-gpu-h200
+      run_timeout_minutes: 180
+    secrets: inherit

--- a/test/registered/moe/test_hybrid_dp_ep_tp_mtp.py
+++ b/test/registered/moe/test_hybrid_dp_ep_tp_mtp.py
@@ -17,7 +17,7 @@ from sglang.test.test_utils import (
 
 # 60 test classes testing hybrid parallelism configurations
 # Each test launches server + runs MMLU eval (~90s per test)
-register_cuda_ci(est_time=5400, suite="weekly-8-gpu-h200", nightly=True)
+register_cuda_ci(est_time=5400, stage="weekly", runner_config="8-gpu-h200")
 
 
 class Test00(CustomTestCase):

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -178,7 +178,11 @@ OTHER_SUITES = {
     ],
     HWBackend.CUDA: [
         "stress",
-        "weekly-8-gpu-h200",
+        # Same `{stage}-test-{runner_config}` shape as the per-commit and
+        # nightly suites; weekly is just another stage. Listed here rather than
+        # in NIGHTLY_SUITES because it is neither per-commit nor nightly -- the
+        # three dicts only differ in which names this backend may declare.
+        "weekly-test-8-gpu-h200",
     ],
 }
 


### PR DESCRIPTION
Stacks on #34065.

Weekly was left in the shape nightly just moved away from: the suite name `weekly-8-gpu-h200` encoded cadence and machine together, the single registration carried `nightly=True` purely so `--nightly` would select it, and `weekly-test-nvidia.yml` hand-wrote its own checkout/install/runs-on.

- `register_cuda_ci(est_time=5400, stage="weekly", runner_config="8-gpu-h200")` -> suite `weekly-test-8-gpu-h200`. This drops the last `nightly=True` on any CUDA registration.
- `_nightly-test-stage.yml` becomes `_scheduled-test-stage.yml` with a `stage` input, so nightly and weekly share one job body. The nightly caller passes `stage: nightly`.
- `weekly-test-nvidia.yml` is now a single `uses:` call.
- Weekly picks up `--timeout-from-est-time` along with nightly. This also fixes a latent misconfiguration: the job had `timeout-minutes: 120` and `--timeout-per-file 7200` (also 120 min), so the per-file timeout could never fire before the job itself expired. The derived budget is 8100s against a 180 min job cap, and the last run took 111 min.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31241913610](https://github.com/sgl-project/sglang/actions/runs/31241913610)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31241913554](https://github.com/sgl-project/sglang/actions/runs/31241913554)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->