### PR TITLE
[CI] Prefetch a scheduled stage's models before the test step

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -156,6 +156,22 @@ jobs:
         run: |
           CUSTOM_BUILD_SGL_KERNEL=${{ fromJson(inputs.check_changes).sgl_kernel }} bash ${{ steps.rc.outputs.install }}
 
+      # Before the warmups on purpose: those launch real servers, which would
+      # pull the same weights inside a step that is measuring compile time.
+      # Scheduled only for now -- per-commit suites reuse a small model set that
+      # stays warm on its own.
+      #
+      # 20 minutes, and whatever is left is the tests' problem again (the step
+      # never fails the job). At CI link speed that is already a lot of weights;
+      # a suite that cannot get through it is not short of budget, it is fetching
+      # something it should not be. Each run also leaves the cache warmer than it
+      # found it, so the steady state is an etag check.
+      - name: Ensure model cache
+        if: inputs.scheduled
+        timeout-minutes: 20
+        continue-on-error: true
+        run: python3 scripts/ci/cuda/ensure_model_cache.py --suite ${{ inputs.self_name }}
+
       - name: Warmup DeepGEMM JIT Compilation
         if: inputs.warmup_deep_gemm_models != ''
         timeout-minutes: ${{ fromJson(inputs.warmup_timeout_minutes) }}

--- a/scripts/ci/cuda/ensure_model_cache.py
+++ b/scripts/ci/cuda/ensure_model_cache.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Pre-download a suite's models so weight fetching leaves the server-launch path.
+
+Server boot is dominated by weight loading, and on a cold cache most of that is
+download: `test_glm_46` has been observed at 818s wall with sglang reporting only
+129s of actual loading, the other ~600s spent in snapshot_download. That makes
+boot time a function of cache warmth rather than of the model, which in turn
+makes any per-test launch timeout a guess -- the same file has run 461s / 557s /
+697s across three nightly runs.
+
+Fetching here instead moves that variance into a step of its own, where a slow
+or failing download reports as a slow or failing download.
+
+The model list comes from list_stage_models.py (static AST analysis of the
+registered tests). Recall is best-effort: a model it misses is simply fetched by
+the test as before, so this step is advisory and never fails the job.
+
+Usage:
+    python3 scripts/ci/cuda/ensure_model_cache.py --suite nightly-test-8-gpu-h200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from typing import List
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import list_stage_models  # noqa: E402
+
+
+def resolve_models(repo_root: str, backend: str, suite: str) -> List[str]:
+    overrides_path = os.path.join(repo_root, "scripts/ci/stage_models_overrides.json")
+    with open(overrides_path) as f:
+        overrides = json.load(f)
+    inventory = list_stage_models.build_inventory(
+        repo_root=repo_root, backend_name=backend, overrides=overrides, commit=""
+    )
+    entry = inventory["suites"].get(suite)
+    if entry is None:
+        known = ", ".join(sorted(inventory["suites"])[:8])
+        print(f"suite {suite!r} not in the inventory (known: {known}, ...)")
+        return []
+    unresolved = entry.get("unresolved_files") or []
+    if unresolved:
+        # Not an error: these files fetch their own weights at launch, the way
+        # every file did before this step existed. Printed so the recall gap is
+        # attributable when a launch is still slow.
+        print(f"{len(unresolved)} file(s) contributed no model id:")
+        for path in unresolved:
+            print(f"    {path}")
+    return list(entry.get("models") or [])
+
+
+def fetch(model: str) -> tuple[bool, float, str]:
+    from huggingface_hub import snapshot_download
+
+    start = time.perf_counter()
+    try:
+        snapshot_download(repo_id=model)
+        return True, time.perf_counter() - start, ""
+    except Exception as e:  # noqa: BLE001 - report every failure kind the same way
+        return False, time.perf_counter() - start, f"{type(e).__name__}: {e}"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--suite", required=True)
+    parser.add_argument("--backend", default="cuda")
+    parser.add_argument(
+        "--repo-root", default=os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+    args = parser.parse_args()
+
+    repo_root = os.path.abspath(args.repo_root)
+    models = resolve_models(repo_root, args.backend, args.suite)
+    if not models:
+        print(f"No models resolved for {args.suite}; nothing to fetch.")
+        return 0
+
+    print(f"Fetching {len(models)} model(s) for {args.suite}")
+    failed = []
+    total = 0.0
+    for i, model in enumerate(models, 1):
+        ok, elapsed, err = fetch(model)
+        total += elapsed
+        status = "ok" if ok else "FAILED"
+        print(f"  [{i}/{len(models)}] {status:6s} {elapsed:7.1f}s  {model}")
+        if not ok:
+            print(f"           {err}")
+            failed.append(model)
+    print(f"Fetched {len(models) - len(failed)}/{len(models)} in {total:.0f}s")
+    if failed:
+        # Exit 0 regardless: the tests that need these still fetch on launch.
+        print(f"Left to the tests: {', '.join(failed)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Server boot on a cold cache is mostly download, not load: `test_glm_46` has been seen at 818s wall while sglang reported 129s of actual weight loading. That puts network variance inside every per-test launch timeout — the same file ran 461s / 557s / 697s across three nightly runs. Fetching up front (20 min, advisory, never fails the job) moves that into a step where a slow download reads as a slow download. Model list comes from the existing `list_stage_models.py` static analysis.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31352761026](https://github.com/sgl-project/sglang/actions/runs/31352761026)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31352760898](https://github.com/sgl-project/sglang/actions/runs/31352760898)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->