### PR TITLE
[Spec] Guard multi-layer EAGLE against diverted dp-attention non-extend batches

### DIFF
--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -978,6 +978,32 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
                 if self.speculative_algorithm.is_standalone()
                 else CaptureHiddenMode.FULL
             )
+
+            # dp_attention stamps the GLOBAL is_extend_in_batch, so a rank
+            # whose LOCAL batch is not an extend can be diverted into this
+            # target-prefill branch. Under the default spec+dp-attention
+            # scheduling that shape is only the staggered-IDLE rank
+            # (prepare_for_idle product: empty tensors, spec_info=None), which
+            # flows through the target forward and the is_idle() guards in the
+            # draft-extend path unchanged. A NON-empty locally-DECODE divert is
+            # only reachable when the pre-merge no-mix sync is skipped via
+            # --speculative-skip-dp-mlp-sync: the scheduler relays that batch's
+            # next-iteration input_ids through spec_info and leaves
+            # batch.input_ids=None, and the multi-layer draft-extend path has
+            # no divert synthesis for it. Fail loud here, before the target
+            # forward, instead of forwarding input_ids=None into the model
+            # while peer ranks are blocked in the dp gather.
+            if not batch.forward_mode.is_extend() and batch.seq_lens.numel() > 0:
+                raise RuntimeError(
+                    "multi-layer EAGLE received a diverted locally-DECODE/"
+                    f"globally-EXTEND dp batch (bs={batch.seq_lens.numel()}, "
+                    f"forward_mode={batch.forward_mode}); its input_ids are "
+                    "relayed via spec_info and are not materialized. This "
+                    "shape is only reachable with --speculative-skip-dp-mlp-sync "
+                    "together with --enable-multi-layer-eagle, a combination "
+                    "the multi-layer draft-extend path does not support."
+                )
+
             batch_output = self.target_worker.forward_batch_generation(
                 batch, capture_hidden_mode=target_capture_mode
             )

