### PR TITLE
Fix deterministic inference all-reduce for tp>1

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -906,6 +906,10 @@ class Envs:
     # Set to 1: force enable (even without --enable-deterministic-inference)
     # Set to 0: force disable (use default Aiter AR even with --enable-deterministic-inference)
     SGLANG_USE_1STAGE_ALLREDUCE = EnvBool(False)
+    # NCCL channel count pinned on CUDA so the all-reduce reduces a token the
+    # same way whatever else shares its batch. Raise it to buy back bandwidth
+    # on links that can drive more channels.
+    SGLANG_DETERMINISTIC_NCCL_NCHANNELS = EnvInt(8)
     SGLANG_OPT_USE_CUSTOM_ALL_REDUCE_V2 = EnvBool(True)
     # MiniMax-M3 on ROCm force-disables custom all-reduce in its model override
     # (arg_groups/overrides.py) when aiter all-reduce fusion is off. Set this to

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7972,8 +7972,14 @@ class ServerArgs:
                     # symmetric-memory path only below a byte threshold, so
                     # which reduce runs would follow the token count.
                     self.enable_torch_symm_mem = False
+                    # Each channel carries a differently shaped tree and the
+                    # channel count is picked from the message size, so a
+                    # token's reduction order would follow the token count.
+                    nchannels = str(envs.SGLANG_DETERMINISTIC_NCCL_NCHANNELS.get())
+                    os.environ["NCCL_MIN_NCHANNELS"] = nchannels
+                    os.environ["NCCL_MAX_NCHANNELS"] = nchannels
                     logger.warning(
-                        "NCCL_ALGO is set to 'allreduce:tree', and custom and symmetric-memory all reduce are disabled for deterministic inference when TP size > 1."
+                        "NCCL_ALGO is set to 'allreduce:tree', the NCCL channel count is pinned, and custom and symmetric-memory all reduce are disabled for deterministic inference when TP size > 1."
                     )
 
     def _handle_unified_memory_pool(self):


### PR DESCRIPTION
## Motivation

`--enable-deterministic-inference` pins the NCCL algorithm to `allreduce:tree` and disables custom / symmetric-memory all-reduce, which makes a reduction reproducible for a given message size. It does not make it invariant to the message size: NCCL picks the channel count from the message size and each channel carries a differently shaped tree, so the same element is reduced in a different order depending on how many tokens share the batch. Prefill and decode consequently disagree on a token's logprob even under deterministic inference.

Pinning the channel count closes that gap. On Inkling-Small-NVFP4 at tp=4 the prefill-vs-decode check goes from 0.151 to **bit-identical**, and all three `kl_test_utils` helpers -- including both cache-hit variants -- report 0 differing logprobs out of 16384.

This is necessary but not always sufficient. A model that still runs kernels outside the aten overrides in `batch_invariant_ops` keeps a nonzero divergence from those; Qwen3-Next at tp=4 goes 6.44e-4 -> 5.06e-4 rather than to zero. What this change removes is the all-reduce as a source.

`SGLANG_DETERMINISTIC_NCCL_NCHANNELS` (default 8) trades the pinned count back for bandwidth.

## Accuracy

`Inkling-Small-NVFP4`, tp=4, 32 prompts x 512 tokens, `--enable-deterministic-inference`:

```
avg_kl_div (input vs output logprobs)   before      after
match                                   0.151464    0.000000
```

Isolating the all-reduce (same config, 16 prompts x 256 tokens):

```
tp=1, deterministic                 0.000000   (no all-reduce)
tp=4, deterministic                 0.182534
tp=4, deterministic + this change   0.000000
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31299370634](https://github.com/sgl-project/sglang/actions/runs/31299370634)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31299421643](https://github.com/sgl-project/sglang/actions/runs/31299421643)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->