### PR TITLE
[Fix] Fence relay staging writes behind the in-flight forward's tail relay writes

### DIFF
--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -153,6 +153,10 @@ class ScheduleBatchDisaggregationDecodeMixin:
         else:
             # Non-spec: stash last token into the relay so the first DECODE's
             # resolve_forward_inputs gathers it like any other decode iter.
+            # Staging fence AFTER the H2D materialization above and
+            # immediately before the relay write -- see
+            # FutureMap.run_staging_fence for the placement contract.
+            future_map.run_staging_fence()
             future_map.stash(
                 self.req_pool_indices, RelayPayload(bonus_tokens=last_tokens_tensor)
             )

--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Optional, Sequence
 
 import msgspec
 import torch
@@ -293,6 +293,30 @@ class FutureMap:
             req_pool_size=self.req_pool_size,
             pool=req_to_token_pool,
         )
+
+        # Staging fence (Scheduler._fence_relay_staging), wired by the scheduler
+        # in run_event_loop once its schedule stream exists. Unwired (direct
+        # FutureMap construction, MLX's stream-free loop) it is a no-op.
+        self._staging_fence: Optional[Callable[[], None]] = None
+
+    def set_staging_fence(self, fence: Optional[Callable[[], None]]) -> None:
+        """Wire the scheduler's staging fence (Scheduler._fence_relay_staging).
+
+        Called once from Scheduler.run_event_loop after the schedule stream
+        exists. Left unwired, staging is unordered (tests, MLX)."""
+        self._staging_fence = fence
+
+    def run_staging_fence(self) -> None:
+        """Order a scheduler-thread staging publish/stash behind the in-flight
+        forward's tail relay writes (see Scheduler._fence_relay_staging).
+
+        Call AFTER the staged payload is fully materialized on device and
+        immediately BEFORE the publish/stash pair: a pageable H2D copy on the
+        fenced stream host-blocks until the forward drains, while the
+        publish/stash scatter writes are enqueue-only."""
+        if self._staging_fence is None:
+            return
+        self._staging_fence()
 
     def _lazy_init_forward_buf(self, payload: RelayPayload):
         # Local import (see decide_needs_cpu_seq_lens): keep module-level deps leaf.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1029,6 +1029,9 @@ class Scheduler(
             _,
             _,
         ) = self.tp_worker.get_worker_info()
+        # Set in run_event_loop's stream setup; None until then and on MLX
+        # (no torch streams).
+        self.schedule_stream = None
         # DFlash auto-enables the legacy formula; other workloads opt in via
         # --min-free-slots-delay. Built independently of the prefill delayer.
         self.min_free_slots_delayer: Optional[MinFreeSlotsDelayer] = None
