### PR TITLE
[AMD] Broadcast the EAGLE greedy verify decision across TP ranks on ROCm

### DIFF
--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -870,6 +870,22 @@ def eagle_sample(
             spec_steps=verify_input.max_tree_depth - 1,
         )
 
+    if _is_hip:
+        # Sync the verify decision across TP ranks: ROCm always takes the greedy branch above
+        # (`_is_hip` is in its condition), whose per-rank argmax can pick different tokens when
+        # the AMD all-reduce feeding the logits is not bitwise identical. Ranks then accept a
+        # different number of drafts and the next TP collective deadlocks. Broadcast from rank 0
+        # to ensure consistency; the sampling branch above already does this for CUDA.
+        tp_group = (
+            get_parallel().attn_tp_group
+            if is_dp_attention_enabled()
+            else get_tp_group()
+        )
+        if tp_group.world_size > 1:
+            tp_group.broadcast(predict, src=0)
+            tp_group.broadcast(accept_index, src=0)
+            tp_group.broadcast(num_correct_drafts, src=0)
+
     # `num_correct_drafts` stays drafts-only inside this function; the returned
     # tensor includes the trailing/bonus token via out-of-place +1 so the
     # name no longer flips semantics mid-function (naming doc C2).

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -821,19 +821,17 @@ def eagle_sample(
             deterministic=True,
         )
 
-        # Sync sampling results across TP ranks: different GPUs may
-        # produce slightly different target_probs due to floating-point
-        # non-determinism in softmax/top_k/top_p, causing different
-        # sampled tokens. Broadcast from rank 0 to ensure consistency.
-        tp_group = (
-            get_parallel().attn_tp_group
-            if is_dp_attention_enabled()
-            else get_tp_group()
-        )
-        if tp_group.world_size > 1:
-            tp_group.broadcast(predict, src=0)
-            tp_group.broadcast(accept_index, src=0)
-            tp_group.broadcast(num_correct_drafts, src=0)
+    # Sync the verify decision across TP ranks: small per-rank differences in the
+    # tensors feeding this point can make one rank accept a different number of
+    # drafts, which desynchronizes the committed seq_lens and deadlocks the next
+    # TP collective. Broadcast from rank 0 to ensure consistency.
+    tp_group = (
+        get_parallel().attn_tp_group if is_dp_attention_enabled() else get_tp_group()
+    )
+    if tp_group.world_size > 1:
+        tp_group.broadcast(predict, src=0)
+        tp_group.broadcast(accept_index, src=0)
+        tp_group.broadcast(num_correct_drafts, src=0)
 
     if SIMULATE_ACC_LEN > 0:
         # Do simulation. The helper builds (and returns) a replacement
@@ -869,22 +867,6 @@ def eagle_sample(
             bs=bs,
             spec_steps=verify_input.max_tree_depth - 1,
         )
-
-    if _is_hip:
-        # Sync the verify decision across TP ranks: ROCm always takes the greedy branch above
-        # (`_is_hip` is in its condition), whose per-rank argmax can pick different tokens when
-        # the AMD all-reduce feeding the logits is not bitwise identical. Ranks then accept a
-        # different number of drafts and the next TP collective deadlocks. Broadcast from rank 0
-        # to ensure consistency; the sampling branch above already does this for CUDA.
-        tp_group = (
-            get_parallel().attn_tp_group
-            if is_dp_attention_enabled()
-            else get_tp_group()
-        )
-        if tp_group.world_size > 1:
-            tp_group.broadcast(predict, src=0)
-            tp_group.broadcast(accept_index, src=0)
-            tp_group.broadcast(num_correct_drafts, src=0)
 
     # `num_correct_drafts` stays drafts-only inside this function; the returned
     # tensor includes the trailing/bonus token via out-of-place +1 so the


### PR DESCRIPTION
Co-author-with: @XinyuJiangCMU 

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On ROCm with TP > 1, EAGLE speculative decoding can intermittently deadlock. Observed on 4x MI355X (gfx950), GLM-4.7-Flash, TP4, with **2 deadlocks in 5 runs**. Before the watchdog fires, TP ranks disagree on the running batch:

```text
TP0: batch_size()=24, first_req=86e5957d…
TP1: batch_size()=24, first_req=86e5957d…
TP2: batch_size()=25, first_req=f224663e…
TP3: batch_size()=25, first_req=f224663e…
```

On ROCm, _is_hip makes `eagle_sample()` always use the greedy verify path. This path can receive different draft candidates across ranks, while the sampling path already broadcasts its result from rank 0. With different draft candidates, TP ranks can therefore accept different numbers of drafts, and eventually diverge in `seq_lens` / batch composition and deadlock.

## Modifications

<!-- Detail the changes made in this pull request. -->

On ROCm, broadcast `predict`, `accept_index`, and `num_correct_drafts` from TP rank 0 after the verify decision is finalized. A normal process-group broadcast is sufficient because `eagle_sample()` runs after the target forward CUDA graph replay.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

End-to-end on 4x MI355X, GLM-4.7-Flash, EAGLE + MTP. Deadlock rate:

| | runs | deadlocks |
|---|---:|---:|
| before | 5 | **2** |
| after | 6 | **0** |

All six post-fix runs completed without watchdog, memory access fault, or scheduler divergence.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31530470317](https://github.com/sgl-project/sglang/actions/runs/31530470317)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31530470092](https://github.com/sgl-project/sglang/actions/runs/31530470092)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->