### PR TITLE
fix(openai): report hidden decode progress in streams

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -681,8 +681,10 @@ class OpenAIServingChat(OpenAIServingBase):
         prompt_tokens: Dict[int, int],
         reasoning_tokens: Dict[int, int],
         completion_tokens: Dict[int, int],
+        stream_progress_tokens: Dict[int, int],
     ) -> AsyncGenerator[str, None]:
         """Generate SSE chunks for streaming content."""
+        completion_token_count = completion_tokens.get(index, 0)
         offset = stream_offsets.get(index, 0)
         if self.tokenizer_manager.server_args.incremental_streaming_output:
             delta = content["text"]
@@ -724,6 +726,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     logprobs=remaining_logprobs,
                     usage=usage,
                 )
+                stream_progress_tokens[index] = completion_token_count
                 remaining_logprobs = None
 
         # Handle tool calls
@@ -754,8 +757,23 @@ class OpenAIServingChat(OpenAIServingBase):
                     yield remaining_chunk
 
         else:
-            # Regular content
-            if delta:
+            # A non-printable token can advance decode without producing a text
+            # delta. Optionally emit bounded, token-driven progress so an
+            # intermediary can distinguish active hidden decode from a genuine
+            # delivery stall. This is deliberately not a timer heartbeat.
+            progress_interval = (
+                self.tokenizer_manager.server_args.stream_empty_delta_progress_interval
+            )
+            last_progress_token = stream_progress_tokens.get(index, 0)
+            emit_empty_delta_progress = (
+                self.tokenizer_manager.server_args.incremental_streaming_output
+                and progress_interval > 0
+                and not delta
+                and finish_reason_type is None
+                and bool(content.get("output_ids"))
+                and completion_token_count - last_progress_token >= progress_interval
+            )
+            if delta or emit_empty_delta_progress:
                 usage = None
                 if continuous_usage_stats:
                     usage = UsageProcessor.calculate_token_usage(
@@ -774,6 +792,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     logprobs=remaining_logprobs,
                     usage=usage,
                 )
+                stream_progress_tokens[index] = completion_token_count
                 remaining_logprobs = None
 
         # Flush logprobs still unattached this step — only when a parser is
@@ -1482,6 +1501,7 @@ class OpenAIServingChat(OpenAIServingBase):
         # State tracking for streaming
         is_firsts = {}
         stream_offsets = {}
+        stream_progress_tokens = {}
         n_prev_tokens = {}
         has_tool_calls = {}
         finish_reasons = {}
@@ -1594,6 +1614,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens,
                     reasoning_tokens=reasoning_tokens,
                     completion_tokens=completion_tokens,
+                    stream_progress_tokens=stream_progress_tokens,
                 ):
                     yield chunk
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1424,6 +1424,11 @@ class ServerArgs:
     incremental_streaming_output: A[
         bool, "Whether to output as a sequence of disjoint segments.", NS("serving")
     ] = False
+    stream_empty_delta_progress_interval: A[
+        int,
+        "When incremental streaming is enabled, emit an empty content delta after this many generated tokens without an emitted delta. Set to 0 to disable. This reports actual decode progress, not elapsed time.",
+        NS("serving"),
+    ] = 0
     enable_streaming_session: A[
         bool,
         "Enable streaming session mode and StreamingSession wrapper.",

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -69,6 +69,8 @@ class _MockTokenizerManager:
             tool_call_parser="hermes",
             reasoning_parser=None,
             stream_response_default_include_usage=False,
+            incremental_streaming_output=False,
+            stream_empty_delta_progress_interval=0,
             default_chat_template_kwargs=None,
         )
         self.model_path = self.server_args.model_path
@@ -2037,6 +2039,7 @@ class ServingChatTestCase(unittest.TestCase):
             prompt_tokens={0: 5},
             reasoning_tokens={0: 0},
             completion_tokens={0: 1},
+            stream_progress_tokens={},
         ):
             chunks.append(chunk)
         return chunks
@@ -2393,6 +2396,7 @@ class ServingChatTestCase(unittest.TestCase):
                 prompt_tokens={0: 10},
                 reasoning_tokens={0: 0},
                 completion_tokens={0: 2},
