### PR TITLE
fix(function_call): stream text that precedes DSML tool calls

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -226,6 +226,20 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
+    def _find_tool_call_start(self, text: str) -> int:
+        """Index of the earliest tool-call opener in `text`, or -1 if absent.
+
+        Mirrors the two markers `has_tool_call` accepts, so subclasses that
+        override `bot_token` (V4 uses `tool_calls` where V3.2 uses
+        `function_calls`) are handled without hardcoding either spelling.
+        """
+        candidates = [
+            idx
+            for idx in (text.find(self.bot_token), text.find("<｜DSML｜invoke"))
+            if idx != -1
+        ]
+        return min(candidates, default=-1)
+
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
     ) -> StreamingParseResult:
@@ -257,6 +271,22 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if e_token in current_text:
                     current_text = current_text.replace(e_token, "")
             return StreamingParseResult(normal_text=current_text)
+
+        # Content the model emitted before the tool-call section is normal text
+        # and still has to be streamed out. `detect_and_parse` already splits on
+        # `text[:idx]`; without the same split here the `normal_text=""` returns
+        # below drop whatever sits in front of the opener, so a response that
+        # mixes content with tool calls loses the tail of its text as soon as
+        # the opening marker lands in the buffer.
+        pending_normal_text = ""
+        if self.current_tool_id == -1:
+            tool_call_start = self._find_tool_call_start(current_text)
+            if tool_call_start > 0:
+                pending_normal_text = current_text[:tool_call_start].removesuffix(
+                    "\n\n"
+                )
+                self._buffer = current_text[tool_call_start:]
+                current_text = self._buffer
 
         all_calls: list[ToolCallItem] = []
         try:
@@ -355,11 +385,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     break
 
             # No more invoke blocks found
