### PR TITLE
[diffusion] perf_logger: SYNC_STAGE_PROFILING must drain the GPU queue for stage records too (fixes 2-3x inflated DecodingStage readings)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
+++ b/python/sglang/multimodal_gen/runtime/utils/perf_logger.py
@@ -212,6 +212,23 @@ class StageProfiler:
     def _should_record_as_step(self) -> bool:
         return self.record_as_step or self.stage_name.startswith("denoising_step_")
 
+    def _maybe_sync_device(self):
+        """Drain the device queue when SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1.
+
+        Called at BOTH the timing start and end, for stage records as well as
+        step records. Historically only step records synced, so a stage that
+        merely launches kernels (e.g. DenoisingStage's tail) leaked its queued
+        GPU work into whichever later stage blocked first — DecodingStage
+        readings came out 2-3x too high. The entry sync attributes queued work
+        to the stage that launched it; the exit sync includes this stage's own
+        queued work. Opt-in diagnostics only: the flag defaults off.
+        """
+        if (
+            os.environ.get("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "0") == "1"
+            and torch.get_device_module().is_available()
+        ):
+            torch.get_device_module().synchronize()
+
     def __enter__(self):
         if self.log_stage_start_end:
             msg = f"[{self.stage_name}] started..."
@@ -226,12 +243,7 @@ class StageProfiler:
             self.logger.info(msg)
 
         if (self.log_timing and self.metrics) or self.log_stage_start_end:
-            if (
-                os.environ.get("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "0") == "1"
-                and self._should_record_as_step()
-                and torch.get_device_module().is_available()
-            ):
-                torch.get_device_module().synchronize()
+            self._maybe_sync_device()
             self.start_time = time.perf_counter()
 
         return self
@@ -240,12 +252,7 @@ class StageProfiler:
         if not ((self.log_timing and self.metrics) or self.log_stage_start_end):
             return False
 
-        if (
-            os.environ.get("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "0") == "1"
-            and self._should_record_as_step()
-            and torch.get_device_module().is_available()
-        ):
-            torch.get_device_module().synchronize()
+        self._maybe_sync_device()
         execution_time_s = time.perf_counter() - self.start_time
 
         if exc_type:

--- a/test/registered/kernels/ops/diffusion/test_stage_profiler_sync.py
+++ b/test/registered/kernels/ops/diffusion/test_stage_profiler_sync.py
@@ -1,0 +1,50 @@
+"""SGLANG_DIFFUSION_SYNC_STAGE_PROFILING must drain the GPU queue at the
+timing start of *stage* records too — otherwise a stage that only launches
+kernels (DenoisingStage's tail) leaks its queued work into whichever later
+stage blocks first, inflating e.g. DecodingStage readings 2-3x."""
+
+import sys
+import time
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.perf_logger import (
+    RequestMetrics,
+    StageProfiler,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")
+def test_stage_entry_sync_excludes_previous_stage_tail(monkeypatch):
+    monkeypatch.setenv("SGLANG_DIFFUSION_SYNC_STAGE_PROFILING", "1")
+    logger = init_logger(__name__)
+    metrics = RequestMetrics("stage-sync-test")
+
+    # Calibrate ~0.5 s of queued GPU work.
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    torch.cuda._sleep(10_000_000)
+    torch.cuda.synchronize()
+    cycles = int(10_000_000 / max(time.perf_counter() - t0, 1e-9) * 0.5)
+
+    # Producer stage queues work without awaiting it (a denoise tail).
+    with StageProfiler("producer", logger, metrics, perf_dump_path_provided=True):
+        torch.cuda._sleep(cycles)
+    # Consumer stage's first blocking op used to absorb the producer's tail.
+    with StageProfiler("consumer", logger, metrics, perf_dump_path_provided=True):
+        torch.ones(8, device="cuda").sum().cpu()
+
+    producer_ms, consumer_ms = metrics.stages["producer"], metrics.stages["consumer"]
+    assert (
+        producer_ms > 250
+    ), f"queued work not attributed to producer: {metrics.stages}"
+    assert consumer_ms < 100, f"producer tail leaked into consumer: {metrics.stages}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
Branch: `p5-stage-sync-fix`, one commit rebased onto current `main`, standalone.
Measurement-infrastructure correctness only — the flag defaults off, so the
production path is untouched.

## The bug (the "95 ms mystery")

`SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1` promises synchronized stage
timings, but `StageProfiler` gated **both** its entry and exit
`synchronize()` on `_should_record_as_step()` — i.e. only
`denoising_step_*` records ever synced. Stage-type records (DecodingStage,
etc.) got **no sync at all**:

- the denoise loop's per-step exits do sync, but the DenoisingStage keeps
  launching GPU work *after* the last step context closes (scheduler /
  guidance / latent post-ops);
- that queued tail is then awaited by whichever later stage blocks first —
  typically DecodingStage's first dependent op —
- so the DecodingStage wall-clock silently included the previous stage's
  GPU tail. In this round's three-model comparison the stage readings came
  out **2-3x too high** (the prH "95 ms" hunt was chasing exactly this
  phantom).

## The fix

When the flag is on, `_maybe_sync_device()` runs at the **timing start and
end of every record** — stages and steps alike. The entry sync attributes
queued work to the stage that launched it (it drains *before* `start_time`),
and the exit sync includes the stage's own queued work. Two call sites, one
helper, no change with the flag off (default).

## Verification

**Unit test** (`test/registered/kernels/ops/diffusion/test_stage_profiler_sync.py`,
CUDA): a producer stage queues ~0.5 s of `torch.cuda._sleep` without awaiting
it; a consumer stage runs a trivial blocking op. Pre-fix the consumer reads
~500 ms (the leak); post-fix producer > 250 ms, consumer < 100 ms. Passes on
H200 GPU 1; fails on `main` as expected.

- fixed: `1 passed` — producer holds the queued time, consumer < 100 ms.
- main (same test file, `PYTHONPATH` pointed at main): `1 failed` with
  `producer: 0.0115 ms, consumer: 471.6 ms` — the entire ~0.5 s queued tail
  billed to the consumer stage.

**Krea2 repro** (H200 GPU 1, `SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1`,
Krea-2-Turbo 1024x1024 / 8 steps, seed 42, steady requests):

| arm | DecodingStage (s) | DenoisingStage (s) |
| --- | ---: | ---: |
| main @ 52afe87a08 | 0.164-0.166 | 1.314-1.315 |
| **this PR** | **0.067-0.068** | **1.461-1.462** |

The ~0.1 s denoise tail that used to be billed to DecodingStage (a 2.4x
inflation of its reading) moves back into DenoisingStage where it was
launched; only the diagnostic attribution changes.

## Checklist

- [x] Flag-off behavior byte-identical (default path never reaches the sync).
- [x] Unit test red on main, green with the fix.
- [x] `pre-commit run --files ...` (pinned) passes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31269920909](https://github.com/sgl-project/sglang/actions/runs/31269920909)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31271634833](https://github.com/sgl-project/sglang/actions/runs/31271634833)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->