### PR TITLE
fix(inkling): preserve ordered reasoning blocks

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1042,6 +1042,18 @@ class ChatMessage(BaseModel):
     content: Optional[str] = None
     reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = Field(default=None, examples=[None])
+    # Backward-compatible structured side channel for model families whose
+    # ordered reasoning/text blocks cannot round-trip through the two flattened
+    # OpenAI fields above. Existing clients continue to consume ``content`` and
+    # ``reasoning_content``; session-aware clients may retain these blocks.
+    content_blocks: Optional[List[ChatCompletionMessageContentPart]] = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler):
+        data = handler(self)
+        if self.content_blocks is None:
+            data.pop("content_blocks", None)
+        return data
 
 
 class ChatCompletionResponseChoice(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1498,6 +1498,7 @@ class OpenAIServingChat(OpenAIServingBase):
 
             # Handle reasoning content
             reasoning_text = None
+            content_blocks = None
             if self.reasoning_parser and request.separate_reasoning:
                 force_reasoning = (
                     self.template_manager.force_reasoning
@@ -1511,6 +1512,23 @@ class OpenAIServingChat(OpenAIServingBase):
                         request=request,
                         tokenizer=self.tokenizer_manager.tokenizer,
                     )
+                    if self.reasoning_parser == "inkling" and request.return_meta_info:
+                        parsed_blocks = parser.parse_non_stream_blocks(text)
+                        if all(
+                            block["type"] in ("reasoning", "text")
+                            for block in parsed_blocks
+                        ):
+                            content_blocks = [
+                                {
+                                    "type": (
+                                        "thinking"
+                                        if block["type"] == "reasoning"
+                                        else "text"
+                                    ),
+                                    "text": block["text"],
+                                }
+                                for block in parsed_blocks
+                            ]
                     reasoning_text, text = parser.parse_non_stream(text)
                 except Exception as e:
                     logger.error(f"Reasoning parsing error: {e}")
@@ -1527,6 +1545,10 @@ class OpenAIServingChat(OpenAIServingBase):
                 and request.tools
                 and self.tool_call_parser
             ):
+                # The ordered side channel currently covers reasoning/text
+                # blocks only. Do not claim losslessness when native tool-call
+                # parsing may remove or reorder invocation blocks.
+                content_blocks = None
                 history_tool_calls_cnt = self._get_history_tool_calls_cnt(request)
                 tool_calls, text, finish_reason = self._process_tool_calls(
                     text,
@@ -1558,6 +1580,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     content=text if text else "",
                     tool_calls=tool_calls,
                     reasoning_content=reasoning_text if reasoning_text else None,
+                    content_blocks=content_blocks,
                 ),
                 logprobs=choice_logprobs,
                 finish_reason=finish_reason["type"] if finish_reason else None,

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -773,6 +773,98 @@ class InklingDetector(BaseReasoningFormatDetector):
         self._pending_reasoning = ""
         return ret
 
