### PR TITLE
Fix mlx unit test batch mock

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -1222,7 +1222,11 @@ class TestMlxOverlapScheduler(unittest.TestCase):
                 set_completion_time=lambda: events.append(("completion", "r0"))
             ),
         )
-        batch = SimpleNamespace()
+        batch = SimpleNamespace(
+            mamba_track_mask_cpu=None,
+            mamba_track_mask_next_cpu=None,
+            mamba_decode_batch_idx_cpu=None,
+        )
         result = SimpleNamespace()
         i = 0
         logits_output = SimpleNamespace(customized_info=None)


### PR DESCRIPTION
## Motivation

#33477 added a `batch.mamba_track_mask_cpu` access in `_handle_finish_state_updated_req`, but the MLX unit test `test_finished_request_snapshots_before_release` builds `batch` as a bare `SimpleNamespace()`, so it raises `AttributeError: 'types.SimpleNamespace' object has no attribute 'mamba_track_mask_cpu'` and `stage-a-unit-test-mlx` is red on current main.

Add the three mamba track fields to the mock batch with their `ScheduleBatch` default of `None`, so the mamba boundary branch short-circuits.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31324771103](https://github.com/sgl-project/sglang/actions/runs/31324771103)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31324770895](https://github.com/sgl-project/sglang/actions/runs/31324770895)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->