### PR TITLE
[AMD] Fix AITER custom reduce-scatter CUDA-graph capture crash under torch_memory_saver

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -1080,7 +1080,10 @@ class GroupCoordinator:
             return False
         if getattr(ca_comm, "_IS_CAPTURING", False):
             if torch.cuda.is_current_stream_capturing():
-                ca_comm.reduce_scatter(input, output, registered=True)
+                if envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
+                    ca_comm.reduce_scatter(input, output, registered=False)
+                else:
+                    ca_comm.reduce_scatter(input, output, registered=True)
             elif is_in_tc_piecewise_cuda_graph():
                 ca_comm.reduce_scatter(input, output, registered=False)
             else:


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

When `SGLANG_MEMORY_SAVER_CUDA_GRAPH=1`, TMS allocates the CUDA-graph pool with HIP VMM. AITER's registered custom-collective path tries to IPC-register the caller's tensor after capture, but HIP IPC does not support these VMM allocations. This causes CUDA-graph capture to abort with `invalid device pointer`. SGLang already uses the unregistered AITER path under TMS for custom all-reduce and all-gather. Reduce-scatter was the remaining gap: `_maybe_aiter_reduce_scatter()` still hardcoded `registered=True` during capture.

This PR uses the unregistered reduce-scatter path under TMS as well.

| collective | TMS handling |
|---|---|
| custom all-reduce | disables registered capture buffers (#19162 / #20155) |
| custom all-gather | uses the unregistered path (#30557) |
| **custom reduce-scatter** | **fixed in this PR** |

## Modifications

<!-- Detail the changes made in this pull request. -->

Use AITER's unregistered reduce-scatter path during CUDA-graph capture when `SGLANG_MEMORY_SAVER_CUDA_GRAPH=1`. Default serving behavior is unchanged.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31350855786](https://github.com/sgl-project/sglang/actions/runs/31350855786)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31350855729](https://github.com/sgl-project/sglang/actions/runs/31350855729)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->