### PR TITLE
[CI] Gate Kimi-K3 acceptance length on the GSM8K average

### DIFF
--- a/test/registered/models_e2e/test_kimi_k3_b300.py
+++ b/test/registered/models_e2e/test_kimi_k3_b300.py
@@ -40,8 +40,14 @@ class TestKimiK3B300LowLatency(GSM8KMixin, SpecDecodingMixin, CustomTestCase):
 
     gsm8k_score_threshold = 0.95
     gsm8k_num_examples = 200
-    accept_length_thres = 6.6
-    bs_1_speed_thres = 440
+    # Acceptance is gated here: avg_spec_accept_length is averaged over 200
+    # questions, so it holds steady when a numerics change shifts where the
+    # single greedy prompt below hits EOS.
+    gsm8k_accept_length_thres = 4.5
+    # test_bs_1_speed runs one greedy prompt, so both metrics scale with how
+    # far that generation happens to run. Keep them as coarse guards only.
+    accept_length_thres = 4.0
+    bs_1_speed_thres = 380
 
     @classmethod
     def setUpClass(cls):

--- a/test/registered/models_e2e/test_kimi_k3_b300.py
+++ b/test/registered/models_e2e/test_kimi_k3_b300.py
@@ -40,12 +40,11 @@ class TestKimiK3B300LowLatency(GSM8KMixin, SpecDecodingMixin, CustomTestCase):
 
     gsm8k_score_threshold = 0.95
     gsm8k_num_examples = 200
-    # Acceptance is gated here: avg_spec_accept_length is averaged over 200
-    # questions, so it holds steady when a numerics change shifts where the
-    # single greedy prompt below hits EOS.
+    # Gated on GSM8K rather than on test_bs_1_speed below: a 200-question
+    # average holds steady when a numerics change moves where the single
+    # greedy prompt hits EOS.
     gsm8k_accept_length_thres = 4.5
-    # test_bs_1_speed runs one greedy prompt, so both metrics scale with how
-    # far that generation happens to run. Keep them as coarse guards only.
+    # Both scale with how far that one greedy prompt runs; coarse guards only.
     accept_length_thres = 4.0
     bs_1_speed_thres = 380
 

--- a/test/registered/models_e2e/test_kimi_k3_b300.py
+++ b/test/registered/models_e2e/test_kimi_k3_b300.py
@@ -44,9 +44,11 @@ class TestKimiK3B300LowLatency(GSM8KMixin, SpecDecodingMixin, CustomTestCase):
     # average holds steady when a numerics change moves where the single
     # greedy prompt hits EOS.
     gsm8k_accept_length_thres = 4.5
-    # Both scale with how far that one greedy prompt runs; coarse guards only.
+    # Both scale with how far that one greedy prompt runs, and speed is
+    # end-to-end, so launch and TTFT are amortized over the output -- it sits
+    # well below the steady decode rate the server logs. Coarse guards only.
     accept_length_thres = 4.0
-    bs_1_speed_thres = 380
+    bs_1_speed_thres = 300
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
## Failing job

`base-c-test-8-gpu-b300` on the scheduled run of `cea16bf2`:
https://github.com/sgl-project/sglang/actions/runs/31283299099/job/93168001231

```
ERROR: test_bs_1_speed (__main__.TestKimiK3B300LowLatency.test_bs_1_speed)
AssertionError: 5.308219178082192 not greater than 6.6
```

GSM8K passed in the same job (score 0.98), so this was acceptance-only.

## Cause

`test_bs_1_speed` sends a single greedy prompt through `send_one_prompt`, and both metrics it
asserts on are ratios over whatever that one generation produced:

- `acc_length = completion_tokens / spec_verify_ct`
- `speed = completion_tokens / e2e_latency`

`5.308219178082192` is exactly `775 / 146`, i.e. the generation stopped at 775 tokens. When the
threshold was set, the same prompt ran the full `max_new_tokens=2048`
(https://github.com/sgl-project/sglang/actions/runs/31247767179). Acceptance on this prompt climbs
as the generation goes on, so a shorter run reports a lower average even when nothing about
speculation changed:

| decode progress | full 2048-token run | 775-token run |
| --- | --- | --- |
| ~200 tokens | 3.77 | 4.25 |
| ~500 tokens | 7.00 | 6.15 |
| ~704 tokens | 4.90 | 5.75 |
| later | 7.28 / 7.80 / 7.72 / 7.83 | (already stopped) |
| mean over first ~704 | 5.22 | 5.38 |

Compared over the same token range acceptance is flat, in fact marginally higher. The drop from
7.83 to 5.31 is entirely the shorter generation.

What moved the EOS position is #33764, which raises the Kimi-K3 router GEMM output to fp32. That is
a correctness fix and should stay: GSM8K is unchanged (0.985 -> 0.98), and the acceptance measured
over GSM8K is unchanged too. Under `temperature=0` any small numerics change can flip a token and
send the greedy path somewhere else, which is expected and not something a threshold should catch.

`bs_1_speed_thres = 440` has a second, independent problem: it is not the same quantity the test
measures. `send_one_prompt` returns `completion_tokens / e2e_latency`, which includes launch, TTFT
and the first decode step, while the rate the server logs during decode is the steady-state one.
The gap is large at bs=1 -- in the same run:

```
Decode batch, #running-req: 1, #full token: 256, ..., gen throughput (token/s): 9.36
Decode batch, #running-req: 1, #full token: 448, ..., gen throughput (token/s): 452.56
Decode batch, #running-req: 1, #full token: 704, ..., gen throughput (token/s): 428.11
```
```
AssertionError: 346.2043018495696 not greater than 380
```

Steady-state decode is 428-452 token/s, but end-to-end over 775 tokens is 346. A threshold near the
steady-state rate cannot pass on the metric this test actually asserts on, and the shorter the
generation the wider the gap.

## Change

Move the acceptance gate onto the GSM8K run, which averages over 200 questions and therefore does
not move when one prompt diverges:

```python
gsm8k_accept_length_thres = 4.5
accept_length_thres = 4.0
bs_1_speed_thres = 300
```

`avg_spec_accept_length` for this recipe across recent b300 runs:

| build | avg_spec_accept_length |
| --- | --- |
| before #33764 | 4.7818 |
| #33764 itself | 4.7954 |
| earlier scheduled runs | 4.75 - 4.86 |

4.5 leaves ~6% margin on a metric that has held within 0.03 across those runs.

The two single-prompt thresholds stay, relaxed to coarse regression guards. Measured on this branch:
`acc_length` 5.31 (guard 4.0) and `speed` 343.99 / 346.20 across two attempts (guard 300). They
still catch speculation or latency falling over, without tracking where one greedy prompt stops.

No shared kit is touched, so the other test classes using `SpecDecodingMixin` are unaffected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31291908330](https://github.com/sgl-project/sglang/actions/runs/31291908330)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31291908276](https://github.com/sgl-project/sglang/actions/runs/31291908276)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->