### PR TITLE
[diffusion] Support lightx2v MiniMax-H3 Turbo LoRA key mapping

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -399,6 +399,20 @@ curl -sS -X POST http://127.0.0.1:30010/v1/set_lora \
 
 When the repository contains multiple safetensors files, prefer `minimax_h3_turbo_4step_ckpt500.safetensors` (upstream default) via `--lora-path` and `--lora-weight-name` on `sglang serve`, or pass the local path to that file as `lora_path`.
 
+[`lightx2v/Minimax-h3-Turbo`](https://huggingface.co/lightx2v/Minimax-h3-Turbo) is a Diffusers/PEFT-format preview LoRA for the same FL2VA few-step path. SGLang maps its keys automatically. The Hub repo ships weights only (no `adapter_config.json`); upstream training uses `lora_alpha=8` with rank `128`, so set `"strength": 0.0625` (or `--lora-scale 0.0625`) to match their official script default of `--lora-alpha 8 --lora-scale 1.0`. Prefer [`larryvrh/MiniMax-H3-Turbo-Lora`](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) when quality matters — lightx2v omits `adaln_proj` adapters.
+
+```bash Command
+curl -sS -X POST http://127.0.0.1:30010/v1/set_lora \
+  -H "Content-Type: application/json" \
+  -d '{
+    "lora_nickname": "h3-turbo-lightx2v",
+    "lora_path": "lightx2v/Minimax-h3-Turbo",
+    "strength": 0.0625
+  }'
+```
+
+Use `minimax_h3_fl2v_turbo_4step_v0.1.safetensors` via `--lora-weight-name` when serving from the repo root.
+
 <Warning>
 LoRAs for the ComfyUI pruned MiniMax-H3 graph (for example H3-GalaxyAce) are not compatible with SGLang's native FL2VA weights.
 </Warning>

--- a/docs/docs/sglang-diffusion/compatibility_matrix.mdx
+++ b/docs/docs/sglang-diffusion/compatibility_matrix.mdx
@@ -799,7 +799,7 @@ The entries below simply reflect configurations that have been manually validate
   <tbody>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>MiniMax-H3</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`larryvrh/MiniMax-H3-Turbo-Lora`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>`larryvrh/MiniMax-H3-Turbo-Lora`<br />`lightx2v/Minimax-h3-Turbo`</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>Wan2.2</td>

--- a/python/sglang/multimodal_gen/configs/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/minimax_h3.py
@@ -14,6 +14,61 @@ class MiniMaxH3DiTArchConfig(DiTArchConfig):
 
     lora_param_names_mapping: dict = field(default_factory=dict)
 
+    # Diffusers/PEFT Turbo LoRA keys (e.g. lightx2v/Minimax-h3-Turbo).
+    param_names_mapping: dict = field(
+        default_factory=lambda: {
+            r"^(.*\.lora_[AB])\.default$": r"\1",
+            r"^transformer_blocks\.(\d+)\.attn\.to_q\.(lora_[AB])$": (
+                r"blocks.\1.attn.qkv_proj.\2",
+                0,
+                3,
+            ),
+            r"^transformer_blocks\.(\d+)\.attn\.to_k\.(lora_[AB])$": (
+                r"blocks.\1.attn.qkv_proj.\2",
+                1,
+                3,
+            ),
+            r"^transformer_blocks\.(\d+)\.attn\.to_v\.(lora_[AB])$": (
+                r"blocks.\1.attn.qkv_proj.\2",
+                2,
+                3,
+            ),
+            r"^transformer_blocks\.(\d+)\.attn\.to_out\.0\.(lora_[AB])$": (
+                r"blocks.\1.attn.out_proj.\2"
+            ),
+            r"^transformer_blocks\.(\d+)\.ff\.net\.0\.proj\.(lora_[AB])$": (
+                r"blocks.\1.mlp.fc1.\2"
+            ),
+            r"^transformer_blocks\.(\d+)\.ff\.net\.2\.(lora_[AB])$": (
+                r"blocks.\1.mlp.fc2.\2"
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.attn\.to_q\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.attn.qkv_proj.\2",
+                0,
+                3,
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.attn\.to_k\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.attn.qkv_proj.\2",
+                1,
+                3,
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.attn\.to_v\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.attn.qkv_proj.\2",
+                2,
+                3,
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.attn\.to_out\.0\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.attn.out_proj.\2"
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.ff\.net\.0\.proj\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.mlp.fc1.\2"
+            ),
+            r"^token_refiner\.refiner_blocks\.(\d+)\.ff\.net\.2\.(lora_[AB])$": (
+                r"token_refiner.blocks.\1.mlp.fc2.\2"
+            ),
+        }
+    )
+
     num_layers: int = 50
     token_refiner_num_layers: int = 2
     hidden_size: int = 5376

--- a/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_format_adapter.py
@@ -280,13 +280,25 @@ def _run_all_tests() -> List[Dict]:
         )
     )
 
