### PR TITLE
[VLM] Rust Kimi-K3 image preprocessing in sglang-mm (library mode)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -986,6 +986,10 @@ class Envs:
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_CACHE_CAPACITY = EnvInt(2)
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_MIN_HITS = EnvInt(2)
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_MAX_SEQLEN = EnvInt(6144)
+    # Preprocess Kimi-K3 images with the Rust sglang-mm pipeline (library mode,
+    # like SGLANG_INKLING_RS_MM_PREPROCESS): bit-exact against the checkpoint's
+    # PIL reference and used from the Python tokenizer manager.
+    SGLANG_KIMI_K3_RS_MM_PREPROCESS = EnvBool(False)
     # Use the fully-vectorized ViT position-embedding interpolation (no per-image
     # Python loop / CPU<->GPU sync). Bit-exact with the legacy implementation;
     # set False to fall back to the per-image loop.

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -977,6 +977,9 @@ class Envs:
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
+    # Select the PIL/CPU reference image preprocessing over the GPU fast paths
+    # (nvJPEG decode + GPU resize/normalize) — for accuracy baselines.
+    SGLANG_USE_PIL_MM_PREPROCESS = EnvBool(False)
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
     SGLANG_VIT_ENABLE_CUDA_GRAPH = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -977,8 +977,7 @@ class Envs:
     SGLANG_VLM_CACHE_SIZE_MB = EnvInt(100)
     SGLANG_IMAGE_MAX_PIXELS = EnvInt(16384 * 28 * 28)
     SGLANG_RESIZE_RESAMPLE = EnvStr("")
-    # Select the PIL/CPU reference image preprocessing over the GPU fast paths
-    # (nvJPEG decode + GPU resize/normalize) — for accuracy baselines.
+    # Select the PIL/CPU reference image preprocessing over the GPU fast paths.
     SGLANG_USE_PIL_MM_PREPROCESS = EnvBool(False)
     SGLANG_MM_BUFFER_SIZE_MB = EnvInt(0)
     SGLANG_MM_PRECOMPUTE_HASH = EnvBool(False)
@@ -986,9 +985,8 @@ class Envs:
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_CACHE_CAPACITY = EnvInt(2)
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_MIN_HITS = EnvInt(2)
     SGLANG_KIMI_K3_VIT_CUDA_GRAPH_MAX_SEQLEN = EnvInt(6144)
-    # Preprocess Kimi-K3 images with the Rust sglang-mm pipeline (library mode,
-    # like SGLANG_INKLING_RS_MM_PREPROCESS): bit-exact against the checkpoint's
-    # PIL reference and used from the Python tokenizer manager.
+    # Preprocess Kimi-K3 images with the Rust sglang-mm pipeline (library
+    # mode, like SGLANG_INKLING_RS_MM_PREPROCESS; bit-exact with PIL).
     SGLANG_KIMI_K3_RS_MM_PREPROCESS = EnvBool(False)
     # Use the fully-vectorized ViT position-embedding interpolation (no per-image
     # Python loop / CPU<->GPU sync). Bit-exact with the legacy implementation;

--- a/python/sglang/srt/multimodal/kimi_k3_rust.py
+++ b/python/sglang/srt/multimodal/kimi_k3_rust.py
@@ -1,0 +1,127 @@
+"""Rust-accelerated Kimi-K3 image preprocessing (sglang-mm's ``kimi_k3`` module).
+
+Library mode, like Inkling: the Python TokenizerManager keeps orchestrating
+(decode, NaViT sizing, prompt expansion) and each decoded image's
+resize -> transparent-bg composite -> normalize -> patchify runs in Rust,
+bit-exact against the checkpoint's PIL/numpy reference
+(``kimi_k3_vision_processing.py`` with ``transparent_bg_fill_stage ==
+"after_resize"``).
+
+The reference resizes each image in its *own* PIL mode and only converts
+after the resize, so an input image is handed to Rust only when an
+equivalent pre-converted RGB/RGBA array exists; anything else (palette
+images, which PIL resizes with NEAREST; CMYK; bilevel; ...) reports "no
+effective array" and the caller falls back to the PIL path for the request.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import torch
+from PIL import Image
+
+from sglang.srt.multimodal._core import kimi_k3 as _rs
+
+# `TransparentBgConfig` defaults from the checkpoint's media_utils.py.
+_BG_DEFAULTS = {
+    "chessboard_square_size": 16,
+    "chessboard_square_on_top_left": True,
+    "chessboard_white_value": 255,
+    "chessboard_gray_value": 200,
+}
+
+
+def bg_tuple(
+    transparent_bg_config: Optional[dict],
+) -> Optional[Tuple[str, int, bool, int, int]]:
+    """Flatten a ``transparent_bg_config`` dict into the Rust binding's tuple."""
+    if transparent_bg_config is None:
+        return None
+    cfg = {**_BG_DEFAULTS, **transparent_bg_config}
+    return (
+        cfg["pattern"],
+        cfg["chessboard_square_size"],
+        cfg["chessboard_square_on_top_left"],
+        cfg["chessboard_white_value"],
+        cfg["chessboard_gray_value"],
+    )
+
+
+def to_effective_array(image) -> Optional[np.ndarray]:
+    """The u8 HWC array whose Rust pipeline output is bit-identical to the
+    reference's resize-in-original-mode semantics, or ``None`` when no such
+    array exists.
+
+    * RGB passes through — including RGB images carrying a stray
+      ``"transparency"`` info key, which ``fill_transparent_bg_with`` returns
+      untouched before it ever inspects the alpha bands.
+    * L converts to RGB up front: the conversion replicates the single channel
+      and PIL's resize convolves channels independently, so convert-then-resize
+      equals the reference's resize-then-convert.
+    * RGBA / LA convert to RGBA up front, by the same per-channel argument.
+    * Everything else has no equivalent array: PIL forces NEAREST resampling
+      for palette ("P"/"1") modes, and CMYK-family conversions do not commute
+      with the resize.
+    """
+    if not isinstance(image, Image.Image):
+        return None
+    if image.mode == "RGB":
+        return np.ascontiguousarray(np.asarray(image))
+    has_alpha = "A" in image.getbands() or "transparency" in image.info
+    if not has_alpha:
+        if image.mode == "L":
+            return np.ascontiguousarray(np.asarray(image.convert("RGB")))
+        return None
+    if image.mode in ("RGBA", "LA"):
+        return np.ascontiguousarray(np.asarray(image.convert("RGBA")))
+    return None
+
+
+def rust_preprocess_images(
+    images: List,
+    resize_configs: List[dict],
+    *,
+    patch_size: int,
+    image_mean,
+    image_std,
+    transparent_bg_config: Optional[dict],
+) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
+    """Run the Rust pipeline over a request's images.
+
+    Returns ``(pixel_values, grid_thws)`` matching the PIL path's schema —
+    f32 ``(sum_patches, 3, ps, ps)`` and int64 ``(n_images, 3)`` — or ``None``
+    when any image has no effective array (the caller falls back to PIL for
+    the whole request so every image of a request takes one path).
+    """
+    arrays = []
+    for image in images:
+        arr = to_effective_array(image)
+        if arr is None:
+            return None
+        arrays.append(arr)
+
+    bg = bg_tuple(transparent_bg_config)
+    mean = tuple(float(v) for v in image_mean)
+    std = tuple(float(v) for v in image_std)
+
+    pixel_values = []
+    grids = []
+    for arr, cfg in zip(arrays, resize_configs):
+        pix, grid = _rs.preprocess(
+            arr,
+            cfg["new_width"],
+            cfg["new_height"],
+            cfg["pad_width"],
+            cfg["pad_height"],
+            patch_size,
+            mean,
+            std,
+            bg,
+        )
+        pixel_values.append(
+            torch.from_numpy(pix.reshape(-1, 3, patch_size, patch_size))
+        )
+        grids.append(torch.tensor(grid, dtype=torch.int64))
+    return torch.cat(pixel_values), torch.stack(grids)

--- a/python/sglang/srt/multimodal/kimi_k3_rust.py
+++ b/python/sglang/srt/multimodal/kimi_k3_rust.py
@@ -111,4 +111,6 @@ def rust_preprocess_images(
             torch.from_numpy(pix.reshape(-1, 3, patch_size, patch_size))
         )
         grids.append(torch.tensor(grid, dtype=torch.int64))
