### PR TITLE
[BugFix] Release LoRARegistry reference for aborted requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -210,6 +210,11 @@ class ReqState:
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
+    # Exactly-once guard for releasing the acquired LoRA registry reference;
+    # the batch-output, abort-ack and scheduler abort/error paths can race
+    # for the same rid, so only the first terminal path may release.
+    lora_released: bool = False
+
     # For streaming output
     last_output_offset: int = 0
 
@@ -401,6 +406,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.enable_metrics = server_args.enable_metrics
         self.incremental_streaming_output = server_args.incremental_streaming_output
         self.enable_lora = server_args.enable_lora
+        # Strong references to in-flight LoRA release tasks so they are not
+        # garbage-collected before the registry counter is decremented.
+        self._lora_release_tasks = set()
         self.enable_trace = server_args.enable_trace
         self.allow_auto_truncate = server_args.allow_auto_truncate
         self.skip_tokenizer_init = server_args.skip_tokenizer_init
@@ -1653,6 +1661,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             finish_reason.get("type") == "abort"
             and finish_reason.get("status_code") == HTTPStatus.BAD_REQUEST
         ):
+            self._release_lora_once(state)
             if not is_stream:
                 raise ValueError(finish_reason["message"])
             return out
@@ -1669,8 +1678,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 del self.rid_to_state[state.obj.rid]
 
             # Mark ongoing LoRA request as finished.
-            if self.enable_lora and state.obj.lora_path:
-                await self.lora_registry.release(state.obj.lora_id)
+            self._release_lora_once(state)
             if not is_stream:
                 raise fastapi.HTTPException(
                     status_code=finish_reason["status_code"],
@@ -2440,8 +2448,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 del self.rid_to_state[rid]
 
                 # Mark ongoing LoRA request as finished.
-                if self.enable_lora and state.obj.lora_path:
-                    asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+                self._release_lora_once(state)
 
             if out_dict is not None:
                 state.out_list.append(out_dict)
@@ -3121,6 +3128,27 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         """Put some custom force exit logic here."""
         pass
 
+    def _release_lora_once(self, state: ReqState):
+        """Release the LoRA registry reference for *state* exactly once.
+
+        The abort ack path, the batch-output path and the scheduler
+        abort/error finish-reason path can race for the same rid; the
+        lora_released flag guarantees the acquire is paired with a single
+        release whichever terminal path wins.
+        """
+        if not (self.enable_lora and state.obj.lora_path):
+            return
+        if state.lora_released:
+            return
+        if not getattr(state.obj, "lora_id", None):
+            # acquire failed before setting lora_id (e.g. unregistered adapter);
+            # nothing was counted, so there is nothing to release.
+            return
+        state.lora_released = True
+        task = asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+        self._lora_release_tasks.add(task)
+        task.add_done_callback(self._lora_release_tasks.discard)
+
     def _handle_abort_req(self, recv_obj: AbortReq):
         if is_health_check_generate_req(recv_obj):
             return
@@ -3174,6 +3202,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             "meta_info": meta_info,
         }
         del self.rid_to_state[recv_obj.rid]
+
+        # Release the LoRA registry reference acquired for this request.
+        self._release_lora_once(state)
 
         state.out_list.append(out)
         state.event.set()
@@ -3386,7 +3417,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             rids = obj.rid
         for rid in rids:
-            self.rid_to_state.pop(rid, None)
+            state = self.rid_to_state.pop(rid, None)
+            if state is not None and not state.finished:
+                # Release the LoRA registry reference acquired for this request.
+                self._release_lora_once(state)
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -730,9 +730,7 @@ class TestLoraReleaseOnAbort(CustomTestCase):
         }
 
         async def drive():
-            abort_out = await tm._handle_abort_finish_reason(
-                out, state, is_stream=True
-            )
+            abort_out = await tm._handle_abort_finish_reason(out, state, is_stream=True)
             self.assertIsNotNone(abort_out)
             await asyncio.sleep(0)
 

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -159,6 +159,25 @@ def _make_abort_req(rid: str, abort_message: str = "Aborted") -> AbortReq:
     )
 
 
