### PR TITLE
[HCU] [CI] Add minimal PR smoke test framework

### DIFF
--- a/.github/workflows/pr-test-hcu.yml
+++ b/.github/workflows/pr-test-hcu.yml
@@ -1,0 +1,246 @@
+name: PR Test (HCU)
+
+on:
+  # A new commit does not inherit approval: maintainers must remove and re-add
+  # run-ci to authorize the current PR head SHA.
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      target_sha:
+        description: "Full commit SHA to test (defaults to the selected ref)"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  actions: read # pr-gate reads workflow history for cooldown enforcement.
+  contents: read # Checkout and pr-gate read repository contents.
+  pull-requests: read # pr-gate live-fetches labels and draft state.
+
+env:
+  HCU_CI_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+  HCU_CI_SMOKE_MODEL: ${{ vars.HCU_CI_SMOKE_MODEL || '' }}
+  HCU_CI_PORT: "31000"
+
+concurrency:
+  group: pr-test-hcu-${{ github.event.pull_request.number || inputs.target_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-changes:
+    name: Check HCU-relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      hcu: ${{ steps.filter.outputs.hcu == 'true' || github.event_name == 'workflow_dispatch' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Detect HCU-relevant changes
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            hcu:
+              - "python/**"
+              - "scripts/ci/**"
+              - "test/**"
+              - ".github/workflows/pr-test-hcu.yml"
+
+  plan:
+    name: Plan HCU smoke
+    needs: check-changes
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.plan.outputs.should_run }}
+      target_sha: ${{ steps.plan.outputs.target_sha }}
+      reason: ${{ steps.plan.outputs.reason }}
+    steps:
+      - name: Authorize target SHA
+        id: plan
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action || '' }}
+          EVENT_LABEL: ${{ github.event.label.name || '' }}
+          HCU_RELEVANT: ${{ needs.check-changes.outputs.hcu }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || inputs.target_sha || github.sha }}
+          HCU_ENABLED: ${{ vars.HCU_CI_ENABLED || '' }}
+          HCU_RUNNER_LABEL: ${{ vars.HCU_CI_RUNNER_LABEL || '' }}
+          HCU_IMAGE: ${{ vars.HCU_CI_IMAGE || '' }}
+          HCU_SMOKE_MODEL: ${{ vars.HCU_CI_SMOKE_MODEL || '' }}
+        run: |
+          set -euo pipefail
+
+          should_run=false
+          reason=""
+          if [[ "${HCU_RELEVANT}" != "true" ]]; then
+            reason="No HCU-relevant changes were detected."
+          elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
+            if [[ "${EVENT_ACTION}" == "labeled" && "${EVENT_LABEL}" == "run-ci" ]]; then
+              should_run=true
+            else
+              reason="The current PR head SHA has not been authorized by a run-ci label event."
+            fi
+          else
+            should_run=true
+          fi
+
+          if [[ "${should_run}" == "true" && "${HCU_ENABLED}" != "true" ]]; then
+            if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+              should_run=false
+              reason="HCU CI is not enabled in this repository."
+            else
+              echo "::error::HCU_CI_ENABLED must be true"
+              exit 1
+            fi
+          fi
+
+          if [[ "${should_run}" == "true" ]]; then
+            [[ "${TARGET_SHA}" =~ ^[0-9a-fA-F]{40}$ ]] || {
+              echo "::error::target_sha must be a full commit SHA"
+              exit 1
+            }
+            [[ -n "${HCU_RUNNER_LABEL}" && -n "${HCU_SMOKE_MODEL}" ]] || {
+              echo "::error::HCU runner label and smoke model must be configured"
+              exit 1
+            }
+            [[ "${HCU_IMAGE}" =~ ^.+@sha256:[0-9a-fA-F]{64}$ ]] || {
+              echo "::error::HCU_CI_IMAGE must use a full immutable sha256 digest"
+              exit 1
+            }
+          fi
+
+          {
+            echo "should_run=${should_run}"
+            echo "target_sha=${TARGET_SHA}"
+            echo "reason=${reason}"
+          } >> "${GITHUB_OUTPUT}"
+
+  pr-gate:
+    name: PR gate
+    needs: [check-changes, plan]
+    if: needs.plan.outputs.should_run == 'true' && github.event_name == 'pull_request'
+    uses: ./.github/workflows/pr-gate.yml
+    with:
+      require-run-ci: true
+
+  hcu-smoke:
+    name: HCU smoke
+    needs: [check-changes, plan, pr-gate]
+    if: |
+      always() &&
+      needs.check-changes.result == 'success' &&
+      needs.plan.outputs.should_run == 'true' &&
+      (
+        (github.event_name == 'pull_request' && needs.pr-gate.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && needs.pr-gate.result == 'skipped')
+      )
+    runs-on: ${{ vars.HCU_CI_RUNNER_LABEL || 'hcu-ci-disabled' }}
+    timeout-minutes: 60
+    env:
+      HCU_CI_TARGET_SHA: ${{ needs.plan.outputs.target_sha }}
+      HCU_CI_CONTAINER_NAME: hcu_pr_${{ github.run_id }}_${{ github.run_attempt }}
+    steps:
+      - name: Reset workspace ownership
+        shell: bash
+        run: |
+          docker pull "${HCU_CI_IMAGE}"
+          docker run --rm \
+            --user root \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            "${HCU_CI_IMAGE}" \
+            bash -c 'chown -R "$1:$2" /workspace' -- "$(id -u)" "$(id -g)" || true
+
+      - name: Checkout exact target
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ env.HCU_CI_TARGET_SHA }}
+          persist-credentials: false
+          clean: true
+
+      - name: Run single-HCU smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$(git rev-parse HEAD)" == "${HCU_CI_TARGET_SHA}" ]]
+          mkdir -p .hcu-ci-logs
+          docker rm -f "${HCU_CI_CONTAINER_NAME}" >/dev/null 2>&1 || true
+          # /opt/hyhal is the Hygon host driver/runtime stack required by HCU devices.
+          docker run --rm \
+            --name "${HCU_CI_CONTAINER_NAME}" \
+            --shm-size 16g \
+            --device /dev/kfd \
+            --device /dev/dri \
+            --group-add video \
+            --cap-add SYS_PTRACE \
+            --security-opt seccomp=unconfined \
+            -v /opt/hyhal:/opt/hyhal:ro \
+            -v "${GITHUB_WORKSPACE}:/sglang-checkout" \
+            -v "${HCU_CI_SMOKE_MODEL}:${HCU_CI_SMOKE_MODEL}:ro" \
+            -e HCU_CI_REPO_ROOT=/sglang-checkout \
+            -e HCU_CI_LOG_DIR=/sglang-checkout/.hcu-ci-logs \
+            -e HCU_CI_SMOKE_MODEL \
+            -e HCU_CI_TARGET_SHA \
+            -e HCU_CI_PORT \
+            -e HIP_VISIBLE_DEVICES=0 \
+            -e ROCR_VISIBLE_DEVICES=0 \
+            -w /sglang-checkout \
+            "${HCU_CI_IMAGE}" \
+            bash scripts/ci/hcu/run_hcu_pr_smoke.sh
+
+      - name: Print logs on failure
+        if: failure()
+        shell: bash
+        run: tail -n 300 .hcu-ci-logs/*.log || true
+
+      - name: Cleanup
+        if: always()
+        shell: bash
+        run: |
+          docker rm -f "${HCU_CI_CONTAINER_NAME}" >/dev/null 2>&1 || true
+          docker run --rm \
+            --user root \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            "${HCU_CI_IMAGE}" \
+            bash -c 'chown -R "$1:$2" /workspace' -- "$(id -u)" "$(id -g)" || true
+
+  pr-test-hcu-finish:
+    name: PR Test (HCU) finish
+    needs: [check-changes, plan, pr-gate, hcu-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Evaluate result
+        shell: bash
+        env:
+          CHECK_CHANGES_RESULT: ${{ needs.check-changes.result }}
+          PLAN_RESULT: ${{ needs.plan.result }}
+          SHOULD_RUN: ${{ needs.plan.outputs.should_run }}
+          GATE_RESULT: ${{ needs.pr-gate.result }}
+          SMOKE_RESULT: ${{ needs.hcu-smoke.result }}
+          REASON: ${{ needs.plan.outputs.reason }}
+        run: |
+          if [[ "${CHECK_CHANGES_RESULT}" != "success" ]]; then
+            echo "::error::HCU change detection failed"
+            exit 1
+          fi
+          if [[ "${PLAN_RESULT}" != "success" ]]; then
+            echo "::error::HCU planning failed"
+            exit 1
+          fi
+          if [[ "${SHOULD_RUN}" == "true" && "${GATE_RESULT}" == "failure" ]]; then
+            echo "::error::HCU PR gate failed"
+            exit 1
+          fi
+          if [[ "${SHOULD_RUN}" == "true" && "${SMOKE_RESULT}" != "success" ]]; then
+            echo "::error::HCU smoke ended with ${SMOKE_RESULT}"
+            exit 1
+          fi
+          echo "${REASON:-HCU smoke passed.}"

--- a/python/sglang/test/ci/ci_register.py
+++ b/python/sglang/test/ci/ci_register.py
@@ -12,6 +12,7 @@ __all__ = [
     "register_cpu_ci",
     "register_cuda_ci",
     "register_amd_ci",
+    "register_hcu_ci",
     "register_musa_ci",
     "register_npu_ci",
     "register_xpu_ci",
@@ -33,6 +34,7 @@ class HWBackend(Enum):
     CPU = auto()
     CUDA = auto()
     AMD = auto()
+    HCU = auto()
     NPU = auto()
     XPU = auto()
     MUSA = auto()
@@ -95,6 +97,19 @@ def register_amd_ci(
     runner_config: Optional[str] = None,
 ):
     """Marker for AMD CI registration (parsed via AST; runtime no-op)."""
+    return None
+
+
+def register_hcu_ci(
+    est_time: float,
+    suite: Optional[str] = None,
+    nightly: bool = False,
+    disabled: Optional[str] = None,
+    *,
+    stage: Optional[str] = None,
+    runner_config: Optional[str] = None,
+):
+    """Marker for HCU CI registration (parsed via AST; runtime no-op)."""
     return None
 
 
@@ -167,6 +182,7 @@ REGISTER_MAPPING = {
     "register_cpu_ci": HWBackend.CPU,
     "register_cuda_ci": HWBackend.CUDA,
     "register_amd_ci": HWBackend.AMD,
+    "register_hcu_ci": HWBackend.HCU,
     "register_musa_ci": HWBackend.MUSA,
     "register_npu_ci": HWBackend.NPU,
     "register_xpu_ci": HWBackend.XPU,

--- a/scripts/ci/hcu/run_hcu_pr_smoke.sh
+++ b/scripts/ci/hcu/run_hcu_pr_smoke.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly REPO_ROOT="${HCU_CI_REPO_ROOT:-/sglang-checkout}"
+readonly MODEL_PATH="${HCU_CI_SMOKE_MODEL:?HCU_CI_SMOKE_MODEL is required}"
+readonly TARGET_SHA="${HCU_CI_TARGET_SHA:?HCU_CI_TARGET_SHA is required}"
+readonly PORT="${HCU_CI_PORT:-31000}"
+readonly LOG_DIR="${HCU_CI_LOG_DIR:-${REPO_ROOT}/.hcu-ci-logs}"
+
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "${SERVER_PID}" ]] && kill -0 "${SERVER_PID}" 2>/dev/null; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+    wait "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+mkdir -p "${LOG_DIR}"
+exec > >(tee -a "${LOG_DIR}/smoke.log") 2>&1
+
+[[ -d "${MODEL_PATH}" ]] || { echo "Model path not found: ${MODEL_PATH}"; exit 1; }
+[[ "${PORT}" =~ ^[0-9]+$ ]] || { echo "Invalid port: ${PORT}"; exit 1; }
+
+cd "${REPO_ROOT}"
+git config --global --add safe.directory "${REPO_ROOT}"
+[[ "$(git rev-parse HEAD)" == "${TARGET_SHA}" ]] || {
+  echo "Checkout SHA does not match ${TARGET_SHA}"
+  exit 1
+}
+
+export PYTHONPATH="${REPO_ROOT}/python:${PYTHONPATH:-}"
+python3 - <<'PY'
+import sgl_kernel
+import tabulate
+
+print(f"Using image-provided sgl_kernel from {sgl_kernel.__file__}")
+print(f"Using image-provided tabulate from {tabulate.__file__}")
+PY
+
+python3 test/run_suite.py \
+  --hw hcu \
+  --suite stage-a-test-1-hcu \
+  --timeout-per-file 300 \
+  2>&1 | tee "${LOG_DIR}/pytest.log"
+
+python3 -m sglang.launch_server \
+  --model-path "${MODEL_PATH}" \
+  --host 127.0.0.1 \
+  --port "${PORT}" \
+  --tp-size 1 \
+  --page-size 64 \
+  --attention-backend triton \
+  --cuda-graph-backend-decode disabled \
+  --cuda-graph-backend-prefill disabled \
+  --trust-remote-code \
+  >"${LOG_DIR}/server.log" 2>&1 &
+SERVER_PID="$!"
+
+HCU_CI_BASE_URL="http://127.0.0.1:${PORT}" \
+HCU_CI_SERVER_PID="${SERVER_PID}" \
+python3 - <<'PY' 2>&1 | tee "${LOG_DIR}/request.log"
+import json
+import os
+import time
+import urllib.request
+
+base_url = os.environ["HCU_CI_BASE_URL"]
+server_pid = int(os.environ["HCU_CI_SERVER_PID"])
+deadline = time.monotonic() + 600
+
+while True:
+    try:
+        os.kill(server_pid, 0)
+    except ProcessLookupError as exc:
+        raise RuntimeError("SGLang server exited before becoming ready") from exc
+
+    try:
+        with urllib.request.urlopen(f"{base_url}/v1/models", timeout=10) as response:
+            models = json.load(response)
+        break
+    except (OSError, ValueError):
+        if time.monotonic() >= deadline:
+            raise RuntimeError("SGLang server did not become ready within 600 seconds")
+        time.sleep(5)
+
+model_id = models["data"][0]["id"]
+payload = json.dumps(
+    {
+        "model": model_id,
+        "messages": [{"role": "user", "content": "Reply with one short greeting."}],
+        "temperature": 0,
+        "max_tokens": 16,
+    }
+).encode()
+request = urllib.request.Request(
+    f"{base_url}/v1/chat/completions",
+    data=payload,
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request, timeout=180) as response:
+    result = json.load(response)
+
+text = result["choices"][0]["message"].get("content", "")
+if not text.strip():
+    raise RuntimeError(f"Chat completion returned no content: {result}")
+print(json.dumps(result, indent=2))
+PY
+
+echo "HCU PR smoke completed successfully."

--- a/scripts/ci/utils/ci_coverage_report.py
+++ b/scripts/ci/utils/ci_coverage_report.py
@@ -32,8 +32,8 @@ from ci_register import CIRegistry, HWBackend, ut_parse_one_file
 # the report -- if the assert below fires, add the new backend name here in
 # the right display slot. Order isn't alphabetical: CUDA/AMD/NPU/CPU lead
 # (highest test volume historically), then accelerators that have been
-# wired into the registry more recently (XPU, MUSA, MLX).
-BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "XPU", "MUSA", "MLX")
+# wired into the registry more recently (HCU, XPU, MUSA, MLX).
+BACKEND_DISPLAY_ORDER = ("CUDA", "AMD", "NPU", "CPU", "HCU", "XPU", "MUSA", "MLX")
 assert set(BACKEND_DISPLAY_ORDER) == {
     b.name for b in HWBackend
 }, "BACKEND_DISPLAY_ORDER is out of sync with HWBackend"

--- a/test/registered/hcu/test_hcu_smoke.py
+++ b/test/registered/hcu/test_hcu_smoke.py
@@ -1,0 +1,91 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from sglang.test.ci.ci_register import (
+    REGISTER_MAPPING,
+    HWBackend,
+    register_hcu_ci,
+    ut_parse_one_file,
+)
+
+register_hcu_ci(est_time=30, suite="stage-a-test-1-hcu")
+
+
+def _torch():
+    return importlib.import_module("torch")
+
+
+def test_hcu_registration_api():
+    assert REGISTER_MAPPING["register_hcu_ci"] is HWBackend.HCU
+    assert register_hcu_ci(est_time=30, suite="stage-a-test-1-hcu") is None
+
+
+def test_hcu_smoke_file_registration():
+    registrations, has_main = ut_parse_one_file(str(Path(__file__)))
+
+    assert has_main
+    assert len(registrations) == 1
+    assert registrations[0].backend is HWBackend.HCU
+    assert registrations[0].effective_suite == "stage-a-test-1-hcu"
+
+
+def test_hip_runtime_and_device_available():
+    torch = _torch()
+
+    assert torch.version.hip
+    assert torch.cuda.is_available()
+    assert torch.cuda.device_count() == 1
+
+
+def test_hcu_tensor_copy():
+    torch = _torch()
+    source = torch.arange(16, dtype=torch.float32)
+
+    assert torch.equal(source.cuda().cpu(), source)
+
+
+def test_hcu_bfloat16_addition():
+    torch = _torch()
+    left = torch.ones(32, device="cuda", dtype=torch.bfloat16)
+    right = torch.full((32,), 2, device="cuda", dtype=torch.bfloat16)
+
+    assert torch.all(left + right == 3)
+
+
+def test_hcu_bfloat16_matmul():
+    torch = _torch()
+    left = torch.ones((16, 16), device="cuda", dtype=torch.bfloat16)
+    right = torch.eye(16, device="cuda", dtype=torch.bfloat16)
+
+    torch.testing.assert_close(left @ right, left)
+
+
+def test_hcu_device_synchronize():
+    torch = _torch()
+    value = torch.ones(1, device="cuda") + 1
+
+    torch.cuda.synchronize()
+    assert value.item() == 2
+
+
+def test_sgl_kernel_common_ops_loaded():
+    sgl_kernel = importlib.import_module("sgl_kernel")
+
+    assert sgl_kernel.common_ops is not None
+
+
+def test_sgl_kernel_silu_and_mul():
+    torch = _torch()
+    sgl_kernel = importlib.import_module("sgl_kernel")
+    inputs = torch.randn((2, 64), device="cuda", dtype=torch.float16)
+    expected = inputs[..., 32:] * torch.nn.functional.silu(inputs[..., :32])
+
+    torch.testing.assert_close(
+        sgl_kernel.silu_and_mul(inputs), expected, rtol=1e-3, atol=1e-3
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -19,6 +19,7 @@ HW_MAPPING = {
     "cpu": HWBackend.CPU,
     "cuda": HWBackend.CUDA,
     "amd": HWBackend.AMD,
+    "hcu": HWBackend.HCU,
     "musa": HWBackend.MUSA,
     "npu": HWBackend.NPU,
     "xpu": HWBackend.XPU,
@@ -64,6 +65,9 @@ PER_COMMIT_SUITES = {
         "extra-a-test-1-gpu-small-amd",
         "extra-a-test-1-gpu-large-amd",
         "extra-a-test-2-gpu-large-amd",
+    ],
+    HWBackend.HCU: [
+        "stage-a-test-1-hcu",
     ],
     HWBackend.MUSA: [],
     HWBackend.CUDA: [
@@ -186,6 +190,7 @@ OTHER_SUITES = {
 _SUITE_CHECKED_BACKENDS = {
     HWBackend.CUDA,
     HWBackend.CPU,
+    HWBackend.HCU,
     HWBackend.MUSA,
     HWBackend.XPU,
     HWBackend.MLX,


### PR DESCRIPTION
## Summary

- register HCU in the shared CI registry, coverage report, and suite runner
- add a minimal HCU PR workflow using hosted change detection and the existing reusable PR gate
- add a containerized single-device smoke suite covering the HCU runtime, `sgl_kernel`, and one serving request

## Motivation

This PR proposes the initial HCU CI integration for upstream review. It intentionally keeps the first version small: one suite, one runner configuration, and no wheel build, multi-stage matrix, nightly coverage, or runner override mechanism.

The upstream repository does not currently provide HCU runner resources, so this PR is intended to establish and review the integration shape before the hardware lane is enabled.

## Safety and rollout

- PR jobs safely no-op until `HCU_CI_ENABLED` is explicitly set to `true`.
- A maintainer must authorize the current PR head through a `run-ci` label event; a new commit does not inherit that authorization.
- The workflow checks out the exact authorized 40-character SHA with persisted Git credentials disabled.
- The HCU image must use an immutable `@sha256` digest.
- No repository secrets or Docker socket are passed into the test container.
- The model and Hygon driver/runtime mounts are read-only. The configured smoke model must be a non-sensitive CI asset because authorized PR code can read mounted files.

## Validation

- `actionlint .github/workflows/pr-test-hcu.yml`
- `bash -n scripts/ci/hcu/run_hcu_pr_smoke.sh`
- Python compilation for the modified Python files
- CI coverage backend synchronization check
- full AST registration scan: 1,573 files and 2,044 registrations
- `git diff --check`
- rebased cleanly onto `upstream/main` at `e226bb711`

## Follow-ups

- configure the official runner label, immutable image, and non-sensitive smoke model
- add hardware-validated architecture constraints after collecting HCU runner output
- expand to additional stages or nightly coverage only after the minimal lane is reviewed and validated

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31362496750](https://github.com/sgl-project/sglang/actions/runs/31362496750)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31362496461](https://github.com/sgl-project/sglang/actions/runs/31362496461)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->