### PR TITLE
[jit_kernel] Fix missing JIT kernel namespaces

### DIFF
--- a/python/sglang/kernels/jit/csrc/diffusion/modulate_scale_shift.cuh
+++ b/python/sglang/kernels/jit/csrc/diffusion/modulate_scale_shift.cuh
@@ -24,6 +24,8 @@
 
 #include <cstdint>
 
+namespace sglang {
+
 namespace sglang_modulate_scale_shift {
 
 namespace {
@@ -219,3 +221,5 @@ struct ModulateScaleShiftKernel {
 };
 
 }  // namespace sglang_modulate_scale_shift
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/moe/align_single_token.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/align_single_token.cuh
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 
-namespace {
+namespace sglang {
 
 struct AlignSingleTokenParams {
   const int32_t* __restrict__ topk_ids;  // [1, topk]
@@ -104,4 +104,4 @@ struct AlignSingleTokenKernel {
   }
 };
 
-}  // namespace
+}  // namespace sglang


### PR DESCRIPTION
## Summary

- Fix the JIT namespace break from #33400 for the single-token MoE kernel added in #32541.
- Fix the same helper-namespace migration break in the diffusion adaLN modulation kernel.
- Restore first-use JIT compilation without changing either kernel's computation.

## Validation

- Targeted pre-commit checks passed, including clang-format and codespell.
- H200 with a fresh TVM-FFI cache: `test_modulate_scale_shift.py` — **12 passed**.
- The modulation test covers BF16/FP16 production and edge shapes and requires bitwise equality with eager PyTorch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31254531405](https://github.com/sgl-project/sglang/actions/runs/31254531405)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31257143614](https://github.com/sgl-project/sglang/actions/runs/31257143614)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->