### PR TITLE
[BugFix] LoRA registry leak on request abort

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1663,14 +1663,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             HTTPStatus.SERVICE_UNAVAILABLE,
             HTTPStatus.INTERNAL_SERVER_ERROR,
         ):
-            # Delete the key to prevent resending abort request to the scheduler and
-            # to ensure aborted request state is cleaned up.
-            if state.obj.rid in self.rid_to_state:
+            # Batch and direct-abort handlers normally remove the state and release
+            # its LoRA reference before notifying the waiter. Keep this as a fallback
+            # only when this handler still owns the same request state.
+            if self.rid_to_state.get(state.obj.rid) is state:
                 del self.rid_to_state[state.obj.rid]
-
-            # Mark ongoing LoRA request as finished.
-            if self.enable_lora and state.obj.lora_path:
-                await self.lora_registry.release(state.obj.lora_id)
+                if self.enable_lora and state.obj.lora_path:
+                    await self.lora_registry.release(state.obj.lora_id)
             if not is_stream:
                 raise fastapi.HTTPException(
                     status_code=finish_reason["status_code"],

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3175,6 +3175,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         }
         del self.rid_to_state[recv_obj.rid]
 
+        # Mark an aborted LoRA request as finished.
+        if self.enable_lora and state.obj.lora_path:
+            asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+
         state.out_list.append(out)
         state.event.set()
 

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -260,6 +260,28 @@ class TestRidToStateCleanupOnAbort(CustomTestCase):
             state.out_list[0]["meta_info"]["finish_reason"]["type"], "abort"
         )
 
+    def test_abort_releases_lora_reference(self):
+        """Aborting a LoRA request should release its registry reference."""
+
+        async def run():
+            tm = _make_tokenizer_manager()
+            tm.enable_lora = True
+            tm.lora_registry = MagicMock()
+            tm.lora_registry.release = AsyncMock()
+            rid = "abort_lora_rid"
+            lora_id = "abort_lora_id"
+            state = _make_req_state(rid)
+            state.obj.lora_path = "abort_lora_path"
+            state.obj.lora_id = lora_id
+            tm.rid_to_state[rid] = state
+
+            tm._handle_abort_req(_make_abort_req(rid))
+            await asyncio.sleep(0)
+
+            tm.lora_registry.release.assert_awaited_once_with(lora_id)
+
+        asyncio.run(run())
+
 
 class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
     """Test that _handle_batch_output removes rid from rid_to_state on completion."""

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -14,6 +14,7 @@ Covers:
 
 import asyncio
 import unittest
+from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import msgspec
@@ -278,6 +279,33 @@ class TestRidToStateCleanupOnAbort(CustomTestCase):
             tm._handle_abort_req(_make_abort_req(rid))
             await asyncio.sleep(0)
 
+            tm.lora_registry.release.assert_awaited_once_with(lora_id)
+
+        asyncio.run(run())
+
+    def test_error_abort_does_not_release_lora_reference_twice(self):
+        """Consuming a scheduler error abort should not release LoRA twice."""
+
+        async def run():
+            tm = _make_tokenizer_manager()
+            tm.enable_lora = True
+            tm.lora_registry = MagicMock()
+            tm.lora_registry.release = AsyncMock()
+            rid = "error_abort_lora_rid"
+            lora_id = "error_abort_lora_id"
+            state = _make_req_state(rid)
+            state.obj.lora_path = "error_abort_lora_path"
+            state.obj.lora_id = lora_id
+            tm.rid_to_state[rid] = state
+            abort_req = _make_abort_req(rid)
+            abort_req.finished_reason["status_code"] = HTTPStatus.SERVICE_UNAVAILABLE
+
+            tm._handle_abort_req(abort_req)
+            await asyncio.sleep(0)
+            out = state.out_list[0]
+            abort_out = await tm._handle_abort_finish_reason(out, state, True)
+
+            self.assertIs(abort_out, out)
             tm.lora_registry.release.assert_awaited_once_with(lora_id)
 
         asyncio.run(run())


### PR DESCRIPTION
## Summary

- release a request's `LoRARegistry` reference when `_handle_abort_req` removes its state
- add a CPU-only regression test that verifies the asynchronous release runs exactly once
- prevent aborted adapters from remaining pinned and blocking dynamic unload or eviction

## Root cause

Normal terminal batch output releases the request-level LoRA reference, but the direct abort path deleted `rid_to_state[rid]` without doing so. Any later scheduler output then skipped the missing state, leaving no remaining release path.

## Validation

- `ruff check python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py`
- `python -m py_compile python/sglang/srt/managers/tokenizer_manager.py test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py`
- isolated async exercise of the edited `_handle_abort_req` method

The exact repository pytest target could not collect on the local Windows host because SGLang imports Unix `resource` and Triton modules that are unavailable there; the added test is registered for Linux CPU CI.

Fixes #34205

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31356896656](https://github.com/sgl-project/sglang/actions/runs/31356896656)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31356896390](https://github.com/sgl-project/sglang/actions/runs/31356896390)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->