### PR TITLE
fix: preserve GQA head mapping in Triton DCP prefill

### DIFF
--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1527,38 +1527,24 @@ class TritonAttnBackend(AttentionBackend):
             dtype=torch.float32,
         )
 
-        # Current chunk K/V is still replicated within the DCP group before the
-        # masked cache write. For GQA with multiple local KV heads, select the
-        # subset belonging to this rank's global Q-head interval. Otherwise the
-        # kernel would restart GQA mapping at KV head zero on every rank.
+        # Select the replicated K/V heads matching this rank's Q shard.
         if k.numel() > 0:
-            current_k = k
-            current_v = v
             if layer.tp_k_head_num > 1:
-                group_q_heads = local_heads * group.world_size
-                assert group_q_heads % layer.tp_k_head_num == 0, (
-                    f"DCP Q heads ({group_q_heads}) must be divisible by local "
-                    f"KV heads ({layer.tp_k_head_num})"
+                kv_head_start = (
+                    group.rank_in_group * layer.tp_k_head_num // group.world_size
                 )
-                q_heads_per_kv = group_q_heads // layer.tp_k_head_num
-                q_head_start = group.rank_in_group * local_heads
-                kv_head_start = q_head_start // q_heads_per_kv
-                kv_head_end = (
-                    q_head_start + local_heads + q_heads_per_kv - 1
-                ) // q_heads_per_kv
-                current_k = k[:, kv_head_start:kv_head_end].contiguous()
-                current_v = v[:, kv_head_start:kv_head_end].contiguous()
-                current_kv_heads = kv_head_end - kv_head_start
-                assert local_heads % current_kv_heads == 0, (
-                    f"Local Q heads ({local_heads}) must be divisible by selected "
-                    f"KV heads ({current_kv_heads})"
+                kv_head_end = max(
+                    (group.rank_in_group + 1) * layer.tp_k_head_num // group.world_size,
+                    kv_head_start + 1,
                 )
+                k = k[:, kv_head_start:kv_head_end]
+                v = v[:, kv_head_start:kv_head_end]
 
             empty_kv_indptr = torch.zeros_like(kv_indptr)
             self.extend_attention_fwd(
                 q_local,
-                current_k.contiguous(),
-                current_v.contiguous(),
+                k.contiguous(),
+                v.contiguous(),
                 current_out,
                 k_buffer,
                 v_buffer,

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1527,14 +1527,38 @@ class TritonAttnBackend(AttentionBackend):
             dtype=torch.float32,
         )
 
-        # Current chunk K/V is still local before masked cache write, so it can
-        # use the original extend kernel's current-token stage directly.
+        # Current chunk K/V is still replicated within the DCP group before the
+        # masked cache write. For GQA with multiple local KV heads, select the
+        # subset belonging to this rank's global Q-head interval. Otherwise the
+        # kernel would restart GQA mapping at KV head zero on every rank.
         if k.numel() > 0:
+            current_k = k
+            current_v = v
+            if layer.tp_k_head_num > 1:
+                group_q_heads = local_heads * group.world_size
+                assert group_q_heads % layer.tp_k_head_num == 0, (
+                    f"DCP Q heads ({group_q_heads}) must be divisible by local "
+                    f"KV heads ({layer.tp_k_head_num})"
+                )
+                q_heads_per_kv = group_q_heads // layer.tp_k_head_num
+                q_head_start = group.rank_in_group * local_heads
+                kv_head_start = q_head_start // q_heads_per_kv
+                kv_head_end = (
+                    q_head_start + local_heads + q_heads_per_kv - 1
+                ) // q_heads_per_kv
+                current_k = k[:, kv_head_start:kv_head_end].contiguous()
+                current_v = v[:, kv_head_start:kv_head_end].contiguous()
+                current_kv_heads = kv_head_end - kv_head_start
+                assert local_heads % current_kv_heads == 0, (
+                    f"Local Q heads ({local_heads}) must be divisible by selected "
+                    f"KV heads ({current_kv_heads})"
+                )
+
             empty_kv_indptr = torch.zeros_like(kv_indptr)
             self.extend_attention_fwd(
                 q_local,
-                k.contiguous(),
-                v.contiguous(),
+                current_k.contiguous(),
+                current_v.contiguous(),
                 current_out,
                 k_buffer,
                 v_buffer,

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -21,6 +21,7 @@ import torch
 
 from sglang.srt import runtime_context as rc
 from sglang.srt.configs.model_config import ModelConfig
+from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 from sglang.srt.layers.dcp.layout import get_dcp_lens
 from sglang.srt.layers.linear import QKVParallelLinear
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
@@ -95,6 +96,77 @@ class TestGetDcpLens(CustomTestCase):
     def test_dcp_size_one_is_identity(self):
         lens = torch.tensor(LENS, dtype=torch.int32)
         self.assertTrue(torch.equal(get_dcp_lens(lens, 1, 0), lens))
+
+    def test_gqa_current_chunk_selects_kv_for_the_global_dcp_head_layout(self):
+        """A local Q shard must not restart GQA mapping at KV head zero."""
+
+        class FakeDcpGroup:
+            world_size = 4
+            rank_in_group = 1
+
+            def __init__(self):
+                self.all_gather_calls = 0
+
+            def all_gather(self, tensor, dim):
+                self.all_gather_calls += 1
+                return torch.cat((tensor, tensor + 10), dim=dim)
+
+        group = FakeDcpGroup()
+        backend = TritonAttnBackend.__new__(TritonAttnBackend)
+        backend.forward_metadata = SimpleNamespace(
+            custom_mask=None,
+            kv_indptr=torch.zeros(2, dtype=torch.int32),
+            kv_indices=torch.empty(0, dtype=torch.int64),
+            max_extend_len=1,
+            qo_indptr=torch.tensor([0, 1], dtype=torch.int64),
+        )
+        backend.token_to_kv_pool = SimpleNamespace(
+            get_key_buffer=lambda _layer_id: torch.empty(0),
+            get_value_buffer=lambda _layer_id: torch.empty(0),
+        )
+
+        kernel_q_shapes = []
+        kernel_k = []
+
+        def fake_extend_attention(q, k, _v, out, *_args, lse_extend, **_kwargs):
+            kernel_q_shapes.append(q.shape)
+            kernel_k.append(k.clone())
+            out.copy_(q.float())
+            lse_extend.zero_()
+
+        backend.extend_attention_fwd = fake_extend_attention
+        layer = SimpleNamespace(
+            sliding_window_size=-1,
+            tp_q_head_num=2,
+            tp_k_head_num=2,
+            qk_head_dim=2,
+            v_head_dim=2,
+            k_scale=None,
+            v_scale=None,
+            layer_id=0,
+            scaling=1.0,
+            xai_temperature_len=-1,
+        )
+        q = torch.arange(4, dtype=torch.bfloat16).view(1, 4)
+        k = torch.tensor([[[0.0, 1.0], [10.0, 11.0]]])
+
+        with rc.get_parallel().override(dcp_group=group):
+            out = backend._forward_extend_dcp(
+                q=q,
+                k=k,
+                v=k.clone(),
+                layer=layer,
+                forward_batch=SimpleNamespace(),
+                causal=True,
+                logits_soft_cap=0.0,
+                sinks=None,
+            )
+
+        self.assertEqual(group.all_gather_calls, 0)
+        self.assertEqual(kernel_q_shapes, [torch.Size([1, 2, 2])])
+        # In TP4/DCP4 with two KV heads, ranks 0 and 1 both belong to KV head 0.
+        self.assertTrue(torch.equal(kernel_k[0], k[:, 0:1]))
+        self.assertTrue(torch.equal(out, q))
 
     def test_paged_allocator_exposes_dcp_virtual_capacity(self):
         real_kv_size = 1024

--- a/test/registered/dcp/test_qwen3p5_triton_dcp.py
+++ b/test/registered/dcp/test_qwen3p5_triton_dcp.py
@@ -45,8 +45,6 @@ class TestQwen35TritonDCPGsm8k(CustomTestCase):
             str(DCP_SIZE),
             "--attention-backend",
             "triton",
-            "--watchdog-timeout",
-            "1200",
             "--context-length",
             "1048576",
             "--disable-radix-cache",

--- a/test/registered/dcp/test_qwen3p5_triton_dcp.py
+++ b/test/registered/dcp/test_qwen3p5_triton_dcp.py
@@ -45,6 +45,8 @@ class TestQwen35TritonDCPGsm8k(CustomTestCase):
             str(DCP_SIZE),
             "--attention-backend",
             "triton",
+            "--watchdog-timeout",
+            "1200",
             "--context-length",
             "1048576",
             "--disable-radix-cache",


### PR DESCRIPTION
## Motivation

After #32858, K/V heads are replicated within a DCP group while Q heads remain sharded. The Triton DCP current-chunk prefill path passed each local Q shard together with all replicated K/V heads to the generic extend kernel.

For Qwen3.5 TP4/DCP4, every rank has 8 local Q heads and 2 replicated KV heads. The kernel therefore inferred a local 4:1 GQA mapping on every rank, even though the correct global mapping is 32:2 (16:1): ranks 0-1 belong to KV head 0 and ranks 2-3 belong to KV head 1. This corrupted every fresh prompt's prefill and reduced GSM8K accuracy from the expected ~0.95 to 0.75-0.77.

This was exposed by #34133. The original [4xB200 run](https://github.com/sgl-project/sglang/actions/runs/31279352796) timed out during cold startup; a subsequent [rerun](https://github.com/sgl-project/sglang/actions/runs/31296982051) completed and exposed the accuracy regression.

## Modifications

- Select the contiguous replicated current-chunk K/V range corresponding to each DCP rank's Q shard before calling the Triton extend kernel.
- Keep Q sharded during prefill; no collective is added, and the existing prefix-attention path is unchanged.
- Add a CPU regression test for the TP4/DCP4 global GQA mapping.

## Accuracy Tests

Qwen3.5-397B-A17B-FP8, Triton attention, `--disable-radix-cache`:

| Configuration | GSM8K score |
| --- | ---: |
| Unpatched DCP4 CI full run | 0.772 (retry: 0.751) |
| Unpatched TP4/DCP4 on 4xB300, 256 examples | 0.773438 |
| Patched TP4/DCP4 on 4xB300, full 1,314 examples | **0.953577** |
| Patched normal TP4/DCP1 on 4xB300, full 1,314 examples | **0.949772** |

The registered DCP test threshold is 0.90. The normal TP4 result verifies that the fix does not regress the non-DCP path.

Additional validation:

- `python -m pytest -q test/registered/dcp/test_dcp_layout_unit.py`: 12 passed
- `pre-commit run --files ...`: passed
- `git diff --check`: passed

## Speed Tests and Profiling

| Configuration | Evaluation latency | Output throughput |
| --- | ---: | ---: |
| Patched TP4/DCP4 | 187.14 s | 1,133.58 tok/s |
| Patched normal TP4/DCP1 | 125.10 s | 1,704.64 tok/s |

Both rows use the full 1,314-example GSM8K evaluation. This change adds no communication; it narrows replicated K/V to the heads consumed by the local Q shard.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31306800909](https://github.com/sgl-project/sglang/actions/runs/31306800909)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31306800823](https://github.com/sgl-project/sglang/actions/runs/31306800823)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->