### PR TITLE
[AMD] [CI] Register the DeepSeek-V4-Pro-DSpark MI35x nightly job so its suite actually runs

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -70,6 +70,7 @@ on:
           - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
           - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
           - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720
+          - nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720
           # 8-GPU Kimi-K2.6 (MI30x + MI35x)
           - nightly-8-gpu-kimi-k26-rocm720
           - nightly-8-gpu-mi35x-kimi-k26-rocm720
@@ -1438,6 +1439,44 @@ jobs:
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro-mtp --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
 
+  nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720,'))
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: |
+          # --skip-test-time-deps: GSM8K doesn't need lmms-eval / human-eval.
+          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
+
+      - name: Accuracy + DSpark Accept Length Test MI35x ROCm 7.2 (8-GPU DeepSeek-V4-Pro-DSpark FP4, unified_kv_triton)
+        timeout-minutes: 300
+        run: |
+          > github_summary.md  # Clear summary file
+          echo "## SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton" >> github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro-dspark --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }}
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+
   # ==============================================================================
   # 8-GPU Kimi-K2.6 (MI30x + MI35x)
   # ==============================================================================
@@ -2077,6 +2116,7 @@ jobs:
       - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720
+      - nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720
       # 8-GPU Kimi-K2.6 (MI30x + MI35x)
       - nightly-8-gpu-kimi-k26-rocm720
       - nightly-8-gpu-mi35x-kimi-k26-rocm720


### PR DESCRIPTION
## Motivation

[#30964](https://github.com/sgl-project/sglang/pull/30964) added `test/registered/amd/test_deepseek_v4_pro_fp4_dspark.py`, the only test covering the AMD DSpark unified-KV path, and registered it as:

```python
register_amd_ci(
    est_time=7200, suite="nightly-amd-8-gpu-mi35x-deepseek-v4-pro-dspark", nightly=True
)
```

No job in `nightly-test-amd.yml` or `nightly-test-amd-rocm720.yml` invokes that suite name, so the test never runs. `register_amd_ci` associates a test file with a suite; something still has to call `run_suite.py --suite <name>` for the suite to execute. `nightly=True` keeps it out of PR CI but does not schedule it anywhere. The result is a registered-but-dormant test: `git grep nightly-amd-8-gpu-mi35x-deepseek-v4-pro-dspark` on `main` matches only the test file itself.

This matters because the merge review for #30964 asked specifically for that suite to be run on MI35x with `unified_kv_triton` and for GSM8K accuracy plus DSpark acceptance to be confirmed. That verification can only be reproduced by hand today.

## Modifications

`.github/workflows/nightly-test-amd-rocm720.yml` only:

- Add the `nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720` job, placed with the other DeepSeek-V4 MI35x jobs and built the same way as its sibling `nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720`: `linux-mi35x-gpu-8`, VRAM pre-clear, ROCm 7.2 container with `ENABLE_CACHE_HOST=1`, dependency install with `--skip-test-time-deps` (GSM8K needs neither lmms-eval nor human-eval), then `run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x-deepseek-v4-pro-dspark`.
- Add it to the `job_select` dropdown so it is individually dispatchable.
- Add it to `check-all-jobs.needs` so a failure fails the nightly rather than being silently absent.

Two deliberate differences from the neighbouring V4 jobs:

- **One backend leg, not two.** The V4-Pro and V4-Flash jobs each run a `unified_kv_triton` leg and a `triton` leg. This test exists to cover unified-KV target-hidden injection and verify metadata, and its own default is `SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton`; a `triton` leg would not exercise the code path the test was written for.
- **`--timeout-per-file 7200`** matches the `est_time=7200` the test registers, with `timeout-minutes: 300` for the step. The headroom is needed because `SERVER_LAUNCH_TIMEOUT` is 5400s on its own for a 1.6T checkpoint before the 1319-question GSM8K run starts.

## Result

Dispatched on this branch, one job selected and the other 46 skipped: [run 31291406552](https://github.com/sgl-project/sglang/actions/runs/31291406552). It checks out branch head, so the code under test was `main` including the merged [#30964](https://github.com/sgl-project/sglang/pull/30964) — this is the post-merge verification that PR's review asked for, and it is now green.

[`nightly-8-gpu-mi35x-deepseek-v4-pro-dspark-rocm720`](https://github.com/sgl-project/sglang/actions/runs/31291406552/job/93189109485) succeeded: `Test Summary: 1/1 passed`, `Ran 3 tests in 2906.133s`, covering the two unified-KV kernel unit tests plus the full GSM8K run.

| Metric | Value | Gate |
|---|---|---|
| GSM8K accuracy (1319 questions, 5-shot) | 0.9515 | > 0.92 |
| DSpark `avg_spec_accept_length` | 3.730 | > 3.0 |
| Invalid outputs | 0.0 | — |
| Eval latency | 39.45s | — |
| Output throughput | 2998 tok/s | — |

Both gates clear with margin. The test writes accuracy and acceptance length into the job summary via `write_github_step_summary`, so the nightly report will carry the numbers rather than just a pass/fail.

Timing for scheduling purposes: 51m queued on `linux-mi35x-gpu-8`, then 55m23s wall for the job including container setup, dependency install and the 1.6T checkpoint load. The suite itself ran 2930s against a registered `est_time=7200`, so the estimate is roughly 2.5x conservative; that value lives in the test file from #30964 and is left alone here, but it is worth tightening if nightly partition balance becomes an issue.

## Accuracy Tests

N/A for this PR's own diff — CI wiring only, no runtime, kernel or model code touched. The job it registers is itself an accuracy test; see the dispatched run above.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31291711881](https://github.com/sgl-project/sglang/actions/runs/31291711881)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31291791086](https://github.com/sgl-project/sglang/actions/runs/31291791086)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
