### PR TITLE
[diffusion] LTX-2 quality=high fused RMSNorm+modulate + FFN GELU epilogue (H200 ltx23-one-stage denoise 45.85->43.24 s, ~matches torch.compile)

### DIFF
--- a/python/sglang/kernels/ops/diffusion/ltx2_rmsnorm_modulate.py
+++ b/python/sglang/kernels/ops/diffusion/ltx2_rmsnorm_modulate.py
@@ -1,0 +1,80 @@
+"""Weightless RMSNorm + adaLN modulate folded into one kernel for LTX-2.
+
+``rms_norm(x) * (1 + scale) + shift`` at the LTX-2 transformer-block adaLN
+sites is otherwise an aten ``F.rms_norm`` plus a separate ``mul``/``add``
+modulate (one reduction kernel plus several pointwise passes per site). This
+folds the whole chain into a single ``fused_rmsnorm_scale_shift_bitexact``
+launch.
+
+The fused kernel reproduces the RMSNorm math via ``rsqrt.approx`` (the
+flashinfer CuTe form), which differs from aten's refined ``rsqrtf`` by at
+most one bf16 ULP on a small fraction of elements. It is therefore *not*
+bit-exact vs the eager reference, so the fold is opt-in per batch: model code
+marks its adaLN sites with :func:`mark_ltx2_rms_norm_modulate_site` (default
+off, reference path) and the denoising stage calls
+:func:`mount_ltx2_rms_norm_modulate` / :func:`unmount_ltx2_rms_norm_modulate`
+at batch boundaries for ``quality="high"`` requests.
+"""
+
+from __future__ import annotations
+
+import torch
+from torch import nn
+
+from sglang.kernels.ops.diffusion.quality_gate import QualityGatedFusion
+from sglang.kernels.ops.diffusion.triton.rmsnorm_scale_shift_bitexact import (
+    can_use_fused_rmsnorm_scale_shift,
+    fused_rmsnorm_scale_shift_bitexact,
+)
+
+_SITE_MARKER_ATTR = "_sgl_ltx2_rms_norm_modulate_site"
+_SITE_ENABLED_ATTR = "_sgl_ltx2_rms_norm_modulate_enabled"
+_FUSION = QualityGatedFusion(
+    name="LTX-2 RMSNorm+modulate",
+    marker_attr=_SITE_MARKER_ATTR,
+    enabled_attr=_SITE_ENABLED_ATTR,
+)
+
+# ``RMSNormNoWeight`` applies no scale, so a ones weight reproduces it exactly.
+_ONES_WEIGHT_CACHE: dict[tuple[torch.device, int], torch.Tensor] = {}
+
+
+def mark_ltx2_rms_norm_modulate_site(module: nn.Module) -> None:
+    """Mark ``module`` as an LTX-2 RMSNorm+modulate fusion site (mounted off)."""
+    _FUSION.mark(module)
+
+
+def ltx2_rms_norm_modulate_active(module: nn.Module) -> bool:
+    return _FUSION.is_enabled(module)
+
+
+def mount_ltx2_rms_norm_modulate(root: nn.Module) -> bool:
+    return _FUSION.mount(root)
+
+
+def unmount_ltx2_rms_norm_modulate(root: nn.Module) -> None:
+    _FUSION.unmount(root)
+
+
+def _ones_weight(x: torch.Tensor) -> torch.Tensor:
+    key = (x.device, int(x.shape[-1]))
+    w = _ONES_WEIGHT_CACHE.get(key)
+    if w is None:
+        w = torch.ones(x.shape[-1], device=x.device, dtype=torch.bfloat16)
+        _ONES_WEIGHT_CACHE[key] = w
+    return w
+
+
+def can_fuse_ltx2_rms_norm_modulate(
+    x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor
+) -> bool:
+    if x.dtype is not torch.bfloat16 or not x.is_cuda:
+        return False
+    return can_use_fused_rmsnorm_scale_shift(x, _ones_weight(x), scale, shift)
+
+
+def fused_ltx2_rms_norm_modulate(
+    x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor, eps: float
+) -> torch.Tensor:
+    """``rms_norm(x) * (1 + scale) + shift`` as one kernel (weightless RMSNorm)."""
+    return fused_rmsnorm_scale_shift_bitexact(x, _ones_weight(x), scale, shift, eps)

