### PR TITLE
[Spec] Budget the DFLASH draft KV pool from its own attention geometry

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_dtype.py
+++ b/python/sglang/srt/mem_cache/kv_cache_dtype.py
@@ -22,7 +22,7 @@ TORCH_DTYPE_TO_KV_CACHE_STR = {
 def configure_kv_cache_dtype(
     *,
     server_args_kv_cache_dtype: str,
-    model: nn.Module,
+    model: nn.Module | None,
     model_dtype: torch.dtype,
     is_draft_worker: bool,
     is_dflash: bool,

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -165,14 +165,14 @@ def _resolve_dflash_aux_hidden_state(
         config.dflash_use_aux_hidden_state = True
         config.dflash_draft_num_layers = int(draft_num_layers)
         config.dflash_target_layer_ids = target_layer_ids
-        config.dflash_draft_cell_size_per_token = _resolve_dflash_draft_kv_bytes(
+        config.dflash_draft_cell_size_per_token = _resolve_dflash_draft_cell_size(
             server_args=server_args,
             draft_model_config=draft_model_config,
             draft_num_layers=int(draft_num_layers),
         )
 
 
-def _resolve_dflash_draft_kv_bytes(
+def _resolve_dflash_draft_cell_size(
     *,
     server_args: ServerArgs,
     draft_model_config: ModelConfig,

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -21,6 +21,8 @@ class SpecAuxHiddenStateConfig(msgspec.Struct, kw_only=True):
     dflash_use_aux_hidden_state: bool = False
     dflash_draft_num_layers: Optional[int] = None
     dflash_target_layer_ids: Any = None
+    # DFLASH draft KV bytes/token; None when unresolved.
+    dflash_draft_kv_bytes_per_token: int | None = None
 
 
 def resolve_spec_aux_hidden_state_config(
@@ -163,3 +165,49 @@ def _resolve_dflash_aux_hidden_state(
         config.dflash_use_aux_hidden_state = True
         config.dflash_draft_num_layers = int(draft_num_layers)
         config.dflash_target_layer_ids = target_layer_ids
+        config.dflash_draft_kv_bytes_per_token = _resolve_dflash_draft_kv_bytes(
+            server_args=server_args,
+            draft_model_config=draft_model_config,
+            draft_num_layers=int(draft_num_layers),
+        )
+
+
+def _resolve_dflash_draft_kv_bytes(
+    *,
+    server_args: ServerArgs,
+    draft_model_config: ModelConfig,
+    draft_num_layers: int,
+) -> int | None:
+    """Bytes/token the DFLASH draft KV pool will cost the target's pool budget.
+
+    Resolved from the draft's own attention geometry and the KV dtype the draft
+    worker will actually resolve. Returns None if anything is unresolvable,
+    leaving callers on layer-count scaling.
+    """
+    from sglang.srt.mem_cache.kv_cache_dtype import configure_kv_cache_dtype
+    from sglang.srt.speculative.dflash_utils import dflash_draft_kv_bytes_per_token
+
+    try:
+        _, draft_kv_cache_dtype = configure_kv_cache_dtype(
+            server_args_kv_cache_dtype=server_args.kv_cache_dtype,
+            model=None,
+            model_dtype=draft_model_config.dtype,
+            is_draft_worker=True,
+            is_dflash=True,
+            speculative_draft_attention_backend=(
+                server_args.speculative_draft_attention_backend
+            ),
+        )
+        return dflash_draft_kv_bytes_per_token(
+            draft_model_config=draft_model_config,
+            draft_num_layers=draft_num_layers,
+            draft_kv_cache_dtype=draft_kv_cache_dtype,
+            tp_size=server_args.tp_size,
+        )
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Could not resolve DFLASH draft KV bytes/token (%s); falling back to "
+            "layer-count scaling for the KV pool budget.",
+            e,
+        )
+        return None

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -22,7 +22,7 @@ class SpecAuxHiddenStateConfig(msgspec.Struct, kw_only=True):
     dflash_draft_num_layers: Optional[int] = None
     dflash_target_layer_ids: Any = None
     # DFLASH draft KV bytes/token; None when unresolved.
-    dflash_draft_kv_bytes_per_token: int | None = None
+    dflash_draft_cell_size_per_token: int | None = None
 
 
 def resolve_spec_aux_hidden_state_config(
@@ -165,7 +165,7 @@ def _resolve_dflash_aux_hidden_state(
         config.dflash_use_aux_hidden_state = True
         config.dflash_draft_num_layers = int(draft_num_layers)
         config.dflash_target_layer_ids = target_layer_ids
-        config.dflash_draft_kv_bytes_per_token = _resolve_dflash_draft_kv_bytes(
+        config.dflash_draft_cell_size_per_token = _resolve_dflash_draft_kv_bytes(
             server_args=server_args,
             draft_model_config=draft_model_config,
             draft_num_layers=int(draft_num_layers),
@@ -185,7 +185,7 @@ def _resolve_dflash_draft_kv_bytes(
     leaving callers on layer-count scaling.
     """
     from sglang.srt.mem_cache.kv_cache_dtype import configure_kv_cache_dtype
-    from sglang.srt.speculative.dflash_utils import dflash_draft_kv_bytes_per_token
+    from sglang.srt.speculative.dflash_utils import dflash_draft_cell_size_per_token
 
     try:
         _, draft_kv_cache_dtype = configure_kv_cache_dtype(
@@ -198,7 +198,7 @@ def _resolve_dflash_draft_kv_bytes(
                 server_args.speculative_draft_attention_backend
             ),
         )
-        return dflash_draft_kv_bytes_per_token(
+        return dflash_draft_cell_size_per_token(
             draft_model_config=draft_model_config,
             draft_num_layers=draft_num_layers,
             draft_kv_cache_dtype=draft_kv_cache_dtype,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -182,6 +182,9 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     target_num_layers=int(num_layers),
                     draft_num_layers=int(draft_num_layers)
                     * get_parallel().attn_dcp_size,
+                    draft_cell_size_per_token=(
+                        kvc.spec_aux_config.dflash_draft_kv_bytes_per_token or None
+                    ),
                 )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
@@ -412,6 +415,13 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 self._draft_swa_full_layers_num = banded_depths
                 self._draft_full_layers_num = draft_layers - banded_depths
 
+        # DFLASH/DSPARK draft KV pool: a flat bytes/token term.
+        self._draft_kv_per_token = 0
+        if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
+            draft_kv_per_token = kvc.spec_aux_config.dflash_draft_kv_bytes_per_token
+            if draft_kv_per_token is not None and int(draft_kv_per_token) > 0:
+                self._draft_kv_per_token = int(draft_kv_per_token)
+
         # Bytes per token of max_total_num_tokens.
         #
         # Hybrid (full_layers > 0): max_total = full_tokens, so cell_size accounts
@@ -426,6 +436,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 self._swa_per_token * self._swa_layers_num
                 + self._full_per_token * self._draft_full_layers_num
                 + self._swa_per_token * self._draft_swa_full_layers_num
+                + self._draft_kv_per_token
             )
         else:
             self._cell_size = (
@@ -435,6 +446,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 + self._swa_full_tokens_ratio
                 * self._swa_per_token
                 * self._swa_layers_num
+                + self._draft_kv_per_token
             )
 
     def _solve_pool_sizes(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -183,7 +183,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     draft_num_layers=int(draft_num_layers)
                     * get_parallel().attn_dcp_size,
                     draft_cell_size_per_token=(
-                        kvc.spec_aux_config.dflash_draft_kv_bytes_per_token or None
+                        kvc.spec_aux_config.dflash_draft_cell_size_per_token or None
                     ),
                 )
 
@@ -418,7 +418,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         # DFLASH/DSPARK draft KV pool: a flat bytes/token term.
         self._draft_kv_per_token = 0
         if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
-            draft_kv_per_token = kvc.spec_aux_config.dflash_draft_kv_bytes_per_token
+            draft_kv_per_token = kvc.spec_aux_config.dflash_draft_cell_size_per_token
             if draft_kv_per_token is not None and int(draft_kv_per_token) > 0:
                 self._draft_kv_per_token = int(draft_kv_per_token)
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -76,6 +76,21 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _dflash_draft_cell_size(kvc: KVCacheConfigurator) -> int:
+    """Bytes/token the DFLASH draft KV pool adds to the target's budget, 0 if none.
+
+    Unlike an EAGLE draft, which reuses the target's attention config and is
+    therefore priced by layer count, a DFLASH draft has its own geometry and is
+    a flat additive term.
+    """
+    if kvc.is_draft_worker or not kvc.spec_algorithm.is_dflash_family():
+        return 0
+    cell_size = kvc.spec_aux_config.dflash_draft_cell_size_per_token
+    if cell_size is None or int(cell_size) <= 0:
+        return 0
+    return int(cell_size)
+
+
 def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
     dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
     if dtype_name in ("float32", "fp32"):
@@ -182,9 +197,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     target_num_layers=int(num_layers),
                     draft_num_layers=int(draft_num_layers)
                     * get_parallel().attn_dcp_size,
-                    draft_cell_size_per_token=(
-                        kvc.spec_aux_config.dflash_draft_cell_size_per_token or None
-                    ),
+                    draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
                 )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
@@ -415,12 +428,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 self._draft_swa_full_layers_num = banded_depths
                 self._draft_full_layers_num = draft_layers - banded_depths
 
-        # DFLASH/DSPARK draft KV pool: a flat bytes/token term.
-        self._draft_kv_per_token = 0
-        if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:
-            draft_kv_per_token = kvc.spec_aux_config.dflash_draft_cell_size_per_token
-            if draft_kv_per_token is not None and int(draft_kv_per_token) > 0:
-                self._draft_kv_per_token = int(draft_kv_per_token)
+        self._draft_cell_size = _dflash_draft_cell_size(kvc)
 
         # Bytes per token of max_total_num_tokens.
         #
@@ -436,7 +444,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 self._swa_per_token * self._swa_layers_num
                 + self._full_per_token * self._draft_full_layers_num
                 + self._swa_per_token * self._draft_swa_full_layers_num
-                + self._draft_kv_per_token
+                + self._draft_cell_size
             )
         else:
             self._cell_size = (
@@ -446,7 +454,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 + self._swa_full_tokens_ratio
                 * self._swa_per_token
                 * self._swa_layers_num
-                + self._draft_kv_per_token
+                + self._draft_cell_size
             )
 
     def _solve_pool_sizes(

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -65,6 +65,22 @@ def is_dflash_sampling_verify_available() -> bool:
     return _DFLASH_SAMPLING_VERIFY_AVAILABLE
 
 
+def dflash_draft_kv_bytes_per_token(
+    *,
+    draft_model_config: Any,
+    draft_num_layers: int,
+    draft_kv_cache_dtype: torch.dtype,
+    tp_size: int,
+) -> int:
+    """Exact bytes/token of the DFLASH draft KV pool."""
+    if draft_num_layers <= 0:
+        return 0
+    kv_heads = draft_model_config.get_num_kv_heads(tp_size)
+    head_dims = draft_model_config.head_dim + draft_model_config.v_head_dim
+    kv_size = torch._utils._element_size(draft_kv_cache_dtype)
+    return int(kv_heads * head_dims * int(draft_num_layers) * kv_size)
+
+
 def scale_kv_cell_size_per_token_for_dflash(
     *,
     target_cell_size_per_token: int,

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -65,7 +65,7 @@ def is_dflash_sampling_verify_available() -> bool:
     return _DFLASH_SAMPLING_VERIFY_AVAILABLE
 
 
-def dflash_draft_kv_bytes_per_token(
+def dflash_draft_cell_size_per_token(
     *,
     draft_model_config: Any,
     draft_num_layers: int,
@@ -75,10 +75,10 @@ def dflash_draft_kv_bytes_per_token(
     """Exact bytes/token of the DFLASH draft KV pool."""
     if draft_num_layers <= 0:
         return 0
-    kv_heads = draft_model_config.get_num_kv_heads(tp_size)
-    head_dims = draft_model_config.head_dim + draft_model_config.v_head_dim
-    kv_size = torch._utils._element_size(draft_kv_cache_dtype)
-    return int(kv_heads * head_dims * int(draft_num_layers) * kv_size)
+    num_kv_heads = draft_model_config.get_num_kv_heads(tp_size)
+    kv_dim_per_head = draft_model_config.head_dim + draft_model_config.v_head_dim
+    dtype_size = torch._utils._element_size(draft_kv_cache_dtype)
+    return int(num_kv_heads * kv_dim_per_head * int(draft_num_layers) * dtype_size)
 
 
 def scale_kv_cell_size_per_token_for_dflash(

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -652,7 +652,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
         import torch
 
         from sglang.srt.speculative.dflash_utils import (
-            dflash_draft_kv_bytes_per_token,
+            dflash_draft_cell_size_per_token,
         )
 
         draft = SimpleNamespace(
@@ -660,7 +660,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
         )
         # 4 kv heads * (128 + 128) dims * 5 layers * 2 bytes
         self.assertEqual(
-            dflash_draft_kv_bytes_per_token(
+            dflash_draft_cell_size_per_token(
                 draft_model_config=draft,
                 draft_num_layers=5,
                 draft_kv_cache_dtype=torch.bfloat16,
@@ -669,7 +669,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
             10240,
         )
         self.assertEqual(
-            dflash_draft_kv_bytes_per_token(
+            dflash_draft_cell_size_per_token(
                 draft_model_config=draft,
                 draft_num_layers=0,
                 draft_kv_cache_dtype=torch.bfloat16,
@@ -693,7 +693,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
             mr.spec_aux_config = SimpleNamespace(
                 eagle_draft_num_layers=None,
                 dflash_draft_num_layers=5,
-                dflash_draft_kv_bytes_per_token=draft_kv_per_token,
+                dflash_draft_cell_size_per_token=draft_kv_per_token,
             )
             with mock_cpu_env():
                 from sglang.srt.model_executor.pool_configurator import (

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -645,5 +645,67 @@ class TestFactory(unittest.TestCase):
         self.assertNotIsInstance(_cfg(None), SWAChunkCapPoolConfigurator)
 
 
+class TestDflashDraftKvBudget(unittest.TestCase):
+    """DFLASH draft KV pool as a flat bytes/token term on the target's budget."""
+
+    def test_bytes_per_token_from_draft_geometry(self):
+        import torch
+
+        from sglang.srt.speculative.dflash_utils import (
+            dflash_draft_kv_bytes_per_token,
+        )
+
+        draft = SimpleNamespace(
+            get_num_kv_heads=lambda tp: 4, head_dim=128, v_head_dim=128
+        )
+        # 4 kv heads * (128 + 128) dims * 5 layers * 2 bytes
+        self.assertEqual(
+            dflash_draft_kv_bytes_per_token(
+                draft_model_config=draft,
+                draft_num_layers=5,
+                draft_kv_cache_dtype=torch.bfloat16,
+                tp_size=1,
+            ),
+            10240,
+        )
+        self.assertEqual(
+            dflash_draft_kv_bytes_per_token(
+                draft_model_config=draft,
+                draft_num_layers=0,
+                draft_kv_cache_dtype=torch.bfloat16,
+                tp_size=1,
+            ),
+            0,
+        )
+
+    def test_hybrid_swa_budget_shrinks_by_draft_pool(self):
+        """HybridSWA carried no draft term, so the draft pool fell outside the budget."""
+        available = 10_000_000
+
+        def _tokens(draft_kv_per_token):
+            mr = _make_model_runner(
+                is_hybrid_swa=True,
+                full_attention_layer_ids=list(range(16)),
+                swa_attention_layer_ids=list(range(16, 32)),
+                swa_num_kv_heads=4,
+            )
+            mr.spec_algorithm.is_dflash_family.return_value = True
+            mr.spec_aux_config = SimpleNamespace(
+                eagle_draft_num_layers=None,
+                dflash_draft_num_layers=5,
+                dflash_draft_kv_bytes_per_token=draft_kv_per_token,
+            )
+            with mock_cpu_env():
+                from sglang.srt.model_executor.pool_configurator import (
+                    create_memory_pool_configurator,
+                )
+
+                cfg = create_memory_pool_configurator(mr)
+                config = cfg.calculate_pool_sizes(available, mr.server_args.page_size)
+            return config.full_max_total_num_tokens
+
+        self.assertLess(_tokens(10240), _tokens(None))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
DFLASH runs a draft model with its own KV pool, and the target's token capacity has to cover both. `scale_kv_cell_size_per_token_for_dflash` derives the draft's share by scaling the target's bytes/token by the layer ratio.

That scaling carries an assumption the EAGLE branch right above it states explicitly:

```python
# EAGLE/STANDALONE: scale cell_size to account for draft model KV cache.
# Assumes draft and target share the same per-layer KV size (head_dim,
# num_kv_heads, dtype), which holds for EAGLE/MTP draft models that
# reuse the target architecture's attention config.
```

It holds for EAGLE because those drafts reuse the target's attention config. A DFLASH draft is a separately trained model, so its geometry need not match:

| draft geometry (5 layers, target 32 layers @ 4 KV heads) | actual | layer-ratio estimate | error |
| :--- | ---: | ---: | ---: |
| 4 KV heads (same as target) | 10240 | 75776 | +0.0% |
| 8 KV heads | 20480 | 75776 | -11.9% |
| 2 KV heads | 5120 | 75776 | +7.2% |

Underestimating means pool sizing hands out more tokens than the two pools can hold.

`scale_kv_cell_size_per_token_for_dflash` already takes `draft_cell_size_per_token` and sums the two pools when it is given -- the docstring says so -- but no caller has ever passed it. This computes it and passes it.

`HybridSWAPoolConfigurator` prices an EAGLE draft by layer count but has no DFLASH term, so a DFLASH draft pool sits entirely outside the budget there. Both configurators now read the draft's cost through one `_dflash_draft_cell_size()` accessor.

## Changes

- `dflash_draft_cell_size_per_token()` in `dflash_utils.py`: exact bytes/token from the draft's KV heads, head dims, layer count and resolved KV dtype
- `_resolve_dflash_draft_cell_size()` in `spec_aux_hidden_state.py`: resolves it once at startup, returning `None` on any failure so callers fall back to the existing layer-ratio path
- `_dflash_draft_cell_size()` in `pool_configurator.py`: single gated accessor; `DefaultPoolConfigurator` feeds it to `draft_cell_size_per_token`, `HybridSWAPoolConfigurator` adds it as a flat term alongside its existing EAGLE layer-count terms
- `configure_kv_cache_dtype` accepts `model=None`, since the budget is resolved before the draft model exists

## Tests

`test_pool_configurator.py` gains the bytes/token computation (including the zero-layer case) and a check that the HybridSWA budget shrinks once the draft term is present.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31366016664](https://github.com/sgl-project/sglang/actions/runs/31366016664)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31366016411](https://github.com/sgl-project/sglang/actions/runs/31366016411)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->