### PR TITLE
Detect scheduler death in the DP controller instead of blocking on recv

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -94,6 +94,7 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
 from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.managers.utils import wait_for_scheduler_ready
 from sglang.srt.observability.startup_time import build_engine_startup_time
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.parser.template_detection import resolve_auto_parsers
@@ -921,7 +922,7 @@ class Engine(EngineScoreMixin, EngineBase):
         scheduler_infos = []
 
         def wait_for_ready():
-            infos = _wait_for_scheduler_ready(scheduler_pipe_readers, scheduler_procs)
+            infos = wait_for_scheduler_ready(scheduler_pipe_readers, scheduler_procs)
             scheduler_infos.extend(infos)
             if use_dp_controller:
                 for info in infos:
@@ -1727,49 +1728,6 @@ def _log_legacy_kernel_cache_dirs():
         envs.SGLANG_CACHE_DIR.get(),
         ", ".join(legacy_dirs),
     )
-
-
-def _scheduler_died_error(rank: int, proc) -> RuntimeError:
-    """Build a descriptive error for a scheduler process that died during init."""
-    proc.join(timeout=10)
-    return RuntimeError(
-        f"Rank {rank} scheduler died during initialization "
-        f"(exit code: {proc.exitcode}). "
-        f"If exit code is -9 (SIGKILL), a common cause is the OS OOM killer. "
-        f"Run `dmesg -T | grep -i oom` to check."
-    )
-
-
-def _wait_for_scheduler_ready(
-    scheduler_pipe_readers: List,
-    scheduler_procs: List,
-) -> List[Dict]:
-    """Wait for the model to finish loading and return scheduler infos.
-
-    Uses poll() with timeout instead of blocking recv(), so that child process
-    death (e.g. OOM SIGKILL) is detected promptly instead of hanging forever.
-    """
-    scheduler_infos = []
-    for i in range(len(scheduler_pipe_readers)):
-        while True:
-            if scheduler_pipe_readers[i].poll(timeout=5.0):
-                try:
-                    data = scheduler_pipe_readers[i].recv()
-                except EOFError:
-                    raise _scheduler_died_error(i, scheduler_procs[i])
-                if data["status"] != "ready":
-                    raise RuntimeError(
-                        "Initialization failed. Please see the error messages above."
-                    )
-                scheduler_infos.append(data)
-                break
-
-            # Poll timed out — check all processes for early death
-            for j in range(len(scheduler_procs)):
-                if not scheduler_procs[j].is_alive():
-                    raise _scheduler_died_error(j, scheduler_procs[j])
-
-    return scheduler_infos
 
 
 def _calculate_rank_ranges(

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -45,6 +45,7 @@ from sglang.srt.managers.io_struct import (
 from sglang.srt.managers.load_snapshot import create_load_snapshot_reader
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.managers.scheduler import run_scheduler_process
+from sglang.srt.managers.utils import wait_for_scheduler_ready
 from sglang.srt.observability.cpu_monitor import start_cpu_monitor_thread
 from sglang.srt.observability.req_time_stats import DPControllerReqTimeStats
 from sglang.srt.observability.startup_time import aggregate_scheduler_startup_times
@@ -607,6 +608,10 @@ class DataParallelController:
         )
 
         scheduler_pipe_readers = []
+        # Local to this call. self.scheduler_procs is shared with the threads
+        # that launch the other DP groups, so it cannot be indexed alongside
+        # the readers collected here.
+        launched_procs = []
 
         pp_size_per_node = max(server_args.pp_size // server_args.nnodes, 1)
         nnodes_per_pp_rank = max(server_args.nnodes // server_args.pp_size, 1)
@@ -723,12 +728,13 @@ class DataParallelController:
                     ):
                         proc.start()
                 self.scheduler_procs.append(proc)
+                launched_procs.append(proc)
                 scheduler_pipe_readers.append(reader)
 
         # Wait for model to finish loading
-        scheduler_info = []
-        for i in range(len(scheduler_pipe_readers)):
-            scheduler_info.append(scheduler_pipe_readers[i].recv())
+        scheduler_info = wait_for_scheduler_ready(
+            scheduler_pipe_readers, launched_procs
+        )
 
         self.max_total_num_tokens = scheduler_info[0]["max_total_num_tokens"]
         self.max_req_input_len = scheduler_info[0]["max_req_input_len"]

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 import msgspec
 import torch
@@ -393,3 +393,46 @@ def compute_num_reserved_tokens(server_args: ServerArgs) -> int:
         server_args.speculative_eagle_topk * server_args.speculative_num_steps,
         server_args.max_speculative_num_draft_tokens,
     )
+
+
+def scheduler_died_error(rank: int, proc) -> RuntimeError:
+    """Build a descriptive error for a scheduler process that died during init."""
+    proc.join(timeout=10)
+    return RuntimeError(
+        f"Rank {rank} scheduler died during initialization "
+        f"(exit code: {proc.exitcode}). "
+        f"If exit code is -9 (SIGKILL), a common cause is the OS OOM killer. "
+        f"Run `dmesg -T | grep -i oom` to check."
+    )
+
+
+def wait_for_scheduler_ready(
+    scheduler_pipe_readers: List,
+    scheduler_procs: List,
+) -> List[Dict]:
+    """Wait for the model to finish loading and return scheduler infos.
+
+    Uses poll() with timeout instead of blocking recv(), so that child process
+    death (e.g. OOM SIGKILL) is detected promptly instead of hanging forever.
+    """
+    scheduler_infos = []
+    for i in range(len(scheduler_pipe_readers)):
+        while True:
+            if scheduler_pipe_readers[i].poll(timeout=5.0):
+                try:
+                    data = scheduler_pipe_readers[i].recv()
+                except EOFError:
+                    raise scheduler_died_error(i, scheduler_procs[i])
+                if data["status"] != "ready":
+                    raise RuntimeError(
+                        "Initialization failed. Please see the error messages above."
+                    )
+                scheduler_infos.append(data)
+                break
+
+            # Poll timed out — check all processes for early death
+            for j in range(len(scheduler_procs)):
+                if not scheduler_procs[j].is_alive():
+                    raise scheduler_died_error(j, scheduler_procs[j])
+
+    return scheduler_infos


### PR DESCRIPTION
## What is broken

`DataParallelController.launch_tensor_parallel_group` creates the ready pipe inside the spawn loop:

```python
reader, writer = mp.Pipe(duplex=False)
```

`writer` is rebound on every iteration. For every rank except the last, the parent-side writer is dropped when the next iteration rebinds the name. So if one of those children dies, the pipe reaches EOF, the bare `recv()` raises `EOFError`, and the `except Exception` in `run_data_parallel_controller_process` turns it into a clean failure with a SIGQUIT to the parent.

The last iteration's writer is different. It stays bound as a live local for the whole wait loop, so the parent still holds a write end and that pipe never reaches EOF. If the last-spawned scheduler dies before it signals ready, for example a CUDA OOM SIGKILL, this blocks forever:

```python
for i in range(len(scheduler_pipe_readers)):
    scheduler_info.append(scheduler_pipe_readers[i].recv())
```

No exception is raised, the existing handler never fires, and the caller's readiness wait hangs too. GPU memory stays held and nothing reports an error.

## Fix

The identical failure was already fixed for the non-DP launcher. `_wait_for_scheduler_ready` in `python/sglang/srt/entrypoints/engine.py` polls with a timeout and checks every child for early death instead of blocking, and its docstring says exactly that. That call site was covered; this one was not.

This routes the DP controller loop through the same helper rather than adding a second copy.

`engine.py` imports `data_parallel_controller` at module level, so importing the helper back the other way would be circular. The helper and `_scheduler_died_error` move to `sglang/srt/managers/utils.py` and lose the leading underscore now that they are shared. Both call sites use them from there.

One detail in the controller: it collects the processes it launched into a local list. `self.scheduler_procs` is appended to by the threads launching the other DP groups, so it cannot be indexed alongside the readers collected in this call.

The controller's schedulers already send `{"status": "ready", ...}` via `Scheduler.get_init_info`, so the helper's status check applies unchanged.

## Testing

**The end-to-end hang was not reproduced.** Triggering it needs multiple GPUs and a scheduler that dies during model load. I do not have that hardware.

What was verified, with stub child processes and no sglang model loading:

- The pipe mechanism the bug depends on. After a spawn loop shaped like the controller's, the earlier readers raise `EOFError` when their children are killed, and the last reader does not reach EOF because the parent still holds its writer.
- With a last child that is SIGKILLed before sending anything, `wait_for_scheduler_ready` raises the "died during initialization" error in a few seconds instead of blocking.
- The all-ready path returns the infos in order.

No GPU test was run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35628641923](https://github.com/sgl-project/sglang/actions/runs/35628641923)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35628641633](https://github.com/sgl-project/sglang/actions/runs/35628641633)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35628641915](https://github.com/sgl-project/sglang/actions/runs/35628641915)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->