### PR TITLE
[diffusion] Add SageAttention3 packed varlen path for MiniMax-H3

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/sage_attn3.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/sage_attn3.py
@@ -17,6 +17,21 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 logger = init_logger(__name__)
 
 
+def _trailing_padding_used_len(
+    *,
+    total_tokens: int,
+    max_seqlen: int,
+    bounds: tuple[int, ...],
+) -> int | None:
+    """Return live token count for H3-style [0, used, total] trailing padding."""
+    if len(bounds) != 3:
+        return None
+    start, used, total = bounds
+    if start != 0 or used >= total or total != total_tokens or used != max_seqlen:
+        return None
+    return used
+
+
 class SageAttention3Backend(AttentionBackend):
     accept_output_buffer: bool = True
 
@@ -87,6 +102,73 @@ class SageAttention3Impl(AttentionImpl):
                 enable_gqa=True,
             )
         else:
-            output = sageattn3_blackwell(query, key, value, is_causal=self.causal)
+            # SageAttention3 centers K in place during preprocessing. Materialize
+            # the transposed view so the backend does not mutate its caller's K.
+            output = sageattn3_blackwell(
+                query, key.contiguous(), value, is_causal=self.causal
+            )
         output = output.transpose(1, 2)
+        return output
+
+    def forward_varlen(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        cu_seqlens: torch.Tensor,
+        max_seqlen: int,
+        cu_seqlens_host: tuple[int, ...] | None = None,
+    ) -> torch.Tensor:
+        bounds = (
+            cu_seqlens_host
+            if cu_seqlens_host is not None
+            else tuple(int(x) for x in cu_seqlens.tolist())
+        )
+        return self._sage_packed(
+            query,
+            key,
+            value,
+            bounds=bounds,
+            max_seqlen=max_seqlen,
+        )
+
+    def _sage_packed(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        bounds: tuple[int, ...],
+        max_seqlen: int,
+    ) -> torch.Tensor:
+        # MiniMax-H3 packs one live document as bounds=(0, used, total):
+        # [0, used) are real tokens; [used, total) is 64-aligned tail padding.
+        used = _trailing_padding_used_len(
+            total_tokens=query.shape[0],
+            max_seqlen=max_seqlen,
+            bounds=bounds,
+        )
+        if used is not None:
+            live_out = self.forward(
+                query[:used].unsqueeze(0),
+                key[:used].unsqueeze(0),
+                value[:used].unsqueeze(0),
+                None,
+            )[0]
+            output = torch.empty_like(query)
+            output[:used].copy_(live_out)
+            output[used:].zero_()
+            return output
+
+        output = torch.empty_like(query)
+        for start, stop in zip(bounds[:-1], bounds[1:]):
+            if start == stop:
+                continue
+            output[start:stop] = self.forward(
+                query[start:stop].unsqueeze(0),
+                key[start:stop].unsqueeze(0),
+                value[start:stop].unsqueeze(0),
+                None,
+            )[0]
         return output

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -43,7 +43,10 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
     AttentionRequirements,
 )
-from sglang.multimodal_gen.runtime.layers.attention.selector import get_attn_backend
+from sglang.multimodal_gen.runtime.layers.attention.selector import (
+    get_attn_backend,
+    get_component_forced_attn_backend,
+)
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
     MergedColumnParallelLinear,
@@ -1178,6 +1181,9 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             quant_config,
             prefix="final_layer",
         )
+        # Attention setup is deferred until the first forward for breakable
+        # graphs. Preserve a component-scoped override beyond model loading.
+        self._selected_attention_backend = get_component_forced_attn_backend()
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()
 
@@ -1187,6 +1193,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         backend = get_attn_backend(
             self.arch.attention_head_dim,
             _BF16_DTYPE,
+            selected_attention_backend=self._selected_attention_backend,
             attention_requirements=AttentionRequirements(packed_varlen=True),
         )
         for module in self.modules():

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
@@ -14,6 +14,9 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     maybe_init_distributed_environment_and_model_parallel,
     model_parallel_is_initialized,
 )
+from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
+    AttentionRequirements,
+)
 from sglang.multimodal_gen.runtime.layers.attention.backends.sdpa import SDPAImpl
 from sglang.multimodal_gen.runtime.layers.linear import UnquantizedLinearMethod
 from sglang.multimodal_gen.runtime.layers.quantization.fp8 import (
@@ -29,6 +32,7 @@ from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
     _copy_grouped_qkv_tp_shard,
     _reorder_grouped_qkv_to_qkv,
 )
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.test.single_test_file.component_accuracy.utils import (
     ensure_distributed_env_defaults,
 )
@@ -193,6 +197,45 @@ def test_online_fp8_keeps_fp32_boundaries_and_ignored_layers_unquantized():
         model.final_layer.audio_out,
     ):
         assert isinstance(layer.quant_method, UnquantizedLinearMethod)
