### PR TITLE
[Fix] Support transformers >= 4.57 configs for DeepSeek V4

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -103,6 +103,22 @@ def _hf_attr(config, name):
     return getattr(config, name, None)
 
 
+def get_deepseek_v4_compress_ratios(config) -> list[int]:
+    """Per-layer DeepSeek V4 compression ratios, normalized across transformers
+    versions. Legacy configs expose ``compress_ratios``; transformers >= 4.57
+    replaces it with ``compress_rates`` (a ``{layer_type: ratio}`` map) keyed by
+    ``layer_types``. Returns ``[]`` when neither representation is present.
+    """
+    ratios = _hf_attr(config, "compress_ratios")
+    if ratios is not None:
+        return list(ratios)
+    layer_types = _hf_attr(config, "layer_types")
+    compress_rates = _hf_attr(config, "compress_rates")
+    if layer_types is not None and compress_rates is not None:
+        return [compress_rates.get(layer_type, 0) for layer_type in layer_types]
+    return []
+
+
 def is_deepseek_dsa(config) -> bool:
     return (
         _hf_arch(config)
@@ -239,8 +255,8 @@ def get_num_indexer_layers(config) -> int:
     if is_deepseek_dsa(config):
         return config.num_hidden_layers
     if is_deepseek_v4(config):
-        compress_ratios = getattr(config, "compress_ratios", None) or []
-        return sum(1 for r in compress_ratios if r == 4)
+        compress_ratios = get_deepseek_v4_compress_ratios(config)
+        return sum(1 for ratio in compress_ratios if ratio == 4)
     return getattr(config, "num_indexer_layers", 0)
 
 
@@ -381,6 +397,12 @@ class ModelConfig:
                     )
             if envs.SGLANG_DSV4_FP4_DEQUANT.get():
                 envs.SGLANG_DSV4_FP4_DEQUANT.set(self.is_fp4_experts is not None)
+            # Normalize compress_ratios onto hf_config so downstream readers
+            # (models/deepseek_v4.py, NPU backend) work on transformers >= 4.57
+            # configs that only expose compress_rates + layer_types.
+            self.hf_config.compress_ratios = get_deepseek_v4_compress_ratios(
+                self.hf_config
+            )
 
             # HF config.json inherits topk_group=4 from the V3 template, but
             # DSV4 trains with no group limiting (sqrtsoftplus + full-expert
@@ -888,9 +910,12 @@ class ModelConfig:
             self.head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
             self.v_head_dim = self.head_dim
             self.index_head_dim = self.hf_config.index_head_dim
-            self.compress_ratios = self.hf_config.compress_ratios
+            self.compress_ratios = get_deepseek_v4_compress_ratios(self.hf_config)
             self.attention_arch = AttentionArch.MHA
