### PR TITLE
[Feature] Support NVFP4 token embedding in ModelOpt mixed-precision checkpoints

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -626,6 +626,106 @@ class ModelOptFp8KVCacheMethod(BaseKVCacheMethod):
         super().__init__(quant_config)
 
 
+# E2M1 code -> value, indexed by the 4-bit code (sign << 3 | magnitude).
+_E2M1_LUT = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+
+class ModelOptNvFp4EmbeddingMethod(QuantizeMethodBase):
+    """NVFP4 token embedding, dequantized on gather."""
+
+    def __init__(self, quant_config: ModelOptFp4Config):
+        self.quant_config = quant_config
+        self.params_dtype = torch.bfloat16
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        self.params_dtype = params_dtype
+        group_size = self.quant_config.group_size
+        if input_size_per_partition % group_size != 0:
+            raise ValueError(
+                f"NVFP4 embedding needs embedding_dim divisible by {group_size}, "
+                f"got {input_size_per_partition}."
+            )
+        num_rows = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                num_rows, input_size_per_partition // 2, dtype=torch.uint8
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+
+        weight_scale = ModelWeightParameter(
+            data=torch.empty(
+                num_rows,
+                input_size_per_partition // group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+        weight_scale_2 = Parameter(
+            torch.empty(1, dtype=torch.float32), requires_grad=False
+        )
+        set_weight_attrs(
+            weight_scale_2,
+            {"weight_loader": lambda p, w: p.data.copy_(w.reshape(p.shape).float())},
+        )
+        layer.register_parameter("weight_scale_2", weight_scale_2)
+
+        # A buffer; CUDA graph capture rejects host->device copies.
+        layer.register_buffer(
+            "e2m1_lut",
+            torch.tensor(_E2M1_LUT, dtype=torch.float32),
+            persistent=False,
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        pass
+
+    def apply(self, *args, **kwargs):
+        raise NotImplementedError(
+            "NVFP4 embedding is gather-only. Reaching here means a tied lm_head "
+            "is sharing this module; exclude the embedding from NVFP4 in the "
+            "quantization recipe to serve such a checkpoint."
+        )
+
+    def embedding(self, layer: torch.nn.Module, input_: torch.Tensor) -> torch.Tensor:
+        index_shape = input_.shape
+        flat = input_.reshape(-1)
+        packed = layer.weight[flat]  # [T, H/2] uint8
+        scale = layer.weight_scale[flat]  # [T, H/16] e4m3
+        rows, half = packed.shape
+        hidden = half * 2
+
+        codes = packed.new_empty((rows, hidden))
+        codes[:, 0::2] = packed & 0x0F
+        codes[:, 1::2] = packed >> 4
+
+        mag = layer.e2m1_lut[(codes & 0x7).long()]
+        vals = torch.where(codes & 0x8 != 0, -mag, mag)
+
+        group_size = self.quant_config.group_size
+        eff = scale.float() * layer.weight_scale_2.float()
+        out = vals.view(rows, hidden // group_size, group_size) * eff.unsqueeze(-1)
+        return out.view(*index_shape, hidden).to(self.params_dtype)
+
+
 class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
     """Configuration for ModelOpt MIXED_PRECISION checkpoints."""
 
@@ -823,7 +923,10 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
     ) -> Optional[QuantizeMethodBase]:
         from sglang.srt.layers.linear import LinearBase
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
-        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+        from sglang.srt.layers.vocab_parallel_embedding import (
+            ParallelLMHead,
+            VocabParallelEmbedding,
+        )
 
         quant_algo = self._resolve_quant_algo(prefix)
 
@@ -841,6 +944,18 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             if quant_algo == "W4A16_NVFP4":
                 return ModelOptNvFp4A16LinearMethod(self.nvfp4a16_config)
             return UnquantizedLinearMethod()
+
+        # Must stay after the ParallelLMHead branch above: ParallelLMHead
+        # subclasses VocabParallelEmbedding, and a tied lm_head IS the
+        # embedding module, so it reaches here and gets a gather-only method.
+        if isinstance(layer, VocabParallelEmbedding):
+            if is_layer_skipped(
+                prefix, self.exclude_modules, self.packed_modules_mapping
+            ) or self.is_layer_excluded(prefix):
+                return None
+            if quant_algo == "NVFP4":
+                return ModelOptNvFp4EmbeddingMethod(self.nvfp4_config)
+            return None
 
         if self.kv_cache_quant_algo and isinstance(layer, RadixAttention):
             return ModelOptFp8KVCacheMethod(self.fp8_config)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -945,9 +945,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return ModelOptNvFp4A16LinearMethod(self.nvfp4a16_config)
             return UnquantizedLinearMethod()
 
-        # Must stay after the ParallelLMHead branch above: ParallelLMHead
-        # subclasses VocabParallelEmbedding, and a tied lm_head IS the
-        # embedding module, so it reaches here and gets a gather-only method.
+        # Must stay after the ParallelLMHead branch: ParallelLMHead subclasses
+        # VocabParallelEmbedding, and a tied lm_head IS the embedding module.
         if isinstance(layer, VocabParallelEmbedding):
             if is_layer_skipped(
                 prefix, self.exclude_modules, self.packed_modules_mapping

--- a/test/registered/quant/test_nvfp4_embedding.py
+++ b/test/registered/quant/test_nvfp4_embedding.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-"""Unit tests for NVFP4 token-embedding dequantization on gather."""
 
 import unittest
 
@@ -24,11 +23,8 @@ _REFERENCE_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
 def reference_dequant(
     packed: torch.Tensor, block_scale: torch.Tensor, global_scale: float
 ) -> torch.Tensor:
-    """Naive per-element NVFP4 dequant used as the comparison oracle.
-
-    Deliberately a plain Python loop over the packed nibbles rather than a
-    vectorized rewrite of the code under test.
-    """
+    """Comparison oracle. Kept as a plain per-element loop on purpose: a
+    vectorized rewrite would mirror the code under test."""
     rows, half = packed.shape
     hidden = half * 2
     out = torch.zeros(rows, hidden, dtype=torch.float32)
@@ -44,8 +40,7 @@ def reference_dequant(
 
 
 def build_layer(method, vocab_size: int, hidden_size: int) -> torch.nn.Module:
-    """Materialize the layer through create_weights, then fill the packed
-    tensors the way a checkpoint would."""
+    """Materialize through create_weights, then fill as a checkpoint would."""
     layer = torch.nn.Module()
     method.create_weights(
         layer,

--- a/test/registered/quant/test_nvfp4_embedding.py
+++ b/test/registered/quant/test_nvfp4_embedding.py
@@ -22,10 +22,7 @@ _REFERENCE_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
 
 
 def reference_dequant(
-    packed: torch.Tensor,
-    block_scale: torch.Tensor,
-    global_scale: float,
-    group_size: int = GROUP_SIZE,
+    packed: torch.Tensor, block_scale: torch.Tensor, global_scale: float
 ) -> torch.Tensor:
     """Naive per-element NVFP4 dequant used as the comparison oracle.
 
@@ -41,24 +38,12 @@ def reference_dequant(
             code = (byte & 0x0F) if c % 2 == 0 else (byte >> 4)
             magnitude = _REFERENCE_E2M1[code & 0x7]
             value = -magnitude if code & 0x8 else magnitude
-            scale = float(block_scale[r, c // group_size]) * global_scale
+            scale = float(block_scale[r, c // GROUP_SIZE]) * global_scale
             out[r, c] = value * scale
     return out
 
 
-def make_method(group_size: int = GROUP_SIZE) -> ModelOptNvFp4EmbeddingMethod:
-    config = ModelOptFp4Config(
-        is_checkpoint_nvfp4_serialized=True, group_size=group_size
-    )
-    return ModelOptNvFp4EmbeddingMethod(config)
-
-
-def build_layer(
-    method: ModelOptNvFp4EmbeddingMethod,
-    vocab_size: int,
-    hidden_size: int,
-    seed: int = 0,
-) -> torch.nn.Module:
+def build_layer(method, vocab_size: int, hidden_size: int) -> torch.nn.Module:
     """Materialize the layer through create_weights, then fill the packed
     tensors the way a checkpoint would."""
     layer = torch.nn.Module()
@@ -71,93 +56,73 @@ def build_layer(
         params_dtype=torch.bfloat16,
     )
 
-    generator = torch.Generator().manual_seed(seed)
-    packed = torch.randint(
-        0, 256, (vocab_size, hidden_size // 2), dtype=torch.uint8, generator=generator
+    generator = torch.Generator().manual_seed(0)
+    layer.weight.data.copy_(
+        torch.randint(
+            0,
+            256,
+            (vocab_size, hidden_size // 2),
+            dtype=torch.uint8,
+            generator=generator,
+        )
     )
     # Keep the block scales in a range e4m3 represents exactly.
-    scale = torch.randint(
-        1,
-        8,
-        (vocab_size, hidden_size // GROUP_SIZE),
-        dtype=torch.int32,
-        generator=generator,
-    ).to(torch.float8_e4m3fn)
-
-    layer.weight.data.copy_(packed)
-    layer.weight_scale.data.copy_(scale)
+    layer.weight_scale.data.copy_(
+        torch.randint(
+            1,
+            8,
+            (vocab_size, hidden_size // GROUP_SIZE),
+            dtype=torch.int32,
+            generator=generator,
+        ).to(torch.float8_e4m3fn)
+    )
     layer.weight_scale_2.data.fill_(0.125)
     return layer
 
 
-class TestNvFp4EmbeddingWeights(CustomTestCase):
-    def test_create_weights_shapes_and_dtypes(self):
-        method = make_method()
-        layer = build_layer(method, vocab_size=32, hidden_size=64)
+class TestNvFp4Embedding(CustomTestCase):
+    def setUp(self):
+        self.method = ModelOptNvFp4EmbeddingMethod(
+            ModelOptFp4Config(
+                is_checkpoint_nvfp4_serialized=True, group_size=GROUP_SIZE
+            )
+        )
 
-        self.assertEqual(tuple(layer.weight.shape), (32, 32))
-        self.assertEqual(layer.weight.dtype, torch.uint8)
-        self.assertEqual(tuple(layer.weight_scale.shape), (32, 4))
-        self.assertEqual(layer.weight_scale.dtype, torch.float8_e4m3fn)
-        self.assertEqual(tuple(layer.weight_scale_2.shape), (1,))
-        self.assertEqual(layer.weight_scale_2.dtype, torch.float32)
+    def test_matches_reference_dequant(self):
+        vocab_size, hidden_size = 24, 64
+        layer = build_layer(self.method, vocab_size, hidden_size)
+        self.assertEqual(tuple(layer.weight.shape), (vocab_size, hidden_size // 2))
+        self.assertEqual(
+            tuple(layer.weight_scale.shape), (vocab_size, hidden_size // GROUP_SIZE)
+        )
+
+        ids = torch.tensor([[0, 5, 5], [23, 11, 0]])
+        got = self.method.embedding(layer, ids)
+        expected = reference_dequant(
+            layer.weight[ids.reshape(-1)],
+            layer.weight_scale[ids.reshape(-1)].float(),
+            float(layer.weight_scale_2),
+        )
+
+        self.assertEqual(tuple(got.shape), (2, 3, hidden_size))
+        self.assertEqual(got.dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            got.reshape(-1, hidden_size).float(),
+            expected.to(torch.bfloat16).float(),
+            rtol=0,
+            atol=0,
+        )
 
     def test_hidden_size_must_divide_group_size(self):
-        method = make_method()
-        layer = torch.nn.Module()
         with self.assertRaisesRegex(ValueError, "divisible by 16"):
-            method.create_weights(
-                layer,
+            self.method.create_weights(
+                torch.nn.Module(),
                 input_size_per_partition=40,
                 output_partition_sizes=[8],
                 input_size=40,
                 output_size=8,
                 params_dtype=torch.bfloat16,
             )
-
-    def test_apply_is_rejected(self):
-        method = make_method()
-        with self.assertRaisesRegex(NotImplementedError, "gather-only"):
-            method.apply(torch.nn.Module(), torch.zeros(1))
-
-
-class TestNvFp4EmbeddingGather(CustomTestCase):
-    def test_matches_reference_dequant(self):
-        method = make_method()
-        vocab_size, hidden_size = 24, 64
-        layer = build_layer(method, vocab_size, hidden_size)
-
-        ids = torch.tensor([0, 5, 5, 23, 11])
-        got = method.embedding(layer, ids)
-
-        expected_rows = reference_dequant(
-            layer.weight[ids],
-            layer.weight_scale[ids].float(),
-            float(layer.weight_scale_2),
-        )
-        self.assertEqual(tuple(got.shape), (ids.numel(), hidden_size))
-        self.assertEqual(got.dtype, torch.bfloat16)
-        torch.testing.assert_close(
-            got.float(), expected_rows.to(torch.bfloat16).float(), rtol=0, atol=0
-        )
-
-    def test_preserves_index_shape(self):
-        method = make_method()
-        layer = build_layer(method, vocab_size=16, hidden_size=32)
-
-        ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
-        got = method.embedding(layer, ids)
-        self.assertEqual(tuple(got.shape), (2, 3, 32))
-
-        flat = method.embedding(layer, ids.reshape(-1))
-        torch.testing.assert_close(got.reshape(-1, 32).float(), flat.float())
-
-    def test_repeated_ids_gather_identical_rows(self):
-        method = make_method()
-        layer = build_layer(method, vocab_size=16, hidden_size=32)
-
-        got = method.embedding(layer, torch.tensor([7, 7]))
-        torch.testing.assert_close(got[0].float(), got[1].float())
 
 
 if __name__ == "__main__":

--- a/test/registered/quant/test_nvfp4_embedding.py
+++ b/test/registered/quant/test_nvfp4_embedding.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Unit tests for NVFP4 token-embedding dequantization on gather."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4Config,
+    ModelOptNvFp4EmbeddingMethod,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GROUP_SIZE = 16
+
+# Written out independently of the implementation: the E2M1 code points in
+# magnitude order, so index == the 3-bit magnitude code.
+_REFERENCE_E2M1 = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+
+
+def reference_dequant(
+    packed: torch.Tensor,
+    block_scale: torch.Tensor,
+    global_scale: float,
+    group_size: int = GROUP_SIZE,
+) -> torch.Tensor:
+    """Naive per-element NVFP4 dequant used as the comparison oracle.
+
+    Deliberately a plain Python loop over the packed nibbles rather than a
+    vectorized rewrite of the code under test.
+    """
+    rows, half = packed.shape
+    hidden = half * 2
+    out = torch.zeros(rows, hidden, dtype=torch.float32)
+    for r in range(rows):
+        for c in range(hidden):
+            byte = int(packed[r, c // 2])
+            code = (byte & 0x0F) if c % 2 == 0 else (byte >> 4)
+            magnitude = _REFERENCE_E2M1[code & 0x7]
+            value = -magnitude if code & 0x8 else magnitude
+            scale = float(block_scale[r, c // group_size]) * global_scale
+            out[r, c] = value * scale
+    return out
+
+
+def make_method(group_size: int = GROUP_SIZE) -> ModelOptNvFp4EmbeddingMethod:
+    config = ModelOptFp4Config(
+        is_checkpoint_nvfp4_serialized=True, group_size=group_size
+    )
+    return ModelOptNvFp4EmbeddingMethod(config)
+
+
+def build_layer(
+    method: ModelOptNvFp4EmbeddingMethod,
+    vocab_size: int,
+    hidden_size: int,
+    seed: int = 0,
+) -> torch.nn.Module:
+    """Materialize the layer through create_weights, then fill the packed
+    tensors the way a checkpoint would."""
+    layer = torch.nn.Module()
+    method.create_weights(
+        layer,
+        input_size_per_partition=hidden_size,
+        output_partition_sizes=[vocab_size],
+        input_size=hidden_size,
+        output_size=vocab_size,
+        params_dtype=torch.bfloat16,
+    )
+
+    generator = torch.Generator().manual_seed(seed)
+    packed = torch.randint(
+        0, 256, (vocab_size, hidden_size // 2), dtype=torch.uint8, generator=generator
+    )
+    # Keep the block scales in a range e4m3 represents exactly.
+    scale = torch.randint(
+        1,
+        8,
+        (vocab_size, hidden_size // GROUP_SIZE),
+        dtype=torch.int32,
+        generator=generator,
+    ).to(torch.float8_e4m3fn)
+
+    layer.weight.data.copy_(packed)
+    layer.weight_scale.data.copy_(scale)
+    layer.weight_scale_2.data.fill_(0.125)
+    return layer
+
+
+class TestNvFp4EmbeddingWeights(CustomTestCase):
+    def test_create_weights_shapes_and_dtypes(self):
+        method = make_method()
+        layer = build_layer(method, vocab_size=32, hidden_size=64)
+
+        self.assertEqual(tuple(layer.weight.shape), (32, 32))
+        self.assertEqual(layer.weight.dtype, torch.uint8)
+        self.assertEqual(tuple(layer.weight_scale.shape), (32, 4))
+        self.assertEqual(layer.weight_scale.dtype, torch.float8_e4m3fn)
+        self.assertEqual(tuple(layer.weight_scale_2.shape), (1,))
+        self.assertEqual(layer.weight_scale_2.dtype, torch.float32)
+
+    def test_hidden_size_must_divide_group_size(self):
+        method = make_method()
+        layer = torch.nn.Module()
+        with self.assertRaisesRegex(ValueError, "divisible by 16"):
+            method.create_weights(
+                layer,
+                input_size_per_partition=40,
+                output_partition_sizes=[8],
+                input_size=40,
+                output_size=8,
+                params_dtype=torch.bfloat16,
+            )
+
+    def test_apply_is_rejected(self):
+        method = make_method()
+        with self.assertRaisesRegex(NotImplementedError, "gather-only"):
+            method.apply(torch.nn.Module(), torch.zeros(1))
+
+
+class TestNvFp4EmbeddingGather(CustomTestCase):
+    def test_matches_reference_dequant(self):
+        method = make_method()
+        vocab_size, hidden_size = 24, 64
+        layer = build_layer(method, vocab_size, hidden_size)
+
+        ids = torch.tensor([0, 5, 5, 23, 11])
+        got = method.embedding(layer, ids)
+
+        expected_rows = reference_dequant(
+            layer.weight[ids],
+            layer.weight_scale[ids].float(),
+            float(layer.weight_scale_2),
+        )
+        self.assertEqual(tuple(got.shape), (ids.numel(), hidden_size))
+        self.assertEqual(got.dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            got.float(), expected_rows.to(torch.bfloat16).float(), rtol=0, atol=0
+        )
+
+    def test_preserves_index_shape(self):
+        method = make_method()
+        layer = build_layer(method, vocab_size=16, hidden_size=32)
+
+        ids = torch.tensor([[0, 1, 2], [3, 4, 5]])
+        got = method.embedding(layer, ids)
+        self.assertEqual(tuple(got.shape), (2, 3, 32))
+
+        flat = method.embedding(layer, ids.reshape(-1))
+        torch.testing.assert_close(got.reshape(-1, 32).float(), flat.float())
+
+    def test_repeated_ids_gather_identical_rows(self):
+        method = make_method()
+        layer = build_layer(method, vocab_size=16, hidden_size=32)
+
+        got = method.embedding(layer, torch.tensor([7, 7]))
+        torch.testing.assert_close(got[0].float(), got[1].float())
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
The MIXED_PRECISION format describes quantization as a per-prefix `quantized_layers` map, and the format itself does not restrict what a prefix points at. `ModelOptMixedPrecisionConfig.get_quant_method` dispatches on `LinearBase`/`ParallelLMHead`, `RadixAttention` and `FusedMoE`, but a `VocabParallelEmbedding` falls through to the closing `return None` -- so a checkpoint whose map marks the token embedding cannot be served at all.

This adds `ModelOptNvFp4EmbeddingMethod`, which keeps the table packed and unpacks rows to the activation dtype on gather. An embedding is a row gather rather than a GEMM, so there is no NVFP4 kernel to dispatch to and no compute win here -- the gain is purely footprint. On a large vocabulary that is not a rounding error: a 200k-token table over a few thousand channels runs to a billion-plus parameters, where the bf16-to-4-bit difference is on the order of a GiB, and on a single-GPU deployment that turns straight into KV cache.

## Behavior

Unchanged for every checkpoint that loads today. The new branch returns `None` unless the map resolves that prefix to `NVFP4`, and honors `exclude_modules` / `is_layer_excluded` first. Whether the embedding is quantized at all remains the checkpoint author's decision; this only makes the result servable.

The branch must stay after the `ParallelLMHead` one. `ParallelLMHead` subclasses `VocabParallelEmbedding`, and under `tie_word_embeddings` the lm_head *is* the embedding module, so it reaches this branch and gets a gather-only method; `apply()` raises with a message pointing at the recipe. A comment records the ordering requirement.

## Dequant

Follows the same NVFP4 decode as `kvfp4_tensor.batched_dequantize`: low nibble to even lanes, `0x8` sign, `0x7` magnitude into the E2M1 table. The scale step differs by format -- NVFP4 carries an e4m3 per-16 block scale plus an fp32 global scale, applied as a product, where the KV path uses a single E8M0 power-of-two.

## Tests

`test/registered/quant/test_nvfp4_embedding.py` checks the gather against a reference dequant written independently as a plain per-element Python loop, at `rtol=0, atol=0`, plus the group-size divisibility guard.