+    def detect_and_parse_block_sequence(self, text: str) -> list[tuple[str, str]]:
+        """Return Inkling's ordered model-block sequence without flattening.
+
+        ``reasoning_content`` and ``content`` cannot distinguish one text block
+        from several adjacent text blocks, nor can they preserve interleaving
+        such as thinking -> text -> thinking.  This lossless side channel keeps
+        canonical thinking/text boundaries while leaving the existing flattened
+        parser result unchanged for OpenAI-compatible clients.
+
+        ``tool`` and ``raw`` entries make incomplete coverage explicit.  The
+        serving layer must not advertise ``content_blocks`` when either appears:
+        native tool calls need their own ordered representation, and unframed
+        text cannot be re-rendered with the original Inkling boundaries.
+        """
+        blocks: list[tuple[str, str]] = []
+        kind: str | None = None
+        parts: list[str] = []
+        pending_header = ""
+        pos = 0
+
+        def finish_block() -> None:
+            nonlocal kind, parts
+            if kind in ("reasoning", "text", "tool"):
+                blocks.append((kind, "".join(parts)))
+            kind = None
+            parts = []
+
+        def append_raw(value: str) -> None:
+            if not value:
+                return
+            if blocks and blocks[-1][0] == "raw":
+                blocks[-1] = ("raw", blocks[-1][1] + value)
+            else:
+                blocks.append(("raw", value))
+
+        for match in _INKLING_CONTROL_RE.finditer(text):
+            fragment = text[pos : match.start()]
+            token = match.group(0)
+            pos = match.end()
+
+            if kind in ("reasoning", "text", "tool"):
+                parts.append(fragment)
+            elif kind == "header":
+                pending_header += fragment
+            else:
+                append_raw(fragment)
+
+            if token == MESSAGE_MODEL:
+                if kind in (None, "header"):
+                    kind = "header"
+                    parts = []
+                    pending_header = ""
+                else:
+                    # A role token inside an open block is literal payload.
+                    parts.append(token)
+            elif token in (CONTENT_INVOKE_TOOL_JSON, CONTENT_INVOKE_TOOL_TEXT):
+                if kind == "header":
+                    parts = [MESSAGE_MODEL, pending_header, token]
+                else:
+                    finish_block()
+                    parts = [token]
+                kind = "tool"
+                pending_header = ""
+            elif kind == "tool":
+                parts.append(token)
+                if token in _INKLING_END_TOKENS:
+                    finish_block()
+            elif token in _INKLING_CONTENT_KINDS:
+                finish_block()
+                kind = "reasoning" if token == CONTENT_THINKING else "text"
+                parts = []
+                pending_header = ""
+            elif token in _INKLING_END_TOKENS:
+                finish_block()
+                pending_header = ""
+            elif kind in ("reasoning", "text"):
+                parts.append(token)
+            else:
+                # Unknown control syntax is intentionally not declared lossless.
+                append_raw(token)
+
+        tail = text[pos:]
+        if kind in ("reasoning", "text", "tool"):
+            parts.append(tail)
+            finish_block()
+        elif kind == "header":
+            append_raw(MESSAGE_MODEL + pending_header + tail)
+        else:
+            append_raw(tail)
+
+        return blocks
+
     def parse_streaming_increment(self, new_text: str) -> StreamingParseResult:
         text = self._buffer + new_text
         partial_len = self._partial_control_length(text)

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -483,6 +483,32 @@ class TestModelSerialization(unittest.TestCase):
         self.assertIn("hidden_states", data["choices"][0])
         self.assertEqual(data["choices"][0]["hidden_states"], [0.1, 0.2, 0.3])
 
