### PR TITLE
flashinfer: pass logits_soft_cap (and ragged window_left) at plan time; gemma-2 / grok ran uncapped

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -29,7 +29,7 @@ from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     KVCacheAttentionAccessKind,
 )
-from sglang.srt.layers.radix_attention import AttentionType
+from sglang.srt.layers.radix_attention import AttentionType, RadixAttention
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.model_executor.cuda_graph_config import (
@@ -57,7 +57,6 @@ from sglang.srt.utils import (
 )
 
 if TYPE_CHECKING:
-    from sglang.srt.layers.radix_attention import RadixAttention
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
@@ -186,6 +185,7 @@ def fast_prefill_plan(
     custom_mask: Optional[torch.Tensor] = None,
     causal: bool = False,
     window_left: int = -1,
+    logits_soft_cap: Optional[float] = None,
     q_data_type: Union[str, torch.dtype] = "float16",
     kv_data_type: Optional[Union[str, torch.dtype]] = None,
     o_data_type: Optional[Union[str, torch.dtype]] = None,
@@ -259,6 +259,7 @@ def fast_prefill_plan(
         kv_data_type if kv_data_type is not None else q_data_type
     )
     self._cached_o_data_type = o_data_type
+    self._logits_soft_cap = logits_soft_cap
     self._block_tables = None
 
     args = [
@@ -284,6 +285,36 @@ def fast_prefill_plan(
         0,  # uniform_q_len
     ]
     self._plan_info = self._cached_module.plan(*args)
+
+
+def _model_logits_soft_cap(model: torch.nn.Module) -> float:
+    """Return the logit cap shared by the model's attention layers, or 0.0.
+
+    FlashInfer bakes ``use_logits_soft_cap`` into the kernel module at
+    plan()/begin_forward() time; the per-layer value handed to the deprecated
+    per-call forward() is silently ignored unless plan() selected the soft-cap
+    module. The cap is declared per layer while planning happens once per
+    forward batch, so plan with the single cap the layers share (gemma-2: 50.0,
+    grok: 30.0; every capped in-tree model uses one value for all layers).
+    """
+    caps = {
+        module.logit_cap
+        for module in model.modules()
+        if isinstance(module, RadixAttention)
+    }
+    nonzero_caps = {cap for cap in caps if cap > 0.0}
+    if not nonzero_caps:
+        return 0.0
+    if len(caps) > 1:
+        # Mixed cap values (or capped and uncapped layers) cannot be planned
+        # with one module per wrapper; refuse loudly instead of applying a
+        # wrong cap to some layers.
+        raise ValueError(
+            "The flashinfer attention backend plans logits_soft_cap once per "
+            f"forward batch and cannot apply distinct per-layer logit caps "
+            f"{sorted(caps)}; use the triton attention backend for this model."
+        )
+    return nonzero_caps.pop()
 
 
 class FlashInferAttnBackend(AttentionBackend):
@@ -369,6 +400,10 @@ class FlashInferAttnBackend(AttentionBackend):
             ),
         )
         self.max_context_len = model_runner.model_config.context_len
+        # Plan-time state: the indices updaters must request soft capping at
+        # plan()/begin_forward() for it to be compiled into the kernel module
+        # (see _model_logits_soft_cap).
+        self.logits_soft_cap = _model_logits_soft_cap(model_runner.model)
         self.page_size = model_runner.page_size
         self.skip_prefill = skip_prefill
         self.is_multimodal = model_runner.model_config.is_multimodal
@@ -1345,6 +1380,14 @@ class FlashInferAttnBackend(AttentionBackend):
             if not self.is_dllm_model and layer.attn_type == AttentionType.ENCODER_ONLY:
                 save_kv_cache = False
 
+            swa_window_left = (
+                layer.sliding_window_size
+                if not (
+                    self.forward_metadata.multi_item_params
+                    and self.forward_metadata.multi_item_params.is_enabled()
+                )
+                else -1
+            )
             if self.forward_metadata.extend_no_prefix:
                 # NOTE: FlashInfer currently has limitations with head_dim = 32 or other dimensions
                 # The FlashInfer head_dim limitation itself is tracked here:
@@ -1355,18 +1398,11 @@ class FlashInferAttnBackend(AttentionBackend):
                     v.view(-1, layer.tp_v_head_num, layer.head_dim),
                     causal=causal,
                     sm_scale=layer.scaling,
+                    window_left=swa_window_left,
                     logits_soft_cap=logits_soft_cap,
                 )
 
             else:
