### PR TITLE
[Scheduler] Fix final chunked-prefill abort commit race

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3561,6 +3561,20 @@ class Scheduler(
             and last_batch
             and last_batch.forward_mode.is_extend()
         ):
+            if getattr(self, "result_queue", None):
+                # Abort can arrive while the final prefill result is still delayed.
+                # Keep that request out of optimistic decode; the result processor
+                # will consume the pending finish and release its resources.
+                chunked_req_to_exclude.update(
+                    req
+                    for req in last_batch.reqs
+                    if req.to_finish is not None
+                    and (
+                        not last_batch.decoding_reqs
+                        or req not in last_batch.decoding_reqs
+                    )
+                )
+
             if last_batch.chunked_req is not None:
                 # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
                 # We need to discard it.

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -304,13 +304,26 @@ class SchedulerBatchResultProcessor:
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
-                drop_prefill_result = req.to_finish is not None and (not batch.decoding_reqs or req not in batch.decoding_reqs)
-                should_commit_output = not req.finished() and not req.is_retracted and req.inflight_middle_chunks <= 0
+                drop_prefill_result = req.to_finish is not None and (
+                    not batch.decoding_reqs or req not in batch.decoding_reqs
+                )
+                should_commit_output = (
+                    not req.finished()
+                    and not req.is_retracted
+                    and req.inflight_middle_chunks <= 0
+                )
                 sampling_mask_finish_reason = None
-                if should_commit_output and req.return_sampling_mask:
+                if (
+                    should_commit_output
+                    and not drop_prefill_result
+                    and req.return_sampling_mask
+                ):
+                    assert logits_output is not None
                     statuses = logits_output.next_token_sampling_mask_status
                     status = None if statuses is None else statuses[i]
-                    sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(status=status)
+                    sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
+                        status=status
+                    )
                 if (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
@@ -323,7 +336,9 @@ class SchedulerBatchResultProcessor:
                         capture_hidden_mode=prefill_hidden_capture_mode,
                         extend_input_len=extend_input_len_per_req[i],
                         store=(
-                            should_commit_output and sampling_mask_finish_reason is None and not drop_prefill_result
+                            should_commit_output
+                            and sampling_mask_finish_reason is None
+                            and not drop_prefill_result
                         ),
                     )
 
@@ -355,7 +370,9 @@ class SchedulerBatchResultProcessor:
                     else:
                         # req output_ids are set here
                         req.output_ids.append(next_token_id)
+
                         self._maybe_update_reasoning_tokens(req, next_token_id)
+
                         req.update_finish_state()
                     # A mixed spec tail committed its pending bonus token; advance
                     # so the next spec prepare_for_decode reserves from the right base.
@@ -393,7 +410,8 @@ class SchedulerBatchResultProcessor:
                             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
                             next_token_ids=next_token_ids,
                             logprob_pt=logprob_pt,
-                            store=sampling_mask_finish_reason is None and not drop_prefill_result,
+                            store=sampling_mask_finish_reason is None
+                            and not drop_prefill_result,
                         )
 
                     if sampling_mask_finish_reason is not None:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -304,19 +304,13 @@ class SchedulerBatchResultProcessor:
             logprob_pt = 0
 
             for i, (req, next_token_id) in enumerate(zip(batch.reqs, next_token_ids)):
-                should_commit_output = (
-                    not req.finished()
-                    and not req.is_retracted
-                    and req.inflight_middle_chunks <= 0
-                )
+                drop_prefill_result = req.to_finish is not None and (not batch.decoding_reqs or req not in batch.decoding_reqs)
+                should_commit_output = not req.finished() and not req.is_retracted and req.inflight_middle_chunks <= 0
                 sampling_mask_finish_reason = None
                 if should_commit_output and req.return_sampling_mask:
-                    assert logits_output is not None
                     statuses = logits_output.next_token_sampling_mask_status
                     status = None if statuses is None else statuses[i]
-                    sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(
-                        status=status
-                    )
+                    sampling_mask_finish_reason = self.get_sampling_mask_finish_reason(status=status)
                 if (
                     batch.return_hidden_states
                     and logits_output.hidden_states is not None
@@ -329,7 +323,7 @@ class SchedulerBatchResultProcessor:
                         capture_hidden_mode=prefill_hidden_capture_mode,
                         extend_input_len=extend_input_len_per_req[i],
                         store=(
-                            should_commit_output and sampling_mask_finish_reason is None
+                            should_commit_output and sampling_mask_finish_reason is None and not drop_prefill_result
                         ),
                     )
 
