### PR TITLE
Add FastSafetensors sharded-state loader

### DIFF
--- a/docs/docs/advanced_features/model_loading.mdx
+++ b/docs/docs/advanced_features/model_loading.mdx
@@ -67,6 +67,10 @@ Set with `--load-format`:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Load safetensors using the <code>fastsafetensors</code> iterator.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>fastsafetensors_sharded</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Load a pre-sharded checkpoint with FastSafetensors. Each tensor-parallel worker reads only its rank-local files, avoiding cross-node weight distribution.</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>layered</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Load weights layer by layer, so a layer can be quantized before the next is loaded, lowering the peak memory envelope.</td>
     </tr>
@@ -150,6 +154,12 @@ python -m sglang.launch_server \
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>enable_gds</code> (bool)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Use GPU Direct Storage. Set to <code>false</code> when the host does not provide the NVIDIA GPUDirect Storage kernel driver, such as in a gVisor sandbox.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>true</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>fastsafetensors_sharded</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>pattern</code>, <code>nogds</code>, <code>bbuf_size_kb</code>, <code>max_threads</code>, <code>max_copy_block_size</code>, <code>debug_log</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Configure rank-local filenames and FastSafetensors transfers. Omit <code>nogds</code> to try GDS and fall back to NoGDS before copying any tensor.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Library defaults</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>bitsandbytes</code></td>

--- a/python/sglang/srt/configs/load_config.py
+++ b/python/sglang/srt/configs/load_config.py
@@ -33,6 +33,7 @@ class LoadFormat(str, enum.Enum):
     RDMA = "rdma"
     LOCAL_CACHED = "local_cached"
     FASTSAFETENSORS = "fastsafetensors"
+    FASTSAFETENSORS_SHARDED = "fastsafetensors_sharded"
     PRIVATE = "private"
     RUNAI_STREAMER = "runai_streamer"
     IPC_CACHE = "ipc_cache"

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1592,8 +1592,6 @@ class ShardedStateLoader(BaseModelLoader):
         model_config: ModelConfig,
         device_config: DeviceConfig,
     ) -> nn.Module:
-        from safetensors.torch import safe_open
-
         local_model_path = self._prepare_weights(
             model_config.model_path, model_config.revision
         )
@@ -1620,34 +1618,43 @@ class ShardedStateLoader(BaseModelLoader):
                     f"pre-sharded checkpoints are currently supported!"
                 )
             state_dict = self._filter_subtensors(model.state_dict())
-            for path in filepaths:
-                with safe_open(path, framework="pt") as f:
-                    for key in f.keys():  # noqa: SIM118
-                        tensor = f.get_tensor(key)
-                        # If loading with LoRA enabled, additional padding may
-                        # be added to certain parameters. We only load into a
-                        # narrowed view of the parameter data.
-                        param_data = state_dict[key].data
-                        param_shape = state_dict[key].shape
-                        for dim, size in enumerate(tensor.shape):
-                            if size < param_shape[dim]:
-                                param_data = param_data.narrow(dim, 0, size)
-                        if tensor.shape != param_shape:
-                            logger.warning(
-                                "loading tensor of shape %s into "
-                                "parameter '%s' of shape %s",
-                                tensor.shape,
-                                key,
-                                param_shape,
-                            )
-                        param_data.copy_(tensor)
-                        state_dict.pop(key)
+            for key, tensor in self.iterate_over_files(filepaths, device_config.device):
+                # If loading with LoRA enabled, additional padding may
+                # be added to certain parameters. We only load into a
+                # narrowed view of the parameter data.
+                param_data = state_dict[key].data
+                param_shape = state_dict[key].shape
+                for dim, size in enumerate(tensor.shape):
+                    if size < param_shape[dim]:
+                        param_data = param_data.narrow(dim, 0, size)
+                if tensor.shape != param_shape:
+                    logger.warning(
+                        "loading tensor of shape %s into parameter '%s' of shape %s",
+                        tensor.shape,
+                        key,
+                        param_shape,
+                    )
+                param_data.copy_(tensor)
+                state_dict.pop(key)
             if state_dict:
                 raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
 
             _post_load_weights(model)
 
         return model.eval()
