### PR TITLE
Normalize the deprecated nsa attention backend alias to dsa

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3984,19 +3984,25 @@ class ServerArgs:
             )
             self.flashinfer_allreduce_fusion_backend = "auto"
         self.enable_flashinfer_allreduce_fusion = False
-        # Deprecated attention-backend alias: "compressed" -> "dsv4".
+        # Deprecated attention-backend aliases: "compressed" -> "dsv4",
+        # "nsa" -> "dsa".
+        deprecated_attention_backends = {"compressed": "dsv4", "nsa": "dsa"}
         for attr in (
             "attention_backend",
             "decode_attention_backend",
             "prefill_attention_backend",
             "speculative_draft_attention_backend",
         ):
-            if getattr(self, attr, None) == "compressed":
+            alias = getattr(self, attr, None)
+            canonical = deprecated_attention_backends.get(alias)
+            if canonical is not None:
                 logger.warning(
-                    "--%s=compressed is deprecated; use 'dsv4' instead.",
+                    "--%s=%s is deprecated; use '%s' instead.",
                     attr.replace("_", "-"),
+                    alias,
+                    canonical,
                 )
-                setattr(self, attr, "dsv4")
+                setattr(self, attr, canonical)
 
         # --grpc-mode is a deprecated alias for --smg-grpc-mode.
         if self.grpc_mode and not self.smg_grpc_mode:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -835,6 +835,23 @@ class TestContextParallelServerArgs(CustomTestCase):
         self.assertEqual(server_args.dsa_prefill_cp_mode, "round-robin-split")
         self.assertEqual(server_args.prefill_cp_mode, "round-robin-split")
 
+    def test_nsa_attention_backend_alias_normalizes_to_dsa(self):
+        args = ServerArgs(model_path="dummy", attention_backend="nsa")
+
+        args._handle_deprecated_args()
+
+        self.assertEqual(args.attention_backend, "dsa")
+
+        server_args = self._new_cp_args(
+            enable_prefill_cp=True,
+            cp_strategy="interleave",
+            attention_backend=args.attention_backend,
+        )
+        server_args._handle_legacy_cp_arguments()
+
+        self.assertTrue(server_args.enable_dsa_prefill_context_parallel)
+        self.assertFalse(server_args.enable_prefill_context_parallel)
+
     def test_context_parallel_handler_initializes_cp_strategy(self):
         server_args = self._new_cp_args(
             enable_prefill_cp=True,


### PR DESCRIPTION
`nsa` is declared in `ATTENTION_BACKEND_CHOICES` as a deprecated alias for `dsa`, but unlike the `compressed` -> `dsv4` alias it was never normalized. It was only handled at the point of use, and not everywhere.

`_handle_legacy_cp_arguments` picks the DSA context parallel branch with:

```python
) in ("dsa", "dsv4")
```

`nsa` is missing there, so `--attention-backend nsa` falls through to `enable_prefill_context_parallel` instead of `enable_dsa_prefill_context_parallel`. The attention backend registry still resolves `nsa` to the DSA backend, so the run does not fail, it just takes the wrong CP path.

Fix normalizes the alias once, in the existing deprecated attention-backend alias loop in `_handle_deprecated_args`, so every downstream consumer sees `dsa`. That loop already runs before both `_handle_legacy_cp_arguments` calls. Patching the single tuple would have left the same trap for the next consumer.

Checked the other consumers first. `forward_mla.py` and `forward_mla_rocm.py` test `current_attention_backend in ("dsa", "nsa")`, which still matches after normalization. `attention_registry.py` keeps its `nsa` registration, so a caller constructing a backend by name directly is unaffected. Nothing distinguishes the two spellings on purpose.

Trigger is narrow: it needs `--attention-backend nsa` specifically, with prefill CP enabled. Anyone using `dsa` is unaffected.

Added a test next to the existing legacy CP alias tests that asserts `nsa` normalizes to `dsa` and that the normalized value takes the DSA CP branch.

I could not run the test locally, torchvision and the rest of the runtime deps are not installed on this machine, so `sglang.srt.server_args` does not import. Both changed files byte-compile clean.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31364289344](https://github.com/sgl-project/sglang/actions/runs/31364289344)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31364289646](https://github.com/sgl-project/sglang/actions/runs/31364289646)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->