### PR TITLE
[diffusion] Z-Image BCG: capture at the native caption length, not text buckets (BCG output now bit-exact vs eager, #34183)

### DIFF
--- a/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/model_padders/zimage.py
+++ b/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/model_padders/zimage.py
@@ -127,9 +127,17 @@ def pad_zimage_prompt_kwargs(
         cap_freq = bcg_utils.first_tensor(freqs_cis[0])
     cap_freq_len = int(cap_freq.shape[0]) if torch.is_tensor(cap_freq) else seq
 
-    bucket = bcg_utils.select_text_bucket(max(seq, cap_freq_len), buckets)
-    if bucket is None:
-        return call_kwargs
+    # Z-Image attends its caption slots UNMASKED: the pipeline pads captions
+    # to the native length (a multiple of 32) with learned pad-token
+    # embeddings that act as attended registers, and the DiT derives the
+    # attention length from the full padded tensor (`lens == target` ->
+    # mask=None). Padding further to a text bucket therefore changes how many
+    # registers every token attends -- a materially different (not bit-exact)
+    # forward, cascading over the few-step distilled sampler. Capture at the
+    # native length instead: signatures stay bounded because the pipeline
+    # already quantizes caption lengths, and unseen lengths fall back to
+    # eager at serving time.
+    bucket = max(seq, cap_freq_len)
 
     out = {
         key: value

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_bcg_padding.py
@@ -175,27 +175,38 @@ class TestDiffusionBCGPadding(unittest.TestCase):
             "image_seq_len_target": 256,
         }
 
-    def test_zimage_prompt_lengths_share_bucket_signature(self):
+    def test_zimage_captures_at_native_caption_length(self):
+        """Z-Image attends its caption slots unmasked (learned pad tokens act
+        as attended registers), so padding to a shared text bucket changes how
+        many registers every token attends and drifts the output
+        (sgl-project/sglang#34183). The padder therefore captures at the
+        incoming native length: lengths are never extended, and distinct
+        native lengths intentionally do NOT share a graph signature (unseen
+        lengths fall back to eager at serving time)."""
         with self._patch_buckets(64, 128):
             short = self.stage._bcg_pad_prompt_kwargs(
+                self._zimage_kwargs(19), current_model=self.zimage_model
+            )
+            short_again = self.stage._bcg_pad_prompt_kwargs(
                 self._zimage_kwargs(19), current_model=self.zimage_model
             )
             longer = self.stage._bcg_pad_prompt_kwargs(
                 self._zimage_kwargs(47), current_model=self.zimage_model
             )
 
-        self.assertEqual(short["encoder_hidden_states"][0].shape, (64, 16))
-        self.assertEqual(longer["encoder_hidden_states"][0].shape, (64, 16))
-        self.assertEqual(short["encoder_hidden_states_mask"].shape, (1, 64))
-        self.assertEqual(short["caption_valid_lens"].shape, (1,))
+        # Captions keep their native length -- no bucket extension.
+        self.assertEqual(short["encoder_hidden_states"][0].shape, (19, 16))
+        self.assertEqual(longer["encoder_hidden_states"][0].shape, (47, 16))
+        self.assertEqual(short["encoder_hidden_states_mask"].shape, (1, 19))
         self.assertEqual(short["caption_valid_lens"].item(), 19)
         self.assertEqual(longer["caption_valid_lens"].item(), 47)
         self.assertTrue(short["_use_caption_valid_mask"])
-        self.assertTrue(longer["_use_caption_valid_mask"])
-        self.assertFalse(short["encoder_hidden_states_mask"][0, 19:].any())
-        self.assertFalse(longer["encoder_hidden_states_mask"][0, 47:].any())
-        self.assertEqual(short["freqs_cis"][0].shape, (64, 8))
-        self.assertEqual(_signature_kwargs(short), _signature_kwargs(longer))
+        self.assertTrue(short["encoder_hidden_states_mask"].all())
+        self.assertEqual(short["freqs_cis"][0].shape, (19, 8))
+        # Same native length -> same signature (graph reuse works); different
+        # native lengths -> different signatures, by design.
+        self.assertEqual(_signature_kwargs(short), _signature_kwargs(short_again))
+        self.assertNotEqual(_signature_kwargs(short), _signature_kwargs(longer))
 
     def _minimax_h3_kwargs(self, text_seq: int):
         image_seq = 4

--- a/python/sglang/multimodal_gen/test/unit/test_zimage_bcg_native_length.py
+++ b/python/sglang/multimodal_gen/test/unit/test_zimage_bcg_native_length.py
@@ -1,0 +1,66 @@
+"""Z-Image BCG must capture at the native caption length, not a text bucket.
+
+Regression for the numeric half of sgl-project/sglang#34183: Z-Image attends
+its caption slots UNMASKED — the pipeline pads captions to the native length
+(a multiple of 32) with learned pad-token embeddings that act as attended
+registers, and the DiT derives the attention span from the full padded tensor
+(``lens == target`` → no mask). Padding further to a BCG text bucket changes
+how many registers every token attends: the first caption self-attention
+block already differs materially (maxdiff ≈ 6 on the valid rows, PSNR ≈ 21 dB
+after 9 distilled steps). Capturing at the incoming (native) length is the
+only bit-exact choice, so the padder must never extend the caption.
+"""
+
+import unittest
+
+import torch
+
+from sglang.multimodal_gen.runtime.breakable_cuda_graph.model_padders.zimage import (
+    pad_zimage_prompt_kwargs,
+)
+
+
+class _FakeRotary:
+    def __call__(self, pos_ids):
+        n = pos_ids.shape[0]
+        return torch.ones(n, 8), torch.zeros(n, 8)
+
+
+class _FakeZImageTransformer2DModel:
+    # transformer_class_name_matches() checks the class NAME for "zimage".
+    rotary_emb = _FakeRotary()
+
+
+_FakeZImageTransformer2DModel.__name__ = "ZImageTransformer2DModel"
+
+
+class TestZImageNativeLengthCapture(unittest.TestCase):
+    def test_padder_never_extends_the_caption(self):
+        nat_len, hidden = 32, 16
+        caption = torch.randn(nat_len, hidden)
+        cap_freqs = (torch.ones(nat_len, 8), torch.zeros(nat_len, 8))
+        img_freqs = (torch.ones(64, 8), torch.zeros(64, 8))
+        kwargs = {
+            "hidden_states": torch.randn(1, 4, 8, 8),
+            "timestep": torch.zeros(1),
+            "encoder_hidden_states": [caption],
+            "freqs_cis": (cap_freqs, img_freqs),
+        }
+        out = pad_zimage_prompt_kwargs(
+            dict(kwargs), _FakeZImageTransformer2DModel(), buckets=(64, 128)
+        )
+
+        padded_caption = out["encoder_hidden_states"][0]
+        # The caption keeps its native length: buckets larger than the
+        # incoming length must not add attended pad registers.
+        self.assertEqual(padded_caption.shape[0], nat_len)
+        self.assertTrue(torch.equal(padded_caption, caption))
+        cap_cos = out["freqs_cis"][0][0]
+        self.assertEqual(cap_cos.shape[0], nat_len)
+        self.assertEqual(
+            out["caption_valid_lens"].tolist(), [nat_len]
+        )  # mask covers exactly the native slots
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Second half of #34183: with the single-GPU BCG crash fixed (#34210), BCG-vs-eager md5 for Z-Image could be measured for the first time — and the default text buckets produce a **visibly drifted image** (PSNR 21.24 dB vs eager; different-seed baseline is 12.8 dB), deterministically.

## Root cause (measured, step by step)

- Eager is fully deterministic (same md5 across 3 fresh processes and 2 in-process consecutive requests, seed pinned) — the drift is a real numeric-path difference, not randomness.
- Layer bisect (same process, same model object, natural vs bucket-64-padded kwargs, hooks on all 37 blocks): image-only `noise_refiner` blocks are **bit-identical**; the first divergent block is **`context_refiner.0`** (the first caption self-attention) with maxdiff ≈ 6 on the *valid* rows, amplifying downstream.
- Everything that "should" be equal was verified equal: caption freqs prefix (0.0), varlen meta content (`cu_seqlens=[0,22]`, exact indices), block-0 inputs (0.0), and `flash_attn_varlen_func` itself is insensitive to `max_seqlen` (0.0 at 32/48/64 in a standalone microtest).
- A mask-query spy delivered the verdict: **Z-Image attends its caption slots unmasked by design.** The pipeline pads captions to the native length (a multiple of 32) with learned pad-token embeddings that act as *attended registers*, and the DiT derives the attention span from the full padded tensor (`lens == target` → mask=None) — on both arms. Padding to a 48/64 bucket changes how many registers every token attends, which is a materially different forward. No mask configuration can reproduce the reference semantics at a larger bucket — masking down to the raw valid length would *also* differ from the native attend-32 behavior.

## Fix

The Z-Image prompt padder captures at the **incoming native caption length** (`max(seq, cap_freq_len)`) instead of `select_text_bucket`. The bucket ladder's warmup captures dedupe to one graph per native length; signature cardinality stays bounded because the pipeline already quantizes caption lengths; unseen lengths keep the existing serving-time eager fallback.

## Validation (H200, Turbo 1024², seed 42, default flags)

| arm | md5 |
| --- | --- |
| eager | `d7e71ba8…` |
| **BCG (this PR)** | **`d7e71ba8…` — identical**, 1 captured graph |
| BCG (before) | `977fb1da…`, PSNR 21.24 dB |

- Unit test (`test_zimage_bcg_native_length.py`): the padder must never extend the caption — **fails on pre-fix main, passes with the fix**.
- Pre-commit clean.
- Composes with #34210 (capture-pinned cache lifetimes); either lands independently.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit test (red on pre-fix code).
- [x] Provide accuracy results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31359772009](https://github.com/sgl-project/sglang/actions/runs/31359772009)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31359771787](https://github.com/sgl-project/sglang/actions/runs/31359771787)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->