### PR TITLE
[Fix] Give multimodal draft-extend one mRoPE position per extended token

### DIFF
--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1266,9 +1266,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     extend_prefix_len : extend_prefix_len + extend_seq_len,
                 ]
                 if mrope_positions.numel() == 0:
+                    # Precomputed positions span only the prompt; an extend past it
+                    # needs one position per token, delta-shifted like decode.
                     mrope_positions = self._expand_mrope_from_input(
-                        mm_input, seq_lens_cpu[batch_idx]
-                    )
+                        mm_input, extend_prefix_len + 1
+                    ) + torch.arange(extend_seq_len, dtype=torch.int64)
             mrope_positions_list[batch_idx] = mrope_positions
 
         self.mrope_positions = torch.cat(

--- a/test/registered/unit/spec/test_mrope_draft_extend_positions.py
+++ b/test/registered/unit/spec/test_mrope_draft_extend_positions.py
@@ -1,0 +1,108 @@
+"""An extend past the precomputed mRoPE prompt gets one position per token.
+
+A multimodal request's precomputed ``mrope_positions`` only span its original
+prompt, so an extend that has moved past it hits a fallback (issue #34152: the
+v1 EAGLE draft-extend re-entered with ``num_draft_tokens`` tokens per request).
+The fallback has to widen to ``extend_seq_len`` positions: emitting a single
+decode-shaped position leaves ``mrope_positions`` with ``batch_size`` entries
+where the forward pass has ``sum(extend_lens)`` tokens, and the rotary
+embedding then reads out of bounds.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PROMPT_LEN = 16
+MROPE_DELTA = 5
+
+
+def _mm_input():
+    """A multimodal request whose mRoPE positions only span its prompt."""
+    return SimpleNamespace(
+        mrope_positions=torch.arange(PROMPT_LEN).unsqueeze(0).repeat(3, 1),
+        mrope_position_delta=torch.tensor([[MROPE_DELTA]]),
+        mrope_position_delta_repeated_cache=None,
+    )
+
+
+class TestMropeDraftExtendPositions(CustomTestCase):
+    def setUp(self):
+        override = get_context().override_server_args(model_path="dummy")
+        override.install()
+        self.addCleanup(override.restore)
+
+    def _run(self, batch_size, num_draft_tokens, seq_len):
+        forward_batch = ForwardBatch.__new__(ForwardBatch)
+        forward_batch.forward_mode = ForwardMode.EXTEND
+        forward_batch.seq_lens_cpu = torch.full(
+            (batch_size,), seq_len, dtype=torch.int64
+        )
+        batch = SimpleNamespace(
+            multimodal_inputs=[_mm_input() for _ in range(batch_size)],
+            extend_lens=[num_draft_tokens] * batch_size,
+            prefix_lens=[seq_len] * batch_size,
+        )
+        forward_batch._compute_mrope_positions(SimpleNamespace(device="cpu"), batch)
+        return forward_batch.mrope_positions
+
+    def test_one_position_per_extended_token(self):
+        batch_size, num_draft_tokens = 3, 4
+        positions = self._run(batch_size, num_draft_tokens, seq_len=PROMPT_LEN + 20)
+        self.assertEqual(positions.shape[0], 3)
+        self.assertEqual(positions.shape[1], batch_size * num_draft_tokens)
+
+    def test_positions_are_the_text_only_ones_shifted_by_the_delta(self):
+        num_draft_tokens, seq_len = 4, PROMPT_LEN + 20
+        positions = self._run(1, num_draft_tokens, seq_len)
+
+        # Text-only extend covers [prefix_len, prefix_len + extend_seq_len);
+        # a multimodal request sits mrope_position_delta above that.
+        expected = torch.arange(seq_len, seq_len + num_draft_tokens) + MROPE_DELTA
+        for section in range(3):
+            self.assertTrue(torch.equal(positions[section], expected))
+
+    def test_single_token_extend_matches_the_decode_position(self):
+        seq_len = PROMPT_LEN + 20
+        extend = self._run(1, 1, seq_len)
+
+        forward_batch = ForwardBatch.__new__(ForwardBatch)
+        decode = forward_batch._expand_mrope_from_input(_mm_input(), seq_len + 1)
+
+        self.assertTrue(torch.equal(extend, decode))
+
+    def test_prompt_slice_still_wins_while_it_covers_the_extend(self):
+        # Prefill-shaped extend: the precomputed prompt positions are in range
+        # and must be used as-is rather than going through the fallback.
+        batch_size, extend_len, prefix_len = 2, 4, 8
+        forward_batch = ForwardBatch.__new__(ForwardBatch)
+        forward_batch.forward_mode = ForwardMode.EXTEND
+        forward_batch.seq_lens_cpu = torch.full(
+            (batch_size,), prefix_len + extend_len, dtype=torch.int64
+        )
+        batch = SimpleNamespace(
+            multimodal_inputs=[_mm_input() for _ in range(batch_size)],
+            extend_lens=[extend_len] * batch_size,
+            prefix_lens=[prefix_len] * batch_size,
+        )
+        forward_batch._compute_mrope_positions(SimpleNamespace(device="cpu"), batch)
+
+        expected = torch.arange(prefix_len, prefix_len + extend_len)
+        self.assertEqual(
+            forward_batch.mrope_positions.shape[1], batch_size * extend_len
+        )
+        self.assertTrue(
+            torch.equal(forward_batch.mrope_positions[0][:extend_len], expected)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #34152

## Motivation

A Qwen3-VL target served with an EAGLE3 draft crashes on the first draft-extend that carries more than a trivial batch. Single requests are served fine, so the server looks healthy until real traffic arrives.

`ForwardBatch._compute_mrope_positions` produces `batch_size` mRoPE positions for a draft-extend whose forward pass has `sum(extend_lens)` = `batch_size * num_draft_tokens` tokens, so the rotary embedding indexes past the end of the position tensor: the fused Triton mRoPE kernel reads out of bounds and raises a CUDA illegal memory access, and `forward_native` raises a shape mismatch.

The chain:

1. `mm_input.mrope_positions` only spans the original prompt.
2. On draft-extend, `prepare_for_extend_to_fill_draft_kvcache` sets `prefix_lens = seq_lens`, which has already moved past the prompt, so the prompt slice is empty and the fallback runs.
3. The fallback calls `_expand_mrope_from_input`, which is decode-shaped and returns a single position — but the extend needs `extend_seq_len` of them.

## Modifications

Widen the fallback in the multimodal extend branch of `_compute_mrope_positions` to `extend_seq_len` consecutive positions.

Text-only extend uses positions `[extend_prefix_len, extend_prefix_len + extend_seq_len)`. A multimodal request's positions are those shifted by `mrope_position_delta`, which is exactly what the decode branch applies as `(mrope_position_delta - 1) + seq_len`. So the extend positions are

```python
self._expand_mrope_from_input(mm_input, extend_prefix_len + 1)
    + torch.arange(extend_seq_len, dtype=torch.int64)
```

and `extend_seq_len == 1` reduces to the decode position.

The non-empty slice path is untouched, so ordinary (chunked) prefill is unaffected.

Added `test/registered/unit/spec/test_mrope_draft_extend_positions.py`, CPU-only and registered under `base-a-test-cpu`. Three cases fail on main and pass with the fix (position count, position values, single-token reduction to the decode position); a fourth covers the in-range prompt slice and passes either way, pinning the path this change must not disturb.

```bash
python3 -m unittest test.registered.unit.spec.test_mrope_draft_extend_positions -v
```

## Accuracy Tests

1x H100 80GB. The speculative server under test:

```bash
python3 -m sglang.launch_server \
    --model-path Qwen/Qwen3-VL-8B-Instruct \
    --speculative-algorithm EAGLE3 \
    --speculative-draft-model-path taobao-mnn/Qwen3-VL-8B-Instruct-Eagle3 \
    --speculative-num-steps 3 \
    --speculative-eagle-topk 1 \
    --speculative-num-draft-tokens 4 \
    --mem-fraction-static 0.85 \
    --port 40000
```

and the non-speculative reference it is compared against:

```bash
python3 -m sglang.launch_server \
    --model-path Qwen/Qwen3-VL-8B-Instruct \
    --mem-fraction-static 0.85 \
    --port 40001
```

Before this change, 12 concurrent image requests kill the server on the first draft-extend. After it, they complete.

To confirm the draft positions are numerically right and not merely correctly shaped, both servers were re-launched with `--enable-deterministic-inference` appended to the commands above, then sent identical greedy (`temperature=0`) image requests and compared byte for byte:

| setting | identical outputs |
|---|---|
| concurrency 1, 250 tokens | 8/8 |
| concurrency 12, 250 tokens | 12/12 |

`spec_accept_length` settles at 1.91-2.00, in line with the ~1.87-2.00 the draft checkpoint's model card reports.

(Without deterministic inference the outputs diverge occasionally, but so does the non-speculative baseline against itself when the batch size changes — 2/12 identical between concurrency 1 and concurrency 12 with no speculative decoding involved. That is ordinary bf16 batch-shape nondeterminism, which is why the comparison above pins it down with deterministic inference.)

## Speed Tests and Profiling

Both servers launched as above, warmed up, then measured with the standard harness:

```bash
python3 -m sglang.bench_serving \
    --backend sglang-oai-chat \
    --model Qwen/Qwen3-VL-8B-Instruct \
    --host 127.0.0.1 --port <40000|40001> \
    --dataset-name image --image-count 1 --image-resolution 360p \
    --num-prompts <8*C, min 32> --max-concurrency <C> \
    --random-input-len 64 --random-output-len 200 --seed 42
```

Both sides generate the same number of output tokens for a given concurrency, so the comparison is like for like.

| concurrency | EAGLE3 tok/s | baseline tok/s | throughput | EAGLE3 ITL | baseline ITL | ITL |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 163.63 | 143.48 | 1.14x | 5.84 ms | 6.69 ms | 1.15x |
| 4 | 552.58 | 490.86 | 1.13x | 6.32 ms | 7.62 ms | 1.21x |
| 16 | 1281.91 | 1197.31 | 1.07x | 10.57 ms | 12.29 ms | 1.16x |

Two caveats worth stating plainly:

- TTFT is slightly *worse* (60.4 vs 52.9 ms at concurrency 1, 165.8 vs 151.9 ms at concurrency 16): speculative decoding does not accelerate prefill, and the draft model adds its own. The win is entirely in the decode phase, which is what the ITL column isolates.
- End-to-end throughput gain therefore tracks how decode-heavy the workload is. This dataset averages ~92 output tokens per request against ~260 input tokens plus an image, so prefill dilutes the decode win considerably. A generation-heavy workload (200+ output tokens) shows a correspondingly larger end-to-end gain.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — no user-facing behaviour or option changes, so no documentation update.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33602423075](https://github.com/sgl-project/sglang/actions/runs/33602423075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33602422656](https://github.com/sgl-project/sglang/actions/runs/33602422656)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33602422816](https://github.com/sgl-project/sglang/actions/runs/33602422816)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->