### PR TITLE
[Fix] Handle mixed precomputed and raw multimodal inputs

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -35,6 +35,7 @@ from sglang.srt.managers.mm_schedule import (
 from sglang.srt.managers.schedule_batch import (
     CudaIpcTensorTransportProxy,
     Modality,
+    MultimodalDataItem,
     MultimodalInputs,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -502,6 +503,11 @@ def embed_mm_inputs(
     return input_embeds, other_info
 
 
+def _is_precomputed_mm_item(item: MultimodalDataItem) -> bool:
+    """Recognize both internal and public precomputed-embedding formats."""
+    return item.precomputed_embeddings is not None or item.is_precomputed_embedding()
+
+
 def _embed_mm_inputs_with_split(
     mm_inputs_list: List[MultimodalInputs],
     extend_prefix_lens: List[int],
@@ -514,14 +520,12 @@ def _embed_mm_inputs_with_split(
     placeholder_tokens: dict[Modality, List[int]] = None,
     use_deepstack: Dict[Modality, bool] = {},
 ):
-    """Split batch into precomputed vs non-precomputed, embed each group, merge back."""
+    """Group requests with precomputed items before per-modality embedding."""
     precomputed_req_indices = []
     non_precomputed_req_indices = []
     for idx, mm_input in enumerate(mm_inputs_list):
         items = [item for item in mm_input.mm_items if item is not None]
-        if items and all(
-            getattr(item, "precomputed_embeddings", None) is not None for item in items
-        ):
+        if items and any(_is_precomputed_mm_item(item) for item in items):
             precomputed_req_indices.append(idx)
         else:
             non_precomputed_req_indices.append(idx)
@@ -657,7 +661,20 @@ def general_mm_embed_routine(
             # encoder/ViT execution and multimodal feature placement, while
             # the language model range below excludes both.
             with torch.profiler.record_function("sglang.vlm.mm_embedding"):
-                if server_args and get_disagg().enable_adaptive_dispatch_to_encoder:
+                should_split_mm_inputs = bool(
+                    server_args is not None
+                    and get_disagg().enable_adaptive_dispatch_to_encoder
+                )
+                if not should_split_mm_inputs:
+                    input_kinds = {
+                        _is_precomputed_mm_item(item)
+                        for mm_input in mm_inputs_list
+                        for item in mm_input.mm_items
+                        if item is not None
+                    }
+                    should_split_mm_inputs = len(input_kinds) > 1
+
+                if should_split_mm_inputs:
                     # Split by precomputed vs non-precomputed so get_embedding_and_mask only sees uniform batches
                     input_embeds, other_info = _embed_mm_inputs_with_split(
                         mm_inputs_list=mm_inputs_list,

--- a/test/registered/unit/managers/test_mm_precomputed_batch.py
+++ b/test/registered/unit/managers/test_mm_precomputed_batch.py
@@ -1,0 +1,211 @@
+"""Regression test for mixed precomputed and raw multimodal batches."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from torch import nn
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers import mm_utils  # noqa: E402
+from sglang.srt.managers.schedule_batch import (  # noqa: E402
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputFormat,
+    MultimodalInputs,
+)
+from sglang.srt.model_executor.forward_batch_info import (  # noqa: E402
+    ForwardBatch,
+    ForwardMode,
+)
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeLanguageModel(nn.Module):
+    def __init__(self, input_embedding):
+        super().__init__()
+        self.input_embedding = input_embedding
+
+    def get_input_embeddings(self):
+        return self.input_embedding
+
+    def forward(self, input_ids=None, forward_batch=None, input_embeds=None, **kwargs):
+        return input_embeds
+
+
+def _run_mm_embedding(mm_inputs, input_ids, data_embedding_funcs, extend_seq_lens):
+    mm_utils.init_mm_embedding_cache()
+    forward_batch = ForwardBatch.__new__(ForwardBatch)
+    forward_batch.forward_mode = ForwardMode.EXTEND
+    forward_batch.mm_inputs = mm_inputs
+    forward_batch.extend_prefix_lens_cpu = [0] * len(mm_inputs)
+    forward_batch.extend_seq_lens_cpu = extend_seq_lens
+    forward_batch.input_embeds = None
+
+    input_embedding = nn.Embedding(128, 4)
+    with torch.no_grad():
+        input_embedding.weight.zero_()
+
+    with patch.object(
+        mm_utils,
+        "get_server_args",
+        return_value=SimpleNamespace(),
+    ), patch.object(
+        mm_utils,
+        "get_disagg",
+        return_value=SimpleNamespace(
+            enable_adaptive_dispatch_to_encoder=False,
+            language_only=False,
+        ),
+    ):
+        return mm_utils.general_mm_embed_routine(
+            input_ids=input_ids,
+            forward_batch=forward_batch,
+            language_model=_FakeLanguageModel(input_embedding),
+            data_embedding_funcs=data_embedding_funcs,
+        )
+
+
+class TestMixedPrecomputedMultimodalBatch(unittest.TestCase):
+    def test_mixes_precomputed_and_raw_requests_without_adaptive_dispatch(self):
+        placeholder_token = 99
+        precomputed_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 0)],
+            pad_value=placeholder_token,
+            hash=1,
+            precomputed_embeddings=torch.full((1, 4), 3.0),
+        )
+        raw_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 0)],
+            pad_value=placeholder_token,
+            hash=2,
+            feature=torch.ones((1, 2, 2, 2)),
+        )
+        mm_inputs = [
+            MultimodalInputs(mm_items=[precomputed_item]),
+            None,
+            MultimodalInputs(mm_items=[raw_item]),
+        ]
+
+        def get_image_feature(items):
+            return torch.full((len(items), 4), 7.0)
+
+        output = _run_mm_embedding(
+            mm_inputs,
+            torch.tensor(
+                [placeholder_token, 0, 1, 2, placeholder_token, 0],
+                dtype=torch.long,
+            ),
+            {Modality.IMAGE: get_image_feature},
+            extend_seq_lens=[2, 2, 2],
+        )
+
+        self.assertEqual(tuple(output.shape), (6, 4))
+        torch.testing.assert_close(output[0], torch.full((4,), 3.0))
+        torch.testing.assert_close(output[4], torch.full((4,), 7.0))
+
+    def test_mixes_public_precomputed_format_and_raw_requests(self):
+        placeholder_token = 99
+        precomputed_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            format=MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+            offsets=[(0, 0)],
+            pad_value=placeholder_token,
+            hash=1,
+            feature=torch.full((1, 4), 3.0),
+        )
+        raw_item = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 0)],
+            pad_value=placeholder_token,
+            hash=2,
+            feature=torch.ones((1, 2, 2, 2)),
+        )
+        mm_inputs = [
+            MultimodalInputs(mm_items=[precomputed_item]),
+            MultimodalInputs(mm_items=[raw_item]),
+        ]
+
+        def get_image_feature(items):
+            if items and items[0].format == MultimodalInputFormat.PRECOMPUTED_EMBEDDING:
+                result = torch.cat([item.feature for item in items])
+                return result.reshape(-1, result.shape[-1])
+            return torch.full((len(items), 4), 7.0)
+
+        output = _run_mm_embedding(
+            mm_inputs,
+            torch.tensor(
+                [placeholder_token, 0, placeholder_token, 0],
+                dtype=torch.long,
+            ),
+            {Modality.IMAGE: get_image_feature},
+            extend_seq_lens=[2, 2],
+        )
+
+        self.assertEqual(tuple(output.shape), (4, 4))
+        torch.testing.assert_close(output[0], torch.full((4,), 3.0))
+        torch.testing.assert_close(output[2], torch.full((4,), 7.0))
+
+    def test_splits_precomputed_and_raw_modalities_in_one_request(self):
+        image_precomputed = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            format=MultimodalInputFormat.PRECOMPUTED_EMBEDDING,
+            offsets=[(0, 0)],
+            pad_value=99,
+            hash=1,
+            feature=torch.full((1, 4), 3.0),
+        )
+        audio_raw = MultimodalDataItem(
+            modality=Modality.AUDIO,
+            offsets=[(1, 1)],
+            pad_value=98,
+            hash=2,
+            feature=torch.ones((1, 2, 2)),
+        )
+        image_raw = MultimodalDataItem(
+            modality=Modality.IMAGE,
+            offsets=[(0, 0)],
+            pad_value=99,
+            hash=3,
+            feature=torch.ones((1, 2, 2, 2)),
+        )
+        mm_inputs = [
+            MultimodalInputs(mm_items=[image_precomputed, audio_raw]),
+            MultimodalInputs(mm_items=[image_raw]),
+        ]
+
+        def get_image_feature(items):
+            features = torch.cat([item.feature for item in items], dim=0)
+            if features.dim() == 2:
+                return features
+            return torch.full((features.shape[0], 4), 7.0)
+
+        def get_audio_feature(items):
+            return torch.full((len(items), 4), 8.0)
+
+        output = _run_mm_embedding(
+            mm_inputs,
+            torch.tensor([99, 98, 0, 99, 0, 1], dtype=torch.long),
+            {
+                Modality.IMAGE: get_image_feature,
+                Modality.AUDIO: get_audio_feature,
+            },
+            extend_seq_lens=[3, 3],
+        )
+
+        self.assertEqual(tuple(output.shape), (6, 4))
+        torch.testing.assert_close(output[0], torch.full((4,), 3.0))
+        torch.testing.assert_close(output[1], torch.full((4,), 8.0))
+        torch.testing.assert_close(output[3], torch.full((4,), 7.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang supports multiple multimodal input representations, including raw processor features and precomputed multimodal embeddings.

When a scheduler batch contains both representations, the current embedding path does not always separate them before invoking the multimodal embedding function. In particular, the split is currently enabled only when adaptive encoder dispatch is active.

As a result, a mixed batch can fail in two ways:

1. A batch containing internal `precomputed_embeddings` and raw features can enter the partial-precomputed path and raise `NotImplementedError`.

2. A batch containing public `MultimodalInputFormat.PRECOMPUTED_EMBEDDING` inputs and raw features can send rank-2 precomputed embeddings and rank-4 raw features to the same model-specific encoder call, resulting in a tensor shape error.

The failure depends on the composition of the scheduled batch rather than on the individual request.

## Modifications

- Recognize both internal `precomputed_embeddings` and public `PRECOMPUTED_EMBEDDING` inputs.
- Detect whether a multimodal batch contains both precomputed and raw items.
- Reuse the existing split-and-merge path whenever both representations are present, regardless of adaptive encoder dispatch settings.
- Preserve the existing adaptive-dispatch behavior for batches that already request it.
- Keep the original request order when combining the results from the two embedding groups.

## Testing

Added regression coverage for:

- A batch containing internal precomputed embeddings and raw image features.
- A batch containing public precomputed embeddings and raw image features.
- A request containing a precomputed image and a raw audio item, followed by a separate raw image request.

The following test command was run:

`pytest -q test/registered/unit/managers/test_mm_precomputed_batch.py test/registered/unit/managers/test_mm_utils_split.py test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py`

Result: 15 tests passed.

Black, Ruff, and diff checks also passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31261835408](https://github.com/sgl-project/sglang/actions/runs/31261835408)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31261835289](https://github.com/sgl-project/sglang/actions/runs/31261835289)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->