+
+
+def test_deferred_attention_resolution_preserves_component_override():
+    _ensure_single_process_parallel_runtime()
+    target = (
+        "sglang.multimodal_gen.runtime.models.dits.minimax_h3."
+        "get_component_forced_attn_backend"
+    )
+    with (
+        patch(target, return_value=AttentionBackendEnum.SAGE_ATTN_3),
+        torch.device("meta"),
+    ):
+        model = MiniMaxH3DiTModel(
+            config=MiniMaxH3DiTConfig(),
+            hf_config={},
+            quant_config=None,
+        )
+
+    class FakeBackend:
+        @staticmethod
+        def get_enum():
+            return AttentionBackendEnum.SAGE_ATTN_3
+
+    resolver_target = (
+        "sglang.multimodal_gen.runtime.models.dits.minimax_h3.get_attn_backend"
+    )
+    with (
+        patch(resolver_target, return_value=FakeBackend) as get_attn_backend,
+        patch.object(model, "modules", return_value=[]),
+    ):
+        model._resolve_attention_backend_once()
+
+    get_attn_backend.assert_called_once_with(
+        model.arch.attention_head_dim,
+        torch.bfloat16,
+        selected_attention_backend=AttentionBackendEnum.SAGE_ATTN_3,
+        attention_requirements=AttentionRequirements(packed_varlen=True),
+    )
+    assert model._resolved_attention_backend is AttentionBackendEnum.SAGE_ATTN_3
 
 
 def test_sdpa_varlen_fallback_matches_naive_packed_reference():

