### PR TITLE
[Fix] Keep token_type_ids aligned across mixed and padded batches

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1005,12 +1005,16 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     for r in batch.reqs
                 ]
 
-        token_type_ids = [
-            r.token_type_ids for r in batch.reqs if r.token_type_ids is not None
-        ]
-        if token_type_ids:
+        if any(r.token_type_ids is not None for r in batch.reqs):
+            flattened_token_type_ids = []
+            for req in batch.reqs:
+                flattened_token_type_ids.extend(
+                    req.token_type_ids
+                    if req.token_type_ids is not None
+                    else [0] * len(req.origin_input_ids)
+                )
             self.token_type_ids = torch.tensor(
-                sum(token_type_ids, []),
+                flattened_token_type_ids,
                 dtype=torch.int64,
                 pin_memory=is_pin_memory_available(batch.device),
             ).to(batch.device, non_blocking=True)
@@ -1438,6 +1442,10 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # padding
         self._original_num_tokens = self.positions.shape[0]
         self.input_ids = self._pad_tensor_to_size(self.input_ids, num_tokens)
+        if self.token_type_ids is not None:
+            self.token_type_ids = self._pad_tensor_to_size(
+                self.token_type_ids, num_tokens
+            )
         self.req_pool_indices = self._pad_tensor_to_size(self.req_pool_indices, bs)
         if self.lora_ids is not None:
             self.lora_ids.extend((bs - len(self.lora_ids)) * [None])
@@ -1554,6 +1562,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # branch below does the same for speculative batches.
         if self.spec_info is None and self._original_num_tokens is not None:
             self.positions = self.positions[: self._original_num_tokens]
+            if self.token_type_ids is not None:
+                self.token_type_ids = self.token_type_ids[: self._original_num_tokens]
             self.seq_lens = self.seq_lens[:bs]
             self.req_pool_indices = self.req_pool_indices[:bs]
             if self.seq_lens_cpu is not None:

--- a/test/registered/unit/model_executor/test_forward_batch_token_type_ids.py
+++ b/test/registered/unit/model_executor/test_forward_batch_token_type_ids.py
@@ -1,0 +1,91 @@
+"""Regression tests for cross-encoder token type metadata assembly."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.model_executor.forward_batch_info import (  # noqa: E402
+    ForwardBatch,
+    ForwardMode,
+)
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_forward_batch():
+    return ForwardBatch(
+        forward_mode=ForwardMode.DECODE,
+        batch_size=2,
+        input_ids=torch.zeros(5, dtype=torch.long),
+        req_pool_indices=torch.zeros(2, dtype=torch.long),
+        seq_lens=torch.ones(2, dtype=torch.long),
+        out_cache_loc=torch.zeros(2, dtype=torch.long),
+        seq_lens_sum=2,
+    )
+
+
+class TestForwardBatchTokenTypeIds(unittest.TestCase):
+    def test_flattens_request_values_in_batch_order(self):
+        forward_batch = _make_forward_batch()
+        batch = SimpleNamespace(
+            device=torch.device("cpu"),
+            reqs=[
+                SimpleNamespace(token_type_ids=[0, 1]),
+                SimpleNamespace(token_type_ids=[1, 0, 1]),
+            ],
+        )
+
+        forward_batch._maybe_init_non_generation_fields(batch)
+
+        torch.testing.assert_close(
+            forward_batch.token_type_ids,
+            torch.tensor([0, 1, 1, 0, 1], dtype=torch.int64),
+        )
+
+    def test_omits_metadata_when_no_request_provides_it(self):
+        forward_batch = _make_forward_batch()
+        batch = SimpleNamespace(
+            device=torch.device("cpu"),
+            reqs=[
+                SimpleNamespace(token_type_ids=None),
+                SimpleNamespace(token_type_ids=None),
+            ],
+        )
+
+        forward_batch._maybe_init_non_generation_fields(batch)
+
+        self.assertIsNone(forward_batch.token_type_ids)
+
+    def test_fills_missing_request_metadata_with_segment_zero(self):
+        forward_batch = _make_forward_batch()
+        batch = SimpleNamespace(
+            device=torch.device("cpu"),
+            reqs=[
+                SimpleNamespace(
+                    origin_input_ids=array("q", [101, 42]),
+                    token_type_ids=None,
+                ),
+                SimpleNamespace(
+                    origin_input_ids=array("q", [101, 43, 102]),
+                    token_type_ids=[0, 1, 1],
+                ),
+            ],
+        )
+
+        forward_batch._maybe_init_non_generation_fields(batch)
+
+        torch.testing.assert_close(
+            forward_batch.token_type_ids,
+            torch.tensor([0, 0, 0, 1, 1], dtype=torch.int64),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
+++ b/test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py
@@ -152,6 +152,7 @@ class TestMlpSyncPadUnpad(CustomTestCase):
             out_cache_loc=torch.arange(7),
             seq_lens_sum=7,
             positions=torch.tensor([0, 1, 2, 0, 1, 2, 3]),
+            token_type_ids=torch.tensor([0, 1, 1, 0, 1, 0, 1]),
             seq_lens_cpu=torch.tensor([3, 4]),
             lora_ids=[None, None],
         )
@@ -160,11 +161,18 @@ class TestMlpSyncPadUnpad(CustomTestCase):
         fb._pad_inputs_to_size(_mock_model_runner(), num_tokens=10, bs=2)
 
         self.assertEqual(fb.positions.shape[0], 10)
+        torch.testing.assert_close(
+            fb.token_type_ids,
+            torch.tensor([0, 1, 1, 0, 1, 0, 1, 0, 0, 0]),
+        )
 
         logits_output = _logits_output(10)
         fb.post_forward_mlp_sync_batch(logits_output)
 
         torch.testing.assert_close(fb.positions, torch.tensor([0, 1, 2, 0, 1, 2, 3]))
+        torch.testing.assert_close(
+            fb.token_type_ids, torch.tensor([0, 1, 1, 0, 1, 0, 1])
+        )
         torch.testing.assert_close(fb.seq_lens, torch.tensor([3, 4]))
         # sample() derives prefill sampling positions from seq_lens - 1, so the
         # row count must match the real request count.


### PR DESCRIPTION
## Motivation

Cross-encoder requests carry per-token `token_type_ids` metadata. This metadata must remain aligned with the flattened `input_ids` tensor during batch construction and synchronized forward execution.

The existing batch initialization filters out requests whose `token_type_ids` is `None` before flattening the remaining request values. When a batch contains both requests with and without segment metadata, the values are concatenated at the wrong token offset.

The DP/TP MLP synchronization path also pads `input_ids` and other token-level tensors to a common size without padding `token_type_ids`. BERT and RoBERTa models can therefore receive input tensors and segment metadata with different token counts.

## Modifications

- Preserve request order while flattening `token_type_ids`.
- Fill requests without explicit segment metadata with segment-zero IDs.
- Replace quadratic list concatenation with linear-time list extension.
- Pad `token_type_ids` together with `input_ids` during synchronized forward preparation.
- Restore the original `token_type_ids` length after the synchronized forward completes.
- Preserve the existing `None` behavior when no request provides segment metadata.

## Testing

Added regression coverage for:

- Flattening request-level segment IDs in batch order.
- Keeping `token_type_ids` unset when no request provides them.
- Filling missing request metadata with segment-zero IDs.
- Padding segment IDs to the synchronized token count.
- Restoring the original segment-ID length after the forward pass.

The following test command was run:

`pytest -q test/registered/unit/model_executor/test_forward_batch_token_type_ids.py test/registered/unit/model_executor/test_mlp_sync_pad_unpad.py test/registered/unit/model_executor/test_forward_metadata_plan_record.py test/registered/unit/managers/test_schedule_batch_out_of_place.py test/registered/utils/test_type_based_dispatcher.py`

Result: 21 tests passed.

Black, Ruff, and Python compilation checks also passed.

## Benchmark

The metadata construction path was benchmarked with `torch.set_num_threads(1)`. Each implementation was warmed up three times, followed by ten timed iterations for each batch shape.

| Batch size | Sequence length | Baseline | Updated | Speedup |
|---:|---:|---:|---:|---:|
| 32 | 512 | 1.688 ms | 1.083 ms | 1.56x |
| 128 | 512 | 14.983 ms | 4.282 ms | 3.50x |
| 256 | 1024 | 117.456 ms | 17.232 ms | 6.82x |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31262013369](https://github.com/sgl-project/sglang/actions/runs/31262013369)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31262013234](https://github.com/sgl-project/sglang/actions/runs/31262013234)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->