-            return StreamingParseResult(normal_text="", calls=all_calls)
+            return StreamingParseResult(
+                normal_text=pending_normal_text, calls=all_calls
+            )
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult(normal_text=current_text)
+            return StreamingParseResult(normal_text=pending_normal_text + current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/test/registered/unit/function_call/test_deepseekv32_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv32_detector.py
@@ -1,0 +1,151 @@
+"""Streaming regression tests for the DeepSeek V3.2 / V4 DSML detectors.
+
+Guards the bug reported in #34214: when a response mixes assistant content with
+tool calls, the streaming parser dropped every character of content that was
+still buffered when the tool-call opener arrived, so clients saw a truncated
+prefix of the text and never received the rest. The one-shot path
+(`detect_and_parse`) always emitted that leading text; only streaming diverged.
+"""
+
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+from sglang.srt.function_call.deepseekv32_detector import DeepSeekV32Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+def _make_tools():
+    return [
+        Tool(
+            type="function",
+            function=Function(
+                name="get_current_weather",
+                description="Get weather information",
+                parameters={
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            ),
+        ),
+    ]
+
+
+def _invoke_block(opener: str, closer: str) -> str:
+    return (
+        f"{opener}\n"
+        '<｜DSML｜invoke name="get_current_weather">\n'
+        '<｜DSML｜parameter name="city" string="true">Beijing</｜DSML｜parameter>\n'
+        "</｜DSML｜invoke>\n"
+        f"{closer}"
+    )
+
+
+def _feed(detector, chunks, tools):
+    """Stream `chunks` through the detector, returning (normal_text, calls)."""
+    normal_text_parts = []
+    calls = []
+    for chunk in chunks:
+        result = detector.parse_streaming_increment(chunk, tools)
+        if result.normal_text:
+            normal_text_parts.append(result.normal_text)
+        calls.extend(result.calls)
+    return "".join(normal_text_parts), calls
+
+
+def _tool_call_summary(calls):
+    name = next((c.name for c in calls if c.name), None)
+    arguments = "".join(c.parameters or "" for c in calls)
+    return name, arguments
+
+
+class TestDeepSeekV4StreamingNormalText(CustomTestCase):
+    """V4 spells the section `tool_calls`; this is the shape #34214 reported."""
+
+    OPENER = "<｜DSML｜tool_calls>"
+    CLOSER = "</｜DSML｜tool_calls>"
+
+    def _detector(self):
+        return DeepSeekV4Detector()
+
+    def test_content_preceding_tool_call_is_streamed(self):
+        """Content sharing a chunk with the opener must still reach the client.
+
+        Pre-fix the parser returned `normal_text=""` for every chunk once the
+        opener was buffered, so the trailing sentence here vanished while the
+        tool call streamed normally.
+        """
+        content = "Sure, let me look that up. One moment please."
+        chunks = [
+            "Sure, let me ",
+            "look that up. ",
+            # Tail of the content arrives in the same chunk as the opener.
+            "One moment please.\n\n" + _invoke_block(self.OPENER, self.CLOSER),
+        ]
+
+        normal_text, calls = _feed(self._detector(), chunks, _make_tools())
+
+        self.assertEqual(normal_text, content)
+        name, arguments = _tool_call_summary(calls)
+        self.assertEqual(name, "get_current_weather")
+        self.assertIn("Beijing", arguments)
+
+    def test_content_emitted_once_when_opener_splits_across_chunks(self):
+        """Buffered content is flushed exactly once, not re-sent or dropped.
+
+        The opener is torn between chunks, so the detector holds the content
+        for a turn. Re-emitting it on later chunks would duplicate text in the
+        stream; never emitting it is the original bug.
+        """
+        content = "Checking the forecast now."
+        body = _invoke_block(self.OPENER, self.CLOSER)
+        split_at = len("<｜DSML｜")
+        chunks = [content + body[:split_at], body[split_at:]]
+
+        normal_text, calls = _feed(self._detector(), chunks, _make_tools())
+
+        self.assertEqual(normal_text, content)
+        name, _ = _tool_call_summary(calls)
+        self.assertEqual(name, "get_current_weather")
+
+    def test_content_preceding_bare_invoke_is_streamed(self):
+        """Models may emit `<｜DSML｜invoke` with no enclosing section wrapper.
+
+        `has_tool_call` accepts that shape, so the leading-text split has to
+        recognise it too; keying only off `bot_token` would drop the content.
+        """
+        content = "Here you go."
+        chunks = [
+            content
+            + '\n\n<｜DSML｜invoke name="get_current_weather">\n'
+            + '<｜DSML｜parameter name="city" string="true">Beijing</｜DSML｜parameter>\n'
+            + "</｜DSML｜invoke>"
+        ]
+
+        normal_text, calls = _feed(self._detector(), chunks, _make_tools())
+
+        self.assertEqual(normal_text, content)
+        name, _ = _tool_call_summary(calls)
+        self.assertEqual(name, "get_current_weather")
+
+
+class TestDeepSeekV32StreamingNormalText(TestDeepSeekV4StreamingNormalText):
+    """V3.2 spells the same section `function_calls`.
+
+    Inherits the V4 cases so the split stays keyed off `bot_token`: hardcoding
+    either spelling turns one of the two subclasses red.
+    """
+
+    OPENER = "<｜DSML｜function_calls>"
+    CLOSER = "</｜DSML｜function_calls>"
+
+    def _detector(self):
+        return DeepSeekV32Detector()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #34214.

On DeepSeek V3.2 / V4, when the model answers with some text *and* a tool call in
the same response, part of the text never reaches the client. The stream delivers
a few content chunks, jumps to the tool call, and the rest of the content is
gone. Content-only and tool-call-only responses are fine, which is what makes it
look intermittent.

## Modifications

`DeepSeekV32Detector.parse_streaming_increment` has two ways out. If the buffer
holds nothing that looks like DSML, it flushes the buffer as `normal_text`.
Otherwise it falls into the invoke-matching loop, and every return there is
`StreamingParseResult(normal_text="", calls=all_calls)`. Nothing in that second
branch looks at what sits *before* the opening tag, and the check that routes
into it trips on a bare `"<｜"`. So as soon as the chunk carrying
`<｜DSML｜tool_calls>` lands, everything buffered ahead of it is thrown away.

`detect_and_parse` doesn't have this problem: it takes `text[:idx]` before
parsing. So the one-shot path was already correct and only streaming disagreed
with it.

This PR does the same split in the streaming path and trims the buffer at the
same time, so the leading text goes out exactly once and is not re-sent on later
chunks. The split only runs before the first tool call (`current_tool_id == -1`),
so nothing changes once a tool call is already in flight.

`_find_tool_call_start` looks for `self.bot_token` or `<｜DSML｜invoke`, the same
two markers `has_tool_call` accepts. `DeepSeekV4Detector` subclasses this
detector and only renames the section tag (`tool_calls` vs `function_calls`), so
it was affected by the bug and is covered by the fix without hardcoding either
spelling. The issue was reported on DeepSeek-V4-Flash.

## Accuracy Tests

Not applicable, this is parser-side only and doesn't touch model outputs.

Added `test/registered/unit/function_call/test_deepseekv32_detector.py`, a CPU
unit test with no server or GPU needed. Three cases, each run against both
`DeepSeekV4Detector` and `DeepSeekV32Detector`:

- content that shares a chunk with the opening tag still gets streamed (the
  reported bug)
- content is flushed exactly once when the opening tag is split across two
  chunks, so it is neither dropped nor duplicated
- content in front of a bare `<｜DSML｜invoke` with no section wrapper is
  streamed, which is the other marker `has_tool_call` accepts

All six fail on current main and pass with the fix. The first one fails as
`'Sure, let me look that up. ' != 'Sure, let me look that up. One moment please.'`,
which is the truncation from the issue.

The existing `TestDeepSeekV32Detector` and `TestDeepSeekV4Detector` cases in
`test_function_call_parser.py` still pass (205 passed), so the leading-text split
doesn't disturb the invoke parsing or the self-closing shapes.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31369847412](https://github.com/sgl-project/sglang/actions/runs/31369847412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31369847140](https://github.com/sgl-project/sglang/actions/runs/31369847140)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->