### PR TITLE
docs: fix model test suite link

### DIFF
--- a/docs/docs/supported-models/support_new_models.mdx
+++ b/docs/docs/supported-models/support_new_models.mdx
@@ -67,7 +67,7 @@ should give the same text output and very similar prefill logits:
 ### Add the Model to the Test Suite
 
 To ensure the new model is well maintained, add it to the test suite by including it in the `ALL_OTHER_MODELS` list in
-the [test_generation_models.py](https://github.com/sgl-project/sglang/blob/main/test/registered/models/test_generation_models.py)
+the [test_generation_models.py](https://github.com/sgl-project/sglang/blob/main/test/registered/models_e2e/test_generation_models.py)
 file, test the new model on your local machine and report the results on demonstrative benchmarks (GSM8K, MMLU, MMMU,
 MMMU-Pro, etc.) in your PR. \\
 For VLMs, also include a test in `test_vision_openai_server_&#123;x&#125;.py` (e.g. [test_vision_openai_server_a.py](https://github.com/sgl-project/sglang/blob/main/test/registered/vlm/test_vision_openai_server_a.py)).


### PR DESCRIPTION
## Motivation

The documentation links to a model test suite path that no longer exists, so readers receive a 404 response.

Fixes #34118.

## Modifications

- Point the `test_generation_models.py` link to `test/registered/models_e2e/test_generation_models.py`.

## Accuracy Tests

Not applicable (documentation-only change).

## Speed Tests and Profiling

Not applicable (documentation-only change).

## Validation

- Old URL: HTTP 404
- Updated URL: HTTP 200
- `npx --yes mint@latest validate`: passed
- `git diff --check`: passed

## Checklist

- [x] The change is limited to the stale documentation link.
- [x] Documentation validation passes.
- [x] No runtime code or model output is affected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31298754509](https://github.com/sgl-project/sglang/actions/runs/31298754509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31298754394](https://github.com/sgl-project/sglang/actions/runs/31298754394)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->