### PR TITLE
[Bugfix] DSA indexer: the Torch reference rejects the shape its caller passes

### DIFF
--- a/python/sglang/srt/layers/attention/dsv4/indexer.py
+++ b/python/sglang/srt/layers/attention/dsv4/indexer.py
@@ -84,7 +84,12 @@ def fp8_paged_mqa_logits_torch(
     assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)
     assert kvcache_fp8.shape[1:] == (block_size, 1, head_dim + 4)
     assert weight.shape == (batch_size, num_heads)
-    assert seq_lens.shape == (batch_size,)
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+    assert seq_lens.shape == (batch_size,), (
+        f"seq_lens must be one entry per sequence, got {tuple(seq_lens.shape)} "
+        f"for batch_size={batch_size}"
+    )
     assert page_table.shape[0] == batch_size
     assert clean_logits == False
 


### PR DESCRIPTION
## Motivation

`fp8_paged_mqa_logits_torch` is the portable Torch route for the DSA c4 indexer —
what `SGLANG_FP8_PAGED_MQA_LOGITS_TORCH` selects on anything that is not SM120, and
the only route left when DeepGEMM (Blackwell/Hopper-only), TileLang (needs the SM89
FP8 MMA) and aiter (ROCm) are all unavailable. **It cannot run today, on any
architecture.**

`forward_c4_indexer` normalises `c4_seq_lens` to 2-D for every path that is neither
TileLang nor aiter, then hands it to whichever kernel it selected
(`dsv4/indexer.py:746`, `:774`):

```python
if _c4sl.dim() == 1 and not _use_tilelang and not _use_aiter:
    _c4sl = _c4sl.unsqueeze(-1)
...
logits = fn(q, c4_indexer_kv_cache, weights, _c4sl, page_table, ...)
```

`fp8_paged_mqa_logits_torch` asserts the opposite (`:87`):

```python
assert seq_lens.shape == (batch_size,)
```

Those two are always selected together: `fn` is chosen in an if/elif chain whose
TileLang and aiter arms come *earlier*, so by the time the Torch reference is picked,
`_use_tilelang` and `_use_aiter` are both `False` and the unsqueeze has already
happened. The assert fires every time, with no message.

The two sibling implementations in the same file already handle it:
`fp8_paged_mqa_logits_torch_sm120` squeezes at `:215-217`, `_aiter_fp8_paged_mqa_logits`
at `:151`. Only this one does not — so the shape contract, not the hardware, is what
is broken here.

## Modifications

Squeeze first, as the sm120 sibling already does, and give the assert a message while
it is being touched (the shape asserts above it already carry one):

```python
+    if seq_lens.dim() > 1:
+        seq_lens = seq_lens.squeeze(-1)
+    assert seq_lens.shape == (batch_size,), (
+        f"seq_lens must be one entry per sequence, got {tuple(seq_lens.shape)} "
+        f"for batch_size={batch_size}"
+    )
```

Squeezing rather than relaxing the assert: the function's own mask does
`seq_lens.unsqueeze(1)` at `:122` and needs the 1-D form to broadcast to
`[batch, padded_seq_len]`. Fixing the callee rather than the caller follows this
file's own convention — both siblings normalise on entry, and the caller's unsqueeze
is what the DeepGEMM path wants.

## Accuracy

Checked on CPU by exec'ing the function verbatim out of the file, before and after,
with the page-segmented buffer it expects (`block_size * head_dim` value bytes, then
the float32 scales, per page):

| | result |
|---|---|
| upstream, handed what the caller builds | `AssertionError`, empty message |
| patched, same inputs | returns finite `[2, 192]` logits |
| patched vs upstream handed 1-D directly | **bitwise equal, max \|diff\| = 0.0** |
| new assert message, on a genuinely wrong shape | `seq_lens must be one entry per sequence, got (3,) for batch_size=2` |

The per-sequence mask is doing real work in that comparison rather than passing
vacuously: `seq_len=70` yields 70 non-zero scores and zeros past the end, `seq_len=150`
yields 150.

So this makes an unreachable path reachable without moving any number it produces.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31248001515](https://github.com/sgl-project/sglang/actions/runs/31248001515)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31248001420](https://github.com/sgl-project/sglang/actions/runs/31248001420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->