### PR TITLE
[Kimi-K3] Fuse pending AttnRes add into direct all-gather

### DIFF
--- a/python/sglang/kernels/jit/csrc/kimi_k3/attn_res/fused_tma.cuh
+++ b/python/sglang/kernels/jit/csrc/kimi_k3/attn_res/fused_tma.cuh
@@ -305,11 +305,13 @@ SGL_DEVICE void KimiK3AttnResTrait<kDim_, kNumBankRows_, kChunkRows_, kConsumerR
 #pragma unroll
           for (uint32_t r = 0; r < an; ++r) {
             const auto row = base_row + r;
-            const auto src = row == kNumRows ? params.prefix_sum + token * kDim  //
+            const auto* prefix = params.prefix_out == nullptr ? params.prefix_sum : params.prefix_out;
+            const auto src = row == kNumRows ? prefix + token * kDim  //
                                              : params.bank + token * params.stride_bm + row * kDim;
-            // Only prefix_sum is written by the immediately-preceding kernel;
-            // one wait before the first token's prefix load covers the rest.
-            if (token == blockIdx.x && row == kNumRows) PDLWaitPrimary<true>();
+            // The pending-add prelude performs the PDL wait when prefix_out is
+            // present. Otherwise one wait before the first prefix load covers
+            // the immediately preceding producer kernel.
+            if (token == blockIdx.x && row == kNumRows && params.prefix_out == nullptr) PDLWaitPrimary<true>();
             ptx::cp_async_bulk_1d_load(&smem->buf[slot][r], src, kRowBytes, &smem->bar_full[slot]);
           }
         }
@@ -664,6 +666,35 @@ __global__ void __launch_bounds__(Trait::kNumThreads, kOccupancy)
   }
   __syncthreads();
 
+  // Materialize the pending local add into caller-owned storage before the
+  // TMA producer consumes the prefix. The output may alias prefix_sum because
+  // every vector is loaded completely before its unique destination store.
+  if (params.residual != nullptr) {
+    if (threadIdx.x == 0) device::PDLWaitPrimary<true>();
+    __syncthreads();
+    using add_vec_t = device::AlignedVector<bf16x2_t, 4>;
+    using SumOp = device::ReductionTrait<device::ReductionOp::SUM, bf16x2_t>;
+    constexpr uint32_t kRowVecs = Trait::kDim * sizeof(bf16_t) / sizeof(add_vec_t);
+    for (auto token = blockIdx.x; token < params.num_tokens; token += gridDim.x) {
+      const auto* input = params.prefix_sum + static_cast<int64_t>(token) * Trait::kDim;
+      const auto* residual = params.residual + static_cast<int64_t>(token) * Trait::kDim;
+      auto* prefix = params.prefix_out + static_cast<int64_t>(token) * Trait::kDim;
+      for (uint32_t vid = threadIdx.x; vid < kRowVecs; vid += blockDim.x) {
+        add_vec_t vec;
+        add_vec_t res;
+        vec.load(input, vid);
+        res.load(residual, vid);
+#pragma unroll
+        for (uint32_t j = 0; j < 4; ++j) {
+          vec[j] = SumOp::reduce(vec[j], res[j]);
+        }
+        vec.store(prefix, vid);
+      }
+    }
+    __threadfence();
+    __syncthreads();
+  }
+
   extern __shared__ char smem_raw[];
   Trait::forward(params, reinterpret_cast<typename Trait::Smem*>(smem_raw));
 
