### PR TITLE
[Fix]  stream parameter None issue in Responses API _make_request

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -569,7 +569,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         chat_request = ChatCompletionRequest(
             model=request.model,
             messages=messages,
-            stream=request.stream,
+            stream=request.stream if request.stream is not None else False,
             tools=chat_tools or None,
             tool_choice=(
                 self._chat_tool_choice(request.effective_tool_choice())

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -246,6 +246,43 @@ class ChatToolForwardingTestCase(CustomTestCase):
         self.assertEqual(request_prompts, [[4, 5, 6]])
         self.assertEqual(engine_prompts, [[4, 5, 6]])
 
+    def test_make_request_normalizes_none_stream_to_false(self):
+        """A forwarded request may carry ``stream=None`` — sgl-model-gateway
+        rewrites an unset stream to None while proxying. ``ChatCompletionRequest``
+        declares ``stream: bool`` (non-Optional), so forwarding ``None`` verbatim
+        raises a Pydantic ValidationError and the client gets a 400. _make_request
+        normalizes None -> False at the hop. Regression for issue #34209."""
+        serving = make_serving()
+        seen = {}
+
+        def fake_process(chat_request, is_multimodal):
+            seen["stream"] = chat_request.stream
+            return MessageProcessingResult(
+                prompt="prompt",
+                prompt_ids=[1, 2, 3],
+                image_data=None,
+                audio_data=None,
+                video_data=None,
+                modalities=[],
+                stop=[],
+            )
+
+        serving._process_messages = Mock(side_effect=fake_process)
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            stream=None,  # gateway-rewritten unset stream
+            store=False,
+        )
+
+        # Pre-fix: ChatCompletionRequest(stream=None) raised ValidationError
+        # before _process_messages ran.
+        asyncio.run(
+            serving._make_request(request, None, serving.tokenizer_manager.tokenizer)
+        )
+
+        self.assertIs(seen["stream"], False)
+
 
 class ReasoningRequestForwardingTestCase(unittest.TestCase):
     def test_create_responses_uses_processed_reasoning_state(self):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Summary
When a request is sent to `/v1/responses` with `stream=None` (e.g., when forwarded through sgl-model-gateway, which rewrites an unset `stream` to `None`), the server returns a 400 validation error.

## Why

In serving_responses.py, the _make_request method directly passes request.stream to ChatCompletionRequest without checking if it is None:

Fixes #34209


## Testing

- Added unit test test_make_request_normalizes_none_stream_to_false in test/registered/unit/entrypoints/openai/test_serving_responses.py.

- The test verifies that a ResponsesRequest with stream=None produces a ChatCompletionRequest with stream=False.

- Verified that the test fails without the fix and passes with the fix applie



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31365746940](https://github.com/sgl-project/sglang/actions/runs/31365746940)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31365746743](https://github.com/sgl-project/sglang/actions/runs/31365746743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->