-    return torch.cat(pixel_values), torch.stack(grids)
+    # Single image (the common case): skip torch.cat's whole-buffer copy.
+    pixels = pixel_values[0] if len(pixel_values) == 1 else torch.cat(pixel_values)
+    return pixels, torch.stack(grids)

--- a/python/sglang/srt/multimodal/kimi_k3_rust.py
+++ b/python/sglang/srt/multimodal/kimi_k3_rust.py
@@ -1,17 +1,10 @@
 """Rust-accelerated Kimi-K3 image preprocessing (sglang-mm's ``kimi_k3`` module).
 
 Library mode, like Inkling: the Python TokenizerManager keeps orchestrating
-(decode, NaViT sizing, prompt expansion) and each decoded image's
-resize -> transparent-bg composite -> normalize -> patchify runs in Rust,
-bit-exact against the checkpoint's PIL/numpy reference
-(``kimi_k3_vision_processing.py`` with ``transparent_bg_fill_stage ==
-"after_resize"``).
-
-The reference resizes each image in its *own* PIL mode and only converts
-after the resize, so an input image is handed to Rust only when an
-equivalent pre-converted RGB/RGBA array exists; anything else (palette
-images, which PIL resizes with NEAREST; CMYK; bilevel; ...) reports "no
-effective array" and the caller falls back to the PIL path for the request.
+(decode, NaViT sizing, prompt expansion); resize -> transparent-bg composite ->
+normalize -> patchify runs in Rust, bit-exact against the checkpoint's
+PIL/numpy reference. Images whose PIL mode has no bit-exact Rust equivalent
+report ``None`` and the caller falls back to the PIL path.
 """
 
 from __future__ import annotations
