### PR TITLE
[jit_kernel] Fix single-token MoE align namespace

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/align_single_token.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/align_single_token.cuh
@@ -17,6 +17,8 @@
 
 #include <cstdint>
 
+namespace sglang {
+
 namespace {
 
 struct AlignSingleTokenParams {
@@ -105,3 +107,5 @@ struct AlignSingleTokenKernel {
 };
 
 }  // namespace
+
+}  // namespace sglang

--- a/test/registered/kernels/ops/moe/test_moe_align_single_token.py
+++ b/test/registered/kernels/ops/moe/test_moe_align_single_token.py
@@ -1,0 +1,29 @@
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.moe_align_single_token import moe_align_single_token
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@pytest.mark.parametrize("topk,block_size", [(1, 16), (8, 32), (32, 64)])
+def test_moe_align_single_token(topk: int, block_size: int) -> None:
+    torch.manual_seed(topk)
+    topk_ids = torch.randperm(256, device="cuda", dtype=torch.int32)[:topk][None]
+
+    sorted_ids, expert_ids, num_post = moe_align_single_token(topk_ids, block_size)
+
+    expected_expert_ids, source_indices = torch.sort(topk_ids.flatten())
+    expected_sorted_ids = torch.full_like(sorted_ids, topk)
+    expected_sorted_ids[::block_size] = source_indices.to(torch.int32)
+
+    assert torch.equal(sorted_ids, expected_sorted_ids)
+    assert torch.equal(expert_ids, expected_expert_ids)
+    assert num_post.item() == topk * block_size
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Summary

- Place the single-token MoE align JIT kernel in `namespace sglang`.
- Add a focused H100 JIT unit test covering top-k 1, 8, and 32 with exact output checks.

## Root cause

PR #33400 moved shared JIT helpers such as `host`, `device`, `TensorMatcher`, and `LaunchKernel` under `namespace sglang`, but `moe/align_single_token.cuh` was missed. Compiling the kernel therefore failed with unresolved namespace/helper errors when the DeepSeek V4 Marlin single-token decode path reached it.

Observed in https://github.com/sgl-project/sglang/actions/runs/31248422142/job/93087675191?pr=34085.

## Validation

- Focused pre-commit checks passed, including clang-format, Ruff, Black, and registered-test validation.
- H200, fresh TVM-FFI JIT cache: `3 passed`.

## Impact

Restores JIT compilation of `moe_align_single_token` after the namespace migration. Kernel behavior and launch configuration are unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31253670311](https://github.com/sgl-project/sglang/actions/runs/31253670311)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31253679828](https://github.com/sgl-project/sglang/actions/runs/31253679828)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->