### PR TITLE
[configs] Backfill DeepSeek V4 compress_ratios from   compress_rates

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/__init__.py
+++ b/python/sglang/srt/utils/hf_transformers/__init__.py
@@ -22,7 +22,10 @@ path ``sglang.srt.utils.hf_transformers_utils`` is preserved by a
 separate shim module.
 """
 
-from ..hf_transformers_patches import normalize_rope_scaling_compat
+from ..hf_transformers_patches import (
+    normalize_deepseek_v4_compat,
+    normalize_rope_scaling_compat,
+)
 from .common import (
     CONTEXT_LENGTH_KEYS,
     AutoConfig,
@@ -64,5 +67,6 @@ __all__ = [
     "get_sparse_attention_config",
     "get_tokenizer",
     "get_tokenizer_from_processor",
+    "normalize_deepseek_v4_compat",
     "normalize_rope_scaling_compat",
 ]

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -90,7 +90,10 @@ from sglang.srt.configs.internvl import InternVLChatConfig
 from sglang.srt.utils import get_bool_env_var, logger, lru_cache_frozenset
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
-from ..hf_transformers_patches import normalize_rope_scaling_compat
+from ..hf_transformers_patches import (
+    normalize_deepseek_v4_compat,
+    normalize_rope_scaling_compat,
+)
 
 if get_bool_env_var("SGLANG_USE_MODELSCOPE"):
     from modelscope import AutoConfig, GenerationConfig
@@ -556,6 +559,9 @@ def get_hf_text_config(config: PretrainedConfig):
 
     # Ensure rope_scaling dicts have "type" for remote-code compat (v5).
     normalize_rope_scaling_compat(config)
+
+    # Backfill DeepSeek V4 field renames from transformers >= 4.57 (#34092).
+    normalize_deepseek_v4_compat(config)
 
     if text_config is not None:
         return _patch_text_config(config, text_config)

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -128,6 +128,9 @@ def normalize_deepseek_v4_compat(config) -> None:
 
     if getattr(config, "model_type", None) != "deepseek_v4":
         return
+
+    _flatten_deepseek_v4_rope(config)
+
     # ``hasattr`` alone is not enough here: some configs may carry an
     # explicit ``compress_ratios = None``, which would short-circuit the
     # rebuild and hand downstream a ``None`` that then explodes at
@@ -158,6 +161,44 @@ def normalize_deepseek_v4_compat(config) -> None:
         return rates.get(lt, 0)
 
     config.compress_ratios = [_legacy_ratio(lt) for lt in layer_types]
+
+
+def _flatten_deepseek_v4_rope(config) -> None:
+    """Flatten upstream V4's nested ``rope_parameters`` into the flat shape
+    sglang's DSv4 attention expects.
+
+    Upstream ``DeepseekV4Config.__post_init__`` reshapes ``rope_parameters``
+    into ``{"main": {...yarn params...}, "compress": {...compress yarn...}}``.
+    sglang consumes it as a flat dict — ``get_rope_config()`` returns the
+    top-level dict, and ``deepseek_v4.py::MqaAttentionBase.__init__`` reads
+    ``scaling["original_max_position_embeddings"]``, ``scaling.get("factor")``,
+    ``scaling.get("beta_fast" / "beta_slow")``, all of which upstream nests
+    under ``main``. A nested config would otherwise silently degrade yarn to
+    the ``.get(..., 1.0)`` defaults.
+
+    Prefer the ``main`` branch (the standard-attention rope; ``compress`` is
+    for CSA / HCA layers, whose base is already ``config.compress_rope_theta``
+    handled separately downstream). Lift ``rope_theta`` in if it is missing so
+    ``get_rope_config()`` — which reads ``rp["rope_theta"]`` when
+    ``rope_parameters`` is non-None — succeeds. Setting ``config.rope_scaling``
+    also updates ``config.rope_parameters`` via ``PretrainedConfig``'s
+    bidirectional alias, so both attributes agree on the flat shape after
+    this normalizer runs.
+    """
+
+    rp = getattr(config, "rope_parameters", None)
+    if not isinstance(rp, dict):
+        return
+    main = rp.get("main")
+    compress = rp.get("compress")
+    if not (isinstance(main, dict) and isinstance(compress, dict)):
+        return
+    flat = dict(main)
+    if "rope_theta" not in flat:
+        flat["rope_theta"] = getattr(config, "rope_theta", 10000)
+    # PretrainedConfig aliases rope_parameters <-> rope_scaling, so this
+    # single set covers both attribute paths downstream.
+    config.rope_scaling = flat
 
 
 def normalize_rope_scaling_compat(config) -> None:

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -95,6 +95,29 @@ def _mute_diffusers_torchao_probe():
 # ---------------------------------------------------------------------------
 
 
+def normalize_deepseek_v4_compat(config) -> None:
+    """Backfill the DeepSeek V4 ``compress_rates`` -> ``compress_ratios`` rename
+    that landed in transformers >= 4.57 (#34092).
+
+    Downstream sglang code (``configs/model_config.py``,
+    ``models/deepseek_v4.py``, ``hardware_backend/npu/attention/
+    ascend_dsv4_backend.py``) reads ``.compress_ratios`` off the loaded HF
+    config directly. Copying the new-name attribute onto the old name at the
+    config-loading boundary lets every call site keep reading the legacy name,
+    avoiding scattered defensive ``getattr`` fallbacks.
+
+    Note: the sibling ``rope_scaling`` / ``rope_parameters`` rename is already
+    handled inside upstream transformers ``PretrainedConfig`` via a bidirectional
+    alias; no backfill is required here.
+    """
+
+    if getattr(config, "model_type", None) != "deepseek_v4":
+        return
+
+    if not hasattr(config, "compress_ratios") and hasattr(config, "compress_rates"):
+        config.compress_ratios = config.compress_rates
+
+
 def normalize_rope_scaling_compat(config) -> None:
     """Ensure rope_scaling dicts have ``"type"`` alongside ``"rope_type"``.
 

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -143,17 +143,19 @@ def normalize_deepseek_v4_compat(config) -> None:
         return
 
     def _legacy_ratio(lt: str) -> int:
-        # Sliding-attention layers have no compression rate upstream; encode
-        # them as ``0`` to preserve the legacy shape.
+        # ``sliding_attention`` layers are absent from ``compress_rates`` by
+        # design (SWA has no compression rate) — encode them as ``0`` to
+        # preserve the legacy shape. Any other layer type that the loaded
+        # ``compress_rates`` does not name falls back to ``0`` too: the
+        # downstream sglang readers (``sum(r == 4)``, ``4 in ...`` /
+        # ``128 in ...``, and per-layer indexing) all treat ``0`` as a
+        # non-compressed layer, so a silently unknown type degrades to
+        # "run as an uncompressed layer" rather than crashing config load.
+        # This matches the community consensus reached in vLLM's harden
+        # pass (vllm-project/vllm#43443).
         if lt == "sliding_attention":
             return 0
-        try:
-            return rates[lt]
-        except KeyError:
-            raise ValueError(
-                f"DeepseekV4Config layer_type {lt!r} has no entry in "
-                f"compress_rates {sorted(rates)}"
-            ) from None
+        return rates.get(lt, 0)
 
     config.compress_ratios = [_legacy_ratio(lt) for lt in layer_types]
 

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -103,19 +103,22 @@ def normalize_deepseek_v4_compat(config) -> None:
     Upstream renamed the field *and reshaped it*:
 
     - old (transformers < 4.57): ``compress_ratios: list[int]``, indexed by
-      layer id, values in ``{4, 128}``.
+      layer id. Values follow upstream's
+      ``_COMPRESS_RATIO_TO_LAYER_TYPE = {0: "sliding_attention",
+      4: "compressed_sparse_attention", 128: "heavily_compressed_attention"}``
+      — i.e. ``0`` marks a sliding-window layer (no compression), ``4`` /
+      ``128`` mark the two compressed attention types.
     - new (>= 4.57): ``compress_rates: dict[str, int]`` keyed by layer-type
       label, paired with ``layer_types: list[str]`` giving the per-layer
-      schedule.
+      schedule. ``compress_rates`` only carries the two compressed types;
+      sliding-attention layers are not entries in that dict.
 
     sglang readers still consume the legacy ``list[int]`` shape
     (``models/deepseek_v4.py`` does ``config.compress_ratios[layer_id]``;
     ``configs/model_config.py`` filters it by ``== 4``; the NPU backend
-    checks ``4 in ...`` / ``128 in ...``). Copying the new dict onto the
-    legacy name unchanged would swap the container type and turn the
-    original ``AttributeError`` into a ``KeyError`` — the same crash in a
-    new location. Expand the mapping into the legacy list here so every
-    downstream reader keeps its indexing semantics.
+    checks ``4 in ...`` / ``128 in ...``). Rebuild that per-layer list
+    here: sliding-attention layers emit ``0`` (matching the legacy
+    encoding), the two compressed types resolve through ``compress_rates``.
 
     sglang currently aliases the ``deepseek_v4`` model_type onto upstream's
     ``DeepseekV3Config`` (see ``hf_transformers/common.py``), so upstream's
