### PR TITLE
[Bugfix] DeepSeek V4 DSpark: fix shared-expert loading performance regression

### DIFF
--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -554,6 +554,11 @@ class DSparkV4Stage(DeepseekV4DecoderLayer):
 
 class DeepseekV4ForCausalLMDSpark(nn.Module):
 
+    @staticmethod
+    def shared_experts_fusion_disable_reason(hf_config, quant_config):
+        del hf_config, quant_config
+        return "DSpark V4 draft weights use separate shared experts."
+
     def __init__(
         self,
         config: DeepSeekV4Config,

--- a/test/registered/unit/spec/test_draft_construction_isolation.py
+++ b/test/registered/unit/spec/test_draft_construction_isolation.py
@@ -98,6 +98,18 @@ class TestFusionDecisionFlag(CustomTestCase):
         # The draft's decision stays inspectable on the twin leaf.
         self.assertTrue(get_flags().moe.speculative_disable_shared_experts_fusion)
 
+    def test_dspark_draft_disables_unsupported_shared_expert_fusion(self):
+        from sglang.srt.models.deepseek_v4_dspark import (
+            DeepseekV4ForCausalLMDSpark,
+        )
+
+        self._seed(disable_shared_experts_fusion=False)
+        _install(_NoGate)  # the target's build
+        with draft_model_build_scope():
+            _install(DeepseekV4ForCausalLMDSpark)
+            self.assertTrue(is_shared_experts_fusion_disabled())
+        self.assertTrue(get_flags().moe.speculative_disable_shared_experts_fusion)
+
     def test_a_gateless_draft_inherits_the_active_decision(self):
         self._seed(disable_shared_experts_fusion=False)
         _install(_AlwaysDisables)  # the target's build


### PR DESCRIPTION
## Motivation

After #33889 made shared-expert fusion model-local, `DeepseekV4ForCausalLMDSpark` could construct fused shared-expert slots even though its checkpoint loader only supports separate `shared_experts.*` modules. The loader then rejected every bundled shared-expert tensor, leaving the DSpark draft with missing shared-expert weights.

On DeepSeek-V4-Flash-0731 with TP=2, this reduced draft-token acceptance from 39.69% to 13.59% and caused a 41–46% decode-throughput regression.

## Modifications

- Disable shared-expert fusion for `DeepseekV4ForCausalLMDSpark`.
- Add a construction-isolation regression test covering target and draft fusion decisions.

## Accuracy Tests

- Focused unit suite: 14 passed.
- Production TP=2 startup loaded all 48 DSpark checkpoint shards with zero rejected shared-expert tensors.
- Draft-token acceptance recovered from 13.59% to 39.69%.
- Accepted tokens per verification, including the target bonus, recovered from 1.680 to 2.984.
- Five complete GSM8K runs averaged 93.72% accuracy (6,181/6,595). All responses were extractable and had valid finish reasons.
- Eight sequential long-generation requests completed normally with closed HTML fences and documents, no placeholders, and JavaScript accepted by `node --check`. Median completion length was 57,956.5 tokens (17,110–67,884).

## Speed Tests and Profiling

Tests used 2x RTX PRO 6000 Blackwell Max-Q GPUs, TP=2, DSpark block size 5, and 30-second sustained decode cells.

The matched diagnostic changed only the DSpark shared-expert gate:

| Concurrency | Before fix | After fix | Improvement |
|---:|---:|---:|---:|
| 1 | 104.7 tok/s | 200.1 tok/s | +91.1% |
| 2 | 164.1 tok/s | 299.1 tok/s | +82.3% |
| 4 | 244.7 tok/s | 432.2 tok/s | +76.6% |
| 8 | 344.1 tok/s | 593.7 tok/s | +72.5% |
| 16 | 535.7 tok/s | 909.9 tok/s | +69.9% |
| 32 | 777.1 tok/s | 1,318.4 tok/s | +69.7% |

Five independent post-fix runs produced median decode throughput of 187.9 / 397.4 / 438.1 / 606.1 / 913.1 / 1,316.5 tok/s at C1/C2/C4/C8/C16/C32.

Matched exact-cold prefill results:

| Context | Before fix | After fix |
|---:|---:|---:|
| 8K | 7,373 tok/s | 7,370 tok/s |
| 64K | 8,336 tok/s | 8,326 tok/s |
| 128K | 7,768 tok/s | 7,747 tok/s |

Five post-fix runs produced median exact-cold prefill of 7,378 / 8,530 / 7,934 tok/s at 8K/64K/128K.

The five-run coding median was 267.9 tok/s. Median aggregate GSM8K throughput was 369.9 tok/s.

## Checklist

- [x] Format code according to the pre-commit configuration.
- [x] Add a unit regression test.
- [x] Documentation is not required for this internal loader correction.
- [x] Provide accuracy and speed results.
- [x] Follow the SGLang code-style guidance.

Prepared with AI assistance