+                stream_progress_tokens={},
             ):
                 chunks.append(chunk)
             return chunks
@@ -2501,6 +2505,168 @@ class ServingChatTestCase(unittest.TestCase):
             "I am a large language model.",
             f"Streaming deltas produced broken text: {deltas!r}",
         )
+
+    def _run_incremental_chat_stream(self, chunks):
+        """Run an incremental stream whose detokenizer has hidden-text batches."""
+
+        async def _mock_generate():
+            for text, completion_tokens, output_ids, finish_reason in chunks:
+                content = {
+                    "text": text,
+                    "meta_info": {
+                        "id": "chatcmpl-progress-test",
+                        "prompt_tokens": 10,
+                        "completion_tokens": completion_tokens,
+                        "reasoning_tokens": 0,
+                        "cached_tokens": 0,
+                        "finish_reason": finish_reason,
+                        "output_token_logprobs": None,
+                        "output_top_logprobs": None,
+                    },
+                    "index": 0,
+                }
+                if output_ids is not None:
+                    content["output_ids"] = output_ids
+                yield content
+
+        self.tm.generate_request.return_value = _mock_generate()
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            max_tokens=100,
+            stream=True,
+        )
+        with patch(
+            "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+        ) as conv_mock:
+            conv_mock.return_value.get_prompt.return_value = "Test prompt"
+            adapted_request, _ = self.chat._convert_to_internal_request(
+                req, self.fastapi_request
+            )
+            return self._run_chat_stream(adapted_request, req)
+
+    def _empty_progress_deltas(self, chunks):
+        return [
+            choice["delta"]
+            for event in self._parse_chunks(chunks)
+            for choice in event.get("choices", [])
+            if choice["delta"].get("content") == ""
+            and choice["delta"].get("role") is None
+            and choice.get("finish_reason") is None
+        ]
+
+    def test_empty_delta_progress_is_default_off(self):
+        self.tm.server_args.incremental_streaming_output = True
+
+        chunks = self._run_incremental_chat_stream(
+            [
+                ("", 3, [1, 2, 3], None),
+                ("", 5, [4, 5], {"type": "stop", "matched": None}),
+            ]
+        )
+
+        self.assertEqual(self._empty_progress_deltas(chunks), [])
+
+    def test_empty_delta_progress_reports_token_driven_hidden_decode(self):
+        self.tm.server_args.incremental_streaming_output = True
+        self.tm.server_args.stream_empty_delta_progress_interval = 3
+
+        chunks = self._run_incremental_chat_stream(
+            [
+                ("", 1, [1], None),
+                ("", 3, [2, 3], None),
+                ("", 4, [4], None),
+                ("visible", 5, [5], None),
+                ("", 7, [6, 7], None),
+                ("", 8, [8], None),
+                ("", 11, [9, 10, 11], {"type": "stop", "matched": None}),
+            ]
+        )
+
+        # Progress appears at generated-token counts 3 and 8. The visible
+        # delta resets the counter at 5, and the terminal batch is never used
+        # as a progress heartbeat.
+        self.assertEqual(len(self._empty_progress_deltas(chunks)), 2)
+        visible_deltas = [
+            choice["delta"].get("content")
+            for event in self._parse_chunks(chunks)
+            for choice in event.get("choices", [])
+            if choice["delta"].get("content")
+        ]
+        self.assertEqual(visible_deltas, ["visible"])
+
+    def test_empty_delta_progress_requires_output_ids(self):
+        self.tm.server_args.incremental_streaming_output = True
+        self.tm.server_args.stream_empty_delta_progress_interval = 1
+
+        chunks = self._run_incremental_chat_stream([("", 3, None, None)])
+
+        self.assertEqual(self._empty_progress_deltas(chunks), [])
+
+    def test_reasoning_delta_resets_empty_delta_progress(self):
+        self.tm.server_args.incremental_streaming_output = True
+        self.tm.server_args.stream_empty_delta_progress_interval = 3
+        self.chat.reasoning_parser = "glm45"
+        req = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Hi?"}],
+            stream=True,
+            separate_reasoning=True,
+        )
+        stream_progress_tokens = {}
+
+        def collect(content, completion_tokens):
+            async def run():
+                chunks = []
+                async for chunk in self.chat._generate_stream_content(
+                    content=content,
+                    index=0,
+                    request=req,
+                    stream_offsets={},
+                    reasoning_parser_dict={},
+                    parser_dict={},
+                    has_tool_calls={},
+                    choice_logprobs=None,
+                    finish_reason_type=None,
+                    continuous_usage_stats=False,
+                    prompt_tokens={0: 10},
+                    reasoning_tokens={0: 0},
+                    completion_tokens={0: completion_tokens},
+                    stream_progress_tokens=stream_progress_tokens,
+                ):
+                    chunks.append(chunk)
+                return chunks
+
+            return get_or_create_event_loop().run_until_complete(run())
+
+        def content(completion_tokens, output_ids):
+            return {
+                "text": "",
+                "output_ids": output_ids,
+                "meta_info": {
+                    "id": "chatcmpl-reasoning-progress",
+                    "prompt_tokens": 10,
+                    "completion_tokens": completion_tokens,
+                    "cached_tokens": 0,
+                },
+            }
+
+        with patch.object(
+            self.chat, "_process_reasoning_stream", return_value=("think", "")
+        ):
+            first = collect(content(3, [1, 2, 3]), 3)
+        self.assertEqual(stream_progress_tokens, {0: 3})
+        self.assertEqual(
+            self._parse_chunks(first)[0]["choices"][0]["delta"]["reasoning_content"],
+            "think",
+        )
+
+        with patch.object(
+            self.chat, "_process_reasoning_stream", return_value=(None, "")
+        ):
+            self.assertEqual(collect(content(5, [4, 5]), 5), [])
+            third = collect(content(6, [6]), 6)
+        self.assertEqual(len(self._empty_progress_deltas(third)), 1)
 
     # ------------- X-Data-Parallel-Rank header tests -------------
     def test_extract_routed_dp_rank_from_header_no_header(self):

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -92,6 +92,16 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
         sa = self._parse(["--stream-output"])
         self.assertTrue(sa.incremental_streaming_output)
 
