### PR TITLE
config: derive the runner's DCP topology from its ParallelState

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -69,10 +69,7 @@ from sglang.srt.distributed.parallel_state import (
     destroy_distributed_environment,
     destroy_model_parallel,
 )
-from sglang.srt.distributed.parallel_state_wrapper import (
-    ParallelState,
-    compute_dcp_rank,
-)
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.entrypoints.engine import _set_envs_and_config
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
@@ -325,7 +322,7 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         attn_tp_size=attn_tp_size,
         attn_cp_rank=0,
         attn_cp_size=server_args.attn_cp_size,
-        attn_dcp_rank=compute_dcp_rank(tp_rank=tp_rank, dcp_size=server_args.dcp_size),
+        attn_dcp_rank=tp_rank % server_args.dcp_size,
         attn_dcp_size=server_args.dcp_size,
         attn_dp_rank=attn_dp_rank,
         attn_dp_size=attn_dp_size,

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -328,7 +328,7 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         moe_ep_size=server_args.ep_size,
         moe_dp_rank=None,
         moe_dp_size=server_args.moe_dp_size,
-        dcp_size=server_args.dcp_size,
+        attn_dcp_size=server_args.dcp_size,
         gpu_id=gpu_id,
     )
     runner_kwargs = dict(

--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -69,7 +69,10 @@ from sglang.srt.distributed.parallel_state import (
     destroy_distributed_environment,
     destroy_model_parallel,
 )
-from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.distributed.parallel_state_wrapper import (
+    ParallelState,
+    compute_dcp_rank,
+)
 from sglang.srt.entrypoints.engine import _set_envs_and_config
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
@@ -322,13 +325,14 @@ def load_model(server_args, port_args, gpu_id, tp_rank):
         attn_tp_size=attn_tp_size,
         attn_cp_rank=0,
         attn_cp_size=server_args.attn_cp_size,
+        attn_dcp_rank=compute_dcp_rank(tp_rank=tp_rank, dcp_size=server_args.dcp_size),
+        attn_dcp_size=server_args.dcp_size,
         attn_dp_rank=attn_dp_rank,
         attn_dp_size=attn_dp_size,
         moe_ep_rank=moe_ep_rank,
         moe_ep_size=server_args.ep_size,
         moe_dp_rank=None,
         moe_dp_size=server_args.moe_dp_size,
-        attn_dcp_size=server_args.dcp_size,
         gpu_id=gpu_id,
     )
     runner_kwargs = dict(

--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -93,7 +93,7 @@ def init_torch_distributed(
             attn_cp_size=ps.attn_cp_size,
             moe_ep_size=ps.moe_ep_size,
             moe_dp_size=ps.moe_dp_size,
-            dcp_size=ps.dcp_size,
+            dcp_size=ps.attn_dcp_size,
         )
 
         # Pre-warm NCCL/RCCL/HCCL to eliminate cold-start latency in first request

--- a/python/sglang/srt/distributed/parallel_state_wrapper.py
+++ b/python/sglang/srt/distributed/parallel_state_wrapper.py
@@ -49,7 +49,3 @@ class ParallelState:
         )
         kwargs.update(overrides)
         return ParallelState(**kwargs)
-
-
-def compute_dcp_rank(*, tp_rank: int, dcp_size: int) -> int:
-    return tp_rank % dcp_size

--- a/python/sglang/srt/distributed/parallel_state_wrapper.py
+++ b/python/sglang/srt/distributed/parallel_state_wrapper.py
@@ -14,6 +14,7 @@ class ParallelState:
     attn_tp_size: int
     attn_cp_rank: int
     attn_cp_size: int
+    attn_dcp_rank: int
     attn_dcp_size: int
     attn_dp_rank: int
     attn_dp_size: int
@@ -22,10 +23,6 @@ class ParallelState:
     moe_dp_rank: Optional[int]
     moe_dp_size: int
     gpu_id: int
-
-    @property
-    def attn_dcp_rank(self) -> int:
-        return self.tp_rank % self.attn_dcp_size
 
     @staticmethod
     def trivial(**overrides: Optional[int]) -> "ParallelState":
