### PR TITLE
feat(sgl-router): S3 token dataset export for offline cache-hit analysis

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -123,6 +123,8 @@ rmp-serde = "1"
 sha2 = "0.10"
 url = "2"
 zeromq = { version = "0.6", default-features = false, features = ["tokio-runtime", "tcp-transport"] }
+hmac = "0.12"
+hex = "0.4"
 
 # Signal-based (SIGPROF/setitimer) CPU profiler, not perf_event_open — works
 # unprivileged in a container regardless of perf_event_paranoid. Optional: only

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -361,6 +361,11 @@ pub struct Cli {
     /// capture. Only meaningful with `--cache-sim-url`.
     #[arg(long, default_value_t = default_cache_sim_max_concurrent_captures())]
     pub cache_sim_max_concurrent_captures: usize,
+    /// `s3://bucket/prefix/` 目标；设置即开启 token 数据集导出，写入每个
+    /// 请求的 ingest/extend token 序列（NDJSON+gzip）。凭证/region 走标准
+    /// AWS 环境变量。不设则关闭。
+    #[arg(long, env = "RADIXARK_TOKEN_EXPORT_S3_URI")]
+    pub token_export_s3_uri: Option<String>,
 }
 
 impl Cli {
@@ -603,6 +608,7 @@ impl Cli {
                 log_format: self.log_format,
                 cache_sim_url: self.cache_sim_url,
                 cache_sim_max_concurrent_captures: self.cache_sim_max_concurrent_captures,
+                token_export_s3_uri: self.token_export_s3_uri,
             },
             model: ModelConfig {
                 // Default the tokenizer source to the model id (treated as a

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -361,9 +361,10 @@ pub struct Cli {
     /// capture. Only meaningful with `--cache-sim-url`.
     #[arg(long, default_value_t = default_cache_sim_max_concurrent_captures())]
     pub cache_sim_max_concurrent_captures: usize,
-    /// `s3://bucket/prefix/` 目标；设置即开启 token 数据集导出，写入每个
-    /// 请求的 ingest/extend token 序列（NDJSON+gzip）。凭证/region 走标准
-    /// AWS 环境变量。不设则关闭。
+    /// `s3://bucket/prefix/` target. When set, enables token-dataset export:
+    /// writes each request's ingest/extend token sequences as NDJSON+gzip.
+    /// Credentials and region come from the standard AWS environment variables.
+    /// When absent, export is disabled.
     #[arg(long, env = "RADIXARK_TOKEN_EXPORT_S3_URI")]
     pub token_export_s3_uri: Option<String>,
 }

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -278,8 +278,8 @@ pub struct ObservabilityConfig {
     /// Excess streams simply aren't captured. Only meaningful with
     /// `cache_sim_url`.
     pub cache_sim_max_concurrent_captures: usize,
-    /// `s3://bucket/prefix/`；设置即开启 token 导出 tee，不设即关闭。
-    /// 见 `crate::server::s3_export`。
+    /// `s3://bucket/prefix/` target; when set, enables the token-export tee;
+    /// when absent, the tee is disabled. See `crate::server::s3_export`.
     pub token_export_s3_uri: Option<String>,
 }
 

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -278,6 +278,9 @@ pub struct ObservabilityConfig {
     /// Excess streams simply aren't captured. Only meaningful with
     /// `cache_sim_url`.
     pub cache_sim_max_concurrent_captures: usize,
+    /// `s3://bucket/prefix/`；设置即开启 token 导出 tee，不设即关闭。
+    /// 见 `crate::server::s3_export`。
+    pub token_export_s3_uri: Option<String>,
 }
 
 /// Default concurrent-capture budget: 256 × 16 MiB = 4 GiB ceiling on aggregate
@@ -309,6 +312,7 @@ impl Default for ObservabilityConfig {
             log_format: LogFormat::default(),
             cache_sim_url: None,
             cache_sim_max_concurrent_captures: default_cache_sim_max_concurrent_captures(),
+            token_export_s3_uri: None,
         }
     }
 }

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -280,6 +280,18 @@ async fn main() -> Result<()> {
     ));
     let server_result = serve.await.context("axum serve");
 
+    // 在停止接受连接、在途请求已 drain 后，把 S3 token 导出的队列/缓冲全部
+    // flush 出去再退出（滚动重启不丢）。用 grace 预算兜底，避免卡死退出。
+    if let Some(sink) = ctx.s3_export_sink.as_ref() {
+        let budget = std::time::Duration::from_secs(cfg.server.shutdown_drain_secs.max(60));
+        sgl_router::server::shutdown::await_with_timeout(
+            sink.drain(),
+            budget,
+            "s3 export drain",
+        )
+        .await;
+    }
+
     // Best-effort: cancel discovery + manager + janitor on shutdown.
     // The janitor handle's drop signals cancellation; we additionally
     // await `shutdown` so the task joins cleanly before the process

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -287,12 +287,8 @@ async fn main() -> Result<()> {
     // shutdown_drain_secs.
     if let Some(sink) = ctx.s3_export_sink.as_ref() {
         let budget = std::time::Duration::from_secs(cfg.server.shutdown_drain_secs.min(60));
-        sgl_router::server::shutdown::await_with_timeout(
-            sink.drain(),
-            budget,
-            "s3 export drain",
-        )
-        .await;
+        sgl_router::server::shutdown::await_with_timeout(sink.drain(), budget, "s3 export drain")
+            .await;
     }
 
     // Best-effort: cancel discovery + manager + janitor on shutdown.

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -280,10 +280,13 @@ async fn main() -> Result<()> {
     ));
     let server_result = serve.await.context("axum serve");
 
