### PR TITLE
Fix follow-bootstrap-room routing with reserved DP slots

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -98,6 +98,9 @@ class PrefillServerInfo:
     kv_cache_dtype: Optional[str]
     follow_bootstrap_room: bool
     enable_dsa_cache_layer_split: bool = False
+    # Elastic prefill topology can grow after registration. Decode resolves
+    # per-room ranks through the bootstrap service instead of a stale modulo.
+    dynamic_dp_size: bool = False
 
     # PD true-retraction rebootstrap: the prefill's HTTP API port. The decode
     # already knows the prefill host (the bootstrap_addr host), so it can POST
@@ -178,6 +181,12 @@ class CommonKVManager(BaseKVManager):
         )
         self.system_dp_rank = (
             self.kv_args.system_dp_rank if self.kv_args.system_dp_rank else 0
+        )
+        # Elastic EP needs an exact room-to-rank handshake: cached topology
+        # cannot safely span a scale transition.
+        self.dynamic_dp_size = bool(
+            get_parallel().max_ep_size
+            and get_parallel().max_ep_size > get_parallel().dp_size
         )
         self.pp_size = server_args.pp_size
         self.pp_rank = self.kv_args.pp_rank
@@ -499,10 +508,12 @@ class CommonKVManager(BaseKVManager):
                 f"PD retract rebootstrap /generate request errored for rid={rid}.",
             )
 
-    def try_ensure_parallel_info(self, bootstrap_addr: str) -> bool:
+    def try_ensure_parallel_info(
+        self, bootstrap_addr: str, force_refresh: bool = False
+    ) -> bool:
         """Single non-blocking attempt to fetch and cache prefill parallel info.
         Returns True if info is available (cached or freshly fetched)."""
-        if bootstrap_addr in self.prefill_info_table:
+        if not force_refresh and bootstrap_addr in self.prefill_info_table:
             return True
 
         info: PrefillServerInfo = None
@@ -706,6 +717,7 @@ class CommonKVManager(BaseKVManager):
             "kv_cache_dtype": self.kv_cache_dtype_str,
             "load_balance_method": get_parallel().load_balance_method,
             "enable_dsa_cache_layer_split": get_parallel().enable_dsa_cache_layer_split,
+            "dynamic_dp_size": self.dynamic_dp_size,
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a
             # router-injected pd_rebootstrap_prefill_url.
@@ -1088,7 +1100,10 @@ class CommonKVSender(BaseKVSender):
 
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
         if get_parallel().dp_size > 1 and not req_has_disagg_prefill_dp_rank:
-            if get_parallel().load_balance_method != "follow_bootstrap_room":
+            if (
+                self.kv_mgr.dynamic_dp_size
+                or get_parallel().load_balance_method != "follow_bootstrap_room"
+            ):
                 self._register_prefill_dp_rank()
             elif (
                 self.kv_mgr.attn_dp_rank != self.bootstrap_room % get_parallel().dp_size
@@ -1541,6 +1556,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.kv_cache_dtype: Optional[str] = None
         self.follow_bootstrap_room: Optional[bool] = None
         self.enable_dsa_cache_layer_split: Optional[bool] = None
+        self.dynamic_dp_size = False
         self.prefill_http_port: Optional[int] = None
         self.prefill_port_table: Dict[
             int, Dict[int, Dict[int, Dict[int, PrefillRankInfo]]]
@@ -1576,6 +1592,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.app.router.add_route("*", "/route", self._handle_route)
         self.app.router.add_post("/register_dp_rank", self._handle_register_dp_rank)
         self.app.router.add_post("/query_dp_ranks", self._handle_query_dp_ranks)
+        self.app.router.add_post("/update_dp_size", self._handle_update_dp_size)
         self.app.router.add_get("/health", self._handle_health_check)
 
     async def _handle_health_check(self, request):
@@ -1636,6 +1653,10 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 "load_balance_method", "follow_bootstrap_room"
             )
             self.follow_bootstrap_room = load_balance_method == "follow_bootstrap_room"
+
+        self.dynamic_dp_size = self.dynamic_dp_size or bool(
+            data.get("dynamic_dp_size", False)
+        )
 
         if self.enable_dsa_cache_layer_split is None:
             self.enable_dsa_cache_layer_split = bool(
@@ -1706,6 +1727,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                     else True
                 ),
                 enable_dsa_cache_layer_split=bool(self.enable_dsa_cache_layer_split),
+                dynamic_dp_size=self.dynamic_dp_size,
                 prefill_http_port=self.prefill_http_port,
             )
             return web.json_response(dataclasses.asdict(info), status=200)
@@ -1731,6 +1753,24 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             )
 
         return web.json_response(dataclasses.asdict(bootstrap_info), status=200)
+
+    async def _handle_update_dp_size(self, request: web.Request):
+        data = await request.json()
+        dp_size = int(data["dp_size"])
+        if dp_size < 1:
+            return web.Response(text="dp_size must be positive", status=400)
+
+        async with self.lock:
+            if self.dp_size is not None and dp_size < self.dp_size:
+                return web.Response(
+                    text=f"Cannot shrink bootstrap DP size from {self.dp_size} to {dp_size}",
+                    status=400,
+                )
+            if dp_size > (self.dp_size or 0):
+                self.dp_size = dp_size
+            self.dynamic_dp_size = True
+        logger.info("Updated prefill bootstrap DP size to %d", dp_size)
+        return web.Response(text="OK", status=200)
 
     async def _handle_register_dp_rank(self, request: web.Request):
         data = await request.json()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -184,9 +184,9 @@ class CommonKVManager(BaseKVManager):
         )
         # Elastic EP needs an exact room-to-rank handshake: cached topology
         # cannot safely span a scale transition.
+        self.bootstrap_max_dp_size = parallel.max_ep_size or parallel.dp_size
         self.dynamic_dp_size = bool(
-            get_parallel().max_ep_size
-            and get_parallel().max_ep_size > get_parallel().dp_size
+            parallel.max_ep_size and parallel.max_ep_size > parallel.dp_size
         )
         self.pp_size = server_args.pp_size
         self.pp_rank = self.kv_args.pp_rank
@@ -718,6 +718,7 @@ class CommonKVManager(BaseKVManager):
             "load_balance_method": get_parallel().load_balance_method,
             "enable_dsa_cache_layer_split": get_parallel().enable_dsa_cache_layer_split,
             "dynamic_dp_size": self.dynamic_dp_size,
+            "max_dp_size": self.bootstrap_max_dp_size,
             # Self-register the HTTP API port so the decode can derive the PD
             # retract rebootstrap /generate URL from bootstrap info instead of a
             # router-injected pd_rebootstrap_prefill_url.