@@ -865,6 +896,8 @@ struct AttnResFusedTmaKernel {
   static void run_direct_ag(
       CommunicatorRef ref,
       const tvm::ffi::TensorView prefix_sum,
+      std::optional<tvm::ffi::TensorView> residual,
+      const tvm::ffi::TensorView prefix_out,
       const tvm::ffi::TensorView bank,
       const tvm::ffi::TensorView cw,
       const tvm::ffi::TensorView ow,
@@ -885,6 +918,10 @@ struct AttnResFusedTmaKernel {
     device.set_options<kDLCUDA>();
 
     TensorMatcher({T_, H_}).with_dtype<bf16_t>().with_device(device).verify(prefix_sum);
+    TensorMatcher({T_, H_}).with_dtype<bf16_t>().with_device(device).verify(prefix_out);
+    if (residual.has_value()) {
+      TensorMatcher({T_, H_}).with_dtype<bf16_t>().with_device(device).verify(residual.value());
+    }
     TensorMatcher({T_, NB_, H_}).with_dtype<bf16_t>().with_device(device).verify(bank);
     TensorMatcher({H_}).with_dtype<bf16_t>().with_device(device).verify(cw).verify(ow);
     TensorMatcher({GT_, H_}).with_dtype<bf16_t>().with_device(device).verify(out);
@@ -924,8 +961,8 @@ struct AttnResFusedTmaKernel {
         .out = static_cast<bf16_t*>(out.data_ptr()),
         .prefix_dst = write_prefix ? static_cast<bf16_t*>(bank.data_ptr()) + nvb * H : nullptr,
         .input_mc = nullptr,
-        .residual = nullptr,
-        .prefix_out = nullptr,
+        .residual = residual.has_value() ? static_cast<const bf16_t*>(residual.value().data_ptr()) : nullptr,
+        .prefix_out = residual.has_value() ? static_cast<bf16_t*>(prefix_out.data_ptr()) : nullptr,
         .sem_local = data.pull_semaphores[data.rank],
         .sem_mc = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(sem_mc_ptr)),
         .output_mc = reinterpret_cast<uint8_t*>(static_cast<uintptr_t>(output_mc_ptr)),

--- a/python/sglang/kernels/ops/kimi_k3/attn_res.py
+++ b/python/sglang/kernels/ops/kimi_k3/attn_res.py
@@ -190,10 +190,12 @@ def attn_res_fused_tma(
     )
 
 
-@register_custom_op(mutates_args=["bank", "out"])
+@register_custom_op(mutates_args=["bank", "out", "prefix_out"])
 def _attn_res_fused_direct_ag_op(
     world_size: int,
     prefix_sum: torch.Tensor,
+    residual: torch.Tensor | None,
+    prefix_out: torch.Tensor,
     bank: torch.Tensor,
     cw: torch.Tensor,
     ow: torch.Tensor,
@@ -210,6 +212,8 @@ def _attn_res_fused_direct_ag_op(
     _jit_fused_tma_module(chunk_rows, occupancy, consumer_regs).run_direct_ag(
         _COMM_MAP[world_size],
         prefix_sum,
+        residual,
+        prefix_out,
         bank,
         cw,
         ow,
@@ -236,6 +240,8 @@ def attn_res_fused_direct_ag(
     output_mc_ptr: int,
     max_blocks: int = 128,
     write_prefix: bool = False,
+    residual: torch.Tensor | None = None,
+    prefix_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Fuse local attention-residual aggregation with direct multicast AG.
 
@@ -243,9 +249,14 @@ def attn_res_fused_direct_ag(
     aggregates its local token shard and multicast-stores normalized vectors
     directly from consumer registers into that rank's slice on every peer.
     """
+    if residual is not None and prefix_out is None:
+        raise ValueError("attn_res_fused_direct_ag requires prefix_out with residual")
+    materialized_prefix = prefix_sum if prefix_out is None else prefix_out
     _attn_res_fused_direct_ag_op(
         world_size,
         prefix_sum,
+        residual,
+        materialized_prefix,
         bank,
         cw,
         ow,

--- a/python/sglang/srt/layers/attn_residual.py
+++ b/python/sglang/srt/layers/attn_residual.py
@@ -21,6 +21,7 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
+
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.utils import is_hip

--- a/python/sglang/srt/layers/attn_residual.py
+++ b/python/sglang/srt/layers/attn_residual.py
@@ -21,7 +21,6 @@ from typing import Optional
 import torch
 import triton
 import triton.language as tl
-
 from sglang.srt.layers.layernorm import RMSNorm
 from sglang.srt.layers.linear import ReplicatedLinear
 from sglang.srt.utils import is_hip
@@ -533,7 +532,10 @@ class AttnResidual:
             return None
         if prefix_sum is not None and prefix_sum.shape != hidden_states.shape:
             prefix_sum = prefix_sum[rows]
-        prefix = hidden_states if prefix_sum is None else prefix_sum.add(hidden_states)
+        # hidden_states is dead after this aggregation. Reuse it as the
+        # materialized prefix so the direct-AG kernel can fold the pending add
+        # without allocating or launching a standalone torch add.
+        prefix = hidden_states
         bank = self.block_residual[rows]
         cw = get_cw(score_proj, score_norm, dtype=torch.bfloat16)
         assert score_norm.variance_epsilon == out_norm.variance_epsilon
@@ -547,6 +549,8 @@ class AttnResidual:
             nvb,
             score_norm.variance_epsilon,
             write_prefix=write,
+            residual=prefix_sum,
+            prefix_out=prefix,
         )
         if normed is None:
             return None

--- a/python/sglang/srt/layers/k3_sp_collective.py
+++ b/python/sglang/srt/layers/k3_sp_collective.py
@@ -14,7 +14,6 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Optional
 
 import torch
-
 from sglang.srt.environ import envs
 from sglang.srt.layers import k3_ar_fusion
 
@@ -419,6 +418,8 @@ def attn_res_all_gather(
     eps: float,
     *,
     write_prefix: bool = False,
+    residual: Optional[torch.Tensor] = None,
+    prefix_out: Optional[torch.Tensor] = None,
 ) -> Optional[torch.Tensor]:
     """Fused local attention-residual aggregation + direct multicast AG."""
     state = _init_state()
@@ -436,6 +437,10 @@ def attn_res_all_gather(
         or not bank.is_contiguous()
         or cw.shape != (_HIDDEN_SIZE,)
         or ow.shape != (_HIDDEN_SIZE,)
+        or (residual is not None and residual.shape != prefix.shape)
+        or (residual is not None and not residual.is_contiguous())
+        or (prefix_out is not None and prefix_out.shape != prefix.shape)
+        or (prefix_out is not None and not prefix_out.is_contiguous())
     ):
         return None
     from sglang.kernels.ops.kimi_k3 import attn_res, sp_collective
@@ -465,5 +470,7 @@ def attn_res_all_gather(
         output_mc_ptr=k3_ar_fusion.get_mc_ptr(output),
         max_blocks=dispatch.max_blocks,
         write_prefix=write_prefix,
+        residual=residual,
+        prefix_out=prefix_out,
     )
     return output

--- a/python/sglang/srt/layers/k3_sp_collective.py
+++ b/python/sglang/srt/layers/k3_sp_collective.py
@@ -14,6 +14,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Optional
 
 import torch
+
 from sglang.srt.environ import envs
 from sglang.srt.layers import k3_ar_fusion
 

--- a/test/registered/kernels/ops/kimi_k3/test_collectives.py
+++ b/test/registered/kernels/ops/kimi_k3/test_collectives.py
@@ -4,10 +4,9 @@ import atexit
 import os
 
 import pytest
+import sglang.srt.distributed.parallel_state as ps
 import torch
 import torch.distributed as dist
-
-import sglang.srt.distributed.parallel_state as ps
 from sglang.kernels.jit.utils import cache_once
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
 from sglang.kernels.ops.kimi_k3 import (
@@ -273,7 +272,8 @@ def test_gemm_all_reduce():
 
 
 @torch.inference_mode()
-def test_attention_residual_direct_all_gather():
+@pytest.mark.parametrize("with_residual", [False, True])
+def test_attention_residual_direct_all_gather(with_residual: bool):
     _require_sm100()
     comm = _init_comm()
     rank, local_tokens, num_bank_rows = dist.get_rank(), 2, 3
@@ -299,9 +299,11 @@ def test_attention_residual_direct_all_gather():
     output_weight = torch.linspace(
         1.25, 0.75, _HIDDEN_SIZE, device=_device(), dtype=torch.bfloat16
     )
+    residual = torch.randn_like(prefix, generator=generator) if with_residual else None
+    expected_prefix = prefix if residual is None else prefix.add(residual)
     local_reference = torch.empty_like(prefix)
     attn_res.attn_res_fused_tma(
-        prefix,
+        expected_prefix,
         bank.clone(),
         combine_weight,
         output_weight,
@@ -323,9 +325,10 @@ def test_attention_residual_direct_all_gather():
     )
 
     output, handle, multicast_ptr = _symmetric_tensor(tuple(full_reference.shape))
+    prefix_out = prefix.clone()
     attn_res.attn_res_fused_direct_ag(
         comm.world_size,
-        prefix,
+        prefix_out,
         bank,
         combine_weight,
         output_weight,
@@ -334,9 +337,44 @@ def test_attention_residual_direct_all_gather():
         1e-6,
         output_mc_ptr=multicast_ptr,
         max_blocks=4,
+        write_prefix=with_residual,
+        residual=residual,
+        prefix_out=prefix_out,
     )
     torch.cuda.synchronize()
     torch.testing.assert_close(output, full_reference, rtol=2e-2, atol=3e-2)
+    torch.testing.assert_close(prefix_out, expected_prefix, rtol=0, atol=0)
+    if with_residual:
+        torch.testing.assert_close(
+            bank[:, num_bank_rows], expected_prefix, rtol=0, atol=0
+        )
+        prefix_out.copy_(prefix)
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            attn_res.attn_res_fused_direct_ag(
+                comm.world_size,
+                prefix_out,
+                bank,
+                combine_weight,
+                output_weight,
+                output,
+                num_bank_rows,
+                1e-6,
+                output_mc_ptr=multicast_ptr,
+                max_blocks=4,
+                write_prefix=True,
+                residual=residual,
+                prefix_out=prefix_out,
+            )
+        for _ in range(2):
+            prefix_out.copy_(prefix)
+            graph.replay()
+            torch.cuda.synchronize()
+            torch.testing.assert_close(output, full_reference, rtol=2e-2, atol=3e-2)
+            torch.testing.assert_close(prefix_out, expected_prefix, rtol=0, atol=0)
+            torch.testing.assert_close(
+                bank[:, num_bank_rows], expected_prefix, rtol=0, atol=0
+            )
     assert handle is not None
 
 

--- a/test/registered/kernels/ops/kimi_k3/test_collectives.py
+++ b/test/registered/kernels/ops/kimi_k3/test_collectives.py
@@ -4,9 +4,10 @@ import atexit
 import os
 
 import pytest
-import sglang.srt.distributed.parallel_state as ps
 import torch
 import torch.distributed as dist
+
+import sglang.srt.distributed.parallel_state as ps
 from sglang.kernels.jit.utils import cache_once
 from sglang.kernels.ops.communication.mp import register_comm_cleanup
 from sglang.kernels.ops.kimi_k3 import (


### PR DESCRIPTION
## What changed

Fuse the pending local residual add into Kimi-K3's existing SM100 direct
attention-residual all-gather kernel.

```text
before:
  prefix_sum + hidden_states -> new BF16 prefix tensor
  prefix tensor -> AttnRes aggregation -> direct multicast all-gather

after:
  direct-AG kernel:
    prefix_sum + hidden_states -> dead hidden_states storage
    materialized prefix -> AttnRes aggregation -> direct multicast all-gather
```

The prefix remains materialized because the later o_proj reduction consumes
it. The optimization removes the standalone add launch and allocation by
reusing the dead local `hidden_states` buffer; it does not discard or alter the
residual chain.

## Why

The sharded attention-side path currently performs a standalone
`prefix_sum.add(hidden_states)` immediately before the fused AttnRes + direct
all-gather kernel. The direct kernel already synchronizes with its producer and
touches the full prefix row, so the pending add can be folded into that launch.

This is a follow-up to the Kimi-K3 implementation in #32541 and the optimization
tracking in #32607.

## Validation

Four GB200 GPUs, H=7168:

- Existing no-residual direct-AG path: passed.
- Pending-add prefix: bit-exact BF16 against PyTorch add.
- Fused `write_prefix` bank snapshot: bit-exact BF16.
- Direct all-gather output: within the existing kernel tolerance.
- CUDA graph capture and two replays: passed.

Three repeated operator runs, nvb=3, 200 timed iterations per cell:

| Local tokens | Baseline add + direct AG | Fused direct AG | Saving |
| ---: | ---: | ---: | ---: |
| 1 | 45.5-49.5 us | 30.1-33.2 us | 15.3-16.4 us (33.01-33.76%) |
| 4 | 44.4-46.4 us | 31.0-31.2 us | 13.3-15.3 us (30.06-32.87%) |
| 16 | 44.4-46.4 us | 30.0-32.1 us | 13.3-14.5 us (29.94-32.52%) |
| 64 | 44.4-46.3 us | 30.4-31.1 us | 13.4-15.2 us (30.09-32.78%) |

The standalone BF16 add measured about 13-14 us, matching the fused saving.
No model-level or serving E2E was run for this draft.

AI assistance was used for implementation, testing, benchmarking, and PR
preparation. The submitting human should understand and be able to defend the
kernel synchronization and aliasing behavior.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31305749037](https://github.com/sgl-project/sglang/actions/runs/31305749037)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31305748921](https://github.com/sgl-project/sglang/actions/runs/31305748921)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->