### PR TITLE
[AMD] [GLM5] use optional AITER BLOCK_Q MQA logits

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -108,6 +108,19 @@ if _is_cuda:
 if _use_aiter:
     from aiter.ops.cache import indexer_k_quant_and_cache
 
+if _is_hip:
+    try:
+        from aiter.ops.triton._gluon_kernels.gfx950.attention.fp8_mqa_logits_blockq import (
+            fp8_mqa_logits_blockq,
+            get_blockq_config,
+        )
+    except ImportError:
+        fp8_mqa_logits_blockq = None
+        get_blockq_config = None
+else:
+    fp8_mqa_logits_blockq = None
+    get_blockq_config = None
+
 from sglang.srt.distributed import (
     get_attn_tp_group,
 )
@@ -195,6 +208,47 @@ def rotate_activation(x: torch.Tensor) -> torch.Tensor:
         hidden_size & (hidden_size - 1)
     ) == 0, "Hidden size must be a power of 2 for Hadamard transform."
     return hadamard_transform(x, scale=hidden_size**-0.5)
+
+
+def _aiter_fp8_mqa_logits_with_optional_blockq(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    kv_scales: torch.Tensor,
+    weights: torch.Tensor,
+    cu_starts: torch.Tensor,
+    cu_ends: torch.Tensor,
+    fp8_mqa_logits,
+) -> torch.Tensor:
+    if (
+        get_blockq_config is None
+        or fp8_mqa_logits_blockq is None
+        or get_blockq_config(q.shape[1], q.shape[2]) is None
+    ):
+        return fp8_mqa_logits(
+            q,
+            kv,
+            kv_scales,
+            weights,
+            cu_starts,
+            cu_ends,
+            clean_logits=False,
+        )
+
+    seq_len_kv_aligned = ceil_align(kv.shape[0], 256)
+    logits = torch.empty(
+        (q.shape[0], seq_len_kv_aligned),
+        dtype=torch.float32,
+        device=q.device,
+    )[:, : kv.shape[0]]
+    return fp8_mqa_logits_blockq(
+        q,
+        kv,
+        kv_scales,
+        weights,
+        cu_starts,
+        cu_ends,
+        logits,
+    )
 
 
 class Indexer(DSANPUIndexerMixin, BaseFusedOp):
@@ -1048,14 +1102,14 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
                     # transform masks invalid positions via ks/ke/lengths, so the
                     # -inf pre-fill of the [tokens x seq_len_kv] logits buffer is
                     # redundant and grows quadratically with context length.