@@ -1099,13 +1100,14 @@ class CommonKVSender(BaseKVSender):
             return
 
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
-        if get_parallel().dp_size > 1 and not req_has_disagg_prefill_dp_rank:
-            if (
-                self.kv_mgr.dynamic_dp_size
-                or get_parallel().load_balance_method != "follow_bootstrap_room"
+        if not req_has_disagg_prefill_dp_rank:
+            if self.kv_mgr.dynamic_dp_size:
+                self._register_prefill_dp_rank()
+            elif get_parallel().dp_size > 1 and (
+                get_parallel().load_balance_method != "follow_bootstrap_room"
             ):
                 self._register_prefill_dp_rank()
-            elif (
+            elif get_parallel().dp_size > 1 and (
                 self.kv_mgr.attn_dp_rank != self.bootstrap_room % get_parallel().dp_size
             ):
                 # follow_bootstrap_room was overridden by external routed_dp_rank
@@ -1552,6 +1554,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.attn_tp_size = None
         self.attn_cp_size = None
         self.dp_size = None
+        self.max_dp_size: Optional[int] = None
         self.page_size = None
         self.kv_cache_dtype: Optional[str] = None
         self.follow_bootstrap_room: Optional[bool] = None
@@ -1625,6 +1628,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         rank_port = int(data["rank_port"])
         page_size = int(data["page_size"])
         kv_cache_dtype = data["kv_cache_dtype"]
+        max_dp_size = data.get("max_dp_size")
         prefill_http_port = data.get("prefill_http_port")
 
         if self.attn_tp_size is None:
@@ -1635,6 +1639,9 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
 
         if self.dp_size is None:
             self.dp_size = attn_dp_size if system_dp_size == 1 else system_dp_size
+
+        if self.max_dp_size is None and max_dp_size is not None:
+            self.max_dp_size = int(max_dp_size)
 
         if self.pp_size is None:
             self.pp_size = pp_size
@@ -1761,6 +1768,18 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
             return web.Response(text="dp_size must be positive", status=400)
 
         async with self.lock:
+            if self.max_dp_size is None:
+                return web.Response(
+                    text="Bootstrap maximum DP size is not registered", status=400
+                )
+            if dp_size > self.max_dp_size:
+                return web.Response(
+                    text=(
+                        f"Cannot grow bootstrap DP size beyond configured maximum "
+                        f"{self.max_dp_size}"
+                    ),
+                    status=400,
+                )
             if self.dp_size is not None and dp_size < self.dp_size:
                 return web.Response(
                     text=f"Cannot shrink bootstrap DP size from {self.dp_size} to {dp_size}",

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -579,6 +579,11 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if req.disagg_prefill_dp_rank is not None:
             return req.disagg_prefill_dp_rank
 
+        if prefill_info.dynamic_dp_size:
+            # Elastic EP records the actual prefill rank for this room. Do not
+            # derive it from cached topology across a scale transition.
+            return None
+
         if prefill_info.dp_size == 1:
             return 0
 

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -409,6 +409,13 @@ class DataParallelController:
         if refresh_load_budget and self.refresh_load_budget_on_dispatch:
             self.refresh_load_budget()
 
+        self._retry_pending_bootstrap_topology_update()
+        if self._pending_elastic_scale_update is not None:
+            self._reject_bootstrap_request(
+                req, "Elastic prefill topology update is still in progress."
+            )
+            return
+
         time_stats = DPControllerReqTimeStats.new_from_obj(
             unwrap_from_pickle(req.time_stats)
         )
@@ -861,13 +868,6 @@ class DataParallelController:
         if self.maybe_external_dp_rank_routing(req):
             return
 
-        self._retry_pending_bootstrap_topology_update()
-        if self._pending_elastic_scale_update is not None:
-            self._reject_bootstrap_request(
-                req, "Elastic prefill topology update is still in progress."
-            )
-            return
-
         assert req.bootstrap_room is not None, (
             "req.bootstrap_room should not be None. Do not send requests directly to "
             "prefill or decode instances; send to the router instead."
@@ -909,6 +909,9 @@ class DataParallelController:
                 except zmq.ZMQError:
                     break
                 self._request_dispatcher(recv_req)
+            # Elastic EP requires round_robin scheduling, so topology retries
+            # must progress independently of follow_bootstrap_room requests.
+            self._retry_pending_bootstrap_topology_update()
 
 
 def run_data_parallel_controller_process(

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -19,9 +19,10 @@ import multiprocessing as mp
 import signal
 import threading
 import time
+from collections import deque
 from enum import Enum, auto
 from http import HTTPStatus
-from typing import Callable, List, Optional
+from typing import Callable, Deque, List, Optional
 
 import psutil
 import requests
@@ -178,7 +179,10 @@ class DataParallelController:
         # follow_bootstrap_room preserves its cross-process rank mapping.
         self.bootstrap_room_dp_size: int = self.launch_dp_size
         self._pending_elastic_scale_update: Optional[ElasticScaleUpdateReq] = None
-        self._last_bootstrap_topology_retry = 0.0
+        self._pending_elastic_scale_updates: Deque[ElasticScaleUpdateReq] = deque()
+        self._published_elastic_scale_update: Optional[ElasticScaleUpdateReq] = None
+        self._bootstrap_topology_update_lock = threading.Lock()
+        self._bootstrap_topology_update_in_progress = False
         self.max_dp_size: int = server_args.max_ep_size or server_args.dp_size
         assert self.max_dp_size >= self.launch_dp_size, (
             f"--max-ep-size ({self.max_dp_size}) must be >= "
@@ -313,18 +317,26 @@ class DataParallelController:
                 f"max_dp_size ({self.max_dp_size})."
             )
 
-        if not self._update_bootstrap_dp_size(msg.effective_ep_size):
-            # Do not expose a larger routing domain until decode can observe it.
-            self._pending_elastic_scale_update = msg
-            self._last_bootstrap_topology_retry = time.monotonic()
+        if self.server_args.disaggregation_mode != "prefill":
+            self._complete_elastic_scale_update(msg)
             return
 
-        self._complete_elastic_scale_update(msg)
+        with self._bootstrap_topology_update_lock:
+            self._pending_elastic_scale_updates.append(msg)
+            self._pending_elastic_scale_update = (
+                self._pending_elastic_scale_updates[0]
+            )
+            if self._bootstrap_topology_update_in_progress:
+                return
+            self._bootstrap_topology_update_in_progress = True
+
+        threading.Thread(
+            target=self._publish_bootstrap_topology_update, daemon=True
+        ).start()
 
     def _complete_elastic_scale_update(self, msg: ElasticScaleUpdateReq) -> None:
         self.add_elastic_workers(msg.slot_offset, msg.slot_count)
         self.bootstrap_room_dp_size = msg.effective_ep_size
-        self._pending_elastic_scale_update = None
 
     def _update_bootstrap_dp_size(self, dp_size: int) -> bool:
         if self.server_args.disaggregation_mode != "prefill":
@@ -358,14 +370,54 @@ class DataParallelController:
                     time.sleep(0.1 * (2**attempt))
         return False
 
-    def _retry_pending_bootstrap_topology_update(self) -> None:
-        pending = self._pending_elastic_scale_update
-        if pending is None or time.monotonic() - self._last_bootstrap_topology_retry < 1:
-            return
+    def _publish_bootstrap_topology_update(self) -> None:
+        while True:
+            with self._bootstrap_topology_update_lock:
+                if not self._pending_elastic_scale_updates:
+                    self._pending_elastic_scale_update = None
+                    self._bootstrap_topology_update_in_progress = False
+                    return
+                pending = self._pending_elastic_scale_updates[0]
 
-        self._last_bootstrap_topology_retry = time.monotonic()
-        if self._update_bootstrap_dp_size(pending.effective_ep_size):
-            self._complete_elastic_scale_update(pending)
+            try:
+                if self._update_bootstrap_dp_size(pending.effective_ep_size):
+                    with self._bootstrap_topology_update_lock:
+                        if self._pending_elastic_scale_updates[0] is pending:
+                            self._published_elastic_scale_update = pending
+                    return
+            except Exception:
+                logger.exception("[Elastic EP] Bootstrap topology update failed")
+
+            # The current routing domain is still valid. Retry its
+            # publication without blocking controller request dispatch.
+            time.sleep(1)
+
+    def _apply_published_bootstrap_topology_update(self) -> None:
+        """Apply a published topology on the controller event-loop thread."""
+        start_next_update = False
+        with self._bootstrap_topology_update_lock:
+            published = self._published_elastic_scale_update
+            if published is None:
+                return
+
+            assert self._pending_elastic_scale_updates[0] is published
+            self._complete_elastic_scale_update(published)
+            self._pending_elastic_scale_updates.popleft()
+            self._pending_elastic_scale_update = (
+                self._pending_elastic_scale_updates[0]
+                if self._pending_elastic_scale_updates
+                else None
+            )
+            self._published_elastic_scale_update = None
+            if self._pending_elastic_scale_updates:
+                start_next_update = True
+            else:
+                self._bootstrap_topology_update_in_progress = False
+
+        if start_next_update:
+            threading.Thread(
+                target=self._publish_bootstrap_topology_update, daemon=True
+            ).start()
 
     def _reject_bootstrap_request(self, req: Req, message: str) -> None:
         logger.warning("Rejecting request %s: %s", req.rid, message)
@@ -408,13 +460,6 @@ class DataParallelController:
     def dispatching_with_trace(self, req: Req, refresh_load_budget: bool = True):
         if refresh_load_budget and self.refresh_load_budget_on_dispatch:
             self.refresh_load_budget()
-
-        self._retry_pending_bootstrap_topology_update()
-        if self._pending_elastic_scale_update is not None:
-            self._reject_bootstrap_request(
-                req, "Elastic prefill topology update is still in progress."
-            )
-            return
 
         time_stats = DPControllerReqTimeStats.new_from_obj(
             unwrap_from_pickle(req.time_stats)
@@ -837,6 +882,13 @@ class DataParallelController:
                 or rank not in self._active_workers
                 or self.workers[rank] is None
             ):
+                if self._pending_elastic_scale_update is not None:
+                    self._reject_bootstrap_request(
+                        req,
+                        "Elastic prefill topology update is still in progress; "
+                        f"DP rank {rank} is not active.",
+                    )
+                    return True
                 raise ValueError(f"DP rank {rank} is not active.")
             logger.debug(f"Direct routing to DP rank {rank}")
             sock_send(self.workers[rank], req)
@@ -903,15 +955,13 @@ class DataParallelController:
     def event_loop(self):
         while True:
             while True:
+                self._apply_published_bootstrap_topology_update()
                 self.soft_watchdog.feed()
                 try:
                     recv_req = sock_recv(self.recv_from_tokenizer, flags=zmq.NOBLOCK)
                 except zmq.ZMQError:
                     break
                 self._request_dispatcher(recv_req)
-            # Elastic EP requires round_robin scheduling, so topology retries
-            # must progress independently of follow_bootstrap_room requests.
-            self._retry_pending_bootstrap_topology_update()
 
 
 def run_data_parallel_controller_process(

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -20,15 +20,18 @@ import signal
 import threading
 import time
 from enum import Enum, auto
+from http import HTTPStatus
 from typing import Callable, List, Optional
 
 import psutil
+import requests
 import setproctitle
 import zmq
 
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.managers.io_struct import (
+    AbortReq,
     ActiveRanksOutput,
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
@@ -152,6 +155,9 @@ class DataParallelController:
             self.recv_from_tokenizer = get_zmq_socket(
                 self.context, zmq.PULL, port_args.scheduler_input_ipc_name, False
             )
+            self.send_to_tokenizer = get_zmq_socket(
+                self.context, zmq.PUSH, port_args.tokenizer_ipc_name, False
+            )
 
         # Dispatch method
         self.round_robin_counter = 0
@@ -168,6 +174,11 @@ class DataParallelController:
         )
 
         self.launch_dp_size: int = server_args.dp_size
+        # Keep this aligned with the scheduler's effective DP size so
+        # follow_bootstrap_room preserves its cross-process rank mapping.
+        self.bootstrap_room_dp_size: int = self.launch_dp_size
+        self._pending_elastic_scale_update: Optional[ElasticScaleUpdateReq] = None
+        self._last_bootstrap_topology_retry = 0.0
         self.max_dp_size: int = server_args.max_ep_size or server_args.dp_size
         assert self.max_dp_size >= self.launch_dp_size, (
             f"--max-ep-size ({self.max_dp_size}) must be >= "
@@ -292,6 +303,85 @@ class DataParallelController:
             self.max_dp_size,
         )
 
+    def handle_elastic_scale_update(self, msg: ElasticScaleUpdateReq):
+        if not msg.success:
+            return
+
+        if msg.effective_ep_size > self.max_dp_size:
+            raise ValueError(
+                f"[Elastic EP] effective_ep_size ({msg.effective_ep_size}) exceeds "
+                f"max_dp_size ({self.max_dp_size})."
+            )
+
+        if not self._update_bootstrap_dp_size(msg.effective_ep_size):
+            # Do not expose a larger routing domain until decode can observe it.
+            self._pending_elastic_scale_update = msg
+            self._last_bootstrap_topology_retry = time.monotonic()
+            return
+
+        self._complete_elastic_scale_update(msg)
+
+    def _complete_elastic_scale_update(self, msg: ElasticScaleUpdateReq) -> None:
+        self.add_elastic_workers(msg.slot_offset, msg.slot_count)
+        self.bootstrap_room_dp_size = msg.effective_ep_size
+        self._pending_elastic_scale_update = None
+
+    def _update_bootstrap_dp_size(self, dp_size: int) -> bool:
+        if self.server_args.disaggregation_mode != "prefill":
+            return True
+
+        if self.server_args.dist_init_addr:
+            host = NetworkAddress.parse(self.server_args.dist_init_addr).resolved().host
+        else:
+            host = {"0.0.0.0": "127.0.0.1", "::": "::1"}.get(
+                self.server_args.host, self.server_args.host
+            )
+        url = NetworkAddress(
+            host, self.server_args.disaggregation_bootstrap_port
+        ).to_url()
+        for attempt in range(3):
+            try:
+                response = requests.post(
+                    f"{url}/update_dp_size", json={"dp_size": dp_size}, timeout=5
+                )
+                response.raise_for_status()
+                return True
+            except requests.RequestException as exc:
+                logger.warning(
+                    "[Elastic EP] Failed to update bootstrap DP size to %d "
+                    "(attempt %d/3): %s",
+                    dp_size,
+                    attempt + 1,
+                    exc,
+                )
+                if attempt < 2:
+                    time.sleep(0.1 * (2**attempt))
+        return False
+
+    def _retry_pending_bootstrap_topology_update(self) -> None:
+        pending = self._pending_elastic_scale_update
+        if pending is None or time.monotonic() - self._last_bootstrap_topology_retry < 1:
+            return
+
+        self._last_bootstrap_topology_retry = time.monotonic()
+        if self._update_bootstrap_dp_size(pending.effective_ep_size):
+            self._complete_elastic_scale_update(pending)
+
+    def _reject_bootstrap_request(self, req: Req, message: str) -> None:
+        logger.warning("Rejecting request %s: %s", req.rid, message)
+        sock_send(
+            self.send_to_tokenizer,
+            AbortReq(
+                rid=req.rid,
+                http_worker_ipc=req.http_worker_ipc,
+                finished_reason={
+                    "type": "abort",
+                    "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
+                    "message": message,
+                },
+            ),
+        )
+
     def _refresh_active_workers(self) -> None:
         self._active_workers = [
             i for i, active in enumerate(self.dp_active) if active and self.status[i]
@@ -351,12 +441,7 @@ class DataParallelController:
                 (BlockReqInput, self.send_to_all_workers),
                 (ProfileReq, self.send_to_all_workers),
                 (ActiveRanksOutput, self.update_active_ranks),
-                (
-                    ElasticScaleUpdateReq,
-                    lambda msg: self.add_elastic_workers(
-                        msg.slot_offset, msg.slot_count
-                    ),
-                ),
+                (ElasticScaleUpdateReq, self.handle_elastic_scale_update),
             ]
         )
         self._request_dispatcher.add_fallback_fn(self.send_control_message)
@@ -776,11 +861,28 @@ class DataParallelController:
         if self.maybe_external_dp_rank_routing(req):
             return
 
+        self._retry_pending_bootstrap_topology_update()
+        if self._pending_elastic_scale_update is not None:
+            self._reject_bootstrap_request(
+                req, "Elastic prefill topology update is still in progress."
+            )
+            return
+
         assert req.bootstrap_room is not None, (
             "req.bootstrap_room should not be None. Do not send requests directly to "
             "prefill or decode instances; send to the router instead."
         )
-        target_rank = req.bootstrap_room % len(self.workers)
+        # The bootstrap server and decode side both derive this rank from the
+        # effective DP size. Do not compact active ranks here: doing so would
+        # remap a room after an elastic-EP fault and make its KV transfer fail.
+        target_rank = req.bootstrap_room % self.bootstrap_room_dp_size
+        if target_rank not in self._active_workers:
+            message = (
+                f"DP rank {target_rank} for bootstrap room {req.bootstrap_room} "
+                "is not active."
+            )
+            self._reject_bootstrap_request(req, message)
+            return
         sock_send(self.workers[target_rank], req)
 
     def total_requests_scheduler(self, req: Req):

--- a/rust/sglang-server/src/api_server/pd_bootstrap.rs
+++ b/rust/sglang-server/src/api_server/pd_bootstrap.rs
@@ -52,6 +52,7 @@ struct PrefillServerInfo {
     kv_cache_dtype: Option<String>,
     follow_bootstrap_room: bool,
     enable_dsa_cache_layer_split: bool,
+    dynamic_dp_size: bool,
     prefill_http_port: Option<i64>,
 }
 
@@ -69,11 +70,13 @@ struct Registry {
     attn_tp_size: Option<i64>,
     attn_cp_size: Option<i64>,
     dp_size: Option<i64>,
+    max_dp_size: Option<i64>,
     pp_size: Option<i64>,
     page_size: Option<i64>,
     kv_cache_dtype: Option<String>,
     follow_bootstrap_room: Option<bool>,
     enable_dsa_cache_layer_split: Option<bool>,
+    dynamic_dp_size: bool,
     prefill_http_port: Option<i64>,
     /// Keyed `(dp_group, attn_cp_rank, attn_tp_rank, pp_rank)` — the flat form
     /// of Python's nested `prefill_port_table` dicts.
@@ -151,6 +154,10 @@ struct RoutePut {
     load_balance_method: Option<String>,
     #[serde(default)]
     enable_dsa_cache_layer_split: Option<bool>,
+    #[serde(default)]
+    dynamic_dp_size: bool,
+    #[serde(default)]
+    max_dp_size: Option<Int>,
 }
 
 fn not_ready(registered_count: i64) -> Response {
@@ -178,6 +185,9 @@ async fn route_put(State(state): State<Shared>, Json(body): Json<RoutePut>) -> R
     reg.attn_tp_size.get_or_insert(body.attn_tp_size);
     reg.attn_cp_size.get_or_insert(body.attn_cp_size);
     reg.dp_size.get_or_insert(dp_size);
+    if reg.max_dp_size.is_none() {
+        reg.max_dp_size = body.max_dp_size.map(|size| size.0);
+    }
     reg.pp_size.get_or_insert(body.pp_size);
     reg.page_size.get_or_insert(body.page_size.0);
     if reg.kv_cache_dtype.is_none() {
@@ -194,6 +204,7 @@ async fn route_put(State(state): State<Shared>, Json(body): Json<RoutePut>) -> R
     );
     reg.enable_dsa_cache_layer_split
         .get_or_insert(body.enable_dsa_cache_layer_split.unwrap_or(false));
+    reg.dynamic_dp_size |= body.dynamic_dp_size;
 
     reg.prefill_ranks.insert(
         (dp_group, body.attn_cp_rank, body.attn_tp_rank, body.pp_rank),
@@ -255,6 +266,7 @@ async fn route_get(
             kv_cache_dtype: reg.kv_cache_dtype.clone(),
             follow_bootstrap_room: reg.follow_bootstrap_room.unwrap_or(true),
             enable_dsa_cache_layer_split: reg.enable_dsa_cache_layer_split.unwrap_or(false),
+            dynamic_dp_size: reg.dynamic_dp_size,
             prefill_http_port: reg.prefill_http_port,
         })
         .into_response();
@@ -313,6 +325,53 @@ async fn query_dp_ranks(State(state): State<Shared>, Json(body): Json<QueryDpRan
     Json(result).into_response()
 }
 
+#[derive(serde::Deserialize)]
+struct UpdateDpSize {
+    dp_size: Int,
+}
+
+/// Update the active DP topology after elastic EP scale-up. This is the
+/// Python bootstrap server's `/update_dp_size` contract: only growth is
+/// allowed, and a successful update makes the topology dynamic so decode uses
+/// the per-room rank registration handshake.
+async fn update_dp_size(State(state): State<Shared>, Json(body): Json<UpdateDpSize>) -> Response {
+    let dp_size = body.dp_size.0;
+    if dp_size < 1 {
+        return (StatusCode::BAD_REQUEST, "dp_size must be positive").into_response();
+    }
+
+    let mut reg = state.lock().unwrap();
+    let Some(max_dp_size) = reg.max_dp_size else {
+        return (
+            StatusCode::BAD_REQUEST,
+            "Bootstrap maximum DP size is not registered",
+        )
+            .into_response();
+    };
+    if dp_size > max_dp_size {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!("Cannot grow bootstrap DP size beyond configured maximum {max_dp_size}"),
+        )
+            .into_response();
+    }
+    if reg.dp_size.is_some_and(|current| dp_size < current) {
+        return (
+            StatusCode::BAD_REQUEST,
+            format!(
+                "Cannot shrink bootstrap DP size from {} to {dp_size}",
+                reg.dp_size.unwrap(),
+            ),
+        )
+            .into_response();
+    }
+    if dp_size > reg.dp_size.unwrap_or(0) {
+        reg.dp_size = Some(dp_size);
+    }
+    reg.dynamic_dp_size = true;
+    "OK".into_response()
+}
+
 /// No `/health` here: the merged api router already serves it (same 200 "OK"
 /// the standalone Python bootstrap server answered, so probes are unchanged).
 fn router(state: Shared) -> Router {
@@ -322,6 +381,7 @@ fn router(state: Shared) -> Router {
         .route("/route", put(route_put).get(route_get))
         .route("/register_dp_rank", post(register_dp_rank))
         .route("/query_dp_ranks", post(query_dp_ranks))
+        .route("/update_dp_size", post(update_dp_size))
         .with_state(state)
 }
 
@@ -402,6 +462,7 @@ mod tests {
             "page_size": 64, "kv_cache_dtype": "auto",
             "load_balance_method": "follow_bootstrap_room",
             "enable_dsa_cache_layer_split": false,
+            "max_dp_size": 1,
             "prefill_http_port": 30000,
         });
         body.as_object_mut()
@@ -490,6 +551,7 @@ mod tests {
                 "page_size": 64, "kv_cache_dtype": "auto",
                 "follow_bootstrap_room": true,
                 "enable_dsa_cache_layer_split": false,
+                "dynamic_dp_size": false,
                 "prefill_http_port": 30000,
             })
         );
@@ -585,6 +647,64 @@ mod tests {
         assert_eq!(status, 200);
         let result: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(result, serde_json::json!({"42": 3}));
+    }
+
+    /// The Python DPC publishes a successful elastic scale through this
+    /// endpoint before routing into the expanded worker domain. Pin the Rust
+    /// implementation to the same growth-only and aggregate-topology contract.
+    #[test]
+    fn elastic_dp_size_update_matches_python_bootstrap() {
+        let (_rt, addr) = start_on_free_port();
+        let (status, _) = request(
+            addr,
+            "PUT",
+            "/route",
+            Some(&put_route(
+                serde_json::json!({"attn_dp_size": 2, "max_dp_size": 2}),
+            )),
+        );
+        assert_eq!(status, 200);
+
+        let (status, text) = request(
+            addr,
+            "POST",
+            "/update_dp_size",
+            Some(&serde_json::json!({"dp_size": 2})),
+        );
+        assert_eq!((status, text.as_str()), (200, "OK"));
+
+        // A duplicate registration satisfies the same count-based readiness
+        // check as the Python bootstrap registry.
+        let (status, _) = request(
+            addr,
+            "PUT",
+            "/route",
+            Some(&put_route(
+                serde_json::json!({"attn_dp_size": 2, "max_dp_size": 2}),
+            )),
+        );
+        assert_eq!(status, 200);
+        let (status, body) = request(addr, "GET", SENTINEL, None);
+        assert_eq!(status, 200);
+        let info: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(info["dp_size"], 2);
+        assert_eq!(info["dynamic_dp_size"], true);
+
+        let (status, _) = request(
+            addr,
+            "POST",
+            "/update_dp_size",
+            Some(&serde_json::json!({"dp_size": 1})),
+        );
+        assert_eq!(status, 400);
+
+        let (status, _) = request(
+            addr,
+            "POST",
+            "/update_dp_size",
+            Some(&serde_json::json!({"dp_size": 3})),
+        );
+        assert_eq!(status, 400);
     }
 
     /// The registry mounts only on prefill (`enable_pd_bootstrap()`): a

--- a/test/registered/unit/disaggregation/test_elastic_prefill_topology.py
+++ b/test/registered/unit/disaggregation/test_elastic_prefill_topology.py
@@ -24,6 +24,7 @@ class TestElasticPrefillTopology(CustomTestCase):
     def test_bootstrap_server_updates_the_advertised_dp_size(self):
         server = CommonKVBootstrapServer.__new__(CommonKVBootstrapServer)
         server.dp_size = 2
+        server.max_dp_size = 4
         server.dynamic_dp_size = False
         server.lock = asyncio.Lock()
         request = MagicMock()
@@ -34,6 +35,10 @@ class TestElasticPrefillTopology(CustomTestCase):
         self.assertEqual(response.status, 200)
         self.assertEqual(server.dp_size, 4)
         self.assertTrue(server.dynamic_dp_size)
+
+        request.json = AsyncMock(return_value={"dp_size": 5})
+        response = asyncio.run(server._handle_update_dp_size(request))
+        self.assertEqual(response.status, 400)
 
     def test_dynamic_prefill_info_never_uses_cached_modulo_routing(self):
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
@@ -62,32 +67,36 @@ class TestElasticPrefillTopology(CustomTestCase):
         self.assertIsNone(queue._resolve_prefill_dp_rank(req))
 
     def test_dynamic_prefill_sender_registers_its_exact_rank(self):
-        manager = SimpleNamespace(
-            is_dummy_cp_rank=False,
-            dynamic_dp_size=True,
-            attn_dp_rank=2,
-            update_status=MagicMock(),
-        )
-        parallel = SimpleNamespace(
-            dp_size=4, load_balance_method="follow_bootstrap_room"
-        )
+        for dp_size, dp_rank in ((1, 0), (4, 2)):
+            with self.subTest(dp_size=dp_size):
+                manager = SimpleNamespace(
+                    is_dummy_cp_rank=False,
+                    dynamic_dp_size=True,
+                    attn_dp_rank=dp_rank,
+                    update_status=MagicMock(),
+                )
+                parallel = SimpleNamespace(
+                    dp_size=dp_size, load_balance_method="follow_bootstrap_room"
+                )
 
-        with (
-            patch(
-                "sglang.srt.disaggregation.common.conn.get_parallel",
-                return_value=parallel,
-            ),
-            patch.object(CommonKVSender, "_register_prefill_dp_rank") as register,
-        ):
-            CommonKVSender(
-                manager,
-                bootstrap_addr="127.0.0.1:8998",
-                bootstrap_room=1,
-                dest_tp_ranks=[],
-                pp_rank=0,
-            )
+                with (
+                    patch(
+                        "sglang.srt.disaggregation.common.conn.get_parallel",
+                        return_value=parallel,
+                    ),
+                    patch.object(
+                        CommonKVSender, "_register_prefill_dp_rank"
+                    ) as register,
+                ):
+                    CommonKVSender(
+                        manager,
+                        bootstrap_addr="127.0.0.1:8998",
+                        bootstrap_room=1,
+                        dest_tp_ranks=[],
+                        pp_rank=0,
+                    )
 
-        register.assert_called_once()
+                register.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_elastic_prefill_topology.py
+++ b/test/registered/unit/disaggregation/test_elastic_prefill_topology.py
@@ -1,0 +1,94 @@
+"""Regression tests for elastic prefill topology metadata."""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVBootstrapServer,
+    CommonKVSender,
+    PrefillServerInfo,
+)
+from sglang.srt.disaggregation.decode import DecodePreallocQueue
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestElasticPrefillTopology(CustomTestCase):
+    def test_bootstrap_server_updates_the_advertised_dp_size(self):
+        server = CommonKVBootstrapServer.__new__(CommonKVBootstrapServer)
+        server.dp_size = 2
+        server.dynamic_dp_size = False
+        server.lock = asyncio.Lock()
+        request = MagicMock()
+        request.json = AsyncMock(return_value={"dp_size": 4})
+
+        response = asyncio.run(server._handle_update_dp_size(request))
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(server.dp_size, 4)
+        self.assertTrue(server.dynamic_dp_size)
+
+    def test_dynamic_prefill_info_never_uses_cached_modulo_routing(self):
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        bootstrap_addr = "127.0.0.1:8998"
+        queue.kv_manager = SimpleNamespace(
+            prefill_info_table={
+                bootstrap_addr: PrefillServerInfo(
+                    attn_tp_size=1,
+                    attn_cp_size=1,
+                    dp_size=4,
+                    pp_size=1,
+                    page_size=None,
+                    kv_cache_dtype=None,
+                    follow_bootstrap_room=True,
+                    dynamic_dp_size=True,
+                )
+            }
+        )
+        req = SimpleNamespace(
+            bootstrap_host="127.0.0.1",
+            bootstrap_port=8998,
+            bootstrap_room=2,
+            disagg_prefill_dp_rank=None,
+        )
+
+        self.assertIsNone(queue._resolve_prefill_dp_rank(req))
+
+    def test_dynamic_prefill_sender_registers_its_exact_rank(self):
+        manager = SimpleNamespace(
+            is_dummy_cp_rank=False,
+            dynamic_dp_size=True,
+            attn_dp_rank=2,
+            update_status=MagicMock(),
+        )
+        parallel = SimpleNamespace(
+            dp_size=4, load_balance_method="follow_bootstrap_room"
+        )
+
+        with (
+            patch(
+                "sglang.srt.disaggregation.common.conn.get_parallel",
+                return_value=parallel,
+            ),
+            patch.object(CommonKVSender, "_register_prefill_dp_rank") as register,
+        ):
+            CommonKVSender(
+                manager,
+                bootstrap_addr="127.0.0.1:8998",
+                bootstrap_room=1,
+                dest_tp_ranks=[],
+                pp_rank=0,
+            )
+
+        register.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -275,6 +275,7 @@ class TestRegisterToBootstrap(CustomTestCase):
         mgr.system_dp_rank = 0
         mgr.local_ip = "127.0.0.1"
         mgr.rank_port = 12345
+        mgr.dynamic_dp_size = False
 
         mgr.kv_args = MagicMock()
         mgr.kv_args.page_size = 16

--- a/test/registered/unit/disaggregation/test_register_to_bootstrap.py
+++ b/test/registered/unit/disaggregation/test_register_to_bootstrap.py
@@ -276,6 +276,7 @@ class TestRegisterToBootstrap(CustomTestCase):
         mgr.local_ip = "127.0.0.1"
         mgr.rank_port = 12345
         mgr.dynamic_dp_size = False
+        mgr.bootstrap_max_dp_size = 1
 
         mgr.kv_args = MagicMock()
         mgr.kv_args.page_size = 16

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -11,15 +11,15 @@ if a scheduler starts reading another attr. `maybe_external_dp_rank_routing`
 is exercised as the real method, no mock.
 """
 
-import time
+import threading
 import unittest
+from collections import deque
 from http import HTTPStatus
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import msgspec.structs
 import requests
-import zmq
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
@@ -64,7 +64,10 @@ def _make_controller(
     ctl.dp_active = [True] * launch_dp_size + [False] * (dp_size - launch_dp_size)
     ctl.server_args = SimpleNamespace(disaggregation_mode="null")
     ctl._pending_elastic_scale_update = None
-    ctl._last_bootstrap_topology_retry = 0.0
+    ctl._pending_elastic_scale_updates = deque()
+    ctl._published_elastic_scale_update = None
+    ctl._bootstrap_topology_update_lock = threading.Lock()
+    ctl._bootstrap_topology_update_in_progress = False
     ctl.round_robin_counter = 0
     ctl.dp_budget = DPBudget(dp_size=dp_size)
     return ctl
@@ -317,10 +320,19 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
         )
         response = MagicMock()
 
-        with patch(
-            "sglang.srt.managers.data_parallel_controller.requests.post",
-            return_value=response,
-        ) as post:
+        def run_now(*, target, daemon):
+            return SimpleNamespace(start=target)
+
+        with (
+            patch(
+                "sglang.srt.managers.data_parallel_controller.requests.post",
+                return_value=response,
+            ) as post,
+            patch(
+                "sglang.srt.managers.data_parallel_controller.threading.Thread",
+                side_effect=run_now,
+            ),
+        ):
             ctl.handle_elastic_scale_update(
                 ElasticScaleUpdateReq(
                     success=True,
@@ -337,7 +349,7 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
         )
         response.raise_for_status.assert_called_once()
 
-    def test_scale_update_withholds_new_ranks_when_bootstrap_update_fails(self):
+    def test_scale_update_retries_bootstrap_update_in_background(self):
         ctl = _make_controller(dp_size=4, launch_dp_size=2)
         ctl.status[2:] = [False, False]
         ctl._active_workers = [0, 1]
@@ -354,21 +366,131 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
             slot_count=2,
         )
 
-        with (
-            patch(
-                "sglang.srt.managers.data_parallel_controller.requests.post",
-                side_effect=requests.RequestException("bootstrap unavailable"),
-            ) as post,
-            patch("sglang.srt.managers.data_parallel_controller.time.sleep"),
-        ):
+        with patch(
+            "sglang.srt.managers.data_parallel_controller.threading.Thread"
+        ) as thread:
             ctl.handle_elastic_scale_update(update)
 
-        self.assertEqual(post.call_count, 3)
         self.assertIs(ctl._pending_elastic_scale_update, update)
-        self.assertEqual(ctl.bootstrap_room_dp_size, 2)
-        self.assertEqual(ctl._active_workers, [0, 1])
+        self.assertTrue(ctl._bootstrap_topology_update_in_progress)
+        thread.assert_called_once()
 
-    def test_event_loop_retries_pending_bootstrap_topology_updates(self):
+    def test_background_bootstrap_retry_activates_new_ranks(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+        update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+        ctl._pending_elastic_scale_updates.append(update)
+        ctl._pending_elastic_scale_update = update
+        ctl._bootstrap_topology_update_in_progress = True
+
+        with (
+            patch.object(ctl, "_update_bootstrap_dp_size", side_effect=[False, True]),
+            patch("sglang.srt.managers.data_parallel_controller.time.sleep"),
+        ):
+            ctl._publish_bootstrap_topology_update()
+
+        self.assertIs(ctl._published_elastic_scale_update, update)
+        self.assertEqual(ctl.bootstrap_room_dp_size, 2)
+        ctl._apply_published_bootstrap_topology_update()
+        self.assertIsNone(ctl._pending_elastic_scale_update)
+        self.assertFalse(ctl._pending_elastic_scale_updates)
+        self.assertEqual(ctl.bootstrap_room_dp_size, 4)
+        self.assertEqual(ctl._active_workers, [0, 1, 2, 3])
+
+    def test_background_bootstrap_publisher_applies_incremental_updates_in_order(self):
+        ctl = _make_controller(dp_size=6, launch_dp_size=2)
+        ctl.status[2:] = [False, False, False, False]
+        ctl._active_workers = [0, 1]
+        first = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+        second = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=6,
+            slot_offset=4,
+            slot_count=2,
+        )
+        ctl._pending_elastic_scale_updates.extend((first, second))
+        ctl._pending_elastic_scale_update = first
+        ctl._bootstrap_topology_update_in_progress = True
+
+        with (
+            patch.object(ctl, "_update_bootstrap_dp_size", return_value=True) as update,
+            patch("sglang.srt.managers.data_parallel_controller.threading.Thread"),
+        ):
+            ctl._publish_bootstrap_topology_update()
+            ctl._apply_published_bootstrap_topology_update()
+            ctl._publish_bootstrap_topology_update()
+            ctl._apply_published_bootstrap_topology_update()
+
+        self.assertEqual(update.call_args_list, [call(4), call(6)])
+        self.assertIsNone(ctl._pending_elastic_scale_update)
+        self.assertEqual(ctl.bootstrap_room_dp_size, 6)
+        self.assertEqual(ctl._active_workers, [0, 1, 2, 3, 4, 5])
+
+    def test_background_publisher_does_not_mutate_active_ranks(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+        update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+        ctl._pending_elastic_scale_updates.append(update)
+        ctl._pending_elastic_scale_update = update
+        ctl._bootstrap_topology_update_in_progress = True
+
+        with patch.object(ctl, "_update_bootstrap_dp_size", return_value=True):
+            ctl._publish_bootstrap_topology_update()
+
+        self.assertEqual(ctl._active_workers, [0, 1])
+        self.assertEqual(ctl.bootstrap_room_dp_size, 2)
+        ctl._apply_published_bootstrap_topology_update()
+        self.assertEqual(ctl._active_workers, [0, 1, 2, 3])
+        self.assertEqual(ctl.bootstrap_room_dp_size, 4)
+
+    def test_pending_topology_update_rejects_inactive_direct_rank(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl._active_workers = [0, 1]
+        ctl._pending_elastic_scale_update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+        req = _req(routed_dp_rank=2)
+
+        ctl.round_robin_scheduler(req)
+
+        ctl.send_to_tokenizer.send_pyobj.assert_called_once()
+
+    def test_pending_topology_update_keeps_old_domain_routable(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl._active_workers = [0, 1]
+        ctl._pending_elastic_scale_update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+
+        ctl.round_robin_scheduler(_req())
+
+        ctl.workers[0].send_pyobj.assert_called_once()
+        ctl.send_to_tokenizer.send_pyobj.assert_not_called()
+
+    def test_event_loop_does_not_retry_bootstrap_topology_updates(self):
         ctl = _make_controller(dp_size=2)
         ctl.soft_watchdog = MagicMock()
         ctl.recv_from_tokenizer = MagicMock()
@@ -376,37 +498,17 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
         with (
             patch(
                 "sglang.srt.managers.data_parallel_controller.sock_recv",
-                side_effect=zmq.ZMQError(),
+                side_effect=KeyboardInterrupt,
             ),
             patch.object(
                 ctl,
-                "_retry_pending_bootstrap_topology_update",
-                side_effect=KeyboardInterrupt,
-            ) as retry,
+                "_publish_bootstrap_topology_update",
+            ) as publish,
         ):
             with self.assertRaises(KeyboardInterrupt):
                 ctl.event_loop()
 
-        retry.assert_called_once()
-
-    def test_pending_topology_update_rejects_direct_rank_routing(self):
-        ctl = _make_controller(dp_size=4, launch_dp_size=2)
-        ctl._pending_elastic_scale_update = ElasticScaleUpdateReq(
-            success=True,
-            effective_ep_size=4,
-            slot_offset=2,
-            slot_count=2,
-        )
-        ctl._last_bootstrap_topology_retry = time.monotonic()
-        ctl.refresh_load_budget_on_dispatch = False
-        ctl.dispatching = MagicMock()
-        req = _req(routed_dp_rank=2)
-        req.time_stats = MagicMock()
-
-        ctl.dispatching_with_trace(req)
-
-        ctl.dispatching.assert_not_called()
-        ctl.send_to_tokenizer.send_pyobj.assert_called_once()
+        publish.assert_not_called()
 
 
 class TestTotalRequestsScheduler(CustomTestCase):

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -12,10 +12,12 @@ is exercised as the real method, no mock.
 """
 
 import unittest
+from http import HTTPStatus
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import msgspec.structs
+import requests
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
@@ -27,6 +29,7 @@ from sglang.srt.managers.data_parallel_controller import (
     DPBudget,
     LoadBalanceMethod,
 )
+from sglang.srt.managers.io_struct import ElasticScaleUpdateReq
 from sglang.srt.managers.load_snapshot import LoadSnapshot
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
@@ -43,23 +46,42 @@ def _load(**overrides) -> LoadSnapshot:
     return msgspec.structs.replace(_BASE_LOAD, **overrides)
 
 
-def _make_controller(dp_size: int) -> DataParallelController:
+def _make_controller(
+    dp_size: int, launch_dp_size: int | None = None
+) -> DataParallelController:
     """Bypass __init__; inject only the attrs dispatch methods read."""
+    launch_dp_size = launch_dp_size or dp_size
     ctl = DataParallelController.__new__(DataParallelController)
     ctl.workers = [MagicMock(name=f"worker_{i}") for i in range(dp_size)]
+    ctl.send_to_tokenizer = MagicMock(name="send_to_tokenizer")
     ctl.status = [True] * dp_size
     ctl._active_workers = list(range(dp_size))
+    ctl.launch_dp_size = launch_dp_size
+    ctl.bootstrap_room_dp_size = launch_dp_size
+    ctl.max_dp_size = dp_size
+    ctl.dp_active = [True] * launch_dp_size + [False] * (dp_size - launch_dp_size)
+    ctl.server_args = SimpleNamespace(disaggregation_mode="null")
+    ctl._pending_elastic_scale_update = None
+    ctl._last_bootstrap_topology_retry = 0.0
     ctl.round_robin_counter = 0
     ctl.dp_budget = DPBudget(dp_size=dp_size)
     return ctl
 
 
-def _req(routed_dp_rank=None, bootstrap_room=None, input_ids=None):
+def _req(
+    routed_dp_rank=None,
+    bootstrap_room=None,
+    input_ids=None,
+    rid="test-rid",
+    http_worker_ipc=None,
+):
     """Req stand-in; SimpleNamespace avoids pinning to the Req dataclass schema."""
     return SimpleNamespace(
         routed_dp_rank=routed_dp_rank,
         bootstrap_room=bootstrap_room,
         input_ids=input_ids or [],
+        rid=rid,
+        http_worker_ipc=http_worker_ipc,
     )
 
 
@@ -233,6 +255,116 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
         ctl.follow_bootstrap_room_scheduler(_req(routed_dp_rank=3, bootstrap_room=1))
         ctl.workers[3].send_pyobj.assert_called_once()
         ctl.workers[1].send_pyobj.assert_not_called()
+
+    def test_excludes_reserved_slots_without_remapping_active_ranks(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.workers[2:] = [None, None]
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+
+        ctl.follow_bootstrap_room_scheduler(_req(bootstrap_room=2))
+
+        ctl.workers[0].send_pyobj.assert_called_once()
+
+    def test_rejects_room_mapped_to_an_inactive_rank(self):
+        ctl = _make_controller(dp_size=4)
+        ctl.status[1] = False
+        ctl._active_workers = [0, 2, 3]
+
+        ctl.follow_bootstrap_room_scheduler(
+            _req(bootstrap_room=1, http_worker_ipc="ipc://tokenizer-worker")
+        )
+
+        for worker in ctl.workers:
+            worker.send_pyobj.assert_not_called()
+        abort = ctl.send_to_tokenizer.send_pyobj.call_args.args[0]
+        self.assertEqual(abort.rid, "test-rid")
+        self.assertEqual(abort.http_worker_ipc, "ipc://tokenizer-worker")
+        self.assertEqual(abort.finished_reason["status_code"], HTTPStatus.SERVICE_UNAVAILABLE)
+        self.assertIn("DP rank 1", abort.finished_reason["message"])
+
+    def test_scale_update_expands_bootstrap_room_modulo_domain(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+
+        ctl.handle_elastic_scale_update(
+            ElasticScaleUpdateReq(
+                success=True,
+                effective_ep_size=4,
+                slot_offset=2,
+                slot_count=2,
+            )
+        )
+        ctl.follow_bootstrap_room_scheduler(_req(bootstrap_room=2))
+
+        self.assertEqual(ctl.bootstrap_room_dp_size, 4)
+        ctl.workers[2].send_pyobj.assert_called_once()
+        for worker in (ctl.workers[0], ctl.workers[1], ctl.workers[3]):
+            worker.send_pyobj.assert_not_called()
+
+    def test_scale_update_advertises_expanded_bootstrap_dp_size(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+        ctl.server_args = SimpleNamespace(
+            disaggregation_mode="prefill",
+            dist_init_addr=None,
+            host="0.0.0.0",
+            disaggregation_bootstrap_port=8998,
+        )
+        response = MagicMock()
+
+        with patch(
+            "sglang.srt.managers.data_parallel_controller.requests.post",
+            return_value=response,
+        ) as post:
+            ctl.handle_elastic_scale_update(
+                ElasticScaleUpdateReq(
+                    success=True,
+                    effective_ep_size=4,
+                    slot_offset=2,
+                    slot_count=2,
+                )
+            )
+
+        post.assert_called_once_with(
+            "http://127.0.0.1:8998/update_dp_size",
+            json={"dp_size": 4},
+            timeout=5,
+        )
+        response.raise_for_status.assert_called_once()
+
+    def test_scale_update_withholds_new_ranks_when_bootstrap_update_fails(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl.status[2:] = [False, False]
+        ctl._active_workers = [0, 1]
+        ctl.server_args = SimpleNamespace(
+            disaggregation_mode="prefill",
+            dist_init_addr=None,
+            host="127.0.0.1",
+            disaggregation_bootstrap_port=8998,
+        )
+        update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.data_parallel_controller.requests.post",
+                side_effect=requests.RequestException("bootstrap unavailable"),
+            ) as post,
+            patch("sglang.srt.managers.data_parallel_controller.time.sleep"),
+        ):
+            ctl.handle_elastic_scale_update(update)
+
+        self.assertEqual(post.call_count, 3)
+        self.assertIs(ctl._pending_elastic_scale_update, update)
+        self.assertEqual(ctl.bootstrap_room_dp_size, 2)
+        self.assertEqual(ctl._active_workers, [0, 1])
 
 
 class TestTotalRequestsScheduler(CustomTestCase):

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -11,6 +11,7 @@ if a scheduler starts reading another attr. `maybe_external_dp_rank_routing`
 is exercised as the real method, no mock.
 """
 
+import time
 import unittest
 from http import HTTPStatus
 from types import SimpleNamespace
@@ -18,6 +19,7 @@ from unittest.mock import MagicMock, patch
 
 import msgspec.structs
 import requests
+import zmq
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
@@ -365,6 +367,46 @@ class TestFollowBootstrapRoomScheduler(CustomTestCase):
         self.assertIs(ctl._pending_elastic_scale_update, update)
         self.assertEqual(ctl.bootstrap_room_dp_size, 2)
         self.assertEqual(ctl._active_workers, [0, 1])
+
+    def test_event_loop_retries_pending_bootstrap_topology_updates(self):
+        ctl = _make_controller(dp_size=2)
+        ctl.soft_watchdog = MagicMock()
+        ctl.recv_from_tokenizer = MagicMock()
+
+        with (
+            patch(
+                "sglang.srt.managers.data_parallel_controller.sock_recv",
+                side_effect=zmq.ZMQError(),
+            ),
+            patch.object(
+                ctl,
+                "_retry_pending_bootstrap_topology_update",
+                side_effect=KeyboardInterrupt,
+            ) as retry,
+        ):
+            with self.assertRaises(KeyboardInterrupt):
+                ctl.event_loop()
+
+        retry.assert_called_once()
+
+    def test_pending_topology_update_rejects_direct_rank_routing(self):
+        ctl = _make_controller(dp_size=4, launch_dp_size=2)
+        ctl._pending_elastic_scale_update = ElasticScaleUpdateReq(
+            success=True,
+            effective_ep_size=4,
+            slot_offset=2,
+            slot_count=2,
+        )
+        ctl._last_bootstrap_topology_retry = time.monotonic()
+        ctl.refresh_load_budget_on_dispatch = False
+        ctl.dispatching = MagicMock()
+        req = _req(routed_dp_rank=2)
+        req.time_stats = MagicMock()
+
+        ctl.dispatching_with_trace(req)
+
+        ctl.dispatching.assert_not_called()
+        ctl.send_to_tokenizer.send_pyobj.assert_called_once()
 
 
 class TestTotalRequestsScheduler(CustomTestCase):


### PR DESCRIPTION
Fixes #34104.

### Problem

When the controller has reserved worker slots that are not active, `follow_bootstrap_room_scheduler` maps a bootstrap room across every allocated slot. A room that selects a reserved slot calls `sock_send` with `None` and crashes.

```text
follow-bootstrap-room routing

bootstrap_room = 2
        |
        +-- before: 2 % 4 allocated slots --> slot 2 --> None --> crash
        |
        `-- after:  2 % 2 active workers --> active[0] = slot 0 --> socket
```

The important distinction is between allocated slots and the smaller active routing domain.

### Change

Map bootstrap rooms across `_active_workers`, matching the routing domain used by round-robin dispatch. Return a clear error when no active workers exist. This preserves the existing room-to-DP-rank mapping for contiguous active workers and skips reserved slots.

### Regression coverage

The added unit test models four allocated slots with workers 0 and 1 active and slots 2 and 3 reserved. On the base behavior, `bootstrap_room=2` dereferences the reserved `None` slot. The fixed behavior routes it to worker 0.

### Validation

- `PYTHONPATH=python python/.venv/bin/python -m pytest -q test/registered/unit/managers/test_data_parallel_controller.py` — 18 passed
- `git show --check` — clean

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31267096157](https://github.com/sgl-project/sglang/actions/runs/31267096157)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31267096075](https://github.com/sgl-project/sglang/actions/runs/31267096075)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->