--- a/python/sglang/multimodal_gen/test/unit/test_sage_attention3_packed.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sage_attention3_packed.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Packed-varlen contracts for the optional SageAttention3 backend."""
+
+import importlib
+import sys
+import types
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+
+@pytest.fixture
+def sage_attention3_module():
+    module_name = "sglang.multimodal_gen.runtime.layers.attention.backends.sage_attn3"
+    fake_sageattn3 = types.ModuleType("sageattn3")
+    fake_sageattn3.sageattn3_blackwell = Mock()
+    original_module = sys.modules.pop(module_name, None)
+    try:
+        with patch.dict(sys.modules, {"sageattn3": fake_sageattn3}):
+            yield importlib.import_module(module_name)
+    finally:
+        sys.modules.pop(module_name, None)
+        if original_module is not None:
+            sys.modules[module_name] = original_module
+
+
+def _attention_impl(module):
+    return module.SageAttention3Impl(
+        num_heads=2,
+        head_size=8,
+        causal=False,
+        softmax_scale=8**-0.5,
+    )
+
+
+def test_h3_packed_attention_skips_and_zeroes_trailing_padding(
+    sage_attention3_module,
+):
+    query = torch.randn(2, 8, 8).transpose(0, 1)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    attention = _attention_impl(sage_attention3_module)
+    attention.forward = Mock(return_value=torch.full((1, 5, 2, 8), 3.0))
+
+    output = attention._sage_packed(
+        query,
+        key,
+        value,
+        bounds=(0, 5, 8),
+        max_seqlen=5,
+    )
+
+    assert sage_attention3_module.SageAttention3Backend.supports_packed_varlen()
+    torch.testing.assert_close(output[:5], torch.full_like(output[:5], 3.0))
+    torch.testing.assert_close(output[5:], torch.zeros_like(output[5:]))
+    attention.forward.assert_called_once()
+    assert attention.forward.call_args.args[0].shape == (1, 5, 2, 8)
+
+
+def test_packed_attention_dispatches_each_nonempty_interval(
+    sage_attention3_module,
+):
+    query = torch.randn(6, 2, 8)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    attention = _attention_impl(sage_attention3_module)
+    attention.forward = Mock(side_effect=lambda q, *_args, **_kwargs: q + 1)
+
+    output = attention._sage_packed(
+        query,
+        key,
+        value,
+        bounds=(0, 2, 2, 6),
+        max_seqlen=4,
+    )
+
+    torch.testing.assert_close(output, query + 1)
+    assert attention.forward.call_count == 2
+    assert attention.forward.call_args_list[0].args[0].shape == (1, 2, 2, 8)
+    assert attention.forward.call_args_list[1].args[0].shape == (1, 4, 2, 8)
+
+
+def test_varlen_uses_host_boundaries_and_preserves_input_layout(
+    sage_attention3_module,
+):
+    class DeviceBoundaries:
+        def tolist(self):
+            raise AssertionError("host boundaries must avoid a device synchronization")
+
+    query = torch.randn(2, 6, 8).transpose(0, 1)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    attention = _attention_impl(sage_attention3_module)
+    expected = object()
+    attention._sage_packed = Mock(return_value=expected)
+
+    output = attention.forward_varlen(
+        query,
+        key,
+        value,
+        cu_seqlens=DeviceBoundaries(),
+        cu_seqlens_host=(0, 6),
+        max_seqlen=6,
+    )
+
+    assert output is expected
+    attention._sage_packed.assert_called_once()
+    call = attention._sage_packed.call_args
+    assert call.kwargs == {"bounds": (0, 6), "max_seqlen": 6}
+    assert call.args[0] is query
+    assert call.args[1] is key
+    assert call.args[2] is value
+    assert not query.is_contiguous()
+
+
+def test_attention_does_not_expose_sage_attention3_key_mutation(
+    sage_attention3_module,
+):
+    query = torch.randn(1, 6, 2, 8)
+    key = torch.randn_like(query)
+    value = torch.randn_like(query)
+    original_key = key.clone()
+    attention = _attention_impl(sage_attention3_module)
+
+    def mutate_key(q, k, _v, **_kwargs):
+        k.zero_()
+        return torch.ones_like(q)
+
+    sage_attention3_module.sageattn3_blackwell.side_effect = mutate_key
+    output = attention.forward(query, key, value, None)
+
+    torch.testing.assert_close(key, original_key)
+    torch.testing.assert_close(output, torch.ones_like(output))


### PR DESCRIPTION
## Motivation

SGLang already exposes the SageAttention3 backend for dense diffusion
attention, but MiniMax-H3 always executes packed Q/K/V through
`forward_varlen`. Because the SageAttention3 implementation did not provide
that interface, H3 rejected the backend through its packed-varlen capability
check.

This PR extends the packed dense-dispatch approach introduced for
SageAttention2 in #33703 to SageAttention3. SageAttention3 remains an explicit
opt-in approximate backend; this PR does not change the default backend or add
a device-specific dispatch.

## Modifications

- Implement `SageAttention3Impl.forward_varlen`:
  - use one dense call for H3's `[0, used, total]` trailing-padding layout;
  - skip and zero the inactive tail;
  - use a segmented dense fallback for general packed boundaries;
  - consume host boundaries when available to avoid a device synchronization.
- Materialize K before entering the current upstream SageAttention3 API,
  because its preprocessing centers K in place. Q and V retain their input
  layout until SageAttention3 performs its required preprocessing.
- Preserve the transformer component's requested backend across MiniMax-H3's
  deferred attention-backend initialization.
- Add unit coverage for the fast path, general segmented path, host-boundary
  path, non-contiguous inputs, caller K non-mutation, and deferred component
  backend selection.

## Accuracy Tests

Validated on MiniMax-H3 with 8 x NVIDIA SM120 GPUs, TP2 x Ulysses4, Ring1,
FSDP disabled, and all offloading disabled. The 50-step comparison used the
same 1344x768 T2VA request, 124 frames, prompt, scheduler settings, and seed
1101 for both backends.

| Metric | Torch SDPA baseline | SageAttention3 |
|---|---:|---:|
| Output | valid H.264/AAC | valid H.264/AAC |
| SSIM | reference | 0.748738 |
| PSNR | reference | 20.145413 dB |

Both videos were temporally and semantically coherent, but their composition
differed visibly. This is expected from SageAttention3's FP4 approximate
attention and is why it remains opt-in.

The final SGLang copy-elision changes were also checked against the original
safe SageAttention3 wrapper path on an 8-step request. Their generated videos
were byte-identical (SHA-256
`61e1660b643d32fea5bce493d53b53984783c5dc59c5711a2e57562d37fadb54`).

## Speed Tests and Profiling

The same 8-GPU configuration was profiled on a stable denoise step. The
baseline was the `TORCH_SDPA` backend; its timeline used
`pytorch_flash::flash_fwd_kernel`.

| Scope | Torch SDPA | SageAttention3 | Change |
|---|---:|---:|---:|
| Attention backend / block | 22.508 ms | 14.079 ms | 1.599x |
| Full attention module / block | 44.262 ms | 35.691 ms | 1.240x |
| Denoise-step GPU span | 2950.729 ms | 2521.694 ms | 1.170x |

In a separate unprofiled 50-step run, the denoise stage decreased from
142.271 s to 123.192 s (1.155x). Peak memory increased from 56,856 MB to
57,624 MB (+768 MB).

Only SM120 performance was measured. The implementation itself does not
contain an SM120-specific gate and relies on SageAttention3's existing
Blackwell backend support.

## Test Plan

```bash
python -m pytest -q \
  python/sglang/multimodal_gen/test/unit/test_sage_attention3_packed.py \
  python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py \
  python/sglang/multimodal_gen/test/unit/test_minimax_h3_admission.py \
  python/sglang/multimodal_gen/test/unit/test_server_args.py
```

Result: `159 passed, 20 subtests passed`.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide accuracy and speed results.
- [x] Follow the SGLang code style guidance.
- [x] Documentation is unchanged because the SageAttention3 backend and its
      installation/selection path already exist; this PR adds the missing
      packed-varlen capability.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31303549726](https://github.com/sgl-project/sglang/actions/runs/31303549726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31303549661](https://github.com/sgl-project/sglang/actions/runs/31303549661)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->