-            self._init_mla_scaling(self.hf_config.rope_scaling)
+            self._init_mla_scaling(
+                _hf_attr(self.hf_config, "rope_parameters")
+                or _hf_attr(self.hf_config, "rope_scaling")
+            )
         elif "Glm4MoeForCausalLMNextN" in self.hf_config.architectures:
             if self.head_dim is None:
                 self.head_dim = (

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -108,13 +108,20 @@ def get_deepseek_v4_compress_ratios(config) -> list[int]:
     versions. Legacy configs expose ``compress_ratios``; transformers >= 4.57
     replaces it with ``compress_rates`` (a ``{layer_type: ratio}`` map) keyed by
     ``layer_types``. Returns ``[]`` when neither representation is present.
+
+    An empty ``compress_ratios`` counts as absent: SGLang's own
+    ``DeepSeekV4Config`` defaults the field to ``[]``, and that placeholder
+    must not shadow a populated modern representation.
     """
     ratios = _hf_attr(config, "compress_ratios")
-    if ratios is not None:
+    if ratios:
         return list(ratios)
     layer_types = _hf_attr(config, "layer_types")
     compress_rates = _hf_attr(config, "compress_rates")
     if layer_types is not None and compress_rates is not None:
+        # A layer type with no entry in compress_rates is uncompressed. Keep
+        # one entry per layer: consumers index this list by layer id (see
+        # models/deepseek_v4.py) and slice it per PP rank (pool_configurator).
         return [compress_rates.get(layer_type, 0) for layer_type in layer_types]
     return []
 
@@ -255,6 +262,9 @@ def get_num_indexer_layers(config) -> int:
     if is_deepseek_dsa(config):
         return config.num_hidden_layers
     if is_deepseek_v4(config):
+        # Keep this aligned with the DeepSeek V4 attention path, which
+        # instantiates C4 indexers from the normalized per-layer
+        # compress_ratios.
         compress_ratios = get_deepseek_v4_compress_ratios(config)
         return sum(1 for ratio in compress_ratios if ratio == 4)
     return getattr(config, "num_indexer_layers", 0)

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -51,6 +51,29 @@ class TestDeepseekV4ConfigCompat(CustomTestCase):
         self.assertEqual(get_num_indexer_layers(legacy), 2)
         self.assertEqual(get_num_indexer_layers(modern), 2)
 
+    def test_deepseek_v4_empty_compress_ratios_falls_back_to_modern(self):
+        # SGLang's own DeepSeekV4Config defaults compress_ratios to [], so an
+        # empty legacy placeholder must not shadow a populated modern
+        # representation. This is hardening rather than the #34092 repro
+        # itself: HF's V4 config drops the legacy kwarg instead of emptying it.
+        config = SimpleNamespace(compress_ratios=[], **MODERN)
+        self.assertEqual(get_deepseek_v4_compress_ratios(config), [128, 4, 128, 4])
+        self.assertEqual(get_num_indexer_layers(config), 2)
+
+    def test_deepseek_v4_layer_type_absent_from_compress_rates_is_uncompressed(self):
+        # sliding_attention carries no compress_rates entry and must resolve to
+        # ratio 0, matching the legacy mapping. Ratios also stay one-per-layer:
+        # consumers index by layer id and slice the list per PP rank, so an
+        # unmapped type must yield 0 rather than drop an entry and shift every
+        # later layer's ratio.
+        config = SimpleNamespace(
+            architectures=["DeepseekV4ForCausalLM"],
+            layer_types=["sliding_attention", "compressed_sparse_attention"],
+            compress_rates={"compressed_sparse_attention": 4},
+        )
+        self.assertEqual(get_deepseek_v4_compress_ratios(config), [0, 4])
+        self.assertEqual(get_num_indexer_layers(config), 1)
+
     def test_deepseek_v4_model_config_accepts_modern_transformers_config(self):
         # transformers >= 4.57 config (compress_rates/layer_types/rope_parameters)
         # must derive shapes without error and match the legacy form (#34092).

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -1,16 +1,105 @@
 """Unit tests for hybrid attention model configuration."""
 
+import math
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.configs.model_config import (
+    get_deepseek_v4_compress_ratios,
     get_hybrid_layer_ids,
+    get_num_indexer_layers,
     is_embedding_gemma,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+LEGACY = dict(
+    architectures=["DeepseekV4ForCausalLM"],
+    compress_ratios=[128, 4, 128, 4],
+    rope_scaling={"rope_type": "yarn"},
+)
+
+MODERN = dict(
+    architectures=["DeepseekV4ForCausalLM"],
+    layer_types=[
+        "heavily_compressed_attention",
+        "compressed_sparse_attention",
+        "heavily_compressed_attention",
+        "compressed_sparse_attention",
+    ],
+    compress_rates={
+        "heavily_compressed_attention": 128,
+        "compressed_sparse_attention": 4,
+    },
+    rope_parameters={"rope_type": "yarn"},
+)
+
+
+class TestDeepseekV4ConfigCompat(CustomTestCase):
+    def test_deepseek_v4_compress_ratios_legacy_and_modern(self):
+        legacy = get_deepseek_v4_compress_ratios(SimpleNamespace(**LEGACY))
+        modern = get_deepseek_v4_compress_ratios(SimpleNamespace(**MODERN))
+        self.assertEqual(legacy, [128, 4, 128, 4])
+        self.assertEqual(legacy, modern)
+
+    def test_deepseek_v4_num_indexer_layers_legacy_and_modern(self):
+        legacy = SimpleNamespace(**LEGACY)
+        modern = SimpleNamespace(**MODERN)
+        # two layers have compress_ratio == 4
+        self.assertEqual(get_num_indexer_layers(legacy), 2)
+        self.assertEqual(get_num_indexer_layers(modern), 2)
+
+    def test_deepseek_v4_model_config_accepts_modern_transformers_config(self):
+        # transformers >= 4.57 config (compress_rates/layer_types/rope_parameters)
+        # must derive shapes without error and match the legacy form (#34092).
+        from sglang.srt.configs.model_config import AttentionArch, ModelConfig
+
+        rope = {"rope_type": "deepseek_yarn", "factor": 16, "mscale_all_dim": 1}
+        # _derive_model_shapes reads these unconditionally after the arch branch
+        # (num_attention_heads/model_type/hidden_size/num_hidden_layers/vocab_size),
+        # plus the V4 branch's head/window/index dims.
+        common = dict(
+            model_type="deepseek_v4",
+            num_attention_heads=64,
+            num_hidden_layers=4,
+            hidden_size=4096,
+            vocab_size=129280,
+            head_dim=576,
+            qk_rope_head_dim=64,
+            sliding_window=128,
+            index_head_dim=128,
+        )
+        legacy_cfg = SimpleNamespace(
+            architectures=["DeepseekV4ForCausalLM"],
+            compress_ratios=[128, 4, 128, 4],
+            rope_scaling=rope,
+            **common,
+        )
+        modern_cfg = SimpleNamespace(
+            architectures=["DeepseekV4ForCausalLM"],
+            layer_types=MODERN["layer_types"],
+            compress_rates=MODERN["compress_rates"],
+            rope_parameters=rope,
+            **common,
+        )
+
+        def derive(cfg):
+            mc = ModelConfig.__new__(ModelConfig)  # bypass the heavy __init__
+            mc.hf_config = cfg
+            mc.hf_text_config = cfg
+            mc._derive_model_shapes()
+            return mc
+
+        legacy = derive(legacy_cfg)
+        modern = derive(modern_cfg)
+        self.assertEqual(modern.compress_ratios, [128, 4, 128, 4])
+        self.assertEqual(legacy.compress_ratios, modern.compress_ratios)
+        self.assertEqual(modern.attention_arch, AttentionArch.MHA)
+        # scaling is equal across both forms and yarn actually applied (not base)
+        self.assertEqual(legacy.scaling, modern.scaling)
+        self.assertNotEqual(modern.scaling, 1 / math.sqrt(576))
 
 
 class TestHybridLayerIds(CustomTestCase):


### PR DESCRIPTION
Fixes #34092

## Motivation

Transformers >= 4.57 changed the DeepSeek V4 configuration format:

* `compress_ratios` was replaced by `compress_rates` + `layer_types`
* `rope_scaling` was replaced by `rope_parameters`

SGLang still reads the legacy attributes directly in DeepSeek V4 configuration paths. As a result, models created with newer Transformers versions can fail during initialization with:

```text
AttributeError: 'DeepseekV4Config' object has no attribute 'compress_ratios'
```

The config change can also cause incorrect derived state: `get_num_indexer_layers()` previously interpreted a modern DeepSeek V4 config without `compress_ratios` as having zero C4/indexer layers.

## Modifications

This PR adds compatibility for both the legacy and Transformers >= 4.57 DeepSeek V4 config formats.

Changes include:

* add a helper to normalize DeepSeek V4 compression configuration into the existing `compress_ratios` representation
* derive `compress_ratios[i]` from `compress_rates[layer_types[i]]` for modern configs
* preserve the legacy `compress_ratios` path
* normalize the result onto `hf_config` so downstream consumers can continue using the existing representation
* update `get_num_indexer_layers()` to support both config formats
* use `rope_parameters` when available while retaining the legacy `rope_scaling` fallback
* treat an empty compress_ratios as absent so SGLang's own DeepSeekV4Config default ([]) does not shadow a populated compress_rates + layer_types pair

The normalization preserves SGLang's existing raw compression values such as `0`, `4`, and `128` without additional clamping.

## Accuracy Tests

Added CPU unit coverage for both legacy and Transformers >= 4.57 DeepSeek V4 configurations.

Before the fix, the legacy representation correctly reported two indexer layers while the modern representation incorrectly reported zero:

```text
legacy compress_ratios=[128, 4, 128, 4] -> 2
modern compress_rates + layer_types     -> 0
```

The tests verify that:

* treat an empty compress_ratios as absent so SGLang's own DeepSeekV4Config default ([]) does not shadow a 
* populated compress_rates + layer_types pair
* an empty compress_ratios does not shadow a populated modern representation
* a layer type with no compress_rates entry resolves to ratio 0, preserving one entry per layer
* legacy rope_scaling remains supported and modern rope_parameters is recognized

Test command:

```bash
python3 test/registered/unit/configs/test_model_config.py
```

Result:

```text
/w/python/sglang/srt/layers/quantization/awq/awq.py:52: UserWarning: Only CUDA, HIP and XPU support AWQ currently.
  warnings.warn(f"Only CUDA, HIP and XPU support AWQ currently.")
/w/python/sglang/srt/layers/quantization/gguf.py:69: UserWarning: Only CUDA, MUSA and NPU support GGUF quantization currently.
  warnings.warn(f"Only CUDA, MUSA and NPU support GGUF quantization currently.")
[CI Test Method] TestDeepseekV4ConfigCompat.test_deepseek_v4_compress_ratios_legacy_and_modern
.[CI Test Method] TestDeepseekV4ConfigCompat.test_deepseek_v4_empty_compress_ratios_falls_back_to_modern
[CI Test Method] TestDeepseekV4ConfigCompat.test_deepseek_v4_layer_type_absent_from_compress_rates_is_uncompressed
..[CI Test Method] TestDeepseekV4ConfigCompat.test_deepseek_v4_model_config_accepts_modern_transformers_config
.[CI Test Method] TestDeepseekV4ConfigCompat.test_deepseek_v4_num_indexer_layers_legacy_and_modern
[CI Test Method] TestEmbeddingGemmaConfig.test_detects_bidirectional_gemma3_text_config
[CI Test Method] TestEmbeddingGemmaConfig.test_does_not_misclassify_causal_gemma3
...[CI Test Method] TestHybridLayerIds.test_layer_type_architectures
.
----------------------------------------------------------------------
Ran 8 tests in 0.001s

OK
```

No model weights or GPU execution are required because this change only affects configuration normalization.

## Speed Tests and Profiling

Not applicable. This change only normalizes model configuration during initialization and does not modify model execution, kernels, attention computation, scheduling, or the inference hot path.

## Checklist

* [x] Format your code according to the [[Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit)](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
* [x] Add unit tests according to the [[Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests)](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
* [x] Update documentation according to [[Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations)](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A; no user-facing documentation changes are required.
* [x] Provide accuracy and speed benchmark results according to [[Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy)](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [[Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed)](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — Unit tests cover the configuration behavior; performance benchmarking is not applicable.
* [x] Follow the SGLang code style [[guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance)](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [[PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process)](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [[CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS)](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [[comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests)](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.

   * Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31364999954](https://github.com/sgl-project/sglang/actions/runs/31364999954)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31364999676](https://github.com/sgl-project/sglang/actions/runs/31364999676)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->