### PR TITLE
[Review vehicle] reader convergence: business code stops reading the published ServerArgs (not for merge)

### DIFF
--- a/.claude/skills/sglang-runtime-context/SKILL.md
+++ b/.claude/skills/sglang-runtime-context/SKILL.md
@@ -10,7 +10,7 @@ One container owns process-static runtime state: `sglang.srt.runtime_context.Run
 
 | Tier | Accessor | Holds | Lifecycle |
 |------|----------|-------|-----------|
-| raw config seed | `get_server_args()` | the published **pristine** `ServerArgs` (resolved-at-startup record; kept for debugging, dumps, per-runner fork copies) | published at process entry; re-publish is **last-publish-wins** (in-process tokenizer build, multi-Engine) and re-projects the bags; read-only |
+| raw config seed | `get_server_args()` | the published `ServerArgs` — the startup record, for debugging, dumps and provenance. **Business code does not read fields off it**: the read ratchet pins that at zero, and "Reading config: the seed is off limits" below says what to read instead, which forms the ratchet sees, and what is outside it by construction (a runtime-computed name; a whole-object hand-off) | published at process entry; re-publish is **last-publish-wins** (in-process tokenizer build, multi-Engine) and re-projects the bags; read-only |
 | resolved config | `get_exec()` `get_memory()` `get_schedule()` `get_model()` `get_spec()` `get_serving()` `get_observability()` `get_disagg()` `get_lora()` `get_mm()` `get_device()` | namespace **config bags** — the single source of truth for resolved config; leaves are real attributes (dynamo-traceable) | projected from `server_args` at `publish`; mutated only via `get_context().override` |
 | runtime flags | `get_flags()` | state that is *not* a pure function of config: `capture` (cuda-graph lifecycle), `moe` (ACTIVE backends, swappable), `dp` (DP-attention runtime flags) | materialized at subsystem init; groups offer `override()` for tests |
 | resources | `get_resources()`, `get_stream(name)`, `get_buffer(name, factory)` | process-level handles: graph pools, EPLB state, EP dispatcher state, named side streams, workspace buffers | lazy; cleared by `reset_context()` |
@@ -79,21 +79,34 @@ re-projects its own bags, so a parent-side override is lost. Values that feed
 construction before any bag exists (group init reads `server_args.tp_size`) have no
 bag to override at all.
 
-- **Nested publishes**: a construction step that must publish a private copy wraps
-  itself in `get_context().preserve_config()` — the enclosing lifecycle, including its
-  post-publish overrides, is value-snapshotted and reinstated on exit. The draft build
-  no longer needs it: per-runner values are constructor arguments now.
+- **Nested publishes**: `get_context().preserve_config()` snapshots the enclosing
+  lifecycle (including its post-publish overrides) and reinstates it on exit. No
+  production caller is left — the draft build was the last one, and per-runner
+  values are constructor arguments now — so it survives for tests and for a future
+  construction step that genuinely has to publish a private copy.
 
 ### Reads that legitimately stay on a `ServerArgs` instance
 
-- **Per-runner (fork) fields** — fields the draft-worker deepcopy rewrites
-  (`attention_backend`, `prefill/decode_attention_backend`,
-  `speculative_draft_attention_backend`, `skip_tokenizer_init`, `context_length`,
-  `load_format`, `json_model_override_args`, `kv_cache_dtype`): each runner's copy is
-  authoritative for that runner, so runner code reads `self.server_args.X`, and
-  *resolved* per-runner values live as runner attributes
-  (`model_runner.kv_cache_dtype_str` is the pattern — threaded to consumers as
-  constructor args, never backfilled onto shared objects).
+- **Per-runner values** — there is no per-runner `ServerArgs` any more. The
+  draft-worker config copy is gone: every worker (`TpModelWorker`, the draft
+  workers in `speculative/`) is handed the *same* instance the process published,
+  so `self.server_args.X` and the bag leaf agree **at publish** — a
+  post-publish `override` moves only the bag, which is exactly why a field that
+  is process-wide config (`attention_backend`, `skip_tokenizer_init`,
+  `kv_cache_dtype`) reads from the bags like any other, and why a residual
+  instance read on this path is stale the moment someone overrides that leaf.
+  What is genuinely per-runner travels two ways, neither of them a config
+  instance: **constructor arguments** (`ModelRunner(draft_attention_backend=...)`,
+  `MMEncoder(gpu_id=...)`) and **runner attributes holding the resolved value**
+  (`model_runner.kv_cache_dtype_str`, `prefill_attention_backend_str`,
+  `num_fused_shared_experts`) — threaded to consumers as arguments, never
+  backfilled onto a shared object. The one sanctioned bend in that rule is
+  *scoped*: `ModelRunner._load_format_scope` exposes the draft's
+  `--speculative-draft-load-format` through `get_model().override(load_format=...)`
+  for exactly the duration of the draft build, because model construction
+  reads that bag leaf — the override restores on exit, so nothing outlives
+  the scope. When there is a runner in hand, read its
+  stamp; that is a different rule from "read the instance".
 - **Per-instance boundaries** — the tokenizer-manager family, everything under
   `entrypoints/`, and the tokenizer-process multimodal processors read
   `self.server_args`: several `Engine`s can share one process, and the process-global
@@ -112,14 +125,127 @@ bag to override at all.
 Config leaves (`nccl_port`, `enable_dp_attention`, `dp_size`, `ep_size`,
 `dwdp_size`, ...) resolve through the parallel bag; live topology (`tp_size`,
 `attn_tp_group`, ranks) are `@property` and **win on name collisions**. Five topology
-sizes are live-shadowed (`tp/pp/dcp/attn_cp/moe_dp_size`): a config-intent read of
-those must stay on `server_args.X` — the live property always wins on the accessor.
-Fail-loud is narrower: before dist init, any live size/group read raises; after it,
+sizes are live-shadowed (`tp/pp/dcp/attn_cp/moe_dp_size`): the live property always
+wins on the accessor, so a config-intent read of those goes through
+`configured_tp_size()` / `configured_pp_size()` / `configured_moe_dp_size()` /
+`configured_attn_cp_size()` (DCP: the live `get_parallel().attn_dcp_size` /
+`.dcp_enabled`, which are safe with no group installed — they answer `1` /
+`False` — but report the *effective* topology, never the requested size;
+a config-intent read would need its own accessor, which no call site
+requires today). A process-global seed field-read of one of these
+sizes (`get_server_args().tp_size`, or an alias of it) is a read-ratchet failure; the
+sites that legitimately go around the live property are the `configured_*_size()`
+readers, and those are what the ratchet registers, each with its reason
+(`_CONFIGURED_SIZE_CALL_SITES` in `test_global_config_read_ratchet.py`). A
+`server_args` the object was *handed* is a different thing and not a ratchet
+matter — see "Reads that legitimately stay on a ServerArgs instance".
+Fail-loud is narrower: before dist init, a live size/group read raises — except
+the DCP pair, which degrades instead (`dcp_enabled` → `False`,
+`attn_dcp_size` → `1` when no group is installed;
+`test_attn_dcp_defaults_when_group_is_uninitialized` pins this). After init,
 only the DCP group is optional (`_DCP` exists only when `dcp_size > 1`; attn-CP and
 moe-DP always install, as size-1 aliases if unused). `ParallelContext.__getattr__` is deliberately dynamo-traceable (no
 `object.__getattribute__`); gate helpers like `enable_moe_dense_fully_dp()` run inside
 compiled model forwards (`test_parallel_config_leaves_trace_under_torch_compile` pins
 this).
+
+### Reading config: the seed is off limits
+
+`get_server_args().field` in business code is a ratchet failure. Read:
+
+- **a resolved leaf** → its namespace bag (`get_exec().moe.moe_runner_backend`,
+  `get_schedule().chunked_prefill_size`, …). Bag-backed reads — a leaf directly, or
+  a bag-derived accessor below, including `configured_*_size()` which reads the
+  parallel bag's own leaf — are what see post-publish overrides. Only the
+  instance-derived accessors (the ones with no leaf to read) answer from the
+  startup record and therefore do not.
+- **the live topology** → `get_parallel()`.
+- **a value derived from published leaves** → an accessor in `runtime_context` that
+  derives it *from the bags*: `mamba_extra_buffer_enabled()` /
+  `mamba_extra_buffer_lazy_enabled()` read `get_memory()` and `get_exec()`, so
+  they see post-publish overrides. Prefer this shape whenever the inputs are
+  leaves; the same-named `ServerArgs` members are the pre-publish equivalents the
+  resolution pipeline uses, and wrapping one of those instead would quietly cost
+  you override visibility. `is_ep_joiner()` / `is_ep_scale_joiner()` are the same
+  shape over `exec.moe.ep_join_mode`, `attention_backends()` derives the
+  `(prefill, decode)` pair from the three `exec.kernel` leaves, and
+  `max_speculative_num_draft_tokens()` / `cutedsl_moe_max_num_tokens()` derive
+  theirs from `spec` / `schedule` / `exec.graph`.
+- **a value only the instance can compute** → the named accessor in
+  `runtime_context`, which is the one module allowed to read the slot:
+  `mamba_cache_chunk_size()`, `uses_mla_backend()`, `process_model_config()`.
+  These have no leaf to read — they combine several fields, the HF config, or a
+  property with no bag of its own. A new derived member gets an accessor here
+  rather than call sites reaching for the record, and only when the bag-derived
+  shape above cannot express it.
+- **what was *configured*, where `get_parallel()` shadows it with the live value**
+  → `configured_{tp,pp,moe_dp,attn_cp}_size()` — the full names are
+  `configured_tp_size`, `configured_pp_size`, `configured_moe_dp_size`,
+  `configured_attn_cp_size`. They read the parallel bag's own leaf (going
+  around the live property that shadows those four names), so they answer with
+  the resolved configuration and follow a post-publish override. DCP has no configured accessor because no
+  config-intent DCP call site exists today — the live reads go through
+  `get_parallel().attn_dcp_size` / `.dcp_enabled`, which answer the effective
+  topology (`1` / `False` when no group is installed). A site
+  that must know the *requested* DCP size before dist init needs its own
+  `configured_dcp_size()` (and an entry in `_CONFIGURED_SIZE_CALL_SITES`, which lives
+  in the ratchet test, not in this skill); note the live pair does not *need*
+  dist init — with no group it answers `1` / `False` — it just cannot answer
+  with the requested size. Every (file, accessor) pair is registered
+  with its reason in `test_global_config_read_ratchet.py`
+  (`_CONFIGURED_SIZE_CALL_SITES`), and that test fails if the code and the list
+  disagree — a new file, or a new accessor in a listed file, has to be added — so a new site needs both an answer the live property cannot give and
+  an entry saying what it is.
+- **this runner's resolved value** → the runner
+  (`prefill_attention_backend_str`, `kv_cache_dtype_str`,
+  `draft_attention_backend`, `num_fused_shared_experts` on the model).
+
+`self.server_args.field` is still right for handed per-instance config (see
+"Reads that legitimately stay on a ServerArgs instance" above for the full set —
+per-instance boundaries and whole-object passes; there are no per-runner config
+copies to read any more). The allow-list is the
+tokenizer-manager family, `entrypoints/`, the tokenizer-process multimodal
+processors, `GrammarManager`, `MMEncoder` — but not for one single reason:
+
+- the tokenizer-manager family and `entrypoints/` are the multi-Engine case
+  proper: several of them can live in one process, so a bag read would answer
+  from whichever Engine published last;
+- `GrammarManager` is a handed instance — it is constructed with the config its
+  owner hands it and never assumes a published namespace;
+- `MMEncoder` publishes the very instance it is handed (`publish(server_args,
+  role="encoder")`) and takes its per-worker device as a separate `gpu_id`
+  argument, so its `self.server_args` reads and the bag agree today. They are on
+  this list as a construction-path convention rather than a semantic exception —
+  and the residual is real: a post-publish `override` would not reach them.
+
+Their tests tell you the same thing: they construct the object standalone, so a
+bag read turns into "config namespace not published".
+
+**Test doubles publish, they do not inject.** A stand-in that carries
+`server_args=SimpleNamespace(field=...)` stops working the moment production reads
+the bag; seed the value with `override_server_args`, which publishes only once it is
+entered or installed — the bare call just builds the override:
+
+```python
+override = get_context().override_server_args(field=...)
+override.install()
+self.addCleanup(override.restore)      # or: with get_context().override_server_args(...):
+```
+
+Five separate test files learned this the hard way during the sweep.
+
+The rule is about a double standing in for **config**: a `SimpleNamespace` that
+pretends to be `server_args`. Prefer the context override even where a
+single-accessor stub would work — `override_server_args(...)` composed with the
+scoped bag / `get_parallel()` overrides expresses the *cause* (the configuration)
+rather than pinning one helper's answer, and it keeps working when a reader
+migrates between the accessor and the leaf. The sweep converted the last two
+accessor stubs to exactly that shape (`test_attention_patching.py` publishes the
+non-lazy strategy; `test_kimi_k3_vision.py` publishes `tp_size` and forces the
+live topology through `get_parallel().override`), so no test stubs an accessor
+today. Stubbing one *named accessor* remains a last resort for a case that
+isolates one branch of one helper where no published config can reach it —
+if you do it, say so in the test.
 
 ### Mid-resolution reads (inside the pipeline only)
 
@@ -229,7 +355,10 @@ ONE thread — do not design for TBO threads that don't exist.
   so a faked accessor silently stops intercepting after any reader migration. Publish
   for real (`override_server_args(...)`), then adjust bag leaves with the scoped bag
   `override` where the constructed `ServerArgs` cannot carry the value (e.g.
-  `get_device().override(device="meta")`).
+  `get_device().override(device="meta")`). The one carve-out is the deliberate
+  single-accessor stub for isolating one predicate — the terms and the two
+  sanctioned examples live under "Test doubles publish, they do not inject"
+  above; anything wider than one named accessor is this rule.
 - Mocked runners/managers still need the **per-runner instance attributes** the code
   under test reads (`kv_cache_dtype_str`, `server_args` for whole-object passes) — set
   them explicitly on the mock; `MagicMock(spec=...)` raises on attributes that only
@@ -257,12 +386,26 @@ ONE thread — do not design for TBO threads that don't exist.
    calls either form. Rerouting a writer to the bags means flipping **all its readers
    in the same commit** (no transitional dual-write).
 4. **Legacy-accessor ratchet** (`test_legacy_global_ratchet.py`): `get_global_server_args`
-   call sites must not grow — new code uses `runtime_context.get_server_args()` (and
-   business decisions should read the bags).
-5. **Module-state ratchet** (`test_module_state_ratchet.py`): `global` statements in the
+   call sites must not grow. The replacement for a *decision* is a bag leaf, a named
+   accessor, or the owning runner's stamp — not `get_server_args().field`, which the
+   read ratchet below pins at zero. `runtime_context.get_server_args()` is only for the
+   whole-object shapes (dumps, provenance, a hand-off to a callee that takes a config).
+5. **Global config read ratchet** (`test_global_config_read_ratchet.py`): baselines are
+   **0** for both the direct `get_server_args().field` and the alias form (function-local
+   — including local copies of an alias, `cfg = sa` — module-level, or parked on an
+   instance attribute, plus the `getattr(..., "field")` spelling of each; a name
+   computed at runtime or indirection deeper than a local name copy is census-tool
+   territory, per the test's docstring). The scanners match `get_server_args` and
+   `configured_*_size` by their literal names, and the same file *bans*
+   `import ... as` renames of them so that matching stays sound. Exempt by owner
+   module only (`runtime_context.py`, `server_args.py`, `arg_groups/`). The same file
+   carries `_CONFIGURED_SIZE_CALL_SITES`, the (file, accessor) map of every
+   `configured_*_size()` reader with the reason the live property cannot serve it — a new
+   file or a new accessor in a listed file must be added there.
+6. **Module-state ratchet** (`test_module_state_ratchet.py`): `global` statements in the
    flag-owning layers are pinned by name. A new module-level runtime global belongs on a
    flags group / resources slot instead; migrating a pinned survivor must shrink the pin.
-6. **Namespace coverage** (`test_server_args_namespaces.py`,
+7. **Namespace coverage** (`test_server_args_namespaces.py`,
    `test_runtime_context_config_bags.py`): every `ServerArgs` field carries `NS(...)`
    metadata and the projected bags must cover the fields exactly (two-way).
 
@@ -272,13 +415,12 @@ Never module-skip a test "until the migration settles" — seed the context inst
 ## Hard-won pitfalls (check these before/while refactoring)
 
 - **Moving code drops first-line guards**: early returns (`if self.is_draft_worker: return`)
-  are the easiest thing to lose when relocating a method body. Every draft is built
-  under a preserved publish of its own config: the scheduler makes the copy with
-  `draft_server_args_copy()` (seeded from the resolved config, so load-time overrides
-  carry) and publishes it around the worker factory, and `build_draft_tp_worker()`
-  nests the same shape for dflash / dspark. The publish ends when construction does —
-  anything the draft reads later (`alloc_memory_pool`, `init_attention_backends`,
-  cuda-graph capture) is back on the target's bags.
+  are the easiest thing to lose when relocating a method body. A draft is built from
+  the target's published config — there is no draft config copy and no nested publish
+  any more — so a body moved out of a draft-aware call site keeps reading the target's
+  bags, and only that guard tells the two apart. What the draft build *does* scope is
+  narrower and named: `draft_model_build_scope()` for the MoE fusion gates,
+  `speculative_moe_backend_context()` for the runner backends.
 - **Registry-completeness timing**: a gate that consults an extensible list is only correct
   after the registrars ran (platform `init_backend()` at module import). See "load-time vs
   resolution-time".
@@ -316,7 +458,7 @@ Key source files: `python/sglang/srt/runtime_context.py` (the container, every t
 `declare_late_resolution`), `python/sglang/srt/server_args.py` (`NS` metadata,
 `Arg(..., resolvable=True)`, `__setattr__` strict guard), and the guardrail tests under
 `test/registered/unit/` (`test_server_args_mutation_ratchet.py`,
-`test_server_args_writer_ratchet.py`, `test_legacy_global_ratchet.py`,
+`test_global_config_read_ratchet.py`, `test_legacy_global_ratchet.py`,
 `test_module_state_ratchet.py`, `test_server_args_namespaces.py`,
 `test_runtime_context.py` — the last one doubles
 as executable documentation of every tier's semantics).

--- a/STACK_REVIEW_PLACEHOLDER.md
+++ b/STACK_REVIEW_PLACEHOLDER.md
@@ -1,0 +1,4 @@
+# Stack review vehicle (not for merge)
+
+This branch carries the whole reader-convergence stack so CI runs once over it.
+Members are reviewed and merged individually; this PR is closed unmerged.

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -290,10 +290,22 @@ def attention_backends_of(cfg: Any) -> tuple:
 
 def mamba_extra_buffer_of(cfg: Any) -> bool:
     """Mid-resolution equivalent of runtime_context.mamba_extra_buffer_enabled:
-    reads the (possibly overlaid) strategy from a config-shaped object."""
+    reads the (possibly overlaid) strategy from a config-shaped object.
+
+    This is the one definition of the predicate: ``ServerArgs`` delegates its
+    member to it, and the runtime_context accessor is its post-publish sibling
+    (which cannot reuse it, because the two leaves land in different bags)."""
     return cfg.disable_radix_cache is False and cfg.mamba_radix_cache_strategy in (
         "extra_buffer",
         "extra_buffer_lazy",
+    )
+
+
+def mamba_extra_buffer_lazy_of(cfg: Any) -> bool:
+    """The lazy variant of :func:`mamba_extra_buffer_of`."""
+    return (
+        cfg.disable_radix_cache is False
+        and cfg.mamba_radix_cache_strategy == "extra_buffer_lazy"
     )
 
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -69,7 +69,11 @@ from sglang.srt.mem_cache.common import (
 )
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.observability.req_time_stats import set_schedule_time_batch
-from sglang.srt.runtime_context import get_disagg
+from sglang.srt.runtime_context import (
+    get_disagg,
+    get_parallel,
+    get_schedule,
+)
 from sglang.srt.utils import is_npu
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 
@@ -158,23 +162,25 @@ class PrefillBootstrapQueue:
                     "SGLANG_DISAGG_STAGING_BUFFER is designed for non-MLA models "
                     "(e.g. GQA, MHA). MLA models should not set this flag."
                 )
-            server_args = self.scheduler.server_args
             page_size = self.scheduler.token_to_kv_pool_allocator.page_size
-            cps = server_args.chunked_prefill_size or 8192
+            # Same source as send_kv_chunk's staging grid below, so validation
+            # and the grid cannot disagree after a post-publish override.
+            chunked_prefill_size = get_schedule().chunked_prefill_size
+            cps = chunked_prefill_size or 8192
             # Staging slices each send into a fixed page-aligned grid, so an
             # unbounded (-1) or non-page-aligned chunk size has no valid grid.
             if cps <= 0 or cps % page_size != 0:
                 raise RuntimeError(
                     f"SGLANG_DISAGG_STAGING_BUFFER requires a positive "
                     f"chunked_prefill_size that is a multiple of page_size "
-                    f"({page_size}); got {server_args.chunked_prefill_size}."
+                    f"({page_size}); got {chunked_prefill_size}."
                 )
             if self.pp_size > 1:
                 # Staging writer accounting has no pp dimension.
                 raise RuntimeError(
                     "SGLANG_DISAGG_STAGING_BUFFER does not support pp_size > 1."
                 )
-            if server_args.enable_prefill_context_parallel:
+            if get_parallel().enable_prefill_context_parallel:
                 # CP rewrites index_slice per rank, breaking the chunk grid.
                 raise RuntimeError(
                     "SGLANG_DISAGG_STAGING_BUFFER does not support "
@@ -1145,7 +1151,7 @@ class SchedulerDisaggregationPrefillMixin:
                 # prefetched grid, so non-last sends must end on a grid
                 # boundary; the remainder rides with the next send.
                 grid_tokens = staging_grid_tokens(
-                    self.server_args.chunked_prefill_size, page_size
+                    get_schedule().chunked_prefill_size, page_size
                 )
                 base = req.disagg_decode_prefix_len
                 end_idx = base + ((end_idx - base) // grid_tokens) * grid_tokens
@@ -1271,7 +1277,7 @@ class SchedulerDisaggregationPrefillMixin:
                 start_idx,
                 end_idx,
                 req.disagg_decode_prefix_len,
-                staging_grid_tokens(self.server_args.chunked_prefill_size, page_size),
+                staging_grid_tokens(get_schedule().chunked_prefill_size, page_size),
             )
         else:
             segments = [(start_idx, end_idx)]

--- a/python/sglang/srt/hardware_backend/mlx/model_runner.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner.py
@@ -49,7 +49,9 @@ from sglang.srt.hardware_backend.mlx.kv_cache import (
     uses_sliding_window_attention,
 )
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.runtime_context import (
+    mamba_cache_chunk_size,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -281,7 +283,7 @@ class MlxModelRunner:
         ):
             return None
 
-        chunk_size = get_server_args().mamba_cache_chunk_size
+        chunk_size = mamba_cache_chunk_size()
         track_len = prefix_len + (new_token_count // chunk_size) * chunk_size
         branching_len = getattr(req, "mamba_branching_seqlen", None)
         if (

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -40,11 +40,11 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     is_in_tc_piecewise_cuda_graph,
 )
 from sglang.srt.runtime_context import (
+    configured_pp_size,
     get_device,
     get_exec,
     get_parallel,
     get_schedule,
-    get_server_args,
 )
 from sglang.srt.state_capturer.indexer_topk import (
     maybe_capture_indexer_topk,
@@ -249,7 +249,7 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
         if _is_cuda:
             self.sm_count = deep_gemm.get_num_sms()
             self.half_device_sm_count = ceil_align(self.sm_count // 2, 8)
-            pp_size = get_server_args().pp_size
+            pp_size = configured_pp_size()
             self.logits_with_pp_recv = pp_size > 1 and not get_pp_group().is_last_rank
         else:
             self.logits_with_pp_recv = False

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -12,7 +12,10 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import 
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_parallel,
+    process_model_config,
+)
 from sglang.srt.utils import get_bool_env_var, is_cuda, is_hip
 from sglang.srt.utils.common import ceil_align, ceil_div
 
@@ -113,7 +116,7 @@ def is_dsa_enable_prefill_cp():
         return False
     from sglang.srt.configs.model_config import is_deepseek_dsa, is_deepseek_v4
 
-    hf_config = get_server_args().get_model_config().hf_config
+    hf_config = process_model_config().hf_config
     return is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)
 
 

--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -25,7 +25,11 @@ from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_exec, get_memory, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_memory,
+    mamba_cache_chunk_size,
+)
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
 from sglang.srt.speculative.spec_info import SpecInput
 
@@ -297,8 +301,8 @@ class MambaAttnBackendBase(AttentionBackend):
         lens_to_track = (
             forward_batch.mamba_track_seqlens - forward_batch.extend_prefix_lens
         )
-        mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
-        aligned_len = (lens_to_track // mamba_cache_chunk_size) * mamba_cache_chunk_size
+        chunk_size = mamba_cache_chunk_size()
+        aligned_len = (lens_to_track // chunk_size) * chunk_size
         start_indices = query_start_loc[:-1] + aligned_len - conv_state_len
         start_indices = start_indices[forward_batch.mamba_track_mask]
 
@@ -316,7 +320,7 @@ class MambaAttnBackendBase(AttentionBackend):
         """src/dst indices to track SSM states for prefix caching: aligned seqs
         cache last_recurrent_state, unaligned cache intermediate `h` at the last
         chunk boundary."""
-        mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        chunk_size = mamba_cache_chunk_size()
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()
@@ -326,9 +330,9 @@ class MambaAttnBackendBase(AttentionBackend):
         prefix_lens = forward_batch.extend_prefix_lens.cpu()
 
         if isinstance(self, Mamba2AttnBackend):
-            num_h_states = extend_seq_lens // mamba_cache_chunk_size
+            num_h_states = extend_seq_lens // chunk_size
         else:
-            num_h_states = (extend_seq_lens - 1) // mamba_cache_chunk_size + 1
+            num_h_states = (extend_seq_lens - 1) // chunk_size + 1
 
         track_ssm_src_offset = torch.zeros_like(num_h_states)
         track_ssm_src_offset[1:] = torch.cumsum(num_h_states[:-1], dim=0)
@@ -338,17 +342,17 @@ class MambaAttnBackendBase(AttentionBackend):
         offset_masked = track_ssm_src_offset[mamba_track_mask]
         dst_masked = mamba_track_indices[mamba_track_mask]
 
-        is_aligned = (lens_masked % mamba_cache_chunk_size) == 0
+        is_aligned = (lens_masked % chunk_size) == 0
 
         # Aligned: last_recurrent_state from ssm_states.
         track_ssm_final_src = mamba_cache_indices[mamba_track_mask][is_aligned]
         track_ssm_final_dst = dst_masked[is_aligned]
 
         # Unaligned: intermediate state from h.
-        # TODO: handle mamba_cache_chunk_size % page size != 0
+        # TODO: handle chunk_size % page size != 0
         not_aligned = ~is_aligned
         track_ssm_h_src = offset_masked[not_aligned] + (
-            lens_masked[not_aligned] // mamba_cache_chunk_size
+            lens_masked[not_aligned] // chunk_size
         )
         track_ssm_h_dst = dst_masked[not_aligned]
 

--- a/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
+++ b/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
@@ -62,7 +62,11 @@ from sglang.srt.models.inkling_common.kernels.sconv import (
     fused_extend_sconv_metadata,
     precompute_helion_extend_metadata,
 )
-from sglang.srt.runtime_context import get_exec, get_server_args, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_spec,
+    mamba_cache_chunk_size,
+)
 from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 
 if TYPE_CHECKING:
@@ -99,7 +103,7 @@ class InklingShortConvAttnBackend(ShortConvAttnBackend):
         # [n_layers, n_slots, conv_kernel - 1, conv_dim].
         self._mamba_cache = self.req_to_token_pool.mamba_pool.mamba_cache
         self.conv_state_len: int = self.conv_states_shape[2]
-        self.mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        self.mamba_cache_chunk_size = mamba_cache_chunk_size()
         # A plain table lookup is recordable; the unified pool's translate is an
         # allocator lookup and must stay in the out-of-graph replay prep.
         self._slot_gather_recordable = (

--- a/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/gdn_flashinfer.py
@@ -19,7 +19,9 @@ import torch
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.runtime_context import (
+    mamba_cache_chunk_size,
+)
 from sglang.srt.utils import is_cuda
 
 if TYPE_CHECKING:
@@ -50,7 +52,7 @@ def maybe_build_flashinfer_checkpoint_plan(
     ):
         return
 
-    checkpoint_every_n_tokens = get_server_args().mamba_cache_chunk_size
+    checkpoint_every_n_tokens = mamba_cache_chunk_size()
     extend_seq_lens = forward_batch.extend_seq_lens.to(device="cpu", dtype=torch.int64)
     track_mask = forward_batch.mamba_track_mask.to(device="cpu", dtype=torch.bool)
     relative_track_lens = forward_batch.mamba_track_seqlens.to(

--- a/python/sglang/srt/layers/attention/linear/kernels/kda_ptx.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_ptx.py
@@ -37,6 +37,7 @@ from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKerne
 from sglang.srt.layers.attention.linear.kernels.kernel_backend import (
     LinearAttnKernelBase,
 )
+from sglang.srt.runtime_context import mamba_cache_chunk_size
 
 logger = logging.getLogger(__name__)
 
@@ -194,11 +195,8 @@ class PtxKDAKernel(LinearAttnKernelBase):
             # which may be larger (for example 256 for Nemotron-H). Returning
             # the raw 64-token rows in that case would silently select the
             # wrong boundary and compute wrong offsets for later sequences.
-            from sglang.srt.runtime_context import get_server_args
 
-            intermediate_stride_supported = (
-                get_server_args().mamba_cache_chunk_size == _CHUNK
-            )
+            intermediate_stride_supported = mamba_cache_chunk_size() == _CHUNK
         seq_lens = (
             [int(length) for length in seq_lens_cpu] if seq_lens_cpu is not None else []
         )

--- a/python/sglang/srt/layers/attention/linear/lightning_backend.py
+++ b/python/sglang/srt/layers/attention/linear/lightning_backend.py
@@ -15,7 +15,10 @@ from sglang.srt.layers.attention.linear.linear_metadata import (
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_parallel,
+    mamba_cache_chunk_size,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +302,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         if h_dst is None or h_dst.numel() == 0:
             return None, None
 
-        mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        chunk_size = mamba_cache_chunk_size()
         num_prefills = metadata.num_prefills
         track_mask = forward_batch.mamba_track_mask[:num_prefills]
         extend_lens = forward_batch.extend_seq_lens[:num_prefills]
@@ -307,9 +310,7 @@ class LightningAttentionBackend(MambaAttnBackendBase):
         track_seqlens = forward_batch.mamba_track_seqlens[:num_prefills]
 
         lens_to_track = track_seqlens - prefix_lens
-        boundary_lens = (
-            lens_to_track // mamba_cache_chunk_size
-        ) * mamba_cache_chunk_size
+        boundary_lens = (lens_to_track // chunk_size) * chunk_size
         track_rows = (track_mask & (boundary_lens < extend_lens)).nonzero(
             as_tuple=True
         )[0]

--- a/python/sglang/srt/layers/cp/base.py
+++ b/python/sglang/srt/layers/cp/base.py
@@ -230,12 +230,15 @@ class ContextParallelStrategy(ABC):
 
 
 def _is_dsa_active() -> bool:
-    from sglang.srt.runtime_context import get_server_args
+    from sglang.srt.runtime_context import get_parallel, get_server_args
 
-    sa = get_server_args()
+    # `_is_dsa_model_arch` is set nowhere in the tree, so this predicate is
+    # inert today (the getattr default makes it False). Kept verbatim rather
+    # than "fixed" here, because deciding what it should name is the CP path's
+    # call; the ratchet exempts it with that reason.
     return bool(
-        getattr(sa, "enable_prefill_cp", False)
-        and getattr(sa, "_is_dsa_model_arch", False)
+        get_parallel().enable_prefill_cp
+        and getattr(get_server_args(), "_is_dsa_model_arch", False)
     )
 
 
@@ -288,7 +291,7 @@ def get_cp_strategy() -> Optional[ContextParallelStrategy]:
             server_args = get_server_args()
         except ValueError:
             return None
-        if server_args is not None and getattr(server_args, "enable_prefill_cp", False):
+        if server_args is not None and get_parallel().enable_prefill_cp:
             init_cp_strategy(server_args)
     return _STRATEGY
 

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -27,7 +27,11 @@ from sglang.srt.distributed import (
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
-from sglang.srt.runtime_context import get_flags, get_server_args
+from sglang.srt.runtime_context import (
+    configured_attn_cp_size,
+    configured_moe_dp_size,
+    get_flags,
+)
 from sglang.srt.utils import get_bool_env_var, is_hip
 
 if TYPE_CHECKING:
@@ -986,8 +990,7 @@ def is_enable_moe_cp_allgather() -> bool:
     (``parallel_state.py``), so the live sizes are equal and the comparison would
     always be false.
     """
-    server_args = get_server_args()
-    return server_args.attn_cp_size > server_args.moe_dp_size
+    return configured_attn_cp_size() > configured_moe_dp_size()
 
 
 def moe_cp_all_gather_into_tensor(output: torch.Tensor, input: torch.Tensor):

--- a/python/sglang/srt/layers/k3_ar_fusion.py
+++ b/python/sglang/srt/layers/k3_ar_fusion.py
@@ -67,16 +67,17 @@ def _get_state() -> Optional[_State]:
 
         if get_device_sm() not in (100, 103):
             return None
-        server_args = ctx.get_server_args()
-        if server_args.enable_symm_mem or server_args.moe_a2a_backend != "none":
+        symm_mem = ctx.get_exec().comm.enable_symm_mem
+        a2a_backend = ctx.get_exec().moe.moe_a2a_backend
+        if symm_mem or a2a_backend != "none":
             logger.info(
                 "K3 all-reduce fusion auto-probe: skipping "
                 "(enable_symm_mem=%s, moe_a2a_backend=%s; under symm-mem the "
                 "allocator contexts conflict, and under EP a2a the model's "
                 "symm-pool allocation contract does not hold on every AR "
                 "call-site. Set SGLANG_K3_AR_FUSION=1 to force.)",
-                server_args.enable_symm_mem,
-                server_args.moe_a2a_backend,
+                symm_mem,
+                a2a_backend,
             )
             return None
     from sglang.srt.distributed.device_communicators.custom_all_reduce_v2 import (
@@ -131,11 +132,11 @@ _BUFS: List[_Buffer] = []
 @cache_once
 def _max_buffer_rows() -> int:
     """Rows to reserve per buffer: the largest batch the server args allow."""
-    server_args = ctx.get_server_args()
-    chunked = server_args.chunked_prefill_size
+    schedule = ctx.get_schedule()
+    chunked = schedule.chunked_prefill_size
     if chunked is not None and chunked > 0:
         return int(chunked)
-    return int(server_args.max_prefill_tokens or 0)
+    return int(schedule.max_prefill_tokens or 0)
 
 
 def _create_buffer(

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -12,7 +12,10 @@ from sglang.srt.layers.moe.moe_runner.base import (
     register_fused_func,
 )
 from sglang.srt.model_executor.cuda_graph_config import cuda_graph_fully_disabled
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import (
+    cutedsl_moe_max_num_tokens,
+    get_parallel,
+)
 from sglang.srt.utils.common import log_info_on_rank0, print_warning_once
 
 if TYPE_CHECKING:
@@ -256,14 +259,11 @@ def ensure_cutedsl_wrapper(layer: torch.nn.Module) -> None:
             "Install with: pip install flashinfer"
         ) from e
 
-    from sglang.srt.runtime_context import get_server_args
-
     assert layer.intermediate_size_per_partition > 0, (
         f"CuteDSL MoE: intermediate_size_per_partition must be > 0, "
         f"got {layer.intermediate_size_per_partition}. Check EP/TP configuration."
     )
 
-    server_args = get_server_args()
     # CuteDSL wrapper preallocates CG buffers used by any captured graph
     # that routes through this MoE — decode and prefill alike.
     use_cuda_graph = not cuda_graph_fully_disabled()
@@ -277,9 +277,7 @@ def ensure_cutedsl_wrapper(layer: torch.nn.Module) -> None:
     else:
         # Standard allgather path: the MoE sees up to dp_size local forwards
         # gathered together, so scale the per-rank forward bound by dp_size.
-        max_num_tokens = (
-            get_parallel().dp_size * server_args.cutedsl_moe_max_num_tokens()
-        )
+        max_num_tokens = get_parallel().dp_size * cutedsl_moe_max_num_tokens()
     top_k = layer.top_k if layer.top_k is not None else layer.moe_runner_config.top_k
     # inference_mode(False) ensures the wrapper's pre-allocated CUDA-graph
     # buffers are normal tensors.  This call typically happens inside

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -15,7 +15,10 @@ from sglang.srt.layers.dp_attention import (
 from sglang.srt.layers.moe import get_moe_a2a_backend
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_parallel,
+    uses_mla_backend,
+)
 
 
 @dataclass
@@ -69,8 +72,7 @@ def is_prefill_cp_in_seq_split():
 
 
 def is_mla_prefill_cp_enabled() -> bool:
-    sa = get_server_args()
-    return get_parallel().enable_prefill_context_parallel and sa.use_mla_backend()
+    return get_parallel().enable_prefill_context_parallel and uses_mla_backend()
 
 
 def mla_use_prefill_cp(forward_batch, mla_enable_prefill_cp=None):

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -7,6 +7,7 @@ from sglang.srt.runtime_context import (
     get_schedule,
     get_serving,
     get_spec,
+    mamba_cache_chunk_size,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
 )
@@ -118,7 +119,7 @@ from sglang.srt.observability.req_time_stats import (
     DPControllerReqTimeStats,
     SchedulerReqTimeStats,
 )
-from sglang.srt.runtime_context import get_parallel, get_server_args
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.server_args import ServerArgs
@@ -2616,21 +2617,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self,
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
-        server_args = get_server_args()
-        mamba_cache_chunk_size = server_args.mamba_cache_chunk_size
+        chunk_size = mamba_cache_chunk_size()
 
         def _force_track_h(i: int) -> int:
-            assert i % mamba_cache_chunk_size == 0
+            assert i % chunk_size == 0
             # There are 3 cases for mamba_track_seqlen passed to mamba_track_seqlens_cpu:
-            # 1) aligned with mamba_cache_chunk_size-> retrieve from last_recurrent_state
+            # 1) aligned with chunk_size-> retrieve from last_recurrent_state
             #    a) is the last position -> retrieve from last_recurrent_state
             #    b) is NOT the last position -> retrieve from h
-            # 2) unaligned with mamba_cache_chunk_size -> retrieve from h
+            # 2) unaligned with chunk_size -> retrieve from h
             # Currently, the math calculation only supports case 1a and 2. So for 1b, we need to add 1
             # to force the math calculation to retrieve the correct mamba state from h.
             return i + 1
 
-        mask = req.extend_range.length >= mamba_cache_chunk_size
+        mask = req.extend_range.length >= chunk_size
         track_index = req.mamba_ping_pong_track_buffer[req.mamba_next_track_idx].item()
         mamba_track_seqlen = -1
         if mask:
@@ -2647,18 +2647,16 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # mamba radix cache to track which seqlen this mamba state should store at.
             mamba_track_seqlen_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // mamba_cache_chunk_size)
-                * mamba_cache_chunk_size
+                + (req.extend_range.length // chunk_size) * chunk_size
             )
 
-            # mamba_track_fla_chunk_aligned is the aligned seqlen based on mamba_cache_chunk_size
+            # mamba_track_fla_chunk_aligned is the aligned seqlen based on chunk_size
             # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which can be true when
-            # page_size > mamba_cache_chunk_size, we need to force the math calculation to retrieve the correct mamba state from h
+            # page_size > chunk_size, we need to force the math calculation to retrieve the correct mamba state from h
             # by _force_track_h()
             mamba_track_fla_chunk_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // mamba_cache_chunk_size)
-                * mamba_cache_chunk_size
+                + (req.extend_range.length // chunk_size) * chunk_size
             )
             if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
                 # We want to track mamba_track_seqlen_aligned, and it's not the last position,
@@ -2679,7 +2677,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 # is within the current extend batch.
                 branching_seqlen_aligned_mask = (
                     req.mamba_branching_seqlen - len(req.prefix_indices)
-                ) % mamba_cache_chunk_size == 0
+                ) % chunk_size == 0
                 if (
                     req.mamba_branching_seqlen > len(req.prefix_indices)
                     and req.mamba_branching_seqlen < mamba_track_seqlen

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2,7 +2,14 @@ from __future__ import annotations
 
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.runtime_context import get_exec, get_schedule, get_serving, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_schedule,
+    get_serving,
+    get_spec,
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+)
 from sglang.srt.utils.common import (
     Range,
     ceil_align,
@@ -2342,7 +2349,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_extend(self):
         self.forward_mode = ForwardMode.EXTEND
-        server_args = get_server_args()
 
         if self.is_dllm():
             # For DLLM, we use a separate forward mode
@@ -2471,7 +2477,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 req.already_computed = seq_len
             req.is_retracted = False
 
-            if server_args.enable_mamba_extra_buffer():
+            if mamba_extra_buffer_enabled():
                 track_entry = self._mamba_radix_cache_v2_req_prepare_for_extend(req)
                 mamba_track_mask_cpu.append(track_entry.track_mask)
                 mamba_track_indices_cpu.append(track_entry.track_index)
@@ -2576,7 +2582,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.extend_logprob_start_lens = extend_logprob_start_lens
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
-        if server_args.enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             self.mamba_track_indices = torch.tensor(
                 mamba_track_indices_cpu,
                 dtype=torch.int64,
@@ -2662,7 +2668,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # In lazy mode, skip the swap — the second ping-pong slot is not
             # allocated yet; it will be allocated on demand at the track boundary
             # in mamba_lazy_prealloc_at_boundary during prepare_for_decode.
-            if not server_args.enable_mamba_extra_buffer_lazy():
+            if not mamba_extra_buffer_lazy_enabled():
                 req.mamba_next_track_idx = (
                     self.req_to_token_pool.get_mamba_ping_pong_other_idx(
                         req.mamba_next_track_idx
@@ -3003,7 +3009,6 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
-        server_args = get_server_args()
         # Decode embeds the last output token via embed_tokens; clear the stale
         # prefill-time tensor so it doesn't leak into ForwardBatch.
         self.input_embeds = None
@@ -3057,7 +3062,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 self.req_pool_indices_cpu,
             )
 
-        if server_args.enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             mamba_track_interval = get_exec().mamba.mamba_track_interval
 
             if len(self.reqs) == 0:
@@ -3065,7 +3070,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                     (0,), dtype=torch.int64, device=self.device
                 )
             else:
-                if server_args.enable_mamba_extra_buffer_lazy():
+                if mamba_extra_buffer_lazy_enabled():
                     self.mamba_lazy_prealloc_at_boundary(mamba_track_interval)
                 set_mamba_track_indices_from_reqs(self)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -420,7 +420,7 @@ class Scheduler(
         self.enable_overlap = not server_args.disable_overlap_schedule and not use_mlx()
         self.enable_overlap_mlx = not server_args.disable_overlap_schedule and use_mlx()
         self.enable_pdmux = server_args.enable_pdmux
-        self.skip_tokenizer_init = server_args.skip_tokenizer_init
+        self.skip_tokenizer_init = get_serving().skip_tokenizer_init
         self.stream_interval = server_args.stream_interval
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
@@ -731,7 +731,10 @@ class Scheduler(
         self.ipc_channels = SchedulerIpcChannels.create(
             port_args=port_args,
             is_rank_zero=is_rank_zero,
-            skip_tokenizer_init=self.server_args.skip_tokenizer_init,
+            # The snapshot taken at construction, not a second bag read: this
+            # scheduler gates its tokenizer init on the same value, and the two
+            # must not be able to disagree.
+            skip_tokenizer_init=self.skip_tokenizer_init,
             metrics_enabled=get_observability().enable_metrics
             and (
                 self.ps.attn_tp_rank == 0
@@ -793,7 +796,7 @@ class Scheduler(
         server_args = self.server_args
         self.is_generation = self.model_config.is_generation
 
-        if server_args.skip_tokenizer_init:
+        if self.skip_tokenizer_init:
             self.tokenizer = self.processor = None
         else:
             if self.model_config.is_multimodal:
@@ -1484,7 +1487,7 @@ class Scheduler(
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
         env_var, default_size = backend_sizes.get(
-            self.server_args.attention_backend, (None, None)
+            get_exec().kernel.attention_backend, (None, None)
         )
         self.truncation_align_size = (
             get_int_env_var(env_var, default_size) if env_var else None

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -37,8 +37,8 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_memory,
     get_observability,
-    get_server_args,
     mamba_extra_buffer_lazy_enabled,
+    max_speculative_num_draft_tokens,
 )
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
@@ -1163,7 +1163,6 @@ class SchedulerBatchResultProcessor:
             keep_written_by_this_step = (
                 crossed and planned_pos == req.mamba_next_track_idx
             )
-            server_args = get_server_args()
             other_idx = 1 - req.mamba_next_track_idx
             # Recompute the in-flight verify's plan (kv_committed_len is
             # frozen since its prepare, so the recompute is exact).
@@ -1172,7 +1171,7 @@ class SchedulerBatchResultProcessor:
             ].item() == -1 and mamba_lazy_spec_in_window(
                 req,
                 get_exec().mamba.mamba_track_interval,
-                server_args.max_speculative_num_draft_tokens,
+                max_speculative_num_draft_tokens(),
             )
             if (
                 planned_pos is None

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -38,6 +38,7 @@ from sglang.srt.runtime_context import (
     get_memory,
     get_observability,
     get_server_args,
+    mamba_extra_buffer_lazy_enabled,
 )
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.state_capturer.indexer_topk import get_global_indexer_capturer
@@ -1073,7 +1074,7 @@ class SchedulerBatchResultProcessor:
                     prepare_release(req)
                 is_insert = (
                     req.mamba_lazy_is_insert
-                    if get_server_args().enable_mamba_extra_buffer_lazy()
+                    if mamba_extra_buffer_lazy_enabled()
                     else True
                 )
                 release_kv_cache(req, self.tree_cache, is_insert=is_insert)
@@ -1109,7 +1110,7 @@ class SchedulerBatchResultProcessor:
         if req.mamba_ping_pong_track_buffer is None:
             return
 
-        lazy = get_server_args().enable_mamba_extra_buffer_lazy()
+        lazy = mamba_extra_buffer_lazy_enabled()
         if known_boundary:
             self._mamba_assert_committed_len_lookahead(req)
             track_seqlen = req.kv_committed_len

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -27,7 +27,7 @@ from sglang.srt.managers.mm_utils import (
     has_shm_features,
     unwrap_shm_features,
 )
-from sglang.srt.runtime_context import get_disagg, get_parallel
+from sglang.srt.runtime_context import get_disagg, get_parallel, is_ep_scale_joiner
 from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
@@ -181,7 +181,7 @@ class SchedulerRequestReceiver:
             # all-ranks gloo sync.
             _local_ctrl = (
                 get_parallel().enable_dp_attention_local_control_broadcast
-                or self.server_args.is_ep_scale_joiner
+                or is_ep_scale_joiner()
             )
             if _local_ctrl:
                 if self.ps.attn_tp_size != 1:

--- a/python/sglang/srt/mem_cache/allocation_sizing.py
+++ b/python/sglang/srt/mem_cache/allocation_sizing.py
@@ -6,10 +6,7 @@ from sglang.srt.runtime_context import get_server_args
 from sglang.srt.server_args import ServerArgs
 
 
-def get_alloc_len_per_decode(server_args: Optional[ServerArgs] = None) -> int:
-    if server_args is None:
-        server_args = get_server_args()
-
+def get_alloc_len_per_decode(server_args: ServerArgs) -> int:
     if server_args.speculative_algorithm is None:
         return 1
 
@@ -39,7 +36,13 @@ def get_alloc_reserve_per_decode(server_args: Optional[ServerArgs] = None) -> in
 
     The 2x is a double-buffer that absorbs the kv_committed_len lag in overlap
     mode; see eagle_utils.eagle_prepare_for_decode.
+
+    Callers on a request path have no config in hand, so this is the module's
+    single "which config" decision point: everything below it takes the
+    instance explicitly.
     """
+    if server_args is None:
+        server_args = get_server_args()
     return 2 * get_alloc_len_per_decode(server_args)
 
 

--- a/python/sglang/srt/mem_cache/allocation_sizing.py
+++ b/python/sglang/srt/mem_cache/allocation_sizing.py
@@ -6,14 +6,23 @@ from sglang.srt.runtime_context import get_server_args
 from sglang.srt.server_args import ServerArgs
 
 
-def get_alloc_len_per_decode(server_args: ServerArgs) -> int:
+def get_alloc_len_per_decode(
+    server_args: ServerArgs, *, max_draft_tokens: Optional[int] = None
+) -> int:
+    """``max_draft_tokens`` lets a caller that already resolved the draft-token
+    bound (the KV-cache configurator reads it off the bags) size with that same
+    value; the default is the handed instance's own member, never the global."""
     if server_args.speculative_algorithm is None:
         return 1
 
     # Spec decoding allocates max(topk * num_steps, num_draft_tokens) per decode step.
     spec_steps = server_args.speculative_num_steps or 1
     spec_topk = server_args.speculative_eagle_topk or 1
-    spec_tokens = server_args.max_speculative_num_draft_tokens
+    spec_tokens = (
+        max_draft_tokens
+        if max_draft_tokens is not None
+        else server_args.max_speculative_num_draft_tokens
+    )
     page_size = server_args.page_size
 
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -31,7 +40,11 @@ def get_alloc_len_per_decode(server_args: ServerArgs) -> int:
         return max(num_new_pages_per_topk * page_size * spec_topk, spec_tokens)
 
 
-def get_alloc_reserve_per_decode(server_args: Optional[ServerArgs] = None) -> int:
+def get_alloc_reserve_per_decode(
+    server_args: Optional[ServerArgs] = None,
+    *,
+    max_draft_tokens: Optional[int] = None,
+) -> int:
     """KV length reserved per request at each decode step.
 
     The 2x is a double-buffer that absorbs the kv_committed_len lag in overlap
@@ -43,23 +56,35 @@ def get_alloc_reserve_per_decode(server_args: Optional[ServerArgs] = None) -> in
     """
     if server_args is None:
         server_args = get_server_args()
-    return 2 * get_alloc_len_per_decode(server_args)
+    return 2 * get_alloc_len_per_decode(server_args, max_draft_tokens=max_draft_tokens)
 
 
-def get_req_to_token_extra_context_len(server_args: ServerArgs) -> int:
+def get_req_to_token_extra_context_len(
+    server_args: ServerArgs, *, max_draft_tokens: Optional[int] = None
+) -> int:
     """req_to_token row headroom beyond the model context length.
 
     Sized to hold the decode over-allocation; the spec v2 page>1 topk>1 holey
     draft footprint can outgrow the default num_draft_tokens headroom.
+
+    ``max_draft_tokens`` keeps this row headroom and the caller's other
+    draft-token-sized buffers on ONE resolved value: the KV-cache configurator
+    passes the bag-derived bound it also hands the pools, so the two cannot
+    disagree after a post-publish override. The default stays the handed
+    instance's member for callers sizing against a specific config object.
     """
+    if max_draft_tokens is None:
+        max_draft_tokens = server_args.max_speculative_num_draft_tokens
     # FIXME(lsyin): temporary fix for the context length issue under spec decoding
-    extra = 4 + (server_args.max_speculative_num_draft_tokens or 0)
+    extra = 4 + (max_draft_tokens or 0)
     if server_args.speculative_algorithm is not None and server_args.page_size > 1:
         # kv_allocated_len is page-aligned (eagle_prepare_for_decode), so near
         # the context limit the aligned reserve can overshoot by page_size - 1;
         # without the headroom the row write silently lands in the neighbor row.
         extra = max(
             extra,
-            get_alloc_reserve_per_decode(server_args) + server_args.page_size - 1,
+            get_alloc_reserve_per_decode(server_args, max_draft_tokens=max_draft_tokens)
+            + server_args.page_size
+            - 1,
         )
     return extra

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -64,6 +64,7 @@ from sglang.srt.mem_cache.memory_pool import (
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
+    configured_pp_size,
     get_context,
     get_disagg,
     get_exec,
@@ -71,6 +72,9 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
     get_spec,
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+    max_speculative_num_draft_tokens,
 )
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -404,7 +408,7 @@ class KVCacheConfigurator:
                     mamba_spec_state_size=sizes.max_running_requests,
                     cache_params=self.mambaish_config.mamba2_cache_params,
                     device=self.device,
-                    enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+                    enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
                     draft_model_idx=self.draft_model_idx,
                     speculative_eagle_topk=get_spec().speculative_eagle_topk,
                 )
@@ -512,7 +516,7 @@ class KVCacheConfigurator:
             max_mamba_cache_size=get_schedule().max_mamba_cache_size,
             max_num_reqs=max_num_reqs,
             enable_memory_saver=get_exec().features.enable_memory_saver,
-            enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+            enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             speculative_num_draft_tokens=get_spec().speculative_num_draft_tokens,
             disable_overlap_schedule=get_schedule().disable_overlap_schedule,
             need_sort=get_disagg().disaggregation_mode in ("decode", "prefill"),
@@ -637,7 +641,7 @@ class KVCacheConfigurator:
         elif current_platform.is_out_of_tree() and not self.mambaish_config:
             unsupported_pool_family = "out-of-tree platform KV pool"
         elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
+            get_exec().kernel.attention_backend == "ascend" and not self.mambaish_config
         ):
             unsupported_pool_family = "NPU/Ascend KV pool"
         elif self.use_mla_backend and is_dsa_model:
@@ -661,7 +665,13 @@ class KVCacheConfigurator:
             )
 
     def _build_req_to_token_pool(self, *, max_num_reqs: int) -> ReqToTokenPool:
-        extra_max_context_len = get_req_to_token_extra_context_len(self.server_args)
+        # The same bag-derived bound the pools below receive, so the row
+        # headroom and the speculative buffers cannot disagree after a
+        # post-publish override.
+        extra_max_context_len = get_req_to_token_extra_context_len(
+            self.server_args,
+            max_draft_tokens=max_speculative_num_draft_tokens(),
+        )
 
         if get_disagg().disaggregation_mode == "decode":
             # Extra slots for pre-allocated requests
@@ -714,9 +724,9 @@ class KVCacheConfigurator:
                     if self.layer_info.start_layer <= i < self.layer_info.end_layer
                 ]
             ),
-            speculative_num_draft_tokens=self.server_args.max_speculative_num_draft_tokens,
+            speculative_num_draft_tokens=max_speculative_num_draft_tokens(),
             speculative_eagle_topk=get_spec().speculative_eagle_topk,
-            enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
+            enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             pre_alloc_size=pre_alloc_size,
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             mamba_size=get_schedule().max_mamba_cache_size,
@@ -768,7 +778,7 @@ class KVCacheConfigurator:
     ) -> ReqToTokenPool:
         # DSPARK/DFLASH commit routes through the backend fold (KDA-only); a
         # non-KDA model there would scatter a None intermediate_ssm and crash.
-        _algo = (self.server_args.speculative_algorithm or "").upper()
+        _algo = (get_spec().speculative_algorithm or "").upper()
         if (
             get_exec().mamba.enable_linear_replayssm_spec
             and _algo in ("DSPARK", "DFLASH")
@@ -793,9 +803,9 @@ class KVCacheConfigurator:
                     if self.layer_info.start_layer <= i < self.layer_info.end_layer
                 ]
             ),
-            enable_mamba_extra_buffer=self.server_args.enable_mamba_extra_buffer(),
-            enable_mamba_extra_buffer_lazy=self.server_args.enable_mamba_extra_buffer_lazy(),
-            speculative_num_draft_tokens=self.server_args.max_speculative_num_draft_tokens,
+            enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
+            enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
+            speculative_num_draft_tokens=max_speculative_num_draft_tokens(),
             speculative_eagle_topk=get_spec().speculative_eagle_topk,
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             start_layer=self.layer_info.start_layer,
@@ -884,7 +894,7 @@ class KVCacheConfigurator:
                     max_total_num_tokens=sizes.max_total_num_tokens,
                 )
         elif (
-            self.server_args.attention_backend == "ascend" and not self.mambaish_config
+            get_exec().kernel.attention_backend == "ascend" and not self.mambaish_config
         ):
             if self.is_hybrid_swa:
                 token_to_kv_pool = self._build_ascend_swa_kv_pool(
@@ -1033,9 +1043,7 @@ class KVCacheConfigurator:
             start_layer=self.layer_info.start_layer,
             end_layer=self.layer_info.end_layer,
             enable_hisparse=get_memory().enable_hisparse,
-            online_mtp_max_draft_tokens=(
-                self.server_args.max_speculative_num_draft_tokens or 0
-            ),
+            online_mtp_max_draft_tokens=(max_speculative_num_draft_tokens() or 0),
         )
         return token_to_kv_pool
 
@@ -1496,7 +1504,7 @@ class KVCacheConfigurator:
                     need_sort=need_sort,
                 )
             elif _is_npu and (
-                self.server_args.attention_backend == "ascend"
+                get_exec().kernel.attention_backend == "ascend"
                 or is_dsv4_model
                 or self.hybrid_gdn_config is not None
             ):
@@ -1686,17 +1694,17 @@ class KVCacheConfigurator:
         )
 
         additional_ratio = 0
-        if self.server_args.enable_mamba_extra_buffer():
+        if mamba_extra_buffer_enabled():
             # ping-pong buffer size is 2 when overlap schedule is on, 1 otherwise.
             # Lazy mode saves 1 slot (2 → 1) for overlap; non-overlap already uses 1.
             if not get_schedule().disable_overlap_schedule:
-                if self.server_args.enable_mamba_extra_buffer_lazy():
+                if mamba_extra_buffer_lazy_enabled():
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP_LAZY
                 else:
                     additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_OVERLAP
             else:
                 assert (
-                    not self.server_args.enable_mamba_extra_buffer_lazy()
+                    not mamba_extra_buffer_lazy_enabled()
                 ), "Lazy extra buffer requires overlap schedule (--disable-overlap-schedule is incompatible)"
                 additional_ratio = MAMBA_CACHE_V2_ADDITIONAL_RATIO_NO_OVERLAP
         elif skip_decode_lock:
@@ -1725,7 +1733,7 @@ class KVCacheConfigurator:
             token_capacity = min(token_capacity, user_limit)
 
         # Sync across PP ranks (each may have different layer counts)
-        if self.server_args.pp_size > 1:
+        if configured_pp_size() > 1:
             tensor = torch.tensor(token_capacity, dtype=torch.int64)
             torch.distributed.all_reduce(
                 tensor,
@@ -1835,7 +1843,6 @@ class KVCacheConfigurator:
 
     def _handle_max_mamba_cache(self, total_rest_memory):
         config = self.mambaish_config
-        server_args = self.server_args
         assert config is not None
 
         # mamba_cache_per_req covers every mamba layer, but under PP a rank only
@@ -1873,10 +1880,11 @@ class KVCacheConfigurator:
         if replayssm_active:
             # GDN sizes the fold window to the draft maximum; the KDA ring
             # stays --linear-replayssm-cache-len long (mirrors MambaPool).
+            max_draft_tokens = max_speculative_num_draft_tokens()
             if kimi_linear_config(self.model_config) is not None:
                 record_len = get_exec().mamba.linear_replayssm_cache_len
-            elif server_args.max_speculative_num_draft_tokens is not None:
-                record_len = server_args.max_speculative_num_draft_tokens
+            elif max_draft_tokens is not None:
+                record_len = max_draft_tokens
             else:
                 record_len = get_exec().mamba.linear_replayssm_cache_len
             replayssm_ring_per_req = (

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -50,7 +50,9 @@ from sglang.srt.mem_cache.multi_ended_allocator import (
 )
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.mem_cache.utils import split_node_hash_value
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.runtime_context import (
+    mamba_cache_chunk_size,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -450,7 +452,7 @@ class MambaRadixCache(KVCacheEventMixin, BasePrefixCache):
         )
         self.req_to_token_pool: HybridReqToTokenPool = params.req_to_token_pool
         self.token_to_kv_pool_allocator = params.token_to_kv_pool_allocator
-        self.mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        self.mamba_cache_chunk_size = mamba_cache_chunk_size()
 
         self.page_size = params.page_size
         self.disable = params.disable

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -35,7 +35,10 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
     TreeComponent,
     get_and_increase_time_counter,
 )
-from sglang.srt.runtime_context import get_exec, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    mamba_cache_chunk_size,
+)
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -65,7 +68,7 @@ class MambaComponent(TreeComponent):
                 params.page_size == 1
             ), f"MambaComponent requires page_size=1 when mamba_extra_buffer is disabled, got {params.page_size}"
         super().__init__(cache, params)
-        self.mamba_cache_chunk_size = get_server_args().mamba_cache_chunk_size
+        self.mamba_cache_chunk_size = mamba_cache_chunk_size()
         self.mamba_max_states_per_path = get_exec().mamba.mamba_max_states_per_path
         # HiCache state
         self._mamba_pool_host = None  # set to host mamba pool when HiCache enabled

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1120,7 +1120,15 @@ class ModelRunner:
             pyt_hooks = PytHooks()
             pyt_hooks.register_hooks(self.model, module_prefix="model")
 
-        load_kv_cache_scales(model=self.model, server_args=self.server_args)
+        # Same leaf `configure_kv_cache_dtype` reads: the bag, not the startup
+        # record, so the FP8 gate and the pool cannot disagree after an
+        # override. (The runner's own stamp is not set yet -- load_model runs
+        # before configure_kv_cache_dtype.)
+        load_kv_cache_scales(
+            model=self.model,
+            server_args=self.server_args,
+            kv_cache_dtype=get_model().kv_cache_dtype,
+        )
 
         self.sliding_window_size = resolve_sliding_window_size(
             self.model, self.model_config
@@ -1268,7 +1276,7 @@ class ModelRunner:
         spec_algorithm = getattr(self, "spec_algorithm", None)
         resolved_kv_cache_dtype, self.kv_cache_dtype = (
             kv_cache_dtype.configure_kv_cache_dtype(
-                server_args_kv_cache_dtype=self.server_args.kv_cache_dtype,
+                server_args_kv_cache_dtype=get_model().kv_cache_dtype,
                 model=getattr(self, "model", None),
                 model_dtype=getattr(self, "dtype", torch.bfloat16),
                 is_draft_worker=getattr(self, "is_draft_worker", False),
@@ -1287,7 +1295,7 @@ class ModelRunner:
         self.kv_cache_dtype_str = (
             resolved_kv_cache_dtype
             if resolved_kv_cache_dtype is not None
-            else self.server_args.kv_cache_dtype
+            else get_model().kv_cache_dtype
         )
 
     def _get_attention_backend(self, init_new_workspace: bool = False):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -178,6 +178,8 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
     get_spec,
+    is_ep_joiner,
+    is_ep_scale_joiner,
     set_global_dwdp_manager,
 )
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -458,10 +460,7 @@ class ModelRunner:
         self.graph_time_usage: dict[str, float] = {}
 
     def _initialize_elastic_ep_joiner(self) -> None:
-        if not (
-            get_exec().moe.elastic_ep_backend is not None
-            and self.server_args.is_ep_scale_joiner
-        ):
+        if not (get_exec().moe.elastic_ep_backend is not None and is_ep_scale_joiner()):
             return
 
         join_effective_ep_size = get_parallel().ep_join_rank_offset + self.ps.tp_size
@@ -677,9 +676,7 @@ class ModelRunner:
         if self.is_draft_worker:
             return
         expert_rank = self.ps.moe_ep_rank + (
-            get_parallel().ep_join_rank_offset
-            if self.server_args.is_ep_scale_joiner
-            else 0
+            get_parallel().ep_join_rank_offset if is_ep_scale_joiner() else 0
         )
         set_global_expert_location_metadata(
             compute_initial_expert_location_metadata(
@@ -1184,7 +1181,7 @@ class ModelRunner:
         dist_barrier_after_load(
             elastic_ep_backend=get_exec().moe.elastic_ep_backend,
             tp_rank=self.ps.tp_rank,
-            is_ep_joiner=self.server_args.is_ep_joiner,
+            is_ep_joiner=is_ep_joiner(),
         )
 
     def maybe_precompile_model_kernels_after_loading(self) -> None:
@@ -1843,7 +1840,7 @@ class ModelRunner:
         self._rearm_eplb_after_elastic_scale()
 
     def _report_elastic_scale_failure(self, error: str, effective_size: int) -> None:
-        if self.ps.tp_rank != 0 or self.server_args.is_ep_scale_joiner:
+        if self.ps.tp_rank != 0 or is_ep_scale_joiner():
             return
         from sglang.srt.managers.io_struct import ElasticScaleUpdateReq
 
@@ -1923,12 +1920,12 @@ class ModelRunner:
         ElasticEPStateManager.mark_syncing_new_world()
         self._elastic_scale_ready_barrier(
             target_size=target_size,
-            log_tag="JOINER" if self.server_args.is_ep_scale_joiner else "PRIMARY",
+            log_tag="JOINER" if is_ep_scale_joiner() else "PRIMARY",
         )
         ElasticEPStateManager.commit_scale()
         self._rearm_eplb_after_elastic_scale()
 
-        if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
+        if self.ps.tp_rank == 0 and not is_ep_scale_joiner():
             from sglang.srt.managers.io_struct import ElasticScaleUpdateReq
 
             self._pending_elastic_scale_update = ElasticScaleUpdateReq(
@@ -1961,7 +1958,7 @@ class ModelRunner:
                 )
                 ElasticEPStateManager.fail_recovery(error)
                 self._report_elastic_scale_failure(error, effective_size)
-                if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
+                if self.ps.tp_rank == 0 and not is_ep_scale_joiner():
                     logger.error("[Elastic EP] %s", error)
                 return
 
@@ -1987,7 +1984,7 @@ class ModelRunner:
             ElasticEPStateManager.fail_scale(error)
             self._reset_eplb_after_elastic_scale_failure()
             self._report_elastic_scale_failure(error, effective_size)
-            if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
+            if self.ps.tp_rank == 0 and not is_ep_scale_joiner():
                 logger.error("[Elastic EP] %s", error)
             return
 
@@ -2003,7 +2000,7 @@ class ModelRunner:
                 ElasticEPStateManager.fail_scale(error)
                 self._reset_eplb_after_elastic_scale_failure()
                 self._report_elastic_scale_failure(error, effective_size)
-                if self.ps.tp_rank == 0 and not self.server_args.is_ep_scale_joiner:
+                if self.ps.tp_rank == 0 and not is_ep_scale_joiner():
                     logger.error("[Elastic EP] %s", error)
                 return
             if not ElasticEPStateManager.begin_scale():

--- a/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/load_model_utils.py
@@ -103,8 +103,13 @@ def maybe_trigger_remote_instance_nccl_send_group(
             t.start()
 
 
-def load_kv_cache_scales(*, model, server_args: ServerArgs) -> None:
-    if server_args.kv_cache_dtype == "fp8_e4m3":
+def load_kv_cache_scales(
+    *, model, server_args: ServerArgs, kv_cache_dtype: str
+) -> None:
+    """``kv_cache_dtype`` is the caller's resolved value. Required rather than
+    defaulted: a fallback to ``server_args`` would be a hidden global read for
+    any future caller that forgets to pass one."""
+    if kv_cache_dtype == "fp8_e4m3":
         if server_args.quantization_param_path is not None:
             if callable(getattr(model, "load_kv_cache_scales", None)):
                 model.load_kv_cache_scales(server_args.quantization_param_path)

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -48,6 +48,7 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     register_memory_region,
 )
 from sglang.srt.runtime_context import (
+    configured_moe_dp_size,
     get_exec,
     get_model,
     get_parallel,
@@ -1776,14 +1777,13 @@ class PreshardedModelLoader(DefaultModelLoader):
                 return 1
 
         parallel = get_parallel()
-        server_args = get_server_args()
         return {
             "tp": _safe(lambda: parallel.tp_size),
             "dp": _safe(lambda: parallel.moe_dp_size),
             "ep": _safe(lambda: parallel.moe_ep_size),
             "pp": _safe(lambda: parallel.pp_size),
             "moe_dense_tp_size": parallel.moe_dense_tp_size,
-            "moe_dp_size": server_args.moe_dp_size,
+            "moe_dp_size": configured_moe_dp_size(),
             "enable_dp_lm_head": parallel.enable_dp_lm_head,
             "enable_fp32_lm_head": get_exec().features.enable_fp32_lm_head,
             "quantization": model_config.quantization,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -193,12 +193,12 @@ from sglang.srt.models.deepseek_common.utils import (
     is_wint4afp8_or_wint4a16_config,
 )
 from sglang.srt.runtime_context import (
+    attention_backends,
     get_device,
     get_exec,
     get_forward,
     get_model,
     get_parallel,
-    get_server_args,
     get_spec,
 )
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -1999,8 +1999,7 @@ class DeepseekV2AttentionMLA(
         # Determine attention backend name for current forward batch: prefer the
         # name stamped per-runner on the backend object, else resolve from server args.
         backend = get_attn_backend()
-        server_args = get_server_args()
-        default_prefill_str, default_decode_str = server_args.get_attention_backends()
+        default_prefill_str, default_decode_str = attention_backends()
         prefill_backend_str = (
             backend.prefill_attention_backend_str or default_prefill_str
         )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -858,11 +858,7 @@ class DeepseekV2MoE(nn.Module):
             )
         ]
 
-    def _can_dual_stream_graph(
-        self, hidden_states: torch.Tensor, server_args=None
-    ) -> bool:
-        if server_args is None:
-            server_args = get_server_args()
+    def _can_dual_stream_graph(self, hidden_states: torch.Tensor) -> bool:
         return (
             _enable_pcg_dsv2_dual_stream
             and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
@@ -875,7 +871,7 @@ class DeepseekV2MoE(nn.Module):
             and not self._enable_a2a_moe
             and not self._fuse_shared_experts_inside_sbo
             and not getattr(self, "is_hash", False)
-            and not server_args.enable_eplb
+            and not get_exec().moe.enable_eplb
         )
 
     def forward(
@@ -898,8 +894,7 @@ class DeepseekV2MoE(nn.Module):
             )
 
         if not self._enable_a2a_moe:
-            server_args = get_server_args()
-            if self._can_dual_stream_graph(hidden_states, server_args):
+            if self._can_dual_stream_graph(hidden_states):
                 fwd = get_forward()
                 return dsv2_flashinfer_moe_dual_stream_graph(
                     hidden_states,

--- a/python/sglang/srt/models/inkling.py
+++ b/python/sglang/srt/models/inkling.py
@@ -80,7 +80,7 @@ from sglang.srt.runtime_context import (
     get_model,
     get_parallel,
     get_schedule,
-    get_server_args,
+    mamba_extra_buffer_enabled,
 )
 from sglang.srt.utils import add_prefix, is_cuda, make_layers
 
@@ -1017,12 +1017,11 @@ class InklingForConditionalGeneration(nn.Module):
         self.config = config
         self.text_config = config.text_config
 
-        server_args = get_server_args()
         assert envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.get()
         if get_disagg().disaggregation_mode != "decode":
             assert not get_memory().disable_radix_cache
             assert not get_schedule().disable_hybrid_swa_memory
-            assert server_args.enable_mamba_extra_buffer()
+            assert mamba_extra_buffer_enabled()
 
         from types import SimpleNamespace
 

--- a/python/sglang/srt/models/inkling_common/sconv.py
+++ b/python/sglang/srt/models/inkling_common/sconv.py
@@ -17,7 +17,11 @@ from sglang.srt.models.inkling_common.kernels.sconv import (
     save_intermediate_conv_windows,
     update_sconv_cache,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_parallel,
+    mamba_extra_buffer_enabled,
+)
 from sglang.srt.utils import is_cuda, set_weight_attrs
 
 
@@ -267,10 +271,7 @@ class ShortConvolution(nn.Module):
             draft_token_num = hidden_states.shape[1]
 
         mamba_track_indices = getattr(forward_batch, "mamba_track_indices", None)
-        do_tracking = (
-            mamba_track_indices is not None
-            and get_server_args().enable_mamba_extra_buffer()
-        )
+        do_tracking = mamba_track_indices is not None and mamba_extra_buffer_enabled()
 
         crossed = track_step = None
         if do_tracking:

--- a/python/sglang/srt/models/kimi_k25.py
+++ b/python/sglang/srt/models/kimi_k25.py
@@ -46,10 +46,9 @@ from sglang.srt.multimodal.mm_utils import (
     run_dp_sharded_mrope_vision_model,
 )
 from sglang.srt.runtime_context import (
+    configured_tp_size,
     get_exec,
     get_mm,
-    get_parallel,
-    get_server_args,
 )
 from sglang.srt.utils import add_prefix, is_cuda, is_npu
 
@@ -731,13 +730,10 @@ class KimiK25ForConditionalGeneration(nn.Module):
             acknowledges the entire TP group so the bounded IPC pool remains
             recyclable.
             """
-            parallel = get_parallel()
-            server_args = get_server_args()
-            # Match MmItemMemoryPool.try_to_recycle(), which waits for the
-            # server TP size rather than the attention subgroup size.
-            ipc_consumer_count = max(
-                getattr(server_args, "tp_size", parallel.attn_tp_size), 1
-            )
+            # Same source as MmItemMemoryPool.try_to_recycle(), which waits on
+            # configured_tp_size(): the live world size agrees once dist is up,
+            # but a refcount that disagrees with the waiter would strand items.
+            ipc_consumer_count = max(configured_tp_size(), 1)
             device_index = device.index
             if device.type == "cuda" and device_index is None:
                 device_index = torch.cuda.current_device()

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -111,7 +111,12 @@ from sglang.srt.multimodal.kimi_k3_image_processing import (
     to_chw_uint8,
 )
 from sglang.srt.multimodal.mm_utils import materialize_multimodal_features
-from sglang.srt.runtime_context import get_exec, get_parallel, get_server_args
+from sglang.srt.runtime_context import (
+    configured_tp_size,
+    get_exec,
+    get_parallel,
+    get_server_args,
+)
 from sglang.srt.utils import is_blackwell_supported, is_hip, make_layers
 from sglang.srt.utils.common import (
     BumpAllocator,
@@ -3082,7 +3087,10 @@ class KimiK3ForConditionalGeneration(nn.Module):
 
         def materialize_item_features(image_indices: List[int]) -> torch.Tensor:
             """Materialize only the images assigned to this vision-DP rank."""
-            ipc_consumer_count = max(get_parallel().tp_size, 1)
+            # Same source as MmItemMemoryPool.try_to_recycle(), which waits on
+            # configured_tp_size(): the live world size agrees once dist is up,
+            # but a refcount that disagrees with the waiter would strand items.
+            ipc_consumer_count = max(configured_tp_size(), 1)
             device_index = device.index
             if device.type == "cuda" and device_index is None:
                 device_index = torch.cuda.current_device()

--- a/python/sglang/srt/models/minimax_m2.py
+++ b/python/sglang/srt/models/minimax_m2.py
@@ -85,7 +85,7 @@ from sglang.srt.runtime_context import (
     get_forward,
     get_parallel,
     get_schedule,
-    get_server_args,
+    process_model_config,
 )
 
 # get_bool_env_var is defined in sglang.srt.utils.common, not sglang.srt.distributed.
@@ -431,10 +431,9 @@ class MiniMaxM2QKRMSNorm:
 
         props = torch.cuda.get_device_properties(device)
         # probe the maximum tokens for one prefill
-        server_args = get_server_args()
         max_tokens = get_schedule().chunked_prefill_size
         if max_tokens is None:
-            max_tokens = server_args.model_config.context_len
+            max_tokens = process_model_config().context_len
         max_tokens = max(max_tokens, get_schedule().max_prefill_tokens)
         logger.info(f"[AR] Using CustomAllReduceV2 for MiniMaxM2 with {max_tokens = }")
         ALIGN = 512

--- a/python/sglang/srt/models/sarvam_moe.py
+++ b/python/sglang/srt/models/sarvam_moe.py
@@ -61,8 +61,10 @@ from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha imp
     DeepseekMHAForwardMixin,
 )
 from sglang.srt.runtime_context import (
+    attention_backends,
     get_exec,
     get_forward,
+    get_memory,
     get_model,
     get_parallel,
     get_server_args,
@@ -609,18 +611,12 @@ class SarvamMoEMLAAttention(nn.Module):
         return k
 
     def _set_current_attention_backend(self, forward_batch: ForwardBatch) -> None:
-        if self._server_args is None:
-            self._server_args = get_server_args()
-        if forward_batch.forward_mode.is_decode_or_idle():
-            self.current_attention_backend = (
-                self._server_args.decode_attention_backend
-                or self._server_args.attention_backend
-            )
-        else:
-            self.current_attention_backend = (
-                self._server_args.prefill_attention_backend
-                or self._server_args.attention_backend
-            )
+        prefill_backend, decode_backend = attention_backends()
+        self.current_attention_backend = (
+            decode_backend
+            if forward_batch.forward_mode.is_decode_or_idle()
+            else prefill_backend
+        )
 
     def _maybe_fp8_bmm(
         self,
@@ -684,7 +680,7 @@ class SarvamMoEMLAAttention(nn.Module):
         )
 
         self._set_current_attention_backend(forward_batch)
-        can_use_prefix_cache = not self._server_args.disable_radix_cache
+        can_use_prefix_cache = not get_memory().disable_radix_cache
         do_prefix_merge = has_extend_prefix and can_use_prefix_cache
 
         if do_prefix_merge and forward_batch.num_prefix_chunks is None:

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1383,3 +1383,26 @@ def reset_context() -> None:
     _CONTEXT.resources = Resources()
     _CONTEXT.forward = ForwardFlags()
     set_global_dwdp_manager(None)
+
+
+def mamba_extra_buffer_enabled() -> bool:
+    """Whether the mamba radix cache keeps its extra state buffer.
+
+    A predicate over two published leaves (``memory.disable_radix_cache`` and
+    ``exec.mamba.mamba_radix_cache_strategy``), so it reads the bags rather
+    than the startup record — the ``ServerArgs`` member of the same name is the
+    pre-publish equivalent used inside the resolution pipeline.
+    """
+    return (
+        get_memory().disable_radix_cache is False
+        and get_exec().mamba.mamba_radix_cache_strategy
+        in ("extra_buffer", "extra_buffer_lazy")
+    )
+
+
+def mamba_extra_buffer_lazy_enabled() -> bool:
+    """The lazy variant of :func:`mamba_extra_buffer_enabled`."""
+    return (
+        get_memory().disable_radix_cache is False
+        and get_exec().mamba.mamba_radix_cache_strategy == "extra_buffer_lazy"
+    )

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -969,12 +969,15 @@ class RuntimeContext:
         dummy-boundary ``ServerArgs`` carrying ``fields`` and returns it;
         ``restore()`` (or exiting) reinstates whatever the slot held before.
 
-        Transitional — to be deprecated: it exists because production code
-        still branches on raw ``server_args`` fields at runtime, so forcing a
-        path needs a full config in the slot. As those readers migrate onto
-        the named runtime tiers (flags / resources / forward), prefer the
-        finer-grained overrides; once they cover the branching surface this
-        override loses its clients and goes away.
+        This is the sanctioned way for a test to get a published context, and
+        it stays. The transitional reason it was introduced for — production
+        code branching on raw ``server_args`` fields at runtime — is gone (the
+        read ratchet pins business reads at zero), but a test that exercises
+        bag readers still needs bags, and the bag tree is projected *from an
+        instance*: something has to publish one. Prefer the finer-grained
+        scoped overrides (``get_exec().override(...)``, the flag groups'
+        ``override``) on top of a published context when a test only needs to
+        force one leaf.
         """
         return _ServerArgsOverride(self, fields)
 
@@ -1194,10 +1197,12 @@ ROLE_NAMESPACE_SETS: dict[str, frozenset[str] | None] = {
     # Audited (record-mode smokes, plain + DP-attention): the DP controller
     # reads only the elastic-EP gate; its module's static read set agrees.
     "dp_controller": frozenset({"exec"}),
-    # Zero bag reads observed (per-instance managers read self.server_args by
-    # design). Keep full: it may need namespaces (e.g. disagg) once tokenizer
-    # paths migrate off self.server_args, and restricting on a zero-read
-    # audit would be guesswork.
+    # Record-mode audit (2026-08-06, text model, /generate + /get_server_info +
+    # /v1/models): reads exactly {"serving"} — the per-instance managers read
+    # self.server_args by design. Still declared full, because that run did not
+    # exercise the multimodal processors, LoRA/score endpoints, the disagg
+    # roles, or the gRPC bridge; narrowing needs those shapes audited too, and
+    # a wrong set fails a request rather than a test.
     "tokenizer": None,
     # Deployment shapes not exercised locally; audit before restricting.
     "encoder": None,

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -47,6 +47,7 @@ test-only ``override(**kw)``.
 from __future__ import annotations
 
 import dataclasses
+import functools
 import os
 import sys
 from contextlib import contextmanager
@@ -827,6 +828,10 @@ class RuntimeContext:
             server_args, "enable_torch_compile", False
         )
         self._server_args = server_args
+        # The adaptive draft-token bound memoizes on the config *path*, so a new
+        # publication that reuses the path must not inherit the bound computed
+        # from the file's previous contents.
+        _adaptive_draft_token_bound.cache_clear()
         # Snapshot resolved config into the namespace bags (the single source of
         # truth for config reads). Driven by NS(...) metadata; a mock/partial
         # config with no NS markers yields an empty tree (no bags projected).
@@ -1376,6 +1381,7 @@ def reset_context() -> None:
     """
     _CONTEXT._server_args = None
     _CONTEXT._config_bags = None
+    _adaptive_draft_token_bound.cache_clear()
     _CONTEXT._overrides_log = []
     _CONTEXT._publish_role = None
     _CONTEXT.parallel._config = None
@@ -1406,3 +1412,144 @@ def mamba_extra_buffer_lazy_enabled() -> bool:
         get_memory().disable_radix_cache is False
         and get_exec().mamba.mamba_radix_cache_strategy == "extra_buffer_lazy"
     )
+
+
+# --- Derived config accessors ------------------------------------------------
+#
+# A few values are computed from several config fields plus the HF config, so
+# they are ``ServerArgs`` members rather than namespace leaves. Business code
+# must not reach for the startup record to get them: these accessors are the
+# named home, and this module — which owns the slot — is the only place that
+# reads it. Each one keeps the member's exact semantics, including which model
+# config it derives from (always the process's, i.e. the target's).
+
+
+def mamba_cache_chunk_size() -> int:
+    """The caching point granularity for mamba state: ``max(the model's mamba
+    chunk size, page_size)``. Cached on the config after the first call."""
+    return get_server_args().mamba_cache_chunk_size
+
+
+def max_speculative_num_draft_tokens() -> int | None:
+    """The largest draft-token count speculative decoding may use.
+
+    All three inputs are ``spec`` leaves, so this derives from the bags and
+    follows a post-publish override; ``ServerArgs.max_speculative_num_draft_tokens``
+    is the pre-publish equivalent. Adaptive spec resolves the count from its
+    candidate-step table instead of the flat field.
+    """
+    spec = get_spec()
+    if spec.speculative_num_draft_tokens is None:
+        return None
+    if not spec.speculative_adaptive:
+        return spec.speculative_num_draft_tokens
+    # The adaptive branch parses a JSON config, and this is called per decode
+    # batch (`spec_prepare_for_decode`), so memoize on the inputs -- keyed, not
+    # cached once, so a post-publish override still recomputes.
+    return _adaptive_draft_token_bound(spec.speculative_adaptive_config)
+
+
+@functools.lru_cache(maxsize=8)
+def _adaptive_draft_token_bound(cfg_path: str | None) -> int:
+    from sglang.srt.speculative.adaptive_spec_params import (
+        resolve_candidate_steps_from_config,
+    )
+
+    candidate_steps = resolve_candidate_steps_from_config(cfg_path=cfg_path)
+    # Adaptive spec requires topk=1 today, so each runtime state needs
+    # steps + 1 draft-token slots (mirrors the ServerArgs member).
+    return max(candidate_steps) + 1
+
+
+def uses_mla_backend() -> bool:
+    """Whether this process's model runs the MLA attention path."""
+    return get_server_args().use_mla_backend()
+
+
+def attention_backends() -> tuple:
+    """The configured ``(prefill, decode)`` backend pair, split fields falling
+    back to ``attention_backend``.
+
+    All three inputs are ``exec.kernel`` leaves, so this derives from the bags
+    and follows a post-publish override; ``ServerArgs.get_attention_backends``
+    is the pre-publish equivalent the resolution pipeline uses. A built runner
+    stamps its own resolved pair (``ModelRunner.prefill_attention_backend_str``);
+    read that when there is a runner in hand.
+    """
+    from sglang.srt.arg_groups.overrides import attention_backends_of
+
+    # All three leaves live in the same bag, so the resolution pipeline's own
+    # helper applies directly -- one definition of the fallback rule.
+    return attention_backends_of(get_exec().kernel)
+
+
+def process_model_config():
+    """The process's ``ModelConfig`` (built once from the published config)."""
+    return get_server_args().get_model_config()
+
+
+def cutedsl_moe_max_num_tokens() -> int:
+    """The CuteDSL A2A per-rank token budget.
+
+    Every input is a published leaf (``spec``, ``schedule``, ``exec.graph``), so
+    this derives from the bags and follows a post-publish override;
+    ``ServerArgs.cutedsl_moe_max_num_tokens`` is the pre-publish equivalent the
+    resolution pipeline uses. Max over the prefill bound, the piecewise-prefill
+    capture, and the decode/verify bound.
+    """
+    from sglang.srt.model_executor.cuda_graph_config import Backend
+
+    spec = get_spec()
+    num_tokens_per_req = (
+        (spec.speculative_num_draft_tokens or 1) if spec.speculative_algorithm else 1
+    )
+    prefill_tokens = get_schedule().max_prefill_tokens
+    cg_config = get_exec().graph.cuda_graph_config
+    if cg_config is not None and cg_config.prefill.backend == Backend.TC_PIECEWISE:
+        prefill_tokens = max(prefill_tokens, cg_config.prefill.max_bs or 0)
+    decode_max_bs = (cg_config.decode.max_bs if cg_config is not None else 0) or 0
+    return max(prefill_tokens, decode_max_bs * num_tokens_per_req)
+
+
+# --- Configured (not live) parallel sizes ------------------------------------
+#
+# ``get_parallel()`` shadows these names with the LIVE topology, which is the
+# right answer almost everywhere. A handful of call sites need what was
+# *configured* instead — before the groups exist, in a process that has none,
+# or where the live value is deliberately aliased to another dimension. Each
+# accessor below names that intent so no business call site has to reach for
+# the startup record; the per-site reasons live in the read ratchet.
+#
+# They read the published leaf rather than the record: the bag is what
+# ``override`` writes, and once the instance holds only the user's raw input
+# the record would answer with what was *typed* instead of what resolution
+# produced. Going through the bag directly is what gets past the live property
+# that shadows these four names on ``get_parallel()``.
+
+
+def _configured_parallel(name: str):
+    # The bag itself, not ParallelContext, whose live property shadows these
+    # four names. Read through the parallel slot the way the leaf accessor
+    # does — ``parallel`` is deliberately outside the per-role namespace table
+    # (every process reads topology config), so this must not route through
+    # ``config_bag()``'s role check, which would record or reject the read.
+    config = _CONTEXT.parallel._config
+    if config is None:
+        raise ValueError("config namespace 'parallel' not published")
+    return getattr(config, name)
+
+
+def configured_tp_size() -> int:
+    return _configured_parallel("tp_size")
+
+
+def configured_pp_size() -> int:
+    return _configured_parallel("pp_size")
+
+
+def configured_moe_dp_size() -> int:
+    return _configured_parallel("moe_dp_size")
+
+
+def configured_attn_cp_size() -> int:
+    return _configured_parallel("attn_cp_size")

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1553,3 +1553,18 @@ def configured_moe_dp_size() -> int:
 
 def configured_attn_cp_size() -> int:
     return _configured_parallel("attn_cp_size")
+
+
+def is_ep_joiner() -> bool:
+    """True in a process launched as an elastic-EP joiner (scale or recover).
+
+    A predicate over the published ``exec.moe.ep_join_mode`` leaf, so it follows
+    a post-publish override; the same-named ``ServerArgs`` property is the
+    pre-publish equivalent.
+    """
+    return get_exec().moe.ep_join_mode in ("scale", "recover")
+
+
+def is_ep_scale_joiner() -> bool:
+    """True in a process launched as an elastic-EP scale-up joiner."""
+    return get_exec().moe.ep_join_mode == "scale"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -40,7 +40,12 @@ from sglang.srt.arg_groups.argparse_actions import (
     DeprecatedStoreTrueAction,
     LoRAPathAction,
 )
-from sglang.srt.arg_groups.overrides import resolved_view
+from sglang.srt.arg_groups.overrides import (
+    attention_backends_of,
+    mamba_extra_buffer_lazy_of,
+    mamba_extra_buffer_of,
+    resolved_view,
+)
 from sglang.srt.configs.embedding_model_spec import BCGPrefillPolicy
 from sglang.srt.configs.linear_attn_model_registry import get_linear_attn_spec_by_arch
 from sglang.srt.connector import ConnectorType
@@ -8689,17 +8694,7 @@ class ServerArgs:
         return attention_backends_of(resolved_view(self))
 
     def get_attention_backends(self):
-        prefill_attention_backend_str = (
-            self.prefill_attention_backend
-            if self.prefill_attention_backend
-            else self.attention_backend
-        )
-        decode_attention_backend_str = (
-            self.decode_attention_backend
-            if self.decode_attention_backend
-            else self.attention_backend
-        )
-        return prefill_attention_backend_str, decode_attention_backend_str
+        return attention_backends_of(self)
 
     def use_mla_backend(self):
         from sglang.srt.configs.model_config import AttentionArch
@@ -8715,16 +8710,10 @@ class ServerArgs:
         )
 
     def enable_mamba_extra_buffer(self) -> bool:
-        return (
-            self.disable_radix_cache is False
-            and self.mamba_radix_cache_strategy in ("extra_buffer", "extra_buffer_lazy")
-        )
+        return mamba_extra_buffer_of(self)
 
     def enable_mamba_extra_buffer_lazy(self) -> bool:
-        return (
-            self.disable_radix_cache is False
-            and self.mamba_radix_cache_strategy == "extra_buffer_lazy"
-        )
+        return mamba_extra_buffer_lazy_of(self)
 
     @cached_property
     def max_speculative_num_draft_tokens(self) -> Optional[int]:

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -177,7 +177,7 @@ class DSparkVerifyPlanner:
                 and not get_schedule().disable_overlap_schedule
                 and not get_spec().speculative_skip_dp_mlp_sync
                 and get_disagg().disaggregation_mode == "null"
-                and self.server_args.pp_size == 1
+                and get_parallel().pp_size == 1
                 and not envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get()
             )
             if tp_rank == 0:
@@ -609,7 +609,7 @@ class DSparkVerifyPlanner:
             )
 
         broadcast_group, group_size = verify_lens_broadcast_group(
-            tp_size=self.server_args.tp_size
+            tp_size=get_parallel().tp_size
         )
         if group_size > 1:
             broadcast_group.broadcast(verify_lens, src=0)

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -44,6 +44,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
+from sglang.srt.runtime_context import attention_backends, get_spec
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.eagle_utils import (
@@ -228,11 +229,15 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         pass
 
     def _resolve_draft_backend_type(self) -> str:
-        return (
-            self.server_args.speculative_draft_attention_backend
-            or self.server_args.decode_attention_backend
-            or self.server_args.attention_backend
-        )
+        # The same chain as before, off the bags: the speculative override if
+        # the operator set one, else the configured decode backend (which falls
+        # back to the base one). Deliberately NOT the runner's stamp: this
+        # worker does not hand its runner a draft backend, so the stamp is the
+        # ordinary pair and reading it would drop the speculative setting --
+        # and forcing the runner onto one backend would collapse a hybrid
+        # prefill/decode config for the topk==1 path, which uses the runner's
+        # own backend.
+        return get_spec().speculative_draft_attention_backend or attention_backends()[1]
 
     def _init_draft_attn_backend(self):
         if self.topk == 1:

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -46,7 +46,7 @@ from sglang.srt.mem_cache.allocation import (
 from sglang.srt.mem_cache.allocation import (
     assign_req_to_token_pool_func as assign_req_to_token_pool_func,
 )
-from sglang.srt.runtime_context import get_exec, get_server_args
+from sglang.srt.runtime_context import get_exec, get_server_args, get_spec
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
@@ -250,16 +250,14 @@ def record_stream_for_v2_verify(batch, verify_input, fwd_stream):
     record_stream_each(candidates, fwd_stream)
 
 
-def spec_need_hidden_states(server_args: Optional[ServerArgs] = None) -> bool:
-    if server_args is None:
-        server_args = get_server_args()
-
+def spec_need_hidden_states() -> bool:
     # STANDALONE drafts don't consume `spec_info.hidden_states` (vanilla LLM).
     # multi_layer_eagle, DFLASH, and DSPARK don't relay hidden_states through FutureMap.
     # TODO(lsyin): also skip when step == 1.
-    if server_args.speculative_algorithm in ("STANDALONE", "DFLASH", "DSPARK"):
+    spec = get_spec()
+    if spec.speculative_algorithm in ("STANDALONE", "DFLASH", "DSPARK"):
         return False
-    return not server_args.enable_multi_layer_eagle
+    return not spec.enable_multi_layer_eagle
 
 
 @torch.compile(dynamic=True, disable=_is_npu or _is_xpu)

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -48,10 +48,10 @@ from sglang.srt.mem_cache.allocation import (
 )
 from sglang.srt.runtime_context import (
     get_exec,
-    get_server_args,
     get_spec,
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
+    max_speculative_num_draft_tokens,
 )
 from sglang.srt.utils import (
     is_cpu,
@@ -1030,12 +1030,11 @@ def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
     """eagle/ngram share a stateless free function; dflash keeps stateful
     prep on its draft input -- the dispatcher routes.
     """
-    server_args = get_server_args()
     if mamba_extra_buffer_lazy_enabled():
         # Scheduler phase (outside forward isolation).
         batch.mamba_lazy_spec_prepare(
             get_exec().mamba.mamba_track_interval,
-            server_args.max_speculative_num_draft_tokens,
+            max_speculative_num_draft_tokens(),
         )
     if batch.spec_algorithm.is_dflash_family():
         batch.spec_info.prepare_for_decode(batch)

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -46,7 +46,13 @@ from sglang.srt.mem_cache.allocation import (
 from sglang.srt.mem_cache.allocation import (
     assign_req_to_token_pool_func as assign_req_to_token_pool_func,
 )
-from sglang.srt.runtime_context import get_exec, get_server_args, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_server_args,
+    get_spec,
+    mamba_extra_buffer_enabled,
+    mamba_extra_buffer_lazy_enabled,
+)
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
@@ -759,11 +765,10 @@ def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:
     Lazy: gather the positions planned by mamba_lazy_spec_prepare. Runs
     inside forward isolation, so it must not mutate req/pool state.
     """
-    server_args = get_server_args()
-    if not server_args.enable_mamba_extra_buffer():
+    if not mamba_extra_buffer_enabled():
         return
     track_positions = None
-    if server_args.enable_mamba_extra_buffer_lazy():
+    if mamba_extra_buffer_lazy_enabled():
         track_positions = batch.mamba_lazy_spec_track_positions_cpu
         assert track_positions is not None and len(track_positions) == len(
             batch.reqs
@@ -1026,7 +1031,7 @@ def spec_prepare_for_decode(batch: ScheduleBatch) -> None:
     prep on its draft input -- the dispatcher routes.
     """
     server_args = get_server_args()
-    if server_args.enable_mamba_extra_buffer_lazy():
+    if mamba_extra_buffer_lazy_enabled():
         # Scheduler phase (outside forward isolation).
         batch.mamba_lazy_spec_prepare(
             get_exec().mamba.mamba_track_interval,

--- a/python/sglang/srt/utils/cuda_ipc_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_ipc_transport_utils.py
@@ -9,7 +9,9 @@ import numpy as np
 import torch
 
 from sglang.srt.environ import envs
-from sglang.srt.runtime_context import get_server_args
+from sglang.srt.runtime_context import (
+    configured_tp_size,
+)
 from sglang.srt.utils.stale_shm_cleanup import make_shm_name
 
 logger = logging.getLogger(__name__)
@@ -130,7 +132,7 @@ class MmItemMemoryChunk:
 
     def try_to_recycle(self) -> bool:
         try:
-            tp_num = get_server_args().tp_size
+            tp_num = configured_tp_size()
         except Exception:
             logger.info(
                 "server_args has not been published yet, skip this turn's recycle"

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -191,25 +191,20 @@ class TestGetDcpLens(CustomTestCase):
         )
         allocators = {}
 
-        # The configurator's bag reads (disaggregation_mode / page_size /
-        # enable_hisparse) come from the published context; the per-iteration
-        # dcp_size stays on the injected instance stand-in.
-        self._sa_override = rc.get_context().override_server_args(
+        # The configurator's own inputs are published leaves now, so the case
+        # publishes them once. The DCP *scale* is not one of them: the allocator
+        # widens from the live get_parallel().attn_dcp_size, which the per-size
+        # override inside the loop drives.
+        override = rc.get_context().override_server_args(
             disaggregation_mode="null",
             page_size=physical_page_size,
             enable_hisparse=False,
         )
-        self._sa_override.install()
-        self.addCleanup(self._sa_override.restore)
-
+        override.install()
+        self.addCleanup(override.restore)
         for dcp_size in (1, 4):
             configurator = SimpleNamespace(
-                server_args=SimpleNamespace(
-                    disaggregation_mode="null",
-                    enable_hisparse=False,
-                    page_size=physical_page_size,
-                    dcp_size=dcp_size,
-                ),
+                server_args=SimpleNamespace(),
                 hybrid_gdn_config=None,
                 is_hybrid_swa=False,
                 kv_cache_dtype=torch.bfloat16,

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -1232,7 +1232,6 @@ class TestMlxOverlapScheduler(unittest.TestCase):
         logits_output = SimpleNamespace(customized_info=None)
         original_release = batch_result_processor_module.release_kv_cache
         original_get_indexer = batch_result_processor_module.get_global_indexer_capturer
-        original_get_server_args = batch_result_processor_module.get_server_args
 
         def fake_release_kv_cache(release_req, tree_cache, is_insert=False):
             events.append(("release", release_req.rid))
@@ -1240,21 +1239,26 @@ class TestMlxOverlapScheduler(unittest.TestCase):
 
         batch_result_processor_module.release_kv_cache = fake_release_kv_cache
         batch_result_processor_module.get_global_indexer_capturer = lambda: None
-        batch_result_processor_module.get_server_args = lambda: SimpleNamespace(
-            enable_mamba_extra_buffer_lazy=lambda: False
+        # The lazy predicate reads the published bags; publish the non-lazy
+        # strategy instead of stubbing the accessor.
+        from sglang.srt.runtime_context import get_context
+
+        override = get_context().override_server_args(
+            mamba_radix_cache_strategy="extra_buffer"
         )
+        override.install()
         try:
             SchedulerBatchResultProcessor._handle_finish_state_updated_req(
                 processor, req, batch, result, i, logits_output
             )
         finally:
+            override.restore()
             for name, original in saved.items():
                 setattr(SchedulerBatchResultProcessor, name, original)
             batch_result_processor_module.release_kv_cache = original_release
             batch_result_processor_module.get_global_indexer_capturer = (
                 original_get_indexer
             )
-            batch_result_processor_module.get_server_args = original_get_server_args
 
         self.assertEqual(
             events,

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (
 )
 from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKernel
 from sglang.srt.layers.attention.linear.utils import LinearAttnKernelBackend
+from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -151,12 +152,12 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
             track_ssm_h_dst=torch.empty(4),
         )
 
-        with patch(
-            "sglang.srt.layers.attention.linear.kernels.gdn_flashinfer."
-            "get_server_args",
-            return_value=SimpleNamespace(mamba_cache_chunk_size=64),
-        ):
-            maybe_build_flashinfer_checkpoint_plan(forward_batch, metadata, "cpu")
+        # The chunk size is a derived config member; seed its private cache on a
+        # published config rather than patching an import binding.
+        override = get_context().override_server_args(_mamba_cache_chunk_size=64)
+        override.install()
+        self.addCleanup(override.restore)
+        maybe_build_flashinfer_checkpoint_plan(forward_batch, metadata, "cpu")
 
         torch.testing.assert_close(
             metadata.state_checkpoint_cu_starts,

--- a/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
+++ b/test/registered/unit/layers/quantization/test_fp4_kv_cache_quant_method.py
@@ -72,10 +72,16 @@ class TestKVCacheQuantRegistry(CustomTestCase):
         from types import SimpleNamespace
 
         from sglang.srt.model_executor.model_runner import ModelRunner
+        from sglang.srt.runtime_context import get_context
 
         runner = object.__new__(ModelRunner)
-        runner.server_args = SimpleNamespace(kv_cache_dtype="fp4_e2m1")
+        runner.server_args = SimpleNamespace()
         runner.draft_attention_backend = None
+        # The runner reads the requested dtype off the model bag, so the double
+        # publishes it rather than carrying it on a stand-in config.
+        override = get_context().override_server_args(kv_cache_dtype="fp4_e2m1")
+        override.install()
+        self.addCleanup(override.restore)
         with self.assertRaisesRegex(ValueError, "fp4_mx_block16"):
             runner.configure_kv_cache_dtype()
 

--- a/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
+++ b/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
@@ -10,6 +10,7 @@ from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.scheduler_components.batch_result_processor import (
     SchedulerBatchResultProcessor,
 )
+from sglang.srt.runtime_context import get_context
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -144,42 +145,25 @@ class TestMambaBoundaryMaskReuse(unittest.TestCase):
                     processor.process_batch_result_decode(result_batch, batch_result)
 
                 scheduler.process_batch_result = process_batch_result
-                server_args = SimpleNamespace(
-                    enable_mamba_extra_buffer=lambda: True,
-                    enable_mamba_extra_buffer_lazy=lambda: False,
-                )
 
                 with (
+                    # The mamba predicates and the track interval read the
+                    # published bags, so publish the configuration under test
+                    # (non-lazy extra buffer, interval 4); observability and
+                    # disagg reads are served by the same publish at their
+                    # defaults.
+                    get_context().override_server_args(
+                        mamba_radix_cache_strategy="extra_buffer",
+                        mamba_track_interval=4,
+                    ),
                     patch(
                         "sglang.srt.managers.schedule_batch.alloc_for_decode",
                         return_value=torch.tensor([3], dtype=torch.int64),
                     ),
                     patch(
-                        "sglang.srt.managers.schedule_batch.get_server_args",
-                        return_value=server_args,
-                    ),
-                    patch(
-                        "sglang.srt.managers.schedule_batch.get_exec",
-                        return_value=SimpleNamespace(
-                            mamba=SimpleNamespace(mamba_track_interval=4)
-                        ),
-                    ),
-                    patch(
                         "sglang.srt.managers.schedule_batch.set_mamba_track_indices_from_reqs"
                     ),
                     patch.object(torch.Tensor, "pin_memory", lambda tensor: tensor),
-                    patch(
-                        "sglang.srt.managers.scheduler_components."
-                        "batch_result_processor.get_observability",
-                        return_value=SimpleNamespace(enable_metrics=False),
-                    ),
-                    patch(
-                        "sglang.srt.managers.scheduler_components."
-                        "batch_result_processor.get_disagg",
-                        return_value=SimpleNamespace(
-                            disaggregation_decode_enable_offload_kvcache=False
-                        ),
-                    ),
                     patch.object(
                         SchedulerBatchResultProcessor,
                         "_mamba_prefix_cache_update",

--- a/test/registered/unit/managers/test_schedule_batch_prepare_for_decode.py
+++ b/test/registered/unit/managers/test_schedule_batch_prepare_for_decode.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import torch
 
+from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
 
@@ -43,18 +44,16 @@ class TestPrepareForDecodeSeqLensOwnership(unittest.TestCase):
         """Each prepare_for_decode call rebinds seq-lens tensors to new +1 objects without mutating the old ones."""
         batch = _make_decode_batch()
 
-        server_args = types.SimpleNamespace(
-            enable_mamba_extra_buffer=lambda: False,
+        # The mamba-extra-buffer predicate reads the published bags, so the
+        # fixture publishes a config with the strategy off.
+        override = get_context().override_server_args(
+            mamba_radix_cache_strategy="no_buffer"
         )
-        with (
-            patch(
-                "sglang.srt.managers.schedule_batch.alloc_for_decode",
-                return_value=torch.tensor([6, 7], dtype=torch.int64),
-            ),
-            patch(
-                "sglang.srt.managers.schedule_batch.get_server_args",
-                return_value=server_args,
-            ),
+        override.install()
+        self.addCleanup(override.restore)
+        with patch(
+            "sglang.srt.managers.schedule_batch.alloc_for_decode",
+            return_value=torch.tensor([6, 7], dtype=torch.int64),
         ):
             for step in range(1, 3):
                 prev_seq_lens = batch.seq_lens

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -35,6 +36,14 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         cls._scheduler_logger.setLevel(cls._old_level)
+
+    def setUp(self):
+        # The scheduler scales the budget by the live DCP size
+        # (`get_parallel().attn_dcp_size`), so the double states a topology
+        # rather than publishing a config it does not otherwise need.
+        cm = get_parallel().override(attn_dcp_size=1)
+        cm.__enter__()
+        self.addCleanup(cm.__exit__, None, None, None)
 
     def _new_scheduler(
         self,

--- a/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
+++ b/test/registered/unit/mem_cache/test_mamba_donated_alloc_ratio.py
@@ -110,22 +110,22 @@ class TestMambaRatioEnvGate(unittest.TestCase):
         from sglang.srt.environ import envs
         from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
 
-        server_args = SimpleNamespace(
-            disable_radix_cache=False,
-            disable_overlap_schedule=disable_overlap,
-            enable_mamba_extra_buffer=lambda: extra_buffer,
-            enable_mamba_extra_buffer_lazy=lambda: lazy,
+        fake = SimpleNamespace(server_args=SimpleNamespace())
+        # Every input is a published leaf now: the extra-buffer predicates read
+        # the radix-cache strategy off the bags, so the fixture publishes the
+        # strategy that produces the combination under test.
+        strategy = (
+            "extra_buffer_lazy"
+            if lazy
+            else "extra_buffer" if extra_buffer else "no_buffer"
         )
-        fake = SimpleNamespace(server_args=server_args)
-        # The bag reads (disable_radix_cache / disable_overlap_schedule) come
-        # from the published context; the derived-method calls stay on the
-        # injected stand-in.
         from sglang.srt import runtime_context as rc
 
         with envs.SGLANG_OPT_MAMBA_SKIP_DECODE_LOCK.override(skip):
             with rc.get_context().override_server_args(
                 disable_radix_cache=False,
                 disable_overlap_schedule=disable_overlap,
+                mamba_radix_cache_strategy=strategy,
             ):
                 return KVCacheConfigurator._calculate_mamba_ratio(fake)
 

--- a/test/registered/unit/model_loader/test_presharded_loader.py
+++ b/test/registered/unit/model_loader/test_presharded_loader.py
@@ -786,13 +786,6 @@ class TestShardConfig(unittest.TestCase):
         # `_collect_shard_config` is the exact failure mode that left
         # moe_dense_tp_size / LM-head flags out of the cache key before.
         loader = object.__new__(PreshardedModelLoader)
-        server_args = SimpleNamespace(
-            moe_dp_size=2,
-            enable_fp32_lm_head=True,
-            ep_num_redundant_experts=4,
-            enable_eplb=True,
-            init_expert_location="trivial",
-        )
         model_config = SimpleNamespace(quantization="fp8", dtype=torch.bfloat16)
         required = {
             "tp",
@@ -819,8 +812,8 @@ class TestShardConfig(unittest.TestCase):
             enable_dp_lm_head=True,
         )
         with mock.patch(
-            "sglang.srt.model_loader.loader.get_server_args",
-            return_value=server_args,
+            "sglang.srt.model_loader.loader.configured_moe_dp_size",
+            return_value=2,
         ), mock.patch(
             "sglang.srt.model_loader.loader.get_parallel",
             return_value=parallel,

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -39,7 +39,7 @@ from sglang.srt.multimodal.processors.kimi_k25 import (
     _resize_bicubic_if_needed,
     _resize_images_by_source_shape,
 )
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.srt.utils.cuda_ipc_transport_utils import (
     DEFER_CUDA_IPC_FEATURE_RECONSTRUCTION_KEY,
     CudaIpcTensorTransportProxy,
@@ -317,7 +317,11 @@ def test_dp_helper_supports_moonvit3d_packed_embeddings_on_tp1():
     tower = _MoonViT3dTower()
     pixel_values = torch.randn(4, 2)
 
-    with get_parallel().override(tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0):
+    # The IPC consumer count asks for the *configured* TP size (matching
+    # MmItemMemoryPool.try_to_recycle), so the double publishes one too.
+    with get_context().override_server_args(tp_size=1), get_parallel().override(
+        tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
+    ):
         output = run_dp_sharded_mrope_vision_model(
             tower, pixel_values, [[1, 2, 2]], rope_type="rope_2d_packed"
         )
@@ -331,7 +335,11 @@ def test_dp_helper_can_lazily_load_kimi_features_on_tp1():
     pixel_values = torch.randn(4, 2)
     loader = Mock(return_value=pixel_values)
 
-    with get_parallel().override(tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0):
+    # The IPC consumer count asks for the *configured* TP size (matching
+    # MmItemMemoryPool.try_to_recycle), so the double publishes one too.
+    with get_context().override_server_args(tp_size=1), get_parallel().override(
+        tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
+    ):
         output = run_dp_sharded_mrope_vision_model(
             tower,
             None,
@@ -479,11 +487,10 @@ def test_kimi_non_dp_keeps_grid_thws_on_the_host():
     model.mm_projector = _IdentityProjector()
     items = [_image_item(torch.randn(4, 2), [[1, 2, 2]])]
 
-    with get_parallel().override(
+    # The IPC consumer count asks for the *configured* TP size (matching
+    # MmItemMemoryPool.try_to_recycle), so the double publishes one too.
+    with get_context().override_server_args(tp_size=1), get_parallel().override(
         tp_size=1, tp_rank=0, attn_tp_size=1, attn_tp_rank=0
-    ), patch(
-        "sglang.srt.models.kimi_k25.get_server_args",
-        return_value=SimpleNamespace(tp_size=1),
     ):
         model.get_image_feature(items)
 

--- a/test/registered/unit/models/test_kimi_k3_vision.py
+++ b/test/registered/unit/models/test_kimi_k3_vision.py
@@ -464,15 +464,17 @@ def test_kimi_k3_encoder_dp_defers_feature_materialization(monkeypatch):
     ]
     sharded_embeddings = torch.randn(2, 2)
 
+    # The IPC consumer count asks for the *configured* TP size (matching
+    # MmItemMemoryPool.try_to_recycle), so publish it; the live topology the
+    # sharding helper reads is forced through the context's own override.
     with mock_patch(
         "sglang.srt.multimodal.mm_utils.run_dp_sharded_mrope_vision_model",
         return_value=sharded_embeddings,
-    ) as run_dp, mock_patch(
-        "sglang.srt.models.kimi_k3.get_parallel",
-        return_value=SimpleNamespace(tp_size=1, attn_tp_size=1),
+    ) as run_dp, get_context().override_server_args(tp_size=1), get_parallel().override(
+        tp_size=1, attn_tp_size=1
     ):
         output = model.get_image_feature(items)
-        # Exercise the loader while the runtime topology is patched.
+        # Exercise the loader while the runtime topology is forced.
         loader_in_scope = run_dp.call_args.kwargs["load_local_pixel_values"]
         local = loader_in_scope([1])
         both = loader_in_scope([0, 1])
@@ -545,12 +547,13 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
         calls.append([int(image[0, 0, 0]) for image in images])
         return torch.tensor([[float(calls[-1][0]), 0.0]]), torch.tensor([[1, 1, 1]])
 
+    # Configured TP size (the IPC consumer count) comes from the published
+    # bags; the live topology is forced through the context's own override.
     with mock_patch(
         "sglang.srt.multimodal.mm_utils.run_dp_sharded_mrope_vision_model",
         return_value=torch.zeros(1, 2),
-    ) as run_dp, mock_patch(
-        "sglang.srt.models.kimi_k3.get_parallel",
-        return_value=SimpleNamespace(tp_size=1, attn_tp_size=1),
+    ) as run_dp, get_context().override_server_args(tp_size=1), get_parallel().override(
+        tp_size=1, attn_tp_size=1
     ), mock_patch(
         "sglang.srt.multimodal.processors.kimi_k25._gpu_preprocess_images",
         side_effect=fake_preprocess,

--- a/test/registered/unit/server_args/test_resolution_is_reproducible.py
+++ b/test/registered/unit/server_args/test_resolution_is_reproducible.py
@@ -1,0 +1,375 @@
+"""Resolution is a pure function of the raw input plus this node's environment.
+
+The end state for the configuration tier keeps ``ServerArgs`` at the user's raw
+input and lets every process that publishes derive the resolved values itself
+(bags do not cross a process boundary — a child projects its own from the record
+it is handed). That is only sound if resolving the same raw input twice gives
+the same answer, so this pins it:
+
+- twice in this process, from equal raw inputs, every field agrees;
+- the resolution is not order-dependent on a shared registry (a second config
+  resolved after the first does not inherit its declarations);
+- the raw record the two started from is itself unchanged by resolving a
+  sibling.
+
+A failure here means some resolution step reads state it also writes, and the
+"re-derive in the child" contract would silently diverge between the launcher
+and its schedulers.
+
+Scope: this pins reproducibility *within one process*, which is the fork case
+(the child inherits the parent's environment and its module-level caches). A
+spawn child starts with cold module state instead -- ``functools`` memos in
+``runtime_context`` among them -- so a divergence that needs a cold cache to
+show up is outside what these cases can see.
+"""
+
+import copy
+import dataclasses
+import json
+import os
+import shutil
+import tempfile
+import unittest
+
+import torch
+
+from sglang.srt.environ import EnvField, envs
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.utils import is_cuda
+from sglang.test.ci.ci_register import (
+    register_amd_ci,
+    register_cpu_ci,
+    register_cuda_ci,
+)
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+# Also on a GPU runner: the resolution branches that matter most (backend
+# defaults, DeepSeek handlers, capability gates) go through `is_cuda()` /
+# `is_hip()` / device capability, which inspect the actual hardware -- passing
+# device="cuda" on a CPU box does not reach them, so a leak confined to a GPU
+# handler would never fail the CPU registration alone.
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+# ROCm too: `is_hip()` gates its own set of backend and DeepSeek handlers, which
+# neither the CPU suite nor a CUDA runner reaches.
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+_MINI_CONFIG = {
+    "architectures": ["LlamaForCausalLM"],
+    "model_type": "llama",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 2,
+    "vocab_size": 128,
+    "max_position_embeddings": 2048,
+}
+
+_DEEPSEEK_MINI_CONFIG = {
+    "architectures": ["DeepseekV3ForCausalLM"],
+    "model_type": "deepseek_v3",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "moe_intermediate_size": 32,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 2,
+    "n_routed_experts": 8,
+    "n_shared_experts": 1,
+    "num_experts_per_tok": 2,
+    "first_k_dense_replace": 1,
+    "vocab_size": 128,
+    "max_position_embeddings": 2048,
+    "kv_lora_rank": 8,
+    "q_lora_rank": 8,
+    "qk_nope_head_dim": 8,
+    "qk_rope_head_dim": 8,
+    "v_head_dim": 8,
+    "topk_method": "greedy",
+    "scoring_func": "softmax",
+    # index_topk puts this config on the DSA path, whose handlers are the ones
+    # that fan out the most (and write process state on the way through).
+    "index_topk": 4,
+    "index_head_dim": 8,
+    "index_n_heads": 2,
+}
+
+_MULTIMODAL_MINI_CONFIG = {
+    "architectures": ["Qwen2VLForConditionalGeneration"],
+    "model_type": "qwen2_vl",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 2,
+    "vocab_size": 128,
+    "max_position_embeddings": 2048,
+    "vision_config": {
+        "depth": 2,
+        "hidden_size": 16,
+        "num_heads": 2,
+        "in_chans": 3,
+        "patch_size": 14,
+        "spatial_merge_size": 2,
+    },
+}
+
+# The shapes the step-12 audit calls out as the ones whose resolution branches
+# touch process state: a plain text model, a speculative launch, and a MoE/MLA
+# architecture whose handlers fan out the most.
+_SHAPES = (
+    ("plain", _MINI_CONFIG, {}),
+    (
+        "speculative",
+        _MINI_CONFIG,
+        dict(
+            speculative_algorithm="EAGLE",
+            speculative_num_steps=2,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=3,
+        ),
+    ),
+    # The multimodal transport handler is the one that writes
+    # SGLANG_USE_CUDA_IPC_TRANSPORT and reads `is_set()` on the way in, so the
+    # shape that exercises it belongs in the dual-resolve matrix.
+    ("multimodal", _MULTIMODAL_MINI_CONFIG, {}),
+    # device="cpu" is the one device every host can resolve, and it is what
+    # reaches `_handle_cpu_backends` — the golden device="cuda" default never
+    # does, so without this shape a leak confined to the CPU handlers would
+    # pass the whole matrix.
+    ("plain_cpu_device", _MINI_CONFIG, dict(device="cpu")),
+)
+
+# Resolving the DSA shape needs a physical device: the DeepSeek-DSA arm of
+# `_handle_model_specific_adjustments` probes `torch.cuda.get_device_capability()`
+# to pick the KV dtype and split backends, and that raises on a driverless
+# host. The GPU registrations are what exercise this shape; a GPU-less runner
+# resolves the other shapes only. (Whether a CPU runner even *reaches* the DSA
+# arm depends on the installed transformers surfacing `index_topk` from the
+# mini config, so without this gate the crash appears runner-dependently.)
+if torch.cuda.is_available():
+    _SHAPES = _SHAPES + (("deepseek_dsa", _DEEPSEEK_MINI_CONFIG, {}),)
+
+# The one field a previous resolution genuinely dictates for the next one in
+# this process: `_handle_multimodal_feature_transport` writes
+# SGLANG_USE_CUDA_IPC_TRANSPORT so tokenizer workers inherit the decision, and
+# the next resolution reads `is_set()` and adopts it -- even for a text-only
+# model, and even across Engines. That is main's behaviour (reproduced on the
+# stack's base commit), it is inert for a text model, and pinning it here is
+# deliberate: the assertion below states the exception explicitly so a *new*
+# sticky field fails this case instead of hiding behind it.
+_STICKY_ACROSS_RESOLUTIONS = frozenset({"mm_feature_transport"})
+
+# `random_seed` is pinned by `_resolved` so it would compare equal anyway; it
+# stays listed because a case that stops pinning it must not silently start
+# comparing a value resolution randomizes.
+_NOT_COMPARABLE = frozenset({"random_seed"})
+
+
+class TestResolutionIsReproducible(CustomTestCase):
+    def _config_dir(self, config: dict = None) -> str:
+        config_dir = tempfile.mkdtemp(prefix="resolution_repro_")
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        with open(os.path.join(config_dir, "config.json"), "w") as handle:
+            json.dump(config or _MINI_CONFIG, handle)
+        return config_dir
+
+    def _process_state(self):
+        """What a resolution may leave behind: the environment and the
+        descriptor-level flag `EnvField.set()` flips, which `os.environ` does
+        not carry."""
+        # Walk the MRO: `vars(type(envs))` alone would miss fields declared on
+        # a base class.
+        fields = {}
+        for klass in reversed(type(envs).__mro__):
+            for name, field in vars(klass).items():
+                if isinstance(field, EnvField):
+                    fields[name] = field
+        return (
+            dict(os.environ),
+            {name: field._set_to_none for name, field in fields.items()},
+        )
+
+    def _restore_process_state(self, state):
+        saved_environ, saved_none_flags = state
+        os.environ.clear()
+        os.environ.update(saved_environ)
+        for name, was_none in saved_none_flags.items():
+            getattr(type(envs), name)._set_to_none = was_none
+
+    def setUp(self):
+        # Resolution writes process state on the way through --
+        # `_handle_multimodal_feature_transport` sets SGLANG_USE_CUDA_IPC_TRANSPORT
+        # so tokenizer workers inherit the decision, and the same handler reads
+        # `is_set()` on the way in. One resolution is therefore visible to the
+        # next one in this process. These cases restore what they touched, and
+        # it is a standing caveat on the determinism pinned here: the guarantee
+        # holds per raw input *and* the process state a previous resolution left.
+        self._pristine_state = self._process_state()
+        self.addCleanup(self._restore_process_state, self._pristine_state)
+
+    def _callTestMethod(self, method):
+        # No retry here. CustomTestCase retries once in CI, but `addCleanup`
+        # runs after the last attempt, so a second attempt would start from the
+        # state the first one leaked -- exactly the regression these cases exist
+        # to catch, turned into a pass.
+        unittest.TestCase._callTestMethod(self, method)
+
+    def _resolved(self, model_path: str, **kwargs) -> ServerArgs:
+        # device="cuda" keeps the golden path host-independent: an
+        # accelerator-less runner resolves only the base platform, where
+        # get_device() raises.
+        kwargs.setdefault("device", "cuda")
+        kwargs.setdefault("random_seed", 42)
+        return ServerArgs(model_path=model_path, **kwargs)
+
+    def _comparable(self, server_args: ServerArgs) -> dict:
+        """The dataclass fields, and only those.
+
+        Non-field artifacts a resolution leaves on the instance (the
+        `_resolved_overrides` provenance, a cached `model_config`) are not in
+        here; `test_the_declaration_provenance_is_reproducible` is what covers
+        the one of those that a shared mutable could corrupt.
+        """
+        out = {}
+        for field in dataclasses.fields(server_args):
+            if field.name in _NOT_COMPARABLE:
+                continue
+            value = getattr(server_args, field.name)
+            # Nested dataclasses (cuda_graph_config) compare structurally, and
+            # everything else is deep-copied: a snapshot that stored the live
+            # list/dict would follow an in-place mutation, which is exactly the
+            # regression `test_resolving_a_sibling_leaves_the_first_alone` looks
+            # for.
+            out[field.name] = (
+                dataclasses.asdict(value)
+                if dataclasses.is_dataclass(value)
+                else copy.deepcopy(value)
+            )
+        return out
+
+    def test_two_resolutions_of_the_same_input_agree(self):
+        for label, config, kwargs in _SHAPES:
+            with self.subTest(shape=label):
+                # Each shape starts from the state the test method started in,
+                # not from what the previous shape's resolution left behind.
+                self._restore_process_state(self._pristine_state)
+                model_path = self._config_dir(config)
+                first = self._resolved(model_path, **kwargs)
+                second = self._resolved(model_path, **kwargs)
+                self.assertEqual(self._comparable(first), self._comparable(second))
+
+    def test_a_resolution_does_not_leak_into_the_next(self):
+        # A config resolved with an explicit, non-default backend must not shift
+        # what the next one picks. Residual process state (env, caches) is the
+        # hazard, not the declaration registry, whose providers are import-time.
+        model_path = self._config_dir()
+        # The control has to be taken *before* the explicit resolution: if that
+        # one contaminated the process, a control read afterwards would inherit
+        # the same contamination and the assertion would pass vacuously.
+        default_before = self._resolved(model_path)
+        # torch_native is not the default on either CPU or CUDA, so the probe
+        # really diverges on the suite that runs this.
+        explicit = self._resolved(model_path, attention_backend="torch_native")
+        self.assertEqual(explicit.attention_backend, "torch_native")
+        self.assertNotEqual(
+            self._comparable(explicit),
+            self._comparable(default_before),
+            "the probe resolved to the same config as the default, so this case "
+            "would pass without exercising order dependence",
+        )
+        default_after = self._resolved(model_path)
+        # Every field, not just the backend: a declaration registry takes
+        # arbitrary field dicts, so a leak can land anywhere.
+        self.assertEqual(
+            self._comparable(default_after), self._comparable(default_before)
+        )
+
+        # A backend probe only diverges on the kernel fields. The shapes whose
+        # handlers write process state on the way through -- the multimodal
+        # transport one sets SGLANG_USE_CUDA_IPC_TRANSPORT and reads `is_set()`
+        # on the way in, DSA fans out the furthest -- are the ones that can
+        # leave something the *next* default reads, so each gets its own turn as
+        # the intermediate. Whether those writes actually fire is
+        # device-dependent, which is why this case is registered on the GPU
+        # runners as well as CPU.
+        intermediates = (
+            ("multimodal", _MULTIMODAL_MINI_CONFIG, {}),
+            ("torch_compile", _MINI_CONFIG, dict(enable_torch_compile=True)),
+        )
+        if torch.cuda.is_available():
+            # Same device gate as _SHAPES: the DSA arm probes the device
+            # capability during resolution.
+            intermediates += (("deepseek_dsa", _DEEPSEEK_MINI_CONFIG, {}),)
+        for label, config, kwargs in intermediates:
+            with self.subTest(intermediate=label):
+                # Each intermediate starts from the pristine process, for two
+                # reasons: it must not inherit what the previous iteration left,
+                # and the handlers under test branch on *unset* state -- the
+                # multimodal one auto-selects the transport only when
+                # SGLANG_USE_CUDA_IPC_TRANSPORT is not set, and any earlier
+                # resolution in this process has already set it. `default_before`
+                # is the control precisely because it was taken on this state.
+                self._restore_process_state(self._pristine_state)
+                # The auto-selection branch under test requires the legacy
+                # variable UNSET; a runner that exports it (a supported
+                # deployment setting) would otherwise pin every resolution to
+                # its value and this subtest would assert the environment
+                # rather than the handler. `_STICKY_ACROSS_RESOLUTIONS`
+                # already excludes the affected field from the equality
+                # against `default_before`, so clearing it here does not skew
+                # that comparison.
+                envs.SGLANG_USE_CUDA_IPC_TRANSPORT.clear()
+                self._resolved(self._config_dir(config), **kwargs)
+                after = self._resolved(model_path)
+                without_sticky = lambda snapshot: {
+                    k: v
+                    for k, v in snapshot.items()
+                    if k not in _STICKY_ACROSS_RESOLUTIONS
+                }
+                self.assertEqual(
+                    without_sticky(self._comparable(after)),
+                    without_sticky(self._comparable(default_before)),
+                )
+                if label == "multimodal":
+                    # And the documented exception, asserted rather than
+                    # assumed: the multimodal handler's env write does reach
+                    # the next resolution. What it carries is the
+                    # intermediate's own device-dependent selection — cuda_ipc
+                    # on single-node CUDA, cpu on the CPU/ROCm runners (the
+                    # same `is_cuda()` gate the handler branches on).
+                    expected = "cuda_ipc" if is_cuda() else "cpu"
+                    self.assertEqual(after.mm_feature_transport, expected)
+
+    def test_resolving_a_sibling_leaves_the_first_alone(self):
+        for label, config, kwargs in _SHAPES:
+            with self.subTest(shape=label):
+                self._restore_process_state(self._pristine_state)
+                model_path = self._config_dir(config)
+                first = self._resolved(model_path, **kwargs)
+                snapshot = self._comparable(first)
+                self._resolved(
+                    model_path, tp_size=2, chunked_prefill_size=1024, **kwargs
+                )
+                self.assertEqual(self._comparable(first), snapshot)
+
+    def test_the_declaration_provenance_is_reproducible(self):
+        model_path = self._config_dir()
+        first = self._resolved(model_path)
+        # Snapshot before the second resolution: if a regression had the
+        # registry hand out a shared mutable list, resolving `second` would
+        # mutate what `first` still points at and the two would compare equal.
+        first_provenance = copy.deepcopy(getattr(first, "_resolved_overrides", None))
+        second = self._resolved(model_path)
+        self.assertEqual(
+            first_provenance,
+            getattr(second, "_resolved_overrides", None),
+        )
+        # And the first record's own list is untouched by the second
+        # resolution -- a shared mutable would show up here.
+        self.assertEqual(getattr(first, "_resolved_overrides", None), first_provenance)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_ngram_mamba_verify_update.py
+++ b/test/registered/unit/spec/test_ngram_mamba_verify_update.py
@@ -198,9 +198,6 @@ class TestNgramMambaVerifyUpdate(CustomTestCase):
             "sglang.srt.speculative.spec_utils.mambaish_config",
             return_value={"some": "config"},
         ), patch(
-            "sglang.srt.speculative.spec_utils.get_server_args",
-            return_value=MagicMock(mamba_track_interval=256),
-        ), patch(
             "sglang.srt.speculative.spec_utils.get_exec",
             return_value=MagicMock(mamba=MagicMock(mamba_track_interval=256)),
         ):

--- a/test/registered/unit/test_context_accessor_shadowing.py
+++ b/test/registered/unit/test_context_accessor_shadowing.py
@@ -1,0 +1,191 @@
+"""No local may shadow a ``runtime_context`` accessor it also calls.
+
+A mechanical sweep that rewrites ``self.server_args.mamba_cache_chunk_size``
+into ``mamba_cache_chunk_size()`` turns
+
+    mamba_cache_chunk_size = self.server_args.mamba_cache_chunk_size
+
+into ``mamba_cache_chunk_size = mamba_cache_chunk_size()``, which is a
+self-referential local: the name is local for the whole function, so the call
+raises ``UnboundLocalError`` the first time that line runs. Five of these
+shipped in one sweep and only one had unit coverage — a mamba model on the
+radix-cache-v2 path found it at request time.
+
+This scans for the shape directly: a function-scope assignment whose target
+name is an imported accessor.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+import sglang
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_PACKAGE_ROOT = Path(next(iter(sglang.__path__)))
+_CONTEXT_MODULE = "sglang.srt.runtime_context"
+
+
+def _module_level_accessor_imports(tree: ast.AST) -> set[str]:
+    """Accessors imported at module scope — visible in every function.
+
+    A *function-local* import is visible only inside its own scope, so it is
+    collected per function in the scan below: charging it file-wide would flag
+    an unrelated sibling function that binds the same name, where no shadowing
+    can occur.
+    """
+    names: set[str] = set()
+    stack = list(tree.body)
+    while stack:
+        stmt = stack.pop()
+        if isinstance(
+            stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)
+        ):
+            continue
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == _CONTEXT_MODULE:
+            for alias in stmt.names:
+                names.add(alias.asname or alias.name)
+        stack.extend(ast.iter_child_nodes(stmt))
+    return names
+
+
+def _bound_names(target):
+    """Every name a binding target introduces, unpacking included.
+
+    ``a, (b, c) = ...`` and ``for x, y in ...`` bind through Tuple/List/Starred
+    nodes, so a check that only accepts a bare ``ast.Name`` misses them.
+    """
+    if isinstance(target, ast.Name):
+        yield target.id
+    elif isinstance(target, ast.Starred):
+        yield from _bound_names(target.value)
+    elif isinstance(target, (ast.Tuple, ast.List)):
+        for element in target.elts:
+            yield from _bound_names(element)
+
+
+def _own_scope_statements(node) -> tuple:
+    """This function's OWN scope: its statements, plus the (name, lineno) of
+    each nested ``def``/``class`` — the definition's *name* is a binding in
+    this scope (an earlier accessor call raises UnboundLocalError just like an
+    assignment), while its *body* is the nested scope's own and descending into
+    it would misattribute bindings."""
+    own_scope = []
+    nested_def_bindings = []
+    pending = list(node.body)
+    while pending:
+        stmt = pending.pop()
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            nested_def_bindings.append((stmt.name, stmt.lineno))
+            continue
+        if isinstance(stmt, ast.Lambda):
+            continue
+        own_scope.append(stmt)
+        pending.extend(ast.iter_child_nodes(stmt))
+    return own_scope, nested_def_bindings
+
+
+def _child_functions(body) -> list:
+    """Function defs directly beneath this scope — descending through plain
+    statements and class bodies (a method closes over the enclosing function's
+    names, not the class's), but never into another function."""
+    funcs = []
+    pending = list(body)
+    while pending:
+        stmt = pending.pop()
+        if isinstance(stmt, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            funcs.append(stmt)
+            continue
+        if isinstance(stmt, ast.Lambda):
+            continue
+        pending.extend(ast.iter_child_nodes(stmt))
+    return funcs
+
+
+def _shadowing_assignments(tree: ast.AST, module_accessors: set[str]):
+    """Function-local bindings whose name shadows an accessor visible in that
+    scope -- every statement form that binds a local, not just ``=``.
+
+    Python decides a name is local from *any* binding in the function, so a
+    loop variable, a ``with ... as``, a walrus, a comprehension target, or an
+    ``except ... as`` all shadow the accessor for the whole function body,
+    exactly like an assignment does.
+
+    Visibility follows lexical scope: module-level imports reach every
+    function; a function-local import reaches its own scope and nested
+    functions (closure), but NOT an unrelated sibling — charging it file-wide
+    would flag bindings where no shadowing occurs. A function-scope *re-import*
+    of the accessor is itself fine: it binds the name to the same callable, so
+    calls after it behave identically (and the module is full of deliberate
+    local imports).
+    """
+    stack = [(fn, module_accessors) for fn in _child_functions(tree.body)]
+    while stack:
+        node, inherited = stack.pop()
+        own_scope, nested_def_bindings = _own_scope_statements(node)
+        local_imports = {
+            alias.asname or alias.name
+            for stmt in own_scope
+            if isinstance(stmt, ast.ImportFrom) and stmt.module == _CONTEXT_MODULE
+            for alias in stmt.names
+        }
+        visible = inherited | local_imports
+        # ``def get_exec(): ...`` nested in the function binds the name in
+        # THIS scope, exactly like an assignment would.
+        for name, lineno in nested_def_bindings:
+            if name in visible:
+                yield node.name, name, lineno
+        for inner in own_scope:
+            targets = []
+            if isinstance(inner, ast.Assign):
+                targets = inner.targets
+            elif isinstance(inner, (ast.AnnAssign, ast.AugAssign)):
+                targets = [inner.target]
+            elif isinstance(inner, (ast.For, ast.AsyncFor, ast.comprehension)):
+                targets = [inner.target]
+            elif isinstance(inner, ast.NamedExpr):
+                targets = [inner.target]
+            elif isinstance(inner, (ast.With, ast.AsyncWith)):
+                targets = [i.optional_vars for i in inner.items if i.optional_vars]
+            elif isinstance(inner, ast.ExceptHandler) and inner.name:
+                targets = [ast.Name(id=inner.name, ctx=ast.Store())]
+            for target in targets:
+                for name in _bound_names(target):
+                    if name in visible:
+                        yield node.name, name, getattr(inner, "lineno", node.lineno)
+        for nested in _child_functions(node.body):
+            stack.append((nested, visible))
+
+
+class TestNoAccessorShadowing(CustomTestCase):
+    def test_no_local_shadows_a_context_accessor(self):
+        offenders = []
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            if rel.startswith("srt/runtime_context.py"):
+                continue
+            source = path.read_text()
+            # A file that never names the module cannot import an accessor
+            # from it, at module scope or inside any function.
+            if _CONTEXT_MODULE not in source:
+                continue
+            try:
+                tree = ast.parse(source)
+            except SyntaxError:
+                continue
+            module_accessors = _module_level_accessor_imports(tree)
+            for func, name, lineno in _shadowing_assignments(tree, module_accessors):
+                offenders.append(f"{rel}:{lineno}: {func}() binds {name!r}")
+        self.assertFalse(
+            offenders,
+            "locals shadow a runtime_context accessor imported in the same "
+            "module; the name is local for the whole function, so any call to "
+            "the accessor there raises UnboundLocalError:\n" + "\n".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -6,22 +6,24 @@ startup record. Config decisions read the namespace accessors instead
 including post-publish overrides, and per-runner values come from the runner
 that owns them.
 
-Two shapes count as a read: the direct ``get_server_args().field``, and the
-alias ``sa = get_server_args()`` followed by ``sa.field`` in the same function.
-A whole-object pass (``def f(server_args)``) is not a global read and is not
-counted — there the caller decided which instance to hand over.
+Business code no longer reads the published record for a config value at all:
+the baselines are zero for both shapes, over the whole package minus the two
+modules that own the slot.
 
-What legitimately remains:
+Where the remaining reads live (``runtime_context.py``, exempt by module):
 
-- **Derived APIs.** ``@property`` and method members of ``ServerArgs``
-  (``mamba_cache_chunk_size``, ``get_model_config()``,
-  ``enable_mamba_extra_buffer()``, …) are computed from several fields plus the
-  HF config, so they are not namespace leaves and ``ServerArgs`` is their only
-  home. Exempt by name below.
+- **Derived members.** ``@property`` / method members of ``ServerArgs``
+  (``mamba_cache_chunk_size``, ``max_speculative_num_draft_tokens``,
+  ``use_mla_backend()``, ``get_attention_backends()``, ``get_model_config()``,
+  ``cutedsl_moe_max_num_tokens()``) are computed from several fields plus the HF
+  config, so they are not namespace leaves and ``ServerArgs`` is their only
+  home. ``runtime_context`` exposes each one as a named accessor
+  (``mamba_cache_chunk_size()`` …) and is the only module that reads the slot
+  for them.
 - **Config-intent reads of live-shadowed sizes.** ``get_parallel()`` shadows
-  ``tp/pp/dcp/attn_cp/moe_dp_size`` with the live topology, so a config-intent
-  read of one has nowhere else to go. Each exempt site needs an answer the live
-  property cannot give:
+  ``tp/pp/dcp/attn_cp/moe_dp_size`` with the live topology, and a few call sites
+  need what was *configured*: the ``configured_*_size()`` accessors. Their
+  reasons, per call site:
 
   - ``dsa_indexer.pp_size`` gates ``pp_size > 1 and not get_pp_group()...``, and
     the short circuit is the point: with PP off the group is never touched, which
@@ -35,8 +37,23 @@ What legitimately remains:
     sizes are equal there and a live comparison is always false.
   - ``model_loader/loader.py`` reports both: the same dict carries the live
     ``moe_dp_size`` under ``"dp"``, so this entry is the configured intent.
-- The alias-form baseline is not zero yet. Lowering it is the next slice; the
-  failure message lists the sites whenever the count moves.
+
+What the ratchet sees, syntactically: ``get_server_args().field``,
+``sa = get_server_args()`` followed by ``sa.field`` (function-local, module-level,
+or parked on an instance attribute -- ``self._sa = get_server_args()`` read from
+another method of the same class), function-local copies of an alias to a
+fixpoint (``cfg = sa`` then ``cfg.field``), and the dynamic form of each --
+``getattr(<either>, "field")`` -- since a string-named read reaches the same
+slot. What it cannot see is a name computed at runtime (``getattr(sa, name)``)
+or indirection deeper than a local name copy (through a container, an
+attribute of another object, a cross-scope copy); the census tool in the
+context repo is what audits those.
+
+A whole-object pass (``def f(server_args)``) is not a global read and is not
+counted -- there the caller decided which instance to hand over. An optional
+parameter that falls back to the global (``f(server_args=None)``) hides one,
+so those fallbacks were removed; the ratchet cannot see them and the census
+tool in the context repo is what audits that shape.
 """
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -54,48 +71,92 @@ from sglang.test.test_utils import CustomTestCase
 # scanned so a new one cannot appear there unnoticed.
 _PACKAGE_ROOT = Path(next(iter(sglang.__path__)))
 
-_DERIVED_MEMBERS = frozenset(
-    {
-        "cutedsl_moe_max_num_tokens",
-        "enable_mamba_extra_buffer",
-        "enable_mamba_extra_buffer_lazy",
-        "get_attention_backends",
-        "get_model_config",
-        "mamba_cache_chunk_size",
-        "max_speculative_num_draft_tokens",
-        "model_config",
-        "use_mla_backend",
-    }
-)
+# The modules that own the slot: runtime_context publishes it and exposes the
+# named accessors for the derived members, server_args/arg_groups ARE the
+# resolution pipeline.
+_SLOT_OWNERS = ("srt/runtime_context.py", "srt/server_args.py", "srt/arg_groups/")
 
-_CONFIG_INTENT_SIZES = frozenset(
-    {
-        ("srt/layers/attention/dsa/dsa_indexer.py", "pp_size"),
-        ("srt/layers/dp_attention.py", "attn_cp_size"),
-        ("srt/layers/dp_attention.py", "moe_dp_size"),
-        ("srt/model_loader/loader.py", "moe_dp_size"),
-        ("srt/utils/cuda_ipc_transport_utils.py", "tp_size"),
-    }
-)
+# Every call site of a ``configured_*_size()`` accessor, with the reason the
+# live topology cannot answer there. The test below asserts this map is exactly
+# the set of call sites, so the reasons cannot drift away from the code.
+_CONFIGURED_SIZE_CALL_SITES = {
+    ("srt/layers/attention/dsa/dsa_indexer.py", "configured_pp_size"): (
+        "gates `pp_size > 1 and not get_pp_group()...`; the short circuit is the "
+        "point, since with PP off the group is never touched, which is what lets "
+        "the Indexer be constructed before distributed init"
+    ),
+    ("srt/layers/dp_attention.py", "configured_attn_cp_size"): (
+        "compared against the configured moe_dp_size below"
+    ),
+    ("srt/layers/dp_attention.py", "configured_moe_dp_size"): (
+        "the configuration this predicate detects (attn_cp_size > moe_dp_size) is "
+        "the one where initialize_model_parallel aliases _MOE_DP to _ATTN_CP, so "
+        "the live sizes are equal there and a live comparison is always false"
+    ),
+    ("srt/model_loader/loader.py", "configured_moe_dp_size"): (
+        "the same dict already carries the live moe_dp_size under 'dp'; this entry "
+        "is the configured intent"
+    ),
+    ("srt/utils/cuda_ipc_transport_utils.py", "configured_tp_size"): (
+        "runs in the tokenizer process, which has no parallel groups at all"
+    ),
+    ("srt/models/kimi_k25.py", "configured_tp_size"): (
+        "the IPC refcount has to name the same number the recycler waits on, and "
+        "that waiter (MmItemMemoryPool.try_to_recycle) reads configured_tp_size() "
+        "because it runs in the tokenizer process; a refcount taken from the live "
+        "attention subgroup would strand items in the bounded pool"
+    ),
+    ("srt/models/kimi_k3.py", "configured_tp_size"): (
+        "same as kimi_k25: the IPC refcount must agree with the recycler's waiter"
+    ),
+}
+
+# A dynamic read whose name is set nowhere in the tree, so the predicate it
+# feeds is inert (the ``getattr`` default decides it). Converting it would mean
+# choosing what it should have named, which is the CP path's call, not this
+# sweep's -- so it is listed here rather than silently counted or "fixed".
+_INERT_DYNAMIC_READS = frozenset({("srt/layers/cp/base.py", "_is_dsa_model_arch")})
 
 _DIRECT_BASELINE = 0
 _ALIAS_BASELINE = 0
 
 
 def _is_global_call(node) -> bool:
-    return (
-        isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "get_server_args"
-    )
+    """``get_server_args()`` however it is spelled: bare, or module-qualified
+    (``ctx.get_server_args()``), which an ast.Name check alone would miss."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id == "get_server_args"
+    return isinstance(func, ast.Attribute) and func.attr == "get_server_args"
 
 
-def _collect(rel: str, tree: ast.AST):
-    """The (direct, alias) field reads in one module."""
+def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
+    """The (direct, alias) field reads in one module.
+
+    ``inert`` names the fields listed in ``_INERT_DYNAMIC_READS`` for this file;
+    they are dropped here, at the point the read is recognized, so the filter
+    matches on the field name rather than on the rendered message.
+    """
     direct, alias = [], []
 
     def counted(attr: str) -> bool:
-        return attr not in _DERIVED_MEMBERS and (rel, attr) not in _CONFIG_INTENT_SIZES
+        return attr not in inert
+
+    def _getattr_name(node):
+        """``getattr(<record>, "field")`` names a field just as ``.field`` does;
+        matching only ast.Attribute would let a dynamic read walk past."""
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "getattr"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Constant)
+            and isinstance(node.args[1].value, str)
+        ):
+            return None
+        return node.args[1].value
 
     for node in ast.walk(tree):
         if (
@@ -105,17 +166,54 @@ def _collect(rel: str, tree: ast.AST):
         ):
             direct.append(f"{rel}:{node.lineno}: get_server_args().{node.attr}")
 
+        name = _getattr_name(node)
+        if name is not None and _is_global_call(node.args[0]) and counted(name):
+            direct.append(f"{rel}:{node.lineno}: getattr(get_server_args(), {name!r})")
+
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
         params = {a.arg for a in list(node.args.args) + list(node.args.kwonlyargs)}
         bound = {}
         for inner in ast.walk(node):
-            if isinstance(inner, ast.Assign) and _is_global_call(inner.value):
-                for target in inner.targets:
-                    if isinstance(target, ast.Name) and target.id not in params:
-                        bound.setdefault(target.id, inner.lineno)
+            # ``sa = get_server_args()`` and its annotated form
+            # ``sa: ServerArgs = get_server_args()``.
+            if isinstance(inner, (ast.Assign, ast.AnnAssign)) and _is_global_call(
+                getattr(inner, "value", None)
+            ):
+                targets = (
+                    inner.targets if isinstance(inner, ast.Assign) else [inner.target]
+                )
+                for target in targets:
+                    if not isinstance(target, ast.Name):
+                        continue
+                    # A parameter reassigned from the global is the
+                    # optional-injection shape (``f(server_args=None)`` then
+                    # ``server_args = get_server_args()``): the reads that
+                    # follow are global reads wearing a parameter's name, so
+                    # they count from the bind on.
+                    bound.setdefault(target.id, inner.lineno)
         if not bound:
             continue
+        # A copy of an alias reaches the same record (``cfg = sa`` after
+        # ``sa = get_server_args()``), so follow Name-to-Name assignments to a
+        # fixpoint. Deeper indirection (through containers, attributes of
+        # other objects, cross-scope copies) stays census-tool territory.
+        changed = True
+        while changed:
+            changed = False
+            for inner in ast.walk(node):
+                if not isinstance(inner, (ast.Assign, ast.AnnAssign)):
+                    continue
+                value = getattr(inner, "value", None)
+                if not (isinstance(value, ast.Name) and value.id in bound):
+                    continue
+                targets = (
+                    inner.targets if isinstance(inner, ast.Assign) else [inner.target]
+                )
+                for target in targets:
+                    if isinstance(target, ast.Name) and target.id not in bound:
+                        bound[target.id] = inner.lineno
+                        changed = True
         for inner in ast.walk(node):
             if (
                 isinstance(inner, ast.Attribute)
@@ -128,6 +226,170 @@ def _collect(rel: str, tree: ast.AST):
                     f"{rel}:{inner.lineno}: {inner.value.id}.{inner.attr} "
                     f"(bound from get_server_args() at line {bound[inner.value.id]})"
                 )
+            name = _getattr_name(inner)
+            if (
+                name is not None
+                and isinstance(inner.args[0], ast.Name)
+                and inner.args[0].id in bound
+                and inner.lineno >= bound[inner.args[0].id]
+                and counted(name)
+            ):
+                alias.append(
+                    f"{rel}:{inner.lineno}: getattr({inner.args[0].id}, {name!r}) "
+                    f"(bound from get_server_args() at line {bound[inner.args[0].id]})"
+                )
+    # A module-level alias is visible to every function in the file, so it needs
+    # its own pass -- the per-function scan above deliberately does not reach
+    # across scopes.
+    module_bound = {}
+    module_stack = list(tree.body)
+    while module_stack:
+        stmt = module_stack.pop()
+        # A module-level bind can sit inside an `if` / `try` / `with`, so the
+        # walk descends into those bodies -- but not into a nested function or
+        # class, whose binds are that scope's own.
+        if isinstance(
+            stmt, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef, ast.Lambda)
+        ):
+            continue
+        module_stack.extend(ast.iter_child_nodes(stmt))
+        if isinstance(stmt, (ast.Assign, ast.AnnAssign)) and _is_global_call(
+            getattr(stmt, "value", None)
+        ):
+            targets = stmt.targets if isinstance(stmt, ast.Assign) else [stmt.target]
+            for target in targets:
+                if isinstance(target, ast.Name):
+                    module_bound.setdefault(target.id, stmt.lineno)
+    if module_bound:
+        # Shadowing is per lexical scope: a function with its own `sa` hides the
+        # module alias *inside that function only*. Aggregating the names
+        # file-wide would suppress every read in the module, including the
+        # top-level ones and the ones in functions that do resolve to the alias.
+        parents = {}
+        scope_binds = {}
+        stack = [tree]
+        while stack:
+            node = stack.pop()
+            enclosing = parents.get(id(node))
+            for child in ast.iter_child_nodes(node):
+                parents[id(child)] = (
+                    node
+                    if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    else enclosing
+                )
+                stack.append(child)
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                names = {
+                    a.arg for a in list(node.args.args) + list(node.args.kwonlyargs)
+                }
+                # Only this scope's own stores: a nested function's local `sa`
+                # shadows the alias inside *that* function, not in its parent.
+                pending = list(node.body)
+                while pending:
+                    inner = pending.pop()
+                    if isinstance(
+                        inner,
+                        (
+                            ast.FunctionDef,
+                            ast.AsyncFunctionDef,
+                            ast.Lambda,
+                            ast.ClassDef,
+                        ),
+                    ):
+                        continue
+                    if isinstance(inner, ast.Name) and isinstance(inner.ctx, ast.Store):
+                        names.add(inner.id)
+                    pending.extend(ast.iter_child_nodes(inner))
+                scope_binds[id(node)] = names
+
+        def _shadowed(node, name):
+            scope = parents.get(id(node))
+            while scope is not None:
+                if name in scope_binds.get(id(scope), ()):
+                    return True
+                scope = parents.get(id(scope))
+            return False
+
+        for node in ast.walk(tree):
+            base = attr = None
+            if (
+                isinstance(node, ast.Attribute)
+                and isinstance(node.value, ast.Name)
+                and node.value.id in module_bound
+            ):
+                base, attr = node.value.id, node.attr
+                shown = f"{base}.{attr}"
+            else:
+                attr_name = _getattr_name(node)
+                if (
+                    attr_name is not None
+                    and isinstance(node.args[0], ast.Name)
+                    and node.args[0].id in module_bound
+                ):
+                    base, attr = node.args[0].id, attr_name
+                    shown = f"getattr({base}, {attr!r})"
+            if base and not _shadowed(node, base) and counted(attr):
+                alias.append(
+                    f"{rel}:{node.lineno}: {shown} "
+                    f"(module-level bind from get_server_args() at line "
+                    f"{module_bound[base]})"
+                )
+
+    # An alias parked on an instance attribute (``self._sa = get_server_args()``
+    # in one method, ``self._sa.field`` in another) reaches the same slot and
+    # crosses function scopes, so it is collected per class rather than per
+    # function.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        attr_bound = {}
+        for inner in ast.walk(node):
+            if isinstance(inner, (ast.Assign, ast.AnnAssign)) and _is_global_call(
+                getattr(inner, "value", None)
+            ):
+                targets = (
+                    inner.targets if isinstance(inner, ast.Assign) else [inner.target]
+                )
+                for target in targets:
+                    if (
+                        isinstance(target, ast.Attribute)
+                        and isinstance(target.value, ast.Name)
+                        and target.value.id in ("self", "cls")
+                    ):
+                        attr_bound.setdefault(
+                            (target.value.id, target.attr), inner.lineno
+                        )
+        if not attr_bound:
+            continue
+
+        def _bound_attr(value):
+            """``self._sa`` when that attribute was bound from the global."""
+            if (
+                isinstance(value, ast.Attribute)
+                and isinstance(value.value, ast.Name)
+                and (value.value.id, value.attr) in attr_bound
+            ):
+                return (value.value.id, value.attr)
+            return None
+
+        for inner in ast.walk(node):
+            key = shown = None
+            if isinstance(inner, ast.Attribute):
+                key = _bound_attr(inner.value)
+                if key is not None and counted(inner.attr):
+                    shown = f"{key[0]}.{key[1]}.{inner.attr}"
+            else:
+                name = _getattr_name(inner)
+                if name is not None:
+                    key = _bound_attr(inner.args[0])
+                    if key is not None and counted(name):
+                        shown = f"getattr({key[0]}.{key[1]}, {name!r})"
+            if shown is not None:
+                alias.append(
+                    f"{rel}:{inner.lineno}: {shown} "
+                    f"(attribute bind from get_server_args() at line "
+                    f"{attr_bound[key]})"
+                )
     return direct, alias
 
 
@@ -135,11 +397,14 @@ def _field_reads():
     direct, alias = [], []
     for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
         rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+        if rel.startswith(_SLOT_OWNERS):
+            continue
         try:
             tree = ast.parse(path.read_text())
         except SyntaxError:
             continue
-        module_direct, module_alias = _collect(rel, tree)
+        inert = frozenset(name for path_, name in _INERT_DYNAMIC_READS if path_ == rel)
+        module_direct, module_alias = _collect(rel, tree, inert)
         direct += module_direct
         alias += module_alias
     return direct, alias
@@ -165,6 +430,91 @@ class TestGlobalConfigReadRatchet(CustomTestCase):
         direct, alias = _field_reads()
         self._check("direct", direct, _DIRECT_BASELINE)
         self._check("alias-form", alias, _ALIAS_BASELINE)
+
+
+class TestConfiguredSizeCallSites(CustomTestCase):
+    """The configured-vs-live exceptions are enumerated, with reasons.
+
+    ``configured_*_size()`` answers what the user asked for where
+    ``get_parallel()`` would answer what the process ended up with. Each such
+    exception is listed above with why the live property cannot serve it, and
+    this case fails if the code and that list disagree.
+
+    The unit is **(file, accessor)**, not the individual call: a second
+    `configured_pp_size()` in a file already registered for it collapses into
+    the same entry, so the reason has to cover the file's use of that accessor
+    rather than one line. A new file, or a new accessor in a listed file, is
+    what this catches -- in either call form (bare or module-qualified).
+    """
+
+    def test_the_call_sites_match_the_documented_set(self):
+        found = set()
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            if rel.startswith(_SLOT_OWNERS):
+                continue
+            try:
+                tree = ast.parse(path.read_text())
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                func = node.func
+                name = (
+                    func.id
+                    if isinstance(func, ast.Name)
+                    else (func.attr if isinstance(func, ast.Attribute) else None)
+                )
+                if name and name.startswith("configured_") and name.endswith("_size"):
+                    found.add((rel, name))
+        documented = set(_CONFIGURED_SIZE_CALL_SITES)
+        self.assertEqual(
+            documented,
+            found,
+            "configured-size call sites drifted from their documented reasons.\n"
+            f"  undocumented: {sorted(found - documented)}\n"
+            f"  stale entries: {sorted(documented - found)}",
+        )
+
+
+class TestNoRenamedAccessorImports(CustomTestCase):
+    """The scanners above match ``get_server_args`` and ``configured_*_size``
+    by their literal names, so an ``import ... as`` rename would walk a read
+    straight past both the zero baseline and the call-site registry. Renaming
+    these accessors buys nothing (the names are already short and unambiguous),
+    so it is banned outright — which is exactly what makes literal-name
+    matching sound."""
+
+    def test_the_scanned_accessors_are_never_import_renamed(self):
+        offenders = []
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            try:
+                tree = ast.parse(path.read_text())
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.ImportFrom, ast.Import)):
+                    continue
+                for imported in node.names:
+                    if imported.asname is None or imported.asname == imported.name:
+                        continue
+                    base = imported.name.rsplit(".", 1)[-1]
+                    if base == "get_server_args" or (
+                        base.startswith("configured_") and base.endswith("_size")
+                    ):
+                        offenders.append(
+                            f"{rel}:{node.lineno}: {imported.name} as "
+                            f"{imported.asname}"
+                        )
+        self.assertFalse(
+            offenders,
+            "get_server_args / configured_*_size imported under another name; "
+            "the read ratchet and the configured-size registry match these "
+            "accessors by their literal names, so a rename silently escapes "
+            "both:\n" + "\n".join(offenders),
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -85,6 +85,11 @@ _CONFIGURED_SIZE_CALL_SITES = {
         "point, since with PP off the group is never touched, which is what lets "
         "the Indexer be constructed before distributed init"
     ),
+    ("srt/mem_cache/kv_cache_configurator.py", "configured_pp_size"): (
+        "decides whether the token capacity needs a cross-PP all-reduce at all; "
+        "asking the configured size keeps that decision independent of whether a "
+        "PP group is installed in this process"
+    ),
     ("srt/layers/dp_attention.py", "configured_attn_cp_size"): (
         "compared against the configured moe_dp_size below"
     ),

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -5,7 +5,10 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import dataclasses
+import json
 import os
+import shutil
+import tempfile
 import unittest
 from unittest.mock import patch
 
@@ -20,8 +23,10 @@ from sglang.srt.runtime_context import (
     get_flags,
     get_parallel,
     get_server_args,
+    max_speculative_num_draft_tokens,
     reset_context,
 )
+from sglang.srt.server_args import ServerArgs
 from sglang.test.test_utils import CustomTestCase
 
 _PS = "sglang.srt.distributed.parallel_state"
@@ -378,6 +383,14 @@ class _FakeResolvedArgs:
     sampling_backend: A[
         str | None, Arg(help="s", resolvable=True), NS("exec.kernel")
     ] = None
+    attention_backend: A[str | None, Arg(help="ab"), NS("exec.kernel")] = None
+    prefill_attention_backend: A[str | None, Arg(help="pab"), NS("exec.kernel")] = None
+    decode_attention_backend: A[str | None, Arg(help="dab"), NS("exec.kernel")] = None
+    disable_radix_cache: A[bool, Arg(help="drc"), NS("memory")] = False
+    mamba_radix_cache_strategy: A[str, Arg(help="mrcs"), NS("exec.mamba")] = "auto"
+    speculative_num_draft_tokens: A[int | None, Arg(help="d"), NS("spec")] = None
+    speculative_adaptive: A[bool, Arg(help="a"), NS("spec")] = False
+    speculative_adaptive_config: A[str | None, Arg(help="c"), NS("spec")] = None
     _resolved_overrides: list = dataclasses.field(default_factory=list)
 
 
@@ -963,6 +976,181 @@ class TestPublishLifecycle(_IsolatedServerArgs):
     def test_capture_tier_defaults_for_sentinel_publish(self):
         get_context().set_server_args(object())
         self.assertFalse(get_flags().capture.enable_torch_compile)
+
+
+class TestDerivedPredicatesAgreeAcrossTiers(_IsolatedServerArgs):
+    """One definition per predicate, checked rather than asserted in prose.
+
+    Each of these exists twice by construction -- once over a config-shaped
+    object (the resolution pipeline's `*_of` helper, which `ServerArgs`
+    delegates to) and once over the published bags. The pair must agree on
+    every input, or a decision made before publish differs from the same
+    decision made after it.
+    """
+
+    _STRATEGIES = ("auto", "no_buffer", "extra_buffer", "extra_buffer_lazy")
+
+    def test_mamba_extra_buffer_matches_the_member(self):
+        from sglang.srt.runtime_context import (
+            mamba_extra_buffer_enabled,
+            mamba_extra_buffer_lazy_enabled,
+        )
+
+        for disable_radix_cache in (False, True):
+            for strategy in self._STRATEGIES:
+                with self.subTest(radix=disable_radix_cache, strategy=strategy):
+                    args = _FakeResolvedArgs(
+                        disable_radix_cache=disable_radix_cache,
+                        mamba_radix_cache_strategy=strategy,
+                    )
+                    get_context().set_server_args(args)
+                    self.assertEqual(
+                        ServerArgs.enable_mamba_extra_buffer(args),
+                        mamba_extra_buffer_enabled(),
+                    )
+                    self.assertEqual(
+                        ServerArgs.enable_mamba_extra_buffer_lazy(args),
+                        mamba_extra_buffer_lazy_enabled(),
+                    )
+
+    def test_attention_backends_match_the_member(self):
+        from sglang.srt.runtime_context import attention_backends
+
+        backends = (None, "fa3", "triton")
+        for base in backends:
+            for prefill in backends:
+                for decode in backends:
+                    with self.subTest(base=base, prefill=prefill, decode=decode):
+                        args = _FakeResolvedArgs(
+                            attention_backend=base,
+                            prefill_attention_backend=prefill,
+                            decode_attention_backend=decode,
+                        )
+                        get_context().set_server_args(args)
+                        self.assertEqual(
+                            ServerArgs.get_attention_backends(args),
+                            attention_backends(),
+                        )
+
+
+class TestAdaptiveDraftBoundLifecycle(_IsolatedServerArgs):
+    """The adaptive draft-token bound is memoized on the config path, so the
+    memo has to end with the publication it was computed under.
+
+    Without that, a process that republishes with the same adaptive-config path
+    -- the file having been rewritten in between -- keeps the previous bound and
+    under-allocates the draft-token buffers sized from it.
+    """
+
+    def _write_config(self, steps):
+        path = os.path.join(tempfile.mkdtemp(prefix="adaptive_cfg_"), "adaptive.json")
+        self.addCleanup(shutil.rmtree, os.path.dirname(path), ignore_errors=True)
+        with open(path, "w") as handle:
+            json.dump({"1": {"candidate_steps": steps}}, handle)
+        return path
+
+    def test_republishing_recomputes_the_bound(self):
+        path = self._write_config([2])
+        get_context().set_server_args(
+            _FakeResolvedArgs(
+                speculative_num_draft_tokens=3,
+                speculative_adaptive=True,
+                speculative_adaptive_config=path,
+            )
+        )
+        self.assertEqual(max_speculative_num_draft_tokens(), 3)
+
+        with open(path, "w") as handle:
+            json.dump({"1": {"candidate_steps": [4]}}, handle)
+        # Same path, new contents: the memo must not survive the republish.
+        get_context().set_server_args(
+            _FakeResolvedArgs(
+                speculative_num_draft_tokens=3,
+                speculative_adaptive=True,
+                speculative_adaptive_config=path,
+            )
+        )
+        self.assertEqual(max_speculative_num_draft_tokens(), 5)
+
+    def test_reset_clears_the_bound(self):
+        path = self._write_config([2])
+        get_context().set_server_args(
+            _FakeResolvedArgs(
+                speculative_num_draft_tokens=3,
+                speculative_adaptive=True,
+                speculative_adaptive_config=path,
+            )
+        )
+        self.assertEqual(max_speculative_num_draft_tokens(), 3)
+        reset_context()
+        with open(path, "w") as handle:
+            json.dump({"1": {"candidate_steps": [6]}}, handle)
+        get_context().set_server_args(
+            _FakeResolvedArgs(
+                speculative_num_draft_tokens=3,
+                speculative_adaptive=True,
+                speculative_adaptive_config=path,
+            )
+        )
+        self.assertEqual(max_speculative_num_draft_tokens(), 7)
+
+
+class TestNamedAccessorsCallWhatTheyWrap(CustomTestCase):
+    """A named accessor must *call* a member that is a method.
+
+    `return get_server_args().x` hands back a bound method when `x` is defined
+    with `def`; the failure then lands far away, in whatever arithmetic the
+    caller does with it. Checked statically so accessors that need a real model
+    config are covered too.
+    """
+
+    def test_accessors_that_wrap_methods_call_them(self):
+        import ast
+        import functools
+        import inspect
+
+        import sglang.srt.runtime_context as rc
+        from sglang.srt.server_args import ServerArgs
+
+        tree = ast.parse(inspect.getsource(rc))
+        wrong = []
+        for node in tree.body:
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for inner in ast.walk(node):
+                if not (isinstance(inner, ast.Return) and inner.value is not None):
+                    continue
+                value = inner.value
+                called = isinstance(value, ast.Call)
+                target = value.func if called else value
+                if not (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Call)
+                    and isinstance(target.value.func, ast.Name)
+                    and target.value.func.id == "get_server_args"
+                ):
+                    continue
+                member = getattr(ServerArgs, target.attr, None)
+                # A `property` / `functools.cached_property` member is already
+                # evaluated by the attribute access, so it is named here to keep
+                # the failure message from calling it "not a method" -- the fix
+                # for those is the opposite one.
+                kind = (
+                    "a property"
+                    if isinstance(member, (property, functools.cached_property))
+                    else "not a method"
+                )
+                if inspect.isfunction(member) and not called:
+                    wrong.append(
+                        f"{node.name}(): returns ServerArgs.{target.attr} without "
+                        "calling it, so callers get a bound method"
+                    )
+                if not inspect.isfunction(member) and called:
+                    wrong.append(
+                        f"{node.name}(): calls ServerArgs.{target.attr}, which is "
+                        f"{kind} -- the attribute access already produced the value"
+                    )
+        self.assertEqual([], wrong, "\n".join(wrong))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Not for merge

Review/CI vehicle carrying the whole reader-convergence stack, so CI runs once over the combined content. The members are reviewed and merged individually; this PR is closed unmerged.

| # | PR | what |
|---|---|---|
| 1 | #34080 | retire the hidden global fallbacks; the mamba-extra-buffer predicates read the bags |
| 2 | #34081 | **business code no longer reads the published `ServerArgs`** (ratchet baselines → 0, exemptions by owner module) |
| 3 | #34094 | pin that resolution is reproducible from the raw input (test only) |
| 4 | #34095 | the runner and scheduler read resolved config from the bags |
| 5 | #34096 | the KV-cache configurator reads the bags |
| 6 | #34097 | skill doc: where config is read now that the seed is off limits |

## Where this sits

`get_server_args().<field>` in business code is **0** after #34081 — everything outside `runtime_context.py` / `server_args.py` / `arg_groups/` reads a namespace bag, the live topology, a named accessor, or its own runner. `self.server_args.<field>` goes 164 → 122, and the remainder is the documented per-instance boundary (several `Engine`s can share one process, so the bags are last-publish-wins across them).

This is the prerequisite for keeping `ServerArgs` at the user's raw input: once no business reader consults the instance, resolution output can move to the bags without silently turning effective values into raw ones.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31327768753](https://github.com/sgl-project/sglang/actions/runs/31327768753)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31327768659](https://github.com/sgl-project/sglang/actions/runs/31327768659)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->