### PR TITLE
[Scheduler] Drop delayed final-prefill results after abort

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -235,6 +235,9 @@ class SchedulerBatchResultProcessor:
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
+                drop_prefill_result = req.to_finish is not None and (
+                    not batch.decoding_reqs or req not in batch.decoding_reqs
+                )
                 if (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
@@ -248,6 +251,7 @@ class SchedulerBatchResultProcessor:
                         extend_input_len=extend_input_len_per_req[i],
                         store=(
                             not req.finished()
+                            and not drop_prefill_result
                             and not req.is_retracted
                             and req.inflight_middle_chunks <= 0
                         ),
@@ -264,12 +268,17 @@ class SchedulerBatchResultProcessor:
                 if req.inflight_middle_chunks <= 0:
                     req.time_stats.set_prefill_finished_time()
 
-                    # req output_ids are set here
-                    req.output_ids.append(next_token_id)
+                    if drop_prefill_result:
+                        # Abort won the race with this delayed prefill result.
+                        # Finish and clean up without committing the sampled token
+                        # or any metadata derived from it.
+                        req.update_finish_state(new_accepted_len=0)
+                    else:
+                        # req output_ids are set here
+                        req.output_ids.append(next_token_id)
+                        self._maybe_update_reasoning_tokens(req, next_token_id)
+                        req.update_finish_state()
 
-                    self._maybe_update_reasoning_tokens(req, next_token_id)
-
-                    req.update_finish_state()
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)
@@ -280,7 +289,8 @@ class SchedulerBatchResultProcessor:
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
-                    self._maybe_collect_customized_info(i, req, logits_output)
+                    if not drop_prefill_result:
+                        self._maybe_collect_customized_info(i, req, logits_output)
 
                     if batch.return_logprob:
                         logprob_pt = self._apply_prefill_logprobs(
@@ -291,12 +301,13 @@ class SchedulerBatchResultProcessor:
                             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
                             next_token_ids=next_token_ids,
                             logprob_pt=logprob_pt,
+                            attach_return_values=not drop_prefill_result,
                         )
 
-                    if req.return_sampling_mask:
+                    if not drop_prefill_result and req.return_sampling_mask:
                         self.add_sampling_mask_return_values(i, req, logits_output)
 
-                    if req.grammar is not None:
+                    if not drop_prefill_result and req.grammar is not None:
                         self._apply_prefill_grammar(
                             req=req,
                             next_token_id=next_token_id,
@@ -430,6 +441,7 @@ class SchedulerBatchResultProcessor:
         extend_logprob_start_len_per_req: Optional[List[int]],
         next_token_ids: List[int],
         logprob_pt: int,
+        attach_return_values: bool = True,
     ) -> int:
         assert extend_logprob_start_len_per_req is not None
         assert extend_input_len_per_req is not None
@@ -442,7 +454,7 @@ class SchedulerBatchResultProcessor:
             extend_logprob_start_len,
         )
 
-        if req.return_logprob:
+        if attach_return_values and req.return_logprob:
             self.logprob_result_processor.add_logprob_return_values(
                 i,
                 req,
@@ -758,10 +770,14 @@ class SchedulerBatchResultProcessor:
             # Extend: advance over the single token each completed-prefill req emitted
             # (mirrors process_batch_result_prefill's per-req token indexing).
             for i, req in enumerate(batch.reqs):
+                drop_prefill_result = req.to_finish is not None and (
+                    not batch.decoding_reqs or req not in batch.decoding_reqs
+                )
                 if (
                     req.grammar is None
                     or req.is_retracted
                     or req.finished()
+                    or drop_prefill_result
                     or req.inflight_middle_chunks > 0
                 ):
                     continue

--- a/test/registered/scripted_runtime/test_scripted_runtime_core.py
+++ b/test/registered/scripted_runtime/test_scripted_runtime_core.py
@@ -7,6 +7,7 @@ from sglang.test.scripted_runtime.http_server import ScriptedHttpServer
 from sglang.test.scripted_runtime.req_handle import ScriptedReqHandle
 from sglang.test.scripted_runtime.test_case import ScriptedTestCase
 from sglang.test.scripted_runtime_chunked_helpers import (
+    DEFAULT_MAX_STEPS,
     advance_to_decode_step,
     advance_to_nth_chunk,
     base_engine_kwargs,
@@ -130,6 +131,54 @@ class TestScriptedRuntimeCore(ScriptedTestCase):
         yield from run_until_finished(r)
         assert not r.is_chunking, "handle.is_chunking still True after finish"
         assert not t.is_chunking(r.rid), "context.is_chunking still True after finish"
+
+    def test_abort_at_last_chunk_does_not_append_output(self):
+        self.server.execute_script(
+            self._script_abort_at_last_chunk_does_not_append_output
+        )
+
+    @staticmethod
+    def _script_abort_at_last_chunk_does_not_append_output(
+        t: ScriptedContext,
+    ):
+        r = t.start_req(prompt_len=_LONG_PROMPT_LEN, max_new_tokens=64, ignore_eos=True)
+        req = None
+        saw_chunked_prefill = False
+        for _ in range(DEFAULT_MAX_STEPS):
+            req = req or r.req
+            last_batch = t.scheduler.last_batch
+            saw_chunked_prefill = saw_chunked_prefill or (
+                req is not None and t.scheduler.chunked_req is req
+            )
+            if (
+                saw_chunked_prefill
+                and req is not None
+                and last_batch is not None
+                and last_batch.forward_mode.is_extend()
+                and req in last_batch.reqs
+                and t.scheduler.chunked_req is None
+                and req.inflight_middle_chunks == 0
+            ):
+                break
+            yield
+        else:
+            raise AssertionError("last prefill chunk was not launched before abort")
+
+        assert len(req.output_ids) == 0
+        assert (
+            t.scheduler.result_queue
+        ), "last prefill result was not pending when abort arrived"
+
+        t.abort(r)
+        yield from run_until_finished(r)
+
+        assert isinstance(req.finished_reason, FINISH_ABORT)
+        assert len(req.output_ids) == 0, (
+            "chunked-prefill result appended a token after abort: "
+            f"{list(req.output_ids)!r}"
+        )
+        assert not t.is_chunking(r.rid), "aborted req remained chunked"
+        assert req.req_pool_idx is None, "aborted req kept its request-pool slot"
 
     def test_pause_retract_parks_in_waiting_queue_then_resumes(self):
         self.server.execute_script(self._script_pause_retract_parks_then_resumes)

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -53,6 +53,7 @@ class _PrefillReq:
         self.hidden_states = []
         self.is_retracted = False
         self.output_ids = []
+        self.to_finish = None
         self.time_stats = Mock()
         self.return_logprob = False
         self.return_sampling_mask = False


### PR DESCRIPTION
Superseded by #34153. This closed draft is retained only as immutable GitHub history; the active fix and review discussion are in #34153.