@@ -40,6 +37,7 @@ class ParallelState:
             attn_tp_size=1,
             attn_cp_rank=0,
             attn_cp_size=1,
+            attn_dcp_rank=0,
             attn_dcp_size=1,
             attn_dp_rank=0,
             attn_dp_size=1,
@@ -51,3 +49,7 @@ class ParallelState:
         )
         kwargs.update(overrides)
         return ParallelState(**kwargs)
+
+
+def compute_dcp_rank(*, tp_rank: int, dcp_size: int) -> int:
+    return tp_rank % dcp_size

--- a/python/sglang/srt/distributed/parallel_state_wrapper.py
+++ b/python/sglang/srt/distributed/parallel_state_wrapper.py
@@ -14,18 +14,18 @@ class ParallelState:
     attn_tp_size: int
     attn_cp_rank: int
     attn_cp_size: int
+    attn_dcp_size: int
     attn_dp_rank: int
     attn_dp_size: int
     moe_ep_rank: int
     moe_ep_size: int
     moe_dp_rank: Optional[int]
     moe_dp_size: int
-    dcp_size: int
     gpu_id: int
 
     @property
-    def dcp_rank(self) -> int:
-        return self.tp_rank % self.dcp_size
+    def attn_dcp_rank(self) -> int:
+        return self.tp_rank % self.attn_dcp_size
 
     @staticmethod
     def trivial(**overrides: Optional[int]) -> "ParallelState":
@@ -40,13 +40,13 @@ class ParallelState:
             attn_tp_size=1,
             attn_cp_rank=0,
             attn_cp_size=1,
+            attn_dcp_size=1,
             attn_dp_rank=0,
             attn_dp_size=1,
             moe_ep_rank=0,
             moe_ep_size=1,
             moe_dp_rank=0,
             moe_dp_size=1,
-            dcp_size=1,
             gpu_id=0,
         )
         kwargs.update(overrides)

--- a/python/sglang/srt/distributed/parallel_state_wrapper.py
+++ b/python/sglang/srt/distributed/parallel_state_wrapper.py
@@ -23,6 +23,10 @@ class ParallelState:
     dcp_size: int
     gpu_id: int
 