+
+    def iterate_over_files(
+        self,
+        filepaths: List[str],
+        target_device: torch.device,
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        del target_device
+        from safetensors.torch import safe_open
+
+        for path in filepaths:
+            with safe_open(path, framework="pt") as file:
+                for key in file.keys():  # noqa: SIM118
+                    yield key, file.get_tensor(key)
 
     @staticmethod
     def save_model(
@@ -1684,6 +1691,134 @@ class ShardedStateLoader(BaseModelLoader):
                 state_dict_part,
                 os.path.join(path, filename),
             )
+
+
+class FastSafetensorsShardedStateLoader(ShardedStateLoader):
+    """Load rank-local sharded-state checkpoints with FastSafetensors."""
+
+    def __init__(self, load_config: LoadConfig):
+        BaseModelLoader.__init__(self, load_config)
+        extra_config = dict(load_config.model_loader_extra_config or {})
+
+        self.pattern = extra_config.pop("pattern", self.DEFAULT_PATTERN)
+        self.nogds = extra_config.pop("nogds", None)
+        self.bbuf_size_kb = self._positive_int(
+            extra_config.pop("bbuf_size_kb", 16 * 1024), "bbuf_size_kb"
+        )
+        self.max_threads = self._positive_int(
+            extra_config.pop("max_threads", 16), "max_threads"
+        )
+        self.max_copy_block_size = self._positive_int(
+            extra_config.pop("max_copy_block_size", 16 * 1024**3),
+            "max_copy_block_size",
+        )
+        self.debug_log = extra_config.pop("debug_log", False)
+
+        if self.nogds is not None and not isinstance(self.nogds, bool):
+            raise ValueError("nogds must be a boolean or null")
+        if not isinstance(self.debug_log, bool):
+            raise ValueError("debug_log must be a boolean")
+        if extra_config:
+            raise ValueError(
+                "Unexpected extra config keys for load format "
+                f"{load_config.load_format}: {tuple(extra_config)}"
+            )
+
+    @staticmethod
+    def _positive_int(value: Any, name: str) -> int:
+        if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+        return value
+
+    @staticmethod
+    def _is_gds_error(error: BaseException) -> bool:
+        message = str(error).lower()
+        return any(marker in message for marker in ("gds", "cufile", "libcufile"))
+
+    @staticmethod
+    def _resolve_target_device(target_device: torch.device) -> torch.device:
+        device = torch.device(target_device)
+        if device.type == "cuda" and device.index is None:
+            return torch.device("cuda", torch.cuda.current_device())
+        return device
+
+    def iterate_over_files(
+        self,
+        filepaths: List[str],
+        target_device: torch.device,
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        device = self._resolve_target_device(target_device)
+        if device.type != "cuda":
+            logger.warning(
+                "fastsafetensors_sharded is unavailable on %s; falling back "
+                "to the standard sharded-state reader",
+                device,
+            )
+            yield from super().iterate_over_files(filepaths, device)
+            return
+
+        try:
+            from fastsafetensors import SafeTensorsFileLoader, SingleGroup
+        except ImportError as exc:
+            raise ImportError(
+                "fastsafetensors is required for load format fastsafetensors_sharded"
+            ) from exc
+
+        all_paths = sorted(str(path) for path in filepaths)
+        use_nogds = self.nogds is True
+
+        while True:
+            loader = None
+            file_buffer = None
+            copy_started = False
+            copy_synchronized = False
+            try:
+                loader = SafeTensorsFileLoader(
+                    SingleGroup(),
+                    str(device),
+                    bbuf_size_kb=self.bbuf_size_kb,
+                    max_threads=self.max_threads,
+                    nogds=use_nogds,
+                    disable_cache=True,
+                    debug_log=self.debug_log,
+                )
+                loader.add_filenames({0: all_paths})
+                file_buffer = loader.copy_files_to_device(
+                    max_copy_block_size=self.max_copy_block_size
+                )
+
+                torch.cuda.synchronize(device)
+                for key in list(file_buffer.key_to_rank_lidx):
+                    tensor = file_buffer.get_tensor(key)
+                    copy_started = True
+                    yield key, tensor
+
+                torch.cuda.current_stream(device).synchronize()
+                copy_synchronized = True
+                return
+            except (RuntimeError, OSError) as exc:
+                can_fallback = (
+                    not copy_started
+                    and self.nogds is None
+                    and not use_nogds
+                    and self._is_gds_error(exc)
+                )
+                if not can_fallback:
+                    raise
+                logger.warning(
+                    "FastSafetensors GDS loading failed; retrying with nogds=True: %s",
+                    exc,
+                )
+                use_nogds = True
+                self.nogds = True
+            finally:
+                if copy_started and not copy_synchronized:
+                    with suppress(Exception):
+                        torch.cuda.current_stream(device).synchronize()
+                if file_buffer is not None:
+                    file_buffer.close()
+                if loader is not None:
+                    loader.close()
 
 
 class PreshardedModelLoader(DefaultModelLoader):
@@ -4177,6 +4312,9 @@ def get_model_loader(
 
     if load_config.load_format == LoadFormat.SHARDED_STATE:
         return ShardedStateLoader(load_config)
+
+    if load_config.load_format == LoadFormat.FASTSAFETENSORS_SHARDED:
+        return FastSafetensorsShardedStateLoader(load_config)
 
     if load_config.load_format == LoadFormat.PRESHARDED:
         return PreshardedModelLoader(load_config)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -123,6 +123,7 @@ LOAD_FORMAT_CHOICES = [
     "remote",
     "remote_instance",
     "fastsafetensors",
+    "fastsafetensors_sharded",
     "private",
     "runai_streamer",
 ]

--- a/test/registered/unit/model_loader/test_fastsafetensors_sharded_loader.py
+++ b/test/registered/unit/model_loader/test_fastsafetensors_sharded_loader.py
@@ -1,0 +1,127 @@
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.configs.load_config import LoadConfig, LoadFormat
+from sglang.srt.model_loader.loader import (
+    FastSafetensorsShardedStateLoader,
+    get_model_loader,
+)
+from sglang.srt.server_args import LOAD_FORMAT_CHOICES
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _fastsafetensors_module(loader_factory):
+    module = types.ModuleType("fastsafetensors")
+    module.SafeTensorsFileLoader = loader_factory
+    module.SingleGroup = MagicMock(return_value=object())
+    return module
+
+
+class TestFastSafetensorsShardedStateLoader(CustomTestCase):
+    def _make_loader(self, **extra_config):
+        return FastSafetensorsShardedStateLoader(
+            LoadConfig(
+                load_format=LoadFormat.FASTSAFETENSORS_SHARDED,
+                model_loader_extra_config=extra_config,
+            )
+        )
+
+    def test_load_format_routes_and_validates_config(self):
+        loader = self._make_loader(
+            pattern="rank-{rank}-{part}.safetensors",
+            nogds=True,
+            bbuf_size_kb=4096,
+            max_threads=4,
+            max_copy_block_size=1024,
+            debug_log=True,
+        )
+
+        self.assertIn("fastsafetensors_sharded", LOAD_FORMAT_CHOICES)
+        self.assertIsInstance(
+            get_model_loader(LoadConfig(load_format="fastsafetensors_sharded"), None),
+            FastSafetensorsShardedStateLoader,
+        )
+        self.assertEqual(loader.pattern, "rank-{rank}-{part}.safetensors")
+        self.assertTrue(loader.nogds)
+        self.assertEqual(loader.bbuf_size_kb, 4096)
+        self.assertEqual(loader.max_threads, 4)
+        self.assertEqual(loader.max_copy_block_size, 1024)
+        self.assertTrue(loader.debug_log)
+
+        with self.assertRaisesRegex(ValueError, "nogds must be a boolean or null"):
+            self._make_loader(nogds="true")
+
+    def test_loads_all_rank_files_together_and_closes_resources(self):
+        loader = self._make_loader(nogds=True)
+        file_buffer = MagicMock()
+        file_buffer.key_to_rank_lidx = {"weight": None}
+        file_buffer.get_tensor.return_value = torch.ones(1)
+        fast_loader = MagicMock()
+        fast_loader.copy_files_to_device.return_value = file_buffer
+        module = _fastsafetensors_module(MagicMock(return_value=fast_loader))
+        stream = MagicMock()
+
+        with (
+            patch.dict(sys.modules, {"fastsafetensors": module}),
+            patch("torch.cuda.synchronize") as synchronize,
+            patch("torch.cuda.current_stream", return_value=stream),
+        ):
+            tensors = list(
+                loader.iterate_over_files(["part-1", "part-0"], torch.device("cuda:0"))
+            )
+
+        self.assertEqual(tensors[0][0], "weight")
+        fast_loader.add_filenames.assert_called_once_with({0: ["part-0", "part-1"]})
+        fast_loader.copy_files_to_device.assert_called_once_with(
+            max_copy_block_size=loader.max_copy_block_size
+        )
+        synchronize.assert_called_once_with(torch.device("cuda:0"))
+        stream.synchronize.assert_called_once()
+        file_buffer.close.assert_called_once()
+        fast_loader.close.assert_called_once()
+
+    def test_retries_gds_failure_before_copy(self):
+        loader = self._make_loader()
+        file_buffer = MagicMock()
+        file_buffer.key_to_rank_lidx = {"weight": None}
+        file_buffer.get_tensor.return_value = torch.ones(1)
+        loaders = [MagicMock(), MagicMock()]
+        loaders[0].copy_files_to_device.side_effect = RuntimeError(
+            "cuFile GDS initialization failed"
+        )
+        loaders[1].copy_files_to_device.return_value = file_buffer
+        loader_factory = MagicMock(side_effect=loaders)
+        module = _fastsafetensors_module(loader_factory)
+
+        with (
+            patch.dict(sys.modules, {"fastsafetensors": module}),
+            patch("torch.cuda.synchronize"),
+            patch("torch.cuda.current_stream", return_value=MagicMock()),
+        ):
+            tensors = list(
+                loader.iterate_over_files(["part-0"], torch.device("cuda:0"))
+            )
+
+        self.assertEqual(tensors[0][0], "weight")
+        self.assertTrue(loader.nogds)
+        self.assertEqual(
+            [call.kwargs["nogds"] for call in loader_factory.call_args_list],
+            [False, True],
+        )
+        for fast_loader in loaders:
+            fast_loader.close.assert_called_once()
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

In multi-node tensor-parallel deployments, distributing or propagating model
weights across nodes can add substantial startup overhead. When a checkpoint is
already sharded into each rank's final layout, every worker should be able to
read only its own files instead of loading weights elsewhere and sending them
over the interconnect.

This PR adds a FastSafetensors-backed sharded-state loader so each TP worker
loads its rank-local files directly and transfers all of that rank's parts to
the GPU together. It supports GDS and can automatically retry with the buffered
NoGDS path when GDS initialization is unavailable.

## Modifications

- Add the `fastsafetensors_sharded` load format and server-argument routing.
- Reuse the existing sharded-state checkpoint naming and rank selection.
- Batch all rank-local files into one FastSafetensors device-copy operation.
- Expose `pattern`, `nogds`, `bbuf_size_kb`, `max_threads`,
  `max_copy_block_size`, and `debug_log` through
  `--model-loader-extra-config`.
- Fall back to the standard sharded-state reader on non-CUDA devices.
- Add documentation and CPU-registered unit coverage for routing, resource
  lifetime, batched file loading, validation, and GDS-to-NoGDS fallback.

## Accuracy

The focused tests verify that the same tensors are yielded to SGLang's existing
sharded-state copy path, all rank-local files are submitted together, CUDA work
is synchronized before FastSafetensors resources are closed, and fallback is
only attempted before any parameter copy starts.

## Speed

Performance benchmarking is still in progress and I will add the measurements
in a follow-up update. Maintainers or developers interested in this loading path
are very welcome to test it on their storage and multi-node setups as well.

The expected benefit is largest when rank-local checkpoint access avoids an
otherwise expensive cross-node weight distribution/propagation stage.

## Checks

- `3 passed` in WSL Ubuntu 24.04 for
  `test/registered/unit/model_loader/test_fastsafetensors_sharded_loader.py`.
  The local launcher stubbed only optional, unused benchmark/CUDA imports
  (`datasets`, `flashinfer`, `gguf`, and `sgl_kernel`) that are absent from this
  minimal environment.
- Ruff targeted checks: `F401`, `F821`, and `UP037`.
- Python syntax compilation for all changed Python files.
- Rebased cleanly onto current upstream `main` (`71043b9`).

## Checklist

- [x] The code is formatted and passes targeted static checks.
- [x] Tests cover the new behavior.
- [x] User-facing documentation is included.
- [ ] End-to-end GPU performance results will be added when benchmarking is complete.

This contribution was prepared with AI assistance and reviewed/tested in the
submitter's local workspace.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31309799153](https://github.com/sgl-project/sglang/actions/runs/31309799153)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31309799030](https://github.com/sgl-project/sglang/actions/runs/31309799030)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->