### PR TITLE
docs: python version and environment pinning in MLX docs

### DIFF
--- a/docs/docs/hardware-platforms/apple_metal.mdx
+++ b/docs/docs/hardware-platforms/apple_metal.mdx
@@ -30,8 +30,12 @@ You can install SGLang using one of the methods below.
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
 
-# Create and activate a virtual environment
-uv venv -p 3.12 sglang-metal
+# Create and activate a virtual environment (Python 3.11; matches MLX CI).
+# Prefer an arm64 interpreter: on machines with both Homebrew installs,
+# `uv venv -p 3.11` can resolve to Intel Python, where torch has no wheel.
+uv venv --python 3.11 sglang-metal
+# If uv picks the wrong arch, pin explicitly:
+# uv venv -p /opt/homebrew/bin/python3.11 sglang-metal
 source sglang-metal/bin/activate
 
 # (Optional) Compile sgl-kernel

--- a/python/sglang/test/ci/ci_utils.py
+++ b/python/sglang/test/ci/ci_utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 import re
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass
@@ -186,11 +187,14 @@ def run_unittest_files(
 
             full_path = os.path.join(os.getcwd(), filename)
             logger.info(
-                f".\n.\nBegin ({i}/{len(files) - 1}):\npython3 {full_path}\n.\n.\n"
+                f".\n.\nBegin ({i}/{len(files) - 1}):\n{sys.executable} {full_path}\n.\n.\n"
             )
             file_tic = time.perf_counter()
 
-            cmd = ["python3", full_path, "-f"]
+            # Use the current interpreter so `python run_suite.py` from an
+            # unactivated venv still hands children the venv's packages.
+            # Bare `python3` follows PATH and often hits system Python.
+            cmd = [sys.executable, full_path, "-f"]
 
             if capture_output:
                 # Capture output for retry decision


### PR DESCRIPTION
## Motivation

I hit two setup issues while bringing up MLX on Apple Silicon (M4 Pro / 48GB):

1. python version pinning. `apple_metal.mdx` told newcomers to create a Python 3.12 venv, but MLX CI (`pr-test-mlx.yml`) pins 3.11. Separately, `uv venv -p 3.11` can resolve to Intel Homebrew Python on dual-arch Macs, where torch has no wheel.

2. `ci_utils.py` spawned each test file with bare `python3`, so running `run_suite.py` via an unactivated venv's interpreter still handed children system Python and every file failed with `ModuleNotFoundError`. CI hides this because `uv run` puts the venv on `PATH`.

After a correct setup, `stage-a-unit-test-mlx` is green locally (11/11) with mlx 0.32.0 / torch 2.11.0 / Python 3.11.15 arm64.

## Modifications

- Docs (`apple_metal.mdx`): use `uv venv --python 3.11`, note the arm64 / dual-Homebrew pitfall, and show pinning `/opt/homebrew/bin/python3.11` if needed.
- Tests (`ci_utils.py`): spawn per-file unit tests with `sys.executable` instead of bare `python3`, and log the same path.

## Accuracy Tests

N/A — docs + test-runner only; no model / kernel / forward changes.

## Speed Tests and Profiling

N/A — no inference path changes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). *(no new tests; existing suite exercise path)*
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). *(N/A)*
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31260618191](https://github.com/sgl-project/sglang/actions/runs/31260618191)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31260618114](https://github.com/sgl-project/sglang/actions/runs/31260618114)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->