+    @property
+    def dcp_rank(self) -> int:
+        return self.tp_rank % self.dcp_size
+
     @staticmethod
     def trivial(**overrides: Optional[int]) -> "ParallelState":
         kwargs: dict[str, Optional[int]] = dict(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -93,7 +93,10 @@ from sglang.srt.disaggregation.utils import (
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state import get_tp_group
-from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.distributed.parallel_state_wrapper import (
+    ParallelState,
+    compute_dcp_rank,
+)
 from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -460,13 +463,16 @@ class Scheduler(
             attn_tp_size=attn_tp_size,
             attn_cp_rank=attn_cp_rank,
             attn_cp_size=server_args.attn_cp_size,
+            attn_dcp_rank=compute_dcp_rank(
+                tp_rank=tp_rank, dcp_size=server_args.dcp_size
+            ),
+            attn_dcp_size=server_args.dcp_size,
             attn_dp_rank=attn_dp_rank,
             attn_dp_size=attn_dp_size,
             moe_ep_rank=moe_ep_rank,
             moe_ep_size=server_args.ep_size,
             moe_dp_rank=moe_dp_rank,
             moe_dp_size=server_args.moe_dp_size,
-            attn_dcp_size=server_args.dcp_size,
             gpu_id=gpu_id,
         )
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -466,7 +466,7 @@ class Scheduler(
             moe_ep_size=server_args.ep_size,
             moe_dp_rank=moe_dp_rank,
             moe_dp_size=server_args.moe_dp_size,
-            dcp_size=server_args.dcp_size,
+            attn_dcp_size=server_args.dcp_size,
             gpu_id=gpu_id,
         )
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -93,10 +93,7 @@ from sglang.srt.disaggregation.utils import (
 )
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state import get_tp_group
-from sglang.srt.distributed.parallel_state_wrapper import (
-    ParallelState,
-    compute_dcp_rank,
-)
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -463,9 +460,7 @@ class Scheduler(
             attn_tp_size=attn_tp_size,
             attn_cp_rank=attn_cp_rank,
             attn_cp_size=server_args.attn_cp_size,
-            attn_dcp_rank=compute_dcp_rank(
-                tp_rank=tp_rank, dcp_size=server_args.dcp_size
-            ),
+            attn_dcp_rank=tp_rank % server_args.dcp_size,
             attn_dcp_size=server_args.dcp_size,
             attn_dp_rank=attn_dp_rank,
             attn_dp_size=attn_dp_size,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -409,7 +409,8 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.dcp_size - 1,
+            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
 
@@ -511,7 +512,8 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.dcp_size - 1,
+            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            - 1,
         )
         return (
             self.model_runner.max_total_num_tokens,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -409,9 +409,7 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens
-            * self.model_runner.dcp_size
-            - 1,
+            self.model_runner.effective_max_total_num_tokens * self.ps.dcp_size - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
 
@@ -513,9 +511,7 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens
-            * self.model_runner.dcp_size
-            - 1,
+            self.model_runner.effective_max_total_num_tokens * self.ps.dcp_size - 1,
         )
         return (
             self.model_runner.max_total_num_tokens,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -961,9 +961,14 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             model_runner.lora_manager.prepare_lora_batch(ret)
 
-        if model_runner.ps.dcp_size > 1 and ret.out_cache_loc is not None and is_hip():
+        if (
+            model_runner.ps.attn_dcp_size > 1
+            and ret.out_cache_loc is not None
+            and is_hip()
+        ):
             ret.dcp_kv_mask = (
-                ret.positions % model_runner.ps.dcp_size == model_runner.ps.dcp_rank
+                ret.positions % model_runner.ps.attn_dcp_size
+                == model_runner.ps.attn_dcp_rank
             )
 
         return ret

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -961,13 +961,9 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
             model_runner.lora_manager.prepare_lora_batch(ret)
 
-        if (
-            getattr(model_runner, "dcp_size", 1) > 1
-            and ret.out_cache_loc is not None
-            and is_hip()
-        ):
+        if model_runner.ps.dcp_size > 1 and ret.out_cache_loc is not None and is_hip():
             ret.dcp_kv_mask = (
-                ret.positions % model_runner.dcp_size == model_runner.dcp_rank
+                ret.positions % model_runner.ps.dcp_size == model_runner.ps.dcp_rank
             )
 
         return ret

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -397,9 +397,6 @@ class ModelRunner:
         # Stored for later use by alloc_memory_pool().
         self.init_torch_distributed()
 
-        self.dcp_size = get_parallel().attn_dcp_size
-        self.dcp_rank = get_parallel().attn_dcp_rank
-
         # Init forward stream for overlap schedule
         self.forward_stream = torch.get_device_module(self.device).Stream()
 

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -264,7 +264,7 @@ class EagerRunner(BaseRunner):
             prepare_cp_forward(forward_batch)
 
         if forward_batch.needs_forward_metadata_init() or cp_v2_active:
-            if model_runner.ps.dcp_size > 1 and hasattr(
+            if model_runner.ps.attn_dcp_size > 1 and hasattr(
                 model_runner.model, "prepare_context_parallel_metadata_for_dcp"
             ):
                 # prepare kv cache buffer for dcp to gather kv cache

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -264,7 +264,7 @@ class EagerRunner(BaseRunner):
             prepare_cp_forward(forward_batch)
 
         if forward_batch.needs_forward_metadata_init() or cp_v2_active:
-            if model_runner.dcp_size > 1 and hasattr(
+            if model_runner.ps.dcp_size > 1 and hasattr(
                 model_runner.model, "prepare_context_parallel_metadata_for_dcp"
             ):
                 # prepare kv cache buffer for dcp to gather kv cache


### PR DESCRIPTION
## Motivation

Follow-up to #33925. That PR moved `ModelRunner.dcp_size` / `.dcp_rank` below `init_torch_distributed()` so they read the live topology (`get_parallel().attn_dcp_*`) instead of the config seed, and in doing so took the `ps.tp_rank % dcp_size` arithmetic out of the frozen file.

Reading them live fixed *when* the value is right, but they are still two process-global facts captured onto a per-worker object. There is one DCP group per process, so `get_parallel().attn_dcp_size` is structurally incapable of differing between the target and a draft — and a draft must not split the token dimension at all (drafts are TP-sharded; this is the failure mode behind #32858, where a draft pool sized for the target's `dcp_size=4` over-allocated 4x).

#32858 (now merged) reaches the same fact from the other side: it taught `get_num_kv_heads` about `dcp_size` so DCP ranks replicate KV, and kept a draft TP-sharded by special-casing `model_config.is_draft_model`. That is the KV-head *layout*; this PR is the runner's DCP *topology*. The two share no code and compose — with both in, a draft is TP-sharded in its head layout and in its `attn_dcp_size`.

The runner already carries the per-worker parallelism that *can* express the difference: `ps` (`ParallelState`), the frozen struct passed explicitly per worker, where the draft already declares `pp_rank=0`.

## Modifications

| File | Change |
|---|---|
| `parallel_state_wrapper.py` | `ParallelState.dcp_size` becomes `attn_dcp_size` and gains `attn_dcp_rank`, both in the `attn_*` block |
| `model_runner.py` | the two `self.dcp_* = get_parallel().attn_dcp_*` assignments are deleted (nothing inside the class read them) |
| `tp_worker.py` ×2 | `max_req_len` reads the worker's own `self.ps.attn_dcp_size` |
| `eager_runner.py`, `forward_batch_info.py` | read `model_runner.ps.attn_dcp_size` / `.ps.attn_dcp_rank` |
| `scheduler.py`, `benchmark/one_batch.py` | supply the pair (`attn_dcp_rank=tp_rank % server_args.dcp_size`) |
| `bootstrap.py` | follows the field rename |

**Where `attn_dcp_rank` comes from.** DCP groups are built as consecutive `dcp_size` slices of each TP group, so a rank with `tp_rank == t` sits at index `t % dcp_size` in its subgroup — the same identity #33925 moved out of `model_runner.py`, now on the per-worker state rather than read back off the group. It cannot be read off the live group at construction time: `ParallelState` is built in `Scheduler.__init__`, before `init_torch_distributed`, and is what feeds group construction. It is written inline at the two construction sites, the same shape as `attn_cp_rank` / `moe_dp_rank` / `moe_ep_rank`.

**The `getattr(model_runner, "dcp_size", 1)` defensive read in `forward_batch_info` goes away.** Every mock runner in `test/kits/attention_unittest` already sets `self.ps = ParallelState.trivial()`, so `.ps.dcp_size` is 1 for them without the fallback.

## Accuracy Test

**Target: no change.** `ps.attn_dcp_size == server_args.dcp_size`, and `get_parallel().attn_dcp_size` differs from that only when the DCP group is absent — which, for a target, happens exactly when `dcp_size == 1` (`_init_parallel_groups` installs `_DCP` iff `dcp_size > 1`, and `initialize_model_parallel` rejects `dcp_size > 1` off HIP/CUDA). `ps.attn_dcp_rank` likewise equals the group's `rank_in_group`.

**Draft: no change either.** A draft's `ps` carries the target's `attn_dcp_size` — which is what the process-global read gave it before. Whether a draft should declare its own `attn_dcp_size=1` (it is TP-sharded and does not split the token dimension) is a separate question from where the value is read; #32858 answers the KV-head half of it via `is_draft_model`, and `triton_backend` still takes `get_parallel().attn_dcp_size` at init. Both are follow-ups, not this PR.

- [x] `pre-commit run` clean on the changed files
- [ ] DCP e2e (`test/registered/dcp/`) — needs a multi-GPU box; not run locally

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31296907988](https://github.com/sgl-project/sglang/actions/runs/31296907988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31296907926](https://github.com/sgl-project/sglang/actions/runs/31296907926)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->




