### PR TITLE
[AMD] Skip aiter's cos_cache and sin_cache rope buffers in the weight checker

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -53,6 +53,8 @@ class QuantizedWeight(NamedTuple):
 
 _NON_PERSISTENT_BUFFER_PATTERNS = (
     "cos_sin_cache",
+    "cos_cache",
+    "sin_cache",
     "inv_freq",
     "freqs_cis",
     "_weight_fp32",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On ROCm with `SGLANG_USE_AITER=1`, the weight checker incorrectly compares AITER's RoPE cache buffers.

`WeightChecker` first overwrites tensors with random values, then pushes weights from the trainer and compares them against the original snapshot. Derived buffers that are not transferred must therefore be skipped.

SGLang already skips its own RoPE cache, AITER instead registers separate `cos_cache` and `sin_cache` buffers. Because the current skip pattern only contains `cos_sin_cache`, the AITER buffers are overwritten by `_reset_tensors()` and never restored. The subsequent comparison then fails:

```text
Exception: check tensor equality failed:
  name=model.layers.0.self_attn.rotary_emb.cos_cache  max_abs_err=2.0  mean_abs_err=0.7023  num_exceed=6476520
  name=model.layers.0.self_attn.rotary_emb.sin_cache  max_abs_err=2.0  mean_abs_err=0.6587  num_exceed=6477174
POST /weights_checker HTTP/1.1  400 Bad Request
```

This was hit while enabling a Miles RL CI case with Megatron + GLM-4.7-Flash on 4x MI355X.

## Modifications

<!-- Detail the changes made in this pull request. -->

Add `cos_cache` and `sin_cache` to `_NON_PERSISTENT_BUFFER_PATTERNS`. This only affects ROCm/AITER. CUDA/NVIDIA does not register buffers with these names, so the new patterns do not match anything there.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

End-to-end validation in Miles on 4x MI355X (gfx950, ROCm 7.2, `SGLANG_USE_AITER=1`) with Megatron + GLM-4.7-Flash RL and `check_weights` enabled:

- before: weight check fails on `cos_cache` and `sin_cache`
- after: 0 mismatches
- 2 rollouts x 2 training steps complete successfully
- repeated 6 times with no failures

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31359809927](https://github.com/sgl-project/sglang/actions/runs/31359809927)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31359809748](https://github.com/sgl-project/sglang/actions/runs/31359809748)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->