@@ -1685,6 +1688,9 @@ class Scheduler(
         # The global WAR barrier fences the scheduler's next shared-buffer write
         # on the previous forward's read of the unified memory pool.
         self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        # Wire the staging fence now that the schedule stream exists (call-site
+        # contract: FutureMap.run_staging_fence).
+        self.future_map.set_staging_fence(self._fence_relay_staging)
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 
@@ -1703,6 +1709,20 @@ class Scheduler(
         if ev is not None and not envs.SGLANG_FORCE_COARSE_WAR_BARRIER.get():
             self.schedule_stream.wait_event(ev)
         else:
+            self.schedule_stream.wait_stream(self.forward_stream)
+
+    def _fence_relay_staging(self):
+        # Order scheduler-thread relay staging writes (PD-disagg decode
+        # bootstrap publish/stash, hisparse rebuild stash) behind the in-flight
+        # forward: the forward's tail relay writes may target the SAME
+        # req_pool rows (freed by the result just processed, reallocated here)
+        # and would otherwise land after the staging writes -- in-range, silent,
+        # wrong payload for the bootstrapped request. Call-site placement
+        # contract: FutureMap.run_staging_fence.
+        if not self.enable_overlap:
+            return
+        # None before run_event_loop's stream setup and on MLX (no torch streams).
+        if self.schedule_stream is not None:
             self.schedule_stream.wait_stream(self.forward_stream)
 
     @DynamicGradMode()
@@ -2987,6 +3007,10 @@ class Scheduler(
         last_tokens = torch.tensor(
             [r.output_ids[-1] for r in reqs], dtype=torch.int64, device=device
         )
+        # Same staging race as the disagg decode bootstrap: these rows may still
+        # be targeted by the in-flight forward's tail relay writes. All H2D
+        # materialization is above (see _fence_relay_staging).
+        self._fence_relay_staging()
         self.future_map.stash(
             batch.req_pool_indices, RelayPayload(bonus_tokens=last_tokens)
         )

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -97,6 +97,10 @@ def build_eagle_disagg_draft_input(
     if batch.enable_overlap:
         spec_info.future_dsa_topk_indices_available = dsa_topk_indices is not None
         spec_info.future_indices = batch.req_pool_indices
+        # Staging fence: all H2D payload materialization is above, so only the
+        # enqueue-only publish/stash relay writes sit behind the fence (see
+        # FutureMap.run_staging_fence).
+        future_map.run_staging_fence()
         # Seed the relay buf with the known seq_lens; publish's chained record
         # keeps the in-flight forward's fence intact (see FutureMap.publish).
         future_map.publish(spec_info.future_indices, batch.seq_lens)

--- a/test/registered/unit/disaggregation/test_relay_staging_fence.py
+++ b/test/registered/unit/disaggregation/test_relay_staging_fence.py
@@ -1,0 +1,464 @@
+"""Relay staging fence: scheduler-thread staging vs the in-flight forward's
+tail relay writes.
+
+The race (pool-indexed relay, the default): batch-prep staging seams --
+PD-disagg decode bootstrap (get_new_prebuilt_batch -> process_prebuilt),
+the EAGLE disagg spec bootstrap (build_eagle_disagg_draft_input), and the
+hisparse staging->decode rebuild -- publish/stash into freshly reallocated
+req_pool rows on the schedule stream, while the rows' previous owner's final
+forward -- still executing on the forward stream -- publishes/stashes those
+SAME rows at its tail. Unordered, the stale tail write can land second, and
+the bootstrapped request's first resolve silently reads the previous owner's
+bonus/topk/seq_lens. The values are in-range: no crash, just wrong tokens.
+Scheduler._fence_relay_staging closes the seam by ordering the staging
+writes behind everything enqueued on the forward stream.
+
+The fence is wired into the FutureMap (set_staging_fence) so the seams can
+invoke it AFTER their H2D payload materialization and immediately BEFORE the
+publish/stash pair: a pageable H2D copy on a fenced schedule stream would
+host-block every bootstrap iteration until the in-flight forward drains,
+while the publish/stash scatter writes are enqueue-only.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
+from sglang.srt.speculative.eagle_disaggregation import (
+    build_eagle_disagg_draft_input,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+register_cuda_ci(est_time=8, stage="base-b", runner_config="1-gpu-small")
+
+_GPU_DELAY_CYCLES = 100_000_000  # ~tens of ms >> host enqueue latency
+
+
+def _make_future_map(
+    spec_algo: SpeculativeAlgorithm, device: torch.device = torch.device("cpu")
+) -> FutureMap:
+    return FutureMap(
+        device=device,
+        spec_algo=spec_algo,
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=torch.zeros((8, 16), dtype=torch.int32, device=device)
+        ),
+    )
+
+
+def _make_disagg_req(token: int = 7, device: str = "cpu") -> SimpleNamespace:
+    """The subset of a PD-transferred Req that build_eagle_disagg_draft_input
+    reads."""
+    return SimpleNamespace(
+        output_topk_p=[0.9],
+        output_topk_index=[token],
+        hidden_states_tensor=torch.zeros(2, device=device),
+        output_dsa_topk_indices=None,
+    )
+
+
+def _make_disagg_batch(
+    rows: torch.Tensor,
+    seq_lens: torch.Tensor,
+    token: int,
+    device: str = "cpu",
+    enable_overlap: bool = True,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        reqs=[_make_disagg_req(token, device) for _ in range(rows.numel())],
+        device=device,
+        enable_overlap=enable_overlap,
+        seq_lens=seq_lens,
+        req_pool_indices=rows,
+    )
+
+
+def _server_args() -> SimpleNamespace:
+    return SimpleNamespace(
+        speculative_eagle_topk=1,
+        speculative_num_steps=5,
+        enable_multi_layer_eagle=False,
+    )
+
+
+def _scheduler_cls():
+    from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+    maybe_stub_sgl_kernel()
+    from sglang.srt.managers.scheduler import Scheduler
+
+    return Scheduler
+
+
+class TestRelayStagingFence(CustomTestCase):
+    def test_fence_orders_schedule_stream_behind_forward_stream(self):
+        scheduler_cls = _scheduler_cls()
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.enable_overlap = True
+        scheduler.schedule_stream = mock.MagicMock(name="schedule_stream")
+        scheduler.forward_stream = mock.MagicMock(name="forward_stream")
+
+        scheduler._fence_relay_staging()
+
+        scheduler.schedule_stream.wait_stream.assert_called_once_with(
+            scheduler.forward_stream
+        )
+
+    def test_fence_inert_without_overlap_or_streams(self):
+        scheduler_cls = _scheduler_cls()
+        # Non-overlap: forwards are synchronous on the scheduler's stream; no
+        # in-flight tail writes to order against.
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.enable_overlap = False
+        scheduler.schedule_stream = mock.MagicMock(name="schedule_stream")
+        scheduler.forward_stream = mock.MagicMock(name="forward_stream")
+        scheduler._fence_relay_staging()
+        scheduler.schedule_stream.wait_stream.assert_not_called()
+
+        # Pre-loop / MLX: schedule_stream is None until run_event_loop's
+        # stream setup (__init__ contract) -- must no-op. Direct attribute
+        # access is deliberate (no getattr defaulting): an instance that
+        # skipped __init__ entirely should fail loud, not silently no-op.
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.enable_overlap = True
+        scheduler.schedule_stream = None
+        scheduler.forward_stream = mock.MagicMock(name="forward_stream")
+        scheduler._fence_relay_staging()  # must not raise
+        with self.assertRaises(AttributeError):
+            bare = scheduler_cls.__new__(scheduler_cls)
+            bare.enable_overlap = True
+            bare.forward_stream = mock.MagicMock(name="forward_stream")
+            bare._fence_relay_staging()  # skipped __init__: loud, not silent
+
+    def test_run_staging_fence_wired_invoke_and_unwired_noop(self):
+        # FutureMap-level contract: staging invokes the wired fence; unwired
+        # (direct FutureMap construction in tests, MLX) is a no-op.
+        future_map = _make_future_map(SpeculativeAlgorithm.EAGLE)
+        future_map.run_staging_fence()  # unwired: must not raise
+        fence = mock.MagicMock(name="fence")
+        future_map.set_staging_fence(fence)
+        future_map.run_staging_fence()
+        fence.assert_called_once_with()
+
+    def test_run_event_loop_wires_staging_fence(self):
+        # The prod wiring: run_event_loop must hand the scheduler's fence to
+        # the FutureMap once the schedule stream exists -- otherwise the seam
+        # calls below are silently inert in production.
+        scheduler_cls = _scheduler_cls()
+        import sglang.srt.managers.scheduler as scheduler_mod
+
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        stream = mock.MagicMock(name="schedule_stream")
+        stream.cuda_stream = 11
+        scheduler.device = "cuda"
+        scheduler.device_module = SimpleNamespace(
+            Stream=mock.MagicMock(return_value=stream),
+            StreamContext=mock.MagicMock(),
+        )
+        scheduler.forward_stream = SimpleNamespace(cuda_stream=22)
+        scheduler.future_map = mock.MagicMock(name="future_map")
+        with mock.patch.object(scheduler_mod, "triton_load_watch"), mock.patch.object(
+            scheduler_mod, "use_mlx", return_value=False
+        ), mock.patch.object(
+            scheduler_mod, "is_cuda", return_value=True
+        ), mock.patch.object(
+            scheduler_mod, "dispatch_event_loop"
+        ) as dispatch:
+            scheduler.run_event_loop()
+        dispatch.assert_called_once_with(scheduler)
+        scheduler.future_map.set_staging_fence.assert_called_once()
+        (wired,) = scheduler.future_map.set_staging_fence.call_args.args
+        self.assertEqual(
+            getattr(wired, "__func__", None),
+            scheduler_cls._fence_relay_staging,
+        )
+        self.assertIs(getattr(wired, "__self__", None), scheduler)
+
+    def test_prebuilt_bootstrap_defers_fence_to_staging_seam(self):
+        # Drive the REAL get_new_prebuilt_batch seam: it must NOT fence before
+        # process_prebuilt -- process_prebuilt's H2D payload materialization
+        # (last_tokens/topk/hidden pageable copies) on a fenced schedule
+        # stream would host-block every bootstrap iteration until the
+        # in-flight forward drains. The fence belongs INSIDE the seam,
+        # immediately before the publish/stash pair (tests below).
+        scheduler_cls = _scheduler_cls()
+        import sglang.srt.disaggregation.decode as decode_mod
+
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.grammar_manager = SimpleNamespace(has_waiting_grammars=lambda: False)
+        req = SimpleNamespace(
+            init_next_round_input=mock.MagicMock(),
+            kv_committed_len=None,
+            last_node=None,
+        )
+        scheduler.waiting_queue = [req]
+        scheduler.enable_priority_scheduling = False
+        scheduler.req_to_token_pool = SimpleNamespace(size=8)
+        scheduler.max_running_requests = 2
+        scheduler.server_args = SimpleNamespace(
+            disaggregation_decode_enable_radix_cache=False
+        )
+        scheduler.tree_cache = object()
+        scheduler.token_to_kv_pool_allocator = object()
+        scheduler.model_config = object()
+        scheduler.enable_overlap = True
+        scheduler.spec_algorithm = SpeculativeAlgorithm.EAGLE
+        scheduler.future_map = object()
+
+        calls = mock.MagicMock()
+        scheduler._fence_relay_staging = calls.fence
+        new_batch = mock.MagicMock(name="new_batch")
+        new_batch.prepare_for_prebuilt = calls.prepare_for_prebuilt
+        new_batch.process_prebuilt = calls.process_prebuilt
+        running_batch = SimpleNamespace(batch_size=lambda: 0)
+
+        with mock.patch.object(
+            decode_mod.ScheduleBatch, "init_new", return_value=new_batch
+        ), mock.patch.object(decode_mod, "set_time_batch"), mock.patch.object(
+            # get_new_prebuilt_batch reads the radix flag from the published
+            # 'disagg' config namespace; this bare unit process publishes
+            # nothing, so stub the bag at the module binding decode.py imports.
+            decode_mod,
+            "get_disagg",
+            return_value=SimpleNamespace(
+                disaggregation_decode_enable_radix_cache=False
+            ),
+        ):
+            out = scheduler.get_new_prebuilt_batch(running_batch)
+
+        self.assertIs(out, new_batch)
+        names = [name for name, _, _ in calls.mock_calls]
+        self.assertNotIn("fence", names)  # the caller-level stall hazard
+        calls.process_prebuilt.assert_called_once_with(
+            scheduler.server_args, scheduler.future_map
+        )
+
+    def test_eagle_staging_fence_after_materialize_before_publish_stash(self):
+        # The REAL eagle staging seam: run_staging_fence must be invoked after
+        # the H2D payload materialization (guaranteed structurally: the mock
+        # future_map's first recorded call IS the fence, and every H2D happens
+        # before any future_map call) and immediately before publish/stash.
+        future_map = mock.MagicMock(name="future_map")
+        batch = _make_disagg_batch(
+            rows=torch.tensor([3, 5], dtype=torch.int64),
+            seq_lens=torch.tensor([9, 17], dtype=torch.int64),
+            token=7,
+        )
+        with mock.patch(
+            "sglang.srt.speculative.spec_utils.spec_need_hidden_states",
+            return_value=False,
+        ):
+            build_eagle_disagg_draft_input(
+                batch,
+                _server_args(),
+                torch.tensor([11, 12], dtype=torch.int64),
+                future_map,
+            )
+        names = [name for name, _, _ in future_map.mock_calls]
+        self.assertEqual(
+            names, ["run_staging_fence", "publish", "stash"]
+        )  # fence first among relay ops, nothing between fence and writes
+
+    def test_eagle_no_overlap_skips_staging_and_fence(self):
+        future_map = mock.MagicMock(name="future_map")
+        batch = _make_disagg_batch(
+            rows=torch.tensor([3], dtype=torch.int64),
+            seq_lens=torch.tensor([9], dtype=torch.int64),
+            token=7,
+            enable_overlap=False,
+        )
+        draft_input = build_eagle_disagg_draft_input(
+            batch, _server_args(), torch.tensor([11], dtype=torch.int64), future_map
+        )
+        self.assertIsNone(draft_input.future_indices)
+        self.assertEqual(future_map.mock_calls, [])
+
+    def test_process_prebuilt_nonspec_fences_before_stash(self):
+        # Non-spec disagg staging (always pool mode): the mixin must call
+        # run_staging_fence after materializing last_tokens_tensor and
+        # immediately before the relay stash.
+        from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
+            ScheduleBatchDisaggregationDecodeMixin,
+        )
+
+        future_map = mock.MagicMock(name="future_map")
+        req = SimpleNamespace(output_ids=[42], grammar=None, rid="r0")
+        fake_self = SimpleNamespace(
+            reqs=[req],
+            tree_cache=object(),
+            device="cpu",
+            spec_algorithm=SimpleNamespace(
+                build_disagg_draft_input=lambda *a, **k: None
+            ),
+            req_pool_indices=torch.tensor([3], dtype=torch.int64),
+        )
+        with mock.patch(
+            "sglang.srt.disaggregation.decode_schedule_batch_mixin."
+            "maybe_cache_unfinished_req"
+        ):
+            ScheduleBatchDisaggregationDecodeMixin.process_prebuilt(
+                fake_self, SimpleNamespace(), future_map
+            )
+        names = [name for name, _, _ in future_map.mock_calls]
+        self.assertEqual(names, ["run_staging_fence", "stash"])
+        self.assertIsNone(fake_self.input_ids)
+
+    def test_hisparse_rebuild_fences_before_stash(self):
+        # Same staging class: the hisparse staging->decode batch rebuild
+        # stashes into pool rows on the scheduler thread.
+        scheduler_cls = _scheduler_cls()
+        import sglang.srt.managers.scheduler as scheduler_mod
+
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.device = "cpu"
+        scheduler.req_to_token_pool = object()
+        scheduler.token_to_kv_pool_allocator = object()
+        scheduler.tree_cache = object()
+        scheduler.model_config = SimpleNamespace(vocab_size=32)
+        scheduler.enable_overlap = True
+        scheduler.spec_algorithm = SpeculativeAlgorithm.NONE
+
+        calls = mock.MagicMock()
+        scheduler._fence_relay_staging = calls.fence
+        scheduler.future_map = SimpleNamespace(stash=calls.stash)
+        batch = mock.MagicMock(name="batch")
+        batch.return_logprob = False
+        reqs = [
+            SimpleNamespace(req_pool_idx=3, origin_input_ids=[1, 2], output_ids=[5])
+        ]
+
+        with mock.patch.object(
+            scheduler_mod.ScheduleBatch, "init_new", return_value=batch
+        ), mock.patch.object(scheduler_mod, "SamplingBatchInfo"):
+            out = scheduler._build_hisparse_decode_batch(reqs)
+
+        self.assertIs(out, batch)
+        names = [name for name, _, _ in calls.mock_calls]
+        self.assertIn("fence", names)
+        self.assertLess(names.index("fence"), names.index("stash"))
+
+    # ---- empirical race closure (real CUDA streams) ------------------------
+
+    def _gpu_race_arm(self, fence: bool):
+        """One arm of the staging race on real streams.
+
+        Previous owner A's final forward is emulated by a forward-stream
+        sequence [sleep, publish(seq=40), sleep, stash(bonus/topk=111)] still
+        in flight when A's row (5) is freed and reassigned to disagg-
+        bootstrapped B, whose staging goes through the REAL seam
+        (build_eagle_disagg_draft_input: publish(seq=9) + stash(222)) on the
+        schedule stream. The fenced arm exercises the SHIPPED wiring: the
+        scheduler fence handed to the FutureMap (set_staging_fence), invoked
+        by the seam itself after payload materialization, immediately before
+        publish/stash. Returns B's first-resolve (bonus, seq_len).
+        """
+        scheduler_cls = _scheduler_cls()
+        dev = torch.device("cuda")
+        future_map = _make_future_map(SpeculativeAlgorithm.EAGLE, device=dev)
+        forward_stream = torch.cuda.Stream()
+        schedule_stream = torch.cuda.Stream()
+        rows = torch.tensor([5], dtype=torch.int64, device=dev)
+
+        scheduler = scheduler_cls.__new__(scheduler_cls)
+        scheduler.enable_overlap = True
+        scheduler.schedule_stream = schedule_stream
+        scheduler.forward_stream = forward_stream
+        if fence:
+            # The shipped run_event_loop wiring; the seam fences itself.
+            future_map.set_staging_fence(scheduler._fence_relay_staging)
+
+        server_args = _server_args()
+        # Everything the raced region touches is pre-built on the default
+        # stream: a pageable H2D (torch.tensor(..., device=...)) host-syncs its
+        # stream and a first-touch cudaMalloc syncs the whole device -- either
+        # inside the choreography would serialize the streams and mask the
+        # race the unfenced arm must exhibit.
+        stale_seq = torch.tensor([40], dtype=torch.int64, device=dev)
+        stale_payload = RelayPayload(
+            bonus_tokens=torch.tensor([111], dtype=torch.int64, device=dev),
+            topk_p=torch.full((1, 1), 0.5, device=dev),
+            topk_index=torch.tensor([[111]], dtype=torch.int64, device=dev),
+        )
+        raced_batch = _make_disagg_batch(
+            rows, torch.tensor([9], dtype=torch.int64, device=dev), 222, device=dev
+        )
+        last_tokens = torch.tensor([222], dtype=torch.int64, device=dev)
+
+        with mock.patch(
+            "sglang.srt.speculative.spec_utils.spec_need_hidden_states",
+            return_value=False,
+        ):
+            # Warmup on the default stream: triggers the FutureMap lazy buf
+            # init and the caching-allocator pools for both write paths (via
+            # an untouched row), so the raced region only enqueues async
+            # scatter kernels.
+            warm_rows = torch.tensor([1], dtype=torch.int64, device=dev)
+            future_map.stash(warm_rows, stale_payload)
+            build_eagle_disagg_draft_input(
+                _make_disagg_batch(
+                    warm_rows,
+                    torch.tensor([1], dtype=torch.int64, device=dev),
+                    7,
+                    device=dev,
+                ),
+                server_args,
+                torch.tensor([7], dtype=torch.int64, device=dev),
+                future_map,
+            )
+            torch.cuda.synchronize()
+
+            # Owner A's in-flight forward tail (forward stream): still mid-
+            # forward (sleep), publishes seq_lens, then stashes the payload.
+            with torch.cuda.stream(forward_stream):
+                torch.cuda._sleep(_GPU_DELAY_CYCLES)
+                future_map.publish(rows, stale_seq)
+                torch.cuda._sleep(_GPU_DELAY_CYCLES)
+                future_map.stash(rows, stale_payload)
+            # Scheduler thread: row 5 freed + reassigned to B; disagg decode
+            # bootstrap stages through the real seam (schedule stream). No
+            # explicit fence call here: in the fenced arm the seam invokes the
+            # wired fence itself (post-materialization, pre-publish/stash).
+            with torch.cuda.stream(schedule_stream):
+                spec_info = build_eagle_disagg_draft_input(
+                    raced_batch, server_args, last_tokens, future_map
+                )
+        torch.cuda.synchronize()
+
+        # B's first decode resolve.
+        resolve_batch = SimpleNamespace(
+            spec_info=spec_info,
+            seq_lens=None,
+            seq_lens_cpu=None,
+            seq_lens_sum=None,
+            req_pool_indices=rows,
+            req_pool_indices_cpu=torch.tensor([5], dtype=torch.int64),
+        )
+        future_map.resolve_seq_lens_cpu(resolve_batch)
+        future_map._resolve_spec_extras(resolve_batch)
+        torch.cuda.synchronize()
+        return (
+            int(spec_info.bonus_tokens.flatten()[0].item()),
+            int(resolve_batch.seq_lens_cpu[0].item()),
+        )
+
+    @unittest.skipUnless(
+        torch.cuda.is_available(), "staging race needs real CUDA streams"
+    )
+    def test_fence_closes_disagg_staging_race_on_gpu(self):
+        # Unfenced arm: the race reproduces -- B resolves A's stale values.
+        # If this arm ever starts seeing the fresh values, the unordered seam
+        # has changed shape; re-derive the fence need before touching it.
+        self.assertEqual(self._gpu_race_arm(fence=False), (111, 40))
+        # Fenced arm: the shipped fence closes it -- B resolves its own
+        # staged values.
+        self.assertEqual(self._gpu_race_arm(fence=True), (222, 9))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Withdrawn by the author — superseded.** #35748 (merged 2026-08-21) fences the decode-bootstrap staging at the caller (`get_new_prebuilt_batch` now runs `schedule_stream.wait_stream(forward_stream)` before `process_prebuilt`), which covers both disaggregation seams this PR addressed, and the chained `publish_ready` records cited in the motivation were removed in the same change. The one call site #35748 does not cover is the hisparse rebuild stash (`_build_hisparse_decode_batch`) — noting it here for anyone running `--enable-hisparse` under the overlap scheduler; the same fence idiom applies there.

## Motivation

Under overlap scheduling, the FutureMap relay is written from two streams
into the same pool-indexed rows:

- the in-flight forward's **tail** relay writes on the forward stream —
  `on_publish` / the non-spec publish and `_relay_forward_payload` -> `stash`
  all execute inside `forward_stream_ctx`;
- **batch-prep staging** on the schedule stream, which publishes/stashes into
  req_pool rows that were just freed by the result the scheduler processed
  and immediately reallocated to a new request:
  1. PD-disagg decode bootstrap, non-spec
     (`ScheduleBatchDisaggregationDecodeMixin.process_prebuilt`);
  2. EAGLE disagg spec bootstrap (`build_eagle_disagg_draft_input`, under
     `enable_overlap`);
  3. the hisparse staging->decode rebuild
     (`Scheduler._build_hisparse_decode_batch`).

Nothing orders the two: `publish`/`stash` are plain scatter stores on the
current stream. If the rows' previous owner's final forward is still
executing when the bootstrap stages the new owner, the stale tail write can
land **after** the staging write, and the bootstrapped request's first
resolve silently reads the previous owner's bonus token / topk / seq_lens.
The values are in-range — no crash, just wrong output. Found while running
speculative-decoding workloads on a downstream deployment.

The chained `publish_ready` event records (#30435) fence **readers** of the
publish event; they do not order these staging scatter **writes** behind the
previous owner's forward. The scheduler already uses exactly the needed
primitive for the adjacent WAR case (`_apply_war_barrier`:
`schedule_stream.wait_stream(forward_stream)`), but batch-prep staging has no
equivalent.

Note on reachability: the two-stream write ordering above is demonstrated
empirically by the GPU arm of the test (see the arm classification below);
the claim that production reaches that state — a previous owner's final
forward still in flight on the forward stream when the scheduler reallocates
its rows and stages a bootstrapped request into them — is argued from the
scheduler source (the overlap event loop's forward tail runs inside
`forward_stream_ctx` while row free/realloc and bootstrap staging happen on
the scheduler thread), not demonstrated end-to-end by this suite; no arm
drives the real two-thread scheduler loop.

## Modifications

- `python/sglang/srt/managers/overlap_utils.py` — `FutureMap` gains
  `set_staging_fence` / `run_staging_fence`. Unwired (direct construction in
  tests, MLX's stream-free loop) the fence is a no-op.
- `python/sglang/srt/managers/scheduler.py`
  - new `Scheduler._fence_relay_staging`: overlap-only
    `schedule_stream.wait_stream(forward_stream)`, None-guarded (the stream
    exists only after `run_event_loop`'s setup);
  - `run_event_loop` wires it into the FutureMap once the schedule stream
    exists; `__init__` now pre-sets `self.schedule_stream = None`;
  - `_build_hisparse_decode_batch` fences before its stash.
- `python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py` — the
  non-spec bootstrap fences before its stash.
- `python/sglang/srt/speculative/eagle_disaggregation.py` — the spec
  bootstrap fences before its publish/stash pair.

Placement contract (documented on `run_staging_fence`): the seams invoke the
fence **after** their H2D payload materialization and **immediately before**
the publish/stash pair. That way only the enqueue-only scatter writes sit
behind the fence; a pageable H2D copy on a fenced schedule stream would
host-block every bootstrap iteration until the in-flight forward drains.

New unit test
`test/registered/unit/disaggregation/test_relay_staging_fence.py` (CPU CI
`base-a-test-cpu`; CUDA CI `base-b` / `1-gpu-small`), ten arms — classified
below by what each one actually establishes.

## Accuracy Tests

Correctness fix for silent wrong-token output in PD-disagg / hisparse
bootstrap under overlap; no numerics change on the healthy path.

**What the ten arms are (what is real vs test-performed):**

1. **One staleness repro on real CUDA streams, with staged-driver caveats**
   (`test_fence_closes_disagg_staging_race_on_gpu`). What is real: the
   staging side goes through the real seam function
   (`build_eagle_disagg_draft_input`) on a real schedule stream, the fenced
   arm exercises the shipped `set_staging_fence` wiring, and the stale
   result is produced by genuinely unordered stream writes — not injected.
   What is test-performed: the previous owner's forward tail is hand-issued
   by the test (real `future_map.publish` / `stash` calls interleaved with
   `torch.cuda._sleep`, with test-chosen payloads), there is no real
   req-pool row free/reallocation (the test reuses row index 5 by
   construction), and the batches are hand-built shells
   (`SimpleNamespace`), not scheduler-produced ScheduleBatches. Unfenced,
   the bootstrapped request deterministically resolves the stale
   `(bonus, seq_len) = (111, 40)`; fenced, its own staged `(222, 9)`.
2. **Four wiring/ordering pins on mock FutureMaps or mocked collaborators**
   — they drive the real seam code and pin that the fence call exists and
   sits in the right place, not that corruption occurs:
   `test_eagle_staging_fence_after_materialize_before_publish_stash`
   (real seam, mock FutureMap: `["run_staging_fence", "publish", "stash"]`
   order), `test_process_prebuilt_nonspec_fences_before_stash` (real mixin
   method, mock FutureMap: `["run_staging_fence", "stash"]`),
   `test_hisparse_rebuild_fences_before_stash` (real rebuild, mocked
   fence/stash: fence before stash), and
   `test_run_event_loop_wires_staging_fence` (real `run_event_loop` with
   mocked streams/dispatch: the bound scheduler fence is handed to the
   FutureMap).
3. **Three API/semantics pins that red at base as `AttributeError`s** —
   their red signal is the absence of the new API; their green value is the
   fence semantics on mock streams:
   `test_fence_orders_schedule_stream_behind_forward_stream`
   (`wait_stream(forward_stream)` is taken),
   `test_fence_inert_without_overlap_or_streams` (non-overlap / pre-loop
   guards), and `test_run_staging_fence_wired_invoke_and_unwired_noop`
   (the FutureMap wired/unwired contract).
4. **Two base-green arms** (they pass with and without the fix, so they
   discriminate placement, not existence):
   `test_prebuilt_bootstrap_defers_fence_to_staging_seam` — a placement pin
   that `get_new_prebuilt_batch` does NOT fence at the caller level (the
   H2D host-block hazard above); and
   `test_eagle_no_overlap_skips_staging_and_fence` — a non-discriminating
   negative guard for the non-overlap path.

Red/green (1 GPU), re-executed for this revision.

Without the fix — the test file alone on a pristine checkout of the base
commit (2b4381956); run twice, identical failure set:

```
$ python3 -m pytest test/registered/unit/disaggregation/test_relay_staging_fence.py -q
...
E       AssertionError: Lists differ: ['publish', 'stash'] != ['run_staging_fence', 'publish', 'stash']
...
E           AttributeError: 'FutureMap' object has no attribute 'set_staging_fence'
...
E       AttributeError: 'Scheduler' object has no attribute '_fence_relay_staging'
...
E       AssertionError: 'fence' not found in ['stash']
...
E       AssertionError: Lists differ: ['stash'] != ['run_staging_fence', 'stash']
...
E           AssertionError: Expected 'set_staging_fence' to have been called once. Called 0 times.
...
E       AttributeError: 'FutureMap' object has no attribute 'run_staging_fence'
...
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_eagle_staging_fence_after_materialize_before_publish_stash
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_fence_closes_disagg_staging_race_on_gpu
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_fence_inert_without_overlap_or_streams
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_fence_orders_schedule_stream_behind_forward_stream
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_hisparse_rebuild_fences_before_stash
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_process_prebuilt_nonspec_fences_before_stash
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_run_event_loop_wires_staging_fence
FAILED test/registered/unit/disaggregation/test_relay_staging_fence.py::TestRelayStagingFence::test_run_staging_fence_wired_invoke_and_unwired_noop
8 failed, 2 passed, 19 warnings in 13.65s
```

In the GPU race arm the unfenced half reproduces the staleness first — the
base run reaches and passes
`self.assertEqual(self._gpu_race_arm(fence=False), (111, 40))` (the
bootstrapped request resolves the previous owner's stale values) — before
the fenced half fails on the missing fence API
(`AttributeError: 'FutureMap' object has no attribute 'set_staging_fence'`).
The two passing arms at base are exactly the two base-green arms classified
above.

With the fix (3 consecutive runs):

```
$ python3 -m pytest test/registered/unit/disaggregation/test_relay_staging_fence.py -q
10 passed, 19 warnings in 12.91s
10 passed, 19 warnings in 11.86s
10 passed, 19 warnings in 11.86s
```

Also green with `SGLANG_IS_IN_CI=true` (the debug-assert relay mode):
`10 passed`. The GPU race arm is guarded by
`skipUnless(torch.cuda.is_available())` and skips without CUDA.

## Speed Tests and Profiling

The fence fires only on the three staging seams (request bootstrap /
rebuild transitions, not steady-state decode iterations) and only under
overlap. It waits on the forward stream *from the schedule stream* — the
same wait `_apply_war_barrier` already takes every launch — and the
placement contract keeps H2D copies in front of it, so no host block is
added. Steady-state TPOT is untouched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31644255456](https://github.com/sgl-project/sglang/actions/runs/31644255456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31644255286](https://github.com/sgl-project/sglang/actions/runs/31644255286)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