-                swa_window_left = (
-                    layer.sliding_window_size
-                    if not (
-                        self.forward_metadata.multi_item_params
-                        and self.forward_metadata.multi_item_params.is_enabled()
-                    )
-                    else -1
-                )
                 o1, s1 = self.prefill_wrapper_ragged.forward_return_lse(
                     q.view(-1, layer.tp_q_head_num, layer.head_dim),
                     k.view(-1, layer.tp_k_head_num, layer.head_dim),
@@ -1489,6 +1525,7 @@ class FlashInferIndicesUpdaterDecode:
         self.data_type = attn_backend.flashinfer_kv_cache_dtype
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
+        self.logits_soft_cap = attn_backend.logits_soft_cap
         self.attn_backend = attn_backend
 
         # Buffers and wrappers
@@ -1714,6 +1751,8 @@ class FlashInferIndicesUpdaterDecode:
                 1,
                 data_type=self.data_type,
                 q_data_type=self.q_data_type,
+                # plan-time: selects the module with soft capping compiled in
+                logits_soft_cap=self.logits_soft_cap,
                 non_blocking=True,
                 fixed_split_size=fixed_split_size,
                 disable_split_kv=(
@@ -1733,6 +1772,8 @@ class FlashInferIndicesUpdaterDecode:
                 1,
                 data_type=self.data_type,
                 q_data_type=self.q_data_type,
+                # plan-time: selects the module with soft capping compiled in
+                logits_soft_cap=self.logits_soft_cap,
                 non_blocking=True,
                 fixed_split_size=fixed_split_size,
                 disable_split_kv=(
@@ -1761,6 +1802,7 @@ class FlashInferIndicesUpdaterPrefill:
         self.data_type = attn_backend.flashinfer_kv_cache_dtype
         self.q_data_type = model_runner.dtype
         self.sliding_window_size = model_runner.sliding_window_size
+        self.logits_soft_cap = attn_backend.logits_soft_cap
         self.attn_backend = attn_backend
         # Buffers and wrappers
         self.kv_indptr = attn_backend.kv_indptr
@@ -2126,6 +2168,17 @@ class FlashInferIndicesUpdaterPrefill:
                 self.num_kv_heads,
                 self.head_dim,
                 q_data_type=self.q_data_type,
+                # Plan-time state: selects the module with soft capping / the
+                # per-element window mask compiled in. The per-layer values
+                # passed to forward() choose the cap and window at run time
+                # (window_left=-1 keeps full attention), but are silently
+                # ignored unless the module was planned with them.
+                logits_soft_cap=self.logits_soft_cap,
+                window_left=(
+                    self.sliding_window_size
+                    if self.sliding_window_size is not None
+                    else -1
+                ),
             )
 
         if use_sliding_window_kv_pool:
@@ -2206,6 +2259,8 @@ class FlashInferIndicesUpdaterPrefill:
             q_data_type=self.q_data_type,
             kv_data_type=self.data_type,
             custom_mask=use_custom_mask,
+            # plan-time: selects the module with soft capping compiled in
+            logits_soft_cap=self.logits_soft_cap,
             non_blocking=True,
             fixed_split_size=fixed_split_size,
             prefix_len_ptr=prefix_len_ptr,

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py
@@ -79,6 +79,7 @@ class DenseAttentionCase:
     prefix_lens: tuple[int, ...]
     extend_lens: tuple[int, ...] = ()
     sliding_window_size: int | None = None
+    logit_cap: float = 0.0
 
     @property
     def batch_size(self) -> int:
@@ -460,6 +461,7 @@ class ProjectedDenseAttention(nn.Module):
         dtype: torch.dtype,
         device: str,
         sliding_window_size: int | None = None,
+        logit_cap: float = 0.0,
     ):
         super().__init__()
         self.hidden_size = hidden_size
@@ -500,6 +502,7 @@ class ProjectedDenseAttention(nn.Module):
             scaling=head_dim**-0.5,
             num_kv_heads=num_kv_heads,
             layer_id=0,
+            logit_cap=logit_cap,
             sliding_window_size=(
                 sliding_window_size if sliding_window_size is not None else -1
             ),
@@ -847,6 +850,8 @@ def _dense_attention_reference(
             query = query.float()
             keys = keys.float()
             scores = torch.einsum("hd,hkd->hk", query, keys) * module.scaling
+            if case.logit_cap > 0.0:
+                scores = case.logit_cap * torch.tanh(scores / case.logit_cap)
             probs = torch.softmax(scores, dim=-1)
             out = torch.einsum("hk,hkd->hd", probs, values.float())
             outputs.append(out.reshape(-1))
@@ -1012,6 +1017,7 @@ def build_dense_attention_fixture(
         dtype=dtype,
         device=device,
         sliding_window_size=case.sliding_window_size,
+        logit_cap=case.logit_cap,
     )
     reference_module = ReferenceDenseAttention(
         hidden_size=hidden_size,
@@ -1116,6 +1122,7 @@ def make_dense_case_with_prefix_lens(
         prefix_lens=prefix_lens,
         extend_lens=extend_lens,
         sliding_window_size=case.sliding_window_size,
+        logit_cap=case.logit_cap,
     )
 
 

--- a/test/registered/attention/unittests/dense/test_flashinfer.py
+++ b/test/registered/attention/unittests/dense/test_flashinfer.py
@@ -2,13 +2,20 @@ import unittest
 
 import torch
 
+from sglang.srt.layers.attention.attention_registry import ATTENTION_BACKENDS
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.utils import is_flashinfer_available
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.dense_attention import (
+    DENSE_ATOL,
+    DENSE_RTOL,
     DenseAttentionCase,
+    build_dense_attention_fixture,
+    expected_dense_fixture_output,
     make_dense_cases,
+    replace_backend,
     run_dense_attention_case,
+    run_dense_fixture_eager,
 )
 from sglang.test.kits.attention_unittest.runner_modes.cuda_graph_decode_runner import (
     run_dense_cuda_graph_decode_case,
@@ -316,6 +323,104 @@ class TestFlashInferDenseAttentionBackendCorrectness(CustomTestCase):
             prefix_lens=(15, 16, 17),
         ),
     )
+
+    # Regression cases for #33915: FlashInfer treats logits_soft_cap (and
+    # window_left on the ragged wrapper) as plan-time state that selects the
+    # compiled kernel module, but the backend passed them only to the
+    # deprecated per-call forward(), which silently ignores them — so capped
+    # models (gemma-2, grok) ran uncapped and SWA layers ran full attention
+    # within a ragged extend chunk. logit_cap=0.5 is far below the typical
+    # logit magnitude of these fixtures so capping visibly changes the output.
+    LOGIT_CAP_CASES = (
+        DenseAttentionCase(
+            name="logit_cap_extend_ragged_no_prefix",
+            backend="flashinfer",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(0, 0, 0),
+            extend_lens=(15, 8, 1),
+            logit_cap=0.1,
+        ),
+        DenseAttentionCase(
+            name="logit_cap_extend_ragged_paged_merge",
+            backend="flashinfer",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(8, 16),
+            extend_lens=(8, 15),
+            logit_cap=0.1,
+        ),
+        DenseAttentionCase(
+            name="logit_cap_decode",
+            backend="flashinfer",
+            forward_mode=ForwardMode.DECODE,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(14, 15, 16),
+            logit_cap=0.1,
+        ),
+    )
+    SWA_RAGGED_WINDOW_CASES = (
+        DenseAttentionCase(
+            name="swa_window_extend_ragged_no_prefix_beyond_window",
+            backend="flashinfer",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(0, 0),
+            extend_lens=(7, 9),
+            sliding_window_size=4,
+        ),
+        DenseAttentionCase(
+            name="swa_window_extend_ragged_merge_beyond_window",
+            backend="flashinfer",
+            forward_mode=ForwardMode.EXTEND,
+            num_heads=4,
+            num_kv_heads=4,
+            page_size=16,
+            prefix_lens=(6, 5),
+            extend_lens=(6, 7),
+            sliding_window_size=4,
+        ),
+    )
+
+    def _run_case_with_model_wired_backend(self, case: DenseAttentionCase):
+        fixture = build_dense_attention_fixture(
+            self,
+            case,
+            head_dim=self.HEAD_DIM,
+            hidden_size=self.HIDDEN_SIZE,
+        )
+        # The kit's MockModelRunner carries an empty nn.Module as the model;
+        # the FlashInfer backend reads the plan-time logit cap off the model's
+        # RadixAttention layers at construction, so rebuild the backend with
+        # the real attention module wired into the runner.
+        fixture.runner.model = fixture.actual_module
+        replace_backend(fixture, ATTENTION_BACKENDS["flashinfer"](fixture.runner))
+        actual = run_dense_fixture_eager(fixture)
+        expected = expected_dense_fixture_output(fixture)
+        torch.testing.assert_close(actual, expected, atol=DENSE_ATOL, rtol=DENSE_RTOL)
+
+    def test_logit_cap_cases(self):
+        """Bug regression (#33915): plan() never requested logits_soft_cap, so
+        the kernels ran uncapped and the per-call forward() cap was dropped."""
+        for case in self.LOGIT_CAP_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                self._run_case_with_model_wired_backend(case)
+
+    def test_swa_ragged_window_cases(self):
+        """Bug regression (#33915): the ragged prefill wrapper was planned
+        without window_left, so SWA layers attended past the window whenever an
+        extend chunk was longer than the window."""
+        for case in self.SWA_RAGGED_WINDOW_CASES:
+            with self.subTest(case=case.name, backend=case.backend):
+                self._run_case_with_model_wired_backend(case)
 
     def test_layout_robustness_cases(self):
         for case in self.LAYOUT_ROBUSTNESS_CASES:


### PR DESCRIPTION
﻿## Motivation

Fixes #33915. Related: flashinfer-ai/flashinfer#1193.

The FlashInfer attention backend never applies `logit_cap`. Since flashinfer >= 0.2,
`use_logits_soft_cap` is compile-time state that `plan()`/`begin_forward()` bakes into
the selected kernel module; the deprecated per-call `forward()`/`forward_return_lse()`
still accepts a `logits_soft_cap` argument but the value only reaches a kernel that was
planned with capping enabled. sglang passed the cap exclusively at forward() time and
never at any of the plan call sites, so every model with a nonzero `logit_cap` ran
uncapped on the default backend:

- gemma-2 family: `logit_cap = config.attn_logit_softcapping` (50.0)
- grok: `logit_cap = max(getattr(config, "attn_logit_softcapping", 30.0), 0.0)`

(gemma-3 / gemma-4 / gemma-3n pass `logit_cap=0.0` and are unaffected.) The triton
backend applies the cap, so the two backends disagreed on the same checkpoint.

`window_left` was dropped by the same mechanism on the ragged prefill path only: the
ragged wrapper was planned without it, and the no-prefix forward() call did not even
pass it per call. The paged prefill path already treats `window_left` as plan-time
state ("selects the module with the per-element window mask compiled in") â€” this PR
extends that idiom to the cap and to the ragged wrapper.

Verified against the pinned flashinfer 0.6.15.post1 wheel: `plan()` selects the module
with `logits_soft_cap > 0` / `window_left >= 0` and `forward()` stores the per-call
values that `run()` passes to the kernel â€” so the plan-time argument enables the
feature and the existing per-layer forward() arguments keep choosing the values:

```
1 cap at plan():                vs capped 0.999999 | vs uncapped 0.593908
2 cap at legacy forward() only: vs capped 0.593905 | vs uncapped 1.000000   <- the bug
3 cap at plan and forward:      vs capped 0.999999 | vs uncapped 0.593908   <- this PR
4 plan(cap25) forward(cap50):   vs cap50 0.999999 | vs cap25 0.857086      <- run-time value wins
5 plan(w8) forward(w8):         vs win8 1.000000 | vs full 0.413510
6 plan(w8) forward(w-1):        vs win8 0.413511 | vs full 1.000000        <- -1 stays full attention
```

(cosine vs an fp32 reference, ragged wrapper, gemma-2-27b shapes, flashinfer
0.6.15.post1 / torch 2.13.0+cu130 / RTX 4090; row 6 is why the single ragged wrapper
shared by SWA and full-attention layers can be planned with the model's window.)

## Modifications

`python/sglang/srt/layers/attention/flashinfer_backend.py`:

- New `_model_logits_soft_cap(model)`: reads the cap the model's `RadixAttention`
  layers request, once, at backend construction (same pattern as
  `trtllm_mha_backend` scanning `model.modules()` for encoder-only layers). The cap
  is per layer while planning is per forward batch, so it returns the single shared
  value â€” every capped in-tree model uses one cap for all layers â€” and raises for a
  model mixing distinct caps (planning one module per wrapper cannot represent that;
  a cap-enabled kernel handed runtime cap 0.0 would corrupt uncapped layers).
- `FlashInferAttnBackend.__init__` stores it; both indices updaters pass
  `logits_soft_cap=` at every plan site: decode `begin_forward` (both the regular
  and `fast_decode_plan` branches), paged prefill `begin_forward`, ragged prefill
  `begin_forward`.
- The ragged prefill `begin_forward` additionally gets
  `window_left=<model sliding_window_size>`, mirroring the paged path's plan-time
  window handling; full-attention layers keep passing `window_left=-1` per call,
  which remains exact full attention (row 6 above).
- The no-prefix ragged `forward()` now passes `window_left=swa_window_left` like the
  merge-path calls already did (the computation is hoisted above the branch).
- `fast_prefill_plan` accepts `logits_soft_cap` and mirrors upstream `plan()`'s
  `self._logits_soft_cap` assignment, since the shared call site now passes it.

For models with `logit_cap == 0` everywhere, `logits_soft_cap=0.0` is normalized by
upstream plan() exactly like the previous implicit `None` â€” identical module
selection, no behavior change.

Tests (`test/registered/attention/unittests/dense/test_flashinfer.py`, kit support in
`python/sglang/test/kits/attention_unittest/attention_methods/dense_attention.py`):

- `DenseAttentionCase` gains `logit_cap` (default 0.0); the fp32 reference applies
  `cap * tanh(scores / cap)`; the projected module forwards it to `RadixAttention`.
- Five regression subtests: capped extend on the ragged no-prefix path, capped
  extend on the ragged+paged merge path, capped decode, and SWA extends whose
  chunk length exceeds the window on both ragged sub-paths. All five fail on the
  pre-fix backend (greatest abs diff 0.08-0.40 vs atol 0.03) and pass with the fix.

## Accuracy Tests

Environment: 1x RTX 4090 24GB (RunPod), CUDA 12.8 toolkit / driver 580.159.04, torch 2.13.0+cu130,
flashinfer_python 0.6.15.post1 (+ flashinfer-cubin / flashinfer-jit-cache
0.6.15.post1), Python 3.12, sglang `-e python` at c69d593.

Pre-fix (tests only applied, backend unchanged) â€” all five regression subtests fail:

```
FAIL: test_logit_cap_cases (case='logit_cap_extend_ragged_no_prefix')
Greatest absolute difference: 0.185546875 (up to 0.03 allowed)
FAIL: test_logit_cap_cases (case='logit_cap_extend_ragged_paged_merge')
Greatest absolute difference: 0.08770751953125 (up to 0.03 allowed)
FAIL: test_logit_cap_cases (case='logit_cap_decode')
Greatest absolute difference: 0.0810546875 (up to 0.03 allowed)
FAIL: test_swa_ragged_window_cases (case='swa_window_extend_ragged_no_prefix_beyond_window')
Greatest absolute difference: 0.403076171875 (up to 0.03 allowed)
FAIL: test_swa_ragged_window_cases (case='swa_window_extend_ragged_merge_beyond_window')
Greatest absolute difference: 0.25634765625 (up to 0.03 allowed)
Ran 2 tests ... FAILED (failures=5)
```

Post-fix â€” the new regression tests pass:

```
test_logit_cap_cases ... ok
test_swa_ragged_window_cases ... ok
----------------------------------------------------------------------
Ran 2 tests in 7.223s

OK
```

Post-fix â€” the full dense attention unit suites pass (existing coverage: eager
extend/decode, layout robustness, cuda-graph decode, split-op bcg/pcg, eagle /
dflash / ngram / frozen-kv-mtp verify and draft runner modes):

```
test_flashinfer.py: Ran 10 tests in 38.668s  OK
test_triton.py:     Ran 10 tests in 36.198s  OK   (sanity for the shared test-kit change)
```

Model-level sanity, gemma-2-2b-it (`attn_logit_softcapping=50.0`), greedy 32-token
generations with `return_logprob` on 4 fixed prompts, flashinfer vs triton backend
(same checkpoint, same server args, CUDA graphs on):

```
=== pre-fix flashinfer vs triton ===
prompt='The capital of France is'         same_text=False  decode_logprob max|d|=1.0633
prompt='Water is composed of two eleme'   same_text=True   decode_logprob max|d|=0.0526
prompt='def fibonacci(n):\n    '          same_text=True   decode_logprob max|d|=0.0362
prompt='In a shocking finding, scienti'   same_text=True   decode_logprob max|d|=0.0560
=== post-fix flashinfer vs triton ===
prompt='The capital of France is'         same_text=True   decode_logprob max|d|=0.0616
prompt='Water is composed of two eleme'   same_text=True   decode_logprob max|d|=0.0382
prompt='def fibonacci(n):\n    '          same_text=True   decode_logprob max|d|=0.0371
prompt='In a shocking finding, scienti'   same_text=True   decode_logprob max|d|=0.0565
```

Pre-fix, the flashinfer backend diverged from triton on greedy decode for 1 of the
4 prompts; with the fix the two backends produce identical text on all four, with
remaining logprob deltas at the usual bf16 cross-backend noise level. (Checkpoint:
`unsloth/gemma-2-2b-it`, an ungated mirror of the gated google checkpoint.)

Note: per the issue's analysis, the 2b checkpoint's logits rarely reach the cap
(`query_pre_attn_scalar == head_dim == 256`), so this is an integration check
(plan-time cap active on a real capped model, CUDA-graph capture/replay,
`fast_decode_plan`) rather than a cap-magnitude measurement; 27b does not fit the
validation GPU. The wrapper-level and unit-test evidence above is what isolates the
cap behavior.

## Speed Tests and Profiling

No new per-token work: the cap/window are plan-time arguments, and forward() already
passed them per call. For capped or SWA models the plan selects the soft-cap /
sliding-window kernel variant (as the triton backend and HF eager semantics require);
uncapped non-SWA models select the exact same module as before. Not benchmarked.

## Checklist

- [x] Format your code according to Format code with pre-commit (black 26.1.0,
      isort 7.0.0, ruff F401/F821/UP037 all clean on the touched files).
- [x] Add unit tests.
- [ ] Update documentation as needed (none needed).
- [x] Provide accuracy results (above).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31992427251](https://github.com/sgl-project/sglang/actions/runs/31992427251)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31992426994](https://github.com/sgl-project/sglang/actions/runs/31992426994)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->