-    # MiniMax-H3 Turbo LoRA (native diffusers/PEFT-style keys).
+    # MiniMax-H3 Turbo LoRA (larryvrh; native H3 DiT keys).
     results.append(
         run_single_test(
             name="MiniMax H3 Turbo LoRA",
             repo_id="larryvrh/MiniMax-H3-Turbo-Lora",
             filename="minimax_h3_turbo_4step.safetensors",
             local_name="minimax_h3_turbo_4step.safetensors",
+            expected_before=LoRAFormat.STANDARD,
+            expected_after=LoRAFormat.STANDARD,
+        )
+    )
+
+    # MiniMax-H3 Turbo LoRA (lightx2v; Diffusers/PEFT keys).
+    results.append(
+        run_single_test(
+            name="MiniMax H3 Turbo LoRA (lightx2v)",
+            repo_id="lightx2v/Minimax-h3-Turbo",
+            filename="minimax_h3_fl2v_turbo_4step_v0.1.safetensors",
+            local_name="minimax_h3_fl2v_turbo_4step_v0.1.safetensors",
             expected_before=LoRAFormat.STANDARD,
             expected_after=LoRAFormat.STANDARD,
         )

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
@@ -43,7 +43,6 @@ def _ensure_single_process_parallel_runtime() -> None:
 
 def test_native_weight_names_and_grouped_qkv_reorder():
     arch = MiniMaxH3DiTArchConfig()
-    assert arch.param_names_mapping == {}
     assert arch.reverse_param_names_mapping == {}
     mapping = get_param_names_mapping(arch.param_names_mapping)
     for key in (


### PR DESCRIPTION
## Motivation

[#33875](https://github.com/sgl-project/sglang/pull/33875) enabled few-step FL2VA with [`larryvrh/MiniMax-H3-Turbo-Lora`](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora), whose keys already match native H3 DiT names.

[`lightx2v/Minimax-h3-Turbo`](https://huggingface.co/lightx2v/Minimax-h3-Turbo) is another 4-step preview LoRA, but it uses Diffusers/PEFT naming (`transformer_blocks.*.to_q/k/v`, `.default`, split Q/K/V). Without a mapping it cannot load onto SGLang's native FL2VA graph.

## Changes

- Add `param_names_mapping` on `MiniMaxH3DiTArchConfig` for lightx2v Diffusers/PEFT keys → native H3 (`transformer_blocks`/`to_q|k|v` → `blocks`/`qkv_proj`, plus `.default` / `to_out` / `ff` renames).
- Document lightx2v in the cookbook + compatibility matrix; add a format-adapter regression case.

### Why `param_names_mapping` (not `lora_param_names_mapping`)

LoRA load is two-stage: `lora_param_names_mapping` (misc→HF, **drops** `merge_index`) then `param_names_mapping` (HF→native, **keeps** merge for Q/K/V stack). lightx2v is already Diffusers/PEFT, and we need the Q/K/V fuse — that belongs in `param_names_mapping` (same as HunyuanVideo). `lora_param_names_mapping` stays empty.

All patterns match Diffusers/PEFT LoRA names only (`transformer_blocks.*`, `.lora_A/B`, split `to_q/k/v`, …). Native FL2VA and larryvrh already use `blocks.*.qkv_proj`, so they pass through unchanged.

## Experiments (4 vs 8 Steps)

Bench on `MiniMaxAI/MiniMax-H3` FL2VA with [`lightx2v/Minimax-h3-Turbo`](https://huggingface.co/lightx2v/Minimax-h3-Turbo) (`minimax_h3_fl2v_turbo_4step_v0.1.safetensors`) 1344×768 / 5 s (124 frames), `flow_shift=12`, `audio_flow_shift=3`, seed **1101**, `lora_scale=0.0625`. Same LoRA and seed; only steps change (4 vs 8).

**Prompt:** _At night, while their owner sleeps in a bedroom, three cats march in loudly playing tiny brass instruments, then abruptly file out._

https://github.com/user-attachments/assets/3ff81cf0-5864-4bab-8c37-5ce9e669c999


https://github.com/user-attachments/assets/129b25c6-cf19-46c9-8555-34f3c1c7979b


https://github.com/user-attachments/assets/ccbf098d-fc9b-4a6a-b0de-5c6bf0d5c2f3



lightx2v is a preview (attn/MLP only, no `adaln_proj`). Prefer [`larryvrh/MiniMax-H3-Turbo-Lora`](https://huggingface.co/larryvrh/MiniMax-H3-Turbo-Lora) when quality matters.

## Example

```bash
sglang generate \
  --model-path MiniMaxAI/MiniMax-H3 --model-variant fl2va \
  --lora-path lightx2v/Minimax-h3-Turbo \
  --lora-weight-name minimax_h3_fl2v_turbo_4step_v0.1.safetensors \
  --lora-scale 0.0625 \
  --num-inference-steps 4 \
  --flow-shift 12.0 --audio-flow-shift 3.0 \
  --seed 1101
```
### Important: LoRA scale
lightx2v ships **weights only** (no `adapter_config.json`). Upstream training uses `lora_alpha=8`, rank `128` (see [`DEFAULT_LORA_ALPHA = 8`](https://github.com/ModelTC/Minimax-H3-Turbo/blob/main/inference_minimax_h3.py#L49)). SGLang falls back to `alpha = rank` when config is missing, so use:

```bash
--lora-scale 0.0625   # = 8/128
```

or API `"strength": 0.0625`. With `--lora-scale 1.0` the adapter is ~16× too strong.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31376517273](https://github.com/sgl-project/sglang/actions/runs/31376517273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31376517113](https://github.com/sgl-project/sglang/actions/runs/31376517113)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->