### PR TITLE
[Bug] Bound deterministic FlashInfer CUDA-graph decode launches

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -17,7 +17,16 @@ import os
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import partial
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import torch
 
@@ -64,6 +73,97 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+
+_PlanInfoT = TypeVar("_PlanInfoT", bound=Sequence[int])
+
+# flashinfer-python==0.6.17 PrefillPlanInfo::ToVector() field positions.
+_FLASHINFER_PREFILL_PLAN_INFO_LENGTH = 15
+_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX = 0
+_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX = 1
+_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX = 3
+_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX = 13
+_FLASHINFER_PREFILL_SPLIT_KV_INDEX = 14
+
+
+def _narrow_deterministic_cuda_graph_decode_plan(
+    plan_info: _PlanInfoT,
+    *,
+    batch_size: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+) -> _PlanInfoT:
+    """Narrow FlashInfer's deterministic FA2 decode plan to initialized q tiles.
+
+    Tensor-core decode reuses ``PrefillPlanInfo``. With split-KV disabled, its
+    CUDA-graph padding has no validity mask, so only the initialized q-tile
+    entries may be launched.
+    """
+    if len(plan_info) != _FLASHINFER_PREFILL_PLAN_INFO_LENGTH:
+        raise RuntimeError(
+            "Unexpected FlashInfer FA2 plan ABI for deterministic CUDA-graph "
+            f"decode: expected {_FLASHINFER_PREFILL_PLAN_INFO_LENGTH} fields from "
+            f"flashinfer_python==0.6.17, got {len(plan_info)}."
+        )
+    if batch_size <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode plan batch_size: expected a positive value, "
+            f"got {batch_size}."
+        )
+    if num_qo_heads <= 0 or num_kv_heads <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: num_qo_heads and num_kv_heads "
+            f"must be positive, got {num_qo_heads} and {num_kv_heads}."
+        )
+    if num_qo_heads % num_kv_heads != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: "
+            f"num_qo_heads ({num_qo_heads}) must be divisible by "
+            f"num_kv_heads ({num_kv_heads})."
+        )
+    if plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX] != 1:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected a CUDA graph plan, "
+            f"got enable_cuda_graph={plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX] != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected split-KV to be disabled, "
+            f"got split_kv={plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX] != batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer deterministic decode plan: expected one query row "
+            f"per request, got total_num_rows="
+            f"{plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX]} and "
+            f"batch_size={batch_size}."
+        )
+
+    cta_tile_q = plan_info[_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX]
+    if cta_tile_q <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: CTA q tile size must be positive, "
+            f"got {cta_tile_q}."
+        )
+
+    group_size = num_qo_heads // num_kv_heads
+    tiles_per_request = (group_size + cta_tile_q - 1) // cta_tile_q
+    # With one q row per request, FA2 packs the GQA group into q rows and
+    # initializes exactly one scheduler entry per CTA q tile. Split-KV-disabled
+    # plans have no validity mask, so the captured grid must stop at that bound.
+    exact_grid_x = batch_size * tiles_per_request
+    padded_batch_size = plan_info[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX]
+    if exact_grid_x > padded_batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: narrowing would enlarge "
+            f"padded_batch_size from {padded_batch_size} to {exact_grid_x}."
+        )
+    if exact_grid_x == padded_batch_size:
+        return plan_info
+
+    narrowed_plan = list(plan_info)
+    narrowed_plan[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX] = exact_grid_x
+    return cast(_PlanInfoT, type(plan_info)(narrowed_plan))
 
 
 if envs.SGLANG_ENABLE_TORCH_COMPILE.get():
@@ -1787,6 +1887,24 @@ class FlashInferIndicesUpdaterDecode:
 
         if locally_override:
             global_override_indptr_cpu = None
+
+        if (
+            disable_split_kv is True
+            and wrapper.is_cuda_graph_enabled
+            and wrapper.use_tensor_cores
+            and getattr(wrapper, "_backend", None) == "fa2"
+        ):
+            plan_info = getattr(wrapper, "_plan_info", None)
+            if plan_info is None:
+                raise RuntimeError(
+                    "FlashInfer split-KV-disabled CUDA graph decode did not produce a plan."
+                )
+            wrapper._plan_info = _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=bs,
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+            )
 
 
 class FlashInferIndicesUpdaterPrefill:

--- a/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
@@ -1,0 +1,223 @@
+"""Unit tests for deterministic FlashInfer CUDA-graph decode launch bounds."""
+
+import unittest
+
+from tvm_ffi import Array
+
+from sglang.srt.layers.attention.flashinfer_backend import (
+    _narrow_deterministic_cuda_graph_decode_plan,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _plan_info(
+    *,
+    padded_batch_size=132,
+    total_num_rows=2,
+    cta_tile_q=16,
+    enable_cuda_graph=1,
+    split_kv=0,
+    offset_seed=100,
+):
+    """Build FlashInfer 0.6.17's 15-field PrefillPlanInfo vector."""
+    return [
+        padded_batch_size,
+        total_num_rows,
+        offset_seed + 2,
+        cta_tile_q,
+        offset_seed + 4,
+        offset_seed + 5,
+        offset_seed + 6,
+        offset_seed + 7,
+        offset_seed + 8,
+        offset_seed + 9,
+        offset_seed + 10,
+        offset_seed + 11,
+        offset_seed + 12,
+        enable_cuda_graph,
+        split_kv,
+    ]
+
+
+class TestFlashInferDecodePlanLaunchBound(CustomTestCase):
+    def test_narrows_mha_and_gqa_to_one_tile_per_request(self):
+        for name, num_qo_heads, num_kv_heads in (
+            ("mha", 16, 16),
+            ("gqa", 16, 2),
+        ):
+            with self.subTest(name=name):
+                plan_info = _plan_info(total_num_rows=4)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=4,
+                    num_qo_heads=num_qo_heads,
+                    num_kv_heads=num_kv_heads,
+                )
+                self.assertEqual(narrowed[0], 4)
+
+    def test_group_larger_than_cta_tile_keeps_all_query_tiles(self):
+        plan_info = _plan_info(total_num_rows=3)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=3,
+            num_qo_heads=32,
+            num_kv_heads=1,
+        )
+
+        # GQA group size 32 needs two CTA-q tiles per request when CTA_TILE_Q=16.
+        self.assertEqual(narrowed[0], 6)
+
+    def test_preserves_native_ffi_array_without_mutating_input(self):
+        plan_info = Array(_plan_info())
+        original = tuple(plan_info)
+
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(type(narrowed), type(plan_info))
+        self.assertIsNot(narrowed, plan_info)
+        self.assertEqual(tuple(plan_info), original)
+
+    def test_changes_only_padded_batch_size(self):
+        plan_info = _plan_info(offset_seed=700)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertEqual(narrowed[0], 2)
+        self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_equal_bound_returns_the_same_object(self):
+        plan_info = _plan_info(padded_batch_size=2)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(narrowed, plan_info)
+
+    def test_representative_normal_and_fast_plan_vectors(self):
+        # The normal capture planner and fast replay planner can produce
+        # different workspace offsets, but share the same scheduling ABI.
+        for planner, offset_seed in (("normal", 100), ("fast", 1000)):
+            with self.subTest(planner=planner):
+                plan_info = _plan_info(offset_seed=offset_seed)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=2,
+                    num_qo_heads=16,
+                    num_kv_heads=2,
+                )
+                self.assertEqual(narrowed[0], 2)
+                self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_rejects_malformed_plan_abi(self):
+        for length in (14, 16):
+            with self.subTest(length=length):
+                plan_info = _plan_info()
+                plan_info = plan_info[:length] if length < 15 else plan_info + [0]
+                with self.assertRaisesRegex(RuntimeError, "expected 15 fields"):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_non_target_plan_flags_and_row_count(self):
+        cases = (
+            (
+                "not_cuda_graph",
+                _plan_info(enable_cuda_graph=0),
+                "expected a CUDA graph plan",
+            ),
+            (
+                "split_kv",
+                _plan_info(split_kv=1),
+                "expected split-KV to be disabled",
+            ),
+            (
+                "multiple_query_rows",
+                _plan_info(total_num_rows=3),
+                "expected one query row per request",
+            ),
+        )
+        for name, plan_info, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_invalid_dimensions(self):
+        cases = (
+            (
+                "batch_size",
+                _plan_info(),
+                dict(batch_size=0, num_qo_heads=16, num_kv_heads=2),
+                "expected a positive value",
+            ),
+            (
+                "qo_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=0, num_kv_heads=2),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "kv_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=0),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "head_divisibility",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=10, num_kv_heads=3),
+                r"num_qo_heads \(10\) must be divisible by num_kv_heads \(3\)",
+            ),
+            (
+                "zero_cta_tile",
+                _plan_info(cta_tile_q=0),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+            (
+                "negative_cta_tile",
+                _plan_info(cta_tile_q=-16),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+        )
+        for name, plan_info, kwargs, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(plan_info, **kwargs)
+
+    def test_rejects_attempted_enlargement(self):
+        plan_info = _plan_info(padded_batch_size=1)
+        with self.assertRaisesRegex(RuntimeError, "narrowing would enlarge"):
+            _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=2,
+                num_qo_heads=16,
+                num_kv_heads=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang pins `flashinfer_python[cu13]==0.6.17`. Deterministic CUDA-graph decode selects FlashInfer's FA2 tensor-core backend and disables split-KV.

FlashInfer initializes scheduler entries for real request and query-tile work, then pads grid-x to a split-work occupancy bound. A no-split plan has no validity mask for this padded tail. The measured zero-filled case executes redundant CTAs. Reused nonzero workspace contents can leave stale request or tile indices in the tail, creating a conditional correctness risk.

For one-token decode, let `group_size = num_qo_heads // num_kv_heads`. The initialized grid is:

`batch_size * ceil(group_size / cta_tile_q)`

The planner issue is tracked in [flashinfer-ai/flashinfer#4002](https://github.com/flashinfer-ai/flashinfer/issues/4002), with the upstream fix proposed in [flashinfer-ai/flashinfer#4430](https://github.com/flashinfer-ai/flashinfer/pull/4430). This PR adds an ABI-pinned integration guard for SGLang's current dependency.

## Modifications

- Add a private helper for FlashInfer 0.6.17's 15-field FA2 `PrefillPlanInfo`.
- Validate the ABI length, CUDA-graph and split-KV flags, one query row per request, head divisibility, CTA tile size, and the no-enlargement invariant.
- Replace only `plan_info[0]` with the initialized grid bound. Fields 1 through 14, including every workspace offset, remain unchanged.
- Reconstruct `type(plan_info)(values)` to preserve FlashInfer's immutable FFI array type.
- Apply the helper after both regular planning and `fast_decode_plan()`, restricted to FA2 tensor-core CUDA-graph decode with split-KV disabled.
- Add a registered CPU unit test for MHA, GQA, multiple query tiles, native-container preservation, unchanged non-grid fields, malformed plans, invalid dimensions, and attempted enlargement.

Eager decode, split-KV graphs, CUDA-core decode, prefill, extend, verify, and non-deterministic execution retain their existing behavior. Public function signatures, configuration, and dependencies remain unchanged.

## Accuracy Tests

The branch is based on SGLang main commit `6480cce9`. The stable patch ID is unchanged from the previously validated commit, and the intervening upstream commits did not touch either modified file. Current-base checks and prior patch validation are summarized below:

| Validation | Result |
|---|---|
| Python compile checks and `git diff --check` | Pass |
| Changed-file pre-commit, including Ruff, codespell, and registered-test guards | Pass |
| Registered-test AST validation | Pass |
| Isolated execution of the new test module with native `tvm_ffi.Array` | 10 of 10 pass |
| Repository lint workflow | Pass |

Prior H100 integration validation used FlashInfer 0.6.14, which has the affected planner behavior:

| Validation | Result |
|---|---|
| Regular and fast native plans at batch sizes 1, 2, and 8 with KV lengths 2, 1,024, and 8,192 | 18 of 18 pass; fields 1 through 14 unchanged |
| Captured regular and fast grids at batch sizes 1, 2, and 8 with KV lengths 2 and 8,192 | 12 of 12 matched the bounded plan |
| Existing FlashInfer dense-attention coverage | 8 of 8 pass |
| `TestFlashinferDeterministic` | 2 of 2 pass |

A graph captured at KV length 2 was replanned with the fast planner at KV length 8,192 and replayed successfully. Its output matched the one-shot eager and reference results. Split-KV graphs retained their padded, validity-masked plans; eager and non-deterministic controls were unchanged.

FlashInfer 0.6.17 retains the same 15-field plan ABI and no-split padding behavior. Those properties were rechecked against the pinned sources. Base CI for the pinned package is pending maintainer authorization.

## Speed Tests and Profiling

Representative case: BF16, batch size 2, 16 query heads, 2 KV heads, head dimension 128, page size 1, and KV length 2.

| Plan | Captured grid | CTAs | Kernel duration |
|---|---|---:|---:|
| Padded grid with zero-filled tail | `(132, 1, 2)` | 264 | 8.543 µs |
| Initialized-grid bound | `(2, 1, 2)` | 4 | 5.600 µs |

CUDA-event graph-replay p50 decreased from 9.0058 µs to 6.1245 µs, a 31.99% reduction. Both runs matched the one-shot BF16 output and had identical FP32-reference error. These measurements isolate the attention graph; end-to-end impact depends on the serving workload. CI contains no timing assertion.

Environment: NVIDIA H100 80GB HBM3, 132 SMs, driver 570.148.08, PyTorch 2.11.0+cu129, and CUDA 12.9.

## Checklist

- [x] Format code with [pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add a registered unit test following the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Review documentation impact; this change has no public surface requiring documentation.
- [x] Provide accuracy and profiling evidence.
- [x] Follow the SGLang [code-style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

CODEOWNER review and Base CI authorization are requested.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33138391071](https://github.com/sgl-project/sglang/actions/runs/33138391071)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33138390994](https://github.com/sgl-project/sglang/actions/runs/33138390994)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33138391047](https://github.com/sgl-project/sglang/actions/runs/33138391047)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->