@@ -353,12 +347,15 @@ class SchedulerBatchResultProcessor:
                         self.beam_coordinator.commit_prefill(
                             req, up_to_tick=batch.forward_iter
                         )
+                    elif drop_prefill_result:
+                        # Abort won the race with this delayed prefill result.
+                        # Finish and clean up without committing the sampled token
+                        # or any metadata derived from it.
+                        req.update_finish_state(new_accepted_len=0)
                     else:
                         # req output_ids are set here
                         req.output_ids.append(next_token_id)
-
                         self._maybe_update_reasoning_tokens(req, next_token_id)
-
                         req.update_finish_state()
                     # A mixed spec tail committed its pending bonus token; advance
                     # so the next spec prepare_for_decode reserves from the right base.
@@ -384,7 +381,7 @@ class SchedulerBatchResultProcessor:
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
-                    if sampling_mask_finish_reason is None:
+                    if sampling_mask_finish_reason is None and not drop_prefill_result:
                         self._maybe_collect_customized_info(i, req, logits_output)
 
                     if batch.return_logprob:
@@ -396,16 +393,16 @@ class SchedulerBatchResultProcessor:
                             extend_logprob_start_len_per_req=extend_logprob_start_len_per_req,
                             next_token_ids=next_token_ids,
                             logprob_pt=logprob_pt,
-                            store=sampling_mask_finish_reason is None,
+                            store=sampling_mask_finish_reason is None and not drop_prefill_result,
                         )
 
                     if sampling_mask_finish_reason is not None:
                         continue
 
-                    if req.return_sampling_mask:
+                    if not drop_prefill_result and req.return_sampling_mask:
                         self.add_sampling_mask_return_values(i, req, logits_output)
 