--- a/test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py
+++ b/test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py
@@ -1,0 +1,163 @@
+"""dp-attention divert seam of the multi-layer EAGLE worker's extend branch.
+
+``forward_batch_generation`` routes on ``batch.forward_mode.is_extend() or
+batch.is_extend_in_batch``: dp_attention stamps the GLOBAL is_extend_in_batch,
+so a rank whose LOCAL batch is not an extend can be diverted into the target
+prefill branch.
+
+Under the default spec+dp-attention scheduling the pre-merge no-mix sync
+converts would-be decode ranks to IDLE while a peer prefills, so the only
+reachable non-extend batch here is the staggered-IDLE one built by
+``prepare_for_idle``: empty tensors, ``spec_info=None``. That shape must pass
+through to the target forward UNCHANGED (behavior pin -- this also holds
+before the guard was added). A NON-empty locally-DECODE/globally-EXTEND batch
+is only reachable when the no-mix sync is skipped
+(``--speculative-skip-dp-mlp-sync``): the scheduler relays its next-iteration
+input_ids through ``spec_info`` and leaves ``batch.input_ids=None``, and the
+worker has no divert synthesis for it -- it must trip loud BEFORE the target
+forward, not forward ``input_ids=None`` into the model with peer ranks blocked
+in the dp gather.
+
+White-box unit test in the ``__new__`` + SimpleNamespace style: only the
+attributes the extend branch touches are provided.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.eagle_info import EagleDraftInput
+from sglang.srt.speculative.multi_layer_eagle_worker_v2 import (
+    MultiLayerEagleWorkerV2,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StopAtTargetForward(Exception):
+    pass
+
+
+def _stub_worker(captured: dict) -> SimpleNamespace:
+    def _target_forward(batch, **kwargs):
+        captured["input_ids"] = batch.input_ids
+        captured["out_cache_loc"] = batch.out_cache_loc
+        raise _StopAtTargetForward()
+
+    return SimpleNamespace(
+        speculative_algorithm=SpeculativeAlgorithm.EAGLE,
+        target_worker=SimpleNamespace(forward_batch_generation=_target_forward),
+    )
+
+
+def _diverted_decode_batch(spec_info, seq_lens) -> SimpleNamespace:
+    """Locally-DECODE batch carrying the global extend stamp; input_ids=None
+    because the scheduler relays spec decode ids via spec_info
+    (resolve_forward_inputs skips the rebuild when a spec algorithm is set)."""
+    return SimpleNamespace(
+        forward_mode=ForwardMode.DECODE,
+        is_extend_in_batch=True,
+        spec_info=spec_info,
+        seq_lens=seq_lens,
+        req_pool_indices=torch.arange(seq_lens.numel(), dtype=torch.int64),
+        input_ids=None,
+        out_cache_loc=None,
+    )
+
+
+class TestMultiLayerEagleDivertGuard(CustomTestCase):
+    def test_non_empty_decode_divert_fails_loud(self):
+        # The relay shape: spec_info is an EagleDraftInput whose bonus_tokens
+        # carry the next-iteration ids that never got materialized into
+        # input_ids. Without the guard this forwards input_ids=None into the
+        # target forward and dies as an anonymous NoneType error downstream.
+        captured = {}
+        worker = _stub_worker(captured)
+        batch = _diverted_decode_batch(
+            spec_info=EagleDraftInput(
+                bonus_tokens=torch.tensor([11, 12], dtype=torch.int64)
+            ),
+            seq_lens=torch.tensor([9, 17], dtype=torch.int64),
+        )
+
+        with self.assertRaises(RuntimeError) as context:
+            MultiLayerEagleWorkerV2.forward_batch_generation(worker, batch)
+
+        self.assertIn("diverted locally-DECODE", str(context.exception))
+        self.assertIn("--speculative-skip-dp-mlp-sync", str(context.exception))
+        # Tripped before the target forward; the batch is untouched.
+        self.assertEqual(captured, {})
+        self.assertIsNone(batch.input_ids)
+        self.assertIsNone(batch.out_cache_loc)
+
+    def test_non_empty_decode_divert_fails_loud_without_spec_info(self):
+        # The tripwire must not depend on spec_info: a non-empty divert with
+        # spec_info=None is the SAME unsupported shape, and a spec_info-gated
+        # guard would let it fall through to the anonymous downstream crash
+        # the guard exists to preempt.
+        captured = {}
+        worker = _stub_worker(captured)
+        batch = _diverted_decode_batch(
+            spec_info=None,
+            seq_lens=torch.tensor([9, 17], dtype=torch.int64),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "diverted locally-DECODE"):
+            MultiLayerEagleWorkerV2.forward_batch_generation(worker, batch)
+        self.assertEqual(captured, {})
+        self.assertIsNone(batch.input_ids)
+        self.assertIsNone(batch.out_cache_loc)
+
+    def test_staggered_idle_passes_through_unchanged(self):
+        # BEHAVIOR PIN (green before and after the guard): the reachable
+        # staggered-IDLE divert is the prepare_for_idle product -- empty
+        # tensors, spec_info=None -- stamped with the global extend flag. It
+        # must reach the target forward bit-identical: same (empty) input_ids
+        # and out_cache_loc objects, no synthesis, no error.
+        captured = {}
+        worker = _stub_worker(captured)
+        input_ids = torch.empty(0, dtype=torch.int64)
+        out_cache_loc = torch.empty(0, dtype=torch.int64)
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.IDLE,
+            is_extend_in_batch=True,
+            spec_info=None,
+            seq_lens=torch.empty(0, dtype=torch.int64),
+            req_pool_indices=torch.empty(0, dtype=torch.int64),
+            input_ids=input_ids,
+            out_cache_loc=out_cache_loc,
+        )
+
+        with self.assertRaises(_StopAtTargetForward):
+            MultiLayerEagleWorkerV2.forward_batch_generation(worker, batch)
+
+        self.assertIs(captured["input_ids"], input_ids)
+        self.assertIs(captured["out_cache_loc"], out_cache_loc)
+        self.assertEqual(batch.input_ids.numel(), 0)
+
+    def test_local_extend_unaffected(self):
+        # A genuinely-extend batch (the normal prefill) must reach the target
+        # forward untouched by the guard, whatever its spec_info.
+        captured = {}
+        worker = _stub_worker(captured)
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            is_extend_in_batch=True,
+            spec_info=None,
+            seq_lens=torch.tensor([4], dtype=torch.int64),
+            req_pool_indices=torch.tensor([0], dtype=torch.int64),
+            input_ids=torch.tensor([1, 2, 3, 4], dtype=torch.int64),
+            out_cache_loc=torch.arange(4, dtype=torch.int64),
+        )
+        with self.assertRaises(_StopAtTargetForward):
+            MultiLayerEagleWorkerV2.forward_batch_generation(worker, batch)
+        self.assertEqual(captured["input_ids"].tolist(), [1, 2, 3, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> **Withdrawn by the author.** Review discussion (thanks @Qiaolin-Yu) established that the idle-fill half addressed a shape current main cannot produce, and the remaining delta was a fail-fast guard only — an error-quality improvement, not a logic fix. Closing until the underlying seam gets a real fix (divert synthesis for the multi-layer path); the analysis in the description stands as a record of the reachable shapes.

## Motivation

`MultiLayerEagleWorkerV2.forward_batch_generation` routes on

```python
if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
```

`is_extend_in_batch` is the **global** dp-attention stamp
(`layers/dp_attention.py`), so a rank whose **local** batch is not an extend
can be diverted into the target-prefill branch while the scheduler nulled
`input_ids` for the spec iteration. Today that branch forwards the batch
straight into `target_worker.forward_batch_generation`:

- the staggered-IDLE rank (a peer prefills while this rank has nothing to
  run — the only non-extend shape the default spec+dp-attention no-mix sync
  produces here) crashes the target forward on `input_ids=None`;
- a NON-empty locally-DECODE batch (only possible when the no-mix sync is
  skipped via `--speculative-skip-dp-mlp-sync`) would run much further and
  fail later in `rotate_input_ids` — an anonymous crash with peer ranks
  already hung in the dp gather.

Found while running multi-rank speculative-decoding workloads on a
downstream deployment (dp-attention with staggered prefill arrival).

## Modifications

`python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py` — in the
extend branch, before the target forward:

1. **Fail-loud tripwire** for a non-empty locally-non-extend divert: a
   `RuntimeError` naming the batch shape (`bs`, `forward_mode`), raised
   before the target forward instead of the later anonymous crash. It sits
   above the bonus-shape condition so a divert with a `None`/mismatched
   bonus is caught too.
2. **Staggered-IDLE fill**: for the empty batch, populate
   `input_ids`/`out_cache_loc` from `spec_info.bonus_tokens` and the
   `req_to_token` rows (both no-op empty tensors), so the IDLE batch flows
   through the target forward like any other idle forward instead of
   carrying `None`s.

New unit test
`test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py` (CPU CI,
`base-a-test-cpu`; white-box `__new__` + SimpleNamespace style like the
existing spec unit tests):

- non-empty DECODE divert raises the RuntimeError before the fill and before
  the target forward (with and without a bonus-shaped spec_info);
- the staggered-IDLE batch reaches the target forward with empty int64
  `input_ids`/`out_cache_loc` (no `None` left for downstream padding helpers);
- a genuine local extend reaches the target forward untouched.

## Accuracy Tests

No numerics change: the fill only affects empty (IDLE) batches, and the
tripwire only turns an existing downstream crash into an immediate, named
error.

Red/green on the new test:

Without the fix (test alone on current main):

```
$ python3 -m pytest test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py -q
...
E       AttributeError: 'NoneType' object has no attribute 'numel'
...
FAILED test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py::TestMultiLayerEagleDivertGuard::test_non_empty_decode_divert_fails_loud
FAILED test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py::TestMultiLayerEagleDivertGuard::test_non_empty_decode_divert_fails_loud_without_bonus_shape
FAILED test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py::TestMultiLayerEagleDivertGuard::test_staggered_idle_fill_noops_into_target_forward
3 failed, 1 passed, 19 warnings in 12.29s
```

(diverted batches reach the target forward with `input_ids=None`; the IDLE
batch leaves `None`s behind)

With the fix:

```
$ python3 -m pytest test/registered/unit/spec/test_multi_layer_eagle_divert_guard.py -q
4 passed, 19 warnings in 16.64s
```

## Speed Tests and Profiling

Not perf-relevant: two host-side checks on the extend branch; the fill runs
only for empty (IDLE) diverted batches.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31915335012](https://github.com/sgl-project/sglang/actions/runs/31915335012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31915334866](https://github.com/sgl-project/sglang/actions/runs/31915334866)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