+def _make_tm_with_lora() -> TokenizerManager:
+    """Create a TokenizerManager with LoRA enabled and a mocked registry."""
+    tm = _make_tokenizer_manager()
+    tm.enable_lora = True
+    tm.server_args.enable_lora = True
+    tm.lora_registry = AsyncMock()
+    tm.lora_registry.release = AsyncMock()
+    tm._lora_release_tasks = set()
+    return tm
+
+
+def _make_lora_req_state(rid: str = "test_rid") -> ReqState:
+    """Create a ReqState whose obj references a loaded LoRA adapter."""
+    state = _make_req_state(rid)
+    state.obj.lora_path = "test-lora"
+    state.obj.lora_id = "lora-id-1"
+    return state
+
+
 def _make_batch_str_output(rid: str, finished_reason=None) -> BatchStrOutput:
     """Create a minimal BatchStrOutput for a single request.
 
@@ -603,6 +622,236 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
             asyncio.run(drive())
 
         self.assertFalse(tm.rid_to_state)
+
+
+class TestLoraReleaseOnAbort(CustomTestCase):
+    """LoRA registry references must be released exactly once on every
+    terminal path.
+
+    Regression guards for issue #34205: aborted or pre-dispatch-failed
+    requests kept their LoRARegistry acquire() reference forever, which
+    wedges wait_for_unload / eviction once the per-adapter counter never
+    reaches zero. Each terminal path (batch output, abort ack, scheduler
+    400/503/500 finish reason, pre-dispatch discard) must pair the single
+    acquire with at most one release.
+    """
+
+    def test_abort_releases_lora_exactly_once(self):
+        """_handle_abort_req must release the acquired LoRA reference."""
+        tm = _make_tm_with_lora()
+        rid = "abort_lora"
+        state = _make_lora_req_state(rid)
+        tm.rid_to_state[rid] = state
+
+        async def drive():
+            tm._handle_abort_req(_make_abort_req(rid))
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_release_lora_once_is_idempotent(self):
+        """Calling _release_lora_once twice must release only once."""
+        tm = _make_tm_with_lora()
+        state = _make_lora_req_state("idem_lora")
+
+        async def drive():
+            tm._release_lora_once(state)
+            tm._release_lora_once(state)
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+
+    def test_abort_then_batch_output_does_not_double_release(self):
+        """An abort that wins the race against a batch output must not
+        double-release: the later output finds no state and is skipped."""
+        tm = _make_tm_with_lora()
+        rid = "abort_then_output"
+        tm.rid_to_state[rid] = _make_lora_req_state(rid)
+        batch_output = _make_batch_str_output(rid)
+
+        async def drive():
+            tm._handle_abort_req(_make_abort_req(rid))
+            await asyncio.sleep(0)
+            await tm._handle_batch_output(batch_output)
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_abort_finish_reason_status_release_once(self):
+        """Scheduler 503/500 finish reasons must release only once even if
+        the path is reached twice for the same state."""
+        tm = _make_tm_with_lora()
+        rid = "afr_status"
+        state = _make_lora_req_state(rid)
+        tm.rid_to_state[rid] = state
+        out = {
+            "meta_info": {
+                "finish_reason": {
+                    "type": "abort",
+                    "status_code": 503,
+                    "message": "scheduler busy",
+                }
+            }
+        }
+
+        async def drive():
+            await tm._handle_abort_finish_reason(out, state, is_stream=True)
+            await tm._handle_abort_finish_reason(out, state, is_stream=True)
+
+        asyncio.run(drive())
+
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_abort_finish_reason_bad_request_releases_lora(self):
+        """The scheduler BAD_REQUEST abort path must also release the
+        acquired LoRA reference."""
+        tm = _make_tm_with_lora()
+        rid = "afr_bad_request"
+        state = _make_lora_req_state(rid)
+        tm.rid_to_state[rid] = state
+        out = {
+            "meta_info": {
+                "finish_reason": {
+                    "type": "abort",
+                    "status_code": 400,
+                    "message": "bootstrap room missing",
+                }
+            }
+        }
+
+        async def drive():
+            abort_out = await tm._handle_abort_finish_reason(
+                out, state, is_stream=True
+            )
+            self.assertIsNotNone(abort_out)
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_discard_pending_req_states_releases_lora(self):
+        """Pre-dispatch failures (via _discard_pending_req_states) must
+        release the acquired LoRA reference."""
+        tm = _make_tm_with_lora()
+        rid = "d_lora"
+        tm.rid_to_state[rid] = _make_lora_req_state(rid)
+        obj = Mock(spec=GenerateReqInput)
+        obj.is_single = True
+        obj.rid = rid
+
+        async def drive():
+            tm._discard_pending_req_states(obj)
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_discard_without_lora_id_does_not_call_release(self):
+        """A request whose lora_id was never set (acquire failed) has nothing
+        to release and must not raise."""
+        tm = _make_tm_with_lora()
+        rid = "d_no_id"
+        state = _make_req_state(rid)
+        state.obj.lora_path = "test-lora"
+        state.obj.lora_id = None
+        tm.rid_to_state[rid] = state
+        obj = Mock(spec=GenerateReqInput)
+        obj.is_single = True
+        obj.rid = rid
+
+        async def drive():
+            tm._discard_pending_req_states(obj)
+            await asyncio.sleep(0)
+
+        asyncio.run(drive())
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_enable_lora_false_does_not_release(self):
+        """With LoRA disabled the abort path must never touch the registry."""
+        tm = _make_tokenizer_manager()
+        tm.lora_registry = AsyncMock()
+        tm.lora_registry.release = AsyncMock()
+        tm._lora_release_tasks = set()
+        rid = "no_lora"
+        tm.rid_to_state[rid] = _make_lora_req_state(rid)
+
+        tm._handle_abort_req(_make_abort_req(rid))
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_running_timeout_no_double_release(self):
+        """Normal finish followed by a scheduler 503 finish reason for the
+        same state must still release exactly once."""
+        tm = _make_tm_with_lora()
+        rid = "timeout_lora"
+        state = _make_lora_req_state(rid)
+        tm.rid_to_state[rid] = state
+        batch_output = _make_batch_str_output(rid)
+        out = {
+            "meta_info": {
+                "finish_reason": {
+                    "type": "abort",
+                    "status_code": 503,
+                    "message": "scheduler timeout",
+                }
+            }
+        }
+
+        async def drive():
+            await tm._handle_batch_output(batch_output)
+            await asyncio.sleep(0)
+            await tm._handle_abort_finish_reason(out, state, is_stream=True)
+
+        asyncio.run(drive())
+
+        self.assertEqual(tm.lora_registry.release.await_count, 1)
+        tm.lora_registry.release.assert_awaited_once_with("lora-id-1")
+
+    def test_abort_without_lora_path_does_not_release(self):
+        """An abort for a request with no LoRA path must not touch the
+        registry."""
+        tm = _make_tm_with_lora()
+        rid = "no_lora_path"
+        state = _make_req_state(rid)
+        tm.rid_to_state[rid] = state
+
+        tm._handle_abort_req(_make_abort_req(rid))
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
+
+    def test_abort_without_lora_id_does_not_release(self):
+        """An abort for a request whose acquire() failed (lora_path set but
+        no lora_id) must not call release(None) and must not raise."""
+        tm = _make_tm_with_lora()
+        rid = "no_lora_id"
+        state = _make_req_state(rid)
+        state.obj.lora_path = "test-lora"
+        state.obj.lora_id = None
+        tm.rid_to_state[rid] = state
+
+        tm._handle_abort_req(_make_abort_req(rid))
+
+        self.assertNotIn(rid, tm.rid_to_state)
+        tm.lora_registry.release.assert_not_awaited()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #34205. When a request that uses a LoRA adapter is aborted before it finishes, the LoRARegistry reference acquired in `_resolve_lora_path` is never released. `_handle_abort_req` removes the request state from `rid_to_state` but does not pair the `acquire` with a `release`, so the adapter's usage counter never reaches zero and `wait_for_unload` blocks forever. This wedges dynamic adapter unload and LRU eviction under `--max-loaded-loras`.

The normal terminal path (`_handle_batch_output`) and the scheduler 503/500 abort path (`_handle_abort_finish_reason`) already release the reference, but the direct abort ack path, the pre-dispatch discard path, and the scheduler 400 abort path do not. Releasing in each path separately would double-release when two terminal paths race for the same request (for example a 503 abort is echoed to `_handle_abort_req` and later processed again by `_handle_abort_finish_reason`), which underflows the counter and wedges unload in the opposite direction.

## Modifications

- Add an exactly-once release guard (`lora_released` on `ReqState`) and a `_release_lora_once` helper in `TokenizerManager`.
- Route all five terminal paths through the helper: batch output, abort ack, scheduler 400/503/500 finish reasons, and pre-dispatch discard.
- The helper skips requests that never acquired a reference (LoRA disabled, no `lora_path`, or `acquire` failed before `lora_id` was set), so it never calls `release(None)`.
- Add unit tests in `test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py` covering each terminal path and the no-double-release guarantee.

Note: this is scoped to single-request LoRA accounting (n=1); parallel-sampling (n>1) counter behavior is out of scope here. #31808 proposes a broader fix for the same accounting issue; this PR intentionally keeps the change minimal and unit-testable on CPU.

## Accuracy Tests

N/A - no model output or inference-path change.

## Speed Tests and Profiling

N/A - no inference-path change; the fix only pairs an existing `acquire` with its `release` on the abort path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31363510450](https://github.com/sgl-project/sglang/actions/runs/31363510450)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31363510339](https://github.com/sgl-project/sglang/actions/runs/31363510339)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->