-                    if req.grammar is not None:
+                    if not drop_prefill_result and req.grammar is not None:
                         self._apply_prefill_grammar(
                             req=req,
                             next_token_id=next_token_id,
@@ -875,10 +872,14 @@ class SchedulerBatchResultProcessor:
             # Extend: advance over the single token each completed-prefill req emitted
             # (mirrors process_batch_result_prefill's per-req token indexing).
             for i, req in enumerate(batch.reqs):
+                drop_prefill_result = req.to_finish is not None and (
+                    not batch.decoding_reqs or req not in batch.decoding_reqs
+                )
                 if (
                     req.grammar is None
                     or req.is_retracted
                     or req.finished()
+                    or drop_prefill_result
                     or req.inflight_middle_chunks > 0
                 ):
                     continue

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import torch
-
 from sglang.srt.environ import envs
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput, SamplingMaskStatus
 from sglang.srt.managers.scheduler_components.batch_result_processor import (
@@ -18,7 +17,9 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
-def _make_processor(case, server_mode: str = "full") -> SchedulerBatchResultProcessor:
+def _make_processor(
+    case, server_mode: str = "full", *, logprob_result_processor=None
+) -> SchedulerBatchResultProcessor:
     # The server-side hidden-state ceiling is a bag leaf.
     override = get_context().override_server_args(
         enable_return_hidden_states=True,
@@ -44,7 +45,7 @@ def _make_processor(case, server_mode: str = "full") -> SchedulerBatchResultProc
         metrics_reporter=metrics_reporter,
         draft_worker=None,
         model_worker=Mock(),
-        logprob_result_processor=None,
+        logprob_result_processor=logprob_result_processor,
         output_streamer=Mock(),
         beam_coordinator=Mock(),
         abort_request=lambda *args, **kwargs: None,
@@ -77,26 +78,39 @@ class TestSamplingMaskMaterialization(CustomTestCase):
 
 
 class _PrefillReq:
-    def __init__(self, *, rid: str, inflight_middle_chunks: int, return_hidden_states):
+    def __init__(
+        self,
+        *,
+        rid: str,
+        inflight_middle_chunks: int,
+        return_hidden_states,
+        return_logprob: bool = False,
+        to_finish=None,
+    ):
         self.rid = rid
         self.inflight_middle_chunks = inflight_middle_chunks
         self.return_hidden_states = return_hidden_states
         self.hidden_states = []
         self.is_retracted = False
         self.output_ids = []
+        self.to_finish = to_finish
+        self.finished_reason = None
         self.time_stats = Mock()
-        self.return_logprob = False
+        self.return_logprob = return_logprob
         self.return_sampling_mask = False
         self.grammar = None
         self.require_reasoning = False
         self.customized_info = None
         self.beam_group = None
+        self.return_routed_experts = False
 
     def finished(self):
-        return False
+        return self.finished_reason is not None
 
-    def update_finish_state(self):
-        return None
+    def update_finish_state(self, new_accepted_len=1):
+        if self.to_finish is not None:
+            self.finished_reason = self.to_finish
+            self.to_finish = None
 
 
 class _DecodeReq:
@@ -191,6 +205,111 @@ class TestPrefillHiddenStateOffsets(CustomTestCase):
 
                 self.assertEqual(middle.hidden_states, [])
                 self.assertEqual(last.hidden_states, [[22.0]])
+
+    def test_aborted_final_prefill_drops_metadata_but_advances_logprob_offset(self):
+        self._assert_aborted_final_prefill()
+
+    def test_pending_abort_wins_over_sampling_mask_overflow(self):
+        self._assert_aborted_final_prefill(SamplingMaskStatus.OVERFLOW)
+
+    def _assert_aborted_final_prefill(self, sampling_status=None):
+        aborted = _PrefillReq(
+            rid="aborted",
+            inflight_middle_chunks=0,
+            return_hidden_states="last",
+            return_logprob=True,
+            to_finish=object(),
+        )
+        abort_reason = aborted.to_finish
+        aborted.return_sampling_mask = sampling_status is not None
+        live = _PrefillReq(
+            rid="live",
+            inflight_middle_chunks=0,
+            return_hidden_states="last",
+            return_logprob=True,
+        )
+        batch = SimpleNamespace(
+            reqs=[aborted, live],
+            decoding_reqs=[],
+            return_logprob=True,
+            return_hidden_states=True,
+            return_hidden_states_mode=CaptureHiddenMode.LAST,
+            spec_info=None,
+            prefill_stats=None,
+            dp_cooperation_info=None,
+        )
+        logits_output = SimpleNamespace(
+            sampling_mask_output=None,
+            next_token_sampling_mask_status=[sampling_status, None],
+            hidden_states=torch.tensor([[10.0], [20.0]]),
+            customized_info={"tag": ["abort-meta", "live-meta"]},
+            next_token_logprobs=None,
+            input_token_logprobs=torch.tensor([-1.0, -2.0, -10.0, -11.0, -12.0]),
+            next_token_top_logprobs_val=[],
+            next_token_top_logprobs_idx=[],
+            next_token_token_ids_logprobs_val=[],
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            auxiliary_host_output=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=logits_output,
+            next_token_ids=torch.tensor([101, 202]),
+            extend_input_len_per_req=[2, 3],
+            extend_logprob_start_len_per_req=[0, 0],
+            grammar_advanced=False,
+            can_run_cuda_graph=False,
+            skipped_output_comm=False,
+        )
+        logprob_processor = Mock()
+        logprob_processor.calculate_num_input_logprobs.side_effect = [2, 3]
+        processor = _make_processor(
+            self, "last", logprob_result_processor=logprob_processor
+        )
+
+        def assert_clean_before_stream(reqs, *_):
+            self.assertEqual(reqs[0].output_ids, [])
+            self.assertEqual(reqs[0].hidden_states, [])
+            self.assertIsNone(reqs[0].customized_info)
+
+        processor.output_streamer.stream_output.side_effect = assert_clean_before_stream
+
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.release_kv_cache"
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.maybe_cache_unfinished_req"
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.get_memory",
+                return_value=SimpleNamespace(enable_hisparse=False),
+            ),
+        ):
+            processor.process_batch_result_prefill(batch, result)
+
+        self.assertTrue(aborted.finished())
+        self.assertIs(aborted.finished_reason, abort_reason)
+        self.assertEqual(aborted.output_ids, [])
+        self.assertEqual(aborted.hidden_states, [])
+        self.assertIsNone(aborted.customized_info)
+        self.assertEqual(live.output_ids, [202])
+        self.assertEqual(live.hidden_states, [[20.0]])
+        self.assertEqual(live.customized_info, {"tag": ["live-meta"]})
+
+        self.assertEqual(logprob_processor.calculate_num_input_logprobs.call_count, 2)
+        logprob_processor.add_logprob_return_values.assert_called_once_with(
+            1,
+            live,
+            2,
+            [101, 202],
+            3,
+            logits_output,
+        )
 
 
 class TestPrefillSkippedOutput(CustomTestCase):

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -1,4 +1,4 @@
-"""Regression tests for the SWA chunked-req stash gate (#24252)."""
+"""Regression tests for scheduler prefill/decode transition gates."""
 
 import unittest
 from array import array
@@ -6,7 +6,6 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import torch
-
 from sglang.srt.mem_cache.base_prefix_cache import DecLockRefParams
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
@@ -107,6 +106,7 @@ def _scheduler_for_get_next_batch(*, tree_cache, chunked_req) -> Scheduler:
     s.tree_cache = tree_cache
     s.chunked_req = chunked_req
     s._pending_chunked_abort_req = None
+    s.result_queue = []
     return s
 
 
@@ -177,6 +177,77 @@ class TestStashGatePreservesPrefixIndices(CustomTestCase):
             s, running_batch=s.running_batch, last_batch=s.last_batch
         )
         self.assertIsNone(s.chunked_req)
