### PR TITLE
[bugfix] fix prefill finish_abort but decode alse running cause error result bug

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -52,6 +52,7 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -957,13 +958,13 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         for i, decode_req in enumerate(self.queue):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
-            if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+            if is_aborted(decode_req.req):
                 if not getattr(decode_req.req, "finished_output", False):
                     self.scheduler.output_streamer.stream_output(
                         [decode_req.req],
                         decode_req.req.return_logprob,
                     )
-                decode_req.kv_receiver.clear()
+                decode_req.kv_receiver.abort()
                 decode_req.kv_receiver = None
                 failed_reqs.append(decode_req)
                 indices_to_remove.add(i)
@@ -2056,7 +2057,7 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 self._commit_transfer_to_req(decode_req)
                 indices_to_remove.add(i)
                 # Check if request was aborted due to corruption
-                if isinstance(decode_req.req.finished_reason, FINISH_ABORT):
+                if is_aborted(decode_req.req):
                     self.scheduler.output_streamer.stream_output(
                         [decode_req.req],
                         decode_req.req.return_logprob,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2249,6 +2249,21 @@ class MooncakeKVSender(CommonKVSender):
         super().abort()
         self.trace_ctx.abort(abort_info={"reason": "Aborted"})
         self.trace_ctx.trace_req_finish()
+        # notify decode side so it can abort the request immediately
+        room = self.bootstrap_room
+        infos = self.kv_mgr.transfer_infos.pop(room, None)
+        if infos:
+            for info in infos.values():
+                try:
+                    self.kv_mgr.sync_status_to_decode_endpoint(
+                        info.endpoint,
+                        info.dst_port,
+                        room,
+                        KVPoll.Failed,
+                        self.kv_mgr.attn_tp_rank,
+                    )
+                except Exception:
+                    pass
 
 
 class MooncakeKVReceiver(CommonKVReceiver):

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -754,6 +754,10 @@ class SchedulerDisaggregationPrefillMixin:
                     self.batch_result_processor.add_sampling_mask_return_values(
                         i, req, logits_output
                     )
+                if is_aborted(req):
+                    req.disagg_kv_sender.abort()
+                    advance_logprob_pt(i, req)
+                    continue
                 if not req.pending_bootstrap:
                     self.send_kv_chunk(req, last_chunk=True)
                 req.time_stats.set_prefill_transfer_queue_entry_time()
@@ -790,6 +794,7 @@ class SchedulerDisaggregationPrefillMixin:
                 # Optimistic bootstrap can fail while this overlapped chunk is
                 # already running. Drop aborted chunks instead of sending KV.
                 if is_aborted(req):
+                    req.disagg_kv_sender.abort()
                     advance_logprob_pt(i, req)
                     req.time_stats.set_last_chunked_prefill_finish_time()
                     continue
@@ -880,7 +885,10 @@ class SchedulerDisaggregationPrefillMixin:
                 # todo: set Transferring correctly in backend
                 undone_reqs.append(req)
             elif poll == KVPoll.Success:  # transfer done
-                if not isinstance(req.finished_reason, FINISH_ABORT):
+                if req.to_finish:
+                    req.finished_reason = req.to_finish
+                    req.to_finish = None
+                elif not isinstance(req.finished_reason, FINISH_ABORT):
                     req.finished_reason = FINISH_LENGTH(length=0)
                 release_kv_cache(req, self.tree_cache)  # unlock the tree
                 # FIXME: clean up req's data in transfer engine
@@ -955,6 +963,8 @@ class SchedulerDisaggregationPrefillMixin:
         req.time_stats.trace_ctx.abort(abort_info={"reason": error_message})
         release_kv_cache(req, self.tree_cache)  # unlock the tree
         if not isinstance(req.finished_reason, FINISH_ABORT):
+            if isinstance(req.to_finish, FINISH_ABORT):
+                error_message = req.to_finish.to_json().get("message")
             prepare_abort(
                 req, error_message, status_code=HTTPStatus.INTERNAL_SERVER_ERROR
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
I have observed that during PD (prefill‑decode) separation, after the P node (prefill node) is marked as set_finish_with_abort, it may still be enqueued into the transfer queue due to validate_input_length or other validation logic (which can be checked in schedule.py). At that point, the node has already sent metadata with len(kv) = 1 (indicating one KV block is expected). The decode node then proceeds with its decoding operation. However, because it never receives the actual KV cache, the resulting output becomes garbled, and in some cases, the decode node may even return results that belong to other requests.

some time ago, i issue some bug, and I couldn't find the cause of the bug at that time : https://github.com/sgl-project/sglang/issues/32605

## Modifications

<!-- Detail the changes made in this pull request. -->
fix prefill about finfish_abort judge，and add mooncake conn.py abort()  send abort message to decode side 。 

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35573167594](https://github.com/sgl-project/sglang/actions/runs/35573167594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35573167451](https://github.com/sgl-project/sglang/actions/runs/35573167451)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35573167628](https://github.com/sgl-project/sglang/actions/runs/35573167628)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->