+    def test_stream_empty_delta_progress_interval(self):
+        """The token-driven stream progress option defaults off and parses as an int."""
+        self.assertEqual(self._parse([]).stream_empty_delta_progress_interval, 0)
+        self.assertEqual(
+            self._parse(
+                ["--stream-empty-delta-progress-interval", "16"]
+            ).stream_empty_delta_progress_interval,
+            16,
+        )
+
     def test_combined_parse(self):
         """Multiple option types parsed together in one invocation."""
         sa = self._parse(


### PR DESCRIPTION
## Problem

With `--incremental-streaming-output`, the tokenizer can report a non-empty
`output_ids` batch and advance `meta_info.completion_tokens` while its
printable `text` delta is empty. This is expected for some token sequences:
decode is making real progress, but there is no visible character delta yet.

`OpenAIServingChat` currently suppresses that batch entirely. A downstream
streaming proxy therefore cannot distinguish active hidden decode from a true
stalled stream, and its liveness deadline may expire after the last visible
chunk even though SGLang is still generating.

## Fix

Add a default-off serving flag:

```text
--stream-empty-delta-progress-interval N
```

When `N > 0`, the OpenAI chat endpoint emits a normal SSE chunk with
`delta.content: ""` only when all of these are true:

- incremental streaming is enabled;
- a non-final batch contains actual `output_ids`;
- at least `N` generated tokens have accumulated since the last visible,
  reasoning, or progress chunk for that choice.

This is deliberately token-driven rather than wall-clock-driven. A real decode
or delivery stall emits no frame, so downstream liveness detection remains
meaningful. `N = 0` preserves the existing wire behavior. The counter is
per-choice and resets after visible content and separate reasoning output.

## Tests

- registered OpenAI chat unit suite: 104 passed;
- registered ServerArgs CLI suite: 9 passed;
- cases cover default-off behavior, interval coalescing, visible-content reset,
  reasoning reset, no progress without output IDs, and final-batch suppression;
- `pre-commit run --files ...` and `git diff --check` pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31268740547](https://github.com/sgl-project/sglang/actions/runs/31268740547)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31268740436](https://github.com/sgl-project/sglang/actions/runs/31268740436)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->