### PR TITLE
[MoE] Write CuTeDSL output directly into FlashInfer A2A workspace

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutedsl.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Optional
 
 import torch
-
 from sglang.srt.layers.moe.moe_runner.base import (
     MoeQuantInfo,
     MoeRunnerConfig,
@@ -32,6 +32,17 @@ logger = logging.getLogger(__name__)
 
 _FP4_SF_VEC_SIZE = 16
 _cutedsl_logged_scalarize: set = set()
+_wrapper_run_supports_moe_output: Optional[bool] = None
+
+
+def _supports_caller_owned_output(wrapper: Any) -> bool:
+    """Whether this FlashInfer wrapper accepts a caller-owned output tensor."""
+    global _wrapper_run_supports_moe_output
+    if _wrapper_run_supports_moe_output is None:
+        _wrapper_run_supports_moe_output = (
+            "moe_output" in inspect.signature(wrapper.run).parameters
+        )
+    return _wrapper_run_supports_moe_output
 
 
 # ---------------------------------------------------------------------------
@@ -456,24 +467,32 @@ def fused_experts_flashinfer_to_flashinfer_cutedsl_fp4(
             is_sf_swizzled_layout=False,
         )
 
-    output = quant_info.wrapper.run(
-        x=x_fp4,
-        x_sf=x_sf,
-        token_selected_experts=topk_ids,
-        token_final_scales=topk_weights,
-        w1_weight=quant_info.w13_weight,
-        w1_weight_sf=quant_info.w13_weight_sf,
-        w1_alpha=quant_info.w1_alpha,
-        fc2_input_scale=quant_info.a2_scale,
-        w2_weight=quant_info.w2_weight,
-        w2_weight_sf=quant_info.w2_weight_sf,
-        w2_alpha=quant_info.w2_alpha,
-    )
+    run_kwargs = {
+        "x": x_fp4,
+        "x_sf": x_sf,
+        "token_selected_experts": topk_ids,
+        "token_final_scales": topk_weights,
+        "w1_weight": quant_info.w13_weight,
+        "w1_weight_sf": quant_info.w13_weight_sf,
+        "w1_alpha": quant_info.w1_alpha,
+        "fc2_input_scale": quant_info.a2_scale,
+        "w2_weight": quant_info.w2_weight,
+        "w2_weight_sf": quant_info.w2_weight_sf,
+        "w2_alpha": quant_info.w2_alpha,
+    }
+    if dispatch_output.moe_output is not None and _supports_caller_owned_output(
+        quant_info.wrapper
+    ):
+        run_kwargs["moe_output"] = dispatch_output.moe_output
+    output = quant_info.wrapper.run(**run_kwargs)
 
     # Note: output contains routed expert results; shared_expert is handled separately
 
     # Write into pre-allocated workspace buffer if available
-    if dispatch_output.moe_output is not None:
+    if (
+        dispatch_output.moe_output is not None
+        and output.data_ptr() != dispatch_output.moe_output.data_ptr()
+    ):
         dispatch_output.moe_output.copy_(output)
         output = dispatch_output.moe_output
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -4,7 +4,6 @@ import logging
 from typing import NamedTuple, Optional
 
 import torch
-
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
@@ -35,7 +34,6 @@ try:
     from flashinfer.comm import MoeAlltoAll, moe_a2a_get_workspace_size_per_rank
     from flashinfer.comm.mapping import Mapping
     from flashinfer.comm.mnnvl import MnnvlConfig
-
     from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
 
     use_flashinfer = True
@@ -107,8 +105,11 @@ class FlashinferDispatcher(BaseDispatcher):
             if get_moe_runner_backend().is_flashinfer_trtllm_routed()
             else self.num_experts
         )
-        # TODO: Can other moe runners use payload_in_workspace too?
-        self.payload_in_workspace = get_moe_runner_backend().is_flashinfer_cutlass()
+        moe_runner_backend = get_moe_runner_backend()
+        self.payload_in_workspace = (
+            moe_runner_backend.is_flashinfer_cutlass()
+            or moe_runner_backend.is_flashinfer_cutedsl()
+        )
 
         # FlashInfer sizes the workspace from the maximum dispatched tokens per
         # EP rank. See FlashInfer's moe_a2a_get_workspace_size_per_rank(),

--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -4,6 +4,7 @@ import logging
 from typing import NamedTuple, Optional
 
 import torch
+
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
@@ -34,6 +35,7 @@ try:
     from flashinfer.comm import MoeAlltoAll, moe_a2a_get_workspace_size_per_rank
     from flashinfer.comm.mapping import Mapping
     from flashinfer.comm.mnnvl import MnnvlConfig
+
     from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
 
     use_flashinfer = True

