### PR TITLE
[Fix] Keep DECODE token-ids logprob entries tensor-typed under no_copy_to_cpu

### DIFF
--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -142,15 +142,18 @@ def get_token_ids_logprobs_raw(
     if stage == LogprobStage.DECODE:
         for i, token_ids in enumerate(token_ids_logprobs_list):
             if token_ids is None:
-                vals.append([])
-                idxs.append([])
+                # No token ids requested for this request: emit an empty row
+                # through the same append below, so every entry has the type
+                # consumers expect (move_logprobs_to_cpu calls .tolist() on
+                # each entry).
+                row = logprobs.new_empty((0,))
             else:
                 token_ids_tensor = torch.tensor(token_ids, dtype=torch.long).to(
                     logprobs.device, non_blocking=True
                 )
                 row = logprobs[i, token_ids_tensor]
-                vals.append(row if no_copy_to_cpu else row.tolist())
-                idxs.append(token_ids)
+            vals.append(row if no_copy_to_cpu else row.tolist())
+            idxs.append([] if token_ids is None else token_ids)
     else:  # prefill
         pt = 0
         for i, (token_ids, pruned_len) in enumerate(

--- a/test/registered/unit/layers/test_logprob_processor.py
+++ b/test/registered/unit/layers/test_logprob_processor.py
@@ -1,0 +1,100 @@
+"""DECODE-stage token-ids logprobs for mixed batches under no_copy_to_cpu.
+
+Both DECODE producers call ``get_token_ids_logprobs(..., no_copy_to_cpu=True)``
+unconditionally (``OutputLogprobProcessor.compute_logprobs`` for the normal
+decode path, ``compute_spec_v2_logprobs`` for spec v2), and a batch is
+processed whenever ANY request asks for token-ids logprobs -- requests that
+did not ask contribute a ``None`` entry. Every val entry must stay
+tensor-typed: the non-overlap result path
+(``SchedulerBatchResultProcessor.move_logprobs_to_cpu``) calls ``.tolist()``
+on every entry unconditionally, so a bare ``[]`` placeholder crashes the
+scheduler with AttributeError on the first mixed decode batch.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.logprob_processor import (
+    LogprobStage,
+    get_token_ids_logprobs_raw,
+)
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDecodeTokenIdsLogprobsMixedBatch(CustomTestCase):
+    """Mixed batch: request 0 did NOT ask for token-ids logprobs (None entry),
+    request 1 asked for tokens [1, 2]."""
+
+    @staticmethod
+    def _mixed_vals_idxs():
+        logprobs = torch.log_softmax(
+            torch.arange(2 * 8, dtype=torch.float32).reshape(2, 8), dim=-1
+        )
+        return get_token_ids_logprobs_raw(
+            logprobs,
+            [None, [1, 2]],
+            stage=LogprobStage.DECODE,
+            no_copy_to_cpu=True,
+        )
+
+    def test_none_entry_stays_tensor_typed(self):
+        vals, idxs = self._mixed_vals_idxs()
+        # The None entry must be an EMPTY TENSOR (not a bare []), keeping the
+        # val list homogeneous for downstream tensor-only consumers.
+        self.assertTrue(torch.is_tensor(vals[0]))
+        self.assertEqual(vals[0].numel(), 0)
+        self.assertEqual(idxs[0], [])
+        self.assertTrue(torch.is_tensor(vals[1]))
+        self.assertEqual(vals[1].shape, (2,))
+        self.assertEqual(idxs[1], [1, 2])
+
+    def test_move_logprobs_to_cpu_survives_mixed_batch(self):
+        # The REAL non-overlap consumer: move_logprobs_to_cpu calls
+        # `v.tolist()` on every val entry unconditionally.
+        vals, idxs = self._mixed_vals_idxs()
+        logits_output = SimpleNamespace(
+            next_token_logprobs=None,
+            input_token_logprobs=None,
+            next_token_top_logprobs_val=None,
+            next_token_top_logprobs_idx=None,
+            next_token_token_ids_logprobs_val=vals,
+            next_token_token_ids_logprobs_idx=idxs,
+        )
+        batch = SimpleNamespace(return_logprob=True)
+
+        SchedulerBatchResultProcessor.move_logprobs_to_cpu(
+            object.__new__(SchedulerBatchResultProcessor),
+            batch=batch,
+            logits_output=logits_output,
+        )
+
+        converted = logits_output.next_token_token_ids_logprobs_val
+        self.assertEqual(converted[0], [])
+        self.assertEqual(len(converted[1]), 2)
+        self.assertIsInstance(converted[1], list)
+
+    def test_copy_to_cpu_path_unchanged(self):
+        # no_copy_to_cpu=False (the plain synchronous path) keeps returning
+        # plain lists for every entry.
+        logprobs = torch.log_softmax(torch.randn(2, 8), dim=-1)
+        vals, idxs = get_token_ids_logprobs_raw(
+            logprobs,
+            [None, [3]],
+            stage=LogprobStage.DECODE,
+            no_copy_to_cpu=False,
+        )
+        self.assertEqual(vals[0], [])
+        self.assertIsInstance(vals[1], list)
+        self.assertEqual(idxs[1], [3])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

A decode batch is processed for token-ids logprobs whenever **any** request in
it asks for them. Requests that did not ask contribute a `None` entry to
`token_ids_logprobs_list`, and `get_token_ids_logprobs_raw` turns that entry
into a bare `[]`:

```python
# python/sglang/srt/layers/logprob_processor.py
if stage == LogprobStage.DECODE:
    for i, token_ids in enumerate(token_ids_logprobs_list):
        if token_ids is None:
            vals.append([])          # <-- bare list
            idxs.append([])
        else:
            ...
            vals.append(row if no_copy_to_cpu else row.tolist())  # <-- tensor
```

Both DECODE producers call this with `no_copy_to_cpu=True` unconditionally
(`OutputLogprobProcessor.compute_logprobs` for the normal decode path,
`compute_spec_v2_logprobs` for spec v2), so the val list is heterogeneous —
a bare `[]` among GPU tensors — on every **mixed** decode batch.

The non-overlap result path then calls `.tolist()` on every entry
unconditionally:

```python
# python/sglang/srt/managers/scheduler_components/batch_result_processor.py
if logits_output.next_token_token_ids_logprobs_val:
    logits_output.next_token_token_ids_logprobs_val = [
        v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
    ]
```

so the first decode batch that mixes one request with `token_ids_logprob` and
one without kills the scheduler:

```
AttributeError: 'list' object has no attribute 'tolist'
```

One logprob client takes the server down for all tenants. Found while running
speculative-decoding workloads on a downstream deployment; the repro is plain
upstream code (no speculative decoding required — the normal decode producer
hits it too).

## Modifications

`python/sglang/srt/layers/logprob_processor.py` — in the
`stage == LogprobStage.DECODE` / `token_ids is None` arm, return a
tensor-typed empty when `no_copy_to_cpu` is set — both branches now flow through the same append, so the entry type rule is structural:

```python
if token_ids is None:
    row = logprobs.new_empty((0,))   # empty entry, same type rule as below
else:
    row = logprobs[i, token_ids_tensor]
vals.append(row if no_copy_to_cpu else row.tolist())
```

`tensor.new_empty((0,)).tolist()` is `[]`, so downstream results are
byte-identical to today's non-mixed behavior; the `no_copy_to_cpu=False`
path is unchanged.

New unit test `test/registered/unit/layers/test_logprob_processor.py`
(CPU CI, `base-a-test-cpu`):

- mixed batch keeps every val entry tensor-typed (and the empty entry empty);
- the **real consumer** (`SchedulerBatchResultProcessor.move_logprobs_to_cpu`)
  survives a mixed batch and produces `[]` for the request that didn't ask;
- the `no_copy_to_cpu=False` path still returns plain lists.

## Accuracy Tests

Not a numerics change: the fix only changes the Python type of an empty
placeholder (`[]` -> empty tensor whose `tolist()` is `[]`). Logprob values
for requests that asked for them are untouched.

Red/green on the new test, re-executed after rebasing onto current main
(base pin 6e2f87d589).

Without the fix (test file alone on a pristine checkout of 6e2f87d589; run
twice, identical):

```
$ python3 -m pytest test/registered/unit/layers/test_logprob_processor.py -q
...
>                   v.tolist() for v in logits_output.next_token_token_ids_logprobs_val
E               AttributeError: 'list' object has no attribute 'tolist'
python/sglang/srt/managers/scheduler_components/batch_result_processor.py:479: AttributeError
...
FAILED test/registered/unit/layers/test_logprob_processor.py::TestDecodeTokenIdsLogprobsMixedBatch::test_move_logprobs_to_cpu_survives_mixed_batch
FAILED test/registered/unit/layers/test_logprob_processor.py::TestDecodeTokenIdsLogprobsMixedBatch::test_none_entry_stays_tensor_typed
2 failed, 1 passed, 19 warnings in 11.51s
```

(the crash is raised from the real consumer, same signature as the server
death)

With the fix:

```
$ python3 -m pytest test/registered/unit/layers/test_logprob_processor.py -q
3 passed, 19 warnings in 26.71s
```

## Speed Tests and Profiling

No perf-relevant change: one `new_empty((0,))` per non-asking request per
decode iteration, only on batches that already compute token-ids logprobs.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35664332006](https://github.com/sgl-project/sglang/actions/runs/35664332006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35664331895](https://github.com/sgl-project/sglang/actions/runs/35664331895)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