--- a/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/ltx_2.py
@@ -10,9 +10,21 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from sglang.kernels.ops.diffusion.fused_linear_gelu import (
+    can_fuse_linear_gelu,
+    fused_gelu_active,
+    fused_linear_gelu_tanh,
+    mark_fused_gelu_site,
+)
 from sglang.kernels.ops.diffusion.ltx2_qknorm_split_rope import (
     can_use_ltx2_qknorm_split_rope_cuda,
     ltx2_qknorm_split_rope_cuda,
+)
+from sglang.kernels.ops.diffusion.ltx2_rmsnorm_modulate import (
+    can_fuse_ltx2_rms_norm_modulate,
+    fused_ltx2_rms_norm_modulate,
+    ltx2_rms_norm_modulate_active,
+    mark_ltx2_rms_norm_modulate_site,
 )
 from sglang.kernels.ops.diffusion.residual_gate_add import residual_gate_add
 from sglang.multimodal_gen.configs.models.dits.ltx_2 import LTX2ArchConfig, LTX2Config
@@ -123,6 +135,29 @@ def adaln_embedding_coefficient(cross_attention_adaln: bool) -> int:
     return ADALN_NUM_BASE_PARAMS + (
         ADALN_NUM_CROSS_ATTN_PARAMS if cross_attention_adaln else 0
     )
+
+
+def _ltx2_rms_norm_modulate(
+    block: nn.Module,
+    rms_norm: nn.Module,
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """``rms_norm(x) * (1 + scale) + shift`` for the LTX-2 adaLN sites.
+
+    Folds the weightless RMSNorm and the modulate into one kernel when the
+    ``quality="high"`` fusion is mounted on ``block`` and the per-call guard
+    passes; otherwise the verbatim eager reference chain (the ``lossless``
+    default). The fused kernel is not bit-exact (<=1 bf16 ULP) so it is gated
+    on the request-scoped mount rather than a runtime self-check.
+    """
+    if ltx2_rms_norm_modulate_active(block) and can_fuse_ltx2_rms_norm_modulate(
+        x, scale, shift
+    ):
+        return fused_ltx2_rms_norm_modulate(x, scale, shift, eps)
+    return rms_norm(x, eps) * (1 + scale) + shift
 
 
 def _ltx2_disable_fused_ada_values(exc: Exception) -> None:
@@ -977,10 +1012,14 @@ class LTX2FeedForward(nn.Module):
             input_is_parallel=True,
             quant_config=quant_config,
         )
+        mark_fused_gelu_site(self, "proj_in")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x, _ = self.proj_in(x)
-        x = self.act(x)
+        if fused_gelu_active(self) and can_fuse_linear_gelu(self.proj_in, x):
+            x = fused_linear_gelu_tanh(x, self.proj_in.weight, self.proj_in.bias)
+        else:
+            x, _ = self.proj_in(x)
+            x = self.act(x)
         x, _ = self.proj_out(x)
         return x
 
@@ -1108,6 +1147,7 @@ class LTX2TransformerBlock(nn.Module):
 
         # 4. Feedforward layers
         self.ff = LTX2FeedForward(dim, dim_out=dim, quant_config=quant_config)
+        mark_ltx2_rms_norm_modulate_site(self)
         self.audio_ff = LTX2FeedForward(
             audio_dim, dim_out=audio_dim, quant_config=quant_config
         )
