### PR TITLE
[Fix] Guard q_b_proj weight probe so DeepSeek AWQ checkpoints load

### DIFF
--- a/python/sglang/kernels/ops/gemm/fused_a_gemm.py
+++ b/python/sglang/kernels/ops/gemm/fused_a_gemm.py
@@ -34,7 +34,8 @@ _DEVICE_SM = get_device_sm()
 
 def fused_a_gemm_weight_eligible(layer: torch.nn.Module) -> bool:
     return (
-        layer.weight.dtype == torch.bfloat16
+        hasattr(layer, "weight")
+        and layer.weight.dtype == torch.bfloat16
         and layer.weight.shape[0] % 16 == 0
         and layer.weight.shape[1] % 256 == 0
         and _IS_CUDA

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1955,8 +1955,12 @@ class DeepseekV2AttentionMLA(
 
         self.has_q_b_proj = hasattr(self, "q_b_proj")
         q_b_proj_verified_shapes = {(2048, 2048), (4096, 2048)}
-        self._q_b_proj_verified_shape = self.has_q_b_proj and (
-            tuple(self.q_b_proj.weight.shape) in q_b_proj_verified_shapes
+        # Packed quantizations (AWQ, GPTQ) register `qweight` and no `weight`,
+        # and can't use the fused-a GEMM anyway; leave them unverified.
+        self._q_b_proj_verified_shape = (
+            self.has_q_b_proj
+            and hasattr(self.q_b_proj, "weight")
+            and tuple(self.q_b_proj.weight.shape) in q_b_proj_verified_shapes
         )
         self._use_min_latency_q_b_gemm: bool | None = None
 


### PR DESCRIPTION
## Motivation

DeepSeek-V3.2-AWQ fails to load on current `main`:

```
AttributeError: 'ColumnParallelLinear' object has no attribute 'weight'. Did you mean: 'qweight'?
  deepseek_v2.py:1959, in DeepseekV2AttentionMLA.__init__
    tuple(self.q_b_proj.weight.shape) in q_b_proj_verified_shapes
```

Packed quantizations (AWQ, GPTQ) register `qweight` / `scales` / `qzeros` and no `weight`, so the probe raises during module construction, before any checkpoint tensor is read. No flag avoids it.

This is a regression: AWQ loading for DeepSeek-V3.2 was fixed in #16907, and `_q_b_proj_verified_shape` was added afterwards in #31241. It guards whether `q_b_proj` exists, but not whether the layer exposes an unpacked `weight` — `.weight` isn't part of `ColumnParallelLinear`'s interface, it's registered by whichever `quant_method` is installed. The pre-existing sibling path for `fused_qkv_a_proj_with_mqa` does carry a packed-weight guard (`not self.is_packed_weight`); the new path did not inherit one.

Repro:

```bash
python -m sglang.launch_server \
    --model-path QuantTrio/DeepSeek-V3.2-AWQ \
    --quantization awq_marlin --tp 4 --page-size 64 --disable-radix-cache
```

Without `--quantization awq_marlin` a separate error fires first (`torch.bfloat16 is not supported for quantization method awq`): plain `AWQConfig` is fp16-only, `AWQMarlinConfig` accepts bf16.

## Modifications

- `deepseek_v2.py`: require a `weight` attribute before probing its shape. The flag only selects the min-latency fused-A GEMM, which needs an unpacked bf16 matrix, so packed layers fall back to the plain `q_b_proj(...)` call — the only path that was ever viable for them.
- `fused_a_gemm.py`: `fused_a_gemm_weight_eligible` has the same unguarded probe, currently unreachable only because `and` short-circuits on the caller's flag. Guarded so future callers are safe.

Checking `hasattr(layer, "weight")` rather than matching quantization names also covers GPTQ and other packed schemes.

No unit test added: no existing test covers `fused_a_gemm_weight_eligible`, and #16907 shipped without one. Happy to add a CPU test asserting a packed layer is reported ineligible rather than raising, if preferred.

## Tests

Functional check on 4×B200 (SM100), DeepSeek-V3.2-AWQ, TP=4, fp8 KV: server reaches `The server is fired up and ready to roll!`.

  ## Checklist

  - [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/deve
  loper_guide/contribution_guide.html#format-code-with-pre-commit).
  - [ ] Add unit tests according to the [Run and add unit
  tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_g
  uide/contribution_guide.html#write-documentations).
  - [ ] Provide accuracy and speed benchmark results according to [Test the
  accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and
  [Benchmark the
  speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - [x] Follow the SGLang code style
  [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31249668131](https://github.com/sgl-project/sglang/actions/runs/31249668131)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31249668008](https://github.com/sgl-project/sglang/actions/runs/31249668008)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->