### PR TITLE
[PD] Skip speculative verify scratch on prefill servers (saves num_draft_tokens x mamba pool per rank)

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -805,7 +805,14 @@ class KVCacheConfigurator:
             ),
             enable_mamba_extra_buffer=mamba_extra_buffer_enabled(),
             enable_mamba_extra_buffer_lazy=mamba_extra_buffer_lazy_enabled(),
-            speculative_num_draft_tokens=max_speculative_num_draft_tokens(),
+            # A PD prefill server never runs TARGET_VERIFY, so skip the
+            # verify-only per-draft-token state snapshots (see the draft-head
+            # case above: None => the pool skips SpeculativeState).
+            speculative_num_draft_tokens=(
+                None
+                if get_disagg().disaggregation_mode == "prefill"
+                else max_speculative_num_draft_tokens()
+            ),
             speculative_eagle_topk=get_spec().speculative_eagle_topk,
             enable_overlap_schedule=not get_schedule().disable_overlap_schedule,
             start_layer=self.layer_info.start_layer,

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -414,6 +414,14 @@ def capture_decode_graph(*, model_runner: ModelRunner) -> GraphCapture:
         capture_time=0,
     )
 
+    # A PD prefill server never replays the target-verify graph, and its pool
+    # is built without the spec-verify scratch the capture would need.
+    if (
+        model_runner.spec_algorithm.is_speculative()
+        and not model_runner.is_draft_worker
+        and model_runner.server_args.disaggregation_mode == "prefill"
+    ):
+        return no_capture
     if not model_runner.is_generation:
         # TODO: Currently, cuda graph only captures decode steps, which only exists for generation models
         return no_capture

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -404,7 +404,13 @@ class BaseRunner(ABC):
             else get_server_return_hidden_states_mode(mr.server_args)
         )
         num_tokens_per_req = 1
-        if mr.spec_algorithm.is_speculative():
+        # A PD prefill target worker's pool has no SpeculativeState, so a
+        # TARGET_VERIFY dummy forward would trip the linear-attn backend's
+        # pool-type assert. Warm up in plain DECODE instead.
+        _is_pd_prefill_target = (
+            mr.server_args.disaggregation_mode == "prefill" and not mr.is_draft_worker
+        )
+        if mr.spec_algorithm.is_speculative() and not _is_pd_prefill_target:
             if mr.is_draft_worker:
                 assert (
                     mr.spec_algorithm.supports_target_verify_for_draft()


### PR DESCRIPTION
## Motivation

On a PD-disaggregation **prefill** server, speculative decoding's TARGET_VERIFY never runs — `server_args` already rejects `--enable-linear-replayssm-spec` there with exactly this rationale ("the prefill server never runs spec verify"). However, with speculative decoding enabled on hybrid linear-attention models (GDN/KDA), the prefill server still pays for the full verify machinery:

1. **Pool**: it allocates the verify-only per-draft-token mamba state snapshots — `intermediate_ssm_state_cache` ≈ `num_draft_tokens × (whole mamba pool)`, plus `intermediate_conv_window_cache`. With a 256-slot pool (~6 GB ssm_state per rank) and `num_draft_tokens=4` (NEXTN, 3 steps), this is **~24 GB of dead weight per rank**.
2. **Graphs**: it captures target-verify CUDA graphs that are never replayed.
3. **Warmup**: its warmup dummy forward runs in TARGET_VERIFY mode.

(1) alone is enough to push deep-PP prefill layouts into OOM at prefill CUDA graph capture (the capture of a large prefill token bucket has a transient footprint well above the final graph size).

## Modifications

Gate all three on `disaggregation_mode == "prefill"` for the **target** worker, reusing the existing draft-head precedent (`speculative_num_draft_tokens=None` ⇒ pools skip the `SpeculativeState` buffers):

- `kv_cache_configurator.py::_build_hybrid_req_pool`: pass `speculative_num_draft_tokens=None` on a PD prefill server.
- `cuda_graph_setup.py::capture_decode_graph`: skip target-verify graph capture on a PD prefill server (with the scratch gone it could not be captured anyway, and it would never be replayed).
- `base_runner.py::_dummy_run`: don't promote the warmup dummy forward to TARGET_VERIFY on a PD prefill target worker — warm up in plain DECODE, identical to a non-speculative server.

Draft workers, decode servers, and aggregated (non-disagg) deployments are unchanged.

## Accuracy Tests

GSM8K (200 examples, 8-shot, temperature 0) on **Qwen3.5-397B-A17B-FP8**, PD-disaggregated 1P1D (TP4 prefill / TP4 decode, mooncake), **NEXTN speculative decoding on both sides** (`num_steps=3`, `eagle_topk=1`, `num_draft_tokens=4`). The two runs are field-for-field identical except that the prefill server runs with vs. without this change:

| | with this change | baseline (unpatched prefill) |
|---|---:|---:|
| GSM8K accuracy | **0.99** | **0.98** |
| MTP accept length (weighted mean) | **3.474** | **3.481** |
| prefill `intermediate_ssm_state_cache` | **not allocated** | 4.31 GB |

Accuracy differs by one example out of 200 (within the sampling noise; reported std 0.099 / 0.140). Accept length is a request-weighted mean over the whole run (259 / 242 decode-batch samples, `#running-req`-weighted) and matches to 0.2% — a meaningful check here, since the acceptance rate depends directly on the state the prefill server hands to the decode server, and would collapse rather than hold if the skipped buffers were live.

Memory saved on the prefill server in that configuration: 4.31 GB/rank (mamba pool 1270 slots, `ssm_state` 27.93 GB, TP4). On a deeper-PP layout with a 256-slot pool the same term is ~24 GB/rank, which is what made prefill CUDA graph capture OOM before this change.

## Speed Tests and Profiling

No speed change expected on unaffected paths (decode/agg identical). Memory saving on PD prefill: `num_draft_tokens × mamba-pool bytes` per rank.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31338061144](https://github.com/sgl-project/sglang/actions/runs/31338061144)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31338060981](https://github.com/sgl-project/sglang/actions/runs/31338060981)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


