### PR TITLE
[diffusion] BCG: fall back to eager when replay fails, mirroring the capture policy

### DIFF
--- a/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
+++ b/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/runner.py
@@ -315,7 +315,17 @@ class BaseBreakableCudaGraphRunner:
             if not self.capture(**kwargs):
                 return self.transformer(**kwargs)
             entry = self.entries[key]
-        return self.replay(entry, kwargs)
+        try:
+            return self.replay(entry, kwargs)
+        except Exception as e:  # noqa: BLE001 — never break generation on replay
+            logger.warning(
+                "[Diffusion BCG] replay failed for signature %s (%s); "
+                "dropping all graphs and permanently running eager.",
+                _signature_summary(key),
+                e,
+            )
+            self.reset(disabled_reason=f"replay failed: {e}")
+            return self.transformer(**kwargs)
 
     def _log_signature_miss(self, key: tuple) -> None:
         """One-shot diagnostic: serving signature missed every captured graph."""

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_replay_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_replay_fallback.py
@@ -1,0 +1,78 @@
+"""BCG replay failures must fall back to eager, mirroring the capture policy."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
+    DiffusionBreakableCudaGraphRunner,
+    _CaptureEntry,
+)
+
+
+class _ExplodingGraph:
+    """Fake BreakableCUDAGraph whose replay always raises."""
+
+    def __init__(self):
+        self._break_fns = []
+        self._segments = []
+
+    def replay(self):
+        raise RuntimeError("injected replay failure")
+
+
+class _RecordingTransformer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.calls = 0
+
+    def forward(self, **kwargs):
+        self.calls += 1
+        return torch.ones(1)
+
+
+def _bare_runner(transformer) -> DiffusionBreakableCudaGraphRunner:
+    runner = DiffusionBreakableCudaGraphRunner.__new__(
+        DiffusionBreakableCudaGraphRunner
+    )
+    runner.transformer = transformer
+    runner.entries = {}
+    runner._blocked = set()
+    runner._pool = None
+    runner._disabled_reason = None
+    runner.device_module = SimpleNamespace(empty_cache=lambda: None)
+    return runner
+
+
+class TestReplayFallback(unittest.TestCase):
+    def test_replay_failure_disables_runner_and_runs_eager(self):
+        transformer = _RecordingTransformer()
+        runner = _bare_runner(transformer)
+
+        kwargs = {"hidden_states": torch.randn(1, 4, 8)}
+        key = runner._signature(kwargs)
+        runner.entries[key] = _CaptureEntry(
+            graph=_ExplodingGraph(),
+            static_kwargs=dict(kwargs),
+            static_leaves=[torch.empty(1, 4, 8)],
+            output=torch.zeros(1),
+            num_segments=1,
+        )
+
+        # Replay raises -> eager result, graphs dropped, runner disabled.
+        out = runner(**kwargs)
+        self.assertTrue(torch.equal(out, torch.ones(1)))
+        self.assertEqual(transformer.calls, 1)
+        self.assertEqual(runner.entries, {})
+        self.assertIsNotNone(runner._disabled_reason)
+        self.assertIn("replay failed", runner._disabled_reason)
+
+        # Disabled runner keeps serving eagerly on later calls.
+        out = runner(**kwargs)
+        self.assertTrue(torch.equal(out, torch.ones(1)))
+        self.assertEqual(transformer.calls, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The BCG runner's `capture()` is deliberately defensive — any exception is caught, the signature is blocked, and the request runs eager ("never break generation on capture"). `replay()` has no such protection: an exception raised while copying live inputs into the static buffers, replaying the graph, or cloning the output escapes and **fails the whole request**.

This is not hypothetical. Investigating why `Tongyi-MAI/Z-Image` / `Z-Image-Turbo` BCG crashes on a single GPU (see the companion issue), the failure fires at the **first replay after warmup capture** — every capture succeeds, then replay raises `CUDA error: an illegal memory access was encountered` and the warmup request dies with a raw `RuntimeError`. A capture failure in the same position would have degraded to eager silently.

## Change

One edit in `runner.py` `__call__`: wrap `self.replay(entry, kwargs)`; on failure, log the signature, drop every captured graph and its static buffers via the existing `reset(disabled_reason=...)`, and return the eager forward — the exact policy and machinery `capture()` already uses.

Honest scope: a context-corrupting device fault (like the async illegal access above) still propagates — once the CUDA context is poisoned nothing in-process is recoverable. What this converts into a seamless eager fallback is the *recoverable* class: allocation failure on the output clone, static-buffer copy mismatches, stream errors — plus it turns "one bad graph" into a structured, logged disable instead of a crash loop.

## Validation

- **Unit test** (`test_diffusion_bcg_replay_fallback.py`): a runner with a captured entry whose graph raises on replay returns the eager result, ends up disabled with a `replay failed` reason and zero entries, and keeps serving eagerly on subsequent calls.
- **No-regression** (H200, SANA1.5-1.6B 1024², `--enable-breakable-cuda-graph --warmup-resolutions 1024x1024`): denoise 0.459 s with this patch vs 0.457 s without — noise level; the fast path is untouched when replay succeeds.
- Pre-commit clean.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit test.
- [x] Provide benchmark result.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31325377152](https://github.com/sgl-project/sglang/actions/runs/31325377152)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31347423553](https://github.com/sgl-project/sglang/actions/runs/31347423553)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->