@@ -1200,8 +1240,8 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             vshift_msa, vscale_msa, vgate_msa = video_ada_values[0:3]
-        norm_hidden_states = (
-            self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_msa) + vshift_msa
+        norm_hidden_states = _ltx2_rms_norm_modulate(
+            self, self.rms_norm, hidden_states, vscale_msa, vshift_msa, self.norm_eps
         )
         attn_hidden_states = self.attn1(
             norm_hidden_states,
@@ -1220,9 +1260,13 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             ashift_msa, ascale_msa, agate_msa = audio_ada_values[0:3]
-        norm_audio_hidden_states = (
-            self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_msa)
-            + ashift_msa
+        norm_audio_hidden_states = _ltx2_rms_norm_modulate(
+            self,
+            self.rms_norm,
+            audio_hidden_states,
+            ascale_msa,
+            ashift_msa,
+            self.norm_eps,
         )
         attn_audio_hidden_states = self.audio_attn1(
             norm_audio_hidden_states,
@@ -1251,8 +1295,8 @@ class LTX2TransformerBlock(nn.Module):
             v_prompt_shift, v_prompt_scale = self.get_ada_values(
                 self.prompt_scale_shift_table, batch_size, temb_prompt, slice(None)
             )
-            norm_hidden_states = (
-                self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_q) + vshift_q
+            norm_hidden_states = _ltx2_rms_norm_modulate(
+                self, self.rms_norm, hidden_states, vscale_q, vshift_q, self.norm_eps
             )
             mod_encoder_hidden_states = (
                 encoder_hidden_states * (1 + v_prompt_scale) + v_prompt_shift
@@ -1278,9 +1322,13 @@ class LTX2TransformerBlock(nn.Module):
                 temb_audio_prompt,
                 slice(None),
             )
-            norm_audio_hidden_states = (
-                self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_q)
-                + ashift_q
+            norm_audio_hidden_states = _ltx2_rms_norm_modulate(
+                self,
+                self.rms_norm,
+                audio_hidden_states,
+                ascale_q,
+                ashift_q,
+                self.norm_eps,
             )
             mod_audio_encoder_hidden_states = (
                 audio_encoder_hidden_states * (1 + a_prompt_scale) + a_prompt_shift
@@ -1428,8 +1476,8 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             vshift_mlp, vscale_mlp, vgate_mlp = video_ada_values[3:6]
-        norm_hidden_states = (
-            self.rms_norm(hidden_states, self.norm_eps) * (1 + vscale_mlp) + vshift_mlp
+        norm_hidden_states = _ltx2_rms_norm_modulate(
+            self, self.rms_norm, hidden_states, vscale_mlp, vshift_mlp, self.norm_eps
         )
         ff_output = self.ff(norm_hidden_states)
         hidden_states = residual_gate_add(hidden_states, ff_output, vgate_mlp)
@@ -1440,9 +1488,13 @@ class LTX2TransformerBlock(nn.Module):
             )
         else:
             ashift_mlp, ascale_mlp, agate_mlp = audio_ada_values[3:6]
-        norm_audio_hidden_states = (
-            self.rms_norm(audio_hidden_states, self.norm_eps) * (1 + ascale_mlp)
-            + ashift_mlp
+        norm_audio_hidden_states = _ltx2_rms_norm_modulate(
+            self,
+            self.rms_norm,
+            audio_hidden_states,
+            ascale_mlp,
+            ashift_mlp,
+            self.norm_eps,
         )
         audio_ff_output = self.audio_ff(norm_audio_hidden_states)
         audio_hidden_states = residual_gate_add(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -32,6 +32,10 @@ from sglang.kernels.ops.diffusion.fused_ln_modulate import (
     mount_fused_ln_modulate,
     unmount_fused_ln_modulate,
 )
+from sglang.kernels.ops.diffusion.ltx2_rmsnorm_modulate import (
+    mount_ltx2_rms_norm_modulate,
+    unmount_ltx2_rms_norm_modulate,
+)
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType, STA_Mode
 from sglang.multimodal_gen.configs.pipeline_configs.flux import (
@@ -155,6 +159,11 @@ _QUALITY_FUSION_HANDLERS: tuple[
         "fused LN+modulate (affine folding)",
         mount_fused_ln_modulate,
         unmount_fused_ln_modulate,
+    ),
+    (
+        "LTX-2 fused RMSNorm+modulate",
+        mount_ltx2_rms_norm_modulate,
+        unmount_ltx2_rms_norm_modulate,
     ),
     (
         "fused gate RMSNorm (BF16-native Triton)",

--- a/test/registered/kernels/ops/diffusion/test_ltx2_rms_norm_modulate.py
+++ b/test/registered/kernels/ops/diffusion/test_ltx2_rms_norm_modulate.py
@@ -1,0 +1,71 @@
+"""LTX-2 quality=high RMSNorm+modulate fusion: gated, close to eager."""
+
+import sys
+
+import pytest
+import torch
+from torch import nn
+
+from sglang.kernels.ops.diffusion.ltx2_rmsnorm_modulate import (
+    fused_ltx2_rms_norm_modulate,
+    mark_ltx2_rms_norm_modulate_site,
+    mount_ltx2_rms_norm_modulate,
+    unmount_ltx2_rms_norm_modulate,
+)
+from sglang.multimodal_gen.runtime.layers.layernorm import RMSNormNoWeight
+from sglang.multimodal_gen.runtime.models.dits.ltx_2 import _ltx2_rms_norm_modulate
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=8, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=8, suite="nightly-amd-kernel-1-gpu", nightly=True)
+
+
+@pytest.fixture(autouse=True)
+def _setup():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.cuda.manual_seed(0)
+
+
+def _eager(rms, x, scale, shift, eps):
+    return rms(x, eps) * (1 + scale) + shift
+
+
+def _inputs(hidden, batch=1, seq=4096):
+    rms = RMSNormNoWeight()
+    x = torch.randn(batch, seq, hidden, device="cuda", dtype=torch.bfloat16)
+    scale = torch.randn(batch, 1, hidden, device="cuda", dtype=torch.bfloat16) * 0.1
+    shift = torch.randn(batch, 1, hidden, device="cuda", dtype=torch.bfloat16) * 0.1
+    return rms, x, scale, shift
+
+
+# hidden 4096 = LTX-2 video stream, 2048 = audio stream.
+@pytest.mark.parametrize("hidden", [4096, 2048])
+def test_lossless_default_is_bitexact(hidden):
+    # A marked-but-unmounted site (the lossless default) runs verbatim eager.
+    block = nn.Module()
+    mark_ltx2_rms_norm_modulate_site(block)
+    rms, x, scale, shift = _inputs(hidden)
+    out = _ltx2_rms_norm_modulate(block, rms, x, scale, shift, 1e-6)
+    assert torch.equal(out, _eager(rms, x, scale, shift, 1e-6))
+
+
+@pytest.mark.parametrize("hidden", [4096, 2048])
+def test_mounted_high_uses_fused_kernel(hidden):
+    block = nn.Module()
+    mark_ltx2_rms_norm_modulate_site(block)
+    assert mount_ltx2_rms_norm_modulate(block)
+    try:
+        rms, x, scale, shift = _inputs(hidden)
+        out = _ltx2_rms_norm_modulate(block, rms, x, scale, shift, 1e-6)
+        # The mounted path routes through the fused kernel exactly.
+        assert torch.equal(out, fused_ltx2_rms_norm_modulate(x, scale, shift, 1e-6))
+        # And stays within half-precision rounding of the eager reference.
+        ref = _eager(rms, x, scale, shift, 1e-6)
+        assert torch.allclose(out.float(), ref.float(), atol=3e-2, rtol=1e-2)
+    finally:
+        unmount_ltx2_rms_norm_modulate(block)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

Profiling `ltx23-one-stage` eager vs `torch.compile` on H200 (5-step denoise trace) shows LTX-2 video denoise is **compute-bound** — GPU-busy ≈ **89%** in eager — so a breakable CUDA graph recovers almost nothing. `torch.compile`'s advantage (~6% denoise) comes almost entirely from **fusing two elementwise chains**: the adaLN `RMSNorm(x) * (1 + scale) + shift` modulate at every transformer block, and the FFN `GELU`. Kernel-time attribution: compile cuts total GPU-op time 8.58 M → 7.37 M µs (−14%) purely by collapsing the aten `vectorized_layer_norm` + generic `elementwise` + `GELU` launches into fused Triton kernels; GEMMs and attention are untouched.

This PR reproduces those two fusions in **eager** behind `quality="high"`, so the high tier reaches near-parity with `torch.compile` **without** compile's ~minutes-long warmup or its cross-session nondeterminism. The `lossless` default is unchanged and runs the verbatim reference path.

## Changes

- **`kernels/ops/diffusion/ltx2_rmsnorm_modulate.py`** (new): a `QualityGatedFusion` wrapper that folds `rms_norm(x) * (1 + scale) + shift` into one launch by reusing the existing `fused_rmsnorm_scale_shift_bitexact` kernel. LTX-2 uses weightless `RMSNormNoWeight`, so a cached ones weight reproduces it. The fused kernel is not bit-exact vs aten `F.rms_norm` (`rsqrt.approx` vs aten's refined `rsqrtf`, ≤ 1 bf16 ULP), hence the `quality="high"` gate rather than a lossless self-check.
- **`models/dits/ltx_2.py`**: the six `LTX2TransformerBlock` adaLN sites route through `_ltx2_rms_norm_modulate` (fused when mounted, verbatim eager otherwise). `LTX2FeedForward`'s `proj_in`+GELU-tanh is marked as a `fused_linear_gelu` site (cublasLt GELU epilogue), reusing the existing handler.
- **`pipelines_core/stages/denoising.py`**: registers the new fusion in `_QUALITY_FUSION_HANDLERS`, so it mounts/unmounts at the batch boundary for `quality="high"` alongside the existing families. Models without marked sites are unaffected.

## Speed (H200)

`quality=high` vs the `lossless` default vs `torch.compile`, denoise / e2e seconds (one warmed process, warmup dropped):

| preset | lossless (default) | **quality=high** | torch.compile |
| --- | ---: | ---: | ---: |
| ltx23-one-stage (768×512×121f, 30 step) | 45.85 / 47.31 | **43.24 / 44.65 (−5.7% / −5.6%)** | 42.95 / 44.54 |
| ltx23-two-stage | 29.87 / 33.27 | 29.61 / 33.15 | 28.93 / 32.33 |

On `one-stage`, `quality=high` lands within **0.7%** of `torch.compile` on denoise and **0.25%** on e2e — i.e. eager parity without compile. On the two-stage / refinement variants the gain is small: the refinement stage is more attention/GEMM-bound, so the elementwise share (and thus the fusible surface) is smaller; the fusion is still applied and remains harmless.

## Accuracy

`quality=high` is numerically equivalent only at half-precision rounding level (each fold is ≤ 1 bf16 ULP), so it is gated per-batch and the `lossless` default is bit-exact.

- **PSNR(high vs lossless)** over the full 121-frame ltx23-one-stage output: **min 35.29 dB / mean 36.34 dB** (acceptance bar > 25 dB). No frame drops below the bar over the 30-step denoise.
- **Unit test** `test/registered/kernels/ops/diffusion/test_ltx2_rms_norm_modulate.py` (registered CUDA CI): the unmounted (lossless) path is `torch.equal` to the eager reference; the mounted path routes through the fused kernel and stays within half-precision rounding of eager. Existing `fused_linear_gelu` / `rmsnorm_scale_shift` suites unchanged.

## Benchmark configuration

```
sglang.multimodal_gen.DiffGenerator, model=Lightricks/LTX-2.3, local_mode=True,
num_gpus=2, enable_torch_compile=false, seed=1234, 768x512, 121 frames,
num_inference_steps=30, quality={lossless|high}
```

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31317359801](https://github.com/sgl-project/sglang/actions/runs/31317359801)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31323949543](https://github.com/sgl-project/sglang/actions/runs/31323949543)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->