### PR TITLE
[router] Add bucket range config parsing, validation, and selection h…

### DIFF
--- a/experimental/sgl-router/src/config/bucket.rs
+++ b/experimental/sgl-router/src/config/bucket.rs
@@ -1,0 +1,121 @@
+use anyhow::{anyhow, Result};
+use std::str::FromStr;
+
+/// Converts String to Bucket Object
+impl FromStr for BucketRange {
+    type Err = anyhow::Error;
+
+    fn from_str(spec: &str) -> Result<Self> {
+        let (name, range_part) = spec
+            .split_once(':')
+            .ok_or_else(|| anyhow!("missing ':' in the bucket spec: {spec:?}"))?;
+
+        let (min, max) = range_part
+            .split_once('-')
+            .ok_or_else(|| anyhow!("missing '-' in the bucket spec: {spec:?}"))?;
+
+        let min_tokens: u32 = min
+            .parse()
+            .map_err(|_| anyhow!("invalid min token count {min:?} in {spec:?}"))?;
+        let max_tokens: Option<u32> = if max.is_empty() {
+            None
+        } else {
+            Some(
+                max.parse()
+                    .map_err(|_| anyhow!("invalid max token count {max:?} in {spec:?}"))?,
+            )
+        };
+        Ok(BucketRange {
+            name: name.to_string(),
+            min_tokens,
+            max_tokens,
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BucketRange {
+    pub name: String,
+    pub min_tokens: u32,
+    pub max_tokens: Option<u32>,
+}
+
+impl BucketRange {
+    pub fn contains(&self, token_count: u32) -> bool {
+        if token_count < self.min_tokens {
+            return false;
+        }
+
+        match self.max_tokens {
+            Some(max_tokens) => token_count <= max_tokens,
+            None => true,
+        }
+    }
+}
+
+/// Check a bucket list for cross-bucket invariants that a single
+/// spec parse cannot see: duplicate names, overlapping ranges, and
+/// min > max.
+pub fn validate_bucket_ranges(buckets: &[BucketRange]) -> Result<()> {
+    let mut seen = std::collections::HashSet::new();
+    for bucket in buckets {
+        if !seen.insert(&bucket.name) {
+            return Err(anyhow!("duplicate bucket name {:?}", bucket.name));
+        }
+        if let Some(max) = bucket.max_tokens {
+            if bucket.min_tokens > max {
+                return Err(anyhow!(
+                    "bucket {:?} has min_tokens {} > max_tokens {}",
+                    bucket.name,
+                    bucket.min_tokens,
+                    max
+                ));
+            }
+        }
+    }
+
+    // Sort by lower bound so overlaps can be detected by comparing
+    // neighbours: an open-ended range covers everything above its min.
+    let mut sorted: Vec<&BucketRange> = buckets.iter().collect();
+    sorted.sort_by_key(|b| b.min_tokens);
+    for pair in sorted.windows(2) {
+        let (a, b) = (&pair[0], &pair[1]);
+        let overlaps = match a.max_tokens {
+            None => true,
+            Some(a_max) => a_max >= b.min_tokens,
+        };
+        if overlaps {
+            return Err(anyhow!(
+                "bucket ranges overlap: {:?} ({}-{:?}) and {:?} ({}-{:?})",
+                a.name,
+                a.min_tokens,
+                a.max_tokens,
+                b.name,
+                b.min_tokens,
+                b.max_tokens
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub fn select_bucket(token_count: u32, buckets: &[BucketRange]) -> Option<&BucketRange> {
+    buckets.iter().find(|b| b.contains(token_count))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn closed_range_contains_token_count() {
+        let bucket = BucketRange {
+            name: "short".to_string(),
+            min_tokens: 0,
+            max_tokens: Some(2048),
+        };
+
+        assert!(bucket.contains(1000));
+        assert!(!bucket.contains(4096));
+    }
+}

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -11,9 +11,10 @@ use std::num::NonZeroU32;
 
 use crate::config::{
     default_cb_cool_down, default_proxy_request_timeout_secs, default_stale_request_timeout_secs,
-    resolve_mode, ActiveLoadConfig, CacheAwareConfig, CircuitBreakerConfig, Config,
-    DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
+    resolve_mode, ActiveLoadConfig, BucketConfig, BucketRange, CacheAwareConfig,
+    CircuitBreakerConfig, Config, DiscoveryBackend, K8sDiscoveryConfig, LogFormat, ModelConfig,
+    ObservabilityConfig, PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    StickyConfig,
 };
 
 /// `sgl-router` — slim KV-aware OpenAI-compatible router for SGLang workers.
@@ -132,6 +133,18 @@ pub struct Cli {
     /// Log output format.
     #[arg(long, value_enum, default_value = "text")]
     pub log_format: LogFormat,
+
+    // ---- bucket dispatch ----
+    /// Prefill bucket ranges, e.g. `short:0-2048` (space-separated or
+    /// repeated). Selected by uncached prefill token count. Omit the max
+    /// for an open-ended range: `long:2049-`. Ranges must not overlap.
+    #[arg(long, num_args = 1.., value_name = "NAME:MIN-MAX")]
+    pub prefill_bucket: Vec<BucketRange>,
+    /// Decode bucket ranges, e.g. `long:4097-` (space-separated or
+    /// repeated). Selected by estimated sequence length. Independent of
+    /// `--prefill-bucket`: the same name may appear in both.
+    #[arg(long, num_args = 1.., value_name = "NAME:MIN-MAX")]
+    pub decode_bucket: Vec<BucketRange>,
 }
 
 impl Cli {
@@ -274,6 +287,10 @@ impl Cli {
             },
             active_load: ActiveLoadConfig {
                 stale_request_timeout_secs: self.stale_request_timeout_secs,
+            },
+            buckets: BucketConfig {
+                prefill: self.prefill_bucket,
+                decode: self.decode_bucket,
             },
         };
         config.validate()?;
@@ -958,5 +975,107 @@ mod tests {
             err.contains("--sticky-idle-secs must be greater than 0"),
             "got: {err}"
         );
+    }
+
+    /// Bucket dispatch is opt-in: with no `--*-bucket` flags both range
+    /// lists are empty and the config is still valid.
+    #[test]
+    fn bucket_ranges_default_to_empty() {
+        let c = into_config_owned(with_model(&["--worker-urls", "http://x:30000"])).unwrap();
+        assert!(c.buckets.prefill.is_empty());
+        assert!(c.buckets.decode.is_empty());
+    }
+
+    #[test]
+    fn parses_repeated_and_space_separated_bucket_flags() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            // repeated flag
+            "--prefill-bucket",
+            "short:0-2048",
+            "--prefill-bucket",
+            "long:2049-",
+            // space-separated values under one flag
+            "--decode-bucket",
+            "short:0-4096",
+            "long:4097-",
+        ]))
+        .unwrap();
+
+        let prefill: Vec<&str> = c.buckets.prefill.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(prefill, ["short", "long"]);
+        assert_eq!(c.buckets.prefill[0].max_tokens, Some(2048));
+        // Omitting the max parses as an open-ended range.
+        assert_eq!(c.buckets.prefill[1].min_tokens, 2049);
+        assert_eq!(c.buckets.prefill[1].max_tokens, None);
+
+        let decode: Vec<&str> = c.buckets.decode.iter().map(|b| b.name.as_str()).collect();
+        assert_eq!(decode, ["short", "long"]);
+        assert_eq!(c.buckets.decode[0].max_tokens, Some(4096));
+    }
+
+    /// The two roles bucket on different quantities, so they are validated
+    /// independently — reusing a name across roles is not a conflict.
+    #[test]
+    fn prefill_and_decode_buckets_are_independent() {
+        let c = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--prefill-bucket",
+            "short:0-2048",
+            "--decode-bucket",
+            "short:0-4096",
+        ]))
+        .unwrap();
+        assert_eq!(c.buckets.prefill[0].max_tokens, Some(2048));
+        assert_eq!(c.buckets.decode[0].max_tokens, Some(4096));
+    }
+
+    /// A malformed spec fails at `clap` parse time via `FromStr`, before
+    /// `into_config` runs.
+    #[test]
+    fn rejects_malformed_bucket_spec() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--prefill-bucket",
+            "short:2048",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("missing '-'"), "got: {err}");
+    }
+
+    /// Overlaps are a cross-bucket invariant, so they surface from
+    /// `Config::validate` — prefixed with the flag that has to change.
+    #[test]
+    fn rejects_overlapping_prefill_buckets() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--prefill-bucket",
+            "a:0-2048",
+            "b:1024-4096",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--prefill-bucket"), "got: {err}");
+        assert!(err.contains("overlap"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_decode_bucket_names() {
+        let err = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--decode-bucket",
+            "short:0-2048",
+            "short:2049-",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("--decode-bucket"), "got: {err}");
+        assert!(err.contains("duplicate"), "got: {err}");
     }
 }

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -64,6 +64,14 @@ impl Config {
             // (including empty, for a cluster-wide watch) is accepted.
             DiscoveryBackend::K8s(_) => {}
         }