--- a/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
+++ b/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import torch
+from sglang.srt.layers.moe.moe_runner import flashinfer_cutedsl as cutedsl
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl import (
+    CuteDslFp4MoeQuantInfo,
+    fused_experts_flashinfer_to_flashinfer_cutedsl_fp4,
+)
+from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
+    FlashinferDispatchOutput,
+)
+from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+
+class _DirectWrapper:
+    def __init__(self):
+        self.output = None
+
+    def run(self, *, x, moe_output=None, **kwargs):
+        assert moe_output is not None
+        self.output = moe_output
+        return moe_output.fill_(3)
+
+
+class _LegacyWrapper:
+    def run(self, *, x, **kwargs):
+        return torch.full((x.shape[0], 8), 5, dtype=torch.bfloat16)
+
+
+def _run(wrapper):
+    rows, hidden = 4, 8
+    workspace = torch.empty(rows, hidden, dtype=torch.bfloat16)
+    topk = StandardTopKOutput(
+        torch.ones(rows, 2), torch.zeros(rows, 2, dtype=torch.int32), torch.empty(0)
+    )
+    dispatch = FlashinferDispatchOutput(
+        torch.empty(rows, hidden // 2, dtype=torch.uint8),
+        torch.ones(rows, 1),
+        topk,
+        workspace,
+    )
+    dummy = torch.empty(0)
+    quant_info = CuteDslFp4MoeQuantInfo(
+        w13_weight=dummy,
+        w2_weight=dummy,
+        w13_weight_sf=dummy,
+        w2_weight_sf=dummy,
+        w1_alpha=dummy,
+        w2_alpha=dummy,
+        a1_scale=dummy,
+        a2_scale=dummy,
+        wrapper=wrapper,
+    )
+    cutedsl._wrapper_run_supports_moe_output = None
+    result = fused_experts_flashinfer_to_flashinfer_cutedsl_fp4(
+        dispatch, quant_info, MoeRunnerConfig(activation="silu")
+    )
+    return result.hidden_states, workspace
+
+
+def test_direct_output_uses_combine_workspace_without_copy():
+    wrapper = _DirectWrapper()
+    output, workspace = _run(wrapper)
+    assert wrapper.output is workspace
+    assert output.data_ptr() == workspace.data_ptr()
+    torch.testing.assert_close(output, torch.full_like(output, 3))
+
+
+def test_legacy_wrapper_falls_back_to_workspace_copy():
+    output, workspace = _run(_LegacyWrapper())
+    assert output.data_ptr() == workspace.data_ptr()
+    torch.testing.assert_close(output, torch.full_like(output, 5))

--- a/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
+++ b/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import torch
+
 from sglang.srt.layers.moe.moe_runner import flashinfer_cutedsl as cutedsl
 from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
 from sglang.srt.layers.moe.moe_runner.flashinfer_cutedsl import (
@@ -11,6 +12,10 @@ from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
     FlashinferDispatchOutput,
 )
 from sglang.srt.layers.moe.topk import StandardTopKOutput
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=5, suite="base-b-test-cpu")
 
 
 class _DirectWrapper:

--- a/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
+++ b/test/registered/moe/test_flashinfer_cutedsl_caller_output.py
@@ -14,7 +14,6 @@ from sglang.srt.layers.moe.token_dispatcher.flashinfer import (
 from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.test.ci.ci_register import register_cpu_ci
 
-
 register_cpu_ci(est_time=5, suite="base-b-test-cpu")
 
 


### PR DESCRIPTION
## What changed

Let the FlashInfer A2A + `flashinfer_cutedsl` path use the A2A combine payload
as the CuTeDSL MoE final output:

```text
before: CuTeDSL output -> device copy -> A2A combine workspace -> combine
after:  CuTeDSL output ----------------> A2A combine workspace -> combine
```

The integration detects the installed FlashInfer wrapper capability once per
process. With a wrapper that exposes caller-owned output, it writes directly
and skips the copy. Older FlashInfer packages retain the existing workspace
copy fallback.

## Dependency

- FlashInfer API draft: https://github.com/flashinfer-ai/flashinfer/pull/4425

The SGLang path is backward compatible before that API lands, but direct output
activates only with a FlashInfer build containing it.

## Why

The FlashInfer dispatcher already owns stable combine-workspace storage. A
separate CuTeDSL output tensor adds an avoidable allocation, HBM
materialization, and device-to-device copy on every routed MoE layer.

This follows the producer-direct / final-layout direction used by Kimi-K3 work
in #32541 and the broader tracking in #32607, while remaining generic to any
model using FlashInfer A2A with the CuTeDSL FP4 runner.

## Validation

- Direct-capability and legacy-copy fallback unit tests: 2 passed.
- FlashInfer caller-owned output correctness on one GB200: passed.
- FlashInfer CUDA graph capture and replay with stable output: passed.
- Three repeated operator runs at H=7168 showed 37-44 us saved, about 9-11%,
  for 1-256 tokens.

No model-level or serving E2E was run for this draft. The reported measurements
are limited to the CuTeDSL output boundary.

AI assistance was used for implementation, testing, benchmarking, and PR
preparation. The submitting human should understand and be able to defend the
change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31305897250](https://github.com/sgl-project/sglang/actions/runs/31305897250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31305897118](https://github.com/sgl-project/sglang/actions/runs/31305897118)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->