### PR TITLE
[CI] Keep the torch compilation cache instead of wiping it on install

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -229,10 +229,10 @@ install_gdrcopy() {
 }
 
 clean_site_packages() {
-    # The torch compilation cache is deliberately NOT wiped here. Its entries are
-    # content-hash addressed, so a stale one is never reused, and hosts that pack
-    # several runners onto one box share the cache dir through a single mount -
-    # wiping it unlinks files a concurrent job is compiling against right now.
+    # The torch compilation cache is deliberately NOT wiped here: entries are
+    # content-hash addressed so stale ones are never reused, and hosts packing
+    # several runners share one cache mount - a wipe unlinks files a concurrent
+    # job is compiling against.
 
     # Remove broken dist-info directories (missing METADATA per PEP 376)
     SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")

--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -229,20 +229,10 @@ install_gdrcopy() {
 }
 
 clean_site_packages() {
-    # Clear torch compilation cache from every location it can be in; sglang
-    # is not installed yet, so it cannot be asked which one is in use.
-    python3 -c '
-import getpass, os, shutil, tempfile
-
-sglang_cache_dir = os.environ.get("SGLANG_CACHE_DIR") or "~/.cache/sglang"
-for cache_dir in (
-    os.environ.get("TORCHINDUCTOR_CACHE_DIR"),
-    os.path.join(tempfile.gettempdir(), "torchinductor_" + getpass.getuser()),
-    os.path.join(os.path.expanduser(sglang_cache_dir), "inductor"),
-):
-    if cache_dir:
-        shutil.rmtree(cache_dir, ignore_errors=True)
-'
+    # The torch compilation cache is deliberately NOT wiped here. Its entries are
+    # content-hash addressed, so a stale one is never reused, and hosts that pack
+    # several runners onto one box share the cache dir through a single mount -
+    # wiping it unlinks files a concurrent job is compiling against right now.
 
     # Remove broken dist-info directories (missing METADATA per PEP 376)
     SITE_PACKAGES=$(python3 -c "import site; print(site.getsitepackages()[0])")


### PR DESCRIPTION
The install step wiped the torch compilation cache. On runner pools that pack several GPU runners onto one host, that cache directory is a single shared mount, so the wipe unlinks files a concurrent job is compiling against. It surfaces from inductor's compile workers as:

```
OSError: source code not available
  -> ValueError: @jit functions should be defined in a Python file
     torch._inductor.exc.InductorError: SubprocException
```

Inductor and triton cache entries are content-hash addressed, so a stale entry is never reused and the wipe has no upside.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31367717874](https://github.com/sgl-project/sglang/actions/runs/31367717874)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31367936138](https://github.com/sgl-project/sglang/actions/runs/31367936138)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->