### PR TITLE
feat(metrics): report abort reasons and terminal outcomes

### DIFF
--- a/docs/docs/references/production_metrics.mdx
+++ b/docs/docs/references/production_metrics.mdx
@@ -134,6 +134,56 @@ sglang:spec_num_steps{model_name="meta-llama/Llama-3.1-8B-Instruct"} 3.0
 sglang:spec_num_draft_tokens{model_name="meta-llama/Llama-3.1-8B-Instruct"} 4.0
 ```
 
+## Abort and request outcome metrics
+
+Use `sglang:num_abort_signals_total` to count cancellation signals by their
+`reason`. A signal is an instruction to abort work; it is not a terminal request
+outcome. For example, one `abort_all` signal can terminate multiple requests, and
+a completion can win a race with an abort signal.
+
+```promql
+sum by (reason) (increase(sglang:num_abort_signals_total[5m]))
+```
+
+Use `sglang:request_outcomes_total` for mutually exclusive terminal outcomes.
+Each metrics-enabled request increments this counter once when its terminal state
+is observed. Completed requests use `outcome="completed"` with `reason="stop"`
+or `reason="length"`. Aborted requests use `outcome="aborted"` and one of the
+bounded abort reasons below.
+
+```promql
+sum by (outcome, reason) (increase(sglang:request_outcomes_total[5m]))
+```
+
+Calculate the terminal abort rate with:
+
+```promql
+sum(increase(sglang:request_outcomes_total{outcome="aborted"}[5m]))
+/
+sum(increase(sglang:request_outcomes_total[5m]))
+```
+
+Abort reason categories are:
+
+- Client disconnects: `http_client_disconnect_waiting`,
+  `http_client_disconnect_running`, and `http_client_disconnect_stream`.
+- Explicit cancellations: `http_abort_request`, `responses_cancel`, `grpc_abort`,
+  and `grpc_backpressure_timeout`.
+- Administrative operations: `pause_generation`, `weight_update`, and
+  `weight_version_update`.
+- Admission and scheduling: `priority_disabled`, `queue_full`,
+  `priority_preempted`, `waiting_timeout`, `running_timeout`, and
+  `kv_cache_exhausted`.
+- Request processing: `invalid_request`, `grammar_error`, `disaggregation_error`,
+  `multimodal_error`, `session_cleanup`, and `request_cleanup`.
+- `unspecified` preserves compatibility for external code that constructs an
+  abort finish reason without a category. All built-in SGLang abort paths emit a
+  specific reason.
+
+`sglang:num_aborted_requests_total` remains available for compatibility. It
+counts tokenizer-manager abort calls and should not be used as a terminal
+failure rate.
+
 ## Setup Guide
 
 This section describes how to set up the monitoring stack (Prometheus + Grafana) provided in the `examples/monitoring` directory.

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -14,6 +14,7 @@ from sglang.srt.constrained.base_grammar_backend import (
 from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
 from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 
 if TYPE_CHECKING:
     from sglang.srt.managers.io_struct import AbortReq
@@ -107,12 +108,16 @@ class GrammarManager:
         return data
 
     def abort_requests(self, recv_req: AbortReq):
+        assert recv_req.abort_reason is not None
         for req in self.grammar_queue:
             if recv_req.abort_all or req.rid.startswith(recv_req.rid):
                 logger.debug(f"Abort grammar queue request. {req.rid=}")
                 if isinstance(req.grammar, futures.Future) and req.grammar:
                     req.grammar.cancel()
-                req.set_finish_with_abort("Aborted by AbortReq.")
+                req.set_finish_with_abort(
+                    "Aborted by AbortReq.",
+                    reason=recv_req.abort_reason,
+                )
 
     def _get_request_thinking_budget(self, req: Req) -> int | None:
         custom_params = req.sampling_params.custom_params
@@ -139,7 +144,10 @@ class GrammarManager:
         ):
             if self.grammar_backend is None:
                 error_msg = "Grammar-based generation (json_schema, regex, ebnf, structural_tag) is not supported when the server is launched with --grammar-backend none"
-                req.set_finish_with_abort(error_msg)
+                req.set_finish_with_abort(
+                    error_msg,
+                    reason=AbortReason.GRAMMAR_ERROR,
+                )
             else:
                 if req.sampling_params.json_schema is not None:
                     key = ("json", req.sampling_params.json_schema)
@@ -165,7 +173,10 @@ class GrammarManager:
                         error_msg = (
                             f"Failed to compile {key[0]} grammar: {value.error_message}"
                         )
-                        req.set_finish_with_abort(error_msg)
+                        req.set_finish_with_abort(
+                            error_msg,
+                            reason=AbortReason.GRAMMAR_ERROR,
+                        )
                     else:
                         self._apply_request_reasoning_budget(req)
         elif self._enable_strict_thinking:
@@ -287,7 +298,10 @@ class GrammarManager:
             self._apply_request_reasoning_budget(req)
             if isinstance(req.grammar, InvalidGrammarObject):
                 error_msg = f"Failed to compile {req.grammar_key[0]} grammar: {req.grammar.error_message}"
-                req.set_finish_with_abort(error_msg)
+                req.set_finish_with_abort(
+                    error_msg,
+                    reason=AbortReason.GRAMMAR_ERROR,
+                )
 
         # Return failed requests
         for i in synced_failed_req_idxs:
@@ -300,7 +314,10 @@ class GrammarManager:
                 req.grammar_key, InvalidGrammarObject("Grammar preprocessing timed out")
             )
             error_msg = f"Grammar preprocessing timed out: {req.grammar_key=}"
-            req.set_finish_with_abort(error_msg)
+            req.set_finish_with_abort(
+                error_msg,
+                reason=AbortReason.GRAMMAR_ERROR,
+            )
 
         # Remove finished requests from grammar_queue
         self.grammar_queue = [

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -61,6 +61,7 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     NextBatchPlan,
@@ -660,7 +661,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         if input_len > self.max_total_num_tokens:
             message = f"Request {req.rid} exceeds the maximum number of tokens: {input_len} > {self.max_total_num_tokens}"
             logger.error(message)
-            prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
+            prepare_abort(
+                req,
+                message,
+                status_code=HTTPStatus.BAD_REQUEST,
+                reason=AbortReason.INVALID_REQUEST,
+            )
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)
             return True
         if self._uses_swa_tail_prealloc():
@@ -672,7 +678,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     f"decode preallocation: {swa_required} > {swa_capacity}"
                 )
                 logger.error(message)
-                prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
+                prepare_abort(
+                    req,
+                    message,
+                    status_code=HTTPStatus.BAD_REQUEST,
+                    reason=AbortReason.INVALID_REQUEST,
+                )
                 self.scheduler.output_streamer.stream_output([req], req.return_logprob)
                 return True
         return False
@@ -802,6 +813,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     decode_req.req,
                     error_message,
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    reason=AbortReason.DISAGGREGATION_ERROR,
                 )
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_bootstrap_failed_reqs()
@@ -1837,6 +1849,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 "Metadata unexpectedly not ready after readiness gate "
                 "(bootstrap_room=0)",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=AbortReason.DISAGGREGATION_ERROR,
             )
             decode_req.kv_receiver.clear()
             decode_req.kv_receiver = None
@@ -1856,6 +1869,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 decode_req.req,
                 "Metadata corruption detected - bootstrap_room mismatch",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=AbortReason.DISAGGREGATION_ERROR,
             )
             decode_req.kv_receiver.clear()
             decode_req.kv_receiver = None
@@ -2032,6 +2046,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                     decode_req.req,
                     error_message,
                     status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    reason=AbortReason.DISAGGREGATION_ERROR,
                 )
                 self.scheduler.output_streamer.stream_output(
                     [decode_req.req],

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, List
 
 import torch
 
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.overlap_utils import RelayPayload
 from sglang.srt.mem_cache.common import maybe_cache_unfinished_req
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
@@ -21,7 +22,6 @@ if TYPE_CHECKING:
 
 
 class ScheduleBatchDisaggregationDecodeMixin:
-
     def prepare_for_prebuilt(self: ScheduleBatch):
         """
         Prepare a prebuilt extend by populate metadata
@@ -135,7 +135,9 @@ class ScheduleBatchDisaggregationDecodeMixin:
                     # handles the release via update_finish_state -> release_kv_cache in one place.
                     error_message = f"Grammar accept_token failed for req {req.rid} with token {req.output_ids[-1]}: {e}"
                     req.to_finish = FINISH_ABORT(
-                        error_message, HTTPStatus.INTERNAL_SERVER_ERROR
+                        error_message,
+                        HTTPStatus.INTERNAL_SERVER_ERROR,
+                        reason=AbortReason.GRAMMAR_ERROR,
                     )
                 req.grammar.finished = req.finished()
         last_tokens_tensor = torch.tensor(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -54,6 +54,7 @@ from sglang.srt.disaggregation.utils import (
     setup_state_kv_args,
 )
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_LENGTH,
@@ -363,7 +364,12 @@ class PrefillBootstrapQueue:
             message = f"Request {req.rid} exceeds the maximum number of tokens: {len(req.origin_input_ids)} > {self.max_total_num_tokens}"
             logger.error(message)
             req.time_stats.trace_ctx.abort(abort_info={"reason": message})
-            prepare_abort(req, message, status_code=HTTPStatus.BAD_REQUEST)
+            prepare_abort(
+                req,
+                message,
+                status_code=HTTPStatus.BAD_REQUEST,
+                reason=AbortReason.INVALID_REQUEST,
+            )
             self.scheduler.output_streamer.stream_output([req], req.return_logprob)
             return True
         return False
@@ -761,6 +767,7 @@ class SchedulerDisaggregationPrefillMixin:
                             req,
                             error_message,
                             status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                            reason=AbortReason.GRAMMAR_ERROR,
                         )
                     req.grammar.finished = req.finished()
             else:
@@ -950,7 +957,10 @@ class SchedulerDisaggregationPrefillMixin:
         release_kv_cache(req, self.tree_cache)  # unlock the tree
         if not isinstance(req.finished_reason, FINISH_ABORT):
             prepare_abort(
-                req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                req,
+                error_message,
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=AbortReason.DISAGGREGATION_ERROR,
             )
         if self.metrics_reporter.enable_metrics:
             self.metrics_collector.increment_transfer_failed_reqs()
@@ -999,7 +1009,12 @@ class SchedulerDisaggregationPrefillMixin:
             release_kv_cache(req, self.tree_cache)
         maybe_release_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
         req.pending_bootstrap = False
-        prepare_abort(req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR)
+        prepare_abort(
+            req,
+            error_message,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            reason=AbortReason.DISAGGREGATION_ERROR,
+        )
         self.output_streamer.stream_output([req], req.return_logprob)
         if self.metrics_reporter.enable_metrics:
             self.metrics_collector.increment_bootstrap_failed_reqs()

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -23,6 +23,7 @@ import torch.distributed as dist
 from sglang.srt.configs.model_config import get_dsa_index_topk
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.utils import is_hip, is_npu
 
 if TYPE_CHECKING:
@@ -420,7 +421,6 @@ class MetadataBuffers:
         )
 
     def set_buf(self, req: Req):
-
         self.output_ids[req.metadata_buffer_index][0] = req.output_ids[0]
         # The cached_tokens buffer is (size, 16); slots 0-3 hold cached token
         # counts and slots 4-6 are reused for multimodal prompt token counts
@@ -1241,11 +1241,17 @@ def setup_state_kv_args(
             )
 
 
-def prepare_abort(req: Req, error_message: str, status_code=None):
+def prepare_abort(
+    req: Req,
+    error_message: str,
+    status_code=None,
+    *,
+    reason: AbortReason,
+):
     from sglang.srt.managers.schedule_batch import FINISH_ABORT
 
     # populate finish metadata and stream output
-    req.finished_reason = FINISH_ABORT(error_message, status_code)
+    req.finished_reason = FINISH_ABORT(error_message, status_code, reason=reason)
 
     if req.return_logprob:
         req.logprob.input_token_logprobs_val = []

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -16,6 +16,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from pydantic import ValidationError
 
 from sglang.srt.configs.embedding_model_spec import resolved_embedding_plan
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
 
 logger = logging.getLogger(__name__)
@@ -106,12 +107,12 @@ class RuntimeHandle:
     def _is_closed_status(status) -> bool:
         return status is not None and status == type(status).Closed
 
-    def _abort_request_id(self, rid) -> None:
+    def _abort_request_id(self, rid, reason: AbortReason) -> None:
         if isinstance(rid, list):
             for single_rid in rid:
-                self.tokenizer_manager.abort_request(rid=single_rid)
+                self.tokenizer_manager.abort_request(rid=single_rid, reason=reason)
         else:
-            self.tokenizer_manager.abort_request(rid=rid)
+            self.tokenizer_manager.abort_request(rid=rid, reason=reason)
 
     async def _send_with_backpressure(
         self,
@@ -139,7 +140,10 @@ class RuntimeHandle:
             )
         except asyncio.TimeoutError:
             if timeout_abort_rid is not None:
-                self._abort_request_id(timeout_abort_rid)
+                self._abort_request_id(
+                    timeout_abort_rid,
+                    AbortReason.GRPC_BACKPRESSURE_TIMEOUT,
+                )
                 logger.warning(
                     "gRPC chunk backpressure wait timed out after %ss; aborted request",
                     self._BACKPRESSURE_TIMEOUT_S,
@@ -371,7 +375,11 @@ class RuntimeHandle:
             running_loop = None
 
         if running_loop is loop:
-            self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+            self.tokenizer_manager.abort_request(
+                rid=rid,
+                abort_all=abort_all,
+                reason=AbortReason.GRPC_ABORT,
+            )
             return
 
         future = asyncio.run_coroutine_threadsafe(
@@ -391,7 +399,11 @@ class RuntimeHandle:
             )
 
     async def _abort_async(self, rid: str, abort_all: bool) -> None:
-        self.tokenizer_manager.abort_request(rid=rid, abort_all=abort_all)
+        self.tokenizer_manager.abort_request(
+            rid=rid,
+            abort_all=abort_all,
+            reason=AbortReason.GRPC_ABORT,
+        )
 
     def get_model_info(self) -> str:
         model_config = self.tokenizer_manager.model_config
@@ -535,9 +547,11 @@ class RuntimeHandle:
             obj = UpdateWeightFromDiskReqInput(
                 model_path=model_path, load_format=load_format
             )
-            success, message, num_paused = (
-                await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
-            )
+            (
+                success,
+                message,
+                num_paused,
+            ) = await self.tokenizer_manager.update_weights_from_disk(obj, request=None)
             return {
                 "success": success,
                 "message": message,

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -113,6 +113,7 @@ from sglang.srt.entrypoints.request_headers import apply_header_overrides
 from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.io_struct import (
     AbortReq,
     AttachHiCacheStorageReqInput,
@@ -1416,7 +1417,10 @@ async def update_weight_version(
 ):
     """Update the weight version. This operation requires no active requests."""
     if obj.abort_all_requests:
-        _global_state.tokenizer_manager.abort_request(abort_all=True)
+        _global_state.tokenizer_manager.abort_request(
+            abort_all=True,
+            reason=AbortReason.WEIGHT_VERSION_UPDATE,
+        )
 
     # Use a simple approach without the complex lock mechanism for now
     # since weight_version update is a simple operation that doesn't affect model weights
@@ -1491,9 +1495,12 @@ async def check_weights(
 ):
     if obj is None:
         obj = CheckWeightsReqInput()
-    success, message, ranks, per_engine_checksum = (
-        await _global_state.tokenizer_manager.check_weights(obj, request)
-    )
+    (
+        success,
+        message,
+        ranks,
+        per_engine_checksum,
+    ) = await _global_state.tokenizer_manager.check_weights(obj, request)
     body = {"success": success, "message": message}
     if ranks is not None:
         body["ranks"] = ranks
@@ -1590,7 +1597,9 @@ async def abort_request(obj: Annotated[AbortReq, Body()], request: Request):
     """Abort a request."""
     try:
         _global_state.tokenizer_manager.abort_request(
-            rid=obj.rid, abort_all=obj.abort_all
+            rid=obj.rid,
+            abort_all=obj.abort_all,
+            reason=AbortReason.HTTP_ABORT_REQUEST,
         )
         return Response(status_code=200)
     except Exception as e:
@@ -2289,7 +2298,7 @@ def _execute_server_warmup(server_args: ServerArgs):
                 _global_state.tokenizer_manager.server_status = ServerStatus.Up
 
         else:
-            logger.info(f"Start of pd disaggregation warmup ...")
+            logger.info("Start of pd disaggregation warmup ...")
             status_codes = asyncio.run(
                 _send_disaggregation_warmup_requests(
                     server_args=server_args,
@@ -2342,8 +2351,7 @@ def _wait_and_warmup(
     skip_elastic_joiner_warmup = server_args.is_ep_scale_joiner
     if skip_elastic_joiner_warmup:
         logger.debug(
-            "[Elastic EP] Skipping server warmup for elastic joiner "
-            "(ep_join_mode=%s)",
+            "[Elastic EP] Skipping server warmup for elastic joiner (ep_join_mode=%s)",
             server_args.ep_join_mode,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -71,6 +71,7 @@ from sglang.srt.entrypoints.openai.tool_server import MCPToolServer, ToolServer
 from sglang.srt.entrypoints.openai.utils import to_openai_style_logprobs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.json_array_parser import JsonArrayParser
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.utils import random_uuid
@@ -333,8 +334,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             )
         ):
             return self.create_error_response(
-                "MCP tool server is not supported in background mode and "
-                "streaming mode"
+                "MCP tool server is not supported in background mode and streaming mode"
             )
 
         # Schedule the request and get the result generator
@@ -610,7 +610,7 @@ class OpenAIServingResponses(OpenAIServingChat):
     ):
         if request.tool_choice != "auto":
             raise NotImplementedError(
-                "Only 'auto' tool_choice is supported in " "response API"
+                "Only 'auto' tool_choice is supported in response API"
             )
         messages = self._construct_input_messages_with_harmony(request, prev_response)
         prompt_token_ids = render_for_completion(messages)
@@ -1320,9 +1320,7 @@ class OpenAIServingResponses(OpenAIServingChat):
                 recent_turn_msgs = prev_msgs[prev_final_msg_idx + 1 :]
                 del prev_msgs[prev_final_msg_idx + 1 :]
                 for msg in recent_turn_msgs:
-                    if (
-                        hasattr(msg, "channel") and msg.channel != "analysis"
-                    ):  # type: ignore[union-attr]
+                    if hasattr(msg, "channel") and msg.channel != "analysis":  # type: ignore[union-attr]
                         prev_msgs.append(msg)
             messages.extend(prev_msgs)
         # Append the new input.
@@ -1419,7 +1417,10 @@ class OpenAIServingResponses(OpenAIServingChat):
             response.status = "cancelled"
 
         # The response_id is the same as the rid used when submitting the request
-        self.tokenizer_manager.abort_request(rid=response_id)
+        self.tokenizer_manager.abort_request(
+            rid=response_id,
+            reason=AbortReason.RESPONSES_CANCEL,
+        )
 
         if task := self.background_tasks.get(response_id):
             task.cancel()
@@ -1476,8 +1477,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             # Get event type from the event's type field if it exists
             event_type = getattr(event, "type", "unknown")
             return (
-                f"event: {event_type}\n"
-                f"data: {event.model_dump_json(indent=None)}\n\n"
+                f"event: {event_type}\ndata: {event.model_dump_json(indent=None)}\n\n"
             )
 
         current_content_index = 0
@@ -1906,8 +1906,7 @@ class OpenAIServingResponses(OpenAIServingChat):
             sequence_number += 1
             event_type = getattr(event, "type", "unknown")
             return (
-                f"event: {event_type}\n"
-                f"data: {event.model_dump_json(indent=None)}\n\n"
+                f"event: {event_type}\ndata: {event.model_dump_json(indent=None)}\n\n"
             )
 
         # The streaming Response* event models echo ``tools`` through a

--- a/python/sglang/srt/managers/abort_reason.py
+++ b/python/sglang/srt/managers/abort_reason.py
@@ -1,0 +1,41 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+from enum import Enum
+
+
+class AbortReason(str, Enum):
+    UNSPECIFIED = "unspecified"
+    HTTP_CLIENT_DISCONNECT_WAITING = "http_client_disconnect_waiting"
+    HTTP_CLIENT_DISCONNECT_RUNNING = "http_client_disconnect_running"
+    HTTP_CLIENT_DISCONNECT_STREAM = "http_client_disconnect_stream"
+    HTTP_ABORT_REQUEST = "http_abort_request"
+    RESPONSES_CANCEL = "responses_cancel"
+    GRPC_BACKPRESSURE_TIMEOUT = "grpc_backpressure_timeout"
+    GRPC_ABORT = "grpc_abort"
+    PAUSE_GENERATION = "pause_generation"
+    WEIGHT_UPDATE = "weight_update"
+    WEIGHT_VERSION_UPDATE = "weight_version_update"
+    REQUEST_CLEANUP = "request_cleanup"
+    PRIORITY_DISABLED = "priority_disabled"
+    QUEUE_FULL = "queue_full"
+    PRIORITY_PREEMPTED = "priority_preempted"
+    WAITING_TIMEOUT = "waiting_timeout"
+    RUNNING_TIMEOUT = "running_timeout"
+    KV_CACHE_EXHAUSTED = "kv_cache_exhausted"
+    INVALID_REQUEST = "invalid_request"
+    GRAMMAR_ERROR = "grammar_error"
+    DISAGGREGATION_ERROR = "disaggregation_error"
+    MULTIMODAL_ERROR = "multimodal_error"
+    SESSION_CLEANUP = "session_cleanup"

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -52,6 +52,7 @@ from pydantic import PlainValidator
 
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.schedule_batch import (
     Modality,
@@ -1928,6 +1929,9 @@ class AbortReq(BaseReq, kw_only=True):
     # The finished reason data (from BaseFinishReason.to_json())
     finished_reason: Optional[FinishReasonDict] = None
     abort_message: Optional[str] = None
+    # Set by internal callers before this request is sent over IPC. The HTTP
+    # /abort_request payload leaves it unset and the endpoint supplies the reason.
+    abort_reason: Optional[AbortReason] = None
 
     def __post_init__(self):
         # FIXME: This is a hack to keep the same with the old code

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -37,6 +37,7 @@ import zmq
 import zmq.asyncio
 
 from sglang.srt.disaggregation.utils import TransferBackend
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.io_struct import (
     BaseBatchReq,
@@ -696,7 +697,10 @@ class TokenizerWorker(TokenizerManager):
         if obj.mode == "abort":
             # Abort polling: only the originator checks its own lock state
             while True:
-                self.abort_request(abort_all=True)
+                self.abort_request(
+                    abort_all=True,
+                    reason=AbortReason.PAUSE_GENERATION,
+                )
                 is_locked = await self.model_update_lock.is_locked()
                 if not is_locked:
                     break

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -75,6 +75,7 @@ from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_evict_dsv4_state,
 )
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.embed_types import PositionalEmbeds
 from sglang.srt.managers.scheduler_components.new_token_ratio_tracker import (
     NewTokenRatioTracker,
@@ -99,7 +100,6 @@ from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
-    ForwardBatch,
     ForwardMode,
 )
 from sglang.srt.observability.metrics_collector import (
@@ -265,11 +265,19 @@ class FINISH_LENGTH(BaseFinishReason):
 
 
 class FINISH_ABORT(BaseFinishReason):
-    def __init__(self, message=None, status_code=None, err_type=None):
+    def __init__(
+        self,
+        message=None,
+        status_code=None,
+        err_type=None,
+        *,
+        reason: AbortReason = AbortReason.UNSPECIFIED,
+    ):
         super().__init__()
         self.message = message or "Aborted"
         self.status_code = status_code
         self.err_type = err_type
+        self.reason = reason
 
     def to_json(self):
         return {
@@ -277,6 +285,7 @@ class FINISH_ABORT(BaseFinishReason):
             "message": self.message,
             "status_code": self.status_code,
             "err_type": self.err_type,
+            "reason": self.reason.value,
         }
 
 
@@ -1573,6 +1582,7 @@ class Req(ReqDllmMixin):
                             f"invalid stop_regex {stop_regex_str!r}: {e}",
                             HTTPStatus.BAD_REQUEST,
                             "BadRequestError",
+                            reason=AbortReason.INVALID_REQUEST,
                         )
                         break
                     if matched:
@@ -1792,7 +1802,11 @@ class Req(ReqDllmMixin):
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
-    def set_finish_with_abort(self, error_msg: str):
+    def set_finish_with_abort(
+        self,
+        error_msg: str,
+        reason: AbortReason = AbortReason.INVALID_REQUEST,
+    ):
         if get_parallel().tp_rank == 0:
             logger.error(f"{error_msg}, {self.rid=}")
         self.multimodal_inputs = None
@@ -1803,7 +1817,10 @@ class Req(ReqDllmMixin):
         self.return_logprob = False
         self.logprob_start_len = -1
         self.to_finish = FINISH_ABORT(
-            error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
+            error_msg,
+            HTTPStatus.BAD_REQUEST,
+            "BadRequestError",
+            reason=reason,
         )
 
     def update_reasoning_tokens(self, token_id, think_end_ids):
@@ -2817,6 +2834,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 "Out of memory even after retracting all other requests "
                 "in the decode batch. Aborting the last request.",
                 status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                reason=AbortReason.KV_CACHE_EXHAUSTED,
             )
             reqs_to_abort.append(last_req)
             self.release_req(last_idx, 0, server_args)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -104,6 +104,7 @@ from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 from sglang.srt.layers.quantization.unquant import initialize_bf16_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
 from sglang.srt.managers.io_struct import (
@@ -276,7 +277,7 @@ from sglang.srt.observability.trace import process_tracing_init, trace_set_threa
 from sglang.srt.parser.reasoning_parser import ReasoningParser
 from sglang.srt.platforms import current_platform
 from sglang.srt.plugins import load_plugins
-from sglang.srt.runtime_context import get_context, get_parallel, publish
+from sglang.srt.runtime_context import get_context, publish
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
 from sglang.srt.sampling.sampling_params import TOP_K_ALL
 from sglang.srt.server_args import PortArgs, ServerArgs
@@ -1597,7 +1598,9 @@ class Scheduler(
         for req in running_batch.reqs:
             if not req.finished() and 0 < req.time_stats.forward_entry_time < deadline:
                 req.to_finish = FINISH_ABORT(
-                    "Request running timeout reached.", HTTPStatus.SERVICE_UNAVAILABLE
+                    "Request running timeout reached.",
+                    HTTPStatus.SERVICE_UNAVAILABLE,
+                    reason=AbortReason.RUNNING_TIMEOUT,
                 )
 
     def get_init_info(self) -> Dict[str, Any]:
@@ -2418,7 +2421,12 @@ class Scheduler(
                         recv_req.time_stats.trace_ctx.abort(
                             abort_info={"reason": error_msg}
                         )
-                    prepare_abort(req, error_msg, status_code=HTTPStatus.BAD_REQUEST)
+                    prepare_abort(
+                        req,
+                        error_msg,
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        reason=AbortReason.INVALID_REQUEST,
+                    )
                     self.output_streamer.stream_output([req], req.return_logprob)
                     return
 
@@ -2703,8 +2711,10 @@ class Scheduler(
                     "type": "abort",
                     "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                     "message": "Using priority is disabled for this server. Please send a new request without a priority.",
+                    "reason": AbortReason.PRIORITY_DISABLED.value,
                 },
                 rid=req.rid,
+                abort_reason=AbortReason.PRIORITY_DISABLED,
             )
             req.time_stats.trace_ctx.abort(abort_info=abort_req.finished_reason)
             self.ipc_channels.send_to_tokenizer.send_output(abort_req, req)
@@ -2722,6 +2732,7 @@ class Scheduler(
         # Reject the incoming request by default.
         req_to_abort = recv_req
         message = "The request queue is full."
+        abort_reason = AbortReason.QUEUE_FULL
         if self.enable_priority_scheduling:
             # With priority scheduling, consider aboritng an existing request based on the priority.
             # direction = 1  => smaller number = higher priority; -1 => larger number = higher priority.
@@ -2745,6 +2756,7 @@ class Scheduler(
                 self.waiting_queue.pop(idx)
                 req_to_abort = candidate_req
                 message = "The request is aborted by a higher priority request."
+                abort_reason = AbortReason.PRIORITY_PREEMPTED
 
         self.ipc_channels.send_to_tokenizer.send_output(
             AbortReq(
@@ -2752,8 +2764,10 @@ class Scheduler(
                     "type": "abort",
                     "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                     "message": message,
+                    "reason": abort_reason.value,
                 },
                 rid=req_to_abort.rid,
+                abort_reason=abort_reason,
             ),
             req_to_abort,
         )
@@ -2778,8 +2792,10 @@ class Scheduler(
                             "type": "abort",
                             "status_code": HTTPStatus.SERVICE_UNAVAILABLE,
                             "message": "Request waiting timeout reached.",
+                            "reason": AbortReason.WAITING_TIMEOUT.value,
                         },
                         rid=req.rid,
+                        abort_reason=AbortReason.WAITING_TIMEOUT,
                     ),
                     req,
                 )
@@ -2886,9 +2902,10 @@ class Scheduler(
         is excluded from streaming and its logprob offset is still accounted).
         Mirrors ``handle_bootstrap_failure``.
         """
-        req = self._pending_chunked_abort_req
-        if req is None:
+        pending_abort = self._pending_chunked_abort_req
+        if pending_abort is None:
             return
+        req, abort_reason = pending_abort
         if self.chunked_req is not req:
             # Already past chunked prefill; the running-batch abort path handles
             # it. Drop the marker once the request is actually gone.
@@ -2896,7 +2913,7 @@ class Scheduler(
                 self._pending_chunked_abort_req = None
             return
 
-        prepare_abort(req, "Aborted")
+        prepare_abort(req, "Aborted", reason=abort_reason)
         req.time_stats.trace_ctx.abort(abort_info={"reason": "Aborted"})
         req.to_finish = None
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -2911,7 +2928,9 @@ class Scheduler(
 
         self.chunked_req = None
         self._pending_chunked_abort_req = None
-        self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+        self.ipc_channels.send_to_tokenizer.send_output(
+            AbortReq(rid=req.rid, abort_reason=abort_reason), req
+        )
         logger.debug(f"Abort chunked prefill request. {req.rid=}")
 
     def _build_hisparse_decode_batch(self, reqs):
@@ -3476,6 +3495,7 @@ class Scheduler(
                     AbortReq(
                         finished_reason=abort_reason.to_json(),
                         rid=req.rid,
+                        abort_reason=abort_reason.reason,
                     ),
                     req,
                 )
@@ -4375,9 +4395,13 @@ class Scheduler(
         return RpcReqOutput(success=success, message="" if not exec else str(exec))
 
     def abort_request(self, recv_req: AbortReq):
+        assert recv_req.abort_reason is not None
         if (chunked_req := self.chunked_req) is not None:
             if recv_req.abort_all or chunked_req.rid.startswith(recv_req.rid):
-                self._pending_chunked_abort_req = chunked_req
+                self._pending_chunked_abort_req = (
+                    chunked_req,
+                    recv_req.abort_reason,
+                )
 
         # todo hisparse, release resources for abort requests in hisparse coordinator
         # Delete requests in the waiting queue
@@ -4395,7 +4419,9 @@ class Scheduler(
             if self.enable_hicache_storage:
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
-            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            self.ipc_channels.send_to_tokenizer.send_output(
+                AbortReq(rid=req.rid, abort_reason=recv_req.abort_reason), req
+            )
             # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 release_kv_cache(req, self.tree_cache)
@@ -4428,7 +4454,7 @@ class Scheduler(
                 if self.enable_hicache_storage:
                     self.tree_cache.release_aborted_request(req.rid)
                 self.ipc_channels.send_to_tokenizer.send_output(
-                    AbortReq(rid=req.rid), req
+                    AbortReq(rid=req.rid, abort_reason=recv_req.abort_reason), req
                 )
                 if (
                     req.req_pool_idx is not None
@@ -4455,7 +4481,11 @@ class Scheduler(
                     if hasattr(req.disagg_kv_sender, "abort"):
                         req.disagg_kv_sender.abort()
                     if self.ps.pp_size > 1:
-                        prepare_abort(req, "Aborted by AbortReq.")
+                        prepare_abort(
+                            req,
+                            "Aborted by AbortReq.",
+                            reason=recv_req.abort_reason,
+                        )
 
             # Abort in-flight requests
             for req in self.disagg_prefill_inflight_queue:
@@ -4471,7 +4501,11 @@ class Scheduler(
                     logger.debug(f"Abort prealloc queue request. {decode_req.req.rid=}")
                     decode_req.kv_receiver.abort()
                     if self.ps.pp_size > 1:
-                        prepare_abort(decode_req.req, "Aborted by AbortReq.")
+                        prepare_abort(
+                            decode_req.req,
+                            "Aborted by AbortReq.",
+                            reason=recv_req.abort_reason,
+                        )
 
             # Abort requests waiting for kvcache to release tree cache
             for decode_req in self.disagg_decode_transfer_queue.queue:
@@ -4487,7 +4521,11 @@ class Scheduler(
                         assert hasattr(decode_req, "kv_cache_cpu")
                         del decode_req.kv_cache_cpu
                         self.ipc_channels.send_to_tokenizer.send_output(
-                            AbortReq(rid=decode_req.rid), decode_req
+                            AbortReq(
+                                rid=decode_req.rid,
+                                abort_reason=recv_req.abort_reason,
+                            ),
+                            decode_req,
                         )
                     else:
                         remaining_retracted.append(decode_req)
@@ -4508,7 +4546,7 @@ class Scheduler(
                 # The request will still run one decode forward pass.
                 # Then we reuse all existing code to clean up the KV cache allocation.
                 logger.debug(f"Abort running request. {req.rid=}")
-                req.to_finish = FINISH_ABORT()
+                req.to_finish = FINISH_ABORT(reason=recv_req.abort_reason)
 
     def _pause_engine(self) -> Tuple[List[Req], int]:
         raise NotImplementedError()

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -16,6 +16,7 @@ import torch
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.schedule_batch import (
     FINISH_ABORT,
     FINISH_MATCHED_TOKEN,
@@ -587,7 +588,7 @@ class SchedulerBatchResultProcessor:
                 logger.error(
                     f"Grammar accept_token failed for req {req.rid} with token {next_token_id}: {e}"
                 )
-                req.to_finish = FINISH_ABORT()
+                req.to_finish = FINISH_ABORT(reason=AbortReason.GRAMMAR_ERROR)
         req.grammar.finished = req.finished()
 
     def _apply_chunked_prefill_logprobs(
@@ -728,7 +729,7 @@ class SchedulerBatchResultProcessor:
                 f"Grammar accept_token failed for req {req.rid} with token "
                 f"{tokens}: {e}"
             )
-            req.to_finish = FINISH_ABORT()
+            req.to_finish = FINISH_ABORT(reason=AbortReason.GRAMMAR_ERROR)
         return retained
 
     def advance_grammar_fsm(

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -16,6 +16,7 @@ from torch.distributed import barrier
 
 from sglang.srt.disaggregation.utils import prepare_abort
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.io_struct import (
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
@@ -244,7 +245,12 @@ class SchedulerRequestReceiver:
                     status_code = error_code
                 else:
                     status_code = HTTPStatus(int(error_code))
-                prepare_abort(req, error_msg, status_code=status_code)
+                prepare_abort(
+                    req,
+                    error_msg,
+                    status_code=status_code,
+                    reason=AbortReason.MULTIMODAL_ERROR,
+                )
                 self.stream_output([req], req.return_logprob)
         return recv_reqs
 

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
 import fastapi
 
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.communicator import FanOutCommunicator
 from sglang.srt.managers.io_struct import (
     AddExternalCorpusReqInput,
@@ -447,7 +448,10 @@ class TokenizerControlMixin:
         ), "dp_size must be 1 or dp attention must be enabled for update weights from distributed"
 
         if obj.abort_all_requests:
-            self.abort_request(abort_all=True)
+            self.abort_request(
+                abort_all=True,
+                reason=AbortReason.WEIGHT_UPDATE,
+            )
 
         # Hold is_pause_cond while updating to prevent unpause from racing.
         async with self.is_pause_cond:
@@ -505,7 +509,10 @@ class TokenizerControlMixin:
         ), "dp_size must be 1 or dp attention must be enabled for update weights from tensor"
 
         if obj.abort_all_requests:
-            self.abort_request(abort_all=True)
+            self.abort_request(
+                abort_all=True,
+                reason=AbortReason.WEIGHT_UPDATE,
+            )
 
         obj.serialized_named_tensors = normalize_serialized_named_tensor_payloads(
             obj.serialized_named_tensors

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -51,6 +51,7 @@ from sglang.srt.disaggregation.encode_receiver import create_mm_receiver
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
 from sglang.srt.lora.lora_registry import LoRARef, LoRARegistry
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.async_dynamic_batch_tokenizer import AsyncDynamicbatchTokenizer
 from sglang.srt.managers.disagg_service import start_disagg_service
 from sglang.srt.managers.embed_types import PositionalEmbeds
@@ -1722,7 +1723,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     and await request.is_disconnected()
                 ):
                     # Abort the request for disconnected requests (non-streaming, waiting queue)
-                    self.abort_request(obj.rid)
+                    self.abort_request(
+                        obj.rid,
+                        reason=AbortReason.HTTP_CLIENT_DISCONNECT_WAITING,
+                    )
                     # Use exception to kill the whole call stack and asyncio task
                     raise ValueError(
                         f"Request is disconnected from the client side (type 1). Abort request {obj.rid=}"
@@ -1803,7 +1807,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     and await request.is_disconnected()
                 ):
                     # Abort the request for disconnected requests (non-streaming, running)
-                    self.abort_request(obj.rid)
+                    self.abort_request(
+                        obj.rid,
+                        reason=AbortReason.HTTP_CLIENT_DISCONNECT_RUNNING,
+                    )
                     # Use exception to kill the whole call stack and asyncio task
                     raise ValueError(
                         f"Request is disconnected from the client side (type 3). Abort request {obj.rid=}"
@@ -1969,7 +1976,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 return_exceptions=True,
             )
 
-    def abort_request(self, rid: str = "", abort_all: bool = False):
+    def abort_request(
+        self,
+        rid: str = "",
+        abort_all: bool = False,
+        *,
+        reason: AbortReason = AbortReason.HTTP_ABORT_REQUEST,
+    ):
         # Empty rid would startswith-match every request on the scheduler.
         if not abort_all and not rid:
             logger.warning("Ignore abort_request with empty rid and abort_all=False")
@@ -2006,11 +2019,18 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             target_rids = (rid,)
 
         for target_rid in target_rids:
-            self._dispatch_to_scheduler(AbortReq(rid=target_rid, abort_all=abort_all))
+            self._dispatch_to_scheduler(
+                AbortReq(
+                    rid=target_rid,
+                    abort_all=abort_all,
+                    abort_reason=reason,
+                )
+            )
         if self.enable_metrics:
             # TODO: also use custom_labels from the request
             self.metrics_collector.observe_one_aborted_request(
-                self.metrics_collector.labels
+                self.metrics_collector.labels,
+                reason,
             )
 
     async def pause_generation(self, obj: PauseGenerationReqInput):
@@ -2022,7 +2042,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # we are using the model_update_lock to check if there is still on-going requests.
                 while True:
                     # TODO: maybe make it async instead of fire-and-forget
-                    self.abort_request(abort_all=True)
+                    self.abort_request(
+                        abort_all=True,
+                        reason=AbortReason.PAUSE_GENERATION,
+                    )
                     is_locked = await self.model_update_lock.is_locked()
                     if not is_locked:
                         break
@@ -2046,7 +2069,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         logger.info("Start update_weights. Load format=%s", obj.load_format)
 
         if obj.abort_all_requests:
-            self.abort_request(abort_all=True)
+            self.abort_request(
+                abort_all=True,
+                reason=AbortReason.WEIGHT_UPDATE,
+            )
 
         # Immediately update the weights if the engine is in paused state
         async with self.is_pause_cond:
@@ -2056,9 +2082,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             self.model_update_lock.writer_lock if not is_paused else nullcontext()
         )
         async with lock_context:
-            success, message, num_paused_requests = (
-                await self._wait_for_model_update_from_disk(obj)
-            )
+            (
+                success,
+                message,
+                num_paused_requests,
+            ) = await self._wait_for_model_update_from_disk(obj)
 
         if success and obj.weight_version is not None:
             self._update_weight_version_if_provided(obj.weight_version)
@@ -2178,10 +2206,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         async def abort_request():
             await asyncio.sleep(2)
             if obj.is_single:
-                self.abort_request(obj.rid)
+                self.abort_request(
+                    obj.rid,
+                    reason=AbortReason.HTTP_CLIENT_DISCONNECT_STREAM,
+                )
             else:
                 for rid in obj.rid:
-                    self.abort_request(rid)
+                    self.abort_request(
+                        rid,
+                        reason=AbortReason.HTTP_CLIENT_DISCONNECT_STREAM,
+                    )
 
         background_tasks = BackgroundTasks()
         background_tasks.add_task(abort_request)
@@ -2591,8 +2625,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         # shared batch-output loop; degrade to nested instead.
                         state.input_top_logprobs_flat_fields = None
                         logger.error(
-                            "Falling back to nested input top logprobs for "
-                            "rid=%s: %s",
+                            "Falling back to nested input top logprobs for rid=%s: %s",
                             meta_info.get("id"),
                             e,
                         )
@@ -2867,6 +2900,17 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             or obj.sampling_params.get("structural_tag", None)
         )
 
+    def _request_metric_labels(self, state: ReqState) -> Dict[str, str]:
+        labels = dict(self.metrics_collector.labels)
+        custom_labels = getattr(state.obj, "custom_labels", None)
+        if custom_labels:
+            labels.update(custom_labels)
+        if self.enable_priority_scheduling:
+            priority = getattr(state.obj, "priority", None)
+            if priority is not None:
+                labels["priority"] = str(priority)
+        return labels
+
     def collect_metrics(self, state: ReqState, recv_obj: BatchStrOutput, i: int):
         completion_tokens = (
             recv_obj.completion_tokens[i]
@@ -2874,14 +2918,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             else 0
         )
 
-        custom_labels = getattr(state.obj, "custom_labels", None)
-        labels = dict(self.metrics_collector.labels)
-        if custom_labels:
-            labels.update(custom_labels)
-        if self.enable_priority_scheduling:
-            priority = getattr(state.obj, "priority", None)
-            if priority is not None:
-                labels["priority"] = str(priority)
+        labels = self._request_metric_labels(state)
         if (
             not state.ttft_observed
             and self.disaggregation_mode != DisaggregationMode.PREFILL
@@ -2905,6 +2942,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 state.last_completion_tokens = completion_tokens
 
         if state.finished:
+            finish_reason = recv_obj.finished_reasons[i]
+            assert finish_reason is not None
             # Get detailed cache breakdown if available
             cached_tokens_details = None
             if (
@@ -2931,6 +2970,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 cached_tokens_details,
                 spec_verify_ct=spec_verify_ct,
                 is_streaming=getattr(state.obj, "stream", False),
+                finish_reason=finish_reason,
             )
 
     def dump_requests(self, state: ReqState, out_dict: dict):
@@ -3066,7 +3106,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 filename = os.path.join(
                     self.crash_dump_folder,
                     hostname,
-                    f'crash_dump_{datetime.now().strftime("%Y-%m-%d_%H-%M-%S")}.pkl',
+                    f"crash_dump_{datetime.now().strftime('%Y-%m-%d_%H-%M-%S')}.pkl",
                 )
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
 
@@ -3201,6 +3241,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "type": "abort",
             "message": abort_message,
         }
+        if recv_obj.abort_reason is not None:
+            finish_reason["reason"] = recv_obj.abort_reason.value
         if recv_obj.finished_reason:
             finish_reason = recv_obj.finished_reason
         meta_info = {
@@ -3229,6 +3271,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "output_ids": output_ids,
             "meta_info": meta_info,
         }
+        if self.enable_metrics and state.obj.log_metrics:
+            assert recv_obj.abort_reason is not None
+            self.metrics_collector.observe_one_request_outcome(
+                self._request_metric_labels(state),
+                is_streaming=is_stream,
+                outcome="aborted",
+                reason=recv_obj.abort_reason.value,
+            )
         self._remove_req_state(recv_obj.rid)
 
         state.out_list.append(out)
@@ -3563,12 +3613,29 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             for target_rid in target_rids:
                 try:
                     self._dispatch_to_scheduler(
-                        AbortReq(rid=target_rid, abort_all=False)
+                        AbortReq(
+                            rid=target_rid,
+                            abort_all=False,
+                            abort_reason=AbortReason.REQUEST_CLEANUP,
+                        )
                     )
+                    if self.enable_metrics:
+                        self.metrics_collector.observe_one_abort_signal(
+                            self.metrics_collector.labels,
+                            AbortReason.REQUEST_CLEANUP,
+                        )
                 except Exception:
                     logger.exception(
                         "Failed to abort request rid=%s",
                         target_rid,
+                    )
+                state = self.rid_to_state[target_rid]
+                if self.enable_metrics and state.obj.log_metrics:
+                    self.metrics_collector.observe_one_request_outcome(
+                        self._request_metric_labels(state),
+                        is_streaming=getattr(state.obj, "stream", False),
+                        outcome="aborted",
+                        reason=AbortReason.REQUEST_CLEANUP.value,
                     )
             for child_rid in child_rids:
                 self._remove_req_state(child_rid, lifecycle_id)

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Mapping, Optional, Set, Union
 
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.environ import envs
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.utils import exponential_buckets, generate_buckets
 from sglang.srt.server_args import ServerArgs
@@ -236,7 +237,6 @@ class SchedulerMetricsCollectorContext:
 
 
 class SchedulerMetricsCollector(_StatLoggerDIMixin):
-
     def __init__(
         self,
         labels: Dict[str, str],
@@ -1619,6 +1619,16 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
             documentation="Number of requests aborted.",
             labelnames=labels.keys(),
         )
+        self.num_abort_signals_total = Counter(
+            name="sglang:num_abort_signals_total",
+            documentation="Number of abort signals dispatched by reason.",
+            labelnames=list(labels.keys()) + ["reason"],
+        )
+        self.request_outcomes_total = Counter(
+            name="sglang:request_outcomes_total",
+            documentation="Number of terminal request outcomes by outcome and reason.",
+            labelnames=list(labels.keys()) + ["is_streaming", "outcome", "reason"],
+        )
 
         if bucket_time_to_first_token is None:
             bucket_time_to_first_token = [
@@ -1748,6 +1758,8 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
         cached_tokens_details: Optional[Dict[str, Any]] = None,
         spec_verify_ct: int = 0,
         is_streaming: bool = False,
+        *,
+        finish_reason: Mapping[str, Any],
     ):
         stream_labels = {
             **labels,
@@ -1784,6 +1796,21 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 self.cached_tokens_total.labels(**labels_total).inc(cached_tokens)
 
         self.num_requests_total.labels(**stream_labels).inc(1)
+        finish_type = finish_reason["type"]
+        if finish_type == "abort":
+            self.observe_one_request_outcome(
+                labels,
+                is_streaming=is_streaming,
+                outcome="aborted",
+                reason=finish_reason["reason"],
+            )
+        else:
+            self.observe_one_request_outcome(
+                labels,
+                is_streaming=is_streaming,
+                outcome="completed",
+                reason=finish_type,
+            )
         if has_grammar:
             self.num_so_requests_total.labels(**labels).inc(1)
         self.histogram_e2e_request_latency.labels(**stream_labels).observe(
@@ -1834,8 +1861,27 @@ class TokenizerMetricsCollector(_StatLoggerDIMixin):
                 his._buckets[i].inc(num_new_tokens)
                 break
 
-    def observe_one_aborted_request(self, labels: Dict[str, str]):
+    def observe_one_aborted_request(self, labels: Dict[str, str], reason: AbortReason):
         self.num_aborted_requests_total.labels(**labels).inc(1)
+        self.observe_one_abort_signal(labels, reason)
+
+    def observe_one_abort_signal(self, labels: Dict[str, str], reason: AbortReason):
+        self.num_abort_signals_total.labels(**labels, reason=reason.value).inc(1)
+
+    def observe_one_request_outcome(
+        self,
+        labels: Dict[str, str],
+        *,
+        is_streaming: bool,
+        outcome: str,
+        reason: str,
+    ):
+        self.request_outcomes_total.labels(
+            **labels,
+            is_streaming="true" if is_streaming else "false",
+            outcome=outcome,
+            reason=reason,
+        ).inc(1)
 
 
 @dataclass

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -18,6 +18,7 @@ import uuid
 from array import array
 from typing import TYPE_CHECKING, Dict, Optional
 
+from sglang.srt.managers.abort_reason import AbortReason
 from sglang.srt.managers.io_struct import (
     CloseSessionReqInput,
     OpenSessionReqInput,
@@ -56,12 +57,12 @@ class SessionReqNode:
             req_node.clear(req_dict)
 
         if self.req.finished_reason is None:
-            self.req.to_finish = FINISH_ABORT()
+            self.req.to_finish = FINISH_ABORT(reason=AbortReason.SESSION_CLEANUP)
         del req_dict[self.req.rid]
 
     def abort(self):
         if self.req.finished_reason is None:
-            self.req.to_finish = FINISH_ABORT()
+            self.req.to_finish = FINISH_ABORT(reason=AbortReason.SESSION_CLEANUP)
 
     def __str__(self):
         return self._str_helper(self.req.rid)


### PR DESCRIPTION
## Motivation

`sglang:num_aborted_requests_total` counts abort dispatches rather than mutually exclusive request failures. It also has no reason label, so operators cannot distinguish client disconnects from explicit cancellation, admission-control rejection, scheduler timeout, KV exhaustion, or request-processing errors. `abort_all` and completion/abort races make the legacy counter especially unsuitable as an abort-rate numerator.

## Modifications

- Add a bounded `AbortReason` enum and propagate an explicit reason through every built-in SGLang abort path.
- Add `sglang:num_abort_signals_total{reason=...}` for cancellation signals while preserving `sglang:num_aborted_requests_total` for compatibility.
- Add `sglang:request_outcomes_total{is_streaming,outcome,reason}`. Each metrics-enabled request is counted once when its terminal state is observed, after completion/abort races resolve.
- Count local request-cleanup outcomes before their request state is removed.
- Document the reason categories, signal/outcome distinction, PromQL breakdown, and terminal abort-rate query.

## Accuracy Tests

Not applicable. This changes request lifecycle metadata and Prometheus counters, not model execution or outputs.

## Speed Tests and Profiling

Not benchmarked. The new work is limited to bounded-label counter increments on abort dispatch and terminal request handling; it is not in the token-generation loop.

## Validation

- SGLang pinned Black 26.1.0, isort 7.0.0, and Ruff 0.15.1 checks pass on all changed Python files.
- Python compilation passes for all changed Python files.
- Codespell and `git diff --check` pass.
- AST audit confirms every built-in `FINISH_ABORT`, `prepare_abort`, and `AbortReq` construction supplies an explicit reason.
- Unit tests were not added or run per the local repository instruction.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; explained above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31274727588](https://github.com/sgl-project/sglang/actions/runs/31274727588)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31274727494](https://github.com/sgl-project/sglang/actions/runs/31274727494)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->