### PR TITLE
[CI] Pin the rust frontend parity test to eager prefill

### DIFF
--- a/test/registered/openai_server/basic/test_openai_completion_rust.py
+++ b/test/registered/openai_server/basic/test_openai_completion_rust.py
@@ -26,10 +26,8 @@ class TestOpenAICompletionRustParity(CustomTestCase):
     api_key = "sk-123456"
 
     def _get_logprobs(self, *, rust_frontend):
-        # The assertions below require bit-identical logprobs. A prefill CUDA
-        # graph pads the batch, so the numerics follow whichever requests share
-        # the forward pass, and the two frontends do not always warm up into the
-        # same batch. Pin prefill to eager so only the frontend differs.
+        # Prefill CUDA graph pads the batch, so numerics follow whichever
+        # requests share the forward pass; the assertions below need equality.
         process = popen_launch_server(
             self.model,
             DEFAULT_URL_FOR_TEST,

--- a/test/registered/openai_server/basic/test_openai_completion_rust.py
+++ b/test/registered/openai_server/basic/test_openai_completion_rust.py
@@ -26,13 +26,21 @@ class TestOpenAICompletionRustParity(CustomTestCase):
     api_key = "sk-123456"
 
     def _get_logprobs(self, *, rust_frontend):
+        # The assertions below require bit-identical logprobs. A prefill CUDA
+        # graph pads the batch, so the numerics follow whichever requests share
+        # the forward pass, and the two frontends do not always warm up into the
+        # same batch. Pin prefill to eager so only the frontend differs.
         process = popen_launch_server(
             self.model,
             DEFAULT_URL_FOR_TEST,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=self.api_key,
             env={"SGLANG_RUST_SERVER": "1" if rust_frontend else "0"},
-            other_args=["--random-seed", "42"],
+            other_args=[
+                "--random-seed",
+                "42",
+                "--disable-prefill-cuda-graph",
+            ],
         )
         try:
             response = requests.post(


### PR DESCRIPTION
## Failing job

`base-b-test-1-gpu-small` on the scheduled run of `cea16bf2`:
https://github.com/sgl-project/sglang/actions/runs/31283299099/job/93168001174

```
ERROR: test_logprobs_have_zero_kl_against_python_frontend
AssertionError: Lists differ: [..., -0.8352525234222412, -1.4414517879486084, ...]
                          !=  [..., -0.8400163650512695, -1.417750597000122,  ...]
```

## Cause

The test asserts bit-identical output between the two frontends:

```python
self.assertEqual(rust_logprobs["token_logprobs"], python_logprobs["token_logprobs"])
self.assertEqual(self._kl_divergence(python_top, rust_top), 0.0)
```

Both servers run the same model with the same args, so that held as long as prefill ran eager. This
model launches with 1.83 GiB free after the KV pool is sized, which used to fall under the
auto-prefill-graph memory gate, so prefill was always eager here and the comparison was exact.

Since #33352 removed that gate the same launch captures a prefill graph:

```
Capture target prefill CUDA graph begin. backend=breakable, ..., avail mem=1.83 GB
```

The graph pads the token count to a bucket, so the numerics now depend on which requests share the
forward pass. The two frontends do not always reach the test request in the same batch state: in the
failing job the python server prefilled it with `#running-req: 0` while the rust server still had
its warmup request decoding (`#running-req: 1`).

This is timing-dependent, not deterministic. #33352's own CI passed because both servers happened to
land on `#running-req: 0` there:

| | python server | rust server | result |
| --- | --- | --- | --- |
| #33352 CI ([job](https://github.com/sgl-project/sglang/actions/runs/31148378656/job/93092427481)) | `#running-req: 0` | `#running-req: 0` | pass |
| scheduled run | `#running-req: 0` | `#running-req: 1` | fail |

## Change

Launch both servers with `--disable-prefill-cuda-graph`.

Whether prefill runs under a CUDA graph is not what this test covers -- it checks that the rust
frontend drives the same inference path as the python frontend. Pinning prefill to eager removes the
batch-composition variable, so the bit-identical assertions test the frontend difference and nothing
else. Prefill graph coverage stays with the tests that target it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31291766340](https://github.com/sgl-project/sglang/actions/runs/31291766340)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31291766227](https://github.com/sgl-project/sglang/actions/runs/31291766227)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->