### PR TITLE
[AMD] Recalibrate MiniMax-M2.7 GSM8K threshold 0.93->0.91 for MI300 runners

### DIFF
--- a/test/registered/amd/accuracy/mi30x/test_minimax_m27_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m27_eval_amd.py
@@ -64,10 +64,7 @@ MINIMAX_M27_MODELS = [
     ModelConfig(
         model_path="MiniMaxAI/MiniMax-M2.7",
         tp_size=8,
-        # Recalibrated for MI300 runners: MI300 measures mean 0.9216 (min 0.9166,
-        # max 0.9249) over 10x full GSM8K (1319q, exact CI config). The prior 0.93
-        # was an MI325 baseline left unchanged after #31409 swapped runners to MI300,
-        # so it never passed on MI300. 0.91 clears the observed range with margin.
+        # MI300: mean 0.9216 over 10x full GSM8K (exact CI config); 0.93 never passes.
         accuracy_threshold=0.91,
         timeout=3600,
         variant="TP8+EP8",

--- a/test/registered/amd/accuracy/mi30x/test_minimax_m27_eval_amd.py
+++ b/test/registered/amd/accuracy/mi30x/test_minimax_m27_eval_amd.py
@@ -64,7 +64,11 @@ MINIMAX_M27_MODELS = [
     ModelConfig(
         model_path="MiniMaxAI/MiniMax-M2.7",
         tp_size=8,
-        accuracy_threshold=0.93,
+        # Recalibrated for MI300 runners: MI300 measures mean 0.9216 (min 0.9166,
+        # max 0.9249) over 10x full GSM8K (1319q, exact CI config). The prior 0.93
+        # was an MI325 baseline left unchanged after #31409 swapped runners to MI300,
+        # so it never passed on MI300. 0.91 clears the observed range with margin.
+        accuracy_threshold=0.91,
         timeout=3600,
         variant="TP8+EP8",
         other_args=[


### PR DESCRIPTION
## What
Relax the `nightly-amd-accuracy-8-gpu-minimax-m27` GSM8K gate **0.93 -> 0.91** for the MI300 runners.

## Why
MiniMax-M2.7 does not reach 0.93 on the current MI300 runners. Offline on MI300X with the exact CI config (TP=8, EP=8, aiter, mem-frac 0.85), 10x full GSM8K (1319q, 5-shot, temp=0):

mean **0.9216**, std 0.0027, min 0.9166, max 0.9249 -> never reaches 0.93.

0.91 clears the observed range with margin and unblocks the nightly. (Repo convention `measured - 0.05` would be ~0.87; reviewers can lower if preferred.)

## Test plan
Threshold constant only, no code-path change. Offline 10x GSM8K on MI300X all >= 0.9166.

cc @michaelzhang-ai @bingxche

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31369382670](https://github.com/sgl-project/sglang/actions/runs/31369382670)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31369382199](https://github.com/sgl-project/sglang/actions/runs/31369382199)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->