+    def test_assistant_content_blocks_are_optional_and_ordered(self):
+        plain = ChatMessage(role="assistant", content="answer")
+        self.assertNotIn("content_blocks", plain.model_dump())
+
+        structured = ChatMessage(
+            role="assistant",
+            content="answer-1answer-2",
+            reasoning_content="think-1think-2",
+            content_blocks=[
+                {"type": "thinking", "text": "think-1"},
+                {"type": "text", "text": "answer-1"},
+                {"type": "thinking", "text": "think-2"},
+                {"type": "text", "text": "answer-2"},
+            ],
+        )
+
+        self.assertEqual(
+            structured.model_dump()["content_blocks"],
+            [
+                {"type": "thinking", "thinking": None, "text": "think-1"},
+                {"type": "text", "text": "answer-1"},
+                {"type": "thinking", "thinking": None, "text": "think-2"},
+                {"type": "text", "text": "answer-2"},
+            ],
+        )
+
     def test_prompt_token_ids_and_meta_info_serialization(self):
         """Test that prompt_token_ids and meta_info serialize only when set."""
         default_choice = ChatCompletionResponseChoice(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2221,6 +2221,52 @@ class ServingChatTestCase(unittest.TestCase):
         self.assertEqual(msg.content, "")
         self.assertEqual(msg.reasoning_content, "42")
 
+    def test_build_chat_response_inkling_preserves_ordered_blocks(self):
+        self.tm.server_args.reasoning_parser = "inkling"
+        self.chat.reasoning_parser = "inkling"
+
+        req = ChatCompletionRequest(
+            model="thinkingmachines/Inkling-Small-NVFP4",
+            messages=[{"role": "user", "content": "Hi?"}],
+            separate_reasoning=True,
+            return_meta_info=True,
+        )
+        ret_item = {
+            "text": (
+                "<|message_model|><|content_thinking|>think-1<|end_message|>"
+                "<|message_model|><|content_text|>answer-1<|end_message|>"
+                "<|message_model|><|content_thinking|>think-2<|end_message|>"
+                "<|message_model|><|content_text|>answer-2<|end_message|>"
+                "<|content_model_end_sampling|>"
+            ),
+            "meta_info": {
+                "id": f"chatcmpl-{uuid.uuid4()}",
+                "prompt_tokens": 10,
+                "completion_tokens": 4,
+                "weight_version": "default",
+                "finish_reason": {"type": "stop", "matched": None},
+            },
+            "index": 0,
+        }
+
+        response = self.chat._build_chat_response(req, [ret_item], created=0)
+        msg = response.choices[0].message
+        self.assertEqual(msg.reasoning_content, "think-1think-2")
+        self.assertEqual(msg.content, "answer-1answer-2")
+        self.assertEqual(
+            [part.model_dump() for part in msg.content_blocks],
+            [
+                {"type": "thinking", "thinking": None, "text": "think-1"},
+                {"type": "text", "text": "answer-1"},
+                {"type": "thinking", "thinking": None, "text": "think-2"},
+                {"type": "text", "text": "answer-2"},
+            ],
+        )
+
+        req.return_meta_info = False
+        compatible = self.chat._build_chat_response(req, [ret_item], created=0)
+        self.assertIsNone(compatible.choices[0].message.content_blocks)
+
     # --- poolside_v1 (Laguna-XS.2) regression tests ---
 
     def test_poolside_v1_enable_thinking_dispatch(self):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -168,6 +168,63 @@ class TestQwen3Detector(CustomTestCase):
 
 
 class TestInklingDetector(CustomTestCase):
+    def test_non_stream_preserves_repeated_and_interleaved_block_boundaries(self):
+        detector = InklingDetector()
+        source = (
+            "<|message_model|><|content_thinking|>think-1<|end_message|>"
+            "<|message_model|><|content_text|>text-1<|end_message|>"
+            "<|message_model|><|content_thinking|>think-2<|end_message|>"
+            "<|message_model|><|content_text|>text-2<|end_message|>"
+            "<|content_model_end_sampling|>"
+        )
+
+        self.assertEqual(
+            detector.detect_and_parse_block_sequence(source),
+            [
+                ("reasoning", "think-1"),
+                ("text", "text-1"),
+                ("reasoning", "think-2"),
+                ("text", "text-2"),
+            ],
+        )
+        flattened = detector.detect_and_parse(source)
+        self.assertEqual(flattened.reasoning_text, "think-1think-2")
+        self.assertEqual(flattened.normal_text, "text-1text-2")
+
+    def test_non_stream_preserves_adjacent_and_empty_text_blocks(self):
+        detector = InklingDetector()
+        source = (
+            "<|message_model|><|content_text|>first<|end_message|>"
+            "<|message_model|><|content_text|><|end_message|>"
+            "<|message_model|><|content_text|>third<|end_message|>"
+            "<|content_model_end_sampling|>"
+        )
+
+        self.assertEqual(
+            detector.detect_and_parse_block_sequence(source),
+            [("text", "first"), ("text", ""), ("text", "third")],
+        )
+
+    def test_non_stream_marks_tool_and_unframed_regions_not_lossless(self):
+        detector = InklingDetector()
+        source = (
+            "unframed"
+            "<|message_model|>weather<|content_invoke_tool_json|>"
+            '{"name":"weather","args":{}}<|end_message|>'
+        )
+
+        self.assertEqual(
+            detector.detect_and_parse_block_sequence(source),
+            [
+                ("raw", "unframed"),
+                (
+                    "tool",
+                    "<|message_model|>weather<|content_invoke_tool_json|>"
+                    '{"name":"weather","args":{}}<|end_message|>',
+                ),
+            ],
+        )
+
     def test_streaming_routes_blocks_across_all_string_boundaries(self):
         detector = InklingDetector()
         source = (


### PR DESCRIPTION
## Motivation

Inkling may emit repeated or interleaved thinking/text model blocks. The existing non-streaming parser intentionally flattens them into `reasoning_content` and `content`, which preserves visible text but loses block order and boundaries. Session-aware consumers then cannot reproduce the original model token structure.

Companion Miles PR: https://github.com/radixark/miles/pull/2282

## Modifications

- Parse canonical Inkling thinking/text blocks into an ordered sequence without changing the existing flattened fields.
- Add an optional `content_blocks` response side channel. It is emitted only for non-streaming Inkling responses with `return_meta_info=true`.
- Do not emit the side channel for raw/unframed output or native tool calls, where the representation is not lossless.
- Keep ordinary OpenAI-compatible responses unchanged when the field is absent.

## Accuracy Tests

- 12 focused parser, response-schema, and serving-response tests passed.
- Cases cover repeated, adjacent, empty, and interleaved blocks, plus tool/raw rejection.
- Paired real-tokenizer round-trip tests reconstruct the original Inkling control-token sequence.
- A two-rollout Miles/Harbor smoke reported zero assistant-text and special-token TITO mismatches across 16 accepted samples.

## Speed Tests and Profiling

No model, kernel, scheduler, or streaming path changes. Ordered-block extraction runs only on the existing non-streaming parsing path when `return_meta_info=true`; normal clients retain the previous path and response shape.

## Checklist

- [x] Black, isort, `git diff --check`, and registered-test validation pass.
- [x] Unit tests added.
- [x] Existing flattened response fields remain backward compatible.
- [x] No documentation change is required for the internal metadata-only side channel.