### PR TITLE
Fix stale track rows corrupting conv checkpoints under the prefill graph

### DIFF
--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1608,6 +1608,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
                 s["extend_start_loc"][bs:r].fill_(self.raw_num_tokens)
                 s["req_pool_indices"][bs:r].zero_()
                 s["orig_seq_lens"][bs:r].zero_()
+                # The captured track scatter reads these rows too, and a stale
+                # mask row still carries a live destination slot: it would land
+                # this replay's window in an earlier request's checkpoint.
+                registry = self.buffer_registry
+                for name in ("mamba_track_mask", "mamba_track_indices"):
+                    if registry.has_slot(name):
+                        registry.get_slot(name).buffer[bs:r].zero_()
 
         # Refresh the static buffer the captured graph reads from.
         if (

--- a/test/registered/models_e2e/test_inkling_small_nvfp4.py
+++ b/test/registered/models_e2e/test_inkling_small_nvfp4.py
@@ -163,7 +163,6 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
                 "--mem-fraction-static",
                 "0.85",
                 "--enable-deterministic-inference",
-                "--disable-prefill-cuda-graph",
             ],
             env={**os.environ, "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"},
         )


### PR DESCRIPTION
## Motivation

A prefix-cache hit on a hybrid-SWA model can decode off a conv state it never produced. The replayed prefill graph reads `_capture_req_slots` rows, but `mamba_track_mask` / `mamba_track_indices` keep whatever the previous replay left past the live batch, so the captured track scatter lands the current window in an earlier request's checkpoint. Whichever request later restores that prefix is wrong for its whole generation.

The sentinel tail directly above exists for this reason -- "the captured graph reads all req_slots entries, so stale values from the previous replay must be cleared" -- and clears six fields. The two track buffers live in the buffer registry instead, and their clear is guarded by `bs != raw_bs` in `PrefillInputBuffers.fill_from`; the prefill graph passes `padded_bs == raw_bs` because it pads tokens rather than requests, so that branch never runs.

This needs no speculative decoding. It takes the prefill CUDA graph, chunked prefill, concurrency and a prefix hit together, and disabling the prefill graph alone makes it go away. #34043 fixed a neighbouring failure on the spec path -- the scatter being specialised out of the capture -- whereas here the checkpoint is written and scattered to a stale destination; it still reproduces with #34043 in.

## Modifications

Zero the two track rows alongside the six the sentinel tail already covers.

https://github.com/sgl-project/sglang/pull/34168 `test_inkling_small_nvfp4.py` drops the `--disable-prefill-cuda-graph` it was carrying. That flag was steering the deterministic KL case around this bug, and that case is the regression guard for it, so it belongs back on the graph path.

The alternative is to make `padded_bs` report the captured slot count, which makes `fill_from`'s clear live and stops its `bs != raw_bs` branch from being dead code. That is the more honest shape -- while the request dimension claims to be unpadded, the next captured kernel that reads `req_slots` rows repeats this -- but it changes behaviour under every phase sharing those buffers, so this PR takes the local fix. Happy to switch.

## Accuracy

Shrunken Inkling checkpoint, tp=1, 32 concurrent prompts, prefill graph on, `--enable-deterministic-inference`. Differing logprobs against a flushed reference prefill:

```
              prefill_cache_hit                match
           512 tokens    8 tokens
before     1022/16384      16/256              0
after         0/16384       0/256              0
```

The two corrupted checkpoints were observed rather than inferred: instrumenting the slot at insert time shows exactly two whose conv state differs from the same run without the graph, and their claimed track seqlens are the prefixes of the two requests that go wrong.

The A/B above is the shrunken checkpoint at tp=1. The CI case runs the real NVFP4 weights at tp=4, where the batch packs differently and picks different victims, so I have not reproduced-and-fixed on that exact configuration -- if it stays red, the same shape of gap exists somewhere else and the instrumentation above finds it.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31327464791](https://github.com/sgl-project/sglang/actions/runs/31327464791)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31327464735](https://github.com/sgl-project/sglang/actions/runs/31327464735)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->