-    // 在停止接受连接、在途请求已 drain 后，把 S3 token 导出的队列/缓冲全部
-    // flush 出去再退出（滚动重启不丢）。用 grace 预算兜底，避免卡死退出。
+    // After stopping accepting new connections and draining in-flight requests,
+    // flush the S3 token-export queue/buffers before exiting so a rolling
+    // restart does not lose records. Cap, not floor: the total shutdown must
+    // stay within the pod termination grace period, which operators size off
+    // shutdown_drain_secs.
     if let Some(sink) = ctx.s3_export_sink.as_ref() {
-        let budget = std::time::Duration::from_secs(cfg.server.shutdown_drain_secs.max(60));
+        let budget = std::time::Duration::from_secs(cfg.server.shutdown_drain_secs.min(60));
         sgl_router::server::shutdown::await_with_timeout(
             sink.drain(),
             budget,

--- a/experimental/sgl-router/src/proxy/sse.rs
+++ b/experimental/sgl-router/src/proxy/sse.rs
@@ -105,9 +105,12 @@ pub struct StreamCapture {
     /// RAII permit from the router-global capture semaphore. Held for the pump's
     /// lifetime and released on drop (clean end, discard, or teardown), so the
     /// TOTAL number of concurrent captures — and hence aggregate capture memory
-    /// (≤ N × `max_bytes`) — is bounded no matter the traffic. `None` only in
-    /// unit tests that don't exercise the budget; production arming acquires one
-    /// and skips the capture entirely when the budget is exhausted.
+    /// (≤ N × `max_bytes`) — is bounded no matter the traffic. `None` in unit
+    /// tests that don't exercise the budget, and in the cache-sim-off /
+    /// S3-export-only path (no cache-sim tee to acquire the permit from); in
+    /// that case each stream is still bounded by `max_bytes`. When cache-sim is
+    /// on, arming acquires one and skips the capture entirely when the budget is
+    /// exhausted.
     pub _permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -11,6 +11,7 @@ use crate::proxy::Proxy;
 use crate::server::admission::AdmissionQueue;
 use crate::server::cache_sim_tee::CacheSimTee;
 use crate::server::metrics::MetricsRegistry;
+use crate::server::s3_export::S3ExportSink;
 use crate::tokenizer::TokenizerRegistry;
 use crate::workers::WorkerRegistry;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -47,6 +48,10 @@ pub struct AppContext {
     /// unset. The chat/completions handler offers to it after tokenizing;
     /// see [`crate::server::cache_sim_tee`].
     pub cache_sim_tee: Option<Arc<CacheSimTee>>,
+    /// Best-effort S3 token-export sink. `None` when
+    /// `observability.token_export_s3_uri` is unset or AWS credentials are
+    /// missing. Zero overhead on the hot path when `None`.
+    pub s3_export_sink: Option<Arc<S3ExportSink>>,
     /// KV-event index, when cache-aware-zmq routing is active.
     ///
     /// Injected rather than constructed here for the same reason as the
@@ -144,6 +149,15 @@ impl AppContext {
             .map(|u| u.trim())
             .filter(|u| !u.is_empty())
             .map(|url| CacheSimTee::spawn(url.to_owned(), Arc::clone(&metrics), max_captures));
+        // 读取 pod 名用于对象 key 去重；未注入时退化为 "unknown-pod"。
+        let pod = std::env::var("POD_NAME").unwrap_or_else(|_| "unknown-pod".to_string());
+        let s3_export_sink = config
+            .observability
+            .token_export_s3_uri
+            .as_ref()
+            .map(|u| u.trim())
+            .filter(|u| !u.is_empty())
+            .and_then(|uri| S3ExportSink::spawn(uri, pod, Arc::clone(&metrics)));
         Self {
             config,
             tokenizers,
@@ -155,6 +169,7 @@ impl AppContext {
             admission,
             itl,
             cache_sim_tee,
+            s3_export_sink,
             kv_index: OnceLock::new(),
             ready: AtomicBool::new(false),
         }
@@ -248,6 +263,7 @@ impl AppContext {
             metrics,
             itl: ItlTable::new(),
             cache_sim_tee: None,
+            s3_export_sink: None,
             // Unset: a stub has no KV index, so `kv_bootstrap_settled()`
             // reports true and the readiness gate is inert unless a test
             // attaches one.

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -149,7 +149,8 @@ impl AppContext {
             .map(|u| u.trim())
             .filter(|u| !u.is_empty())
             .map(|url| CacheSimTee::spawn(url.to_owned(), Arc::clone(&metrics), max_captures));
-        // 读取 pod 名用于对象 key 去重；未注入时退化为 "unknown-pod"。
+        // Read the pod name for object-key deduplication; fall back to
+        // "unknown-pod" when the downward-API env var is not injected.
         let pod = std::env::var("POD_NAME").unwrap_or_else(|_| "unknown-pod".to_string());
         let s3_export_sink = config
             .observability
@@ -157,7 +158,7 @@ impl AppContext {
             .as_ref()
             .map(|u| u.trim())
             .filter(|u| !u.is_empty())
-            .and_then(|uri| S3ExportSink::spawn(uri, pod, Arc::clone(&metrics)));
+            .and_then(|uri| S3ExportSink::spawn(uri, pod, Arc::clone(&metrics), max_captures));
         Self {
             config,
             tokenizers,

--- a/experimental/sgl-router/src/server/cache_sim_extend.rs
+++ b/experimental/sgl-router/src/server/cache_sim_extend.rs
@@ -176,7 +176,7 @@ pub(crate) fn spawn_extend_tee(
     prompt: Option<IngressPrompt>,
     source: ReplySource,
 ) {
-    if ctx.cache_sim_tee.is_none() {
+    if ctx.cache_sim_tee.is_none() && ctx.s3_export_sink.is_none() {
         return;
     }
     tokio::spawn(async move {
@@ -238,7 +238,7 @@ pub(crate) fn spawn_extend_tee(
                 )
                 .map(|ids| (ids, None)),
             };
-            if let (Some(tee), Some((ids, prompt_len))) = (ctx.cache_sim_tee.as_ref(), produced) {
+            if let Some((ids, prompt_len)) = produced {
                 // Only tag a genuine fan-out. A single-choice response is the
                 // common case and needs no discriminator; N>1 must have one or
                 // the N records collapse onto one join key.
@@ -254,14 +254,28 @@ pub(crate) fn spawn_extend_tee(
                 } else {
                     output_tokens
                 };
-                tee.offer_extend(
-                    &model,
-                    &ids,
-                    &request_id,
-                    prompt_len,
-                    choice,
-                    per_choice_output,
-                );
+                if let Some(tee) = ctx.cache_sim_tee.as_ref() {
+                    tee.offer_extend(
+                        &model,
+                        &ids,
+                        &request_id,
+                        prompt_len,
+                        choice,
+                        per_choice_output,
+                    );
+                }
+                if let Some(sink) = ctx.s3_export_sink.as_ref() {
+                    sink.offer_extend(
+                        &model,
+                        &ids,
+                        &request_id,
+                        prompt_len,
+                        per_choice_output,
+                        choice.as_ref().map(|c| c.index),
+                        choice.as_ref().map(|c| c.count),
+                        None, // extend 路径当前不持有 attribution（见 spec §11）
+                    );
+                }
             } else {
                 tracing::debug!(model = %model, "cache-sim extend: tokenize failed; skipping");
             }

--- a/experimental/sgl-router/src/server/cache_sim_extend.rs
+++ b/experimental/sgl-router/src/server/cache_sim_extend.rs
@@ -175,6 +175,7 @@ pub(crate) fn spawn_extend_tee(
     request_body: Bytes,
     prompt: Option<IngressPrompt>,
     source: ReplySource,
+    slug: Option<String>,
 ) {
     if ctx.cache_sim_tee.is_none() && ctx.s3_export_sink.is_none() {
         return;
@@ -273,7 +274,7 @@ pub(crate) fn spawn_extend_tee(
                         per_choice_output,
                         choice.as_ref().map(|c| c.index),
                         choice.as_ref().map(|c| c.count),
-                        None, // extend 路径当前不持有 attribution（见 spec §11）
+                        slug.as_deref(),
                     );
                 }
             } else {
@@ -956,6 +957,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(1, 9)),
+            None,
         );
 
         let got = wait_for(&cap, 1).await;
@@ -997,6 +999,7 @@ mod spawn_tests {
             request_body(),
             None,
             ReplySource::Json(body_with(1, 5)),
+            None,
         );
         let got = wait_for(&cap, 1).await;
         let v = &got[0];
@@ -1025,6 +1028,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(1, 5)),
+            None,
         );
         let got = wait_for(&cap, 1).await;
         assert!(got[0].get("prompt_len").is_none(), "{:?}", got[0]);
@@ -1059,6 +1063,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(3, 30)),
+            None,
         );
 
         let got = wait_for(&cap, 3).await;
@@ -1128,6 +1133,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(resp),
+            None,
         );
         let got = wait_for(&cap, 1).await;
         let v = &got[0];
@@ -1187,6 +1193,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(resp),
+            None,
         );
         let got = wait_for(&cap, 2).await;
         let mut idx: Vec<u64> = got
@@ -1227,6 +1234,7 @@ mod spawn_tests {
                 opts,
             }),
             ReplySource::Json(body_with(1, 12)),
+            None,
         );
         let got = wait_for(&cap, 1).await;
         let v = &got[0];

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -542,7 +542,8 @@ pub struct MetricsRegistry {
     cache_sim_tee_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     /// Outcomes of the best-effort S3 token-export tee (see
     /// [`crate::server::s3_export`]), keyed by `result` — one of `enqueued`,
-    /// `dropped_queue_full`, `object_put`, `put_failed`, `drain_flushed`.
+    /// `dropped_queue_full`, `dropped_capture_capped`, `dropped_upload_backlog`,
+    /// `dropped_closed`, `object_put`, `put_failed`, `drain_flushed`.
     s3_export_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     /// Total records (NDJSON lines) successfully uploaded to S3 by the token
     /// export sink — records-out counterpart to `s3_export_total{result="enqueued"}`
@@ -1125,7 +1126,7 @@ impl MetricsRegistry {
     }
 
     /// Bump `sgl_router_s3_export_total{result}`. `result` is a fixed
-    /// `&'static str` (enqueued|dropped_queue_full|object_put|put_failed|drain_flushed), so label
+    /// `&'static str` (enqueued|dropped_queue_full|dropped_capture_capped|dropped_upload_backlog|dropped_closed|object_put|put_failed|drain_flushed), so label
     /// cardinality is bounded regardless of traffic.
     pub fn record_s3_export(&self, result: &'static str) {
         let mut guard = self.s3_export_total.lock();
@@ -1717,7 +1718,7 @@ impl MetricsRegistry {
 
         // s3_export_total
         out.push_str(
-            "# HELP sgl_router_s3_export_total Token-export S3 tee outcomes (result=enqueued|dropped_queue_full|object_put|put_failed|drain_flushed).\n",
+            "# HELP sgl_router_s3_export_total Token-export S3 tee outcomes (result=enqueued|dropped_queue_full|dropped_capture_capped|dropped_upload_backlog|dropped_closed|object_put|put_failed|drain_flushed).\n",
         );
         out.push_str("# TYPE sgl_router_s3_export_total counter\n");
         let guard = self.s3_export_total.lock();

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -540,6 +540,10 @@ pub struct MetricsRegistry {
     /// broken tee is failing while serving stays healthy — `http_error` +
     /// `error` are the two that indict it.
     cache_sim_tee_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
+    /// Outcomes of the best-effort S3 token-export tee (see
+    /// [`crate::server::s3_export`]), keyed by `result` — one of `enqueued`,
+    /// `dropped_queue_full`, `object_put`, `put_failed`, `drain_flushed`.
+    s3_export_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     /// Extensions teed with a prompt/output boundary that could not be true
     /// (0, or >= the sequence length). Deliberately NOT a `result` label on
     /// cache_sim_tee_total: those partition delivery attempts and the message
@@ -608,6 +612,7 @@ impl Default for MetricsRegistry {
             decode_affinity_total: Default::default(),
             sticky_total: Default::default(),
             cache_sim_tee_total: Default::default(),
+            s3_export_total: Default::default(),
             cache_sim_boundary_impossible_total: AtomicU64::new(0),
             ingress_tokenize_errors_total: Default::default(),
             backpressure_rejected_total: Default::default(),
@@ -1112,6 +1117,17 @@ impl MetricsRegistry {
             .clone();
         drop(guard);
         counter.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Bump `sgl_router_s3_export_total{result}`. `result` is a fixed
+    /// `&'static str` (enqueued|dropped_queue_full|object_put|put_failed|drain_flushed), so label
+    /// cardinality is bounded regardless of traffic.
+    pub fn record_s3_export(&self, result: &'static str) {
+        let mut guard = self.s3_export_total.lock();
+        guard
+            .entry(result)
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
+            .fetch_add(1, Ordering::Relaxed);
     }
 
     /// Bump `sgl_router_engine_aborts_total{reason}` — one increment per
@@ -1683,6 +1699,21 @@ impl MetricsRegistry {
             out.push_str(&format!(
                 "sgl_router_cache_sim_tee_total{{result=\"{}\"}} {}\n",
                 result, value,
+            ));
+        }
+        drop(guard);
+
+        // s3_export_total
+        out.push_str(
+            "# HELP sgl_router_s3_export_total Token-export S3 tee outcomes (result=enqueued|dropped_queue_full|object_put|put_failed|drain_flushed).\n",
+        );
+        out.push_str("# TYPE sgl_router_s3_export_total counter\n");
+        let guard = self.s3_export_total.lock();
+        for (result, v) in guard.iter() {
+            out.push_str(&format!(
+                "sgl_router_s3_export_total{{result=\"{}\"}} {}\n",
+                result,
+                v.load(Ordering::Relaxed)
             ));
         }
         drop(guard);
@@ -2718,5 +2749,16 @@ mod tests {
         let out = reg.render();
         assert!(out.contains(r#"sgl_router_overlap_blocks_bucket{model_id="m",le="8000"} 0"#));
         assert!(out.contains(r#"sgl_router_overlap_blocks_bucket{model_id="m",le="+Inf"} 1"#));
+    }
+
+    #[test]
+    fn record_s3_export_counts_by_result() {
+        let m = MetricsRegistry::new();
+        m.record_s3_export("enqueued");
+        m.record_s3_export("enqueued");
+        m.record_s3_export("dropped_queue_full");
+        let out = m.render();
+        assert!(out.contains("sgl_router_s3_export_total{result=\"enqueued\"} 2"));
+        assert!(out.contains("sgl_router_s3_export_total{result=\"dropped_queue_full\"} 1"));
     }
 }

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -1140,7 +1140,8 @@ impl MetricsRegistry {
     /// record count of a successfully uploaded S3 object. Compare against
     /// `s3_export_total{result="enqueued"}` (records-in) to detect silent loss.
     pub fn add_s3_export_records_uploaded(&self, n: u64) {
-        self.s3_export_records_uploaded.fetch_add(n, Ordering::Relaxed);
+        self.s3_export_records_uploaded
+            .fetch_add(n, Ordering::Relaxed);
     }
 
     /// Bump `sgl_router_engine_aborts_total{reason}` — one increment per

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -544,6 +544,10 @@ pub struct MetricsRegistry {
     /// [`crate::server::s3_export`]), keyed by `result` — one of `enqueued`,
     /// `dropped_queue_full`, `object_put`, `put_failed`, `drain_flushed`.
     s3_export_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
+    /// Total records (NDJSON lines) successfully uploaded to S3 by the token
+    /// export sink — records-out counterpart to `s3_export_total{result="enqueued"}`
+    /// (records-in). A persistent gap between the two reveals silent loss.
+    s3_export_records_uploaded: AtomicU64,
     /// Extensions teed with a prompt/output boundary that could not be true
     /// (0, or >= the sequence length). Deliberately NOT a `result` label on
     /// cache_sim_tee_total: those partition delivery attempts and the message
@@ -613,6 +617,7 @@ impl Default for MetricsRegistry {
             sticky_total: Default::default(),
             cache_sim_tee_total: Default::default(),
             s3_export_total: Default::default(),
+            s3_export_records_uploaded: AtomicU64::new(0),
             cache_sim_boundary_impossible_total: AtomicU64::new(0),
             ingress_tokenize_errors_total: Default::default(),
             backpressure_rejected_total: Default::default(),
@@ -1128,6 +1133,13 @@ impl MetricsRegistry {
             .entry(result)
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Add `n` to `sgl_router_s3_export_records_uploaded_total` — the NDJSON
+    /// record count of a successfully uploaded S3 object. Compare against
+    /// `s3_export_total{result="enqueued"}` (records-in) to detect silent loss.
+    pub fn add_s3_export_records_uploaded(&self, n: u64) {
+        self.s3_export_records_uploaded.fetch_add(n, Ordering::Relaxed);
     }
 
     /// Bump `sgl_router_engine_aborts_total{reason}` — one increment per
@@ -1717,6 +1729,14 @@ impl MetricsRegistry {
             ));
         }
         drop(guard);
+        out.push_str(
+            "# HELP sgl_router_s3_export_records_uploaded_total Records (NDJSON lines) successfully uploaded to S3 by the token export sink (records-out; compare to s3_export_total{result=\"enqueued\"} records-in to detect loss).\n",
+        );
+        out.push_str("# TYPE sgl_router_s3_export_records_uploaded_total counter\n");
+        out.push_str(&format!(
+            "sgl_router_s3_export_records_uploaded_total {}\n",
+            self.s3_export_records_uploaded.load(Ordering::Relaxed)
+        ));
 
         // cache_sim_boundary_impossible_total — rendered unconditionally (not
         // a lazily-created label child), so a dashboard sees a 0 rather than
@@ -2760,5 +2780,14 @@ mod tests {
         let out = m.render();
         assert!(out.contains("sgl_router_s3_export_total{result=\"enqueued\"} 2"));
         assert!(out.contains("sgl_router_s3_export_total{result=\"dropped_queue_full\"} 1"));
+    }
+
+    #[test]
+    fn add_s3_export_records_uploaded_sums() {
+        let m = MetricsRegistry::new();
+        m.add_s3_export_records_uploaded(30);
+        m.add_s3_export_records_uploaded(12);
+        let out = m.render();
+        assert!(out.contains("sgl_router_s3_export_records_uploaded_total 42"));
     }
 }

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -11,3 +11,4 @@ pub mod header_utils;
 pub mod metrics;
 pub mod routes;
 pub mod shutdown;
+pub mod s3_export;

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -10,5 +10,5 @@ pub mod error;
 pub mod header_utils;
 pub mod metrics;
 pub mod routes;
-pub mod shutdown;
 pub mod s3_export;
+pub mod shutdown;

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -621,6 +621,7 @@ async fn chat_completions_inner(
         let request_body = body.clone();
         let prompt = extend_prompt.clone();
         let request_id = derived_request_id.clone();
+        let slug = tee_attr.slug.clone();
         move || -> Option<StreamCapture> {
             if !armed {
                 return None;
@@ -630,21 +631,38 @@ async fn chat_completions_inner(
             // stay bounded under any load. Budget exhausted ⇒ don't capture this
             // stream (skip its extend tee, counted as `capture_capped`); the
             // capture is observational, so shedding it never affects serving.
-            // When cache-sim is off (s3-only path), there is no permit pool to
-            // draw from — proceed without one.
-            let permit = ctx
-                .cache_sim_tee
-                .as_ref()
-                .and_then(|t| t.try_acquire_capture_permit());
-            if ctx.cache_sim_tee.is_some() && permit.is_none() {
-                ctx.metrics.record_cache_sim_tee("capture_capped");
+            //
+            // When cache-sim is on, draw from the cache-sim tee's pool and record
+            // `capture_capped` there. Also record `dropped_capture_capped` on the
+            // S3 sink so both consumers reflect the drop.
+            // When cache-sim is off but the S3 sink is on, draw from the sink's
+            // own permit pool so S3-only mode is equally memory-bounded.
+            let permit = if let Some(tee) = ctx.cache_sim_tee.as_ref() {
+                let p = tee.try_acquire_capture_permit();
+                if p.is_none() {
+                    ctx.metrics.record_cache_sim_tee("capture_capped");
+                    if ctx.s3_export_sink.is_some() {
+                        ctx.metrics.record_s3_export("dropped_capture_capped");
+                    }
+                    return None;
+                }
+                p
+            } else if let Some(sink) = ctx.s3_export_sink.as_ref() {
+                let p = sink.try_acquire_capture_permit();
+                if p.is_none() {
+                    ctx.metrics.record_s3_export("dropped_capture_capped");
+                    return None;
+                }
+                p
+            } else {
                 return None;
-            }
+            };
             let ctx = Arc::clone(&ctx);
             let model = model.clone();
             let request_body = request_body.clone();
             let prompt = prompt.clone();
             let request_id = request_id.clone();
+            let slug = slug.clone();
             Some(StreamCapture {
                 max_bytes: cache_sim_extend::MAX_EXTEND_CAPTURE_BYTES,
                 _permit: permit,
@@ -656,6 +674,7 @@ async fn chat_completions_inner(
                         request_body,
                         prompt,
                         ReplySource::Sse(buf),
+                        slug,
                     );
                 }),
             })
@@ -1334,6 +1353,7 @@ async fn chat_completions_inner(
                     body.clone(),
                     extend_prompt,
                     ReplySource::Json(bytes.clone()),
+                    tee_attr.slug.clone(),
                 );
             }
         }

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -409,12 +409,7 @@ async fn chat_completions_inner(
     // exactly when the fleet is shedding, i.e. anti-correlated with health.
     let tee_attr = tee_attribution(&headers);
     if let (Some(tee), Some(t)) = (ctx.cache_sim_tee.as_ref(), request_tokens.as_ref()) {
-        tee.offer(
-            &model_str,
-            &t.ids,
-            &derived_request_id,
-            tee_attr.clone(),
-        );
+        tee.offer(&model_str, &t.ids, &derived_request_id, tee_attr.clone());
     }
     if let (Some(sink), Some(t)) = (ctx.s3_export_sink.as_ref(), request_tokens.as_ref()) {
         sink.offer_ingest(

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -311,7 +311,7 @@ async fn chat_completions_inner(
     // extension must be matchable at all (`extension_can_match`: DSV4 thinking
     // mode without tools re-renders history divergently, so its extensions
     // could only ever be dead blocks — mirroring the engine's own miss).
-    let extend_tee_armed = ctx.cache_sim_tee.is_some()
+    let extend_tee_armed = (ctx.cache_sim_tee.is_some() || ctx.s3_export_sink.is_some())
         && request_tokens.is_some()
         && request_value
             .as_ref()
@@ -407,12 +407,21 @@ async fn chat_completions_inner(
     // ingest record whose extend can never arrive — indistinguishable
     // downstream from a response that generated nothing. The bias would grow
     // exactly when the fleet is shedding, i.e. anti-correlated with health.
+    let tee_attr = tee_attribution(&headers);
     if let (Some(tee), Some(t)) = (ctx.cache_sim_tee.as_ref(), request_tokens.as_ref()) {
         tee.offer(
             &model_str,
             &t.ids,
             &derived_request_id,
-            tee_attribution(&headers),
+            tee_attr.clone(),
+        );
+    }
+    if let (Some(sink), Some(t)) = (ctx.s3_export_sink.as_ref(), request_tokens.as_ref()) {
+        sink.offer_ingest(
+            &model_str,
+            &t.ids,
+            &derived_request_id,
+            tee_attr.slug.as_deref(),
         );
     }
     if let Some(p) = &phase {
@@ -621,17 +630,16 @@ async fn chat_completions_inner(
             // stay bounded under any load. Budget exhausted ⇒ don't capture this
             // stream (skip its extend tee, counted as `capture_capped`); the
             // capture is observational, so shedding it never affects serving.
-            let permit = match ctx
+            // When cache-sim is off (s3-only path), there is no permit pool to
+            // draw from — proceed without one.
+            let permit = ctx
                 .cache_sim_tee
                 .as_ref()
-                .and_then(|t| t.try_acquire_capture_permit())
-            {
-                Some(p) => p,
-                None => {
-                    ctx.metrics.record_cache_sim_tee("capture_capped");
-                    return None;
-                }
-            };
+                .and_then(|t| t.try_acquire_capture_permit());
+            if ctx.cache_sim_tee.is_some() && permit.is_none() {
+                ctx.metrics.record_cache_sim_tee("capture_capped");
+                return None;
+            }
             let ctx = Arc::clone(&ctx);
             let model = model.clone();
             let request_body = request_body.clone();
@@ -639,7 +647,7 @@ async fn chat_completions_inner(
             let request_id = request_id.clone();
             Some(StreamCapture {
                 max_bytes: cache_sim_extend::MAX_EXTEND_CAPTURE_BYTES,
-                _permit: Some(permit),
+                _permit: permit,
                 on_done: Box::new(move |buf| {
                     cache_sim_extend::spawn_extend_tee(
                         ctx,

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -714,13 +714,15 @@ async fn run_pump(
 }
 
 /// Dispatch all ready batches from the batcher as concurrent upload jobs.
-/// When `force` is true, flushes all remaining slugs.
+/// When `force` is true (drain/close), flushes every remaining batch and is
+/// exempt from the pending-job cap, so shutdown loses nothing (upload
+/// completion is separately bounded by the shutdown budget in `main.rs`).
 ///
 /// This function is synchronous (no `.await`): the pump never blocks on
 /// permit acquisition. Jobs self-acquire their semaphore permits, so a
-/// stalled S3 upload does not freeze the tick or the drain path. Pending
-/// job count is bounded by `MAX_PENDING_UPLOADS`; excess batches are dropped
-/// and metered as `dropped_upload_backlog`.
+/// stalled S3 upload does not freeze the tick or the drain path. In steady
+/// state (`force=false`) pending job count is bounded by `MAX_PENDING_UPLOADS`;
+/// excess batches are dropped and metered as `dropped_upload_backlog`.
 #[allow(clippy::too_many_arguments)]
 fn dispatch_ready(
     batcher: &mut SlugBatcher,
@@ -737,7 +739,10 @@ fn dispatch_ready(
         let current_seq = *seq;
         *seq += 1;
 
-        if join_set.len() >= MAX_PENDING_UPLOADS {
+        // Steady-state backpressure only: cap pending jobs to bound memory.
+        // The drain/close path (`force`) is exempt — shutdown must flush every
+        // remaining batch.
+        if !force && join_set.len() >= MAX_PENDING_UPLOADS {
             metrics.record_s3_export("dropped_upload_backlog");
             continue;
         }

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -82,8 +82,8 @@ pub(crate) const DEFAULT_MAX_BATCH_AGE: Duration = Duration::from_secs(10);
 pub(crate) struct ReadyObject {
     pub slug: String,
     pub raw_bytes: Vec<u8>,
-    // Read by tests (record-count assertions) but not by the production pump.
-    #[allow(dead_code)]
+    /// NDJSON record count in this batch; added to
+    /// `sgl_router_s3_export_records_uploaded_total` on successful upload.
     pub records: u64,
 }
 
@@ -518,6 +518,7 @@ fn gzip_fast(raw: Vec<u8>) -> Option<Vec<u8>> {
 
 struct UploadJobArgs {
     raw_bytes: Vec<u8>,
+    records: u64,
     slug: String,
     seq: u64,
     prefix: String,
@@ -532,8 +533,18 @@ struct UploadJobArgs {
 /// Single upload job: gzip in a blocking thread, compute key, put with retry, record metrics.
 /// The semaphore permit is moved in and held for the job's lifetime, providing backpressure.
 async fn upload_job(args: UploadJobArgs) {
-    let UploadJobArgs { raw_bytes, slug, seq, prefix, pod, uploader, metrics, is_drain, _permit } =
-        args;
+    let UploadJobArgs {
+        raw_bytes,
+        records,
+        slug,
+        seq,
+        prefix,
+        pod,
+        uploader,
+        metrics,
+        is_drain,
+        _permit,
+    } = args;
 
     // Gzip on a blocking thread so we don't hold the async executor during CPU work.
     let gz = match tokio::task::spawn_blocking(move || gzip_fast(raw_bytes)).await {
@@ -550,6 +561,7 @@ async fn upload_job(args: UploadJobArgs) {
 
     if put_with_retry(&uploader, &key, gz, PUT_MAX_ATTEMPTS).await {
         metrics.record_s3_export("object_put");
+        metrics.add_s3_export_records_uploaded(records);
         if is_drain {
             metrics.record_s3_export("drain_flushed");
         }
@@ -655,6 +667,7 @@ async fn dispatch_ready(
 
         join_set.spawn(upload_job(UploadJobArgs {
             raw_bytes: obj.raw_bytes,
+            records: obj.records,
             slug: obj.slug,
             seq: current_seq,
             prefix: prefix.to_string(),

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -1,0 +1,1051 @@
+//! S3 token 数据集导出：与 cache-sim 独立的第二条 tee，把 ingest/extend 的
+//! token 序列以 NDJSON+gzip 批量写入 S3，供离线复算 cache hit。
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ExportKind {
+    Ingest,
+    Extend,
+}
+
+/// 一条导出记录（序列化成一行 NDJSON）。可选字段缺失即省略，语义与
+/// `cache_sim_tee::IngestIdsBody` 对齐。
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct ExportRecord {
+    pub kind: ExportKind,
+    pub request_id: String,
+    pub slug: String,
+    pub model: String,
+    pub input_ids: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_len: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub choice_index: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub choice_count: Option<usize>,
+    pub ts: String,
+}
+
+impl ExportRecord {
+    /// 序列化为一行 NDJSON（含结尾换行）。序列化不可能失败（纯值类型），
+    /// 万一失败返回空串，由调用方计数而非 panic。
+    pub(crate) fn to_ndjson_line(&self) -> String {
+        match serde_json::to_string(self) {
+            Ok(mut s) => {
+                s.push('\n');
+                s
+            }
+            Err(_) => String::new(),
+        }
+    }
+}
+
+/// 解析 `s3://bucket/prefix/...` -> `(bucket, key_prefix)`。
+/// `key_prefix` 去掉前导 `/`、去掉末尾 `/`（拼 key 时再补）。非 s3:// 返回 None。
+pub fn parse_s3_uri(uri: &str) -> Option<(String, String)> {
+    let rest = uri.trim().strip_prefix("s3://")?;
+    let mut parts = rest.splitn(2, '/');
+    let bucket = parts.next().filter(|b| !b.is_empty())?.to_string();
+    let prefix = parts.next().unwrap_or("").trim_matches('/').to_string();
+    Some((bucket, prefix))
+}
+
+/// Hive 风格分区的对象 key。`unix_nanos + seq` 保证同 pod 不碰撞；
+/// `pod` 保证跨 replica 不碰撞。
+pub(crate) fn object_key(
+    prefix: &str,
+    slug: &str,
+    date: &str,
+    pod: &str,
+    unix_nanos: u128,
+    seq: u64,
+) -> String {
+    let head = if prefix.is_empty() {
+        String::new()
+    } else {
+        format!("{prefix}/")
+    };
+    format!("{head}slug={slug}/date={date}/{pod}-{unix_nanos}-{seq}.ndjson.gz")
+}
+
+pub(crate) const DEFAULT_MAX_BATCH_BYTES: usize = 8 << 20;
+pub(crate) const DEFAULT_MAX_BATCH_AGE: Duration = Duration::from_secs(10);
+
+pub(crate) struct ReadyObject {
+    pub slug: String,
+    pub raw_bytes: Vec<u8>,
+    // Read by tests (record-count assertions) but not by the production pump.
+    #[allow(dead_code)]
+    pub records: u64,
+}
+
+struct Buf {
+    raw: Vec<u8>,
+    records: u64,
+    opened_at: Instant,
+}
+
+/// per-slug 累积未压缩 NDJSON 字节；按大小或年龄触发，产出原始（未压缩）字节。
+/// gzip 压缩由 upload worker 异步完成。
+pub(crate) struct SlugBatcher {
+    max_bytes: usize,
+    max_age: Duration,
+    bufs: HashMap<String, Buf>,
+}
+
+impl SlugBatcher {
+    pub(crate) fn new(max_bytes: usize, max_age: Duration) -> Self {
+        Self { max_bytes, max_age, bufs: HashMap::new() }
+    }
+
+    pub(crate) fn push(&mut self, slug: &str, line: &str, now: Instant) {
+        let buf = self.bufs.entry(slug.to_string()).or_insert_with(|| Buf {
+            raw: Vec::new(),
+            records: 0,
+            opened_at: now,
+        });
+        buf.raw.extend_from_slice(line.as_bytes());
+        buf.records += 1;
+    }
+
+    /// 取出所有「已就绪」的 slug 缓冲（超 size 或超 age，或 `force`），返回原始字节。
+    /// 未就绪的保留。size 触发比较未压缩字节数与 `max_bytes`（spec §5.3）。
+    /// gzip 压缩由 upload worker 完成（不在此处）。
+    pub(crate) fn take_ready(&mut self, now: Instant, force: bool) -> Vec<ReadyObject> {
+        let ready_slugs: Vec<String> = self
+            .bufs
+            .iter()
+            .filter(|(_, b)| {
+                force
+                    || b.raw.len() >= self.max_bytes
+                    || now.duration_since(b.opened_at) >= self.max_age
+            })
+            .map(|(s, _)| s.clone())
+            .collect();
+
+        let mut out = Vec::with_capacity(ready_slugs.len());
+        for slug in ready_slugs {
+            let buf = self.bufs.remove(&slug).expect("just listed");
+            if buf.raw.is_empty() {
+                continue;
+            }
+            out.push(ReadyObject { slug, raw_bytes: buf.raw, records: buf.records });
+        }
+        out
+    }
+}
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use crate::server::metrics::MetricsRegistry;
+use tokio::sync::mpsc;
+use tokio::sync::Mutex as AsyncMutex;
+
+/// 测试用内存 store。`fail_first` 次 put 先返回错误，之后成功并记录。
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) struct FakeStore {
+    pub puts: Mutex<Vec<(String, Vec<u8>)>>,
+    fail_first: AtomicU64,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl FakeStore {
+    pub(crate) fn new(fail_first: u64) -> Self {
+        Self { puts: Mutex::new(Vec::new()), fail_first: AtomicU64::new(fail_first) }
+    }
+}
+
+// ---- SigV4 helpers（纯函数，可单测）----
+
+pub(crate) fn sha256_hex(data: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(data);
+    hex::encode(h.finalize())
+}
+
+pub(crate) fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
+    use hmac::{Hmac, Mac};
+    type H = Hmac<sha2::Sha256>;
+    let mut m = <H as Mac>::new_from_slice(key).expect("hmac accepts any key length");
+    m.update(msg);
+    m.finalize().into_bytes().into()
+}
+
+/// SigV4 signing key：HMAC 链 AWS4+secret -> date -> region -> service -> aws4_request。
+pub(crate) fn signing_key(secret: &str, date_stamp: &str, region: &str, service: &str) -> [u8; 32] {
+    let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date_stamp.as_bytes());
+    let k_region = hmac_sha256(&k_date, region.as_bytes());
+    let k_service = hmac_sha256(&k_region, service.as_bytes());
+    hmac_sha256(&k_service, b"aws4_request")
+}
+
+/// RFC3986 编码；`encode_slash=false` 时保留 `/`（用于 S3 canonical URI）。
+pub(crate) fn uri_encode(s: &str, encode_slash: bool) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            b'/' if !encode_slash => out.push('/'),
+            _ => out.push_str(&format!("%{b:02X}")),
+        }
+    }
+    out
+}
+
+/// 我们固定只签 host / x-amz-content-sha256 / x-amz-date 三个头，query 为空。
+pub(crate) fn canonical_request(
+    method: &str,
+    canonical_uri: &str,
+    host: &str,
+    amz_date: &str,
+    payload_hash: &str,
+) -> String {
+    format!(
+        "{method}\n{canonical_uri}\n\nhost:{host}\nx-amz-content-sha256:{payload_hash}\nx-amz-date:{amz_date}\n\nhost;x-amz-content-sha256;x-amz-date\n{payload_hash}"
+    )
+}
+
+pub(crate) fn string_to_sign(
+    amz_date: &str,
+    date_stamp: &str,
+    region: &str,
+    service: &str,
+    creq_hash: &str,
+) -> String {
+    format!("AWS4-HMAC-SHA256\n{amz_date}\n{date_stamp}/{region}/{service}/aws4_request\n{creq_hash}")
+}
+
+pub(crate) enum Uploader {
+    S3 {
+        http: reqwest::Client,
+        access_key: String,
+        secret_key: String,
+        region: String,
+        bucket: String,
+    },
+    // Test-only variant; suppressed outside #[cfg(test)] builds.
+    #[cfg_attr(not(test), allow(dead_code))]
+    Fake(Arc<FakeStore>),
+}
+
+impl Uploader {
+    async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
+        match self {
+            Uploader::S3 { http, access_key, secret_key, region, bucket } => {
+                // virtual-hosted-style（radixark bucket 名无点，无 TLS SNI 问题）。
+                let host = format!("{bucket}.s3.{region}.amazonaws.com");
+                let canonical_uri = format!("/{}", uri_encode(key, false));
+                let url = format!("https://{host}{canonical_uri}");
+                let now = chrono::Utc::now();
+                let amz_date = now.format("%Y%m%dT%H%M%SZ").to_string();
+                let date_stamp = now.format("%Y%m%d").to_string();
+                let payload_hash = sha256_hex(&body);
+
+                let creq =
+                    canonical_request("PUT", &canonical_uri, &host, &amz_date, &payload_hash);
+                let sts = string_to_sign(
+                    &amz_date,
+                    &date_stamp,
+                    region,
+                    "s3",
+                    &sha256_hex(creq.as_bytes()),
+                );
+                let sig = hex::encode(hmac_sha256(
+                    &signing_key(secret_key, &date_stamp, region, "s3"),
+                    sts.as_bytes(),
+                ));
+                let authz = format!(
+                    "AWS4-HMAC-SHA256 Credential={access_key}/{date_stamp}/{region}/s3/aws4_request, \
+                     SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature={sig}"
+                );
+
+                let resp = http
+                    .put(&url)
+                    .header("x-amz-date", &amz_date)
+                    .header("x-amz-content-sha256", &payload_hash)
+                    .header("authorization", &authz)
+                    .header("content-encoding", "gzip")
+                    .header("content-type", "application/x-ndjson")
+                    .body(body)
+                    .send()
+                    .await?;
+                let status = resp.status();
+                if status.is_success() {
+                    Ok(())
+                } else {
+                    // Include S3's error body (XML: <Code>…</Code>) so a failed
+                    // upload is diagnosable (SignatureDoesNotMatch / AccessDenied /
+                    // InvalidAccessKeyId …) instead of a bare status.
+                    let body = resp.text().await.unwrap_or_default();
+                    anyhow::bail!("s3 put returned {status}: {body}");
+                }
+            }
+            Uploader::Fake(store) => {
+                if store.fail_first.load(Ordering::SeqCst) > 0 {
+                    store.fail_first.fetch_sub(1, Ordering::SeqCst);
+                    anyhow::bail!("injected failure");
+                }
+                store.puts.lock().unwrap().push((key.to_string(), body));
+                Ok(())
+            }
+        }
+    }
+}
+
+/// 指数退避重试；`max_attempts` 次内成功返回 true，否则 false（由调用方计数）。
+/// 退避从 100ms 起翻倍，封顶 5s。
+pub(crate) async fn put_with_retry(
+    up: &Uploader,
+    key: &str,
+    body: Vec<u8>,
+    max_attempts: u32,
+) -> bool {
+    let mut backoff = Duration::from_millis(100);
+    for attempt in 1..=max_attempts {
+        match up.put(key, body.clone()).await {
+            Ok(()) => return true,
+            Err(e) => {
+                tracing::warn!(key, attempt, error = %e, "s3 export put failed; will retry");
+                if attempt == max_attempts {
+                    return false;
+                }
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(Duration::from_secs(5));
+            }
+        }
+    }
+    false
+}
+
+pub(crate) const CHANNEL_CAPACITY: usize = 8192;
+const PUT_MAX_ATTEMPTS: u32 = 8;
+/// pump 的定时 flush 心跳；配合 batcher 的 age 触发。
+const TICK: Duration = Duration::from_secs(1);
+/// Bounded pool of concurrent gzip+upload worker tasks. Keeps CPU usage bounded
+/// on the shared 8-core container while allowing parallelism.
+const UPLOAD_CONCURRENCY: usize = 4;
+
+enum PumpMsg {
+    Record(Box<ExportRecord>),
+    Drain(tokio::sync::oneshot::Sender<()>),
+}
+
+pub struct S3ExportSink {
+    tx: mpsc::Sender<PumpMsg>,
+    metrics: Arc<MetricsRegistry>,
+    join: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl std::fmt::Debug for S3ExportSink {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3ExportSink").finish_non_exhaustive()
+    }
+}
+
+impl S3ExportSink {
+    /// 生产入口：解析 uri、从标准 AWS env 读凭证/region、构造 reqwest S3 uploader、
+    /// 起 pump。uri 无效或凭证缺失返回 None（sink 不启用）。
+    pub fn spawn(uri: &str, pod: String, metrics: Arc<MetricsRegistry>) -> Option<Arc<Self>> {
+        let (bucket, prefix) = parse_s3_uri(uri)?;
+        // `.trim()`: a secretKeyRef-injected value can carry a trailing newline
+        // (if the stored secret was created with a trailing `\n`); an untrimmed
+        // key silently breaks SigV4 with SignatureDoesNotMatch. Creds/region
+        // never legitimately contain surrounding whitespace, so trimming is safe.
+        let clean = |v: String| {
+            let t = v.trim().to_string();
+            if t.is_empty() { None } else { Some(t) }
+        };
+        let access_key = std::env::var("AWS_ACCESS_KEY_ID").ok().and_then(clean);
+        let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok().and_then(clean);
+        let region = std::env::var("AWS_REGION")
+            .or_else(|_| std::env::var("AWS_DEFAULT_REGION"))
+            .ok()
+            .and_then(clean);
+        let (access_key, secret_key, region) = match (access_key, secret_key, region) {
+            (Some(a), Some(s), Some(r)) => (a, s, r),
+            _ => {
+                tracing::error!(
+                    "token export uri set but AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION \
+                     missing; disabling s3 export"
+                );
+                return None;
+            }
+        };
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .ok()?;
+        let uploader = Uploader::S3 { http, access_key, secret_key, region, bucket };
+
+        let metrics2 = Arc::clone(&metrics);
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let join = tokio::spawn(async move {
+            run_pump(rx, Arc::new(uploader), prefix, pod, metrics2, DEFAULT_MAX_BATCH_BYTES).await;
+        });
+        tracing::info!("s3 token export enabled");
+        Some(Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)) }))
+    }
+
+    /// 测试入口：注入 uploader（不触碰 AWS）。
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn spawn_with_uploader(
+        uploader: Uploader,
+        prefix: String,
+        pod: String,
+        metrics: Arc<MetricsRegistry>,
+    ) -> Arc<Self> {
+        Self::spawn_with_uploader_batch(uploader, prefix, pod, metrics, DEFAULT_MAX_BATCH_BYTES)
+    }
+
+    /// 测试入口（可配置 batch size）：用于需要在小输入量下触发多 batch 的测试。
+    #[cfg_attr(not(test), allow(dead_code))]
+    pub(crate) fn spawn_with_uploader_batch(
+        uploader: Uploader,
+        prefix: String,
+        pod: String,
+        metrics: Arc<MetricsRegistry>,
+        max_batch_bytes: usize,
+    ) -> Arc<Self> {
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let metrics2 = Arc::clone(&metrics);
+        let uploader = Arc::new(uploader);
+        let join = tokio::spawn(async move {
+            run_pump(rx, uploader, prefix, pod, metrics2, max_batch_bytes).await;
+        });
+        Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)) })
+    }
+
+    fn enqueue(&self, rec: ExportRecord) {
+        match self.tx.try_send(PumpMsg::Record(Box::new(rec))) {
+            Ok(()) => self.metrics.record_s3_export("enqueued"),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.metrics.record_s3_export("dropped_queue_full")
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {}
+        }
+    }
+
+    pub fn offer_ingest(
+        &self,
+        model: &str,
+        input_ids: &[u32],
+        request_id: &str,
+        slug: Option<&str>,
+    ) {
+        if input_ids.is_empty() {
+            return;
+        }
+        self.enqueue(ExportRecord {
+            kind: ExportKind::Ingest,
+            request_id: request_id.to_string(),
+            slug: slug.filter(|s| !s.is_empty()).unwrap_or("unknown").to_string(),
+            model: model.to_string(),
+            input_ids: input_ids.to_vec(),
+            prompt_len: None,
+            output_tokens: None,
+            choice_index: None,
+            choice_count: None,
+            ts: chrono::Utc::now().to_rfc3339(),
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn offer_extend(
+        &self,
+        model: &str,
+        input_ids: &[u32],
+        request_id: &str,
+        prompt_len: Option<usize>,
+        output_tokens: Option<u64>,
+        choice_index: Option<usize>,
+        choice_count: Option<usize>,
+        slug: Option<&str>,
+    ) {
+        if input_ids.is_empty() {
+            return;
+        }
+        self.enqueue(ExportRecord {
+            kind: ExportKind::Extend,
+            request_id: request_id.to_string(),
+            slug: slug.filter(|s| !s.is_empty()).unwrap_or("unknown").to_string(),
+            model: model.to_string(),
+            input_ids: input_ids.to_vec(),
+            prompt_len,
+            output_tokens,
+            choice_index,
+            choice_count,
+            ts: chrono::Utc::now().to_rfc3339(),
+        });
+    }
+
+    /// 发关闭信号，等 pump flush 全部剩余并结束。用于 SIGTERM 关闭序列。
+    pub async fn drain(&self) {
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        // `send` awaits capacity; the pump keeps draining records and freeing
+        // slots, so the Drain message enqueues behind any backlog and is
+        // processed normally. The is_ok()==false branch is only reached when
+        // the channel is already closed (pump already exited).
+        if self.tx.send(PumpMsg::Drain(ack_tx)).await.is_ok() {
+            let _ = ack_rx.await;
+        }
+        if let Some(handle) = self.join.lock().await.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+/// Gzip-compress `raw` using fast compression. Returns None on error (never panics).
+fn gzip_fast(raw: Vec<u8>) -> Option<Vec<u8>> {
+    let mut enc = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::fast());
+    // Writing to an in-memory Vec cannot produce IO errors, but we match anyway
+    // to preserve the never-panic invariant.
+    if enc.write_all(&raw).is_err() {
+        return None;
+    }
+    enc.finish().ok()
+}
+
+struct UploadJobArgs {
+    raw_bytes: Vec<u8>,
+    slug: String,
+    seq: u64,
+    prefix: String,
+    pod: String,
+    uploader: Arc<Uploader>,
+    metrics: Arc<MetricsRegistry>,
+    is_drain: bool,
+    /// Held for the job's lifetime to bound concurrency via the semaphore.
+    _permit: tokio::sync::OwnedSemaphorePermit,
+}
+
+/// Single upload job: gzip in a blocking thread, compute key, put with retry, record metrics.
+/// The semaphore permit is moved in and held for the job's lifetime, providing backpressure.
+async fn upload_job(args: UploadJobArgs) {
+    let UploadJobArgs { raw_bytes, slug, seq, prefix, pod, uploader, metrics, is_drain, _permit } =
+        args;
+
+    // Gzip on a blocking thread so we don't hold the async executor during CPU work.
+    let gz = match tokio::task::spawn_blocking(move || gzip_fast(raw_bytes)).await {
+        Ok(Some(gz)) => gz,
+        Ok(None) | Err(_) => {
+            metrics.record_s3_export("put_failed");
+            return;
+        }
+    };
+
+    let date = chrono::Utc::now().format("%Y-%m-%d").to_string();
+    let nanos = chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0) as u128;
+    let key = object_key(&prefix, &slug, &date, &pod, nanos, seq);
+
+    if put_with_retry(&uploader, &key, gz, PUT_MAX_ATTEMPTS).await {
+        metrics.record_s3_export("object_put");
+        if is_drain {
+            metrics.record_s3_export("drain_flushed");
+        }
+    } else {
+        metrics.record_s3_export("put_failed");
+    }
+    // _permit is dropped here, releasing the semaphore slot.
+}
+
+/// 后台泵：消费记录 → 攒批 → 定时/超量 flush → 并发上传。永不 panic。
+async fn run_pump(
+    mut rx: mpsc::Receiver<PumpMsg>,
+    uploader: Arc<Uploader>,
+    prefix: String,
+    pod: String,
+    metrics: Arc<MetricsRegistry>,
+    max_batch_bytes: usize,
+) {
+    let mut batcher = SlugBatcher::new(max_batch_bytes, DEFAULT_MAX_BATCH_AGE);
+    let mut seq: u64 = 0;
+    let mut tick = tokio::time::interval(TICK);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    let sem = Arc::new(tokio::sync::Semaphore::new(UPLOAD_CONCURRENCY));
+    let mut join_set: tokio::task::JoinSet<()> = tokio::task::JoinSet::new();
+
+    loop {
+        tokio::select! {
+            maybe = rx.recv() => {
+                match maybe {
+                    Some(PumpMsg::Record(rec)) => {
+                        let line = rec.to_ndjson_line();
+                        if !line.is_empty() {
+                            batcher.push(&rec.slug, &line, Instant::now());
+                        }
+                        dispatch_ready(
+                            &mut batcher, &uploader, &prefix, &pod, &metrics,
+                            &mut seq, false, &sem, &mut join_set,
+                        ).await;
+                    }
+                    Some(PumpMsg::Drain(ack)) => {
+                        dispatch_ready(
+                            &mut batcher, &uploader, &prefix, &pod, &metrics,
+                            &mut seq, true, &sem, &mut join_set,
+                        ).await;
+                        // Wait for all in-flight uploads before acking.
+                        while join_set.join_next().await.is_some() {}
+                        let _ = ack.send(());
+                        return;
+                    }
+                    None => {
+                        // All senders closed: force flush then exit.
+                        dispatch_ready(
+                            &mut batcher, &uploader, &prefix, &pod, &metrics,
+                            &mut seq, true, &sem, &mut join_set,
+                        ).await;
+                        while join_set.join_next().await.is_some() {}
+                        return;
+                    }
+                }
+            }
+            _ = tick.tick() => {
+                dispatch_ready(
+                    &mut batcher, &uploader, &prefix, &pod, &metrics,
+                    &mut seq, false, &sem, &mut join_set,
+                ).await;
+            }
+        }
+        // Opportunistically reap finished jobs so the JoinSet doesn't grow unbounded.
+        while join_set.try_join_next().is_some() {}
+    }
+}
+
+/// Dispatch all ready batches from the batcher as concurrent upload jobs.
+/// When `force` is true, flushes all remaining slugs.
+/// Acquiring the semaphore permit awaits when all UPLOAD_CONCURRENCY slots are busy,
+/// providing backpressure: the mpsc channel fills and offer() sheds under overload.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_ready(
+    batcher: &mut SlugBatcher,
+    uploader: &Arc<Uploader>,
+    prefix: &str,
+    pod: &str,
+    metrics: &Arc<MetricsRegistry>,
+    seq: &mut u64,
+    force: bool,
+    sem: &Arc<tokio::sync::Semaphore>,
+    join_set: &mut tokio::task::JoinSet<()>,
+) {
+    for obj in batcher.take_ready(Instant::now(), force) {
+        let current_seq = *seq;
+        *seq += 1;
+
+        // Await a permit — this is the backpressure point.
+        let permit = match Arc::clone(sem).acquire_owned().await {
+            Ok(p) => p,
+            Err(_) => {
+                // Semaphore closed; should not happen in normal operation.
+                metrics.record_s3_export("put_failed");
+                continue;
+            }
+        };
+
+        join_set.spawn(upload_job(UploadJobArgs {
+            raw_bytes: obj.raw_bytes,
+            slug: obj.slug,
+            seq: current_seq,
+            prefix: prefix.to_string(),
+            pod: pod.to_string(),
+            uploader: Arc::clone(uploader),
+            metrics: Arc::clone(metrics),
+            is_drain: force,
+            _permit: permit,
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use std::time::{Duration, Instant};
+
+    fn gunzip(b: &[u8]) -> String {
+        use std::io::Read;
+        let mut d = flate2::read::GzDecoder::new(b);
+        let mut s = String::new();
+        d.read_to_string(&mut s).unwrap();
+        s
+    }
+
+    #[test]
+    fn batcher_flushes_on_size() {
+        // line is ~53 bytes uncompressed, which is >= 32 (the uncompressed threshold)
+        let mut b = SlugBatcher::new(32, Duration::from_secs(999));
+        let t0 = Instant::now();
+        // Single ~53-byte line >= max_bytes(32) -> immediately ready
+        let line = "{\"kind\":\"ingest\",\"input_ids\":[1,2,3,4,5,6,7,8,9,10]}\n";
+        b.push("slugA", line, t0);
+        let ready = b.take_ready(t0, false);
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].slug, "slugA");
+        assert_eq!(ready[0].records, 1);
+        // Batcher now returns raw bytes; verify the content directly.
+        assert_eq!(std::str::from_utf8(&ready[0].raw_bytes).unwrap(), line);
+    }
+
+    #[test]
+    fn batcher_flushes_on_age_and_separates_slugs() {
+        let mut b = SlugBatcher::new(1 << 20, Duration::from_millis(100));
+        let t0 = Instant::now();
+        b.push("slugA", "a\n", t0);
+        b.push("slugB", "b\n", t0);
+        // 未到 age、未超 size -> 不 ready
+        assert!(b.take_ready(t0, false).is_empty());
+        // 过了 age -> 两个 slug 各出一个对象
+        let later = t0 + Duration::from_millis(150);
+        let mut ready = b.take_ready(later, false);
+        ready.sort_by(|x, y| x.slug.cmp(&y.slug));
+        assert_eq!(ready.len(), 2);
+        assert_eq!(ready[0].slug, "slugA");
+        assert_eq!(std::str::from_utf8(&ready[0].raw_bytes).unwrap(), "a\n");
+        assert_eq!(ready[1].slug, "slugB");
+    }
+
+    #[test]
+    fn batcher_force_flushes_everything() {
+        let mut b = SlugBatcher::new(1 << 20, Duration::from_secs(999));
+        let t0 = Instant::now();
+        b.push("slugA", "a\n", t0);
+        let ready = b.take_ready(t0, true);
+        assert_eq!(ready.len(), 1);
+    }
+
+    #[test]
+    fn parse_s3_uri_splits_bucket_and_prefix() {
+        assert_eq!(
+            parse_s3_uri("s3://my-bucket/token-export/"),
+            Some(("my-bucket".into(), "token-export".into()))
+        );
+        assert_eq!(
+            parse_s3_uri("s3://b/a/b/c"),
+            Some(("b".into(), "a/b/c".into()))
+        );
+        assert_eq!(parse_s3_uri("s3://only-bucket"), Some(("only-bucket".into(), "".into())));
+        assert_eq!(parse_s3_uri("https://x"), None);
+        assert_eq!(parse_s3_uri("s3://"), None);
+    }
+
+    #[test]
+    fn ingest_line_omits_extend_only_fields() {
+        let r = ExportRecord {
+            kind: ExportKind::Ingest,
+            request_id: "rid".into(),
+            slug: "slugA".into(),
+            model: "m".into(),
+            input_ids: vec![128, 9021],
+            prompt_len: None,
+            output_tokens: None,
+            choice_index: None,
+            choice_count: None,
+            ts: "2026-08-10T00:00:00Z".into(),
+        };
+        let line = r.to_ndjson_line();
+        assert!(line.ends_with('\n'));
+        let v: serde_json::Value = serde_json::from_str(line.trim_end()).unwrap();
+        assert_eq!(v["kind"], "ingest");
+        assert_eq!(v["input_ids"], serde_json::json!([128, 9021]));
+        assert_eq!(v["slug"], "slugA");
+        assert!(v.get("prompt_len").is_none());
+        assert!(v.get("output_tokens").is_none());
+        assert!(v.get("choice_index").is_none());
+        assert!(v.get("choice_count").is_none());
+    }
+
+    #[test]
+    fn fanout_line_includes_choice_index_and_count() {
+        let r = ExportRecord {
+            kind: ExportKind::Extend,
+            request_id: "rid".into(),
+            slug: "s".into(),
+            model: "m".into(),
+            input_ids: vec![1, 2],
+            prompt_len: None,
+            output_tokens: None,
+            choice_index: Some(0),
+            choice_count: Some(3),
+            ts: "2026-08-10T00:00:00Z".into(),
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
+        assert_eq!(v["choice_index"], 0);
+        assert_eq!(v["choice_count"], 3);
+    }
+
+    #[test]
+    fn extend_line_includes_prompt_len_and_output_tokens() {
+        let r = ExportRecord {
+            kind: ExportKind::Extend,
+            request_id: "rid".into(),
+            slug: "unknown".into(),
+            model: "m".into(),
+            input_ids: vec![1, 2, 3],
+            prompt_len: Some(2),
+            output_tokens: Some(9),
+            choice_index: None,
+            choice_count: None,
+            ts: "2026-08-10T00:00:00Z".into(),
+        };
+        let v: serde_json::Value =
+            serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
+        assert_eq!(v["kind"], "extend");
+        assert_eq!(v["prompt_len"], 2);
+        assert_eq!(v["output_tokens"], 9);
+    }
+
+    #[test]
+    fn object_key_is_hive_partitioned_and_unique() {
+        let k1 = object_key("token-export", "slugA", "2026-08-10", "pod-1", 111, 0);
+        assert_eq!(
+            k1,
+            "token-export/slug=slugA/date=2026-08-10/pod-1-111-0.ndjson.gz"
+        );
+        let k2 = object_key("token-export", "slugA", "2026-08-10", "pod-1", 111, 1);
+        assert_ne!(k1, k2, "seq must disambiguate same-nanos objects");
+        // 空 prefix 不产生前导斜杠
+        let k3 = object_key("", "s", "2026-08-10", "pod-1", 1, 0);
+        assert_eq!(k3, "slug=s/date=2026-08-10/pod-1-1-0.ndjson.gz");
+    }
+
+    #[tokio::test]
+    async fn put_with_retry_succeeds_after_transient_failures() {
+        let store = Arc::new(FakeStore::new(/*fail_first=*/ 2));
+        let up = Uploader::Fake(Arc::clone(&store));
+        let ok = put_with_retry(&up, "k", b"payload".to_vec(), 5).await;
+        assert!(ok, "should succeed on the 3rd attempt");
+        let puts = store.puts.lock().unwrap();
+        assert_eq!(puts.len(), 1);
+        assert_eq!(puts[0].0, "k");
+        assert_eq!(puts[0].1, b"payload");
+    }
+
+    #[tokio::test]
+    async fn put_with_retry_gives_up_after_max_attempts() {
+        let store = Arc::new(FakeStore::new(/*fail_first=*/ 100));
+        let up = Uploader::Fake(Arc::clone(&store));
+        let ok = put_with_retry(&up, "k", b"x".to_vec(), 3).await;
+        assert!(!ok);
+        assert!(store.puts.lock().unwrap().is_empty());
+    }
+
+    /// Real S3 round-trip against the actual `Uploader::S3` SigV4 path.
+    /// Ignored by default (no creds in CI). Run manually with STATIC keys:
+    ///   AWS_ACCESS_KEY_ID=.. AWS_SECRET_ACCESS_KEY=.. AWS_REGION=us-west-2 \
+    ///   TEST_S3_URI=s3://<bucket>/<prefix>/ \
+    ///   cargo test --lib s3_export::tests::real_s3_roundtrip -- --ignored --nocapture
+    /// (SSO/temporary creds won't work — we don't sign x-amz-security-token.)
+    #[tokio::test]
+    #[ignore]
+    async fn real_s3_roundtrip() {
+        let (ak, sk, region, uri) = match (
+            std::env::var("AWS_ACCESS_KEY_ID"),
+            std::env::var("AWS_SECRET_ACCESS_KEY"),
+            std::env::var("AWS_REGION").or_else(|_| std::env::var("AWS_DEFAULT_REGION")),
+            std::env::var("TEST_S3_URI"),
+        ) {
+            (Ok(a), Ok(s), Ok(r), Ok(u)) if !a.is_empty() && !s.is_empty() && !r.is_empty() => {
+                (a, s, r, u)
+            }
+            _ => {
+                eprintln!("real_s3_roundtrip skipped: set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION/TEST_S3_URI");
+                return;
+            }
+        };
+        let (bucket, prefix) = parse_s3_uri(&uri).expect("TEST_S3_URI must be s3://bucket/prefix/");
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+            .expect("build reqwest client");
+        if std::env::var("AWS_SESSION_TOKEN").map(|v| !v.is_empty()).unwrap_or(false) {
+            eprintln!(
+                "WARNING: AWS_SESSION_TOKEN is set — these are TEMPORARY/SSO credentials. \
+                 Our SigV4 signer does NOT send x-amz-security-token, so S3 will reject them. \
+                 Use STATIC IAM user keys (not temporary/SSO credentials)."
+            );
+        }
+        let up = Uploader::S3 { http, access_key: ak, secret_key: sk, region, bucket };
+        let key = if prefix.is_empty() {
+            "roundtrip-check.txt".to_string()
+        } else {
+            format!("{prefix}/roundtrip-check.txt")
+        };
+        // Call put() directly (not put_with_retry) so the real S3 error surfaces.
+        // Retry a few times to tolerate fresh-IAM propagation.
+        let mut last_err = None;
+        for attempt in 1..=6u32 {
+            match up.put(&key, b"sgl-router s3 export roundtrip\n".to_vec()).await {
+                Ok(()) => {
+                    eprintln!("real_s3_roundtrip OK -> s3://.../{key}");
+                    return;
+                }
+                Err(e) => {
+                    eprintln!("attempt {attempt}/6 failed: {e}");
+                    last_err = Some(e);
+                    tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+                }
+            }
+        }
+        panic!("real S3 PutObject to {key} failed: {}", last_err.unwrap());
+    }
+
+    // ---- SigV4 building blocks ----
+
+    #[test]
+    fn sha256_hex_of_empty_is_known_vector() {
+        // 众所周知的 SHA-256("") 向量。
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn hmac_sha256_matches_rfc4231_case2() {
+        // RFC 4231 Test Case 2：key="Jefe", data="what do ya want for nothing?"
+        let mac = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            hex::encode(mac),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn signing_key_is_deterministic_and_32_bytes() {
+        let k1 = signing_key("secret", "20260810", "us-west-2", "s3");
+        let k2 = signing_key("secret", "20260810", "us-west-2", "s3");
+        assert_eq!(k1, k2);
+        assert_eq!(k1.len(), 32);
+        // 不同 date -> 不同 key（证明派生链引用了各段）
+        assert_ne!(k1, signing_key("secret", "20260811", "us-west-2", "s3"));
+    }
+
+    #[test]
+    fn uri_encode_preserves_slash_when_asked() {
+        assert_eq!(uri_encode("a b/c", false), "a%20b/c");
+        assert_eq!(uri_encode("a b/c", true), "a%20b%2Fc");
+        assert_eq!(uri_encode("k-._~", false), "k-._~");
+    }
+
+    #[test]
+    fn canonical_request_has_exact_shape() {
+        let creq = canonical_request(
+            "PUT",
+            "/pfx/slug=s/date=2026-08-10/pod-1-1-0.ndjson.gz",
+            "b.s3.us-west-2.amazonaws.com",
+            "20260810T000000Z",
+            "abc123",
+        );
+        let expected = "PUT\n\
+            /pfx/slug=s/date=2026-08-10/pod-1-1-0.ndjson.gz\n\
+            \n\
+            host:b.s3.us-west-2.amazonaws.com\n\
+            x-amz-content-sha256:abc123\n\
+            x-amz-date:20260810T000000Z\n\
+            \n\
+            host;x-amz-content-sha256;x-amz-date\n\
+            abc123";
+        assert_eq!(creq, expected);
+    }
+
+    #[test]
+    fn string_to_sign_has_exact_shape() {
+        let sts = string_to_sign("20260810T000000Z", "20260810", "us-west-2", "s3", "deadbeef");
+        assert_eq!(
+            sts,
+            "AWS4-HMAC-SHA256\n20260810T000000Z\n20260810/us-west-2/s3/aws4_request\ndeadbeef"
+        );
+    }
+
+    fn test_metrics() -> Arc<MetricsRegistry> {
+        MetricsRegistry::new()
+    }
+
+    #[tokio::test]
+    async fn drain_flushes_offered_records_to_uploader() {
+        let store = Arc::new(FakeStore::new(0));
+        let up = Uploader::Fake(Arc::clone(&store));
+        let sink = S3ExportSink::spawn_with_uploader(
+            up,
+            "pfx".into(),
+            "pod-1".into(),
+            test_metrics(),
+        );
+        sink.offer_ingest("m", &[1, 2, 3], "rid", Some("slugA"));
+        sink.offer_extend("m", &[1, 2, 3, 4], "rid", Some(3), Some(1), None, None, Some("slugA"));
+        sink.drain().await;
+
+        let puts = store.puts.lock().unwrap();
+        assert_eq!(puts.len(), 1, "one slug -> one object");
+        assert!(puts[0].0.starts_with("pfx/slug=slugA/date="));
+        assert!(puts[0].0.ends_with(".ndjson.gz"));
+        let body = gunzip(&puts[0].1);
+        assert_eq!(body.lines().count(), 2, "ingest + extend");
+        assert!(body.contains("\"kind\":\"ingest\""));
+        assert!(body.contains("\"kind\":\"extend\""));
+    }
+
+    #[tokio::test]
+    async fn offer_never_blocks_and_missing_slug_becomes_unknown() {
+        let store = Arc::new(FakeStore::new(0));
+        let sink = S3ExportSink::spawn_with_uploader(
+            Uploader::Fake(Arc::clone(&store)),
+            "".into(),
+            "pod-1".into(),
+            test_metrics(),
+        );
+        sink.offer_ingest("m", &[7], "rid", None); // slug 缺失
+        sink.drain().await;
+        let puts = store.puts.lock().unwrap();
+        assert_eq!(puts.len(), 1);
+        assert!(puts[0].0.starts_with("slug=unknown/date="));
+    }
+
+    /// Verifies that a single slug can produce multiple concurrent upload objects, and
+    /// that drain waits for ALL of them before returning. Uses a tiny batch threshold
+    /// to force multiple batches from a small number of records.
+    #[tokio::test]
+    async fn drain_waits_for_all_concurrent_uploads() {
+        // Use a 1-byte batch threshold to force one object per record.
+        let store = Arc::new(FakeStore::new(0));
+        let sink = S3ExportSink::spawn_with_uploader_batch(
+            Uploader::Fake(Arc::clone(&store)),
+            "pfx".into(),
+            "pod-1".into(),
+            test_metrics(),
+            1, // 1-byte max: every push triggers a new batch immediately
+        );
+
+        // Offer several records for a single slug.
+        const N: usize = 8;
+        for i in 0..N {
+            sink.offer_ingest("m", &[i as u32, i as u32 + 1], "rid", Some("slugA"));
+        }
+        sink.drain().await;
+
+        let puts = store.puts.lock().unwrap();
+        // Every record produces its own gzipped object (batch size = 1 byte).
+        assert_eq!(puts.len(), N, "expected {N} objects, got {}", puts.len());
+
+        // All objects are under the correct prefix.
+        for (key, _) in puts.iter() {
+            assert!(key.starts_with("pfx/slug=slugA/date="), "unexpected key: {key}");
+        }
+
+        // Total decompressed line count must equal N.
+        let total_lines: usize = puts.iter().map(|(_, gz)| gunzip(gz).lines().count()).sum();
+        assert_eq!(total_lines, N, "decompressed line count mismatch");
+    }
+}

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -1,5 +1,6 @@
-//! S3 token 数据集导出：与 cache-sim 独立的第二条 tee，把 ingest/extend 的
-//! token 序列以 NDJSON+gzip 批量写入 S3，供离线复算 cache hit。
+//! S3 token-dataset export: a second tee independent of the cache-sim that
+//! writes ingest/extend token sequences as NDJSON+gzip batches to S3 for
+//! offline cache-hit recomputation.
 
 use std::collections::HashMap;
 use std::io::Write;
@@ -14,8 +15,8 @@ pub(crate) enum ExportKind {
     Extend,
 }
 
-/// 一条导出记录（序列化成一行 NDJSON）。可选字段缺失即省略，语义与
-/// `cache_sim_tee::IngestIdsBody` 对齐。
+/// One export record (serialized as one NDJSON line). Optional fields are
+/// omitted when absent; semantics align with `cache_sim_tee::IngestIdsBody`.
 #[derive(Clone, Debug, Serialize)]
 pub(crate) struct ExportRecord {
     pub kind: ExportKind,
@@ -35,8 +36,9 @@ pub(crate) struct ExportRecord {
 }
 
 impl ExportRecord {
-    /// 序列化为一行 NDJSON（含结尾换行）。序列化不可能失败（纯值类型），
-    /// 万一失败返回空串，由调用方计数而非 panic。
+    /// Serialize to one NDJSON line (with a trailing newline). Serialization
+    /// cannot fail for pure value types; if it does, return an empty string
+    /// and let the caller count it rather than panicking.
     pub(crate) fn to_ndjson_line(&self) -> String {
         match serde_json::to_string(self) {
             Ok(mut s) => {
@@ -48,8 +50,9 @@ impl ExportRecord {
     }
 }
 
-/// 解析 `s3://bucket/prefix/...` -> `(bucket, key_prefix)`。
-/// `key_prefix` 去掉前导 `/`、去掉末尾 `/`（拼 key 时再补）。非 s3:// 返回 None。
+/// Parse `s3://bucket/prefix/...` into `(bucket, key_prefix)`.
+/// `key_prefix` is stripped of leading and trailing `/` (re-added when
+/// constructing the key). Returns `None` for non-s3:// URIs.
 pub fn parse_s3_uri(uri: &str) -> Option<(String, String)> {
     let rest = uri.trim().strip_prefix("s3://")?;
     let mut parts = rest.splitn(2, '/');
@@ -58,8 +61,8 @@ pub fn parse_s3_uri(uri: &str) -> Option<(String, String)> {
     Some((bucket, prefix))
 }
 
-/// Hive 风格分区的对象 key。`unix_nanos + seq` 保证同 pod 不碰撞；
-/// `pod` 保证跨 replica 不碰撞。
+/// Hive-style partitioned object key. `unix_nanos + seq` prevents collisions
+/// within one pod; `pod` prevents collisions across replicas.
 pub(crate) fn object_key(
     prefix: &str,
     slug: &str,
@@ -74,6 +77,22 @@ pub(crate) fn object_key(
         format!("{prefix}/")
     };
     format!("{head}slug={slug}/date={date}/{pod}-{unix_nanos}-{seq}.ndjson.gz")
+}
+
+/// The slug is a client-suppliable header (x-radixark-endpoint-slug). Only a
+/// strict allowlist may reach S3 key paths or the batcher map: hostile values
+/// (path separators, huge/high-cardinality strings) collapse to "unknown".
+fn safe_slug(slug: Option<&str>) -> String {
+    match slug {
+        Some(s)
+            if !s.is_empty()
+                && s.len() <= 64
+                && s.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-')) =>
+        {
+            s.to_string()
+        }
+        _ => "unknown".to_string(),
+    }
 }
 
 pub(crate) const DEFAULT_MAX_BATCH_BYTES: usize = 8 << 20;
@@ -93,8 +112,9 @@ struct Buf {
     opened_at: Instant,
 }
 
-/// per-slug 累积未压缩 NDJSON 字节；按大小或年龄触发，产出原始（未压缩）字节。
-/// gzip 压缩由 upload worker 异步完成。
+/// Per-slug accumulator of uncompressed NDJSON bytes. Triggers on size or age
+/// and yields raw (uncompressed) bytes. Gzip compression is done by the upload
+/// worker asynchronously.
 pub(crate) struct SlugBatcher {
     max_bytes: usize,
     max_age: Duration,
@@ -116,9 +136,10 @@ impl SlugBatcher {
         buf.records += 1;
     }
 
-    /// 取出所有「已就绪」的 slug 缓冲（超 size 或超 age，或 `force`），返回原始字节。
-    /// 未就绪的保留。size 触发比较未压缩字节数与 `max_bytes`（spec §5.3）。
-    /// gzip 压缩由 upload worker 完成（不在此处）。
+    /// Remove all "ready" slug buffers (over size, over age, or `force=true`)
+    /// and return their raw bytes. Unready buffers are retained. The size
+    /// trigger compares uncompressed bytes against `max_bytes` (spec §5.3);
+    /// gzip compression is done by the upload worker, not here.
     pub(crate) fn take_ready(&mut self, now: Instant, force: bool) -> Vec<ReadyObject> {
         let ready_slugs: Vec<String> = self
             .bufs
@@ -149,7 +170,8 @@ use crate::server::metrics::MetricsRegistry;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 
-/// 测试用内存 store。`fail_first` 次 put 先返回错误，之后成功并记录。
+/// In-memory store for tests. The first `fail_first` `put` calls return an
+/// error; subsequent calls succeed and record the key+body.
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) struct FakeStore {
     pub puts: Mutex<Vec<(String, Vec<u8>)>>,
@@ -163,7 +185,7 @@ impl FakeStore {
     }
 }
 
-// ---- SigV4 helpers（纯函数，可单测）----
+// ---- SigV4 helpers (pure functions, unit-testable) ----
 
 pub(crate) fn sha256_hex(data: &[u8]) -> String {
     use sha2::{Digest, Sha256};
@@ -180,7 +202,7 @@ pub(crate) fn hmac_sha256(key: &[u8], msg: &[u8]) -> [u8; 32] {
     m.finalize().into_bytes().into()
 }
 
-/// SigV4 signing key：HMAC 链 AWS4+secret -> date -> region -> service -> aws4_request。
+/// SigV4 signing key: HMAC chain AWS4+secret -> date -> region -> service -> aws4_request.
 pub(crate) fn signing_key(secret: &str, date_stamp: &str, region: &str, service: &str) -> [u8; 32] {
     let k_date = hmac_sha256(format!("AWS4{secret}").as_bytes(), date_stamp.as_bytes());
     let k_region = hmac_sha256(&k_date, region.as_bytes());
@@ -188,7 +210,8 @@ pub(crate) fn signing_key(secret: &str, date_stamp: &str, region: &str, service:
     hmac_sha256(&k_service, b"aws4_request")
 }
 
-/// RFC3986 编码；`encode_slash=false` 时保留 `/`（用于 S3 canonical URI）。
+/// RFC3986 percent-encode. When `encode_slash=false`, `/` is left literal
+/// (used for S3 canonical URIs).
 pub(crate) fn uri_encode(s: &str, encode_slash: bool) -> String {
     let mut out = String::with_capacity(s.len());
     for b in s.bytes() {
@@ -203,7 +226,8 @@ pub(crate) fn uri_encode(s: &str, encode_slash: bool) -> String {
     out
 }
 
-/// 我们固定只签 host / x-amz-content-sha256 / x-amz-date 三个头，query 为空。
+/// We sign exactly three headers: host, x-amz-content-sha256, x-amz-date.
+/// The query string is empty.
 pub(crate) fn canonical_request(
     method: &str,
     canonical_uri: &str,
@@ -243,7 +267,8 @@ impl Uploader {
     async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
         match self {
             Uploader::S3 { http, access_key, secret_key, region, bucket } => {
-                // virtual-hosted-style（radixark bucket 名无点，无 TLS SNI 问题）。
+                // Virtual-hosted-style URL (bucket names without dots have no
+                // TLS SNI issue).
                 let host = format!("{bucket}.s3.{region}.amazonaws.com");
                 let canonical_uri = format!("/{}", uri_encode(key, false));
                 let url = format!("https://{host}{canonical_uri}");
@@ -303,8 +328,9 @@ impl Uploader {
     }
 }
 
-/// 指数退避重试；`max_attempts` 次内成功返回 true，否则 false（由调用方计数）。
-/// 退避从 100ms 起翻倍，封顶 5s。
+/// Exponential-backoff retry. Returns true on success within `max_attempts`,
+/// false otherwise (the caller is responsible for counting). Backoff starts at
+/// 100 ms, doubles on each failure, and is capped at 5 s.
 pub(crate) async fn put_with_retry(
     up: &Uploader,
     key: &str,
@@ -328,13 +354,19 @@ pub(crate) async fn put_with_retry(
     false
 }
 
-pub(crate) const CHANNEL_CAPACITY: usize = 8192;
+/// Count-only channel bound. At long-context record sizes this caps worst-case
+/// queue memory while a fast non-blocking pump keeps normal buffering ample.
+pub(crate) const CHANNEL_CAPACITY: usize = 2048;
 const PUT_MAX_ATTEMPTS: u32 = 8;
-/// pump 的定时 flush 心跳；配合 batcher 的 age 触发。
+/// Periodic flush heartbeat for the pump, paired with the batcher's age trigger.
 const TICK: Duration = Duration::from_secs(1);
 /// Bounded pool of concurrent gzip+upload worker tasks. Keeps CPU usage bounded
 /// on the shared 8-core container while allowing parallelism.
 const UPLOAD_CONCURRENCY: usize = 4;
+/// Bounds pending raw-batch memory (~32×8 MiB) and keeps the pump loop live
+/// during an S3 outage — a best-effort tee sheds, never stalls its own
+/// heartbeat.
+const MAX_PENDING_UPLOADS: usize = 32;
 
 enum PumpMsg {
     Record(Box<ExportRecord>),
@@ -345,6 +377,10 @@ pub struct S3ExportSink {
     tx: mpsc::Sender<PumpMsg>,
     metrics: Arc<MetricsRegistry>,
     join: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
+    /// Semaphore bounding the number of concurrent captures in S3-only mode.
+    /// Mirrors `CacheSimTee::try_acquire_capture_permit` so S3-only deployments
+    /// have the same aggregate-capture memory bound as cache-sim deployments.
+    capture_sem: Arc<tokio::sync::Semaphore>,
 }
 
 impl std::fmt::Debug for S3ExportSink {
@@ -354,9 +390,16 @@ impl std::fmt::Debug for S3ExportSink {
 }
 
 impl S3ExportSink {
-    /// 生产入口：解析 uri、从标准 AWS env 读凭证/region、构造 reqwest S3 uploader、
-    /// 起 pump。uri 无效或凭证缺失返回 None（sink 不启用）。
-    pub fn spawn(uri: &str, pod: String, metrics: Arc<MetricsRegistry>) -> Option<Arc<Self>> {
+    /// Production entry point: parse `uri`, read credentials/region from the
+    /// standard AWS environment variables, build an S3 uploader, and start the
+    /// pump. Returns `None` if the URI is invalid, credentials are missing, or
+    /// temporary (session-token) credentials are detected.
+    pub fn spawn(
+        uri: &str,
+        pod: String,
+        metrics: Arc<MetricsRegistry>,
+        max_captures: usize,
+    ) -> Option<Arc<Self>> {
         let (bucket, prefix) = parse_s3_uri(uri)?;
         // `.trim()`: a secretKeyRef-injected value can carry a trailing newline
         // (if the stored secret was created with a trailing `\n`); an untrimmed
@@ -382,6 +425,17 @@ impl S3ExportSink {
                 return None;
             }
         };
+        // Reject temporary credentials: our static-key SigV4 signer only signs
+        // host;x-amz-content-sha256;x-amz-date, so STS/SSO creds would produce
+        // a 403 SignatureDoesNotMatch on every PUT because the unsigned
+        // x-amz-security-token header is not in SignedHeaders.
+        if std::env::var("AWS_SESSION_TOKEN").map(|v| !v.trim().is_empty()).unwrap_or(false) {
+            tracing::error!(
+                "token export: AWS_SESSION_TOKEN is set (temporary credentials) but the signer \
+                 only supports static keys; disabling s3 export"
+            );
+            return None;
+        }
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .build()
@@ -393,11 +447,19 @@ impl S3ExportSink {
         let join = tokio::spawn(async move {
             run_pump(rx, Arc::new(uploader), prefix, pod, metrics2, DEFAULT_MAX_BATCH_BYTES).await;
         });
+        let capture_sem = Arc::new(tokio::sync::Semaphore::new(max_captures.max(1)));
         tracing::info!("s3 token export enabled");
-        Some(Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)) }))
+        Some(Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)), capture_sem }))
     }
 
-    /// 测试入口：注入 uploader（不触碰 AWS）。
+    /// Try to acquire one capture permit. Returns `None` when the pool is
+    /// exhausted. Mirrors `CacheSimTee::try_acquire_capture_permit` so the
+    /// same backpressure logic applies whether cache-sim is on or off.
+    pub fn try_acquire_capture_permit(&self) -> Option<tokio::sync::OwnedSemaphorePermit> {
+        Arc::clone(&self.capture_sem).try_acquire_owned().ok()
+    }
+
+    /// Test entry point: inject an uploader (does not touch AWS).
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn spawn_with_uploader(
         uploader: Uploader,
@@ -408,7 +470,8 @@ impl S3ExportSink {
         Self::spawn_with_uploader_batch(uploader, prefix, pod, metrics, DEFAULT_MAX_BATCH_BYTES)
     }
 
-    /// 测试入口（可配置 batch size）：用于需要在小输入量下触发多 batch 的测试。
+    /// Test entry point (configurable batch size): for tests that need to
+    /// trigger multiple batches from a small number of records.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn spawn_with_uploader_batch(
         uploader: Uploader,
@@ -423,7 +486,8 @@ impl S3ExportSink {
         let join = tokio::spawn(async move {
             run_pump(rx, uploader, prefix, pod, metrics2, max_batch_bytes).await;
         });
-        Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)) })
+        let capture_sem = Arc::new(tokio::sync::Semaphore::new(64));
+        Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)), capture_sem })
     }
 
     fn enqueue(&self, rec: ExportRecord) {
@@ -432,7 +496,11 @@ impl S3ExportSink {
             Err(mpsc::error::TrySendError::Full(_)) => {
                 self.metrics.record_s3_export("dropped_queue_full")
             }
-            Err(mpsc::error::TrySendError::Closed(_)) => {}
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                // Pump is gone (post-drain offers). Make these visible so a
+                // closed sink doesn't look like zero traffic.
+                self.metrics.record_s3_export("dropped_closed")
+            }
         }
     }
 
@@ -449,7 +517,7 @@ impl S3ExportSink {
         self.enqueue(ExportRecord {
             kind: ExportKind::Ingest,
             request_id: request_id.to_string(),
-            slug: slug.filter(|s| !s.is_empty()).unwrap_or("unknown").to_string(),
+            slug: safe_slug(slug),
             model: model.to_string(),
             input_ids: input_ids.to_vec(),
             prompt_len: None,
@@ -478,7 +546,7 @@ impl S3ExportSink {
         self.enqueue(ExportRecord {
             kind: ExportKind::Extend,
             request_id: request_id.to_string(),
-            slug: slug.filter(|s| !s.is_empty()).unwrap_or("unknown").to_string(),
+            slug: safe_slug(slug),
             model: model.to_string(),
             input_ids: input_ids.to_vec(),
             prompt_len,
@@ -489,7 +557,8 @@ impl S3ExportSink {
         });
     }
 
-    /// 发关闭信号，等 pump flush 全部剩余并结束。用于 SIGTERM 关闭序列。
+    /// Send the drain signal and wait for the pump to flush all remaining
+    /// records and exit. Used in the SIGTERM shutdown sequence.
     pub async fn drain(&self) {
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         // `send` awaits capacity; the pump keeps draining records and freeing
@@ -526,12 +595,14 @@ struct UploadJobArgs {
     uploader: Arc<Uploader>,
     metrics: Arc<MetricsRegistry>,
     is_drain: bool,
-    /// Held for the job's lifetime to bound concurrency via the semaphore.
-    _permit: tokio::sync::OwnedSemaphorePermit,
+    /// The semaphore to acquire a permit from at job start. The permit is held
+    /// for the job's lifetime to bound concurrency.
+    sem: Arc<tokio::sync::Semaphore>,
 }
 
-/// Single upload job: gzip in a blocking thread, compute key, put with retry, record metrics.
-/// The semaphore permit is moved in and held for the job's lifetime, providing backpressure.
+/// Single upload job: gzip in a blocking thread, compute key, put with retry,
+/// record metrics. Acquires a semaphore permit at start so the pump never
+/// blocks on permit acquisition.
 async fn upload_job(args: UploadJobArgs) {
     let UploadJobArgs {
         raw_bytes,
@@ -543,8 +614,14 @@ async fn upload_job(args: UploadJobArgs) {
         uploader,
         metrics,
         is_drain,
-        _permit,
+        sem,
     } = args;
+
+    // Acquire the permit inside the job so the pump loop is never blocked.
+    let _permit = match sem.acquire_owned().await {
+        Ok(p) => p,
+        Err(_) => return, // semaphore closed; should not happen in normal operation
+    };
 
     // Gzip on a blocking thread so we don't hold the async executor during CPU work.
     let gz = match tokio::task::spawn_blocking(move || gzip_fast(raw_bytes)).await {
@@ -571,7 +648,8 @@ async fn upload_job(args: UploadJobArgs) {
     // _permit is dropped here, releasing the semaphore slot.
 }
 
-/// 后台泵：消费记录 → 攒批 → 定时/超量 flush → 并发上传。永不 panic。
+/// Background pump: consume records, accumulate batches, flush on time/size,
+/// upload concurrently. Never panics.
 async fn run_pump(
     mut rx: mpsc::Receiver<PumpMsg>,
     uploader: Arc<Uploader>,
@@ -600,13 +678,13 @@ async fn run_pump(
                         dispatch_ready(
                             &mut batcher, &uploader, &prefix, &pod, &metrics,
                             &mut seq, false, &sem, &mut join_set,
-                        ).await;
+                        );
                     }
                     Some(PumpMsg::Drain(ack)) => {
                         dispatch_ready(
                             &mut batcher, &uploader, &prefix, &pod, &metrics,
                             &mut seq, true, &sem, &mut join_set,
-                        ).await;
+                        );
                         // Wait for all in-flight uploads before acking.
                         while join_set.join_next().await.is_some() {}
                         let _ = ack.send(());
@@ -617,7 +695,7 @@ async fn run_pump(
                         dispatch_ready(
                             &mut batcher, &uploader, &prefix, &pod, &metrics,
                             &mut seq, true, &sem, &mut join_set,
-                        ).await;
+                        );
                         while join_set.join_next().await.is_some() {}
                         return;
                     }
@@ -627,7 +705,7 @@ async fn run_pump(
                 dispatch_ready(
                     &mut batcher, &uploader, &prefix, &pod, &metrics,
                     &mut seq, false, &sem, &mut join_set,
-                ).await;
+                );
             }
         }
         // Opportunistically reap finished jobs so the JoinSet doesn't grow unbounded.
@@ -637,10 +715,14 @@ async fn run_pump(
 
 /// Dispatch all ready batches from the batcher as concurrent upload jobs.
 /// When `force` is true, flushes all remaining slugs.
-/// Acquiring the semaphore permit awaits when all UPLOAD_CONCURRENCY slots are busy,
-/// providing backpressure: the mpsc channel fills and offer() sheds under overload.
+///
+/// This function is synchronous (no `.await`): the pump never blocks on
+/// permit acquisition. Jobs self-acquire their semaphore permits, so a
+/// stalled S3 upload does not freeze the tick or the drain path. Pending
+/// job count is bounded by `MAX_PENDING_UPLOADS`; excess batches are dropped
+/// and metered as `dropped_upload_backlog`.
 #[allow(clippy::too_many_arguments)]
-async fn dispatch_ready(
+fn dispatch_ready(
     batcher: &mut SlugBatcher,
     uploader: &Arc<Uploader>,
     prefix: &str,
@@ -655,15 +737,10 @@ async fn dispatch_ready(
         let current_seq = *seq;
         *seq += 1;
 
-        // Await a permit — this is the backpressure point.
-        let permit = match Arc::clone(sem).acquire_owned().await {
-            Ok(p) => p,
-            Err(_) => {
-                // Semaphore closed; should not happen in normal operation.
-                metrics.record_s3_export("put_failed");
-                continue;
-            }
-        };
+        if join_set.len() >= MAX_PENDING_UPLOADS {
+            metrics.record_s3_export("dropped_upload_backlog");
+            continue;
+        }
 
         join_set.spawn(upload_job(UploadJobArgs {
             raw_bytes: obj.raw_bytes,
@@ -675,7 +752,7 @@ async fn dispatch_ready(
             uploader: Arc::clone(uploader),
             metrics: Arc::clone(metrics),
             is_drain: force,
-            _permit: permit,
+            sem: Arc::clone(sem),
         }));
     }
 }
@@ -716,9 +793,9 @@ mod tests {
         let t0 = Instant::now();
         b.push("slugA", "a\n", t0);
         b.push("slugB", "b\n", t0);
-        // 未到 age、未超 size -> 不 ready
+        // Not yet over age or size -> not ready
         assert!(b.take_ready(t0, false).is_empty());
-        // 过了 age -> 两个 slug 各出一个对象
+        // Past the age threshold -> one object per slug
         let later = t0 + Duration::from_millis(150);
         let mut ready = b.take_ready(later, false);
         ready.sort_by(|x, y| x.slug.cmp(&y.slug));
@@ -828,7 +905,7 @@ mod tests {
         );
         let k2 = object_key("token-export", "slugA", "2026-08-10", "pod-1", 111, 1);
         assert_ne!(k1, k2, "seq must disambiguate same-nanos objects");
-        // 空 prefix 不产生前导斜杠
+        // Empty prefix must not produce a leading slash.
         let k3 = object_key("", "s", "2026-08-10", "pod-1", 1, 0);
         assert_eq!(k3, "slug=s/date=2026-08-10/pod-1-1-0.ndjson.gz");
     }
@@ -918,7 +995,7 @@ mod tests {
 
     #[test]
     fn sha256_hex_of_empty_is_known_vector() {
-        // 众所周知的 SHA-256("") 向量。
+        // Well-known SHA-256("") test vector.
         assert_eq!(
             sha256_hex(b""),
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
@@ -927,7 +1004,7 @@ mod tests {
 
     #[test]
     fn hmac_sha256_matches_rfc4231_case2() {
-        // RFC 4231 Test Case 2：key="Jefe", data="what do ya want for nothing?"
+        // RFC 4231 Test Case 2: key="Jefe", data="what do ya want for nothing?"
         let mac = hmac_sha256(b"Jefe", b"what do ya want for nothing?");
         assert_eq!(
             hex::encode(mac),
@@ -941,7 +1018,7 @@ mod tests {
         let k2 = signing_key("secret", "20260810", "us-west-2", "s3");
         assert_eq!(k1, k2);
         assert_eq!(k1.len(), 32);
-        // 不同 date -> 不同 key（证明派生链引用了各段）
+        // Different date -> different key (proves each segment contributes to the chain).
         assert_ne!(k1, signing_key("secret", "20260811", "us-west-2", "s3"));
     }
 
@@ -1019,7 +1096,7 @@ mod tests {
             "pod-1".into(),
             test_metrics(),
         );
-        sink.offer_ingest("m", &[7], "rid", None); // slug 缺失
+        sink.offer_ingest("m", &[7], "rid", None); // missing slug
         sink.drain().await;
         let puts = store.puts.lock().unwrap();
         assert_eq!(puts.len(), 1);
@@ -1060,5 +1137,19 @@ mod tests {
         // Total decompressed line count must equal N.
         let total_lines: usize = puts.iter().map(|(_, gz)| gunzip(gz).lines().count()).sum();
         assert_eq!(total_lines, N, "decompressed line count mismatch");
+    }
+
+    #[test]
+    fn safe_slug_allowlists() {
+        // Well-formed slugs pass through unchanged.
+        assert_eq!(safe_slug(Some("good-slug.1")), "good-slug.1");
+        // Path separators collapse to "unknown".
+        assert_eq!(safe_slug(Some("a/date=1")), "unknown");
+        // Empty string collapses.
+        assert_eq!(safe_slug(Some("")), "unknown");
+        // A 65-character slug exceeds the 64-byte cap and collapses.
+        assert_eq!(safe_slug(Some(&"a".repeat(65))), "unknown");
+        // None collapses.
+        assert_eq!(safe_slug(None), "unknown");
     }
 }

--- a/experimental/sgl-router/src/server/s3_export.rs
+++ b/experimental/sgl-router/src/server/s3_export.rs
@@ -87,7 +87,8 @@ fn safe_slug(slug: Option<&str>) -> String {
         Some(s)
             if !s.is_empty()
                 && s.len() <= 64
-                && s.bytes().all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-')) =>
+                && s.bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'.' | b'_' | b'-')) =>
         {
             s.to_string()
         }
@@ -123,7 +124,11 @@ pub(crate) struct SlugBatcher {
 
 impl SlugBatcher {
     pub(crate) fn new(max_bytes: usize, max_age: Duration) -> Self {
-        Self { max_bytes, max_age, bufs: HashMap::new() }
+        Self {
+            max_bytes,
+            max_age,
+            bufs: HashMap::new(),
+        }
     }
 
     pub(crate) fn push(&mut self, slug: &str, line: &str, now: Instant) {
@@ -158,15 +163,19 @@ impl SlugBatcher {
             if buf.raw.is_empty() {
                 continue;
             }
-            out.push(ReadyObject { slug, raw_bytes: buf.raw, records: buf.records });
+            out.push(ReadyObject {
+                slug,
+                raw_bytes: buf.raw,
+                records: buf.records,
+            });
         }
         out
     }
 }
 
+use crate::server::metrics::MetricsRegistry;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use crate::server::metrics::MetricsRegistry;
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 
@@ -181,7 +190,10 @@ pub(crate) struct FakeStore {
 #[cfg_attr(not(test), allow(dead_code))]
 impl FakeStore {
     pub(crate) fn new(fail_first: u64) -> Self {
-        Self { puts: Mutex::new(Vec::new()), fail_first: AtomicU64::new(fail_first) }
+        Self {
+            puts: Mutex::new(Vec::new()),
+            fail_first: AtomicU64::new(fail_first),
+        }
     }
 }
 
@@ -247,7 +259,9 @@ pub(crate) fn string_to_sign(
     service: &str,
     creq_hash: &str,
 ) -> String {
-    format!("AWS4-HMAC-SHA256\n{amz_date}\n{date_stamp}/{region}/{service}/aws4_request\n{creq_hash}")
+    format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{date_stamp}/{region}/{service}/aws4_request\n{creq_hash}"
+    )
 }
 
 pub(crate) enum Uploader {
@@ -266,7 +280,13 @@ pub(crate) enum Uploader {
 impl Uploader {
     async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
         match self {
-            Uploader::S3 { http, access_key, secret_key, region, bucket } => {
+            Uploader::S3 {
+                http,
+                access_key,
+                secret_key,
+                region,
+                bucket,
+            } => {
                 // Virtual-hosted-style URL (bucket names without dots have no
                 // TLS SNI issue).
                 let host = format!("{bucket}.s3.{region}.amazonaws.com");
@@ -407,7 +427,11 @@ impl S3ExportSink {
         // never legitimately contain surrounding whitespace, so trimming is safe.
         let clean = |v: String| {
             let t = v.trim().to_string();
-            if t.is_empty() { None } else { Some(t) }
+            if t.is_empty() {
+                None
+            } else {
+                Some(t)
+            }
         };
         let access_key = std::env::var("AWS_ACCESS_KEY_ID").ok().and_then(clean);
         let secret_key = std::env::var("AWS_SECRET_ACCESS_KEY").ok().and_then(clean);
@@ -429,7 +453,10 @@ impl S3ExportSink {
         // host;x-amz-content-sha256;x-amz-date, so STS/SSO creds would produce
         // a 403 SignatureDoesNotMatch on every PUT because the unsigned
         // x-amz-security-token header is not in SignedHeaders.
-        if std::env::var("AWS_SESSION_TOKEN").map(|v| !v.trim().is_empty()).unwrap_or(false) {
+        if std::env::var("AWS_SESSION_TOKEN")
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+        {
             tracing::error!(
                 "token export: AWS_SESSION_TOKEN is set (temporary credentials) but the signer \
                  only supports static keys; disabling s3 export"
@@ -440,16 +467,35 @@ impl S3ExportSink {
             .timeout(Duration::from_secs(30))
             .build()
             .ok()?;
-        let uploader = Uploader::S3 { http, access_key, secret_key, region, bucket };
+        let uploader = Uploader::S3 {
+            http,
+            access_key,
+            secret_key,
+            region,
+            bucket,
+        };
 
         let metrics2 = Arc::clone(&metrics);
         let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
         let join = tokio::spawn(async move {
-            run_pump(rx, Arc::new(uploader), prefix, pod, metrics2, DEFAULT_MAX_BATCH_BYTES).await;
+            run_pump(
+                rx,
+                Arc::new(uploader),
+                prefix,
+                pod,
+                metrics2,
+                DEFAULT_MAX_BATCH_BYTES,
+            )
+            .await;
         });
         let capture_sem = Arc::new(tokio::sync::Semaphore::new(max_captures.max(1)));
         tracing::info!("s3 token export enabled");
-        Some(Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)), capture_sem }))
+        Some(Arc::new(Self {
+            tx,
+            metrics,
+            join: AsyncMutex::new(Some(join)),
+            capture_sem,
+        }))
     }
 
     /// Try to acquire one capture permit. Returns `None` when the pool is
@@ -487,7 +533,12 @@ impl S3ExportSink {
             run_pump(rx, uploader, prefix, pod, metrics2, max_batch_bytes).await;
         });
         let capture_sem = Arc::new(tokio::sync::Semaphore::new(64));
-        Arc::new(Self { tx, metrics, join: AsyncMutex::new(Some(join)), capture_sem })
+        Arc::new(Self {
+            tx,
+            metrics,
+            join: AsyncMutex::new(Some(join)),
+            capture_sem,
+        })
     }
 
     fn enqueue(&self, rec: ExportRecord) {
@@ -829,7 +880,10 @@ mod tests {
             parse_s3_uri("s3://b/a/b/c"),
             Some(("b".into(), "a/b/c".into()))
         );
-        assert_eq!(parse_s3_uri("s3://only-bucket"), Some(("only-bucket".into(), "".into())));
+        assert_eq!(
+            parse_s3_uri("s3://only-bucket"),
+            Some(("only-bucket".into(), "".into()))
+        );
         assert_eq!(parse_s3_uri("https://x"), None);
         assert_eq!(parse_s3_uri("s3://"), None);
     }
@@ -874,8 +928,7 @@ mod tests {
             choice_count: Some(3),
             ts: "2026-08-10T00:00:00Z".into(),
         };
-        let v: serde_json::Value =
-            serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
         assert_eq!(v["choice_index"], 0);
         assert_eq!(v["choice_count"], 3);
     }
@@ -894,8 +947,7 @@ mod tests {
             choice_count: None,
             ts: "2026-08-10T00:00:00Z".into(),
         };
-        let v: serde_json::Value =
-            serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
+        let v: serde_json::Value = serde_json::from_str(r.to_ndjson_line().trim_end()).unwrap();
         assert_eq!(v["kind"], "extend");
         assert_eq!(v["prompt_len"], 2);
         assert_eq!(v["output_tokens"], 9);
@@ -964,14 +1016,23 @@ mod tests {
             .timeout(Duration::from_secs(30))
             .build()
             .expect("build reqwest client");
-        if std::env::var("AWS_SESSION_TOKEN").map(|v| !v.is_empty()).unwrap_or(false) {
+        if std::env::var("AWS_SESSION_TOKEN")
+            .map(|v| !v.is_empty())
+            .unwrap_or(false)
+        {
             eprintln!(
                 "WARNING: AWS_SESSION_TOKEN is set — these are TEMPORARY/SSO credentials. \
                  Our SigV4 signer does NOT send x-amz-security-token, so S3 will reject them. \
                  Use STATIC IAM user keys (not temporary/SSO credentials)."
             );
         }
-        let up = Uploader::S3 { http, access_key: ak, secret_key: sk, region, bucket };
+        let up = Uploader::S3 {
+            http,
+            access_key: ak,
+            secret_key: sk,
+            region,
+            bucket,
+        };
         let key = if prefix.is_empty() {
             "roundtrip-check.txt".to_string()
         } else {
@@ -981,7 +1042,10 @@ mod tests {
         // Retry a few times to tolerate fresh-IAM propagation.
         let mut last_err = None;
         for attempt in 1..=6u32 {
-            match up.put(&key, b"sgl-router s3 export roundtrip\n".to_vec()).await {
+            match up
+                .put(&key, b"sgl-router s3 export roundtrip\n".to_vec())
+                .await
+            {
                 Ok(()) => {
                     eprintln!("real_s3_roundtrip OK -> s3://.../{key}");
                     return;
@@ -1057,7 +1121,13 @@ mod tests {
 
     #[test]
     fn string_to_sign_has_exact_shape() {
-        let sts = string_to_sign("20260810T000000Z", "20260810", "us-west-2", "s3", "deadbeef");
+        let sts = string_to_sign(
+            "20260810T000000Z",
+            "20260810",
+            "us-west-2",
+            "s3",
+            "deadbeef",
+        );
         assert_eq!(
             sts,
             "AWS4-HMAC-SHA256\n20260810T000000Z\n20260810/us-west-2/s3/aws4_request\ndeadbeef"
@@ -1072,14 +1142,19 @@ mod tests {
     async fn drain_flushes_offered_records_to_uploader() {
         let store = Arc::new(FakeStore::new(0));
         let up = Uploader::Fake(Arc::clone(&store));
-        let sink = S3ExportSink::spawn_with_uploader(
-            up,
-            "pfx".into(),
-            "pod-1".into(),
-            test_metrics(),
-        );
+        let sink =
+            S3ExportSink::spawn_with_uploader(up, "pfx".into(), "pod-1".into(), test_metrics());
         sink.offer_ingest("m", &[1, 2, 3], "rid", Some("slugA"));
-        sink.offer_extend("m", &[1, 2, 3, 4], "rid", Some(3), Some(1), None, None, Some("slugA"));
+        sink.offer_extend(
+            "m",
+            &[1, 2, 3, 4],
+            "rid",
+            Some(3),
+            Some(1),
+            None,
+            None,
+            Some("slugA"),
+        );
         sink.drain().await;
 
         let puts = store.puts.lock().unwrap();
@@ -1136,7 +1211,10 @@ mod tests {
 
         // All objects are under the correct prefix.
         for (key, _) in puts.iter() {
-            assert!(key.starts_with("pfx/slug=slugA/date="), "unexpected key: {key}");
+            assert!(
+                key.starts_with("pfx/slug=slugA/date="),
+                "unexpected key: {key}"
+            );
         }
 
         // Total decompressed line count must equal N.


### PR DESCRIPTION
## What

Adds an optional S3 token-dataset export sink to `sgl-router`. When enabled, each request's prompt token ids (ingest) and the response-completion re-rendered sequence (extend) are written to S3 as gzipped NDJSON, for **offline cache-hit analysis**. It is a second, fully independent tee alongside the existing cache-sim tee — the cache-sim path is unchanged. Disabled by default (zero overhead when unset).

## Design

- **New module `src/server/s3_export.rs`** — independent `mpsc` + background pump. Reuses the already-computed ingest/extend token data (no extra tokenization).
- **Non-blocking offer** on the ingress hot path (`try_send`; a full queue is counted and dropped, never blocks serving).
- **Per-slug batching** into gzipped NDJSON objects with Hive-partitioned keys (`…/slug=<slug>/date=<YYYY-MM-DD>/<pod>-<nanos>-<seq>.ndjson.gz`), safe across replicas.
- **Concurrent upload pool**: gzip + `PutObject` run in a bounded pool of worker tasks (fast gzip), so high-throughput / large-record traffic isn't bottlenecked on serial gzip.
- **Hand-rolled SigV4** over `reqwest` (no `aws-sdk`; static-key + single `PutObject`). Signing is anchored by known-answer vectors (SHA-256(""), RFC 4231 HMAC-SHA256, exact canonical-request / string-to-sign).
- **Exponential-backoff retry**; **graceful drain** on SIGTERM flushes all in-flight uploads before exit so a rolling restart doesn't lose data.
- **NDJSON** with plain-integer `input_ids` (no base64). Metrics: `sgl_router_s3_export_total{result}` (`enqueued|dropped_queue_full|object_put|put_failed|drain_flushed`).

## Config

Single env `RADIXARK_TOKEN_EXPORT_S3_URI=s3://<bucket>/<prefix>/` enables it (unset ⇒ disabled). Credentials/region via the standard `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` env — no keys in code. Requires the IAM identity to have `s3:PutObject` on the target bucket/prefix.

## Testing

- `cargo test --lib` passes; `cargo build` + `cargo clippy --all-targets -- -D warnings` clean.
- Unit coverage: S3 URI parse, NDJSON serialization (optional-field / fan-out semantics), object-key uniqueness, per-slug batching, SigV4 building blocks (known vectors + exact canonical strings), retry (transient-failure recovery + give-up), and end-to-end drain-to-fake-store with concurrent uploads.
- An `#[ignore]`d `real_s3_roundtrip` integration test (gated on `AWS_*` + `TEST_S3_URI`, skipped in CI) exercises the real SigV4 path against a bucket; verified manually.

## Notes

- Both tees are independently switchable: extend export fires when either the cache-sim tee or the S3 export is enabled. cache-sim-on behavior is unchanged.
- extend records currently carry no attribution `slug` (the extend path runs detached from ingress headers) → they land under `slug=unknown`; threading attribution through is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31382976001](https://github.com/sgl-project/sglang/actions/runs/31382976001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31382975678](https://github.com/sgl-project/sglang/actions/runs/31382975678)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->