@@ -50,20 +43,15 @@ def bg_tuple(
 
 
 def to_effective_array(image) -> Optional[np.ndarray]:
-    """The u8 HWC array whose Rust pipeline output is bit-identical to the
-    reference's resize-in-original-mode semantics, or ``None`` when no such
-    array exists.
+    """The u8 HWC array matching the reference's resize-in-original-mode
+    semantics, or ``None`` when no such array exists.
 
-    * RGB passes through — including RGB images carrying a stray
-      ``"transparency"`` info key, which ``fill_transparent_bg_with`` returns
-      untouched before it ever inspects the alpha bands.
-    * L converts to RGB up front: the conversion replicates the single channel
-      and PIL's resize convolves channels independently, so convert-then-resize
-      equals the reference's resize-then-convert.
-    * RGBA / LA convert to RGBA up front, by the same per-channel argument.
-    * Everything else has no equivalent array: PIL forces NEAREST resampling
-      for palette ("P"/"1") modes, and CMYK-family conversions do not commute
-      with the resize.
+    The reference converts modes only *after* the resize, so pre-converting is
+    valid exactly when it commutes with PIL's per-channel resize: RGB passes
+    through (even with a stray ``"transparency"`` info key, which the
+    reference ignores on RGB), L/LA/RGBA convert by channel replication.
+    Palette modes (PIL forces NEAREST) and CMYK-family conversions don't
+    commute — no equivalent array.
     """
     if not isinstance(image, Image.Image):
         return None
@@ -90,10 +78,9 @@ def rust_preprocess_images(
 ) -> Optional[Tuple[torch.Tensor, torch.Tensor]]:
     """Run the Rust pipeline over a request's images.
 
-    Returns ``(pixel_values, grid_thws)`` matching the PIL path's schema —
-    f32 ``(sum_patches, 3, ps, ps)`` and int64 ``(n_images, 3)`` — or ``None``
-    when any image has no effective array (the caller falls back to PIL for
-    the whole request so every image of a request takes one path).
+    Returns ``(pixel_values, grid_thws)`` in the PIL path's schema, or
+    ``None`` when any image has no effective array (the whole request then
+    falls back to PIL so all its images take one path).
     """
     arrays = []
     for image in images:

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -663,8 +663,7 @@ class BaseMultimodalProcessor(ABC):
         try:
             if modality == Modality.IMAGE:
                 gpu_image_decode = (
-                    cls.gpu_image_decode
-                    and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
+                    cls.gpu_image_decode and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
                 )
                 img, _ = load_image(data, gpu_image_decode)
                 if isinstance(img, torch.Tensor):

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -13,6 +13,7 @@ import torch
 from PIL import Image
 from transformers import BaseImageProcessor
 
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import (
     Modality,
     MultimodalDataItem,
@@ -661,7 +662,11 @@ class BaseMultimodalProcessor(ABC):
             return data
         try:
             if modality == Modality.IMAGE:
-                img, _ = load_image(data, cls.gpu_image_decode)
+                gpu_image_decode = (
+                    cls.gpu_image_decode
+                    and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
+                )
+                img, _ = load_image(data, gpu_image_decode)
                 if isinstance(img, torch.Tensor):
                     return img  # JPEG already decoded on GPU by nvJPEG
                 # PIL decodes lazily; do it here in the io worker so the decode

--- a/python/sglang/srt/multimodal/processors/kimi_k25.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k25.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from PIL import Image
 
 from sglang.kernels.ops.mm.process import normalize_and_patchify
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import (
     MultimodalProcessorOutput,
 )
@@ -27,6 +28,14 @@ from sglang.srt.utils.cuda_ipc_transport_utils import (
 # ---------------------------------------------------------------------------
 # GPU image preprocessing utilities (resize, pad, normalize, patchify on CUDA)
 # ---------------------------------------------------------------------------
+
+
+def gpu_mm_preprocess_enabled() -> bool:
+    """Whether the GPU image-preprocessing fast path may be used; the
+    PIL/CPU reference path (the checkpoint's own HF processor) runs otherwise."""
+    return (
+        torch.cuda.is_available() and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
+    )
 
 
 def navit_resize_config(
@@ -388,7 +397,7 @@ class KimiGPUProcessorWrapper:
         images = images or kwargs.pop("images", None)
         original_input_ids = kwargs.pop("sglang_original_input_ids", None)
 
-        if images and torch.cuda.is_available():
+        if images and gpu_mm_preprocess_enabled():
             return self._gpu_call(text, images, original_input_ids)
         return self._cpu_call(text, images, original_input_ids, **kwargs)
 

--- a/python/sglang/srt/multimodal/processors/kimi_k25.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k25.py
@@ -31,11 +31,8 @@ from sglang.srt.utils.cuda_ipc_transport_utils import (
 
 
 def gpu_mm_preprocess_enabled() -> bool:
-    """Whether the GPU image-preprocessing fast path may be used; the
-    PIL/CPU reference path (the checkpoint's own HF processor) runs otherwise."""
-    return (
-        torch.cuda.is_available() and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
-    )
+    """GPU fast path allowed? Otherwise the PIL/CPU reference path runs."""
+    return torch.cuda.is_available() and not envs.SGLANG_USE_PIL_MM_PREPROCESS.get()
 
 
 def navit_resize_config(

--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -28,6 +28,7 @@ from sglang.srt.multimodal.processors.kimi_k25 import (
     KimiGPUProcessorWrapper,
     _get_image_dimensions,
     _gpu_preprocess_images,
+    gpu_mm_preprocess_enabled,
     navit_resize_config,
 )
 from sglang.srt.utils.cuda_ipc_transport_utils import (
@@ -211,7 +212,7 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
     def __call__(self, text=None, images=None, **kwargs):
         images = images or kwargs.pop("images", None)
         original_input_ids = kwargs.pop("sglang_original_input_ids", None)
-        if images and torch.cuda.is_available():
+        if images and gpu_mm_preprocess_enabled():
             return self._gpu_call(text, images, original_input_ids)
         return self._cpu_call(text, images, original_input_ids, **kwargs)
 

--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -217,8 +217,7 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
             result = self._rust_call(text, images, original_input_ids)
             if result is not None:
                 return result
-            # An image mode outside the Rust pipeline's bit-exact scope
-            # (palette/CMYK/...): the PIL reference handles the request.
+            # Image mode outside the Rust pipeline's bit-exact scope.
             return self._cpu_call(text, images, original_input_ids, **kwargs)
         if images and gpu_mm_preprocess_enabled():
             return self._gpu_call(text, images, original_input_ids)
@@ -244,9 +243,7 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
         return resize_configs, image_sizes
 
     def _rust_call(self, text, images, original_input_ids=None):
-        """Preprocess via the Rust sglang-mm pipeline (bit-exact with the PIL
-        reference); ``None`` means an image is outside its scope and the
-        caller must take the PIL path instead."""
+        """Preprocess via Rust sglang-mm; ``None`` = out of scope, use PIL."""
         from sglang.srt.multimodal.kimi_k3_rust import rust_preprocess_images
 
         input_text = text[0] if isinstance(text, list) else text
@@ -336,9 +333,7 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
 
 class KimiK3ImageProcessor(KimiGridMMDataMixin, SGLangBaseProcessor):
     models = [KimiK3ForConditionalGeneration]
-    # The Rust pipeline consumes decoded PIL images, so nvJPEG CUDA decode is
-    # incompatible with it (class attribute: read once at import, after the
-    # launch environment is set).
+    # The Rust pipeline consumes decoded PIL images, not nvJPEG CUDA tensors.
     gpu_image_decode = not envs.SGLANG_KIMI_K3_RS_MM_PREPROCESS.get()
     prefer_tokenized_input = True
     precompute_hash_before_cpu_transfer = True

--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -15,6 +15,7 @@ import numpy as np
 import torch
 from PIL import Image
 
+from sglang.srt.environ import envs
 from sglang.srt.managers.schedule_batch import MultimodalProcessorOutput
 from sglang.srt.models.kimi_k3 import KimiK3ForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
@@ -212,13 +213,18 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
     def __call__(self, text=None, images=None, **kwargs):
         images = images or kwargs.pop("images", None)
         original_input_ids = kwargs.pop("sglang_original_input_ids", None)
+        if images and envs.SGLANG_KIMI_K3_RS_MM_PREPROCESS.get():
+            result = self._rust_call(text, images, original_input_ids)
+            if result is not None:
+                return result
+            # An image mode outside the Rust pipeline's bit-exact scope
+            # (palette/CMYK/...): the PIL reference handles the request.
+            return self._cpu_call(text, images, original_input_ids, **kwargs)
         if images and gpu_mm_preprocess_enabled():
             return self._gpu_call(text, images, original_input_ids)
         return self._cpu_call(text, images, original_input_ids, **kwargs)
 
-    def _gpu_call(self, text, images, original_input_ids=None):
-        input_text = text[0] if isinstance(text, list) else text
-
+    def _resize_configs_and_sizes(self, images):
         resize_configs = []
         image_sizes = []
         for image in images:
@@ -235,6 +241,40 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
                     self._fixed_output_tokens,
                 )
             )
+        return resize_configs, image_sizes
+
+    def _rust_call(self, text, images, original_input_ids=None):
+        """Preprocess via the Rust sglang-mm pipeline (bit-exact with the PIL
+        reference); ``None`` means an image is outside its scope and the
+        caller must take the PIL path instead."""
+        from sglang.srt.multimodal.kimi_k3_rust import rust_preprocess_images
+
+        input_text = text[0] if isinstance(text, list) else text
+        resize_configs, image_sizes = self._resize_configs_and_sizes(images)
+
+        preprocessed = rust_preprocess_images(
+            images,
+            resize_configs,
+            patch_size=self._patch_size,
+            image_mean=self._image_mean,
+            image_std=self._image_std,
+            transparent_bg_config=self._transparent_bg_config,
+        )
+        if preprocessed is None:
+            return None
+        pixel_values, grid_thws = preprocessed
+
+        return {
+            "input_ids": self._prepare_input_ids(
+                input_text, resize_configs, original_input_ids, image_sizes
+            ),
+            "pixel_values": pixel_values,
+            "image_grid_thw": grid_thws,
+        }
+
+    def _gpu_call(self, text, images, original_input_ids=None):
+        input_text = text[0] if isinstance(text, list) else text
+        resize_configs, image_sizes = self._resize_configs_and_sizes(images)
 
         input_ids = self._prepare_input_ids(
             input_text, resize_configs, original_input_ids, image_sizes
@@ -296,7 +336,10 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
 
 class KimiK3ImageProcessor(KimiGridMMDataMixin, SGLangBaseProcessor):
     models = [KimiK3ForConditionalGeneration]
-    gpu_image_decode = True
+    # The Rust pipeline consumes decoded PIL images, so nvJPEG CUDA decode is
+    # incompatible with it (class attribute: read once at import, after the
+    # launch environment is set).
+    gpu_image_decode = not envs.SGLANG_KIMI_K3_RS_MM_PREPROCESS.get()
     prefer_tokenized_input = True
     precompute_hash_before_cpu_transfer = True
     auto_mm_processor_worker_num = 2

--- a/rust/sglang-mm/src/common/resize.rs
+++ b/rust/sglang-mm/src/common/resize.rs
@@ -165,46 +165,52 @@ fn clip8(v: i32, prec: u32) -> u8 {
     }
 }
 
-fn resample_horizontal(src: &[u8], h: usize, w: usize, out_w: usize, c: &Coeffs) -> Vec<u8> {
-    let mut out = vec![0u8; h * out_w * 3];
-    par::for_chunks_mut(&mut out, out_w * 3, |y, row| {
-        let src_row = &src[y * w * 3..(y + 1) * w * 3];
+fn resample_horizontal<const C: usize>(
+    src: &[u8],
+    h: usize,
+    w: usize,
+    out_w: usize,
+    c: &Coeffs,
+) -> Vec<u8> {
+    let mut out = vec![0u8; h * out_w * C];
+    par::for_chunks_mut(&mut out, out_w * C, |y, row| {
+        let src_row = &src[y * w * C..(y + 1) * w * C];
         for xx in 0..out_w {
             let (xmin, count) = c.bounds[xx];
             let k = &c.kk[xx * c.ksize..xx * c.ksize + count];
-            let mut s = [1i32 << (c.prec - 1); 3];
+            let mut s = [1i32 << (c.prec - 1); C];
             for (x, &coef) in k.iter().enumerate() {
-                let p = (xmin + x) * 3;
-                s[0] += src_row[p] as i32 * coef;
-                s[1] += src_row[p + 1] as i32 * coef;
-                s[2] += src_row[p + 2] as i32 * coef;
+                let p = (xmin + x) * C;
+                for ch in 0..C {
+                    s[ch] += src_row[p + ch] as i32 * coef;
+                }
             }
-            let o = xx * 3;
-            row[o] = clip8(s[0], c.prec);
-            row[o + 1] = clip8(s[1], c.prec);
-            row[o + 2] = clip8(s[2], c.prec);
+            let o = xx * C;
+            for ch in 0..C {
+                row[o + ch] = clip8(s[ch], c.prec);
+            }
         }
     });
     out
 }
 
-fn resample_vertical(src: &[u8], w: usize, out_h: usize, c: &Coeffs) -> Vec<u8> {
-    let mut out = vec![0u8; out_h * w * 3];
-    par::for_chunks_mut(&mut out, w * 3, |yy, row| {
+fn resample_vertical<const C: usize>(src: &[u8], w: usize, out_h: usize, c: &Coeffs) -> Vec<u8> {
+    let mut out = vec![0u8; out_h * w * C];
+    par::for_chunks_mut(&mut out, w * C, |yy, row| {
         let (ymin, count) = c.bounds[yy];
         let k = &c.kk[yy * c.ksize..yy * c.ksize + count];
         for x in 0..w {
-            let mut s = [1i32 << (c.prec - 1); 3];
+            let mut s = [1i32 << (c.prec - 1); C];
             for (y, &coef) in k.iter().enumerate() {
-                let p = ((ymin + y) * w + x) * 3;
-                s[0] += src[p] as i32 * coef;
-                s[1] += src[p + 1] as i32 * coef;
-                s[2] += src[p + 2] as i32 * coef;
+                let p = ((ymin + y) * w + x) * C;
+                for ch in 0..C {
+                    s[ch] += src[p + ch] as i32 * coef;
+                }
             }
-            let o = x * 3;
-            row[o] = clip8(s[0], c.prec);
-            row[o + 1] = clip8(s[1], c.prec);
-            row[o + 2] = clip8(s[2], c.prec);
+            let o = x * C;
+            for ch in 0..C {
+                row[o + ch] = clip8(s[ch], c.prec);
+            }
         }
     });
     out
@@ -222,10 +228,24 @@ pub fn resize_rgb(
     out_w: usize,
     resample: Resample,
 ) -> Vec<u8> {
-    par::in_pool(move || resize_passes(src, h, w, out_h, out_w, resample))
+    par::in_pool(move || resize_passes::<3>(src, h, w, out_h, out_w, resample))
 }
 
-fn resize_passes(
+/// [`resize_rgb`] for a flat HWC RGBA buffer. PIL resamples the alpha channel
+/// with the same kernel as the color channels (no premultiplication), so the
+/// four channels share one code path.
+pub fn resize_rgba(
+    src: &[u8],
+    h: usize,
+    w: usize,
+    out_h: usize,
+    out_w: usize,
+    resample: Resample,
+) -> Vec<u8> {
+    par::in_pool(move || resize_passes::<4>(src, h, w, out_h, out_w, resample))
+}
+
+fn resize_passes<const C: usize>(
     src: &[u8],
     h: usize,
     w: usize,
@@ -237,11 +257,11 @@ fn resize_passes(
     let coeffs = |in_size, out_size| precompute_coeffs(in_size, out_size, resample);
     match (out_w != w, out_h != h) {
         (true, true) => {
-            let tmp = resample_horizontal(src, h, w, out_w, &coeffs(w, out_w));
-            resample_vertical(&tmp, out_w, out_h, &coeffs(h, out_h))
+            let tmp = resample_horizontal::<C>(src, h, w, out_w, &coeffs(w, out_w));
+            resample_vertical::<C>(&tmp, out_w, out_h, &coeffs(h, out_h))
         }
-        (true, false) => resample_horizontal(src, h, w, out_w, &coeffs(w, out_w)),
-        (false, true) => resample_vertical(src, w, out_h, &coeffs(h, out_h)),
+        (true, false) => resample_horizontal::<C>(src, h, w, out_w, &coeffs(w, out_w)),
+        (false, true) => resample_vertical::<C>(src, w, out_h, &coeffs(h, out_h)),
         (false, false) => src.to_vec(),
     }
 }

--- a/rust/sglang-mm/src/kimi_k3/mod.rs
+++ b/rust/sglang-mm/src/kimi_k3/mod.rs
@@ -1,0 +1,331 @@
+//! Kimi-K3 image preprocessing, bit-exact against the checkpoint's PIL/numpy
+//! reference (`kimi_k3_vision_processing.py` + `media_utils.py` with
+//! `transparent_bg_fill_stage == "after_resize"`):
+//!
+//! 1. PIL `Image.resize(..., BICUBIC)` in the image's own mode — RGBA keeps
+//!    its alpha through the resize.
+//! 2. `fill_transparent_bg_with`: composite the resized RGBA onto the
+//!    configured background in f32, truncating back to u8 like
+//!    `np.ndarray.astype(np.uint8)`.
+//! 3. Zero-pad bottom/right so both sides divide the patch size.
+//! 4. `normalize`: `(x / 255.0).astype(f32); x -= mean; x *= 1/std` — numpy
+//!    computes the in-place ops through f64 and casts back, reproduced here in
+//!    a per-channel 256-entry LUT.
+//! 5. `navit_patchify`: reshape to `(n_patches, 3, ps, ps)` f32, C-order.
+//!
+//! Sizing (`navit_resize_config`) and prompt handling stay in Python; this
+//! module turns one decoded u8 image into the model-ready patch buffer.
+
+use crate::common::par;
+use crate::common::resize::{self, Filter, Resample};
+
+/// `media_utils.TransparentBgConfig` — what to composite RGBA images onto.
+#[derive(Clone, Copy, Debug)]
+pub enum Background {
+    White,
+    Black,
+    Gray,
+    Chessboard {
+        square_size: usize,
+        /// Historical name: `True` keeps the *white* square at the top-left.
+        square_on_top_left: bool,
+        white_value: u8,
+        gray_value: u8,
+    },
+}
+
+impl Background {
+    fn value_at(&self, y: usize, x: usize) -> u8 {
+        match *self {
+            Background::White => 255,
+            Background::Black => 0,
+            Background::Gray => 128,
+            Background::Chessboard {
+                square_size,
+                square_on_top_left,
+                white_value,
+                gray_value,
+            } => {
+                let gray_parity = usize::from(square_on_top_left);
+                if (y / square_size + x / square_size) % 2 == gray_parity {
+                    gray_value
+                } else {
+                    white_value
+                }
+            }
+        }
+    }
+}
+
+/// Composite a flat HWC RGBA buffer onto `bg`, reproducing
+/// `fill_transparent_bg_with`'s numpy math exactly: f32 alpha blend, then
+/// `astype(np.uint8)` truncation. `bg == None` reproduces `Image.convert("RGB")`
+/// on an RGBA image, which simply drops the alpha channel.
+pub fn composite_rgba(rgba: &[u8], h: usize, w: usize, bg: Option<Background>) -> Vec<u8> {
+    let mut out = vec![0u8; h * w * 3];
+    par::for_chunks_mut(&mut out, w * 3, |y, row| {
+        for x in 0..w {
+            let p = (y * w + x) * 4;
+            let o = x * 3;
+            match bg {
+                None => row[o..o + 3].copy_from_slice(&rgba[p..p + 3]),
+                Some(bg) => {
+                    let alpha = rgba[p + 3] as f32 / 255.0;
+                    let bg_v = bg.value_at(y, x) as f32;
+                    for ch in 0..3 {
+                        let v = alpha * rgba[p + ch] as f32 + (1.0 - alpha) * bg_v;
+                        row[o + ch] = v as u8;
+                    }
+                }
+            }
+        }
+    });
+    out
+}
+
+/// Per-channel u8 -> normalized-f32 table reproducing `media_utils.normalize`:
+/// `(x / 255.0).astype(np.float32)` then in-place `-= mean`, `*= 1/std` (numpy
+/// runs the f32 (x) f64-scalar in-place ops through f64 and casts back).
+fn norm_lut(mean: f64, std: f64) -> [f32; 256] {
+    let std_inv = 1.0 / std;
+    core::array::from_fn(|v| {
+        let a = (v as f64 / 255.0) as f32;
+        let b = ((a as f64) - mean) as f32;
+        ((b as f64) * std_inv) as f32
+    })
+}
+
+pub struct PreprocessOutput {
+    /// `(n_patches, 3, ps, ps)` f32, C-order, flattened.
+    pub patches: Vec<f32>,
+    /// `grid_thw = (1, padded_h / ps, padded_w / ps)`.
+    pub grid_thw: [i64; 3],
+}
+
+/// The full post-decode Kimi-K3 image pipeline (steps 1-5 above) for one
+/// decoded u8 image of `channels` 3 (RGB) or 4 (RGBA, composited onto `bg`
+/// after the resize).
+#[allow(clippy::too_many_arguments)]
+pub fn preprocess_image(
+    src: &[u8],
+    h: usize,
+    w: usize,
+    channels: usize,
+    new_w: usize,
+    new_h: usize,
+    pad_w: usize,
+    pad_h: usize,
+    patch_size: usize,
+    mean: [f64; 3],
+    std: [f64; 3],
+    bg: Option<Background>,
+) -> Result<PreprocessOutput, String> {
+    if src.len() != h * w * channels {
+        return Err(format!(
+            "source buffer holds {} bytes, expected {h}x{w}x{channels}",
+            src.len()
+        ));
+    }
+    if new_w == 0 || new_h == 0 || patch_size == 0 {
+        return Err("resized dims and patch size must be positive".into());
+    }
+    let (out_h, out_w) = (new_h + pad_h, new_w + pad_w);
+    if out_h % patch_size != 0 || out_w % patch_size != 0 {
+        return Err(format!(
+            "padded dims {out_h}x{out_w} not divisible by patch size {patch_size}"
+        ));
+    }
+
+    par::in_pool(move || {
+        let bicubic = Resample::Pil(Filter::Bicubic);
+        let rgb = match channels {
+            3 => resize::resize_rgb(src, h, w, new_h, new_w, bicubic),
+            4 => {
+                let rgba = resize::resize_rgba(src, h, w, new_h, new_w, bicubic);
+                composite_rgba(&rgba, new_h, new_w, bg)
+            }
+            other => return Err(format!("expected 3 or 4 channels, got {other}")),
+        };
+
+        let luts: [[f32; 256]; 3] = core::array::from_fn(|c| norm_lut(mean[c], std[c]));
+        let (nph, npw) = (out_h / patch_size, out_w / patch_size);
+        let patch_elems = 3 * patch_size * patch_size;
+        let mut patches = vec![0f32; nph * npw * patch_elems];
+        // One chunk per patch row: patches land in row-major (i * npw + j)
+        // order, matching navit_patchify's reshape/transpose.
+        par::for_chunks_mut(&mut patches, npw * patch_elems, |i, row| {
+            for j in 0..npw {
+                let patch = &mut row[j * patch_elems..(j + 1) * patch_elems];
+                for (ch, lut) in luts.iter().enumerate() {
+                    for py in 0..patch_size {
+                        let y = i * patch_size + py;
+                        for px in 0..patch_size {
+                            let x = j * patch_size + px;
+                            let v = if y < new_h && x < new_w {
+                                rgb[(y * new_w + x) * 3 + ch]
+                            } else {
+                                0 // np.pad zeros run through the same normalize
+                            };
+                            patch[(ch * patch_size + py) * patch_size + px] = lut[v as usize];
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(PreprocessOutput {
+            patches,
+            grid_thw: [1, nph as i64, npw as i64],
+        })
+    })
+}
+
+// --- Python bindings (feature-gated: absent from the pure-Rust rlib) ---
+
+#[cfg(feature = "python")]
+mod python {
+    use numpy::{IntoPyArray, PyArray1, PyReadonlyArray3, PyUntypedArrayMethods};
+    use pyo3::exceptions::PyValueError;
+    use pyo3::prelude::*;
+
+    use super::{Background, composite_rgba, preprocess_image};
+    use crate::common::resize::{self, Filter, Resample};
+
+    /// `(pattern, square_size, square_on_top_left, white_value, gray_value)`
+    /// mirroring `TransparentBgConfig`; only chessboard reads the last four.
+    type PyBg = (String, usize, bool, u8, u8);
+
+    fn parse_bg(bg: Option<PyBg>) -> PyResult<Option<Background>> {
+        let Some((pattern, square_size, square_on_top_left, white_value, gray_value)) = bg else {
+            return Ok(None);
+        };
+        Ok(Some(match pattern.as_str() {
+            "white" => Background::White,
+            "black" => Background::Black,
+            "gray" => Background::Gray,
+            "chessboard" => {
+                if square_size == 0 {
+                    return Err(PyValueError::new_err("chessboard square size must be > 0"));
+                }
+                Background::Chessboard {
+                    square_size,
+                    square_on_top_left,
+                    white_value,
+                    gray_value,
+                }
+            }
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "invalid background pattern {other:?}"
+                )));
+            }
+        }))
+    }
+
+    fn contiguous(arr: &PyReadonlyArray3<'_, u8>) -> PyResult<(Vec<u8>, usize, usize, usize)> {
+        let shape = arr.shape();
+        let (h, w, c) = (shape[0], shape[1], shape[2]);
+        let data = arr
+            .as_slice()
+            .map_err(|_| PyValueError::new_err("array must be C-contiguous"))?
+            .to_vec();
+        Ok((data, h, w, c))
+    }
+
+    /// PIL-bit-exact `Image.resize(..., BICUBIC)` of an HWC u8 array with 3
+    /// (RGB) or 4 (RGBA) channels. Exposed for the stage-parity tests.
+    #[pyfunction]
+    pub fn resize_bicubic<'py>(
+        py: Python<'py>,
+        arr: PyReadonlyArray3<'py, u8>,
+        out_w: usize,
+        out_h: usize,
+    ) -> PyResult<Bound<'py, PyArray1<u8>>> {
+        if out_w == 0 || out_h == 0 {
+            return Err(PyValueError::new_err("output size must be positive"));
+        }
+        let (data, h, w, c) = contiguous(&arr)?;
+        let bicubic = Resample::Pil(Filter::Bicubic);
+        let out = py.detach(move || match c {
+            3 => Ok(resize::resize_rgb(&data, h, w, out_h, out_w, bicubic)),
+            4 => Ok(resize::resize_rgba(&data, h, w, out_h, out_w, bicubic)),
+            other => Err(format!("expected 3 or 4 channels, got {other}")),
+        });
+        Ok(out.map_err(PyValueError::new_err)?.into_pyarray(py))
+    }
+
+    /// `fill_transparent_bg_with` on an HWC RGBA u8 array. Exposed for the
+    /// stage-parity tests.
+    #[pyfunction]
+    #[pyo3(signature = (arr, bg=None))]
+    pub fn fill_transparent_bg<'py>(
+        py: Python<'py>,
+        arr: PyReadonlyArray3<'py, u8>,
+        bg: Option<PyBg>,
+    ) -> PyResult<Bound<'py, PyArray1<u8>>> {
+        let bg = parse_bg(bg)?;
+        let (data, h, w, c) = contiguous(&arr)?;
+        if c != 4 {
+            return Err(PyValueError::new_err(format!(
+                "expected HWC RGBA array with 4 channels, got {c}"
+            )));
+        }
+        Ok(py
+            .detach(move || composite_rgba(&data, h, w, bg))
+            .into_pyarray(py))
+    }
+
+    /// The full post-decode pipeline for one image; returns the flattened
+    /// `(n_patches, 3, patch_size, patch_size)` f32 buffer and its
+    /// `(t, h, w)` grid.
+    #[pyfunction]
+    #[pyo3(signature = (arr, new_w, new_h, pad_w, pad_h, patch_size, mean, std, bg=None))]
+    #[allow(clippy::too_many_arguments)]
+    pub fn preprocess<'py>(
+        py: Python<'py>,
+        arr: PyReadonlyArray3<'py, u8>,
+        new_w: usize,
+        new_h: usize,
+        pad_w: usize,
+        pad_h: usize,
+        patch_size: usize,
+        mean: (f64, f64, f64),
+        std: (f64, f64, f64),
+        bg: Option<PyBg>,
+    ) -> PyResult<(Bound<'py, PyArray1<f32>>, (i64, i64, i64))> {
+        let bg = parse_bg(bg)?;
+        let (data, h, w, c) = contiguous(&arr)?;
+        let out = py
+            .detach(move || {
+                preprocess_image(
+                    &data,
+                    h,
+                    w,
+                    c,
+                    new_w,
+                    new_h,
+                    pad_w,
+                    pad_h,
+                    patch_size,
+                    [mean.0, mean.1, mean.2],
+                    [std.0, std.1, std.2],
+                    bg,
+                )
+            })
+            .map_err(PyValueError::new_err)?;
+        let [t, gh, gw] = out.grid_thw;
+        Ok((out.patches.into_pyarray(py), (t, gh, gw)))
+    }
+
+    pub fn register(parent: &Bound<'_, PyModule>) -> PyResult<()> {
+        let m = PyModule::new(parent.py(), "kimi_k3")?;
+        m.add_function(wrap_pyfunction!(resize_bicubic, &m)?)?;
+        m.add_function(wrap_pyfunction!(fill_transparent_bg, &m)?)?;
+        m.add_function(wrap_pyfunction!(preprocess, &m)?)?;
+        parent.add_submodule(&m)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "python")]
+pub use python::register;

--- a/rust/sglang-mm/src/kimi_k3/mod.rs
+++ b/rust/sglang-mm/src/kimi_k3/mod.rs
@@ -1,20 +1,9 @@
 //! Kimi-K3 image preprocessing, bit-exact against the checkpoint's PIL/numpy
-//! reference (`kimi_k3_vision_processing.py` + `media_utils.py` with
-//! `transparent_bg_fill_stage == "after_resize"`):
-//!
-//! 1. PIL `Image.resize(..., BICUBIC)` in the image's own mode — RGBA keeps
-//!    its alpha through the resize.
-//! 2. `fill_transparent_bg_with`: composite the resized RGBA onto the
-//!    configured background in f32, truncating back to u8 like
-//!    `np.ndarray.astype(np.uint8)`.
-//! 3. Zero-pad bottom/right so both sides divide the patch size.
-//! 4. `normalize`: `(x / 255.0).astype(f32); x -= mean; x *= 1/std` — numpy
-//!    computes the in-place ops through f64 and casts back, reproduced here in
-//!    a per-channel 256-entry LUT.
-//! 5. `navit_patchify`: reshape to `(n_patches, 3, ps, ps)` f32, C-order.
-//!
-//! Sizing (`navit_resize_config`) and prompt handling stay in Python; this
-//! module turns one decoded u8 image into the model-ready patch buffer.
+//! reference (`kimi_k3_vision_processing.py`, fill stage `"after_resize"`):
+//! PIL BICUBIC resize (RGBA keeps alpha) -> f32 background composite with
+//! `astype(u8)` truncation -> zero-pad -> normalize (numpy's f64-through
+//! in-place ops, as per-channel LUTs) -> NaViT patchify to
+//! `(n_patches, 3, ps, ps)` f32. Sizing and prompt handling stay in Python.
 
 use crate::common::par;
 use crate::common::resize::{self, Filter, Resample};
@@ -57,10 +46,9 @@ impl Background {
     }
 }
 
-/// Composite a flat HWC RGBA buffer onto `bg`, reproducing
-/// `fill_transparent_bg_with`'s numpy math exactly: f32 alpha blend, then
-/// `astype(np.uint8)` truncation. `bg == None` reproduces `Image.convert("RGB")`
-/// on an RGBA image, which simply drops the alpha channel.
+/// Composite a flat HWC RGBA buffer onto `bg`: f32 alpha blend, then
+/// `astype(np.uint8)` truncation. `bg == None` = `Image.convert("RGB")`,
+/// which just drops the alpha channel.
 pub fn composite_rgba(rgba: &[u8], h: usize, w: usize, bg: Option<Background>) -> Vec<u8> {
     let mut out = vec![0u8; h * w * 3];
     par::for_chunks_mut(&mut out, w * 3, |y, row| {
@@ -83,9 +71,8 @@ pub fn composite_rgba(rgba: &[u8], h: usize, w: usize, bg: Option<Background>) -
     out
 }
 
-/// Per-channel u8 -> normalized-f32 table reproducing `media_utils.normalize`:
-/// `(x / 255.0).astype(np.float32)` then in-place `-= mean`, `*= 1/std` (numpy
-/// runs the f32 (x) f64-scalar in-place ops through f64 and casts back).
+/// u8 -> normalized f32 table for `media_utils.normalize`: numpy runs the
+/// in-place f32 (x) f64-scalar ops through f64 and casts back each step.
 fn norm_lut(mean: f64, std: f64) -> [f32; 256] {
     let std_inv = 1.0 / std;
     core::array::from_fn(|v| {
@@ -102,9 +89,8 @@ pub struct PreprocessOutput {
     pub grid_thw: [i64; 3],
 }
 
-/// The full post-decode Kimi-K3 image pipeline (steps 1-5 above) for one
-/// decoded u8 image of `channels` 3 (RGB) or 4 (RGBA, composited onto `bg`
-/// after the resize).
+/// The full post-decode pipeline for one u8 image of `channels` 3 (RGB) or
+/// 4 (RGBA, composited onto `bg` after the resize).
 #[allow(clippy::too_many_arguments)]
 pub fn preprocess_image(
     src: &[u8],
@@ -194,6 +180,9 @@ mod python {
     /// `(pattern, square_size, square_on_top_left, white_value, gray_value)`
     /// mirroring `TransparentBgConfig`; only chessboard reads the last four.
     type PyBg = (String, usize, bool, u8, u8);
+
+    /// Flattened patch buffer plus its `(t, h, w)` grid.
+    type PyPatches<'py> = (Bound<'py, PyArray1<f32>>, (i64, i64, i64));
 
     fn parse_bg(bg: Option<PyBg>) -> PyResult<Option<Background>> {
         let Some((pattern, square_size, square_on_top_left, white_value, gray_value)) = bg else {
@@ -292,7 +281,7 @@ mod python {
         mean: (f64, f64, f64),
         std: (f64, f64, f64),
         bg: Option<PyBg>,
-    ) -> PyResult<(Bound<'py, PyArray1<f32>>, (i64, i64, i64))> {
+    ) -> PyResult<PyPatches<'py>> {
         let bg = parse_bg(bg)?;
         let (data, h, w, c) = contiguous(&arr)?;
         let out = py

--- a/rust/sglang-mm/src/lib.rs
+++ b/rust/sglang-mm/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod common;
 pub mod driver;
 pub mod inkling;
+pub mod kimi_k3;
 pub mod pipeline;
 pub mod qwen_vl;
 pub mod registry;
@@ -21,6 +22,7 @@ use pyo3::prelude::*;
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     common::register(m)?;
     inkling::register(m)?;
+    kimi_k3::register(m)?;
     qwen_vl::register(m)?;
     Ok(())
 }

--- a/rust/sglang-mm/tests/test_kimi_k3_parity.py
+++ b/rust/sglang-mm/tests/test_kimi_k3_parity.py
@@ -1,0 +1,279 @@
+"""Bit-exact parity: Rust Kimi-K3 preprocessing vs the checkpoint's PIL path.
+
+The PIL reference below is a line-for-line transcription of the checkpoint's
+``media_utils.py`` / ``kimi_k3_vision_processing.py`` (fill stage
+``"after_resize"``), so every assertion pins the Rust pipeline to the exact
+numpy/PIL semantics the ``SGLANG_USE_PIL_MM_PREPROCESS`` path executes:
+
+* load       — ``to_effective_array`` vs the mode PIL hands the reference,
+* resize     — ``resize_bicubic`` vs ``Image.resize(..., BICUBIC)`` per mode,
+* composite  — ``fill_transparent_bg`` vs ``fill_transparent_bg_with``,
+* end-to-end — ``preprocess`` vs resize+composite+pad+normalize+patchify,
+  compared with ``assert_array_equal`` on the f32 tensors (no tolerance).
+"""
+
+import io
+import math
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from sglang.srt.multimodal._core import kimi_k3 as _rs
+from sglang.srt.multimodal.kimi_k3_rust import (
+    bg_tuple,
+    rust_preprocess_images,
+    to_effective_array,
+)
+
+# The K3 checkpoint's preprocessor_config.json values.
+PATCH_SIZE = 14
+MERGE_KERNEL_SIZE = 2
+IN_PATCH_LIMIT = 65536
+PATCH_LIMIT_ON_ONE_SIDE = 512
+MEAN = (0.5, 0.5, 0.5)
+STD = (0.5, 0.5, 0.5)
+BG_CFG = {
+    "pattern": "chessboard",
+    "chessboard_square_size": 8,
+    "chessboard_square_on_top_left": True,
+    "chessboard_white_value": 255,
+    "chessboard_gray_value": 180,
+}
+
+
+# --- PIL reference: transcribed from the checkpoint's media_utils.py ---------
+
+
+def ref_chessboard(height, width, square, on_top_left, white, gray):
+    bg = np.ones((height, width, 3), dtype=np.uint8) * white
+    for y in range(0, height, square):
+        for x in range(0, width, square):
+            if (y // square + x // square) % 2 == (1 if on_top_left else 0):
+                bg[y : y + square, x : x + square] = gray
+    return bg
+
+
+def ref_fill_transparent_bg(image: Image.Image, bg_cfg) -> Image.Image:
+    if bg_cfg is None:
+        return image.convert("RGB")
+    if image.mode == "RGB":
+        return image
+    if not ("A" in image.getbands() or "transparency" in image.info):
+        return image.convert("RGB")
+    img = np.array(image.convert("RGBA"))
+    height, width = img.shape[:2]
+    pattern = bg_cfg["pattern"]
+    if pattern == "white":
+        bg = np.full((height, width, 3), 255, dtype=np.uint8)
+    elif pattern == "black":
+        bg = np.zeros((height, width, 3), dtype=np.uint8)
+    elif pattern == "gray":
+        bg = np.full((height, width, 3), 128, dtype=np.uint8)
+    else:
+        bg = ref_chessboard(
+            height,
+            width,
+            bg_cfg["chessboard_square_size"],
+            bg_cfg["chessboard_square_on_top_left"],
+            bg_cfg["chessboard_white_value"],
+            bg_cfg["chessboard_gray_value"],
+        )
+    alpha = img[:, :, 3].astype(np.float32) / 255.0
+    alpha_3d = np.stack([alpha] * 3, axis=2)
+    result = alpha_3d * img[:, :, :3] + (1 - alpha_3d) * bg
+    return Image.fromarray(result.astype(np.uint8))
+
+
+def ref_navit_resize(width, height):
+    s1 = math.sqrt(
+        IN_PATCH_LIMIT
+        / (max(1.0, width // PATCH_SIZE) * max(1.0, height // PATCH_SIZE))
+    )
+    s2 = PATCH_LIMIT_ON_ONE_SIDE * PATCH_SIZE / width
+    s3 = PATCH_LIMIT_ON_ONE_SIDE * PATCH_SIZE / height
+    scale = min(1.0, s1, s2, s3)
+    new_w = min(max(1, int(width * scale)), PATCH_LIMIT_ON_ONE_SIDE * PATCH_SIZE)
+    new_h = min(max(1, int(height * scale)), PATCH_LIMIT_ON_ONE_SIDE * PATCH_SIZE)
+    factor = MERGE_KERNEL_SIZE * PATCH_SIZE
+    return {
+        "new_width": new_w,
+        "new_height": new_h,
+        "pad_width": (factor - new_w % factor) % factor,
+        "pad_height": (factor - new_h % factor) % factor,
+    }
+
+
+def ref_preprocess(image: Image.Image, cfg, bg_cfg):
+    """resize (original mode) -> composite -> pad -> normalize -> patchify."""
+    resized = image.resize(
+        (cfg["new_width"], cfg["new_height"]), resample=Image.Resampling.BICUBIC
+    )
+    arr = np.asarray(ref_fill_transparent_bg(resized, bg_cfg))
+    arr = np.pad(
+        arr,
+        ((0, cfg["pad_height"]), (0, cfg["pad_width"]), (0, 0)),
+        mode="constant",
+        constant_values=0,
+    )
+    x = (arr / 255.0).astype(np.float32)
+    x -= np.array(MEAN)
+    x *= 1.0 / np.array(STD)
+    h, w, c = x.shape
+    patches = x.reshape(1, h // PATCH_SIZE, PATCH_SIZE, w // PATCH_SIZE, PATCH_SIZE, c)
+    patches = patches.transpose(0, 1, 3, 5, 2, 4).reshape(-1, c, PATCH_SIZE, PATCH_SIZE)
+    return patches, np.array([1, h // PATCH_SIZE, w // PATCH_SIZE], dtype=np.int64)
+
+
+# --- fixtures ----------------------------------------------------------------
+
+
+def _rng(seed):
+    return np.random.RandomState(seed)
+
+
+def gradient_rgba(w, h, seed=0):
+    arr = _rng(seed).randint(0, 256, (h, w, 4), dtype=np.uint8)
+    # Sweep the full alpha range so the composite exercises every blend value.
+    arr[:, :, 3] = np.linspace(0, 255, h * w, dtype=np.uint8).reshape(h, w)
+    return Image.fromarray(arr, "RGBA")
+
+
+def noise_rgb(w, h, seed=1):
+    return Image.fromarray(_rng(seed).randint(0, 256, (h, w, 3), dtype=np.uint8), "RGB")
+
+
+def jpeg_roundtrip(image: Image.Image) -> Image.Image:
+    buf = io.BytesIO()
+    image.save(buf, format="JPEG", quality=85)
+    return Image.open(io.BytesIO(buf.getvalue()))
+
+
+IMAGES = {
+    "rgb_noise": noise_rgb(640, 480),
+    "rgb_jpeg": jpeg_roundtrip(noise_rgb(1023, 767, seed=2)),
+    "rgb_tiny": noise_rgb(3, 5, seed=3),
+    "rgb_huge_downscale": noise_rgb(9000, 4000, seed=4),  # trips the patch limits
+    "rgba_gradient": gradient_rgba(400, 300),
+    "rgba_odd": gradient_rgba(37, 53, seed=5),
+    "la": Image.fromarray(
+        _rng(6).randint(0, 256, (120, 80, 2), dtype=np.uint8), "LA"
+    ),
+    "l": Image.fromarray(_rng(7).randint(0, 256, (90, 70), dtype=np.uint8), "L"),
+}
+
+
+# --- stage parity ------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", sorted(IMAGES))
+def test_load_matches_reference_mode(name):
+    """`to_effective_array` must hand Rust exactly the pixels PIL would
+    resize: RGB stays put, alpha modes canonicalize to RGBA, L to RGB."""
+    image = IMAGES[name]
+    arr = to_effective_array(image)
+    assert arr is not None
+    if image.mode in ("RGBA", "LA"):
+        np.testing.assert_array_equal(arr, np.asarray(image.convert("RGBA")))
+    elif image.mode == "L":
+        np.testing.assert_array_equal(arr, np.asarray(image.convert("RGB")))
+    else:
+        np.testing.assert_array_equal(arr, np.asarray(image))
+
+
+def test_load_rejects_out_of_scope_modes():
+    """Palette images resize with NEAREST in PIL — no equivalent array exists,
+    so they must report None (PIL fallback) instead of silently diverging."""
+    palette = noise_rgb(32, 32, seed=8).convert("P")
+    assert to_effective_array(palette) is None
+    assert to_effective_array(noise_rgb(8, 8, seed=9).convert("CMYK")) is None
+    assert to_effective_array(np.zeros((4, 4, 3), dtype=np.uint8)) is None
+
+
+@pytest.mark.parametrize("name", sorted(IMAGES))
+def test_resize_bit_exact(name):
+    image = IMAGES[name]
+    arr = to_effective_array(image)
+    cfg = ref_navit_resize(*image.size)
+    tw, th = cfg["new_width"], cfg["new_height"]
+
+    got = _rs.resize_bicubic(arr, tw, th).reshape(th, tw, -1)
+    # The reference resizes in the image's own mode; the canonicalization is
+    # per-channel so the converted-mode resize must equal it exactly.
+    ref_mode = image.resize((tw, th), resample=Image.Resampling.BICUBIC)
+    if arr.shape[2] == 4:
+        ref = np.asarray(ref_mode.convert("RGBA"))
+    else:
+        ref = np.asarray(ref_mode.convert("RGB"))
+    np.testing.assert_array_equal(got, ref)
+
+
+@pytest.mark.parametrize("pattern", ["chessboard", "white", "black", "gray", None])
+def test_composite_bit_exact(pattern):
+    bg_cfg = None if pattern is None else {**BG_CFG, "pattern": pattern}
+    rgba = np.asarray(gradient_rgba(101, 67, seed=10))
+    got = _rs.fill_transparent_bg(rgba, bg_tuple(bg_cfg)).reshape(67, 101, 3)
+    ref = np.asarray(ref_fill_transparent_bg(Image.fromarray(rgba, "RGBA"), bg_cfg))
+    np.testing.assert_array_equal(got, ref)
+
+
+@pytest.mark.parametrize("name", sorted(IMAGES))
+def test_end_to_end_bit_exact(name):
+    """The full pipeline output — the tensors handed to the scheduler — must
+    equal the PIL reference bit for bit, f32 with zero tolerance."""
+    image = IMAGES[name]
+    cfg = ref_navit_resize(*image.size)
+
+    out = rust_preprocess_images(
+        [image],
+        [cfg],
+        patch_size=PATCH_SIZE,
+        image_mean=MEAN,
+        image_std=STD,
+        transparent_bg_config=BG_CFG,
+    )
+    assert out is not None
+    pixel_values, grid_thws = out
+
+    ref_patches, ref_grid = ref_preprocess(image, cfg, BG_CFG)
+    np.testing.assert_array_equal(grid_thws[0].numpy(), ref_grid)
+    assert pixel_values.numpy().dtype == np.float32
+    np.testing.assert_array_equal(pixel_values.numpy(), ref_patches)
+
+
+def test_multi_image_request_concatenates_like_reference():
+    images = [IMAGES["rgb_noise"], IMAGES["rgba_gradient"], IMAGES["l"]]
+    cfgs = [ref_navit_resize(*im.size) for im in images]
+    out = rust_preprocess_images(
+        images,
+        cfgs,
+        patch_size=PATCH_SIZE,
+        image_mean=MEAN,
+        image_std=STD,
+        transparent_bg_config=BG_CFG,
+    )
+    assert out is not None
+    pixel_values, grid_thws = out
+    refs = [ref_preprocess(im, cfg, BG_CFG) for im, cfg in zip(images, cfgs)]
+    np.testing.assert_array_equal(
+        pixel_values.numpy(), np.concatenate([r[0] for r in refs])
+    )
+    np.testing.assert_array_equal(grid_thws.numpy(), np.stack([r[1] for r in refs]))
+
+
+def test_fallback_poisons_whole_request():
+    """One out-of-scope image sends the whole request to the PIL path — mixed
+    Rust/PIL requests would make per-image provenance untraceable."""
+    images = [IMAGES["rgb_noise"], noise_rgb(16, 16, seed=11).convert("P")]
+    cfgs = [ref_navit_resize(*im.size) for im in images]
+    assert (
+        rust_preprocess_images(
+            images,
+            cfgs,
+            patch_size=PATCH_SIZE,
+            image_mean=MEAN,
+            image_std=STD,
+            transparent_bg_config=BG_CFG,
+        )
+        is None
+    )

--- a/rust/sglang-mm/tests/test_kimi_k3_parity.py
+++ b/rust/sglang-mm/tests/test_kimi_k3_parity.py
@@ -1,15 +1,9 @@
 """Bit-exact parity: Rust Kimi-K3 preprocessing vs the checkpoint's PIL path.
 
-The PIL reference below is a line-for-line transcription of the checkpoint's
-``media_utils.py`` / ``kimi_k3_vision_processing.py`` (fill stage
-``"after_resize"``), so every assertion pins the Rust pipeline to the exact
-numpy/PIL semantics the ``SGLANG_USE_PIL_MM_PREPROCESS`` path executes:
-
-* load       — ``to_effective_array`` vs the mode PIL hands the reference,
-* resize     — ``resize_bicubic`` vs ``Image.resize(..., BICUBIC)`` per mode,
-* composite  — ``fill_transparent_bg`` vs ``fill_transparent_bg_with``,
-* end-to-end — ``preprocess`` vs resize+composite+pad+normalize+patchify,
-  compared with ``assert_array_equal`` on the f32 tensors (no tolerance).
+The reference below transcribes the checkpoint's ``media_utils.py`` (fill
+stage ``"after_resize"``). Each stage — load/mode canonicalization, resize,
+composite — and the end-to-end f32 tensors are compared with
+``assert_array_equal`` (no tolerance).
 """
 
 import io

--- a/rust/sglang-mm/tests/test_kimi_k3_parity.py
+++ b/rust/sglang-mm/tests/test_kimi_k3_parity.py
@@ -150,9 +150,7 @@ IMAGES = {
     "rgb_huge_downscale": noise_rgb(9000, 4000, seed=4),  # trips the patch limits
     "rgba_gradient": gradient_rgba(400, 300),
     "rgba_odd": gradient_rgba(37, 53, seed=5),
-    "la": Image.fromarray(
-        _rng(6).randint(0, 256, (120, 80, 2), dtype=np.uint8), "LA"
-    ),
+    "la": Image.fromarray(_rng(6).randint(0, 256, (120, 80, 2), dtype=np.uint8), "LA"),
     "l": Image.fromarray(_rng(7).randint(0, 256, (90, 70), dtype=np.uint8), "L"),
 }
 


### PR DESCRIPTION
## Motivation

Kimi-K3's CPU image preprocessing (the checkpoint's PIL path) is slow and single-threaded per request. This PR adds a Rust implementation in `sglang-mm`, used as a library from the Python tokenizer manager (same pattern as Inkling): resize → transparent-bg composite → normalize → NaViT patchify run GIL-free on the crate's rayon pool, **bit-exact** against the checkpoint's PIL/numpy reference.

## Modifications

- `rust/sglang-mm/src/kimi_k3/`: the pipeline, reproducing PIL bicubic (in the image's own mode — RGBA keeps alpha through the resize), the after-resize background composite with numpy's f32-blend + `astype(u8)` truncation, and numpy's f64-through normalize as per-channel LUTs. The shared resize core is generalized to const-generic channel count (3/4).
- `python/sglang/srt/multimodal/kimi_k3_rust.py`: thin wrapper; canonicalizes PIL modes only where that provably commutes with the resize (RGB/L/LA/RGBA). Palette/CMYK images fall back to the PIL path per request (PIL switches to NEAREST for palette modes — no bit-exact equivalent).
- `SGLANG_KIMI_K3_RS_MM_PREPROCESS=1` opts in (also disables nvJPEG decode for K3 — the pipeline consumes PIL images). `SGLANG_USE_PIL_MM_PREPROCESS=1` forces the PIL/CPU reference path on any Kimi model, for baselines.
- `rust/sglang-mm/tests/test_kimi_k3_parity.py`: 32 bit-exact parity cases against an inline transcription of the checkpoint's `media_utils.py` — per stage (load/mode canonicalization, resize, composite) and end-to-end f32 tensors with zero tolerance, over RGB/RGBA/JPEG/L/LA/tiny/9000×4000 inputs, multi-image concat, and fallback behavior.

Additionally verified against the real checkpoint `AutoProcessor` (not the transcription): 72,852 patches across 4 images — `pixel_values`, `image_grid_thw`, `input_ids` all `torch.equal` between the PIL and Rust paths. Existing consumers of the shared resize core are covered: the inkling golden suite, the three-resampler resize-parity suite, `cargo test` in both rlib and parallel configs, and a clean `cargo check -p sglang-server`.

## Accuracy Tests

Kimi-K3 TP8 on 8×B300, full benchmark sets, temperature 0, `--max-tokens 65536` (K3's thinking overruns smaller budgets):

| | GPU path (default) | PIL reference | Rust (this PR) |
|---|---|---|---|
| MMMU val (900) | 0.837 | 0.833 | 0.837 |
| OCRBench (1000) | 0.896 | 0.895 | 0.896 |

## Speed Tests and Profiling

Median per-image latency, 240-core host, idle B300 (GPU timings synchronized; Rust uses the crate's rayon pool, ≤8 threads).

Decode (JPEG q85 bytes → pixels):

| Input | PIL | nvJPEG |
|---|---|---|
| 640×480 | 1.6 ms | 0.5 ms |
| 1024×768 | 3.8 ms | 1.1 ms |
| 2048×1536 | 15.5 ms | 4.1 ms |
| 4000×3000 | 70.5 ms | 15.6 ms |

Post-decode preprocessing (decoded image → model tensors):

| Input | PIL | Rust | GPU (CUDA) |
|---|---|---|---|
| 640×480 RGB | 7.3 ms | 0.7 ms | 0.3 ms |
| 1024×768 RGB | 23.1 ms | 1.6 ms | 0.4 ms |
| 2048×1536 RGB | 76.5 ms | 10.2 ms | 2.0 ms |
| 4000×3000 RGB | 308.5 ms | 57.9 ms | 28.2 ms |
| 64 real MMMU images | 692 ms | 49 ms | 18 ms |

End-to-end JPEG bytes → tensors (2048×1536): PIL 95.1 ms, Rust 25.2 ms (PIL-decode-bound), nvJPEG+GPU 4.2 ms.

The GPU path stays fastest in isolation but spends GPU cycles that otherwise serve inference and needs CUDA in the preprocessing process; the Rust path is the fast **CPU** option (14–65× over PIL post-decode) for library-mode deployments and keeps the bit-exact-with-PIL contract. End-to-end OCRBench wall clock (1000 requests, 128 threads): 7:53 (PIL) → 7:03 (Rust). MMMU wall clock is decode-bound and unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->