-                    logits = fp8_mqa_logits(
+                    logits = _aiter_fp8_mqa_logits_with_optional_blockq(
                         q_fp8[:q_offset],
                         kv,
                         scale,
                         weights[:q_offset],
                         ks,
                         ke,
-                        clean_logits=False,
+                        fp8_mqa_logits,
                     )
                 else:
                     q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(
@@ -1104,14 +1158,14 @@ class Indexer(DSANPUIndexerMixin, BaseFusedOp):
 
                     kv, scale = kv_fp8
                     # clean_logits=False: topk transform handles masking (see above)
-                    logits_chunk = fp8_mqa_logits(
+                    logits_chunk = _aiter_fp8_mqa_logits_with_optional_blockq(
                         q_fp8[start:end],
                         kv,
                         scale,
                         weights[start:end],
                         ks[start:end],
                         ke[start:end],
-                        clean_logits=False,
+                        fp8_mqa_logits,
                     )
                 else:
                     q_padded, w_padded, _ = self._pad_heads_for_deep_gemm(

--- a/test/registered/unit/layers/attention/dsa/test_aiter_blockq_dispatch.py
+++ b/test/registered/unit/layers/attention/dsa/test_aiter_blockq_dispatch.py
@@ -1,0 +1,125 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.attention.dsa import dsa_indexer
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestAiterBlockQDispatch(CustomTestCase):
+    def setUp(self):
+        self.q = torch.empty((3, 32, 128), dtype=torch.uint8)
+        self.kv = torch.empty((513, 128), dtype=torch.uint8)
+        self.kv_scales = torch.empty(513, dtype=torch.float32)
+        self.weights = torch.empty((3, 32), dtype=torch.float32)
+        self.cu_starts = torch.zeros(3, dtype=torch.int32)
+        self.cu_ends = torch.full((3,), 513, dtype=torch.int32)
+        self.fallback_result = object()
+        self.fp8_mqa_logits = MagicMock(return_value=self.fallback_result)
+
+    def _dispatch(self):
+        return dsa_indexer._aiter_fp8_mqa_logits_with_optional_blockq(
+            self.q,
+            self.kv,
+            self.kv_scales,
+            self.weights,
+            self.cu_starts,
+            self.cu_ends,
+            self.fp8_mqa_logits,
+        )
+
+    def test_unavailable_kernel_falls_back(self):
+        with (
+            patch.object(dsa_indexer, "get_blockq_config", None),
+            patch.object(dsa_indexer, "fp8_mqa_logits_blockq", None),
+        ):
+            result = self._dispatch()
+
+        self.assertIs(result, self.fallback_result)
+        self.fp8_mqa_logits.assert_called_once_with(
+            self.q,
+            self.kv,
+            self.kv_scales,
+            self.weights,
+            self.cu_starts,
+            self.cu_ends,
+            clean_logits=False,
+        )
+
+    def test_unsupported_shape_falls_back(self):
+        get_config = MagicMock(return_value=None)
+        blockq = MagicMock()
+
+        with (
+            patch.object(dsa_indexer, "get_blockq_config", get_config),
+            patch.object(dsa_indexer, "fp8_mqa_logits_blockq", blockq),
+        ):
+            result = self._dispatch()
+
+        self.assertIs(result, self.fallback_result)
+        get_config.assert_called_once_with(32, 128)
+        blockq.assert_not_called()
+        self.fp8_mqa_logits.assert_called_once_with(
+            self.q,
+            self.kv,
+            self.kv_scales,
+            self.weights,
+            self.cu_starts,
+            self.cu_ends,
+            clean_logits=False,
+        )
+
+    def test_supported_shape_allocates_aligned_logits_and_calls_directly(self):
+        get_config = MagicMock(return_value={"BLOCK_KV": 64})
+        blockq = MagicMock(side_effect=lambda *args: args[-1])
+
+        with (
+            patch.object(dsa_indexer, "get_blockq_config", get_config),
+            patch.object(dsa_indexer, "fp8_mqa_logits_blockq", blockq),
+        ):
+            logits = self._dispatch()
+
+        self.assertEqual(logits.shape, (3, 513))
+        self.assertEqual(logits.stride(), (768, 1))
+        self.assertEqual(logits.dtype, torch.float32)
+        self.assertEqual(logits.device, self.q.device)
+        get_config.assert_called_once_with(32, 128)
+        blockq.assert_called_once()
+        self.fp8_mqa_logits.assert_not_called()
+        call = blockq.call_args
+        self.assertEqual(call.kwargs, {})
+        expected_args = (
+            self.q,
+            self.kv,
+            self.kv_scales,
+            self.weights,
+            self.cu_starts,
+            self.cu_ends,
+        )
+        for actual, expected in zip(call.args[:-1], expected_args):
+            self.assertIs(actual, expected)
+        self.assertIs(call.args[-1], logits)
+
+    def test_supported_kernel_errors_propagate(self):
+        with (
+            patch.object(dsa_indexer, "get_blockq_config", return_value={}),
+            patch.object(
+                dsa_indexer,
+                "fp8_mqa_logits_blockq",
+                side_effect=RuntimeError("compile failed"),
+            ),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "compile failed"):
+                self._dispatch()
+        self.fp8_mqa_logits.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

[ROCm/aiter#4180](https://github.com/ROCm/aiter/pull/4180) adds a config-gated BLOCK_Q kernel for the GLM-5.2 DSA prefill MQA-logits shape. On MI355X it reduces the raw MQA-logits time from 10.06 ms to 7.53 ms per prefill forward (−25.2%) and produces small, consistent serving gains across the full concurrency sweep.

The kernel is not yet available in released AITER builds. SGLang therefore needs capability detection that preserves the existing stock-AITER path while automatically using BLOCK_Q when the dependency provides it.

## Modifications

- Optionally import the config-gated BLOCK_Q Gluon kernel from ROCm/aiter#4180 on HIP.
- Dispatch supported `(num_heads, head_dim)` shapes directly to BLOCK_Q.
- Preserve the existing public `fp8_mqa_logits(..., clean_logits=False)` path when the optional module is unavailable or the shape is unsupported.
- Preserve 256-element logits row alignment.
- Propagate compile/runtime errors from an available BLOCK_Q kernel instead of silently falling back.
- Add CPU mock coverage for unavailable, unsupported, supported, aligned-output, direct-call, and error-propagation behavior.

## Accuracy Tests

| Validation | Stock AITER | BLOCK_Q |
| --- | ---: | ---: |
| GSM8K, 20 examples | 0.95 | 0.95 |

## Speed Benchmarks

GLM-5.2-MXFP4, TP4 MI355X, 8k input / 1k output, REPS=2, `sglang.bench_serving`.

A. Stock AITER:

| concurrency | TTFT (ms) | ITL (ms) | E2EL (ms) | output tok/s |
| ---: | ---: | ---: | ---: | ---: |
| 4 | 1243.4 | 12.23 | 14168 | 288.7 |
| 8 | 2058.4 | 13.91 | 17497 | 468.0 |
| 16 | 3682.3 | 16.34 | 23260 | 704.3 |
| 32 | 7094.1 | 20.05 | 33619 | 972.7 |
| 64 | 13638.7 | 27.02 | 53701 | 1220.7 |

B. BLOCK_Q from ROCm/aiter#4180 (Δ vs stock):

| concurrency | TTFT (ms) | Δ | ITL (ms) | Δ | E2EL (ms) | Δ | output tok/s | Δ |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 1237.7 | −0.46% | 12.20 | −0.25% | 14138 | −0.21% | 289.3 | +0.22% |
| 8 | 2042.2 | −0.79% | 13.89 | −0.11% | 17441 | −0.32% | 469.5 | +0.32% |
| 16 | 3672.4 | −0.27% | 16.33 | −0.06% | 23231 | −0.12% | 704.8 | +0.07% |
| 32 | 7081.0 | −0.19% | 20.00 | −0.22% | 33413 | −0.61% | 980.4 | +0.79% |
| 64 | 13552.0 | −0.64% | 26.98 | −0.11% | 53519 | −0.34% | 1224.6 | +0.32% |

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with comments or contact authorized users.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31270392490](https://github.com/sgl-project/sglang/actions/runs/31270392490)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31270392320](https://github.com/sgl-project/sglang/actions/runs/31270392320)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->