+
+
+class TestPendingPrefillAbortGate(CustomTestCase):
+    @staticmethod
+    def _make_last_batch():
+        aborted_prefill = MagicMock(rid="aborted-prefill", to_finish=object())
+        live_prefill = MagicMock(rid="live-prefill", to_finish=None)
+        aborted_decode = MagicMock(rid="aborted-decode", to_finish=object())
+        for req in (aborted_prefill, live_prefill, aborted_decode):
+            req.finished.return_value = False
+
+        last_batch = MagicMock()
+        last_batch.forward_mode.is_extend.return_value = True
+        last_batch.reqs = [aborted_prefill, live_prefill, aborted_decode]
+        last_batch.decoding_reqs = [aborted_decode]
+        last_batch.chunked_req = None
+        last_batch.is_prefill_only = False
+        last_batch.batch_size.side_effect = lambda: len(last_batch.reqs)
+        last_batch.is_empty.side_effect = lambda: not last_batch.reqs
+
+        def filter_batch(*, chunked_req_to_exclude):
+            excluded = set(chunked_req_to_exclude)
+            last_batch.reqs = [req for req in last_batch.reqs if req not in excluded]
+
+        last_batch.filter_batch.side_effect = filter_batch
+        return last_batch, aborted_prefill, live_prefill, aborted_decode
+
+    def _scheduled_reqs(self, *, has_pending_result):
+        scheduler = _scheduler_for_get_next_batch(
+            tree_cache=MagicMock(), chunked_req=None
+        )
+        scheduler.result_queue = [object()] if has_pending_result else []
+        last_batch, aborted_prefill, live_prefill, aborted_decode = (
+            self._make_last_batch()
+        )
+        scheduler.get_new_batch_prefill.side_effect = lambda running_batch: (
+            NextBatchPlan(batch_to_run=None, running_batch=running_batch)
+        )
+        scheduled_reqs = []
+
+        def update_running_batch(batch):
+            scheduled_reqs.extend(batch.reqs)
+            return batch
+
+        scheduler.update_running_batch.side_effect = update_running_batch
+
+        Scheduler.get_next_batch_to_run(
+            scheduler,
+            running_batch=scheduler.running_batch,
+            last_batch=last_batch,
+        )
+
+        return scheduled_reqs, aborted_prefill, live_prefill, aborted_decode
+
+    def test_abort_is_excluded_before_optimistic_decode(self):
+        scheduled_reqs, aborted_prefill, live_prefill, aborted_decode = (
+            self._scheduled_reqs(has_pending_result=True)
+        )
+
+        self.assertNotIn(aborted_prefill, scheduled_reqs)
+        self.assertIn(live_prefill, scheduled_reqs)
+        self.assertIn(aborted_decode, scheduled_reqs)
+
+    def test_abort_is_not_excluded_after_prefill_result_was_processed(self):
+        scheduled_reqs, aborted_prefill, live_prefill, aborted_decode = (
+            self._scheduled_reqs(has_pending_result=False)
+        )
+
+        self.assertIn(aborted_prefill, scheduled_reqs)
+        self.assertIn(live_prefill, scheduled_reqs)
+        self.assertIn(aborted_decode, scheduled_reqs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #34149.
Related prior report: #34112.

While testing chunked-prefill cancellation on latest `main`, we independently reproduced the same user-visible symptom reported in #34112: a cancelled request can expose one token and then finish with `abort`.

The #34112 attachment used SGLang v0.5.9. Its negative batch-level output IDs were old FutureMap relay handles and are not the failure criterion or target of this PR. Current `main` no longer uses that `ScheduleBatch.output_ids` representation.

Our deterministic current-main reproduction isolates a final-prefill overlap race. An abort can arrive after the final chunked-prefill `EXTEND` is launched but before its delayed result is committed. At that point `scheduler.chunked_req` is already clear, `Req.output_ids` is empty, and the result is pending in `result_queue`.

## Root cause

There were two commit boundaries to protect:

1. `abort_request()` records `req.to_finish = FINISH_ABORT()`, but the prefill result processor previously appended the sampled token and token-derived metadata before `update_finish_state()` consumed the pending finish.
2. In the CUDA/HIP overlap loop, scheduling the next batch happens before processing the delayed final-prefill result. Without an admission guard, the pending-finish prefill request can enter optimistic decode, increment `decode_batch_idx` / the KV committed watermark, and perform an optimistic decode step and its associated allocation before the result is dropped (which may reserve multiple slots or pages under speculative decoding).

Filtering only in the output streamer is too late: request output, reasoning state, logprobs, hidden states, sampling metadata, grammar state, and KV accounting may already be mutated.

## Modifications

- When a delayed result is actually pending, exclude pending-finish prefill requests from the prefill-to-decode merge before optimistic decode preparation.
- Keep decode requests in mixed batches on their existing partial-output path.
- In the final-prefill result processor, promote the pending finish with `new_accepted_len=0` and reuse normal finished-request cleanup.
- Do not commit the dropped token's output ID, reasoning state, hidden state, customized info, sampling mask, returned logprob values, or grammar state.
- Still advance packed hidden-state and logprob cursors so later live requests in the same batch read their own slices.
- Preserve synchronous, MLX, and PP scheduling semantics by applying the merge guard only while `result_queue` contains a delayed result.
- Leave PD-prefill transfer lifecycle unchanged; it uses a separate scheduler/result path.

## Regression coverage

The scripted test deterministically waits for this window:

- the request has passed through chunked prefill;
- the final `EXTEND` is launched;
- `scheduler.chunked_req is None`;
- no middle chunks remain in flight;
- `Req.output_ids` is empty;
- the final result is pending.

It then aborts and verifies:

- finish reason is `FINISH_ABORT`;
- no token is appended;
- no optimistic decode step occurs;
- the request-pool row and KV object are released;
- reclaimable KV capacity returns to its baseline after the scheduler drains.

Additional CPU tests cover both sides of the scheduler gate (pending queue vs. already-processed result), mixed prefill/decode membership, and a two-request packed-logprob case where the aborted segment advances the cursor without attaching metadata to the aborted request.

## Accuracy Tests

Cancellation control flow only; normal token generation is unchanged.

Validated on top of `main` commit `7605529bdf98ded2815e48c7054b1bc4533256c9`:

```text
PYTHONPATH=python .venv/bin/python -m pytest -q \
  test/registered/unit/managers/test_scheduler_chunked_req_gate.py \
  test/registered/unit/managers/test_batch_result_processor_hidden_states.py \
  test/registered/unit/managers/test_batch_result_processor_spec_grammar.py

11 passed, 2 subtests passed
```

```text
SGLANG_USE_MLX=1 PYTHONPATH=python .venv/bin/python \
  test/registered/scripted_runtime/test_scripted_runtime_core.py \
  TestScriptedRuntimeCore.test_abort_at_last_chunk_does_not_append_output

Ran 1 test in 129.234s
OK
```

Also passed:

- direct CI-style execution of the two modified CPU test files;
- Python compile checks for all touched files;
- registered-test and package-registration repository checks;
- Black 26.1.0, Ruff 0.15.1, isort 7.0.0, codespell 2.4.1, and `git diff --check`.

The packed-logprob test was mutation-checked: it fails both if the aborted request attaches returned logprobs and if its packed cursor contribution is skipped.

## Speed Tests and Profiling

Not applicable. The new checks are scheduler control-flow predicates; the result-drop branch runs only for a request that is already finishing.

## Topology notes

The race is not caused by TP, DP, or PP. TP/DP use the same per-request result state. PP and MLX process their pending result before the relevant `last_batch` is reused, so the queue-gated admission change is a no-op there while the result-drop protection remains valid. PD-prefill is intentionally out of scope because it has a separate transfer and result lifecycle.

The registered end-to-end regression is TP=1 / DP=1 / PP=1. Multi-rank topology behavior was source-reviewed but not claimed as a multi-GPU runtime validation.

## Checklist

- [x] Rebased onto current `main`.
- [x] Added deterministic registered regression coverage.
- [x] Added focused scheduler and packed-metadata unit coverage.
- [x] Ran relevant unit and scripted-runtime tests.
- [x] Ran formatting, compile, and test-registration checks.
- [x] Documentation and performance benchmarks are not applicable to this abort-only correctness fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34569404588](https://github.com/sgl-project/sglang/actions/runs/34569404588)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34906948637](https://github.com/sgl-project/sglang/actions/runs/34906948637)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34569404459](https://github.com/sgl-project/sglang/actions/runs/34569404459)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
