### PR TITLE
Revert "feat(cache-sim-tee): concurrent ingest sender (fix peak tee-drop / oracle undercount)"

### DIFF
--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -10,8 +10,8 @@ use clap::Parser;
 use std::num::{NonZeroU32, NonZeroU64, NonZeroUsize};
 
 use crate::config::{
-    default_cache_sim_max_concurrent_captures, default_cache_sim_send_concurrency,
-    default_cb_cool_down, default_proxy_request_timeout_secs, default_shutdown_drain_secs,
+    default_cache_sim_max_concurrent_captures, default_cb_cool_down,
+    default_proxy_request_timeout_secs, default_shutdown_drain_secs,
     default_stale_request_timeout_secs, default_stream_idle_timeout_secs,
     default_stream_send_stall_secs, default_tokenizer_shards, resolve_mode, ActiveLoadConfig,
     AdmissionConfig, CacheAwareConfig, CircuitBreakerConfig, Config, DiscoveryBackend,
@@ -361,18 +361,6 @@ pub struct Cli {
     /// capture. Only meaningful with `--cache-sim-url`.
     #[arg(long, default_value_t = default_cache_sim_max_concurrent_captures())]
     pub cache_sim_max_concurrent_captures: usize,
-    /// Concurrent in-flight POSTs the cache-sim ingest tee's sender runs. The
-    /// serial (single-task) sender capped tee throughput at ~1/POST-latency
-    /// (≈110 req/s), so peak traffic overflowed the bounded tee channel and
-    /// dropped records; N concurrent POSTs raise that ceiling ~N×. Also read
-    /// from `RADIXARK_CACHE_SIM_SEND_CONCURRENCY`. Only meaningful with
-    /// `--cache-sim-url`.
-    #[arg(
-        long,
-        env = "RADIXARK_CACHE_SIM_SEND_CONCURRENCY",
-        default_value_t = default_cache_sim_send_concurrency()
-    )]
-    pub cache_sim_send_concurrency: usize,
 }
 
 impl Cli {
@@ -615,7 +603,6 @@ impl Cli {
                 log_format: self.log_format,
                 cache_sim_url: self.cache_sim_url,
                 cache_sim_max_concurrent_captures: self.cache_sim_max_concurrent_captures,
-                cache_sim_send_concurrency: self.cache_sim_send_concurrency,
             },
             model: ModelConfig {
                 // Default the tokenizer source to the model id (treated as a

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -278,15 +278,6 @@ pub struct ObservabilityConfig {
     /// Excess streams simply aren't captured. Only meaningful with
     /// `cache_sim_url`.
     pub cache_sim_max_concurrent_captures: usize,
-    /// Number of concurrent in-flight POSTs the cache-sim ingest tee's
-    /// background sender runs. The sender was single-task/serial, so tee
-    /// throughput was capped at ~`1 / POST-latency` (≈110 req/s at a ~9 ms
-    /// in-cluster POST); any sustained arrival above that filled the bounded
-    /// tee channel and dropped the excess
-    /// (`sgl_router_cache_sim_tee_total{result="dropped"}`), making the oracle
-    /// undercount vs the engine at peak. N concurrent POSTs raise the ceiling
-    /// to ~`N / POST-latency`. Only meaningful with `cache_sim_url`.
-    pub cache_sim_send_concurrency: usize,
 }
 
 /// Default concurrent-capture budget: 256 × 16 MiB = 4 GiB ceiling on aggregate
@@ -294,19 +285,6 @@ pub struct ObservabilityConfig {
 /// small next to any sane router memory limit.
 pub fn default_cache_sim_max_concurrent_captures() -> usize {
     256
-}
-
-/// Default concurrent-POST fan-out for the cache-sim ingest tee sender.
-/// 8 × (~1/9 ms in-cluster POST) ≈ ~880 req/s ceiling — already ~8× the old
-/// serial ~110 req/s and above observed peak tee arrival, while deliberately
-/// CONSERVATIVE: the single-consumer cache-sim pod is the next backstop, so we
-/// start moderate and let operators dial UP via
-/// `RADIXARK_CACHE_SIM_SEND_CONCURRENCY` while watching the pod's
-/// `queue_high_water` / `ingest_dropped_total` — raising the router ceiling only
-/// moves drops to the pod if the consumer can't keep up. 0 is clamped to 1 by
-/// the sender (serial), so it can never disable the drain.
-pub fn default_cache_sim_send_concurrency() -> usize {
-    8
 }
 
 /// `text` for human-readable dev output, `json` for one-line-per-record
@@ -331,7 +309,6 @@ impl Default for ObservabilityConfig {
             log_format: LogFormat::default(),
             cache_sim_url: None,
             cache_sim_max_concurrent_captures: default_cache_sim_max_concurrent_captures(),
-            cache_sim_send_concurrency: default_cache_sim_send_concurrency(),
         }
     }
 }

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -137,21 +137,13 @@ impl AppContext {
         // Spawn the cache-sim tee when configured. Read before `config` is
         // moved into `Self`; an empty/whitespace URL is treated as unset.
         let max_captures = config.observability.cache_sim_max_concurrent_captures;
-        let send_concurrency = config.observability.cache_sim_send_concurrency;
         let cache_sim_tee = config
             .observability
             .cache_sim_url
             .as_ref()
             .map(|u| u.trim())
             .filter(|u| !u.is_empty())
-            .map(|url| {
-                CacheSimTee::spawn(
-                    url.to_owned(),
-                    Arc::clone(&metrics),
-                    max_captures,
-                    send_concurrency,
-                )
-            });
+            .map(|url| CacheSimTee::spawn(url.to_owned(), Arc::clone(&metrics), max_captures));
         Self {
             config,
             tokenizers,

--- a/experimental/sgl-router/src/server/cache_sim_extend.rs
+++ b/experimental/sgl-router/src/server/cache_sim_extend.rs
@@ -862,7 +862,7 @@ mod spawn_tests {
         }
         let mut ctx = AppContext::stub();
         ctx.tokenizers = Arc::new(reg);
-        ctx.cache_sim_tee = Some(CacheSimTee::spawn(url, MetricsRegistry::new(), 64, 8));
+        ctx.cache_sim_tee = Some(CacheSimTee::spawn(url, MetricsRegistry::new(), 64));
         (Arc::new(ctx), cap)
     }
 

--- a/experimental/sgl-router/src/server/cache_sim_tee.rs
+++ b/experimental/sgl-router/src/server/cache_sim_tee.rs
@@ -16,9 +16,8 @@
 //!
 //! Fire-and-forget by construction: [`CacheSimTee::offer`] enqueues onto a
 //! bounded channel and returns immediately; a full queue is dropped + counted
-//! (never parked), and a background sender drains it with a bounded fan-out of
-//! concurrent POSTs (see [`run_sender`]). The tee is purely observational, so it
-//! must never slow, block, or fail the serving path.
+//! (never parked), and one background task POSTs serially. The tee is purely
+//! observational, so it must never slow, block, or fail the serving path.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -167,15 +166,7 @@ impl CacheSimTee {
     /// base (e.g. `http://radixark-cache-sim:9095`); `/ingest_ids` is appended.
     /// `max_captures` caps concurrent streaming captures (see `capture_sem`);
     /// `0` is clamped to `1` so the semaphore is always constructible.
-    /// `send_concurrency` is how many teed POSTs the background sender keeps in
-    /// flight at once — see [`run_sender`] for why serial draining was the tee's
-    /// throughput ceiling; `0` is clamped to `1` (serial).
-    pub fn spawn(
-        url: String,
-        metrics: Arc<MetricsRegistry>,
-        max_captures: usize,
-        send_concurrency: usize,
-    ) -> Arc<Self> {
+    pub fn spawn(url: String, metrics: Arc<MetricsRegistry>, max_captures: usize) -> Arc<Self> {
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         // .expect, not a fallback: reqwest::Client::new() would panic on the
         // same (near-impossible, TLS-backend-init) failure, and a fallback
@@ -196,7 +187,6 @@ impl CacheSimTee {
             ingest_url,
             extend_url,
             Arc::clone(&metrics),
-            send_concurrency,
         ));
         Arc::new(Self {
             tx,
@@ -320,131 +310,81 @@ impl CacheSimTee {
     }
 }
 
-/// Drain the queue, POSTing each request's ids to the cache-sim with up to
-/// `concurrency` POSTs in flight at once. Errors are metered and dropped — a
-/// down cache-sim must never spam the router's logs or affect serving. Ends when
-/// the channel closes (all senders dropped, i.e. shutdown).
+/// Drain the queue and POST each request's ids to the cache-sim, serially.
+/// Errors are metered and dropped — a down cache-sim must never spam the
+/// router's logs or affect serving. Ends when the channel closes (all senders
+/// dropped, i.e. shutdown).
 ///
-/// Why concurrent: the sender used to `.await` each POST serially, so tee
-/// throughput was capped at ~`1 / POST-latency` (≈110 req/s at a ~9 ms
-/// in-cluster POST). Any sustained arrival above that filled the bounded tee
-/// channel and dropped the excess
-/// (`sgl_router_cache_sim_tee_total{result="dropped"}`) — the oracle then
-/// undercounted vs the engine at peak. Fanning out to `concurrency` tasks raises
-/// the ceiling to ~`concurrency / POST-latency`; the per-POST timeout still
-/// bounds a hung cache-sim.
-///
-/// A `concurrency`-permit semaphore backpressures the DRAIN, never the
-/// offer/serving path (that's the non-blocking `try_send` in `offer`): when all
-/// permits are out the recv loop parks until a POST finishes, so we never spawn
-/// unbounded tasks. The queue keeps absorbing offers meanwhile, dropping on
-/// overflow exactly as before.
-///
-/// INVARIANT: the recv loop must never panic — it is the sole consumer of the
-/// tee channel, and a panic ends teeing permanently and silently. Each POST now
-/// runs in its own task, so a (nonexistent — every step is matched) panic there
-/// can't kill the consumer, and its permit is released on unwind.
+/// INVARIANT: this loop must never be able to panic. It is the sole consumer of
+/// the tee channel; a panic ends the task permanently and silently (teeing just
+/// stops — no counter moves). Every fallible step is matched, not unwrapped.
 async fn run_sender(
     mut rx: mpsc::Receiver<TeeMsg>,
     client: reqwest::Client,
     ingest_url: String,
     extend_url: String,
     metrics: Arc<MetricsRegistry>,
-    concurrency: usize,
 ) {
-    let ingest_url = Arc::new(ingest_url);
-    let extend_url = Arc::new(extend_url);
-    let sem = Arc::new(tokio::sync::Semaphore::new(concurrency.max(1)));
     while let Some(msg) = rx.recv().await {
-        // Acquire BEFORE spawning so at most `concurrency` POSTs are in flight;
-        // this await parks the drain (not serving) when saturated.
-        // `acquire_owned` errors only on a closed semaphore, which we never
-        // close (we hold an Arc) — treat the impossible case as shutdown rather
-        // than unwrap-panicking the sole consumer.
-        let permit = match Arc::clone(&sem).acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => break,
+        let body = IngestIdsBody {
+            model: &msg.model,
+            input_ids: &msg.input_ids,
+            request_id: &msg.request_id,
+            prompt_len: msg.prompt_len,
+            // A single-choice response carries no discriminator: absent means
+            // "not a fan-out", which is the common case and the cheapest wire.
+            choice_index: msg.choice.map(|c| c.index),
+            choice_count: msg.choice.map(|c| c.count),
+            output_tokens: msg.output_tokens,
         };
-        // reqwest::Client is Arc-backed — cloning shares the connection pool.
-        let client = client.clone();
-        let ingest_url = Arc::clone(&ingest_url);
-        let extend_url = Arc::clone(&extend_url);
-        let metrics = Arc::clone(&metrics);
-        tokio::spawn(async move {
-            let _permit = permit; // released when the POST finishes (or unwinds)
-            post_one(msg, &client, &ingest_url, &extend_url, &metrics).await;
-        });
-    }
-}
-
-/// POST one teed message to the cache-sim and meter the outcome. Split out of
-/// [`run_sender`] so the concurrent fan-out can spawn it directly. Never panics:
-/// every fallible step is matched, not unwrapped.
-async fn post_one(
-    msg: TeeMsg,
-    client: &reqwest::Client,
-    ingest_url: &str,
-    extend_url: &str,
-    metrics: &MetricsRegistry,
-) {
-    let body = IngestIdsBody {
-        model: &msg.model,
-        input_ids: &msg.input_ids,
-        request_id: &msg.request_id,
-        prompt_len: msg.prompt_len,
-        // A single-choice response carries no discriminator: absent means
-        // "not a fan-out", which is the common case and the cheapest wire.
-        choice_index: msg.choice.map(|c| c.index),
-        choice_count: msg.choice.map(|c| c.count),
-        output_tokens: msg.output_tokens,
-    };
-    // Per-kind outcome labels so a version-skewed cache-sim (no /extend_ids yet
-    // → 404) shows up as `extend_http_error` while the ingest tee stays visibly
-    // healthy.
-    let (url, sent, http_error, error) = match msg.kind {
-        TeeKind::Ingest => (ingest_url, "sent", "http_error", "error"),
-        TeeKind::Extend => (
-            extend_url,
-            "extend_sent",
-            "extend_http_error",
-            "extend_error",
-        ),
-    };
-    // Serializing {model, input_ids} cannot realistically fail; count it rather
-    // than unwrap-panicking the sender task.
-    let bytes = match serde_json::to_vec(&body) {
-        Ok(b) => b,
-        Err(_) => {
-            metrics.record_cache_sim_tee(error);
-            return;
+        // Per-kind outcome labels so a version-skewed cache-sim (no
+        // /extend_ids yet → 404) shows up as `extend_http_error` while the
+        // ingest tee stays visibly healthy.
+        let (url, sent, http_error, error) = match msg.kind {
+            TeeKind::Ingest => (&ingest_url, "sent", "http_error", "error"),
+            TeeKind::Extend => (
+                &extend_url,
+                "extend_sent",
+                "extend_http_error",
+                "extend_error",
+            ),
+        };
+        // Serializing {model, input_ids} cannot realistically fail; count it
+        // rather than unwrap-panicking the sole sender task.
+        let bytes = match serde_json::to_vec(&body) {
+            Ok(b) => b,
+            Err(_) => {
+                metrics.record_cache_sim_tee(error);
+                continue;
+            }
+        };
+        // reqwest returns Ok for ANY completed exchange, INCLUDING 4xx/5xx, so
+        // inspect the status: a misconfigured URL (404) or an overloaded/OOM
+        // cache-sim (503) is a broken tee, not a delivery — counting it "sent"
+        // would blind the one health signal this counter exists to be. `error`
+        // stays transport-only (connect refused / DNS / the 2s timeout) so a
+        // dashboard can tell "cache-sim rejecting" from "cache-sim unreachable".
+        // Re-attach the upstream's per-request attribution as x-radixark-* headers
+        // so the cache-sim receiver reads them into each record (it reads headers,
+        // not the JSON body). Non-empty values only — an empty header would look
+        // like a real value and collapse a downstream group-by / join. Pure
+        // pass-through: the router relays what the upstream stamped, minting nothing.
+        let mut rb = client.post(url).header("content-type", "application/json");
+        for (name, value) in [
+            ("x-radixark-correlation-id", &msg.attr.correlation_id),
+            ("x-radixark-endpoint-id", &msg.attr.endpoint_id),
+            ("x-radixark-key-id", &msg.attr.key_id),
+            ("x-radixark-endpoint-slug", &msg.attr.slug),
+        ] {
+            if let Some(v) = value.as_deref().filter(|s| !s.is_empty()) {
+                rb = rb.header(name, v);
+            }
         }
-    };
-    // reqwest returns Ok for ANY completed exchange, INCLUDING 4xx/5xx, so
-    // inspect the status: a misconfigured URL (404) or an overloaded/OOM
-    // cache-sim (503) is a broken tee, not a delivery — counting it "sent"
-    // would blind the one health signal this counter exists to be. `error`
-    // stays transport-only (connect refused / DNS / the 2s timeout) so a
-    // dashboard can tell "cache-sim rejecting" from "cache-sim unreachable".
-    // Re-attach the upstream's per-request attribution as x-radixark-* headers
-    // so the cache-sim receiver reads them into each record (it reads headers,
-    // not the JSON body). Non-empty values only — an empty header would look
-    // like a real value and collapse a downstream group-by / join. Pure
-    // pass-through: the router relays what the upstream stamped, minting nothing.
-    let mut rb = client.post(url).header("content-type", "application/json");
-    for (name, value) in [
-        ("x-radixark-correlation-id", &msg.attr.correlation_id),
-        ("x-radixark-endpoint-id", &msg.attr.endpoint_id),
-        ("x-radixark-key-id", &msg.attr.key_id),
-        ("x-radixark-endpoint-slug", &msg.attr.slug),
-    ] {
-        if let Some(v) = value.as_deref().filter(|s| !s.is_empty()) {
-            rb = rb.header(name, v);
+        match rb.body(bytes).send().await {
+            Ok(r) if r.status().is_success() => metrics.record_cache_sim_tee(sent),
+            Ok(_) => metrics.record_cache_sim_tee(http_error),
+            Err(_) => metrics.record_cache_sim_tee(error),
         }
-    }
-    match rb.body(bytes).send().await {
-        Ok(r) if r.status().is_success() => metrics.record_cache_sim_tee(sent),
-        Ok(_) => metrics.record_cache_sim_tee(http_error),
-        Err(_) => metrics.record_cache_sim_tee(error),
     }
 }
 
@@ -496,7 +436,7 @@ mod tests {
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let metrics = MetricsRegistry::new();
-        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64, 8);
+        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64);
         // Full attribution — plus an empty key_id, which must be OMITTED
         // (not sent as a blank header).
         tee.offer(
@@ -555,64 +495,6 @@ mod tests {
         assert!(
             rendered.contains(r#"sgl_router_cache_sim_tee_total{result="sent"} 1"#),
             "tee sent counter not rendered:\n{rendered}"
-        );
-    }
-
-    /// The sender POSTs concurrently, not serially. A mock that holds each POST
-    /// briefly while tracking the live in-flight count proves the fan-out: with
-    /// the old serial sender only ONE POST was ever in flight (peak == 1); the
-    /// concurrent sender drives the peak above 1. This is the regression guard
-    /// for the throughput ceiling that made the oracle undercount at peak.
-    #[tokio::test]
-    async fn sender_posts_concurrently_not_serially() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        #[derive(Clone, Default)]
-        struct Live {
-            cur: Arc<AtomicUsize>,
-            max: Arc<AtomicUsize>,
-        }
-        let live = Live::default();
-        let app = Router::new()
-            .route(
-                "/ingest_ids",
-                post(|State(l): State<Live>, _b: axum::body::Bytes| async move {
-                    // Track peak concurrency: bump on entry, hold, drop on exit.
-                    let now = l.cur.fetch_add(1, Ordering::SeqCst) + 1;
-                    l.max.fetch_max(now, Ordering::SeqCst);
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    l.cur.fetch_sub(1, Ordering::SeqCst);
-                    axum::http::StatusCode::NO_CONTENT
-                }),
-            )
-            .with_state(live.clone());
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap();
-        tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-
-        let metrics = MetricsRegistry::new();
-        // Concurrency 8, and 8 requests that each hold the mock 100 ms: a serial
-        // sender would take ~800 ms with peak in-flight 1; the concurrent sender
-        // runs them together.
-        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64, 8);
-        for i in 0..8u32 {
-            tee.offer("m", &[1, 2, 3], &format!("rid-{i}"), Attribution::default());
-        }
-
-        // Wait until all 8 land (or time out), then assert the peak in-flight
-        // exceeded 1 — impossible under a serial sender.
-        for _ in 0..80 {
-            if metrics
-                .render()
-                .contains(r#"sgl_router_cache_sim_tee_total{result="sent"} 8"#)
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-        let peak = live.max.load(Ordering::SeqCst);
-        assert!(
-            peak > 1,
-            "sender must POST concurrently; peak in-flight was {peak} (a serial sender pins it at 1)"
         );
     }
 
@@ -703,7 +585,7 @@ mod tests {
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let metrics = MetricsRegistry::new();
-        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64, 8);
+        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64);
         tee.offer_extend(
             "m",
             &[10, 11, 12, 13],
@@ -797,7 +679,7 @@ mod tests {
         tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
         let metrics = MetricsRegistry::new();
-        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64, 8);
+        let tee = CacheSimTee::spawn(format!("http://{addr}"), Arc::clone(&metrics), 64);
         tee.offer("m", &[1, 2, 3], "rid-1", Attribution::default());
 
         let mut rendered = String::new();


### PR DESCRIPTION
Reverts sgl-project/sglang#34088

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31358378396](https://github.com/sgl-project/sglang/actions/runs/31358378396)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31358378256](https://github.com/sgl-project/sglang/actions/runs/31358378256)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->