+        // Prefix the role so the diagnostic names the flag that has to
+        // change — `validate_bucket_ranges` only sees a list of ranges
+        // and can't tell prefill from decode. The two lists are checked
+        // independently: the same bucket name in both roles is fine.
+        validate_bucket_ranges(&self.buckets.prefill)
+            .map_err(|e| anyhow!("--prefill-bucket: {e}"))?;
+        validate_bucket_ranges(&self.buckets.decode)
+            .map_err(|e| anyhow!("--decode-bucket: {e}"))?;
         Ok(())
     }
 }
@@ -96,6 +104,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            buckets: BucketConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/config/mod.rs
+++ b/experimental/sgl-router/src/config/mod.rs
@@ -1,5 +1,7 @@
+pub mod bucket;
 pub mod cli;
 pub mod types;
+pub use bucket::*;
 pub use cli::Cli;
 pub use types::*;
 
@@ -95,6 +97,165 @@ mod tests {
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
         }
+    }
+
+    #[test]
+    fn parses_closed_range_spec() {
+        let range: BucketRange = "short:0-2048".parse().unwrap();
+        assert_eq!(range.name, "short");
+        assert_eq!(range.min_tokens, 0);
+        assert_eq!(range.max_tokens, Some(2048));
+    }
+
+    #[test]
+    fn parses_open_ended_range_spec() {
+        let range: BucketRange = "long:2049-".parse().unwrap();
+        assert_eq!(range.name, "long");
+        assert_eq!(range.min_tokens, 2049);
+        assert_eq!(range.max_tokens, None);
+    }
+
+    #[test]
+    fn rejects_spec_missing_colon() {
+        let err = "short0-2048"
+            .parse::<BucketRange>()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("missing ':'"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_spec_missing_dash() {
+        let err = "short:2048".parse::<BucketRange>().unwrap_err().to_string();
+        assert!(err.contains("missing '-'"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_spec_bad_min_token_count() {
+        let err = "short:abc-2048"
+            .parse::<BucketRange>()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid min token count"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_spec_bad_max_token_count() {
+        let err = "short:0-xyz"
+            .parse::<BucketRange>()
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("invalid max token count"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_duplicate_bucket_names() {
+        let buckets = vec![
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 0,
+                max_tokens: Some(2048),
+            },
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 2049,
+                max_tokens: None,
+            },
+        ];
+        let err = validate_bucket_ranges(&buckets).unwrap_err().to_string();
+        assert!(err.contains("duplicate"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_overlapping_bucket_ranges() {
+        let buckets = vec![
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 0,
+                max_tokens: Some(2048),
+            },
+            BucketRange {
+                name: "mid".into(),
+                min_tokens: 1024,
+                max_tokens: Some(4096),
+            },
+        ];
+        let err = validate_bucket_ranges(&buckets).unwrap_err().to_string();
+        assert!(err.contains("overlap"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_min_greater_than_max() {
+        let buckets = vec![BucketRange {
+            name: "bad".into(),
+            min_tokens: 2048,
+            max_tokens: Some(0),
+        }];
+        let err = validate_bucket_ranges(&buckets).unwrap_err().to_string();
+        assert!(err.contains("min_tokens 2048 > max_tokens 0"), "got: {err}");
+    }
+
+    #[test]
+    fn accepts_disjoint_bucket_ranges() {
+        let buckets = vec![
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 0,
+                max_tokens: Some(2048),
+            },
+            BucketRange {
+                name: "long".into(),
+                min_tokens: 2049,
+                max_tokens: None,
+            },
+        ];
+        validate_bucket_ranges(&buckets).unwrap();
+    }
+
+    #[test]
+    fn selects_short_bucket_for_small_count() {
+        let buckets = vec![
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 0,
+                max_tokens: Some(2048),
+            },
+            BucketRange {
+                name: "long".into(),
+                min_tokens: 2049,
+                max_tokens: None,
+            },
+        ];
+        assert_eq!(select_bucket(1000, &buckets).unwrap().name, "short");
+        assert_eq!(select_bucket(2048, &buckets).unwrap().name, "short");
+    }
+
+    #[test]
+    fn selects_long_bucket_for_large_count() {
+        let buckets = vec![
+            BucketRange {
+                name: "short".into(),
+                min_tokens: 0,
+                max_tokens: Some(2048),
+            },
+            BucketRange {
+                name: "long".into(),
+                min_tokens: 2049,
+                max_tokens: None,
+            },
+        ];
+        assert_eq!(select_bucket(2049, &buckets).unwrap().name, "long");
+        assert_eq!(select_bucket(100000, &buckets).unwrap().name, "long");
+    }
+
+    #[test]
+    fn returns_none_when_no_bucket_matches() {
+        let buckets = vec![BucketRange {
+            name: "short".into(),
+            min_tokens: 100,
+            max_tokens: Some(2048),
+        }];
+        assert!(select_bucket(50, &buckets).is_none());
     }
 
     #[test]

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -1,5 +1,7 @@
 use std::num::NonZeroU32;
 
+use crate::config::BucketRange;
+
 /// In-memory router configuration, built from CLI flags by
 /// [`crate::config::cli::Cli::into_config`] and validated by
 /// [`Config::validate`]. The router serves exactly one model.
@@ -8,6 +10,12 @@ pub struct Config {
     pub server: ServerConfig,
     pub observability: ObservabilityConfig,
     pub model: ModelConfig,
+    /// Bucket-dispatch ranges, per role. Built from the
+    /// `--prefill-bucket` / `--decode-bucket` flags; empty vecs mean
+    /// bucket dispatch is not configured. Cross-bucket invariants
+    /// (duplicate names, overlaps) are checked by [`Config::validate`].
+    pub buckets: BucketConfig,
+
     /// Selected discovery backend. Built from CLI flags by
     /// [`crate::config::cli::Cli::into_config`]: the static-vs-k8s choice
     /// and the k8s selector grammar are resolved there (the latter via
@@ -16,6 +24,16 @@ pub struct Config {
     pub discovery: DiscoveryBackend,
     pub proxy: ProxyConfig,
     pub active_load: ActiveLoadConfig,
+}
+
+/// Length-range buckets used to narrow worker selection before the
+/// routing policy runs. Prefill and decode carry independent range
+/// lists because the two roles bucket on different quantities —
+/// uncached prefill tokens vs estimated sequence length.
+#[derive(Debug, Clone, Default)]
+pub struct BucketConfig {
+    pub prefill: Vec<BucketRange>,
+    pub decode: Vec<BucketRange>,
 }
 
 /// Outbound proxy tuning. Default mirrors SGLang's typical prefill /

--- a/experimental/sgl-router/src/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/src/policies/cache_aware_zmq.rs
@@ -308,6 +308,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            buckets: crate::config::BucketConfig::default(),
         };
         Arc::new(TokenizerRegistry::load_from_config(&cfg).expect("load tiny tokenizer"))
     }

--- a/experimental/sgl-router/src/policies/factory.rs
+++ b/experimental/sgl-router/src/policies/factory.rs
@@ -152,8 +152,8 @@ pub fn build_registry_with_defaults(cfg: &Config) -> Result<PolicyRegistry> {
 mod tests {
     use super::*;
     use crate::config::{
-        ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ProxyConfig, ServerConfig,
-        StaticUrlsDiscoveryConfig,
+        ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ProxyConfig,
+        ServerConfig, StaticUrlsDiscoveryConfig,
     };
 
     use crate::config::PolicyKind;
@@ -178,6 +178,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            buckets: BucketConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -120,6 +120,7 @@ impl AppContext {
                 ),
                 proxy: crate::config::ProxyConfig::default(),
                 active_load: crate::config::ActiveLoadConfig::default(),
+                buckets: crate::config::BucketConfig::default(),
             },
             tokenizers: Arc::new(TokenizerRegistry::default()),
             proxy: Arc::new(Proxy::new(std::time::Duration::from_secs(60)).expect("stub proxy")),

--- a/experimental/sgl-router/src/server/routes/tokenize.rs
+++ b/experimental/sgl-router/src/server/routes/tokenize.rs
@@ -129,6 +129,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            buckets: crate::config::BucketConfig::default(),
         };
         let registry = crate::tokenizer::TokenizerRegistry::load_from_config(&cfg).unwrap();
         let proxy = Arc::new(

--- a/experimental/sgl-router/src/tokenizer/mod.rs
+++ b/experimental/sgl-router/src/tokenizer/mod.rs
@@ -243,6 +243,7 @@ mod tests {
             ),
             proxy: crate::config::ProxyConfig::default(),
             active_load: crate::config::ActiveLoadConfig::default(),
+            buckets: crate::config::BucketConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/src/workers/manager.rs
+++ b/experimental/sgl-router/src/workers/manager.rs
@@ -454,8 +454,8 @@ async fn register_one(
 mod tests {
     use super::*;
     use crate::config::{
-        ActiveLoadConfig, CircuitBreakerConfig as RawCbConfig, DiscoveryBackend, ModelConfig,
-        PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+        ActiveLoadConfig, BucketConfig, CircuitBreakerConfig as RawCbConfig, DiscoveryBackend,
+        ModelConfig, PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
     };
     use crate::discovery::{WorkerId, WorkerMode};
     use axum::{routing::get, Json, Router};
@@ -487,6 +487,7 @@ mod tests {
             }),
             proxy: ProxyConfig::default(),
             active_load: ActiveLoadConfig::default(),
+            buckets: BucketConfig::default(),
         }
     }
 

--- a/experimental/sgl-router/tests/component/discovery/static_urls.rs
+++ b/experimental/sgl-router/tests/component/discovery/static_urls.rs
@@ -90,7 +90,8 @@ async fn static_urls_pd_role_resolved_end_to_end() {
     use axum::{routing::get, Json, Router};
     use serde_json::json;
     use sgl_router::config::{
-        ActiveLoadConfig, Config, DiscoveryBackend, ObservabilityConfig, ProxyConfig, ServerConfig,
+        ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ObservabilityConfig, ProxyConfig,
+        ServerConfig,
     };
     use sgl_router::discovery::{spawn_discovery, WorkerId};
     use sgl_router::workers::{manager, WorkerRegistry};
@@ -139,6 +140,7 @@ async fn static_urls_pd_role_resolved_end_to_end() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
 
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
+++ b/experimental/sgl-router/tests/component/policies/cache_aware_zmq.rs
@@ -22,7 +22,7 @@ use std::time::Duration;
 use zeromq::SocketSend;
 
 use sgl_router::config::CacheAwareConfig;
-use sgl_router::config::{ActiveLoadConfig, ProxyConfig};
+use sgl_router::config::{ActiveLoadConfig, BucketConfig, ProxyConfig};
 
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::cache_aware_zmq::CacheAwareZmqPolicy;
@@ -80,6 +80,7 @@ async fn zmq_indexer_routes_to_publishing_worker_e2e() {
         ),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
 

--- a/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/cache_aware_input_ids.rs
@@ -21,8 +21,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::{json, Value};
 use sgl_router::config::{
-    ActiveLoadConfig, CacheAwareConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
-    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, CacheAwareConfig, Config, DiscoveryBackend, ModelConfig,
+    ObservabilityConfig, PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry;
@@ -60,6 +60,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/chat_routing.rs
+++ b/experimental/sgl-router/tests/proxy/chat_routing.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -43,6 +43,7 @@ fn config_for(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/failover.rs
+++ b/experimental/sgl-router/tests/proxy/failover.rs
@@ -47,6 +47,7 @@ async fn failover_when_one_worker_dies() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
 
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());

--- a/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
+++ b/experimental/sgl-router/tests/proxy/graceful_shutdown.rs
@@ -16,8 +16,8 @@
 
 use bytes::Bytes;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -53,6 +53,7 @@ fn build_ctx_with_worker(worker_url: &str) -> Arc<AppContext> {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/header_forwarding.rs
+++ b/experimental/sgl-router/tests/proxy/header_forwarding.rs
@@ -4,8 +4,8 @@
 use axum::body::Body;
 use axum::http::Request;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -40,6 +40,7 @@ async fn forwards_whitelisted_headers_strips_others() {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
+++ b/experimental/sgl-router/tests/proxy/pd_bootstrap_injection.rs
@@ -21,8 +21,8 @@ use axum::http::{Request, StatusCode};
 use bytes::Bytes;
 use serde_json::{json, Value};
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -55,6 +55,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
+++ b/experimental/sgl-router/tests/proxy/pd_pool_isolation.rs
@@ -20,8 +20,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -54,6 +54,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/roundrobin_input_ids.rs
@@ -11,8 +11,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::{json, Value};
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults;
@@ -51,6 +51,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_input_ids.rs
@@ -24,8 +24,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use serde_json::{json, Value};
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -70,6 +70,7 @@ fn config() -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 

--- a/experimental/sgl-router/tests/proxy/sticky_routing.rs
+++ b/experimental/sgl-router/tests/proxy/sticky_routing.rs
@@ -7,8 +7,8 @@
 //! `MockWorker` backends (CPU-only, no GPU).
 
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig, StickyConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -56,6 +56,7 @@ fn build_sticky_ctx(header_name: &str, worker_urls: &[String]) -> Arc<AppContext
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     };
     let tokenizers = Arc::new(TokenizerRegistry::load_from_config(&cfg).unwrap());
     let registry = Arc::new(WorkerRegistry::default());

--- a/experimental/sgl-router/tests/proxy/timeout.rs
+++ b/experimental/sgl-router/tests/proxy/timeout.rs
@@ -13,8 +13,8 @@ use axum::body::Body;
 use axum::http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use sgl_router::config::{
-    ActiveLoadConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig, PolicyKind,
-    ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
+    ActiveLoadConfig, BucketConfig, Config, DiscoveryBackend, ModelConfig, ObservabilityConfig,
+    PolicyKind, ProxyConfig, ServerConfig, StaticUrlsDiscoveryConfig,
 };
 use sgl_router::discovery::{ModelId, WorkerId, WorkerMode, WorkerSpec};
 use sgl_router::policies::factory::build_registry_with_defaults as build_policy_registry;
@@ -47,6 +47,7 @@ fn config(_worker_url: &str) -> Config {
         }),
         proxy: ProxyConfig::default(),
         active_load: ActiveLoadConfig::default(),
+        buckets: BucketConfig::default(),
     }
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Part of #25760 ([Roadmap] SGLang's new lightweight SessionAware Router module for bucket-based PD serving). The roadmap's Step 2 requires selecting prefill/decode bucket groups from configurable token-length ranges, but the router currently has no bucket config surface at all. This PR lays that foundation: a pure config/helper layer that later PRs can wire into CLI flags and routing without touching policy internals.
## Modifications

<!-- Detail the changes made in this pull request. -->

- `experimental/sgl-router/src/config/bucket.rs` (new):
  - `BucketRange` struct: `name`, `min_tokens`, `max_tokens: Option<u32>` (open-ended support)
  - `contains(token_count)` — range membership test
  - `FromStr` — parses specs like `"short:0-2048"` and `"long:2049-"`, with descriptive errors for malformed specs
  - `validate_bucket_ranges` — rejects duplicate names, overlapping ranges, and `min > max`
  - `select_bucket` — first matching bucket for a token count, `None` when nothing matches
- `experimental/sgl-router/src/config/mod.rs`: `pub mod bucket` + re-export
- Unit tests: 12 new tests covering parsing (happy + error paths), validation (dup/overlap/min>max/accept), and selection (short/long/none)

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
N/A — config-only change, no model/routing behavior touched. All code paths are dead code until wired into the router; existing test suite passes.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
N/A — no runtime path changes.


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31488787787](https://github.com/sgl-project/sglang/actions/runs/31488787787)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31488787502](https://github.com/sgl-project/sglang/actions/runs/31488787502)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->