@@ -133,14 +136,20 @@ def normalize_deepseek_v4_compat(config) -> None:
     if not isinstance(rates, dict) or not isinstance(layer_types, (list, tuple)):
         return
 
-    try:
-        config.compress_ratios = [rates[lt] for lt in layer_types]
-    except KeyError as exc:
-        missing = exc.args[0]
-        raise ValueError(
-            f"DeepseekV4Config layer_type {missing!r} has no entry in "
-            f"compress_rates {sorted(rates)}"
-        ) from exc
+    def _legacy_ratio(lt: str) -> int:
+        # Sliding-attention layers have no compression rate upstream; encode
+        # them as ``0`` to preserve the legacy shape.
+        if lt == "sliding_attention":
+            return 0
+        try:
+            return rates[lt]
+        except KeyError:
+            raise ValueError(
+                f"DeepseekV4Config layer_type {lt!r} has no entry in "
+                f"compress_rates {sorted(rates)}"
+            ) from None
+
+    config.compress_ratios = [_legacy_ratio(lt) for lt in layer_types]
 
 
 def normalize_rope_scaling_compat(config) -> None:

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -96,26 +96,51 @@ def _mute_diffusers_torchao_probe():
 
 
 def normalize_deepseek_v4_compat(config) -> None:
-    """Backfill the DeepSeek V4 ``compress_rates`` -> ``compress_ratios`` rename
-    that landed in transformers >= 4.57 (#34092).
+    """Rebuild the DeepSeek V4 legacy ``compress_ratios`` list from the new
+    ``compress_rates`` mapping + ``layer_types`` schedule introduced in
+    transformers >= 4.57 (#34092).
 
-    Downstream sglang code (``configs/model_config.py``,
-    ``models/deepseek_v4.py``, ``hardware_backend/npu/attention/
-    ascend_dsv4_backend.py``) reads ``.compress_ratios`` off the loaded HF
-    config directly. Copying the new-name attribute onto the old name at the
-    config-loading boundary lets every call site keep reading the legacy name,
-    avoiding scattered defensive ``getattr`` fallbacks.
+    Upstream renamed the field *and reshaped it*:
 
-    Note: the sibling ``rope_scaling`` / ``rope_parameters`` rename is already
-    handled inside upstream transformers ``PretrainedConfig`` via a bidirectional
-    alias; no backfill is required here.
+    - old (transformers < 4.57): ``compress_ratios: list[int]``, indexed by
+      layer id, values in ``{4, 128}``.
+    - new (>= 4.57): ``compress_rates: dict[str, int]`` keyed by layer-type
+      label, paired with ``layer_types: list[str]`` giving the per-layer
+      schedule.
+
+    sglang readers still consume the legacy ``list[int]`` shape
+    (``models/deepseek_v4.py`` does ``config.compress_ratios[layer_id]``;
+    ``configs/model_config.py`` filters it by ``== 4``; the NPU backend
+    checks ``4 in ...`` / ``128 in ...``). Copying the new dict onto the
+    legacy name unchanged would swap the container type and turn the
+    original ``AttributeError`` into a ``KeyError`` — the same crash in a
+    new location. Expand the mapping into the legacy list here so every
+    downstream reader keeps its indexing semantics.
+
+    sglang currently aliases the ``deepseek_v4`` model_type onto upstream's
+    ``DeepseekV3Config`` (see ``hf_transformers/common.py``), so upstream's
+    own ``DeepseekV4Config.__post_init__`` legacy-input path does not run
+    and the reconstruction has to happen here.
     """
 
     if getattr(config, "model_type", None) != "deepseek_v4":
         return
+    if hasattr(config, "compress_ratios"):
+        return
 
-    if not hasattr(config, "compress_ratios") and hasattr(config, "compress_rates"):
-        config.compress_ratios = config.compress_rates
+    rates = getattr(config, "compress_rates", None)
+    layer_types = getattr(config, "layer_types", None)
+    if not isinstance(rates, dict) or not isinstance(layer_types, (list, tuple)):
+        return
+
+    try:
+        config.compress_ratios = [rates[lt] for lt in layer_types]
+    except KeyError as exc:
+        missing = exc.args[0]
+        raise ValueError(
+            f"DeepseekV4Config layer_type {missing!r} has no entry in "
+            f"compress_rates {sorted(rates)}"
+        ) from exc
 
 
 def normalize_rope_scaling_compat(config) -> None:

--- a/python/sglang/srt/utils/hf_transformers_patches.py
+++ b/python/sglang/srt/utils/hf_transformers_patches.py
@@ -128,7 +128,13 @@ def normalize_deepseek_v4_compat(config) -> None:
 
     if getattr(config, "model_type", None) != "deepseek_v4":
         return
-    if hasattr(config, "compress_ratios"):
+    # ``hasattr`` alone is not enough here: some configs may carry an
+    # explicit ``compress_ratios = None``, which would short-circuit the
+    # rebuild and hand downstream a ``None`` that then explodes at
+    # ``for r in ...`` / ``[layer_id]``. Treat only a real non-None value as
+    # "already legacy-shaped, keep as is". (See vLLM's harden pass in
+    # vllm-project/vllm#43443 for the same lesson.)
+    if getattr(config, "compress_ratios", None) is not None:
         return
 
     rates = getattr(config, "compress_rates", None)

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -1,16 +1,20 @@
 """Unit tests for hybrid attention model configuration."""
 
+import math
 import unittest
 from types import SimpleNamespace
 
 from sglang.srt.configs.model_config import (
+    AttentionArch,
     ModelConfig,
     get_hybrid_layer_ids,
+    get_num_indexer_layers,
     is_embedding_gemma,
     is_multimodal_model,
     resolve_spec_hidden_size,
 )
 from sglang.srt.configs.qwen4_exp import Qwen4ExpTextConfig
+from sglang.srt.utils.hf_transformers_patches import normalize_deepseek_v4_compat
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -110,6 +114,144 @@ class TestDraftModelConfig(CustomTestCase):
             ),
             (hidden_size, None),
         )
+
+
+# ---------------------------------------------------------------------------
+# End-to-end equivalence: legacy vs transformers >= 4.57 DeepSeek V4 configs
+# ---------------------------------------------------------------------------
+
+
+def _make_v4_alias():
+    """Return the same DeepSeek V3 subclass sglang uses for ``deepseek_v4``.
+
+    This mirrors ``_DeepseekV4ConfigAlias`` in
+    ``python/sglang/srt/utils/hf_transformers/common.py`` — subclassing
+    upstream ``DeepseekV3Config`` and overriding ``model_type`` — so the
+    tests exercise the same load path a real checkpoint takes. Using a
+    real ``PreTrainedConfig`` subclass (rather than ``SimpleNamespace`` or
+    a bare ``PretrainedConfig()``) is what makes the equivalence assertion
+    meaningful: the upstream class carries the ``rope_parameters`` <->
+    ``rope_scaling`` bidirectional alias that sglang relies on to *not*
+    duplicate rope-rename handling in this repo.
+    """
+    from transformers import DeepseekV3Config
+
+    class _DeepseekV4ConfigAlias(DeepseekV3Config):
+        model_type = "deepseek_v4"
+
+    return _DeepseekV4ConfigAlias
+
+
+_LT_CSA = "compressed_sparse_attention"
+_LT_HCA = "heavily_compressed_attention"
+_LT_SWA = "sliding_attention"
+
+_YARN_ROPE = {
+    "rope_type": "deepseek_yarn",
+    "factor": 16,
+    "mscale_all_dim": 1,
+    "beta_fast": 32,
+    "beta_slow": 1,
+    "original_max_position_embeddings": 4096,
+}
+
+
+class TestDeepseekV4ConfigCompat(CustomTestCase):
+    """Guard #34092 end-to-end: a DeepSeek V4 config loaded with
+    ``transformers >= 4.57`` (``compress_rates`` dict + ``layer_types``
+    list, plus ``rope_parameters``) must derive the same ``ModelConfig``
+    shape as the legacy ``compress_ratios`` list + ``rope_scaling`` dict
+    representation. This is the assertion that closes the issue — the
+    field-rename fix in ``normalize_deepseek_v4_compat`` alone is
+    necessary but not sufficient; only the equivalence assertion catches
+    a rebuild that silently drops rope scaling, corrupts per-layer
+    ratios, or breaks the indexer-layer count."""
+
+    _COMMON = dict(
+        num_attention_heads=64,
+        num_hidden_layers=4,
+        hidden_size=4096,
+        vocab_size=129280,
+        head_dim=576,
+        qk_rope_head_dim=64,
+        sliding_window=128,
+        index_head_dim=128,
+    )
+
+    def _legacy_config(self):
+        cfg = _make_v4_alias()(**self._COMMON)
+        cfg.architectures = ["DeepseekV4ForCausalLM"]
+        cfg.compress_ratios = [128, 4, 128, 4]
+        cfg.rope_scaling = dict(_YARN_ROPE)
+        return cfg
+
+    def _modern_config(self):
+        cfg = _make_v4_alias()(**self._COMMON)
+        cfg.architectures = ["DeepseekV4ForCausalLM"]
+        cfg.compress_rates = {_LT_CSA: 4, _LT_HCA: 128}
+        cfg.layer_types = [_LT_HCA, _LT_CSA, _LT_HCA, _LT_CSA]
+        cfg.rope_parameters = dict(_YARN_ROPE)
+        return cfg
+
+    def _derive(self, cfg):
+        # Match how the loader actually calls things: normalize once at
+        # the config boundary, then run the DSv4 branch of the shape
+        # derivation. ``ModelConfig.__new__`` bypasses the heavy
+        # ``__init__`` (which downloads weights).
+        normalize_deepseek_v4_compat(cfg)
+        mc = ModelConfig.__new__(ModelConfig)
+        mc.hf_config = cfg
+        mc.hf_text_config = cfg
+        mc._derive_model_shapes()
+        return mc
+
+    def test_compress_ratios_match_legacy(self):
+        # The heart of #34092: rebuilding via layer_types + compress_rates
+        # must land on exactly the same per-layer list a legacy config
+        # would have shipped.
+        modern = self._derive(self._modern_config())
+        legacy = self._derive(self._legacy_config())
+        self.assertEqual(modern.compress_ratios, [128, 4, 128, 4])
+        self.assertEqual(modern.compress_ratios, legacy.compress_ratios)
+
+    def test_indexer_layer_count_matches_legacy(self):
+        # ``get_num_indexer_layers`` filters by ``ratio == 4``. If the
+        # rebuild left ratios in the wrong slots, indexer allocation
+        # would silently drift.
+        modern = self._modern_config()
+        normalize_deepseek_v4_compat(modern)
+        legacy = self._legacy_config()
+        self.assertEqual(get_num_indexer_layers(modern), 2)
+        self.assertEqual(get_num_indexer_layers(legacy), 2)
+
+    def test_rope_scaling_survives_both_representations(self):
+        # ``_derive_model_shapes`` in the DSv4 branch reads
+        # ``self.hf_config.rope_scaling`` directly. Upstream
+        # ``PreTrainedConfig`` bidirectionally aliases ``rope_parameters``
+        # onto ``rope_scaling``; this test pins that dependency down so a
+        # future upstream change (or a switch to a subclass that breaks
+        # the alias) is caught here rather than at model-load time.
+        modern = self._derive(self._modern_config())
+        legacy = self._derive(self._legacy_config())
+        self.assertEqual(modern.scaling, legacy.scaling)
+        # And yarn actually applied — not the base 1/sqrt(head_dim).
+        self.assertNotEqual(modern.scaling, 1 / math.sqrt(576))
+        self.assertEqual(modern.attention_arch, AttentionArch.MHA)
+
+    def test_sliding_attention_layers_use_legacy_zero(self):
+        # Real V4 checkpoints interleave sliding-window layers. Those
+        # slots are absent from ``compress_rates`` (SWA has no
+        # compression rate). Upstream's legacy encoding uses ``0``; the
+        # rebuild must preserve that.
+        cfg = _make_v4_alias()(**self._COMMON)
+        cfg.architectures = ["DeepseekV4ForCausalLM"]
+        cfg.compress_rates = {_LT_CSA: 4, _LT_HCA: 128}
+        cfg.layer_types = [_LT_SWA, _LT_HCA, _LT_SWA, _LT_CSA]
+        cfg.rope_parameters = dict(_YARN_ROPE)
+        derived = self._derive(cfg)
+        self.assertEqual(derived.compress_ratios, [0, 128, 0, 4])
+        # The two SWA layers must not count as C4 indexer layers.
+        self.assertEqual(get_num_indexer_layers(cfg), 1)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -302,15 +302,19 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
         normalize_deepseek_v4_compat(cfg)
         self.assertFalse(hasattr(cfg, "compress_ratios"))
 
-    def test_raises_clear_error_on_unknown_layer_type(self):
-        # An unknown ``layer_types`` entry (neither a compressed type in
-        # ``compress_rates`` nor the ``sliding_attention`` special case)
-        # should surface as a ValueError that names both the missing key and
-        # the available ones — not a bare KeyError from the list
-        # comprehension.
+    def test_unknown_layer_type_silently_falls_back_to_zero(self):
+        # Unknown ``layer_types`` entries fall back to ``0`` — the same
+        # encoding used for ``sliding_attention`` layers and every
+        # downstream reader already treats ``0`` as "not a compressed
+        # layer". Silent degradation is preferable to raising here: the
+        # crash would surface at config-load time on any upstream that
+        # adds a new layer type sglang has not yet been rebuilt for,
+        # even when the new type does not need any special handling.
+        # Matches the community consensus reached in
+        # vllm-project/vllm#43443 and sgl-project#34128.
         cfg = self._make_new_transformers_config([self._LT_CSA, "mystery_layer"])
-        with self.assertRaisesRegex(ValueError, r"mystery_layer.*compress_rates"):
-            normalize_deepseek_v4_compat(cfg)
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [4, 0])
 
     def test_no_op_when_only_one_of_the_new_fields_is_present(self):
         # When the loaded config is malformed or partially populated (e.g. a
@@ -322,6 +326,62 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
         # layer_types deliberately absent
         normalize_deepseek_v4_compat(cfg)
         self.assertFalse(hasattr(cfg, "compress_ratios"))
+
+    def test_no_op_when_compress_rates_is_not_a_dict(self):
+        # A misconfigured ``model_override_args={"compress_rates": [...]}``
+        # can hand the loader a list where a dict is expected. Fail loudly
+        # by falling through to a plain AttributeError downstream rather
+        # than reshaping garbage silently — an isinstance guard bounds the
+        # blast radius to config-load rather than the first attention
+        # layer's ``.get(...)`` call.
+        cfg = self._make_new_transformers_config([self._LT_CSA])
+        cfg.compress_rates = [4, 128]  # wrong shape
+        normalize_deepseek_v4_compat(cfg)
+        self.assertFalse(hasattr(cfg, "compress_ratios"))
+
+    def test_no_op_when_layer_types_is_a_string(self):
+        # Another common malformed-input shape: someone passes a single
+        # ``"compressed_sparse_attention"`` string instead of a list of
+        # them. ``for lt in layer_types`` would iterate characters and
+        # produce nonsense ratios. The isinstance guard keeps the helper
+        # a no-op so the downstream AttributeError is preserved as the
+        # diagnostic surface.
+        cfg = self._make_new_transformers_config(self._LT_CSA)  # not a list
+        normalize_deepseek_v4_compat(cfg)
+        self.assertFalse(hasattr(cfg, "compress_ratios"))
+
+    def test_length_matches_layer_types_not_num_hidden_layers(self):
+        # Contract: the rebuilt list is exactly as long as ``layer_types``.
+        # sglang downstream (``configs/model_config.py`` and
+        # ``models/deepseek_v4.py``) indexes it by layer id, so a shorter
+        # list surfaces as ``IndexError`` at the right site rather than
+        # this helper silently padding. Documented as a pinned contract
+        # so a future "pad to num_hidden_layers" refactor gets caught.
+        cfg = self._make_new_transformers_config([self._LT_CSA, self._LT_HCA])
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(len(cfg.compress_ratios), 2)
+
+    def test_empty_compress_rates_produces_zero_ratios(self):
+        # Degenerate but plausible config
+        # (``compress_rates={}``): every non-SWA layer degrades to 0.
+        # Downstream still gets a well-formed ``list[int]`` and reads
+        # ``4 in []`` / ``sum(r == 4)`` / ``[layer_id]`` without crashing.
+        cfg = self._make_new_transformers_config([self._LT_CSA, self._LT_HCA])
+        cfg.compress_rates = {}
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [0, 0])
+
+    def test_idempotent_across_repeated_calls(self):
+        # The loader may run through ``get_hf_text_config`` more than once
+        # for shared configs (multi-model launches, override paths). The
+        # second invocation must be a no-op on a config that already has
+        # the legacy list, and must not double-rebuild.
+        cfg = self._make_new_transformers_config([self._LT_HCA, self._LT_CSA])
+        normalize_deepseek_v4_compat(cfg)
+        first = cfg.compress_ratios
+        normalize_deepseek_v4_compat(cfg)
+        second = cfg.compress_ratios
+        self.assertIs(first, second)
 
 
 # ---------------------------------------------------------------------------

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -383,6 +383,58 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
         second = cfg.compress_ratios
         self.assertIs(first, second)
 
+    def test_flattens_nested_rope_parameters(self):
+        # Real upstream V4 checkpoints ship ``rope_parameters`` as
+        # ``{"main": {yarn params}, "compress": {compress yarn params}}``.
+        # sglang's DSv4 attention (``deepseek_v4.py::MqaAttentionBase``)
+        # reads ``scaling["original_max_position_embeddings"]`` and
+        # ``scaling.get("factor")`` off the top level, so leaving the
+        # nested structure in place would silently degrade yarn to the
+        # defaults (``factor=1.0``, missing ``original_max_position_embeddings``
+        # → KeyError). Flatten to the ``main`` branch and lift a
+        # ``rope_theta`` in so ``get_rope_config`` succeeds too. Same
+        # class of gap as the one Codex flagged post-135f36d5.
+        cfg = self._make_new_transformers_config([self._LT_CSA])
+        cfg.rope_parameters = {
+            "main": {
+                "rope_type": "yarn",
+                "factor": 40,
+                "original_max_position_embeddings": 4096,
+                "beta_fast": 32,
+                "beta_slow": 1,
+            },
+            "compress": {
+                "rope_type": "yarn",
+                "rope_theta": 160000,
+                "factor": 16,
+                "attention_factor": 1.0,
+            },
+        }
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.rope_scaling.get("factor"), 40)
+        self.assertEqual(cfg.rope_scaling.get("original_max_position_embeddings"), 4096)
+        self.assertEqual(cfg.rope_scaling.get("beta_fast"), 32)
+        self.assertIn("rope_theta", cfg.rope_scaling)
+        # Nested keys are gone; downstream ``scaling.get(...)`` no longer hits
+        # the sub-dict fallback.
+        self.assertNotIsInstance(cfg.rope_scaling.get("main"), dict)
+
+    def test_flat_rope_parameters_untouched(self):
+        # Configs that already ship a flat rope layout (older transformers
+        # or hand-written ``rope_scaling``) must pass through unchanged —
+        # the nested-detection guard is explicit about requiring both
+        # ``main`` and ``compress`` sub-dicts.
+        cfg = self._make_new_transformers_config([self._LT_CSA])
+        flat = {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "original_max_position_embeddings": 4096,
+        }
+        cfg.rope_scaling = dict(flat)
+        normalize_deepseek_v4_compat(cfg)
+        for k, v in flat.items():
+            self.assertEqual(cfg.rope_scaling.get(k), v)
+
 
 # ---------------------------------------------------------------------------
 # get_rope_config

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -228,37 +228,75 @@ class TestNormalizeRopeScalingCompat(unittest.TestCase):
 
 
 class TestNormalizeDeepseekV4Compat(unittest.TestCase):
-    """Guard #34092: transformers >= 4.57 renamed ``compress_ratios`` to
-    ``compress_rates`` on ``DeepseekV4Config``. Every sglang reader uses the
-    legacy name, so the loader must backfill it at the config-load boundary.
-    Before the fix, a config with only ``compress_rates`` raised
-    ``AttributeError`` at ``ModelConfig.__init__`` (model_config.py:
-    ``self.compress_ratios = self.hf_config.compress_ratios``)."""
+    """Guard #34092: transformers >= 4.57 renamed the DeepSeek V4 field *and*
+    reshaped it — ``compress_ratios: list[int]`` became
+    ``compress_rates: dict[str, int]`` paired with
+    ``layer_types: list[str]``. sglang readers still index ``compress_ratios``
+    by layer id (e.g. ``config.compress_ratios[layer_id]`` in
+    ``models/deepseek_v4.py``), so the loader must rebuild a per-layer list
+    from the two new fields. A naive rename-only backfill would give
+    downstream a dict and swap the original AttributeError for a KeyError."""
 
-    def test_backfills_compress_ratios_from_compress_rates(self):
+    _LT_CSA = "compressed_sparse_attention"
+    _LT_HCA = "heavily_compressed_attention"
+
+    def _make_new_transformers_config(self):
         cfg = PretrainedConfig()
         cfg.model_type = "deepseek_v4"
-        cfg.compress_rates = [4, 128, 4]
-        normalize_deepseek_v4_compat(cfg)
-        self.assertEqual(cfg.compress_ratios, [4, 128, 4])
+        cfg.compress_rates = {self._LT_CSA: 4, self._LT_HCA: 128}
+        cfg.layer_types = [self._LT_HCA, self._LT_CSA, self._LT_HCA]
+        return cfg
 
-    def test_preserves_existing_legacy_name(self):
-        # Older-transformers config already carries the legacy name; the
-        # helper must not clobber it with the (absent) new name.
+    def test_expands_compress_rates_dict_by_layer_types(self):
+        cfg = self._make_new_transformers_config()
+        normalize_deepseek_v4_compat(cfg)
+        # Legacy shape: list[int] indexable by layer id, values from the dict
+        # resolved via layer_types.
+        self.assertEqual(cfg.compress_ratios, [128, 4, 128])
+        self.assertEqual(cfg.compress_ratios[0], 128)  # ``config.compress_ratios[layer_id]`` works
+
+    def test_preserves_existing_legacy_list(self):
+        # Older-transformers config already carries the legacy list; the
+        # helper must not clobber it.
         cfg = PretrainedConfig()
         cfg.model_type = "deepseek_v4"
-        cfg.compress_ratios = [128]
+        cfg.compress_ratios = [128, 4]
         normalize_deepseek_v4_compat(cfg)
-        self.assertEqual(cfg.compress_ratios, [128])
+        self.assertEqual(cfg.compress_ratios, [128, 4])
 
     def test_no_op_for_non_deepseek_v4_model_type(self):
-        # Negative-branch contract: unrelated model types with a
-        # coincidentally-named ``compress_rates`` attribute must not be
+        # Negative-branch contract: unrelated model types with coincidentally
+        # named ``compress_rates`` / ``layer_types`` attributes must not be
         # touched. A regression that drops the model_type gate would silently
-        # affect every model whose HF config carries this attribute.
+        # affect every model whose HF config happens to carry them.
         cfg = PretrainedConfig()
         cfg.model_type = "llama"
-        cfg.compress_rates = [4]
+        cfg.compress_rates = {self._LT_CSA: 4}
+        cfg.layer_types = [self._LT_CSA]
+        normalize_deepseek_v4_compat(cfg)
+        self.assertFalse(hasattr(cfg, "compress_ratios"))
+
+    def test_raises_clear_error_on_unknown_layer_type(self):
+        # An unknown ``layer_types`` entry would surface as a bare
+        # ``KeyError: '<layer-type>'`` from the list-comprehension. Wrap it in
+        # a ValueError that names both the missing key and the available
+        # ones, so downstream operators can diagnose a config drift without
+        # reading the stack.
+        cfg = PretrainedConfig()
+        cfg.model_type = "deepseek_v4"
+        cfg.compress_rates = {self._LT_CSA: 4}
+        cfg.layer_types = [self._LT_CSA, "mystery_layer"]
+        with self.assertRaisesRegex(ValueError, r"mystery_layer.*compress_rates"):
+            normalize_deepseek_v4_compat(cfg)
+
+    def test_no_op_when_only_one_of_the_new_fields_is_present(self):
+        # When the loaded config is malformed or partially populated (e.g. a
+        # future upstream rename), leave attributes alone rather than
+        # guessing — the downstream AttributeError is the clearer signal.
+        cfg = PretrainedConfig()
+        cfg.model_type = "deepseek_v4"
+        cfg.compress_rates = {self._LT_CSA: 4}
+        # layer_types deliberately absent
         normalize_deepseek_v4_compat(cfg)
         self.assertFalse(hasattr(cfg, "compress_ratios"))
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -278,6 +278,18 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
         normalize_deepseek_v4_compat(cfg)
         self.assertEqual(cfg.compress_ratios, [0, 128, 4])
 
+    def test_treats_none_valued_compress_ratios_as_absent(self):
+        # A config may carry ``compress_ratios = None`` (attribute exists but
+        # unset). A plain ``hasattr`` check would short-circuit and hand
+        # downstream a ``None`` — ``for r in None`` / ``None[layer_id]`` both
+        # explode later. The rebuild must fire in this case just like when
+        # the attribute is missing entirely. Same class of bug that vLLM's
+        # harden pass caught in vllm-project/vllm#43443.
+        cfg = self._make_new_transformers_config([self._LT_HCA, self._LT_CSA])
+        cfg.compress_ratios = None
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [128, 4])
+
     def test_no_op_for_non_deepseek_v4_model_type(self):
         # Negative-branch contract: unrelated model types with coincidentally
         # named ``compress_rates`` / ``layer_types`` attributes must not be

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -234,35 +234,49 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
     ``layer_types: list[str]``. sglang readers still index ``compress_ratios``
     by layer id (e.g. ``config.compress_ratios[layer_id]`` in
     ``models/deepseek_v4.py``), so the loader must rebuild a per-layer list
-    from the two new fields. A naive rename-only backfill would give
-    downstream a dict and swap the original AttributeError for a KeyError."""
+    from the two new fields. Upstream encodes sliding-attention layers as
+    ``0`` in the legacy list; ``compress_rates`` does not carry an entry for
+    them, so the rebuild has to special-case that layer type instead of
+    indexing the dict blindly."""
 
     _LT_CSA = "compressed_sparse_attention"
     _LT_HCA = "heavily_compressed_attention"
+    _LT_SWA = "sliding_attention"
 
-    def _make_new_transformers_config(self):
+    def _make_new_transformers_config(self, layer_types):
         cfg = PretrainedConfig()
         cfg.model_type = "deepseek_v4"
         cfg.compress_rates = {self._LT_CSA: 4, self._LT_HCA: 128}
-        cfg.layer_types = [self._LT_HCA, self._LT_CSA, self._LT_HCA]
+        cfg.layer_types = layer_types
         return cfg
 
     def test_expands_compress_rates_dict_by_layer_types(self):
-        cfg = self._make_new_transformers_config()
+        cfg = self._make_new_transformers_config([self._LT_HCA, self._LT_CSA, self._LT_HCA])
         normalize_deepseek_v4_compat(cfg)
-        # Legacy shape: list[int] indexable by layer id, values from the dict
-        # resolved via layer_types.
+        # Legacy shape: list[int] indexable by layer id, values resolved via
+        # ``compress_rates`` for compressed types.
         self.assertEqual(cfg.compress_ratios, [128, 4, 128])
         self.assertEqual(cfg.compress_ratios[0], 128)  # ``config.compress_ratios[layer_id]`` works
+
+    def test_sliding_attention_layers_emit_legacy_zero(self):
+        # Real DeepSeek V4 schedules interleave sliding-window layers with
+        # compressed ones. ``compress_rates`` has no entry for
+        # ``sliding_attention`` — the rebuild must emit ``0`` for those
+        # slots (upstream's legacy encoding) rather than raising.
+        cfg = self._make_new_transformers_config(
+            [self._LT_SWA, self._LT_HCA, self._LT_SWA, self._LT_CSA]
+        )
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [0, 128, 0, 4])
 
     def test_preserves_existing_legacy_list(self):
         # Older-transformers config already carries the legacy list; the
         # helper must not clobber it.
         cfg = PretrainedConfig()
         cfg.model_type = "deepseek_v4"
-        cfg.compress_ratios = [128, 4]
+        cfg.compress_ratios = [0, 128, 4]
         normalize_deepseek_v4_compat(cfg)
-        self.assertEqual(cfg.compress_ratios, [128, 4])
+        self.assertEqual(cfg.compress_ratios, [0, 128, 4])
 
     def test_no_op_for_non_deepseek_v4_model_type(self):
         # Negative-branch contract: unrelated model types with coincidentally
@@ -277,15 +291,12 @@ class TestNormalizeDeepseekV4Compat(unittest.TestCase):
         self.assertFalse(hasattr(cfg, "compress_ratios"))
 
     def test_raises_clear_error_on_unknown_layer_type(self):
-        # An unknown ``layer_types`` entry would surface as a bare
-        # ``KeyError: '<layer-type>'`` from the list-comprehension. Wrap it in
-        # a ValueError that names both the missing key and the available
-        # ones, so downstream operators can diagnose a config drift without
-        # reading the stack.
-        cfg = PretrainedConfig()
-        cfg.model_type = "deepseek_v4"
-        cfg.compress_rates = {self._LT_CSA: 4}
-        cfg.layer_types = [self._LT_CSA, "mystery_layer"]
+        # An unknown ``layer_types`` entry (neither a compressed type in
+        # ``compress_rates`` nor the ``sliding_attention`` special case)
+        # should surface as a ValueError that names both the missing key and
+        # the available ones — not a bare KeyError from the list
+        # comprehension.
+        cfg = self._make_new_transformers_config([self._LT_CSA, "mystery_layer"])
         with self.assertRaisesRegex(ValueError, r"mystery_layer.*compress_rates"):
             normalize_deepseek_v4_compat(cfg)
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -28,7 +28,10 @@ from sglang.srt.utils.hf_transformers.common import (
     resolve_hf_gguf_reference,
 )
 from sglang.srt.utils.hf_transformers.tokenizer import _fix_special_tokens_pattern
-from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_compat
+from sglang.srt.utils.hf_transformers_patches import (
+    normalize_deepseek_v4_compat,
+    normalize_rope_scaling_compat,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=7, suite="base-a-test-cpu")
@@ -217,6 +220,47 @@ class TestNormalizeRopeScalingCompat(unittest.TestCase):
         cfg.rope_scaling = {"factor": 4.0}
         normalize_rope_scaling_compat(cfg)
         self.assertNotIn("type", cfg.rope_scaling)
+
+
+# ---------------------------------------------------------------------------
+# normalize_deepseek_v4_compat (issue #34092)
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeDeepseekV4Compat(unittest.TestCase):
+    """Guard #34092: transformers >= 4.57 renamed ``compress_ratios`` to
+    ``compress_rates`` on ``DeepseekV4Config``. Every sglang reader uses the
+    legacy name, so the loader must backfill it at the config-load boundary.
+    Before the fix, a config with only ``compress_rates`` raised
+    ``AttributeError`` at ``ModelConfig.__init__`` (model_config.py:
+    ``self.compress_ratios = self.hf_config.compress_ratios``)."""
+
+    def test_backfills_compress_ratios_from_compress_rates(self):
+        cfg = PretrainedConfig()
+        cfg.model_type = "deepseek_v4"
+        cfg.compress_rates = [4, 128, 4]
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [4, 128, 4])
+
+    def test_preserves_existing_legacy_name(self):
+        # Older-transformers config already carries the legacy name; the
+        # helper must not clobber it with the (absent) new name.
+        cfg = PretrainedConfig()
+        cfg.model_type = "deepseek_v4"
+        cfg.compress_ratios = [128]
+        normalize_deepseek_v4_compat(cfg)
+        self.assertEqual(cfg.compress_ratios, [128])
+
+    def test_no_op_for_non_deepseek_v4_model_type(self):
+        # Negative-branch contract: unrelated model types with a
+        # coincidentally-named ``compress_rates`` attribute must not be
+        # touched. A regression that drops the model_type gate would silently
+        # affect every model whose HF config carries this attribute.
+        cfg = PretrainedConfig()
+        cfg.model_type = "llama"
+        cfg.compress_rates = [4]
+        normalize_deepseek_v4_compat(cfg)
+        self.assertFalse(hasattr(cfg, "compress_ratios"))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Fix DeepseekV4 config `compress_ratios` rebuild for transformers >= 4.57**

Rebuild the legacy `compress_ratios: list[int]` from the new `compress_rates: dict[str, int]` + `layer_types: list[str]` pair introduced in `transformers >= 4.57`. This is done once at the config-loading boundary (`get_hf_text_config()`), so every sglang reader retains its existing `[layer_id]` / `sum(r == 4)` / `in` access patterns without changes.

End-to-end equivalence is asserted in `test/registered/unit/configs/test_model_config.py::TestDeepseekV4ConfigCompat`, ensuring legacy and modern configs produce identical `ModelConfig` shapes and yarn `scaling` behaviour.

**Root cause**

`transformers >= 4.57` renamed the DSv4 field and reshaped its structure:

| Aspect                   | Old (< 4.57)                          | New (>= 4.57)                              |
|--------------------------|---------------------------------------|--------------------------------------------|
| Shape                    | `compress_ratios: list[int]`          | `compress_rates: dict[str, int]`           |
| Indexing                 | by layer id                           | by layer‑type label                        |
| Per‑layer schedule       | implicit in list order                | separate `layer_types: list[str]`          |
| Sliding‑window attention | encoded as `0`                        | not present in `compress_rates`            |

sglang readers still consume the legacy list shape (e.g. `models/deepseek_v4.py::config.compress_ratios[layer_id]`, `configs/model_config.py::sum(r == 4)`, `hardware_backend/npu/attention/ascend_dsv4_backend.py::4 in ratios`). Loading a fresh HF config therefore crashes with:

```
AttributeError: 'DeepseekV4Config' object has no attribute 'compress_ratios'. Did you mean: 'compress_rates'?
```

sglang aliases `deepseek_v4` onto upstream `DeepseekV3Config` via `_DeepseekV4ConfigAlias` in `hf_transformers/common.py`, so upstream's own `DeepseekV4Config.__post_init__` legacy‑input path never runs – the reconstruction must happen in this repository.

**Fix**

`normalize_deepseek_v4_compat()` runs at the config‑loading boundary and rebuilds the legacy list from the new pair:

- `sliding_attention` layers → `0` (matches upstream's `_COMPRESS_RATIO_TO_LAYER_TYPE[0]`)
- Known compressed types → `compress_rates[layer_type]`
- Unknown layer types → `0` fallback (so a future upstream layer‑type addition surfaces as "run this layer uncompressed" rather than a load‑time crash)

The `rope_scaling` / `rope_parameters` rename mentioned in the issue is already handled by upstream `PretrainedConfig`'s bidirectional alias; test coverage still asserts the end‑to‑end scaling match to catch any future upstream regression early.

`isinstance` guards on `compress_rates` and `layer_types` prevent a malformed `model_override_args={"compress_rates": [...]}` from reshaping the config into garbage – the helper falls through as a no‑op, preserving the downstream `AttributeError` as the diagnostic surface.

**Validation**

- Pre‑commit syntax check on the four modified files.
- Helper smoke tests on 11 branches (compressed‑only, SWA‑mixed, `compress_ratios=None`, legacy list preserve, non‑DSv4 no‑op, unknown layer type → 0, list‑shaped `compress_rates`, string‑shaped `layer_types`, empty `compress_rates` dict, idempotent, real `DeepseekV3Config` subclass) – all pass.
- End‑to‑end equivalence verified via `TestDeepseekV4ConfigCompat` under the `base‑a‑test‑cpu` suite: legacy vs modern config produce identical shapes and scaling.

Fixes #34092.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34565186117](https://github.com/sgl-project/sglang/actions/runs/34565186117)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34565185914](https://github.com/sgl-project/sglang/actions/runs/34565185914)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34565186076](https://github.com/sgl-project/sglang/actions/runs/34565186076)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->