### PR TITLE
[Review vehicle] config: the runner-side instance reads finish converging (not for merge)

### DIFF
--- a/.claude/skills/sglang-runtime-context/SKILL.md
+++ b/.claude/skills/sglang-runtime-context/SKILL.md
@@ -99,8 +99,10 @@ bag to override at all.
   instance: **constructor arguments** (`ModelRunner(draft_attention_backend=...)`,
   `MMEncoder(gpu_id=...)`) and **runner attributes holding the resolved value**
   (`model_runner.kv_cache_dtype_str`, `prefill_attention_backend_str`,
-  `num_fused_shared_experts`) — threaded to consumers as arguments, never
-  backfilled onto a shared object. The one sanctioned bend in that rule is
+  `num_fused_shared_experts`, `linear_attn_backends`) — threaded to consumers as
+  arguments, never backfilled onto a shared object. A per-runner choice also stays
+  *out* of the bags: recording it there is how a second runner inherits the first
+  one's answer, which is exactly the bug `linear_attn_backends` replaced. The one sanctioned bend in that rule is
   *scoped*: `ModelRunner._load_format_scope` exposes the draft's
   `--speculative-draft-load-format` through `get_model().override(load_format=...)`
   for exactly the duration of the draft build, because model construction
@@ -116,9 +118,28 @@ bag to override at all.
   encode-server DP workers used to specialize a config copy for the same reason;
   their device now travels as `MMEncoder(gpu_id=...)`.)
 - **Whole-object passes** (`f(server_args)` handing the instance along) keep the
-  supplied-instance contract; don't rewrite the parameter reads to bag reads unless the
+  supplied-instance contract; don't rewrite the parameter reads unless the
   field is runtime-mutated (see the elastic-EP `ep_size` case in
-  `eplb/expert_location.py`).
+  `eplb/expert_location.py`) — **or the field is one that resolution fills in
+  and the callee runs in a process that has published.** That second case is
+  step-12 debt, not a style question: the record is destined to carry the
+  user's raw input, so `server_args.page_size` inside a runner-owned
+  constructor will read the raw pre-resolution value instead of the effective
+  one. Debt means a decision, not automatically a bag read: pick where the
+  value should come from — usually the `get_*()` bag, sometimes a runner stamp
+  or a constructor argument (the per-mode attention pair and the encode-server
+  `gpu_id` above are dispositions of exactly this debt). And the per-instance
+  boundaries above stay exempt from this unless-clause: a multi-Engine site
+  must not become a process-global bag read even for a resolution-filled
+  field. `test_supplied_instance_exposure_ratchet.py`
+  pins the remaining set — three spellings of the read: `server_args.field`,
+  literal-name `getattr(server_args, "field", default)`, and the parked form
+  (`self.x = server_args` in a method that takes the parameter, read as
+  `self.x.field` anywhere in the class) — and fails on a new one, so the
+  disposition gets picked when the read is written. Two shapes stay parameter-form on purpose: a helper the
+  *resolution pipeline* calls with a `resolved_view` (its parameter happens to be
+  named `server_args`), and a factory whose contract is "build X from the record
+  you are handed" (`create_kt_config_from_server_args`, `DllmConfig.from_server_args`).
 
 ### `get_parallel()`: config leaves vs live topology
 

--- a/STACK_REVIEW_PLACEHOLDER.md
+++ b/STACK_REVIEW_PLACEHOLDER.md
@@ -1,0 +1,5 @@
+# Stack review vehicle — not for merge
+
+This branch carries the whole `cheng/gc-selfread` stack so CI runs it as one
+unit and review comments have one place to land. The members merge
+individually (see the PR body); this branch is closed unmerged.

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import dataclasses
 import inspect
+import json
 import logging
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -288,6 +289,42 @@ def attention_backends_of(cfg: Any) -> tuple:
         else cfg.attention_backend
     )
     return prefill, decode
+
+
+def modelexpress_transport_of(cfg: Any) -> str:
+    """The modelexpress transport a config-shaped object asks for.
+
+    ``modelexpress_config`` is a JSON string (or an already-parsed dict) rather
+    than a leaf of its own; this is the shared parse for the transfer-engine
+    gate (`remote_instance_transfer_engine_of`) and any future bag reader.
+    ``ServerArgs.modelexpress_transport`` keeps its own instance-cached parse
+    (`_parsed_modelexpress_config`) -- same rule, cached seed-side."""
+    raw = cfg.modelexpress_config
+    if raw is None:
+        parsed = {}
+    elif isinstance(raw, str):
+        parsed = json.loads(raw)
+    else:
+        parsed = raw
+    return parsed.get("transport", "nixl")
+
+
+def remote_instance_transfer_engine_of(cfg: Any, load_format: Any = None) -> bool:
+    """Whether remote-instance weight loading runs over the transfer engine.
+
+    ``load_format`` overrides the config's: a draft runner loading under
+    ``--speculative-draft-load-format`` needs its own transfer engine. Every
+    input is a ``model`` leaf, so this serves both the pre-publish member and
+    the post-publish accessor."""
+    if cfg.remote_instance_weight_loader_start_seed_via_transfer_engine:
+        return True
+    if (load_format or cfg.load_format) != "remote_instance":
+        return False
+    backend = cfg.remote_instance_weight_loader_backend
+    return backend == "transfer_engine" or (
+        backend == "modelexpress"
+        and modelexpress_transport_of(cfg) == "transfer_engine"
+    )
 
 
 def mamba_extra_buffer_of(cfg: Any) -> bool:

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -40,7 +40,11 @@ from sglang.srt.model_executor.forward_batch_info import (
     compute_position,
 )
 from sglang.srt.model_executor.forward_context import get_attn_backend
-from sglang.srt.runtime_context import get_device, get_exec, get_parallel
+from sglang.srt.runtime_context import (
+    attention_backends,
+    get_device,
+    get_parallel,
+)
 from sglang.srt.speculative.spec_info import SpecInput
 from sglang.srt.utils import BumpAllocator, empty_context, get_bool_env_var, is_hip
 
@@ -631,8 +635,10 @@ class TboForwardBatchPreparer:
             device_field="extend_prefix_lens",
             sum_field=None,
         )
+        # The prefill half: this computes extend positions.
+        prefill_backend, _ = attention_backends()
         _, child_b.extend_start_loc = compute_position(
-            get_exec().kernel.attention_backend,
+            prefill_backend,
             child_b.extend_prefix_lens,
             child_b.extend_seq_lens,
             child_b.extend_num_tokens,

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -21,6 +21,7 @@ from sglang.srt.mem_cache.memory_pool import (
 from sglang.srt.mem_cache.pool_host.common import get_allocator_type
 from sglang.srt.mem_cache.pool_host.mha import get_mha_host_pool_cls
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.common import ceil_align
 
@@ -43,8 +44,7 @@ class DecodeKVCacheOffloadManager:
     ) -> None:
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
-        self.page_size = server_args.page_size
-        self.server_args = server_args
+        self.page_size = get_schedule().page_size
         self.request_counter = 0
         self.tree_cache = tree_cache
         env_stride = envs.SGLANG_HICACHE_DECODE_OFFLOAD_STRIDE.get()

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1669,7 +1669,7 @@ def _set_envs_and_config(server_args: ServerArgs):
 
     # Check flashinfer version
     if not get_bool_env_var("SGLANG_SKIP_SGL_KERNEL_VERSION_CHECK"):
-        if server_args.attention_backend == "flashinfer":
+        if "flashinfer" in server_args.get_attention_backends():
             assert_pkg_version(
                 "flashinfer_python",
                 "0.6.17",

--- a/python/sglang/srt/eplb/expert_distribution.py
+++ b/python/sglang/srt/eplb/expert_distribution.py
@@ -35,6 +35,7 @@ from sglang.srt.observability.metrics_collector import (
     ExpertDispatchCollector,
     resolve_collector_class,
 )
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import Withable, get_device, get_int_env_var
 
@@ -390,7 +391,7 @@ class _DetailSinglePassGatherer(_SinglePassGatherer):
             (
                 expert_location_metadata.num_layers,
                 # TODO determine the max number
-                server_args.chunked_prefill_size * 8,
+                get_schedule().chunked_prefill_size * 8,
                 self._TOP_K_NUM,
             ),
             dtype=torch.int32,

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_gdn_backend.py
@@ -10,10 +10,6 @@ from sglang.srt.hardware_backend.npu.attention.ascend_hybrid_linear_attn_backend
     AscendMambaAttnBackendBase,
 )
 from sglang.srt.layers.attention.linear.gdn_backend import GDNKernelDispatcher
-from sglang.srt.layers.attention.linear.utils import (
-    get_linear_attn_decode_backend,
-    get_linear_attn_prefill_backend,
-)
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
@@ -36,8 +32,9 @@ class AscendGDNAttnBackend(AscendMambaAttnBackendBase):
                 model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape[-2],
             )
         )
-        decode_backend = get_linear_attn_decode_backend()
-        prefill_backend = get_linear_attn_prefill_backend()
+        backends = model_runner.linear_attn_backends
+        decode_backend = backends.decode
+        prefill_backend = backends.prefill
         self.kernel_dispatcher = GDNKernelDispatcher(decode_backend, prefill_backend)
 
     def _prepare_mamba_track_metadata(self, forward_batch: ForwardBatch):

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -13,7 +13,7 @@ from sglang.srt.configs.linear_attn_model_registry import (
     get_linear_attn_config,
     import_backend_class,
 )
-from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import get_device_capability, is_hip, is_musa, is_npu
 
 _is_musa = is_musa()
@@ -351,7 +351,7 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
             LightningAttentionBackend,
         )
         from sglang.srt.layers.attention.linear.utils import (
-            initialize_linear_attn_config,
+            resolve_linear_attn_backends,
         )
         from sglang.srt.utils import (
             is_blackwell,
@@ -383,13 +383,8 @@ def attn_backend_wrapper(runner: "ModelRunner", full_attn_backend: "AttentionBac
         prefill_default = None
         if hybrid_gdn_config(runner.model_config) is not None and not is_npu():
             prefill_default = flashinfer_gdn_prefill_default(runner)
-        if prefill_default is not None:
-            get_context().override(
-                "gdn_backend.sm100_flashinfer_default",
-                linear_attn_prefill_backend=prefill_default,
-            )
-        initialize_linear_attn_config(
-            runner.server_args, prefill_default=prefill_default
+        runner.linear_attn_backends = resolve_linear_attn_backends(
+            prefill_default=prefill_default
         )
         hybrid_backend_cls = HybridLinearAttnBackend
         if hybrid_gdn_config(runner.model_config) is not None:

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -30,7 +30,14 @@ from sglang.srt.layers.utils.cp_utils import (
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.runtime_context import get_schedule, get_spec
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_memory,
+    get_model,
+    get_parallel,
+    get_schedule,
+    get_spec,
+)
 from sglang.srt.speculative.ragged_verify import build_ragged_target_verify_geometry
 from sglang.srt.speculative.spec_info import SpecInput, SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
@@ -49,8 +56,8 @@ from sglang.kernels.ops.attention.flash_attention import (
 )
 
 
-def _should_disable_scheduler_metadata_precompute(server_args) -> bool:
-    return bool(server_args.enable_prefill_cp or server_args.enable_dp_attention)
+def _should_disable_scheduler_metadata_precompute() -> bool:
+    return bool(get_parallel().enable_prefill_cp or get_parallel().enable_dp_attention)
 
 
 @dataclass
@@ -202,7 +209,7 @@ class FlashAttentionBackend(AttentionBackend):
             and model_runner.token_to_kv_pool.swa_layer_nums > 0
         )
 
-        self.topk = model_runner.server_args.speculative_eagle_topk or 0
+        self.topk = get_spec().speculative_eagle_topk or 0
         self.speculative_num_steps = speculative_num_steps
         self.speculative_num_draft_tokens = get_spec().speculative_num_draft_tokens
         if (
@@ -214,7 +221,7 @@ class FlashAttentionBackend(AttentionBackend):
                 phase="target_verify",
                 server_args=model_runner.server_args,
                 spec_algorithm=SpeculativeAlgorithm.from_string(
-                    model_runner.server_args.speculative_algorithm
+                    get_spec().speculative_algorithm
                 ),
                 is_draft_worker=True,
                 num_draft_tokens=int(self.speculative_num_draft_tokens),
@@ -283,7 +290,7 @@ class FlashAttentionBackend(AttentionBackend):
                 self._get_fa_runtime_policy = None
 
             self._get_scheduler_metadata = None
-            if model_runner.server_args.enable_deterministic_inference:
+            if get_exec().deterministic.enable_deterministic_inference:
                 # Must precede the first kernel compile.
                 from sglang.kernels.ops.attention.flash_attn.cute.batch_invariance import (
                     set_batch_invariant,
@@ -311,7 +318,7 @@ class FlashAttentionBackend(AttentionBackend):
         self.has_softcap = _softcapping is not None and _softcapping > 0.0
 
         # num_splits == 0 delegates SplitKV sizing to the selected FA runtime.
-        deterministic = model_runner.server_args.enable_deterministic_inference
+        deterministic = get_exec().deterministic.enable_deterministic_inference
         if self._get_fa_runtime_policy is None:
             self.num_splits = 1 if deterministic else 0
             self.decode_num_splits = self.num_splits
@@ -339,11 +346,10 @@ class FlashAttentionBackend(AttentionBackend):
         # guard wraps both set_kv_buffer and set_mla_kv_buffer. Without this
         # gate, MLA + is_embedding would skip the write but still read stale
         # cache via get_key_buffer in the absorbed-MLA path.
-        server_args = model_runner.server_args
         self.fa_skip_kv_cache = (
-            server_args.is_embedding
-            and server_args.chunked_prefill_size == -1
-            and server_args.disable_radix_cache
+            get_model().is_embedding
+            and get_schedule().chunked_prefill_size == -1
+            and get_memory().disable_radix_cache
             and not self.use_mla
         )
 
@@ -353,7 +359,7 @@ class FlashAttentionBackend(AttentionBackend):
         # combine kernel (flash_fwd_combine_launch_template.h:52). Leaving
         # scheduler_metadata unset uses the existing per-layer metadata path.
         self._disable_scheduler_metadata_precompute = (
-            _should_disable_scheduler_metadata_precompute(server_args)
+            _should_disable_scheduler_metadata_precompute()
         )
 
     def _compute_scheduler_metadata(

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -18,6 +18,7 @@ from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.model_runner import ModelRunner
+from sglang.srt.runtime_context import get_exec, get_memory, get_schedule
 from sglang.srt.utils import is_cpu, is_cuda, is_hip, is_npu, is_xpu
 from sglang.srt.utils.common import rank0_log
 
@@ -64,23 +65,22 @@ elif is_cpu():
 
 def flashinfer_gdn_prefill_default(model_runner: ModelRunner) -> Optional[str]:
     """FlashInfer for the narrow SM100 GDN prefill domain we validated, else None."""
-    args = model_runner.server_args
     if (
-        args.linear_attn_prefill_backend is not None
-        or args.linear_attn_backend != "triton"
-        or args.enable_page_major_kv_layout
+        get_exec().mamba.linear_attn_prefill_backend is not None
+        or get_exec().mamba.linear_attn_backend != "triton"
+        or get_memory().enable_page_major_kv_layout
         or not is_cuda()
         or torch.cuda.get_device_capability()[0] != 10
     ):
         return None
 
     cuda_version = torch.version.cuda
-    chunk_size = args.chunked_prefill_size
+    chunk_size = get_schedule().chunked_prefill_size
     config = hybrid_gdn_config(model_runner.model_config)
     if (
         cuda_version is None
         or int(cuda_version.split(".", 1)[0]) < 13
-        or args.enable_dynamic_chunking
+        or get_schedule().enable_dynamic_chunking
         or chunk_size is None
         or not 1 <= chunk_size <= 8192
         or getattr(config, "linear_key_head_dim", None) != 128

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -13,9 +13,6 @@ from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKerne
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
     build_verify_intermediate_state_indices,
-    get_linear_attn_decode_backend,
-    get_linear_attn_prefill_backend,
-    get_linear_attn_verify_backend,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
@@ -359,11 +356,9 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 self.conv_states_shape[-1] < FLA_CHUNK_SIZE
             ), f"{self.conv_states_shape[-1]=} should be less than {FLA_CHUNK_SIZE}"
 
-        decode_backend = get_linear_attn_decode_backend()
-        prefill_backend = get_linear_attn_prefill_backend()
-        verify_backend = get_linear_attn_verify_backend()
+        backends = model_runner.linear_attn_backends
         self.kernel_dispatcher = GDNKernelDispatcher(
-            decode_backend, prefill_backend, verify_backend
+            backends.decode, backends.prefill, backends.verify
         )
         # Sized past the pool for attn_tp-padded warmup/MLP-sync batches (see helper).
         self.verify_intermediate_state_indices = (

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -13,9 +13,6 @@ from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKerne
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
     build_verify_intermediate_state_indices,
-    get_linear_attn_decode_backend,
-    get_linear_attn_prefill_backend,
-    get_linear_attn_verify_backend,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.utils import is_cpu, is_cuda, is_npu
@@ -379,9 +376,10 @@ class KDAAttnBackend(MambaAttnBackendBase):
             .transpose(-1, -2)
             .shape
         )
-        decode_backend = get_linear_attn_decode_backend()
-        prefill_backend = get_linear_attn_prefill_backend()
-        verify_backend = get_linear_attn_verify_backend()
+        backends = model_runner.linear_attn_backends
+        decode_backend = backends.decode
+        prefill_backend = backends.prefill
+        verify_backend = backends.verify
         # KDA FlashInfer target_verify (recurrent_kda) is chain-only (no tree-ancestor
         # traversal). Reject EAGLE tree verify (topk > 1) early at setup, keyed on the
         # verify backend (not decode). The kernel keeps a per-call

--- a/python/sglang/srt/layers/attention/linear/utils.py
+++ b/python/sglang/srt/layers/attention/linear/utils.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
-import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
+import msgspec
+
+from sglang.srt.runtime_context import get_exec
 from sglang.srt.utils.common import rank0_log
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
-
-logger = logging.getLogger(__name__)
 
 
 class LinearAttnKernelBackend(Enum):
@@ -55,56 +55,48 @@ class LinearAttnKernelBackend(Enum):
         return self == LinearAttnKernelBackend.CUSTOM
 
 
-_BACKENDS: Dict[str, Optional[LinearAttnKernelBackend]] = {
-    "decode": None,
-    "prefill": None,
-    "verify": None,
-}
+class LinearAttnBackends(msgspec.Struct, frozen=True):
+    """One runner's linear-attn kernel choice, per phase.
+
+    Per runner, not per process: a target and its draft coexist and can want
+    different kernels (only the runner whose model is GDN gets the SM100
+    FlashInfer prefill default, and an explicit flag applies to whichever runner
+    was launched with it).
+    """
+
+    decode: LinearAttnKernelBackend
+    prefill: LinearAttnKernelBackend
+    verify: LinearAttnKernelBackend
 
 
-def initialize_linear_attn_config(
-    server_args: ServerArgs, prefill_default: Optional[str] = None
-):
-    base = server_args.linear_attn_backend
-    decode = server_args.linear_attn_decode_backend or base
-    prefill = server_args.linear_attn_prefill_backend or prefill_default or base
+def resolve_linear_attn_backends(
+    prefill_default: Optional[str] = None,
+) -> LinearAttnBackends:
+    """This runner's kernel choice from the published leaves.
 
-    _BACKENDS["decode"] = LinearAttnKernelBackend(decode)
-    _BACKENDS["prefill"] = LinearAttnKernelBackend(prefill)
-
-    # Verify backend. Unset -> follow decode (flashinfer -> its recurrent kernel,
-    # else triton), preserving historical behavior.
-    verify = server_args.linear_attn_verify_backend
-    if verify is None:
-        verify = decode if _BACKENDS["decode"].is_flashinfer() else "triton"
-    _BACKENDS["verify"] = LinearAttnKernelBackend(verify)
-
-    rank0_log(
-        f"Linear attention kernel backend: decode={decode}, prefill={prefill}, "
-        f"verify={verify}"
+    ``prefill_default`` is the caller's own auto-default (the SM100 GDN
+    domain); an explicitly configured ``--linear-attn-prefill-backend`` wins.
+    """
+    mamba = get_exec().mamba
+    base = mamba.linear_attn_backend
+    decode = LinearAttnKernelBackend(mamba.linear_attn_decode_backend or base)
+    prefill = LinearAttnKernelBackend(
+        mamba.linear_attn_prefill_backend or prefill_default or base
     )
 
+    # Unset verify follows decode (flashinfer -> its recurrent kernel, else triton).
+    verify = mamba.linear_attn_verify_backend
+    if verify is None:
+        verify = decode.value if decode.is_flashinfer() else "triton"
 
-def _get_backend(phase: str) -> LinearAttnKernelBackend:
-    backend = _BACKENDS[phase]
-    if backend is None:
-        logger.warning(
-            "linear-attn %s backend is not initialized, using triton backend", phase
-        )
-        backend = _BACKENDS[phase] = LinearAttnKernelBackend.TRITON
-    return backend
-
-
-def get_linear_attn_decode_backend() -> LinearAttnKernelBackend:
-    return _get_backend("decode")
-
-
-def get_linear_attn_prefill_backend() -> LinearAttnKernelBackend:
-    return _get_backend("prefill")
-
-
-def get_linear_attn_verify_backend() -> LinearAttnKernelBackend:
-    return _get_backend("verify")
+    backends = LinearAttnBackends(
+        decode=decode, prefill=prefill, verify=LinearAttnKernelBackend(verify)
+    )
+    rank0_log(
+        f"Linear attention kernel backend: decode={backends.decode.value}, "
+        f"prefill={backends.prefill.value}, verify={backends.verify.value}"
+    )
+    return backends
 
 
 def build_verify_intermediate_state_indices(

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -171,7 +171,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
 
         # Speculative decoding
         # Only support topk <= 1 for now.
-        self.topk = model_runner.server_args.speculative_eagle_topk or 0
+        self.topk = get_spec().speculative_eagle_topk or 0
         self.speculative_step_id = speculative_step_id
         self.target_verify_metadata = {}
 

--- a/python/sglang/srt/layers/cp/base.py
+++ b/python/sglang/srt/layers/cp/base.py
@@ -230,16 +230,8 @@ class ContextParallelStrategy(ABC):
 
 
 def _is_dsa_active() -> bool:
-    from sglang.srt.runtime_context import get_parallel, get_server_args
-
-    # `_is_dsa_model_arch` is set nowhere in the tree, so this predicate is
-    # inert today (the getattr default makes it False). Kept verbatim rather
-    # than "fixed" here, because deciding what it should name is the CP path's
-    # call; the ratchet exempts it with that reason.
-    return bool(
-        get_parallel().enable_prefill_cp
-        and getattr(get_server_args(), "_is_dsa_model_arch", False)
-    )
+    # Placeholder: a real answer needs the model architecture, not config.
+    return False
 
 
 _STRATEGY: Optional[ContextParallelStrategy] = None

--- a/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/compile_utils.py
@@ -16,7 +16,7 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.environ import envs
 from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import ceil_align, ceil_div, get_available_gpu_memory, is_musa
 
@@ -67,9 +67,10 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
         #   8192, 9008, ... 16384 (step 16)
         # Totally 1024 + 1024 / 2 + 2048 / 4 + 4096 / 8 + 8192 / 16 = 3072 kernels
         next_m, sample_step = 1024, 2
+        chunked_prefill_size = get_schedule().chunked_prefill_size
         max_prefill_bs = (
-            min(server_args.chunked_prefill_size, 32 * 1024)
-            if server_args.chunked_prefill_size >= 1
+            min(chunked_prefill_size, 32 * 1024)
+            if chunked_prefill_size >= 1
             else 16 * 1024
         )
         while next_m < max_prefill_bs:
@@ -81,10 +82,11 @@ def update_deep_gemm_config(gpu_id: int, server_args: ServerArgs):
     else:
         # When fast warmup isn't enabled, generate m_max and compile all the covered Ms.
         m_max = 1024 * 16
-        if server_args.chunked_prefill_size < 1:
+        chunked_prefill_size = get_schedule().chunked_prefill_size
+        if chunked_prefill_size < 1:
             m_max = 1024 * 64
-        elif server_args.chunked_prefill_size > 8192:
-            m_max = server_args.chunked_prefill_size * 2
+        elif chunked_prefill_size > 8192:
+            m_max = chunked_prefill_size * 2
         m_max = min(1024 * 128, m_max)
         _BUILTIN_M_LIST += list(range(1, m_max + 1))
 

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -18,7 +18,7 @@ from sglang.srt.layers.rotary_embedding.yarn import (
     yarn_get_mscale_simple,
     yarn_linear_ramp_mask,
 )
-from sglang.srt.runtime_context import get_exec
+from sglang.srt.runtime_context import attention_backends, get_exec
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
@@ -143,7 +143,9 @@ class MRotaryEmbedding(RotaryEmbedding):
         last_dim = cos_sin.size()[-1]
         cos, sin = cos_sin.chunk(2, dim=-1)
         if self.mrope_interleaved:
-            if support_triton(get_exec().kernel.attention_backend):
+            # Runs in prefill and decode: both halves must support triton.
+            prefill_backend, decode_backend = attention_backends()
+            if support_triton(prefill_backend) and support_triton(decode_backend):
                 cos = apply_interleaved_rope_triton(cos, self.mrope_section)
                 sin = apply_interleaved_rope_triton(sin, self.mrope_section)
             else:

--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -46,7 +46,7 @@ from sglang.srt.lora.utils import (
 )
 from sglang.srt.managers.io_struct import LoRAUpdateOutput
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import get_available_gpu_memory, replace_submodule
 from sglang.srt.utils.hf_transformers_utils import AutoConfig
@@ -1030,7 +1030,7 @@ def init_lora_cuda_graph_moe_buffers(
     """
     from sglang.srt.lora.layers import FusedMoEWithLoRA
 
-    max_bs = server_args.cuda_graph_config.decode.max_bs
+    max_bs = get_exec().graph.cuda_graph_config.decode.max_bs
     max_loras = server_args.max_loras_per_batch
     for module in model.modules():
         if isinstance(module, FusedMoEWithLoRA):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Set, Tuple, 
 
 from sglang.srt.runtime_context import (
     attention_backends,
+    configured_pp_size,
     get_device,
     get_disagg,
     get_exec,
@@ -4900,13 +4901,12 @@ class Scheduler(
 
 
 def dispatch_event_loop(scheduler: Scheduler):
-    # Dispatch to the appropriate event loop based on the disaggregation mode
-    server_args = scheduler.server_args
+    # The live PP property asserts before torch.distributed init (MLX stub).
     disaggregation_mode: DisaggregationMode = scheduler.disaggregation_mode
     if disaggregation_mode == DisaggregationMode.NULL:
         if scheduler.enable_pdmux:
             scheduler.event_loop_pdmux()
-        elif server_args.pp_size > 1:
+        elif configured_pp_size() > 1:
             scheduler.event_loop_pp()
         elif scheduler.enable_overlap_mlx:
             scheduler.event_loop_overlap_mlx()
@@ -4915,14 +4915,14 @@ def dispatch_event_loop(scheduler: Scheduler):
         else:
             scheduler.event_loop_normal()
     elif disaggregation_mode == DisaggregationMode.PREFILL:
-        if server_args.pp_size > 1:
+        if configured_pp_size() > 1:
             scheduler.event_loop_pp_disagg_prefill()
         elif scheduler.enable_overlap:
             scheduler.event_loop_overlap_disagg_prefill()
         else:
             scheduler.event_loop_normal_disagg_prefill()
     elif disaggregation_mode == DisaggregationMode.DECODE:
-        if server_args.pp_size > 1:
+        if configured_pp_size() > 1:
             scheduler.event_loop_pp_disagg_decode()
         elif scheduler.enable_overlap:
             scheduler.event_loop_overlap_disagg_decode()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -28,6 +28,7 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Set, Tuple, Union
 
 from sglang.srt.runtime_context import (
+    attention_backends,
     get_device,
     get_disagg,
     get_exec,
@@ -1517,9 +1518,10 @@ class Scheduler(
             "flashinfer": ("SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE", 4096),
             "triton": ("SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE", 4096),
         }
-        env_var, default_size = backend_sizes.get(
-            get_exec().kernel.attention_backend, (None, None)
-        )
+        # Both entries are prefill knobs (SPLIT_TILE / PREFILL_TRUNCATION):
+        # the prefill half decides.
+        prefill_backend, _ = attention_backends()
+        env_var, default_size = backend_sizes.get(prefill_backend, (None, None))
         self.truncation_align_size = (
             get_int_env_var(env_var, default_size) if env_var else None
         )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1876,7 +1876,7 @@ class Scheduler(
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
-        if self.server_args.mm_feature_transport == "cuda_vmm":
+        if get_mm().mm_feature_transport == "cuda_vmm":
             for recv_req in recv_reqs:
                 self._materialize_cuda_vmm_inputs(recv_req)
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -436,7 +436,7 @@ class Scheduler(
         self.spec_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.enable_hierarchical_cache = server_args.enable_hierarchical_cache
         self.enable_session_radix_cache = server_args.enable_session_radix_cache
         self.enable_hicache_storage = server_args.hicache_storage_backend is not None

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -338,15 +338,15 @@ class SchedulerMetricsReporter:
                 "num_draft_tokens": 0,
             }
 
-        # Fallback to server_args if draft_worker does not have the attributes.
-        server_args = self.scheduler.server_args
+        # Fallback to the published `spec` bag if draft_worker does not have
+        # the attributes.
         num_steps = getattr(
-            draft_worker, "speculative_num_steps", server_args.speculative_num_steps
+            draft_worker, "speculative_num_steps", get_spec().speculative_num_steps
         )
         num_draft_tokens = getattr(
             draft_worker,
             "speculative_num_draft_tokens",
-            server_args.speculative_num_draft_tokens,
+            get_spec().speculative_num_draft_tokens,
         )
 
         return {

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -26,7 +26,7 @@ from sglang.srt.mem_cache.common import (
     evict_from_tree_cache,
 )
 from sglang.srt.mem_cache.memory_pool import HybridReqToTokenPool, ReqToTokenPool
-from sglang.srt.runtime_context import get_exec, get_parallel
+from sglang.srt.runtime_context import attention_backends, get_parallel
 from sglang.srt.utils import (
     is_cpu,
     is_cuda,
@@ -65,7 +65,10 @@ def write_cache_indices(
     prefix_tensors: list[torch.Tensor],
     req_to_token_pool: ReqToTokenPool,
 ):
-    if support_triton(get_exec().kernel.attention_backend):
+    # This writer's one caller is `alloc_for_extend`, so the prefill half
+    # decides; the fallback below pays several `.item()` syncs per request.
+    prefill_backend, _ = attention_backends()
+    if support_triton(prefill_backend):
         prefix_pointers = torch.tensor(
             [t.data_ptr() for t in prefix_tensors],
             dtype=torch.uint64,
@@ -106,8 +109,11 @@ def get_last_loc(
     req_pool_indices_tensor: torch.Tensor,
     prefix_lens_tensor: torch.Tensor,
 ) -> torch.Tensor:
-    attn_backend = get_exec().kernel.attention_backend
-    uses_triton_dispatch = attn_backend not in ("ascend", "torch_native")
+    prefill_backend, decode_backend = attention_backends()
+    uses_triton_dispatch = prefill_backend not in (
+        "ascend",
+        "torch_native",
+    ) and decode_backend not in ("ascend", "torch_native")
 
     if _is_hip and uses_triton_dispatch:
         # HIP-only: the legacy get_last_loc_triton kernel emits a

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -36,7 +36,7 @@ from sglang.srt.managers.mm_schedule import init_mm_embedding_cache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.registry import TreeCacheBuildContext, create_tree_cache
 from sglang.srt.model_loader.utils import get_resolved_model_impl
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_parallel, get_schedule
 
 if TYPE_CHECKING:
 
@@ -205,7 +205,7 @@ def build_kv_cache(
                 "with Mamba/SSM models"
             )
 
-    effective_chunked_prefill_size = server_args.chunked_prefill_size
+    effective_chunked_prefill_size = get_schedule().chunked_prefill_size
     if model_config.is_multimodal and uses_transformers_backend:
         effective_chunked_prefill_size = None
 

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -75,6 +75,7 @@ from sglang.srt.runtime_context import (
     mamba_extra_buffer_enabled,
     mamba_extra_buffer_lazy_enabled,
     max_speculative_num_draft_tokens,
+    pre_capture_activation_reserve_mb,
 )
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -1782,7 +1783,7 @@ class KVCacheConfigurator:
             # Mamba state is a fixed pre-capture allocation, so it can't ride the ~0 post-capture slack.
             slack_gb = max(
                 slack_gb,
-                self.server_args.pre_capture_activation_reserve_mb(
+                pre_capture_activation_reserve_mb(
                     get_device_memory_capacity(self.device)
                 )
                 / 1024,

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 from sglang.srt.environ import envs
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.runtime_context import get_memory
 from sglang.srt.utils.tensor_bridge import use_mlx
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
         )
         return cache
 
-    if server_args.enable_lmcache:
+    if get_memory().enable_lmcache:
         from sglang.srt.mem_cache.storage.lmcache.lmc_radix_cache import (
             LMCRadixCache,
         )
@@ -141,7 +142,7 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
             tp_group=ctx.tp_group,
         )
 
-    if server_args.enable_flexkv:
+    if get_memory().enable_flexkv:
         # Importing the package side-effect registers the explicit
         # ``--radix-cache-backend=flexkv`` factory; we then call the
         # factory directly so --enable-flexkv stands on its own.
@@ -151,8 +152,8 @@ def default_radix_cache_factory(ctx: TreeCacheBuildContext) -> BasePrefixCache:
 
         # Honor a CLI --flexkv-config-file by forwarding it via the env
         # var that FlexKV's config loader actually reads.
-        if server_args.flexkv_config_file and not os.environ.get("FLEXKV_CONFIG_PATH"):
-            os.environ["FLEXKV_CONFIG_PATH"] = server_args.flexkv_config_file
+        if get_memory().flexkv_config_file and not os.environ.get("FLEXKV_CONFIG_PATH"):
+            os.environ["FLEXKV_CONFIG_PATH"] = get_memory().flexkv_config_file
         return _flexkv_factory(ctx)
 
     from sglang.srt.mem_cache.radix_cache import RadixCache

--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -39,7 +39,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner_utils.capture_mode import model_capture_mode
-from sglang.srt.runtime_context import get_flags, get_parallel, get_spec
+from sglang.srt.runtime_context import get_exec, get_flags, get_parallel, get_spec
 from sglang.srt.utils import (
     empty_context,
     log_info_on_rank0,
@@ -127,14 +127,13 @@ def set_torch_compile_config():
 
 def get_batch_sizes_to_capture(model_runner: ModelRunner):
     # torch compile speeds up decoding by reducing python overhead on CPU
-    server_args = model_runner.server_args
     # Reuse cuda_graph_config[decode].bs here.
     # Users can customize the batch sizes supported by cpu_graph, such as:
     # --cuda-graph-bs-decode 1 2 4 8 16
-    capture_bs = server_args.cuda_graph_config.decode.bs
+    capture_bs = get_exec().graph.cuda_graph_config.decode.bs
     assert (
-        max(capture_bs) <= server_args.torch_compile_max_bs
-    ), f"{capture_bs=}, {server_args.torch_compile_max_bs=}"
+        max(capture_bs) <= get_exec().graph.torch_compile_max_bs
+    ), f"{capture_bs=}, {get_exec().graph.torch_compile_max_bs=}"
     capture_bs = [bs for bs in capture_bs if bs <= model_runner.req_to_token_pool.size]
     capture_bs = list(sorted(set(capture_bs)))
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -179,6 +179,7 @@ from sglang.srt.runtime_context import (
     get_spec,
     is_ep_joiner,
     is_ep_scale_joiner,
+    remote_instance_transfer_engine_enabled,
     set_global_dwdp_manager,
 )
 from sglang.srt.sampling.sampling_batch_info import SamplingBatchInfo
@@ -560,7 +561,6 @@ class ModelRunner:
 
     def init_remote_instance_weight_transporter(self):
         self.remote_instance_weight_transporter = RemoteInstanceWeightTransporter(
-            server_args=self.server_args,
             get_model=lambda: self.model,
             tp_rank=self.ps.tp_rank,
             gpu_id=self.gpu_id,
@@ -671,9 +671,7 @@ class ModelRunner:
         )
 
     def maybe_init_remote_instance_transfer_engine(self):
-        if self.server_args.remote_instance_weight_loader_use_transfer_engine(
-            load_format=self.draft_load_format
-        ):
+        if remote_instance_transfer_engine_enabled(load_format=self.draft_load_format):
             self.remote_instance_weight_transporter.init_engine()
 
     def maybe_init_expert_location_metadata(self):

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -313,6 +313,13 @@ class ModelRunner:
         self.dist_port = nccl_port
         self.server_args = server_args
         self.is_draft_worker = is_draft_worker
+        # Set the global server_args in the scheduler process (target worker
+        # only, so a draft init cannot clobber target-derived global state).
+        # Before the constructor's bag reads (page_size below): a standalone
+        # construction (benchmark/one_batch, the manual runner tests) has no
+        # earlier publish.
+        if not is_draft_worker:
+            set_global_server_args_for_scheduler(server_args)
         self.draft_attention_backend = resolve_draft_attention_backend(
             draft_attention_backend=draft_attention_backend,
             server_args=server_args,
@@ -332,7 +339,7 @@ class ModelRunner:
             server_args.speculative_algorithm
         )
         self.capture_tail_hooks = []
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.req_to_token_pool = req_to_token_pool
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.mtp_draft_device_pools = ()
@@ -359,11 +366,6 @@ class ModelRunner:
         # Apply the rank zero filter to logger
         if server_args.show_time_cost:
             enable_show_time_cost()
-
-        # Set the global server_args in the scheduler process (target worker
-        # only, so a draft init cannot clobber target-derived global state).
-        if not self.is_draft_worker:
-            set_global_server_args_for_scheduler(server_args)
 
         misc_utils.maybe_disable_chunked_prefix_cache(
             use_mla_backend=self.use_mla_backend,

--- a/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/attention_backend_setup.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
     from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
     from sglang.srt.model_executor.model_runner import ModelRunner
 
+from sglang.srt.runtime_context import attention_backends, get_disagg, get_exec
+
 logger = logging.getLogger(__name__)
 
 
@@ -66,7 +68,6 @@ def configure_aux_hidden_state_capture(
 
 def build_attention_backends(*, model_runner: ModelRunner) -> AttentionBackends:
     """Init attention kernel backend."""
-    server_args = model_runner.server_args
 
     # TODO: Refactor device-specific init branches into platform interface (separate PR).
     if model_runner.device in ("cuda", "musa"):
@@ -81,7 +82,7 @@ def build_attention_backends(*, model_runner: ModelRunner) -> AttentionBackends:
         ),
     )
 
-    if server_args.enable_pdmux:
+    if get_disagg().enable_pdmux:
         attn_backend = _build_resolved_backend(
             model_runner=model_runner, resolved=resolved, init_new_workspace=True
         )
@@ -91,10 +92,12 @@ def build_attention_backends(*, model_runner: ModelRunner) -> AttentionBackends:
                 resolved=resolved,
                 init_new_workspace=False,
             )
-            for _ in range(server_args.sm_group_num)
+            for _ in range(get_disagg().sm_group_num)
         ]
         decode_attn_backend = decode_attn_backend_group[0]
-    elif server_args.enable_two_batch_overlap and not model_runner.is_draft_worker:
+    elif (
+        get_exec().overlap.enable_two_batch_overlap and not model_runner.is_draft_worker
+    ):
         attn_backend = TboAttnBackend.init_new(
             lambda: _build_resolved_backend(
                 model_runner=model_runner,
@@ -161,7 +164,6 @@ def resolve_attention_backend_strs(
     target and draft coexist in one process, so it cannot come from the
     process-wide config.
     """
-    server_args = model_runner.server_args
     is_draft_worker = model_runner.is_draft_worker
     draft_attn_backend = model_runner.draft_attention_backend
     if is_draft_worker and draft_attn_backend:
@@ -172,7 +174,7 @@ def resolve_attention_backend_strs(
             decode=draft_attn_backend,
             is_draft_override=True,
         )
-    prefill, decode = server_args.get_attention_backends()
+    prefill, decode = attention_backends()
     return ResolvedAttentionBackendStr(prefill=prefill, decode=decode)
 
 

--- a/python/sglang/srt/model_executor/model_runner_components/kv_pool_runtime.py
+++ b/python/sglang/srt/model_executor/model_runner_components/kv_pool_runtime.py
@@ -11,6 +11,7 @@ from sglang.srt.distributed import get_world_group
 from sglang.srt.mem_cache.kv_cache_configurator import mm_runtime_reservation_gb
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.platforms import current_platform
+from sglang.srt.runtime_context import pre_capture_activation_reserve_mb
 from sglang.srt.utils.common import get_available_gpu_memory, get_device_memory_capacity
 
 if TYPE_CHECKING:
@@ -72,7 +73,7 @@ def compute_post_capture_kv_resize(
     if eager_decode_gap or mambaish_config(model_runner.model_config) is not None:
         headroom_gb = max(
             headroom_gb,
-            model_runner.server_args.pre_capture_activation_reserve_mb(
+            pre_capture_activation_reserve_mb(
                 get_device_memory_capacity(model_runner.device)
             )
             / 1024,

--- a/python/sglang/srt/model_executor/model_runner_components/misc_utils.py
+++ b/python/sglang/srt/model_executor/model_runner_components/misc_utils.py
@@ -8,7 +8,11 @@ from sglang.srt.configs.model_config import (
     is_deepseek_dsa,
     is_kimi_k3,
 )
-from sglang.srt.runtime_context import get_context, get_exec, get_schedule
+from sglang.srt.runtime_context import (
+    attention_backends,
+    get_context,
+    get_schedule,
+)
 from sglang.srt.server_args import CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
 
 if TYPE_CHECKING:
@@ -29,10 +33,11 @@ def maybe_disable_chunked_prefix_cache(
     # model's (often non-MLA) config must not flip the shared setting.
     if is_draft_worker:
         return
+    # Chunked prefix cache is a prefill feature: the prefill half decides.
+    prefill_backend, _ = attention_backends()
     if (
         not use_mla_backend
-        or get_exec().kernel.attention_backend
-        not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
+        or prefill_backend not in CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS
     ):
         if not get_schedule().disable_chunked_prefix_cache:
             get_context().override(

--- a/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
+++ b/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.speculative.ngram_embedding import update_token_table
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.managers.schedule_batch import ForwardMode
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 
 if TYPE_CHECKING:
@@ -50,7 +51,7 @@ class NgramEmbeddingManager:
                 dtype=torch.int32,
                 device=device,
             )
-            chunked_prefill_size = server_args.chunked_prefill_size
+            chunked_prefill_size = get_schedule().chunked_prefill_size
             assert (
                 chunked_prefill_size is not None and chunked_prefill_size > 0
             ), "Ngram embedding requires chunked prefill to be enabled (chunked_prefill_size > 0)"

--- a/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
+++ b/python/sglang/srt/model_executor/model_runner_components/remote_instance_weight_transporter.py
@@ -11,8 +11,11 @@ from sglang.srt.model_loader.remote_instance_weight_loader_utils import (
     RemoteInstanceWeightLoaderBackend,
     register_memory_region,
 )
-from sglang.srt.runtime_context import get_model, get_parallel
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.runtime_context import (
+    get_model,
+    get_parallel,
+    remote_instance_transfer_engine_enabled,
+)
 from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 logger = logging.getLogger(__name__)
@@ -20,7 +23,6 @@ logger = logging.getLogger(__name__)
 
 @dataclass(slots=True, kw_only=True)
 class RemoteInstanceWeightTransporter:
-    server_args: ServerArgs
     get_model: Callable[[], torch.nn.Module]
     tp_rank: int
     gpu_id: int
@@ -55,7 +57,7 @@ class RemoteInstanceWeightTransporter:
 
     def maybe_register_and_publish_weight_info(self) -> None:
         if (
-            self.server_args.remote_instance_weight_loader_use_transfer_engine()
+            remote_instance_transfer_engine_enabled()
             # ModelExpress owns TransferEngine memory registration and metadata
             # publishing for backend=modelexpress. Re-registering here would
             # overlap the same weight buffers.

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -36,7 +36,14 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_write_pad,
 )
 from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import (
+    get_disagg,
+    get_memory,
+    get_parallel,
+    get_schedule,
+    get_spec,
+    max_speculative_num_draft_tokens,
+)
 from sglang.srt.utils.common import (
     ceil_align,
     ceil_div,
@@ -533,10 +540,9 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         super().__init__(kvc)
         assert self._full_layers_num > 0
 
-        sa = kvc.server_args
         page_size = kvc.page_size
         window = kvc.sliding_window_size
-        draft_tokens = sa.speculative_num_draft_tokens or 1
+        draft_tokens = get_spec().speculative_num_draft_tokens or 1
         eviction_interval = max(1, envs.SGLANG_SWA_EVICTION_INTERVAL.get())
 
         """
@@ -544,40 +550,47 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         Padding to make sure eviction point is page-aligned.
         """
         trailing_tokens = window + eviction_interval * draft_tokens + page_size
-        if sa.speculative_algorithm is None:
+        if get_spec().speculative_algorithm is None:
             decode_alloc = page_size
-        elif sa.disable_overlap_schedule:
+        elif get_schedule().disable_overlap_schedule:
             # spec-v1: new_tokens_required_next_decode per request.
-            decode_alloc = spec_decode_alloc_len_per_request(sa)
+            decode_alloc = spec_decode_alloc_len_per_request(
+                page_size=page_size,
+                speculative_num_steps=get_spec().speculative_num_steps,
+                speculative_eagle_topk=get_spec().speculative_eagle_topk,
+                speculative_num_draft_tokens=get_spec().speculative_num_draft_tokens,
+            )
         else:
             # spec-v2: the overlap allocator keeps 2 * alloc_len outstanding
             # (eagle_utils.eagle_prepare_for_decode: kv_committed_len + 2 * alloc_len).
-            decode_alloc = 2 * get_alloc_len_per_decode(sa)
+            decode_alloc = 2 * get_alloc_len_per_decode(
+                kvc.server_args,
+                max_draft_tokens=max_speculative_num_draft_tokens(),
+            )
         per_request = trailing_tokens + decode_alloc
 
-        num_reqs = sa.max_running_requests // kvc.ps.attn_dp_size
-        if sa.disaggregation_mode == "decode":
+        num_reqs = get_schedule().max_running_requests // kvc.ps.attn_dp_size
+        if get_disagg().disaggregation_mode == "decode":
             self._swa_cap = (
                 per_request * num_reqs
-                + (window + page_size) * sa.disaggregation_decode_extra_slots
+                + (window + page_size) * get_disagg().disaggregation_decode_extra_slots
             )
         else:
-            chunks_in_flight = 1 if sa.disable_overlap_schedule else 2
+            chunks_in_flight = 1 if get_schedule().disable_overlap_schedule else 2
             self._swa_cap = (
                 per_request * num_reqs
-                + chunks_in_flight * sa.chunked_prefill_size
+                + chunks_in_flight * get_schedule().chunked_prefill_size
                 + page_size
             )
 
     @staticmethod
     def is_applicable(kvc: KVCacheConfigurator) -> bool:
         """True when SWAChunkCache can be sized from explicit max requests."""
-        sa = kvc.server_args
-        if sa.max_running_requests is None:
+        if get_schedule().max_running_requests is None:
             return False
-        if not sa.disable_radix_cache:
+        if not get_memory().disable_radix_cache:
             return False
-        if sa.chunked_prefill_size is None:
+        if get_schedule().chunked_prefill_size is None:
             return False
         if kvc.sliding_window_size is None:
             return False

--- a/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
@@ -23,7 +23,10 @@ from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, List, Sequence, Tuple
 
 from sglang.srt.model_executor.runner.base_runner import BaseRunner
-from sglang.srt.runtime_context import get_flags
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_flags,
+)
 from sglang.srt.utils import (
     get_cuda_graph_batch_size_alignment,
     get_cuda_graph_max_batch_size,
@@ -68,14 +71,14 @@ def get_batch_sizes_to_capture(
     """
 
     server_args = model_runner.server_args
-    capture_bs = list(server_args.cuda_graph_config.decode.bs)
+    capture_bs = list(get_exec().graph.cuda_graph_config.decode.bs)
     num_max_requests = model_runner.req_to_token_pool.size
 
     mul_base = get_cuda_graph_batch_size_alignment(server_args)
     # TBO splits each request's rows across two micro-batches, so the
     # alignment constraint applies per request rather than per token row.
     alignment_width = captured_req_width
-    if server_args.enable_two_batch_overlap:
+    if get_exec().overlap.enable_two_batch_overlap:
         alignment_width = 1
 
     # pad `num_max_requests` to avoid being filtered out
@@ -92,7 +95,7 @@ def get_batch_sizes_to_capture(
 
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
     compile_bs = (
-        [bs for bs in capture_bs if bs <= server_args.torch_compile_max_bs]
+        [bs for bs in capture_bs if bs <= get_exec().graph.torch_compile_max_bs]
         if get_flags().capture.enable_torch_compile
         else []
     )

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -49,6 +49,13 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     enable_tc_piecewise_cuda_graph,
     set_tc_piecewise_forward_context,
 )
+from sglang.srt.runtime_context import (
+    get_parallel,
+    get_spec,
+    mamba_extra_buffer_enabled,
+    max_prefill_buffer_tokens,
+    max_speculative_num_draft_tokens,
+)
 from sglang.srt.utils import is_hip
 from sglang.srt.utils.common import (
     ceil_align,
@@ -76,14 +83,14 @@ class EagerRunner(BaseRunner):
         num_tokens_per_req = 1
         if mr.spec_algorithm.is_speculative():
             # speculative_adaptive can grow draft tokens at runtime; size to the max.
-            num_draft_tokens = sa.max_speculative_num_draft_tokens or 1
+            num_draft_tokens = max_speculative_num_draft_tokens() or 1
             if mr.is_draft_worker:
                 num_tokens_per_req = max(
-                    sa.speculative_eagle_topk or 1,
+                    get_spec().speculative_eagle_topk or 1,
                     num_draft_tokens,
                     (
-                        2 * (sa.speculative_num_steps or 0)
-                        if sa.enable_multi_layer_eagle
+                        2 * (get_spec().speculative_num_steps or 0)
+                        if get_spec().enable_multi_layer_eagle
                         else 0
                     ),
                 )
@@ -100,14 +107,14 @@ class EagerRunner(BaseRunner):
         if (
             mr.is_draft_worker
             and mr.spec_algorithm.is_frozen_kv_mtp()
-            and sa.speculative_eagle_topk > 1
+            and get_spec().speculative_eagle_topk > 1
         ):
             # Frozen-KV MTP expands the draft batch by topk on the bs axis
             # (expand_for_topk_draft) before the eager fallback.
-            max_bs *= sa.speculative_eagle_topk
+            max_bs *= get_spec().speculative_eagle_topk
         # Mirror prepare_mlp_sync_batch padding so the registry holds what load_batch copies.
         max_bs = get_eager_max_batch_size(sa, max_bs)
-        prefill_ceiling = max(mr.max_total_num_tokens, sa.max_prefill_buffer_tokens())
+        prefill_ceiling = max(mr.max_total_num_tokens, max_prefill_buffer_tokens())
         max_num_token = max(prefill_ceiling, max_bs * num_tokens_per_req)
         if require_mlp_sync(sa):
             from sglang.srt.layers.cp.padding import get_cp_padding_align_size
@@ -123,7 +130,7 @@ class EagerRunner(BaseRunner):
             max_num_token=max_num_token,
             cache_loc_dtype=torch.int64,
             enable_mamba_track=(
-                sa.enable_mamba_extra_buffer() and mr.spec_algorithm.is_none()
+                mamba_extra_buffer_enabled() and mr.spec_algorithm.is_none()
             ),
             is_encoder_decoder=is_encoder_decoder,
             encoder_len_fill_value=(
@@ -134,7 +141,7 @@ class EagerRunner(BaseRunner):
             encoder_lens_dtype=(
                 torch.int64 if torch.device(mr.device).type == "cpu" else torch.int32
             ),
-            dp_size=sa.dp_size,
+            dp_size=get_parallel().dp_size,
         )
         # Eager has no capture step, so warm up here (run-once via mr._kernel_warmed_up).
         self.warmup()

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -25,6 +25,11 @@ import torch
 
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import (
+    get_exec,
+    get_model,
+    get_spec,
+)
 from sglang.srt.utils import empty_context, log_info_on_rank0
 
 if TYPE_CHECKING:
@@ -37,7 +42,7 @@ FLASHINFER_AUTOTUNE_WORKAROUND_SKIPS = frozenset()
 
 
 def get_flashinfer_autotune_skip_ops(model_runner: ModelRunner) -> set[str]:
-    skip_ops = set(model_runner.server_args.flashinfer_autotune_skip_ops or ())
+    skip_ops = set(get_exec().kernel.flashinfer_autotune_skip_ops or ())
     skip_ops.update(FLASHINFER_AUTOTUNE_WORKAROUND_SKIPS)
     return skip_ops
 
@@ -49,28 +54,29 @@ def should_run_flashinfer_autotune(
     mr = model_runner
     if mr.device != "cuda":
         return False
-    if mr.server_args.disable_flashinfer_autotune:
+    if get_exec().kernel.disable_flashinfer_autotune:
         return False
-    if mr.server_args.enable_deterministic_inference:
+    if get_exec().deterministic.enable_deterministic_inference:
         # Tuned configs are per problem shape, so the reduction order would follow
         # the batch shape.
         return False
 
-    server_args = mr.server_args
     if for_speculative_draft:
         backend_str = (
-            server_args.speculative_moe_runner_backend or server_args.moe_runner_backend
+            get_spec().speculative_moe_runner_backend
+            or get_exec().moe.moe_runner_backend
         )
         a2a_backend_str = (
-            server_args.speculative_moe_a2a_backend or server_args.moe_a2a_backend
+            get_spec().speculative_moe_a2a_backend or get_exec().moe.moe_a2a_backend
         )
     else:
-        backend_str = server_args.moe_runner_backend
-        a2a_backend_str = server_args.moe_a2a_backend
+        backend_str = get_exec().moe.moe_runner_backend
+        a2a_backend_str = get_exec().moe.moe_a2a_backend
 
     # Autotune can run before the MoE backend globals are initialized, so read
-    # the target or draft backend from server_args. CuteDSL v1 bypasses
-    # MoeRunner, and its dummy dispatch can exceed DeepEP low-latency's token limit.
+    # the configured backends -- the draft leaves (`get_spec()`) or the target
+    # leaves (`get_exec().moe`) above. CuteDSL v1 bypasses MoeRunner, and its
+    # dummy dispatch can exceed DeepEP low-latency's token limit.
     if backend_str == "flashinfer_cutedsl" and a2a_backend_str == "deepep":
         return False
 
@@ -130,12 +136,11 @@ def flashinfer_autotune_cache_path(model_runner: ModelRunner) -> Path:
     arch = f"sm{major}{minor}"
     flashinfer_version = getattr(flashinfer, "__version__", "unknown")
 
-    server_args = mr.server_args
     model_key_parts = [
-        str(server_args.model_path),
+        str(get_model().model_path),
         str(mr.dtype),
-        str(server_args.quantization),
-        str(server_args.moe_runner_backend),
+        str(get_model().quantization),
+        str(get_exec().moe.moe_runner_backend),
         str(mr.ps.tp_size),
         str(mr.ps.pp_size),
         str(mr.ps.attn_dp_size),

--- a/python/sglang/srt/models/inkling_common/attn.py
+++ b/python/sglang/srt/models/inkling_common/attn.py
@@ -30,9 +30,11 @@ from sglang.srt.models.inkling_common.norm import RMSNorm
 from sglang.srt.models.inkling_common.sconv import SconvType, ShortConvolution
 from sglang.srt.models.utils import apply_qk_norm
 from sglang.srt.runtime_context import (
+    attention_backends,
     get_exec,
     get_model,
     get_parallel,
+    get_spec,
 )
 from sglang.srt.utils import add_prefix, get_current_device_stream_fast
 
@@ -103,6 +105,30 @@ _REL_PROJ_MATMUL_MAX_T = 48
 # the kernel's launch floor loses -- there is no hidden copy to remove at
 # t=1 (r is contiguous).
 _REL_PROJ_TAU_KERNEL_MAX_T = 32
+
+
+def serving_attention_backend(forward_batch: ForwardBatch) -> str:
+    """The pair member serving this forward.
+
+    Mirrors ``HybridAttnBackend._select_backend`` exactly: decode for
+    decode/idle, the ``speculative_attention_mode`` half for target-verify,
+    prefill otherwise -- including draft-extend, which the hybrid dispatcher
+    routes through its prefill branch. The pair the runner stamped on its
+    backend wins over the configured one, so a draft runner answers with its
+    own backend.
+    """
+    from sglang.srt.model_executor.forward_context import get_attn_backend
+
+    backend = get_attn_backend()
+    configured_prefill, configured_decode = attention_backends()
+    prefill = backend.prefill_attention_backend_str or configured_prefill
+    decode = backend.decode_attention_backend_str or configured_decode
+    mode = forward_batch.forward_mode
+    if mode.is_decode_or_idle():
+        return decode
+    if mode.is_target_verify():
+        return decode if get_spec().speculative_attention_mode == "decode" else prefill
+    return prefill
 
 
 def _rel_proj_kernel_eligible(r: torch.Tensor) -> bool:
@@ -735,7 +761,9 @@ class InklingAttention(nn.Module):
 
         apply_log_scaling = log_scaling_tau is not None and not self.is_local
 
-        attention_backend = get_exec().kernel.attention_backend
+        # The kwargs below must describe the backend `self.attn` dispatches
+        # this forward to.
+        attention_backend = serving_attention_backend(forward_batch)
         assert attention_backend in ("fa4", "triton")
         # The overlap threads a CUDA event into the FA4 sheared-bias kernel, so it
         # is FA4-only for now.

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1434,6 +1434,35 @@ def remote_instance_transfer_engine_enabled(load_format: str | None = None) -> b
     return remote_instance_transfer_engine_of(get_model(), load_format)
 
 
+def max_prefill_buffer_tokens() -> int:
+    """The prefill-buffer ceiling: ``chunked_prefill_size``, except PP dynamic
+    chunking can grow chunks toward ``max_prefill_tokens`` and probe at 1.25x.
+
+    Every input is a published leaf (``schedule`` plus the configured PP size),
+    so this derives from the bags and follows a post-publish override;
+    ``ServerArgs.max_prefill_buffer_tokens`` is the pre-publish equivalent and
+    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal.
+    """
+    import math
+
+    schedule = get_schedule()
+    chunked = (
+        schedule.chunked_prefill_size
+        if schedule.chunked_prefill_size and schedule.chunked_prefill_size > 0
+        else 0
+    )
+    tokens = chunked
+    if (
+        schedule.enable_dynamic_chunking
+        and _configured_parallel("pp_size") > 1
+        and chunked
+    ):
+        tokens = max(
+            tokens, schedule.max_prefill_tokens or 0, math.ceil(chunked * 1.25)
+        )
+    return tokens
+
+
 def pre_capture_activation_reserve_mb(gpu_mem: float | None) -> float:
     """The activation working-set reserve held back before cuda-graph capture.
 

--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1420,6 +1420,53 @@ def mamba_extra_buffer_lazy_enabled() -> bool:
     )
 
 
+def remote_instance_transfer_engine_enabled(load_format: str | None = None) -> bool:
+    """Whether remote-instance weight loading runs over the transfer engine.
+
+    Every input is a ``model`` leaf, so this derives from the bags and follows a
+    post-publish override; ``ServerArgs.remote_instance_weight_loader_use_transfer_engine``
+    is the pre-publish equivalent, and both go through the same helper.
+    ``load_format`` is the caller's own (a draft runner loading under
+    ``--speculative-draft-load-format`` has one the process record does not).
+    """
+    from sglang.srt.arg_groups.overrides import remote_instance_transfer_engine_of
+
+    return remote_instance_transfer_engine_of(get_model(), load_format)
+
+
+def pre_capture_activation_reserve_mb(gpu_mem: float | None) -> float:
+    """The activation working-set reserve held back before cuda-graph capture.
+
+    Derived from published leaves across four bags (``disagg`` / ``schedule`` /
+    ``exec.graph`` / ``spec``) plus the configured parallel sizes, so it follows
+    a post-publish override; ``ServerArgs.pre_capture_activation_reserve_mb`` is
+    the pre-publish equivalent and
+    ``TestDerivedPredicatesAgreeAcrossTiers`` pins the two equal.
+    """
+    schedule = get_schedule()
+    if get_disagg().disaggregation_mode == "decode":
+        running_requests = (
+            schedule.max_running_requests
+            or get_exec().graph.cuda_graph_config.decode.max_bs
+            or 1
+        )
+        activation_tokens = max(
+            running_requests * (get_spec().speculative_num_draft_tokens or 1), 2048
+        )
+    elif schedule.chunked_prefill_size > 0:
+        activation_tokens = max(schedule.chunked_prefill_size, 2048)
+    else:
+        activation_tokens = max(schedule.max_prefill_tokens, 2048)
+    reserved_mem = (
+        512
+        + activation_tokens * 1.5
+        + _configured_parallel("tp_size") * _configured_parallel("pp_size") / 8 * 1024
+    )
+    if gpu_mem is not None and gpu_mem > 60 * 1024:
+        reserved_mem = max(reserved_mem, 10 * 1024)
+    return reserved_mem
+
+
 # --- Derived config accessors ------------------------------------------------
 #
 # A few values are computed from several config fields plus the HF config, so

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -44,6 +44,7 @@ from sglang.srt.arg_groups.overrides import (
     attention_backends_of,
     mamba_extra_buffer_lazy_of,
     mamba_extra_buffer_of,
+    remote_instance_transfer_engine_of,
     resolved_view,
 )
 from sglang.srt.configs.embedding_model_spec import BCGPrefillPolicy
@@ -9470,20 +9471,7 @@ class ServerArgs:
     def remote_instance_weight_loader_use_transfer_engine(self, load_format=None):
         """``load_format`` overrides the seed's: a draft runner loading under
         ``--speculative-draft-load-format`` needs its own transfer engine."""
-        # Use TransferEngine as seed backend.
-        if self.remote_instance_weight_loader_start_seed_via_transfer_engine:
-            return True
-        # Use TransferEngine as client backend.
-        if (load_format or self.load_format) == "remote_instance" and (
-            self.remote_instance_weight_loader_backend == "transfer_engine"
-            or (
-                self.remote_instance_weight_loader_backend == "modelexpress"
-                and self.modelexpress_transport == "transfer_engine"
-            )
-        ):
-            return True
-        else:
-            return False
+        return remote_instance_transfer_engine_of(self, load_format)
 
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3527,6 +3527,9 @@ class ServerArgs:
     ] = None
 
     def __post_init__(self):
+        self._run_resolution_pipeline()
+
+    def _run_resolution_pipeline(self):
         """
         Orchestrates the handling of various server arguments, ensuring proper configuration and validation.
 

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -11,7 +11,7 @@ from sglang.srt.model_executor.graph_memory_usage import (
     merge_graph_memory_usage,
     merge_graph_time_usage,
 )
-from sglang.srt.runtime_context import get_exec, get_schedule
+from sglang.srt.runtime_context import get_exec, get_memory, get_schedule
 
 if TYPE_CHECKING:
     from sglang.srt.managers.io_struct import (
@@ -235,7 +235,7 @@ class BaseSpecWorker(ABC):
         target_model_runner = self.target_worker.model_runner
         target_model_runner.mtp_draft_device_pools = ()
         spec_algorithm = target_model_runner.spec_algorithm
-        if not self.server_args.enable_hierarchical_cache:
+        if not get_memory().enable_hierarchical_cache:
             return HiCacheDraftPlan()
 
         draft_runners = self._draft_model_runners()

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -28,7 +28,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     ForwardMode,
     compute_position,
 )
-from sglang.srt.runtime_context import get_exec
+from sglang.srt.runtime_context import get_exec, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
@@ -189,7 +189,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self._need_mamba_verify_commit = False
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = (
             server_args.speculative_draft_window_size

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,5 +1,4 @@
-from sglang.srt.runtime_context import get_spec
-from sglang.srt.server_args import ServerArgs
+from sglang.srt.runtime_context import attention_backends, get_spec
 from sglang.srt.utils.common import (
     cpu_has_amx_support,
     is_blackwell,
@@ -28,13 +27,11 @@ def _assert_draft_needs_no_conv_sidecar(draft_model_runner) -> None:
 class DraftBackendFactory:
     def __init__(
         self,
-        server_args: ServerArgs,
         draft_model_runner,
         topk: int,
         speculative_num_steps: int,
         seed_dsa_topk_from_draft_extend: bool = False,
     ):
-        self.server_args = server_args
         self.draft_model_runner = draft_model_runner
         self.topk = topk
         self.speculative_num_steps = speculative_num_steps
@@ -45,13 +42,14 @@ class DraftBackendFactory:
     def _create_backend(
         self, backend_name: str, backend_map: dict, error_template: str
     ):
-        backend_type = (
-            self.draft_attn_backend
-            if self.draft_attn_backend
-            else getattr(self.server_args, backend_name)
+        # The split pair with the base-backend fallback already applied.
+        prefill_backend, decode_backend = attention_backends()
+        configured = (
+            decode_backend
+            if backend_name == "decode_attention_backend"
+            else prefill_backend
         )
-        if backend_type is None:
-            backend_type = self.server_args.attention_backend
+        backend_type = self.draft_attn_backend or configured
 
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -40,7 +40,11 @@ class DraftBackendFactory:
         self.draft_attn_backend = draft_model_runner.draft_attention_backend
 
     def _create_backend(
-        self, backend_name: str, backend_map: dict, error_template: str
+        self,
+        backend_name: str,
+        backend_map: dict,
+        error_template: str,
+        stamps_children: bool = False,
     ):
         # The split pair with the base-backend fallback already applied.
         prefill_backend, decode_backend = attention_backends()
@@ -54,7 +58,15 @@ class DraftBackendFactory:
         if backend_type not in backend_map:
             raise ValueError(error_template.format(backend_type=backend_type))
 
-        return backend_map[backend_type]()
+        stamp, backend = backend_map[backend_type]()
+        if backend is not None:
+            backend.prefill_attention_backend_str = stamp
+            backend.decode_attention_backend_str = stamp
+            if stamps_children:
+                for child in backend.attn_backends:
+                    child.prefill_attention_backend_str = stamp
+                    child.decode_attention_backend_str = stamp
+        return backend
 
     def create_decode_backend(self):
         # No multi-step draft backend for steps=0 (nospec) or steps=1.
@@ -88,6 +100,7 @@ class DraftBackendFactory:
             "decode_attention_backend",
             backend_map,
             "EAGLE is not supported in decode attention backend {backend_type}",
+            stamps_children=True,
         )
 
     def create_draft_extend_backend(self):
@@ -125,27 +138,41 @@ class DraftBackendFactory:
             attn_backend_wrapper_for_draft_extend,
         )
 
-        return attn_backend_wrapper_for_draft_extend(self.draft_model_runner, backend)
+        wrapped = attn_backend_wrapper_for_draft_extend(
+            self.draft_model_runner, backend
+        )
+        if wrapped is not backend and wrapped is not None and backend is not None:
+            wrapped.prefill_attention_backend_str = (
+                backend.prefill_attention_backend_str
+            )
+            wrapped.decode_attention_backend_str = backend.decode_attention_backend_str
+        return wrapped
 
     def _create_dsa_decode_backend(self):
         from sglang.srt.layers.attention.dsa_backend import (
             DeepseekSparseAttnMultiStepBackend,
         )
 
-        return DeepseekSparseAttnMultiStepBackend(
-            self.draft_model_runner,
-            self.topk,
-            self.speculative_num_steps,
-            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+        return (
+            "dsa",
+            DeepseekSparseAttnMultiStepBackend(
+                self.draft_model_runner,
+                self.topk,
+                self.speculative_num_steps,
+                seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+            ),
         )
 
     def _create_dsa_prefill_backend(self):
         from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
 
-        return DeepseekSparseAttnBackend(
-            self.draft_model_runner,
-            skip_prefill=False,
-            seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+        return (
+            "dsa",
+            DeepseekSparseAttnBackend(
+                self.draft_model_runner,
+                skip_prefill=False,
+                seed_dsa_topk_from_draft_extend=self.seed_dsa_topk_from_draft_extend,
+            ),
         )
 
     def _create_flashinfer_decode_backend(self):
@@ -154,16 +181,22 @@ class DraftBackendFactory:
                 FlashInferMultiStepDraftBackend,
             )
 
-            return FlashInferMultiStepDraftBackend(
-                self.draft_model_runner, self.topk, self.speculative_num_steps
+            return (
+                "flashinfer",
+                FlashInferMultiStepDraftBackend(
+                    self.draft_model_runner, self.topk, self.speculative_num_steps
+                ),
             )
         else:
             from sglang.srt.layers.attention.flashinfer_mla_backend import (
                 FlashInferMLAMultiStepDraftBackend,
             )
 
-            return FlashInferMLAMultiStepDraftBackend(
-                self.draft_model_runner, self.topk, self.speculative_num_steps
+            return (
+                "flashinfer",
+                FlashInferMLAMultiStepDraftBackend(
+                    self.draft_model_runner, self.topk, self.speculative_num_steps
+                ),
             )
 
     def _create_triton_decode_backend(self):
@@ -171,8 +204,11 @@ class DraftBackendFactory:
             TritonMultiStepDraftBackend,
         )
 
-        return TritonMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "triton",
+            TritonMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_intel_amx_decode_backend(self):
@@ -180,8 +216,11 @@ class DraftBackendFactory:
             IntelAMXMultiStepDraftBackend,
         )
 
-        return IntelAMXMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "intel_amx",
+            IntelAMXMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_hybrid_linear_attn_decode_backend(self):
@@ -201,8 +240,11 @@ class DraftBackendFactory:
     def _create_aiter_decode_backend(self):
         from sglang.srt.layers.attention.aiter_backend import AiterMultiStepDraftBackend
 
-        return AiterMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "aiter",
+            AiterMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_fa_decode_backend(self, fa_impl_ver: int = 3):
@@ -215,11 +257,14 @@ class DraftBackendFactory:
                 MusaFlashAttentionMultiStepBackend as FlashAttentionMultiStepBackend,
             )
 
-        return FlashAttentionMultiStepBackend(
-            self.draft_model_runner,
-            self.topk,
-            self.speculative_num_steps,
-            fa_impl_ver=fa_impl_ver,
+        return (
+            f"fa{fa_impl_ver}",
+            FlashAttentionMultiStepBackend(
+                self.draft_model_runner,
+                self.topk,
+                self.speculative_num_steps,
+                fa_impl_ver=fa_impl_ver,
+            ),
         )
 
     def _create_fa3_decode_backend(self):
@@ -233,8 +278,11 @@ class DraftBackendFactory:
             FlashMLAMultiStepDraftBackend,
         )
 
-        return FlashMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "flashmla",
+            FlashMLAMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_trtllm_mha_decode_backend(self):
@@ -242,8 +290,11 @@ class DraftBackendFactory:
             TRTLLMHAAttnMultiStepDraftBackend,
         )
 
-        return TRTLLMHAAttnMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "trtllm_mha",
+            TRTLLMHAAttnMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_trtllm_mla_decode_backend(self, backend: str = "trtllm-gen"):
@@ -256,11 +307,14 @@ class DraftBackendFactory:
             TRTLLMMLAMultiStepDraftBackend,
         )
 
-        return TRTLLMMLAMultiStepDraftBackend(
-            self.draft_model_runner,
-            self.topk,
-            self.speculative_num_steps,
-            backend=backend,
+        return (
+            "trtllm_mla",
+            TRTLLMMLAMultiStepDraftBackend(
+                self.draft_model_runner,
+                self.topk,
+                self.speculative_num_steps,
+                backend=backend,
+            ),
         )
 
     def _create_cutedsl_mla_decode_backend(self):
@@ -273,8 +327,11 @@ class DraftBackendFactory:
             CuteDslMLAMultiStepDraftBackend,
         )
 
-        return CuteDslMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "cutedsl_mla",
+            CuteDslMLAMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_tokenspeed_mla_decode_backend(self):
@@ -287,8 +344,11 @@ class DraftBackendFactory:
             TokenspeedMLAMultiStepDraftBackend,
         )
 
-        return TokenspeedMLAMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "tokenspeed_mla",
+            TokenspeedMLAMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_ascend_decode_backend(self):
@@ -296,8 +356,11 @@ class DraftBackendFactory:
             AscendAttnMultiStepDraftBackend,
         )
 
-        return AscendAttnMultiStepDraftBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "ascend",
+            AscendAttnMultiStepDraftBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_dsv4_decode_backend(self):
@@ -307,8 +370,11 @@ class DraftBackendFactory:
                 DeepseekV4AscendMultiStepDraftBackend,
             )
 
-            return DeepseekV4AscendMultiStepDraftBackend(
-                self.draft_model_runner, self.topk, self.speculative_num_steps
+            return (
+                "dsv4",
+                DeepseekV4AscendMultiStepDraftBackend(
+                    self.draft_model_runner, self.topk, self.speculative_num_steps
+                ),
             )
         elif is_hip():
             from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
@@ -319,8 +385,11 @@ class DraftBackendFactory:
                 DeepseekV4MultiStepBackend,
             )
 
-        return DeepseekV4MultiStepBackend(
-            self.draft_model_runner, self.topk, self.speculative_num_steps
+        return (
+            "dsv4",
+            DeepseekV4MultiStepBackend(
+                self.draft_model_runner, self.topk, self.speculative_num_steps
+            ),
         )
 
     def _create_flashinfer_prefill_backend(self):
@@ -329,28 +398,37 @@ class DraftBackendFactory:
                 FlashInferAttnBackend,
             )
 
-            return FlashInferAttnBackend(self.draft_model_runner, skip_prefill=False)
+            return (
+                "flashinfer",
+                FlashInferAttnBackend(self.draft_model_runner, skip_prefill=False),
+            )
         else:
             from sglang.srt.layers.attention.flashinfer_mla_backend import (
                 FlashInferMLAAttnBackend,
             )
 
-            return FlashInferMLAAttnBackend(self.draft_model_runner, skip_prefill=False)
+            return (
+                "flashinfer",
+                FlashInferMLAAttnBackend(self.draft_model_runner, skip_prefill=False),
+            )
 
     def _create_triton_prefill_backend(self):
         from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
 
-        return TritonAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "triton",
+            TritonAttnBackend(self.draft_model_runner, skip_prefill=False),
+        )
 
     def _create_intel_amx_prefill_backend(self):
         from sglang.srt.layers.attention.intel_amx_backend import IntelAMXAttnBackend
 
-        return IntelAMXAttnBackend(self.draft_model_runner)
+        return ("intel_amx", IntelAMXAttnBackend(self.draft_model_runner))
 
     def _create_aiter_prefill_backend(self):
         from sglang.srt.layers.attention.aiter_backend import AiterAttnBackend
 
-        return AiterAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return ("aiter", AiterAttnBackend(self.draft_model_runner, skip_prefill=False))
 
     def _create_fa_prefill_backend(self, fa_impl_ver: int = 3):
         if not is_musa():
@@ -361,8 +439,11 @@ class DraftBackendFactory:
             from sglang.srt.hardware_backend.musa.attention.flashattention_backend import (
                 MusaFlashAttentionBackend as FlashAttentionBackend,
             )
-        return FlashAttentionBackend(
-            self.draft_model_runner, skip_prefill=False, fa_impl_ver=fa_impl_ver
+        return (
+            f"fa{fa_impl_ver}",
+            FlashAttentionBackend(
+                self.draft_model_runner, skip_prefill=False, fa_impl_ver=fa_impl_ver
+            ),
         )
 
     def _create_fa3_prefill_backend(self):
@@ -374,7 +455,10 @@ class DraftBackendFactory:
     def _create_trtllm_mha_prefill_backend(self):
         from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 
-        return TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "trtllm_mha",
+            TRTLLMHAAttnBackend(self.draft_model_runner, skip_prefill=False),
+        )
 
     def _create_trtllm_mla_prefill_backend(self):
         if not self.draft_model_runner.use_mla_backend:
@@ -384,7 +468,10 @@ class DraftBackendFactory:
 
         from sglang.srt.layers.attention.trtllm_mla_backend import TRTLLMMLABackend
 
-        return TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "trtllm_mla",
+            TRTLLMMLABackend(self.draft_model_runner, skip_prefill=False),
+        )
 
     def _create_tokenspeed_mla_prefill_backend(self):
         if not self.draft_model_runner.use_mla_backend:
@@ -396,19 +483,25 @@ class DraftBackendFactory:
             TokenspeedMLABackend,
         )
 
-        return TokenspeedMLABackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "tokenspeed_mla",
+            TokenspeedMLABackend(self.draft_model_runner, skip_prefill=False),
+        )
 
     def _create_ascend_prefill_backend(self):
         from sglang.srt.hardware_backend.npu.attention.ascend_backend import (
             AscendAttnBackend,
         )
 
-        return AscendAttnBackend(self.draft_model_runner)
+        return ("ascend", AscendAttnBackend(self.draft_model_runner))
 
     def _create_flashmla_prefill_backend(self):
         from sglang.srt.layers.attention.flashmla_backend import FlashMLABackend
 
-        return FlashMLABackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "flashmla",
+            FlashMLABackend(self.draft_model_runner, skip_prefill=False),
+        )
 
     def _create_dsv4_prefill_backend(self):
         # On NPU the "dsv4" backend resolves to the Ascend V4 subclass; its
@@ -418,17 +511,21 @@ class DraftBackendFactory:
                 ATTENTION_BACKENDS,
             )
 
-            return ATTENTION_BACKENDS["dsv4"](self.draft_model_runner)
+            return ("dsv4", ATTENTION_BACKENDS["dsv4"](self.draft_model_runner))
         elif is_hip():
             from sglang.srt.layers.attention.deepseek_v4_backend_hip_radix import (
                 DeepseekV4HipRadixBackend,
             )
 
-            return DeepseekV4HipRadixBackend(
-                self.draft_model_runner, skip_prefill=False
+            return (
+                "dsv4",
+                DeepseekV4HipRadixBackend(self.draft_model_runner, skip_prefill=False),
             )
         from sglang.srt.layers.attention.deepseek_v4_backend import (
             DeepseekV4AttnBackend,
         )
 
-        return DeepseekV4AttnBackend(self.draft_model_runner, skip_prefill=False)
+        return (
+            "dsv4",
+            DeepseekV4AttnBackend(self.draft_model_runner, skip_prefill=False),
+        )

--- a/python/sglang/srt/speculative/dspark_components/dspark_planner.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_planner.py
@@ -1139,6 +1139,6 @@ def build_sps_cost_table(
         return load_sps_table_from_path(sps_table_path)
     max_batch_tokens = max(
         1,
-        int(server_args.max_running_requests or 1) * verify_num_draft_tokens,
+        int(get_schedule().max_running_requests or 1) * verify_num_draft_tokens,
     )
     return build_uninitialized_sps_table(max_batch_tokens=max_batch_tokens)

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -229,7 +229,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             and is_cuda()
         ):
             self._verify_epilogue = DsparkVerifyEpilogue(
-                max_bs=max(server_args.cuda_graph_config.decode.bs),
+                max_bs=max(get_exec().graph.cuda_graph_config.decode.bs),
                 verify_num_draft_tokens=self.verify_num_draft_tokens,
                 device=self.device,
                 commit_ctx=CommitInjectCtx(

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -18,7 +18,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     compute_position,
 )
-from sglang.srt.runtime_context import get_exec, get_parallel, get_spec
+from sglang.srt.runtime_context import get_exec, get_parallel, get_schedule, get_spec
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
@@ -88,7 +88,7 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.nccl_port = nccl_port
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.device = target_worker.device
 
         self._draft_is_moe = draft_is_deepseek_v4(server_args=server_args)

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -320,7 +320,6 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.draft_extend_attn_backend = None
 
         draft_backend_factory = DraftBackendFactory(
-            self.server_args,
             self.draft_runner,
             self.topk,
             self.speculative_num_steps,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -50,6 +50,7 @@ from sglang.srt.runtime_context import (
     get_exec,
     get_model,
     get_parallel,
+    get_schedule,
     get_spec,
 )
 from sglang.srt.server_args import ServerArgs
@@ -1024,7 +1025,7 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
+++ b/python/sglang/srt/speculative/frozen_kv_mtp_worker_v2.py
@@ -44,7 +44,7 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
-from sglang.srt.runtime_context import attention_backends, get_spec
+from sglang.srt.runtime_context import attention_backends, get_schedule, get_spec
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.eagle_utils import (
@@ -109,7 +109,7 @@ class FrozenKVMTPDraftWorker(EagleDraftWorkerBase, TpModelWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self.target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
@@ -697,7 +697,7 @@ class FrozenKVMTPWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -43,6 +43,7 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     ForwardBatch,
 )
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.draft_utils import DraftBackendFactory
@@ -933,7 +934,7 @@ class MultiLayerEagleWorkerV2(BaseSpecWorker):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -362,7 +362,6 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
         self.draft_extend_attn_backend_list = []
         for step in range(self.speculative_num_steps):
             draft_backend_factory = DraftBackendFactory(
-                self.server_args,
                 self.draft_runner_list[step],
                 self.topk,
                 self.speculative_num_steps,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -15,6 +15,7 @@ from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.observability.req_time_stats import set_time_batch
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker, EagleDraftWorkerBase
 from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
@@ -91,7 +92,7 @@ class NGRAMWorker(BaseSpecWorker):
         self._target_worker = target_worker
         self.model_runner = target_worker.model_runner
         self.tp_rank = ps.tp_rank
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.draft_token_num: int = server_args.speculative_num_draft_tokens
         self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens

--- a/python/sglang/srt/speculative/standalone_worker_v2.py
+++ b/python/sglang/srt/speculative/standalone_worker_v2.py
@@ -10,6 +10,7 @@ from sglang.srt.layers.moe.utils import (
     speculative_moe_backend_context,
 )
 from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.runtime_context import get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.adaptive_runtime_state import (
     AdaptiveController,
@@ -163,7 +164,7 @@ class StandaloneWorkerV2(EAGLEWorkerV2):
         self.gpu_id = gpu_id
         self.device = server_args.device
         self._target_worker = target_worker
-        self.page_size = server_args.page_size
+        self.page_size = get_schedule().page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -3903,14 +3903,20 @@ def ceil_align(x: int, y: int) -> int:
     return ceil_div(x, y) * y
 
 
-def spec_decode_alloc_len_per_request(server_args) -> int:
+def spec_decode_alloc_len_per_request(
+    *,
+    page_size,
+    speculative_num_steps,
+    speculative_eagle_topk,
+    speculative_num_draft_tokens,
+) -> int:
     """Per-request KV tokens a (spec-v1) decode step allocates: the draft-decode
-    topk*num_steps peak vs. the verify num_draft_tokens, page-aligned.
+    topk*num_steps peak vs. the verify num_draft_tokens, page-aligned. A pure
+    function of the resolved values its one caller reads off the bags.
     """
-    page_size = server_args.page_size
-    len_per_topk = server_args.speculative_num_steps or 1
-    spec_topk = server_args.speculative_eagle_topk or 1
-    spec_tokens = server_args.speculative_num_draft_tokens or 1
+    len_per_topk = speculative_num_steps or 1
+    spec_topk = speculative_eagle_topk or 1
+    spec_tokens = speculative_num_draft_tokens or 1
 
     if page_size > 1 and spec_topk > 1:
         # last partial page and ceil alignment

--- a/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/gdn_attention.py
@@ -16,7 +16,7 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     HybridLinearAttnBackend,
 )
 from sglang.srt.layers.attention.linear.gdn_backend import GDNAttnBackend
-from sglang.srt.layers.attention.linear.utils import initialize_linear_attn_config
+from sglang.srt.layers.attention.linear.utils import resolve_linear_attn_backends
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import (
     HybridReqToTokenPool,
@@ -605,7 +605,9 @@ def build_gdn_attention_fixture(
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
 
-    initialize_linear_attn_config(runner.server_args)
+    # Standing in for `attn_backend_wrapper`, which is what stamps this on a
+    # runner before building the backend that reads it.
+    runner.linear_attn_backends = resolve_linear_attn_backends()
     linear_backend = GDNAttnBackend(runner)
     if case.linear_attn_prefill_backend == "flashinfer":
         from sglang.srt.layers.attention.linear.kernels.gdn_flashinfer import (

--- a/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/kda_attention.py
@@ -16,7 +16,7 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     HybridLinearAttnBackend,
 )
 from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
-from sglang.srt.layers.attention.linear.utils import initialize_linear_attn_config
+from sglang.srt.layers.attention.linear.utils import resolve_linear_attn_backends
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import (
     HybridReqToTokenPool,
@@ -609,7 +609,9 @@ def build_kda_attention_fixture(
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
 
-    initialize_linear_attn_config(runner.server_args)
+    # Standing in for `attn_backend_wrapper`, which is what stamps this on a
+    # runner before building the backend that reads it.
+    runner.linear_attn_backends = resolve_linear_attn_backends()
     linear_backend = KDAAttnBackend(runner)
     backend = HybridLinearAttnBackend(full_backend, linear_backend, full_attn_layers=[])
     actual_module = ProjectedKDAAttention(

--- a/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/lightning_attention.py
@@ -15,7 +15,7 @@ from sglang.srt.layers.attention.attention_registry import ATTENTION_BACKENDS
 from sglang.srt.layers.attention.linear.lightning_backend import (
     LightningAttentionBackend,
 )
-from sglang.srt.layers.attention.linear.utils import initialize_linear_attn_config
+from sglang.srt.layers.attention.linear.utils import resolve_linear_attn_backends
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.mem_cache.memory_pool import (
     HybridReqToTokenPool,
@@ -581,7 +581,9 @@ def build_lightning_attention_fixture(
     except (AssertionError, ImportError, ModuleNotFoundError) as exc:
         testcase.skipTest(f"{case.backend} backend is not available: {exc}")
 
-    initialize_linear_attn_config(runner.server_args)
+    # Standing in for `attn_backend_wrapper`, which is what stamps this on a
+    # runner before building the backend that reads it.
+    runner.linear_attn_backends = resolve_linear_attn_backends()
     backend = LightningAttentionBackend(runner)
     actual_module = ProjectedLightningAttention(
         num_heads=case.num_heads,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_extend_runner.py
@@ -498,7 +498,6 @@ def _build_eagle_draft_extend_fixture(
         speculative_attention_mode="prefill",
     )
     draft_extend_attn_backend = DraftBackendFactory(
-        fixture.runner.server_args,
         fixture.runner,
         settings.topk,
         settings.speculative_num_steps,

--- a/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
+++ b/python/sglang/test/kits/attention_unittest/runner_modes/speculative_draft_runner.py
@@ -359,7 +359,6 @@ def _build_eagle_draft_fixture(
     )
     _configure_runner_for_eagle_draft(fixture.runner, case, settings)
     draft_attn_backend = DraftBackendFactory(
-        fixture.runner.server_args,
         fixture.runner,
         settings.topk,
         settings.speculative_num_steps,

--- a/test/registered/spec/dspark/test_dspark_sps_table.py
+++ b/test/registered/spec/dspark/test_dspark_sps_table.py
@@ -1,7 +1,6 @@
 import tempfile
 import unittest
 from pathlib import Path
-from types import SimpleNamespace
 
 from sglang.srt.speculative.dspark_components.dspark_sps import (
     SpsAdditiveCostTable,
@@ -143,22 +142,30 @@ class TestProfileSpsTable(CustomTestCase):
         self.assertEqual(table.max_batch_tokens, 256)
 
 
-def _build_sps_cost_table_for(*, sps_table_path):
+def _build_sps_cost_table_for(testcase, *, sps_table_path):
+    from sglang.srt.runtime_context import get_context, get_server_args
     from sglang.srt.speculative.dspark_components.dspark_planner import (
         build_sps_cost_table,
     )
 
-    server_args = SimpleNamespace(
+    # The table bound reads `max_running_requests` from the published bags, so
+    # the case publishes it; the table path stays on the handed record, which is
+    # what `build_sps_cost_table` takes.
+    override = get_context().override_server_args(
         speculative_dspark_sps_table_path=sps_table_path,
         max_running_requests=4,
     )
-    return build_sps_cost_table(server_args=server_args, verify_num_draft_tokens=5)
+    override.install()
+    testcase.addCleanup(override.restore)
+    return build_sps_cost_table(
+        server_args=get_server_args(), verify_num_draft_tokens=5
+    )
 
 
 class TestBuildSpsCostTableContract(CustomTestCase):
     def test_unset_table_path_returns_flat_table(self):
         for sps_table_path in (None, ""):
-            table = _build_sps_cost_table_for(sps_table_path=sps_table_path)
+            table = _build_sps_cost_table_for(self, sps_table_path=sps_table_path)
             self.assertEqual(table.sample_batch_tokens, [1])
             self.assertEqual(table.sample_steps_per_sec, [1.0])
             self.assertEqual(table.max_batch_tokens, 20)
@@ -168,7 +175,7 @@ class TestBuildSpsCostTableContract(CustomTestCase):
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "sps.json"
             path.write_text(table.to_json(), encoding="utf-8")
-            loaded = _build_sps_cost_table_for(sps_table_path=str(path))
+            loaded = _build_sps_cost_table_for(self, sps_table_path=str(path))
         self.assertEqual(loaded.sample_batch_tokens, table.sample_batch_tokens)
         self.assertEqual(loaded.sample_steps_per_sec, table.sample_steps_per_sec)
         self.assertEqual(loaded.max_batch_tokens, table.max_batch_tokens)

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -86,6 +86,110 @@ def test_epd_language_only_rejects_missing_dispatched_embedding():
     assert getattr(exc_info.value, "status_code", None) == 503
 
 
+def test_epd_rejection_reads_the_resolved_transfer_backend():
+    """Tripwire for step 12: this guard fires on the *resolved* backend.
+
+    The record is produced by actual resolution -- a language-only Kimi-K3
+    launch at TP2, whose `encoder_transfer_backend` starts at the argument
+    default `"auto"` (`ENCODER_TRANSFER_BACKEND_CHOICES[0]`) and is filled in
+    by `resolve_encoder_transfer_backend` to `"zmq_to_tokenizer"`. Today the
+    guard therefore rejects. When step 12 makes the instance raw, this same
+    launch hands the guard a record still at `"auto"`, the rejection silently
+    stops, and *this test fails* -- which is the signal to give this reader
+    the resolved value (per-engine overlay or bag) rather than the record.
+    Fixed doubles cannot trip on that change, so the record here must come
+    from resolution, not a SimpleNamespace.
+    """
+    import json
+    import os
+    import shutil
+    import tempfile
+
+    from sglang.srt.server_args import ServerArgs
+
+    def env_field_flags():
+        from sglang.srt.environ import EnvField, envs
+
+        return {
+            name: field._set_to_none
+            for klass in reversed(type(envs).__mro__)
+            for name, field in vars(klass).items()
+            if isinstance(field, EnvField)
+        }
+
+    config_dir = tempfile.mkdtemp(prefix="epd_tripwire_")
+    try:
+        payload = {
+            "architectures": ["KimiK3ForConditionalGeneration"],
+            "model_type": "kimi_k3",
+            "text_config": {
+                "architectures": ["DeepseekV3ForCausalLM"],
+                "model_type": "deepseek_v3",
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "moe_intermediate_size": 32,
+                "num_attention_heads": 2,
+                "num_key_value_heads": 2,
+                "num_hidden_layers": 2,
+                "n_routed_experts": 8,
+                "n_shared_experts": 1,
+                "num_experts_per_tok": 2,
+                "first_k_dense_replace": 1,
+                "vocab_size": 128,
+                "max_position_embeddings": 2048,
+                "kv_lora_rank": 8,
+                "q_lora_rank": 8,
+                "qk_nope_head_dim": 8,
+                "qk_rope_head_dim": 8,
+                "v_head_dim": 8,
+                "topk_method": "greedy",
+                "scoring_func": "softmax",
+            },
+            "vision_config": {
+                "model_type": "kimi_k3_vision",
+                "hidden_size": 16,
+                "num_heads": 2,
+                "depth": 2,
+                "patch_size": 14,
+                "merge_kernel_size": [2, 2],
+            },
+        }
+        with open(os.path.join(config_dir, "config.json"), "w") as handle:
+            json.dump(payload, handle)
+        environ_before = dict(os.environ)
+        flags_before = env_field_flags()
+        try:
+            resolved = ServerArgs(
+                model_path=config_dir,
+                device="cuda",
+                random_seed=42,
+                language_only=True,
+                tp_size=2,
+                # Resolution branches on the host device for the hybrid
+                # state-cache sizing (extra_buffer asserts a GPU stack, which
+                # the CPU CI runner does not have); the guard under test reads
+                # `encoder_transfer_backend`, independent of that branch, so
+                # pin the strategy every host can resolve.
+                mamba_radix_cache_strategy="no_buffer",
+                disable_overlap_schedule=True,
+            )
+        finally:
+            os.environ.clear()
+            os.environ.update(environ_before)
+            from sglang.srt.environ import envs
+
+            for name, was_none in flags_before.items():
+                getattr(type(envs), name)._set_to_none = was_none
+    finally:
+        shutil.rmtree(config_dir, ignore_errors=True)
+
+    assert resolved.encoder_transfer_backend == "zmq_to_tokenizer"
+    request = SimpleNamespace(need_wait_for_mm_inputs=True)
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_missing_dispatched_encoder_embedding(resolved, request, None)
+    assert getattr(exc_info.value, "status_code", None) == 503
+
+
 def test_epd_allows_local_processing_when_request_was_not_dispatched():
     server_args = SimpleNamespace(
         language_only=True,

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -24,14 +24,29 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
+def _publish(testcase, **fields):
+    """Install a published config for one case and restore on its cleanup --
+    a failed case must not leave a partial publish for a later file in a
+    monolithic local run."""
+    from sglang.srt.runtime_context import get_context, get_server_args
+
+    override = get_context().override_server_args(**fields)
+    override.install()
+    testcase.addCleanup(override.restore)
+    return get_server_args()
+
+
 def make_runner(
+    testcase,
     *,
     state_dtype=torch.bfloat16,
     key_dim=128,
     value_dim=128,
     **arg_overrides,
 ):
-    args = SimpleNamespace(
+    # The policy reads the published bags, so the fixture publishes the
+    # configuration under test.
+    fields = dict(
         linear_attn_backend="triton",
         linear_attn_prefill_backend=None,
         uses_mamba_radix_cache=False,
@@ -40,8 +55,8 @@ def make_runner(
         enable_dynamic_chunking=False,
         chunked_prefill_size=8192,
     )
-    for name, value in arg_overrides.items():
-        setattr(args, name, value)
+    fields.update(arg_overrides)
+    args = _publish(testcase, **fields)
 
     return SimpleNamespace(
         server_args=args,
@@ -86,12 +101,13 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
             return flashinfer_gdn_prefill_default(runner)
 
     def test_selects_flashinfer_for_supported_sm100_gdn(self):
-        self.assertEqual(self.apply_policy(make_runner()), "flashinfer")
+        self.assertEqual(self.apply_policy(make_runner(self)), "flashinfer")
 
     def test_selects_flashinfer_for_radix_cache_strategies(self):
         for strategy in ("no_buffer", "extra_buffer", "extra_buffer_lazy"):
             with self.subTest(strategy=strategy):
                 runner = make_runner(
+                    self,
                     uses_mamba_radix_cache=True,
                     mamba_radix_cache_strategy=strategy,
                 )
@@ -100,7 +116,7 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
     def test_declines_when_the_prefill_backend_is_explicit(self):
         for backend in ("triton", "flashinfer", "cutedsl"):
             with self.subTest(backend=backend):
-                runner = make_runner(linear_attn_prefill_backend=backend)
+                runner = make_runner(self, linear_attn_prefill_backend=backend)
                 self.assertIsNone(self.apply_policy(runner))
 
     def test_rejects_unsupported_capability(self):
@@ -117,11 +133,11 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
         for name, runner_args, hardware in cases:
             with self.subTest(name=name):
                 self.assertIsNone(
-                    self.apply_policy(make_runner(**runner_args), **hardware)
+                    self.apply_policy(make_runner(self, **runner_args), **hardware)
                 )
 
     def test_rejects_gdn_config_without_qwen_head_dims(self):
-        runner = make_runner()
+        runner = make_runner(self)
         runner.hybrid_gdn_config = SimpleNamespace()
         self.assertIsNone(self.apply_policy(runner))
 
@@ -136,7 +152,7 @@ class TestFlashInferGDNPrefillBackendPolicy(unittest.TestCase):
         )
         for name, runner_args in cases:
             with self.subTest(name=name):
-                self.assertIsNone(self.apply_policy(make_runner(**runner_args)))
+                self.assertIsNone(self.apply_policy(make_runner(self, **runner_args)))
 
     def test_builds_compact_checkpoint_plan_for_packed_sequences(self):
         forward_batch = SimpleNamespace(

--- a/test/registered/unit/layers/attention/test_linear_attn_config.py
+++ b/test/registered/unit/layers/attention/test_linear_attn_config.py
@@ -1,80 +1,160 @@
-"""Backend selection in initialize_linear_attn_config.
+"""Each runner carries its own linear-attn kernel choice.
 
-The SM100 GDN default reaches the module state as an argument rather than as a
-ServerArgs mutation, so the precedence between an explicit flag, that default,
-and the shared base backend is pinned here.
+A target and its draft coexist in one process and can want different kernels:
+only the runner whose model is GDN gets the SM100 FlashInfer prefill default,
+and the operator's explicit flag applies to the launch. So the choice is a
+per-runner stamp read from the runner, the way the full-attention pair already
+works (`prefill_attention_backend_str` / `decode_attention_backend_str`), rather
+than one process-wide table.
+
+It used to be that table: `attn_backend_wrapper` rebuilt a module-level dict
+once per runner, from the handed record plus a local default. Two consequences,
+both pinned below -- a second runner could not hold a different choice, and its
+rebuild replaced the first runner's (the record never carries the recorded
+default, so a runner with no default of its own resolved back to the base
+backend).
 """
 
 import unittest
+from types import SimpleNamespace
 
-from sglang.srt.layers.attention.linear import utils as linear_utils
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
-    initialize_linear_attn_config,
+    resolve_linear_attn_backends,
 )
-from sglang.srt.server_args import ServerArgs
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-class TestLinearAttnConfig(CustomTestCase):
-    def setUp(self):
-        self.addCleanup(linear_utils._BACKENDS.update, linear_utils._BACKENDS.copy())
+class _Runner:
+    """The only thing the readers need from a runner: the stamp."""
 
-    def _init(self, prefill_default=None, **fields):
-        args = ServerArgs(model_path="dummy")
-        for key, value in fields.items():
-            setattr(args, key, value)
-        initialize_linear_attn_config(args, prefill_default)
-        return (
-            linear_utils.get_linear_attn_prefill_backend(),
-            linear_utils.get_linear_attn_decode_backend(),
-        )
 
-    def test_default_applies_when_the_flag_is_unset(self):
-        prefill, _ = self._init(
-            prefill_default="flashinfer", linear_attn_backend="triton"
-        )
-        self.assertEqual(prefill, LinearAttnKernelBackend.FLASHINFER)
+class TestLinearAttnBackends(CustomTestCase):
+    def _publish(self, **fields):
+        from sglang.srt.runtime_context import get_context
 
-    def test_explicit_flag_wins_over_the_default(self):
-        prefill, _ = self._init(
-            prefill_default="flashinfer",
-            linear_attn_backend="triton",
-            linear_attn_prefill_backend="cutedsl",
-        )
-        self.assertEqual(prefill, LinearAttnKernelBackend.CUTEDSL)
-
-    def test_base_backend_applies_without_a_default(self):
-        prefill, decode = self._init(linear_attn_backend="triton")
-        self.assertEqual(prefill, LinearAttnKernelBackend.TRITON)
-        self.assertEqual(decode, LinearAttnKernelBackend.TRITON)
-
-    def test_a_recorded_default_shows_in_the_resolved_config(self):
-        from sglang.srt.runtime_context import get_context, get_exec
-
-        override = get_context().override_server_args(linear_attn_backend="triton")
-        server_args = override.install()
+        override = get_context().override_server_args(**fields)
+        override.install()
         self.addCleanup(override.restore)
 
-        get_context().override(
-            "gdn_backend.sm100_flashinfer_default",
-            linear_attn_prefill_backend="flashinfer",
-        )
-        self.assertEqual(get_exec().mamba.linear_attn_prefill_backend, "flashinfer")
-        self.assertEqual(
-            get_context().resolved_server_args_dict()["linear_attn_prefill_backend"],
-            "flashinfer",
-        )
-        self.assertIsNone(server_args.linear_attn_prefill_backend)
+    def test_the_default_applies_when_the_flag_is_unset(self):
+        self._publish(linear_attn_backend="triton")
+        backends = resolve_linear_attn_backends(prefill_default="flashinfer")
+        self.assertEqual(backends.prefill, LinearAttnKernelBackend.FLASHINFER)
+
+    def test_the_base_backend_applies_without_a_default(self):
+        self._publish(linear_attn_backend="triton")
+        backends = resolve_linear_attn_backends()
+        self.assertEqual(backends.prefill, LinearAttnKernelBackend.TRITON)
+        self.assertEqual(backends.decode, LinearAttnKernelBackend.TRITON)
 
     def test_the_default_does_not_reach_the_decode_backend(self):
-        _, decode = self._init(
-            prefill_default="flashinfer", linear_attn_backend="triton"
+        self._publish(linear_attn_backend="triton")
+        backends = resolve_linear_attn_backends(prefill_default="flashinfer")
+        self.assertEqual(backends.decode, LinearAttnKernelBackend.TRITON)
+
+    def test_explicit_flag_wins_over_the_default(self):
+        """Precedence lives in the gate, which declines once the flag is set.
+
+        The resolver takes the default as an argument, so the flag has to win
+        upstream: `flashinfer_gdn_prefill_default` returns None the moment the
+        leaf is set, and that condition is checked before anything touches the
+        device -- which is what lets this run anywhere.
+        """
+        from types import SimpleNamespace
+
+        from sglang.srt.layers.attention.linear.gdn_backend import (
+            flashinfer_gdn_prefill_default,
         )
-        self.assertEqual(decode, LinearAttnKernelBackend.TRITON)
+        from sglang.srt.runtime_context import get_server_args
+
+        self._publish(
+            linear_attn_backend="triton", linear_attn_prefill_backend="cutedsl"
+        )
+        runner = SimpleNamespace(server_args=get_server_args())
+        self.assertIsNone(flashinfer_gdn_prefill_default(runner))
+        self.assertEqual(
+            resolve_linear_attn_backends().prefill, LinearAttnKernelBackend.CUTEDSL
+        )
+
+    def test_two_runners_hold_different_choices(self):
+        """The property the process-wide table could not express.
+
+        The GDN target gets the SM100 default; the draft that is not GDN has no
+        default of its own. Both stamps stand, and reading one does not disturb
+        the other -- under the old table the draft's rebuild replaced the
+        target's choice with the base backend.
+        """
+        self._publish(linear_attn_backend="triton")
+
+        target, draft = _Runner(), _Runner()
+        target.linear_attn_backends = resolve_linear_attn_backends(
+            prefill_default="flashinfer"
+        )
+        draft.linear_attn_backends = resolve_linear_attn_backends()
+
+        self.assertEqual(
+            target.linear_attn_backends.prefill, LinearAttnKernelBackend.FLASHINFER
+        )
+        self.assertEqual(
+            draft.linear_attn_backends.prefill, LinearAttnKernelBackend.TRITON
+        )
+
+    def test_an_unstamped_runner_raises_rather_than_guessing(self):
+        """No default for "nobody stamped this", on the production read path.
+
+        `attn_backend_wrapper` stamps before it builds the backends that read
+        the stamp, so a missing one means a backend was built outside that
+        path. The runner double below satisfies everything `GDNAttnBackend`
+        touches *before* the stamp read, so the `AttributeError` this asserts
+        comes from `model_runner.linear_attn_backends` itself -- a default
+        stamp on the runner or a restored module-level fallback would turn
+        this red-to-green, which is the regression it guards. Silent triton
+        fallback would hide the wiring mistake behind a working-but-wrong
+        kernel.
+        """
+        import torch
+
+        from sglang.srt.layers.attention.linear.gdn_backend import GDNAttnBackend
+
+        runner = SimpleNamespace(
+            device="cpu",
+            server_args=SimpleNamespace(
+                speculative_eagle_topk=0, enable_unified_memory=False
+            ),
+            is_draft_worker=False,
+            req_to_token_pool=SimpleNamespace(
+                mamba_pool=SimpleNamespace(
+                    mamba_cache=SimpleNamespace(conv=[torch.zeros(1, 1, 4, 7)])
+                )
+            ),
+            token_to_kv_pool=None,
+        )
+        with self.assertRaises(AttributeError) as caught:
+            GDNAttnBackend(runner)
+        self.assertIn("linear_attn_backends", str(caught.exception))
+
+    def test_the_per_runner_default_stays_out_of_the_process_config(self):
+        """The process-wide config cannot represent one runner's choice.
+
+        Recording the auto-default there is how a second runner used to inherit
+        it: the leaf then reads as "the operator named a backend", which is the
+        one question the gate asks. So the default lives in the runner's stamp
+        and the leaf keeps meaning what was asked for at launch.
+        """
+        from sglang.srt.runtime_context import get_context, get_exec
+
+        self._publish(linear_attn_backend="triton")
+        backends = resolve_linear_attn_backends(prefill_default="flashinfer")
+
+        self.assertEqual(backends.prefill, LinearAttnKernelBackend.FLASHINFER)
+        self.assertIsNone(get_exec().mamba.linear_attn_prefill_backend)
+        self.assertIsNone(
+            get_context().resolved_server_args_dict()["linear_attn_prefill_backend"]
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -19,7 +19,18 @@ from sglang.srt.mem_cache.registry import (
 from sglang.test.test_utils import CustomTestCase
 
 
+def _publish(testcase, **fields):
+    """Install a published config for one case and restore on its cleanup."""
+    from sglang.srt.runtime_context import get_context, get_server_args
+
+    override = get_context().override_server_args(**fields)
+    override.install()
+    testcase.addCleanup(override.restore)
+    return get_server_args()
+
+
 def _make_ctx(
+    testcase,
     *,
     backend=None,
     enable_streaming=False,
@@ -32,11 +43,16 @@ def _make_ctx(
     effective_chunked_prefill_size=None,
     full_tokens_per_layer=None,
 ):
-    server_args = MagicMock()
-    server_args.radix_cache_backend = backend
-    server_args.enable_streaming_session = enable_streaming
-    server_args.enable_lmcache = enable_lmcache
-    server_args.enable_flexkv = False
+    # The factory reads the published bags for the cache-backend leaves, so the
+    # fixture publishes them; the instance stays for the whole-object contract
+    # `TreeCacheBuildContext` carries.
+    server_args = _publish(
+        testcase,
+        radix_cache_backend=backend,
+        enable_streaming_session=enable_streaming,
+        enable_lmcache=enable_lmcache,
+        enable_flexkv=False,
+    )
     return TreeCacheBuildContext(
         server_args=server_args,
         params=MagicMock(),
@@ -101,14 +117,14 @@ class TestCreateTreeCacheRouting(_RegistryIsolationMixin, CustomTestCase):
         factory = MagicMock(return_value=cache)
         register_radix_cache_backend("custom", factory)
 
-        result = create_tree_cache(_make_ctx(backend="custom"))
+        result = create_tree_cache(_make_ctx(self, backend="custom"))
 
         factory.assert_called_once()
         self.assertIs(result, cache)
 
     def test_unknown_backend_raises(self):
         with self.assertRaises(ValueError):
-            create_tree_cache(_make_ctx(backend="not_a_real_backend"))
+            create_tree_cache(_make_ctx(self, backend="not_a_real_backend"))
 
     @patch("sglang.srt.mem_cache.registry.default_radix_cache_factory")
     def test_unset_backend_falls_back_to_default(self, default_factory):
@@ -116,7 +132,7 @@ class TestCreateTreeCacheRouting(_RegistryIsolationMixin, CustomTestCase):
         cache.supports_streaming_session.return_value = True
         default_factory.return_value = cache
 
-        result = create_tree_cache(_make_ctx(backend=None))
+        result = create_tree_cache(_make_ctx(self, backend=None))
 
         default_factory.assert_called_once()
         self.assertIs(result, cache)
@@ -131,7 +147,7 @@ class TestCreateTreeCacheRouting(_RegistryIsolationMixin, CustomTestCase):
         ) as session_cls:
             session_cls.return_value = MagicMock(name="wrapped")
             result = create_tree_cache(
-                _make_ctx(backend="nonstreaming", enable_streaming=True)
+                _make_ctx(self, backend="nonstreaming", enable_streaming=True)
             )
 
         session_cls.assert_called_once_with(inner)
@@ -143,7 +159,7 @@ class TestCreateTreeCacheRouting(_RegistryIsolationMixin, CustomTestCase):
         register_radix_cache_backend("streaming", MagicMock(return_value=inner))
 
         result = create_tree_cache(
-            _make_ctx(backend="streaming", enable_streaming=True)
+            _make_ctx(self, backend="streaming", enable_streaming=True)
         )
 
         self.assertIs(result, inner)
@@ -158,7 +174,9 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
     """
 
     def test_chunk_cache_when_chunked_prefill_and_disable_radix(self):
-        ctx = _make_ctx(effective_chunked_prefill_size=512, disable_radix_cache=True)
+        ctx = _make_ctx(
+            self, effective_chunked_prefill_size=512, disable_radix_cache=True
+        )
         with patch("sglang.srt.mem_cache.chunk_cache.ChunkCache") as ChunkCache:
             ChunkCache.return_value = MagicMock()
             result = default_radix_cache_factory(ctx)
@@ -167,6 +185,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
 
     def test_swa_chunk_cache_when_chunked_prefill_disable_and_hybrid_swa(self):
         ctx = _make_ctx(
+            self,
             effective_chunked_prefill_size=512,
             disable_radix_cache=True,
             is_hybrid_swa=True,
@@ -179,6 +198,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
 
     def test_pure_swa_chunk_cache_when_chunked_prefill_disable_and_all_swa(self):
         ctx = _make_ctx(
+            self,
             effective_chunked_prefill_size=512,
             disable_radix_cache=True,
             is_hybrid_swa=True,
@@ -193,7 +213,9 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, PureSWAChunkCache.return_value)
 
     def test_cpp_radix_cache_when_env_flag_set(self):
-        ctx = _make_ctx()
+        ctx = _make_ctx(
+            self,
+        )
         # `radix_cache_cpp` requires ninja + C++ extension to import, so
         # we inject a stand-in module rather than letting patch() trigger
         # the real import.
@@ -215,7 +237,9 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_module.RadixCacheCpp.return_value)
 
     def test_unified_radix_cache_when_env_flag_set(self):
-        ctx = _make_ctx()
+        ctx = _make_ctx(
+            self,
+        )
         # Shim both factory imports — each transitively loads sgl_kernel.
         fake_components = MagicMock()
         fake_radix = MagicMock()
@@ -237,7 +261,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_hi_radix_cache_when_hierarchical(self):
-        ctx = _make_ctx(enable_hierarchical_cache=True)
+        ctx = _make_ctx(self, enable_hierarchical_cache=True)
         # `hiradix_cache` imports `hicache_storage` and
         # `memory_pool_host`, both of which transitively load
         # `sgl_kernel`; inject a stand-in module.
@@ -254,7 +278,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_module.HiRadixCache.return_value)
 
     def test_unified_radix_cache_when_hierarchical_and_hybrid_ssm(self):
-        ctx = _make_ctx(enable_hierarchical_cache=True, is_hybrid_ssm=True)
+        ctx = _make_ctx(self, enable_hierarchical_cache=True, is_hybrid_ssm=True)
         # Hybrid SSM with hierarchical cache now uses UnifiedRadixCache.
         fake_components = MagicMock()
         fake_radix = MagicMock()
@@ -274,7 +298,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_unified_radix_cache_when_hierarchical_and_hybrid_swa(self):
-        ctx = _make_ctx(enable_hierarchical_cache=True, is_hybrid_swa=True)
+        ctx = _make_ctx(self, enable_hierarchical_cache=True, is_hybrid_swa=True)
         # Hybrid SWA with hierarchical cache also uses UnifiedRadixCache.
         fake_components = MagicMock()
         fake_radix = MagicMock()
@@ -294,7 +318,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_unified_radix_cache_when_hierarchical_and_dsa(self):
-        ctx = _make_ctx(enable_hierarchical_cache=True, is_dsa=True)
+        ctx = _make_ctx(self, enable_hierarchical_cache=True, is_dsa=True)
         # DSA models (e.g. DeepSeek V3.2 / GLM-5.1) with hierarchical cache
         # use UnifiedRadixCache.
         fake_components = MagicMock()
@@ -315,7 +339,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_swa_radix_cache_when_hybrid_swa(self):
-        ctx = _make_ctx(is_hybrid_swa=True)
+        ctx = _make_ctx(self, is_hybrid_swa=True)
         # SWA hybrid models now default to the unified radix tree.
         fake_components = MagicMock()
         fake_radix = MagicMock()
@@ -331,7 +355,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_pure_swa_radix_cache_when_all_swa(self):
-        ctx = _make_ctx(is_hybrid_swa=True, full_tokens_per_layer=0)
+        ctx = _make_ctx(self, is_hybrid_swa=True, full_tokens_per_layer=0)
         with patch(
             "sglang.srt.mem_cache.pure_swa_radix_cache.PureSWARadixCache"
         ) as PureSWA:
@@ -341,7 +365,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, PureSWA.return_value)
 
     def test_mamba_radix_cache_when_hybrid_ssm(self):
-        ctx = _make_ctx(is_hybrid_ssm=True)
+        ctx = _make_ctx(self, is_hybrid_ssm=True)
         # Mamba hybrid models now default to the unified radix tree.
         fake_components = MagicMock()
         fake_radix = MagicMock()
@@ -357,7 +381,7 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_radix.UnifiedRadixCache.return_value)
 
     def test_lmc_radix_cache_when_enable_lmcache(self):
-        ctx = _make_ctx(enable_lmcache=True)
+        ctx = _make_ctx(self, enable_lmcache=True)
         # The lmcache backend raises at import time when the `lmcache`
         # package isn't installed, so inject a stand-in module instead
         # of letting patch() trigger the real import.
@@ -377,7 +401,9 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
             self.assertIs(result, fake_module.LMCRadixCache.return_value)
 
     def test_fallback_to_radix_cache(self):
-        ctx = _make_ctx()
+        ctx = _make_ctx(
+            self,
+        )
         with patch("sglang.srt.mem_cache.radix_cache.RadixCache") as RadixCache:
             RadixCache.return_value = MagicMock()
             result = default_radix_cache_factory(ctx)

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
-from sglang.srt.runtime_context import get_parallel
+from sglang.srt.runtime_context import get_parallel, get_server_args
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
@@ -35,7 +35,21 @@ def mock_cpu_env(kv_size=2, tp_size=1, swa_eviction_interval=4):
         yield
 
 
+def _publish_config(testcase, **fields):
+    """Publish the configuration a runner double describes.
+
+    Installed per call and restored on the calling case's cleanup, so a failed
+    case cannot leave a partial publish for a later file in a monolithic run.
+    """
+    from sglang.srt.runtime_context import get_context
+
+    override = get_context().override_server_args(**fields)
+    override.install()
+    testcase.addCleanup(override.restore)
+
+
 def _make_model_runner(
+    testcase,
     *,
     num_kv_heads=4,
     head_dim=64,
@@ -56,7 +70,6 @@ def _make_model_runner(
     disable_overlap_schedule=False,
     sliding_window_size=None,
     speculative_num_draft_tokens=None,
-    max_speculative_num_draft_tokens=None,
     speculative_algorithm=None,
     speculative_num_steps=None,
     speculative_eagle_topk=None,
@@ -105,27 +118,29 @@ def _make_model_runner(
     mr.model_config = mc
     mr.kv_cache_dtype = "fake_bf16"
 
-    sa = SimpleNamespace()
-    sa.max_total_tokens = None
-    sa.swa_full_tokens_ratio = swa_full_tokens_ratio
-    sa.page_size = page_size
-    sa.disable_radix_cache = disable_radix_cache
-    sa.chunked_prefill_size = chunked_prefill_size
-    sa.disable_overlap_schedule = disable_overlap_schedule
-    sa.speculative_num_draft_tokens = speculative_num_draft_tokens
-    sa.max_speculative_num_draft_tokens = (
-        max_speculative_num_draft_tokens or speculative_num_draft_tokens
+    # The configurator reads the published bags, so the fixture publishes the
+    # configuration it describes. The instance stays for the whole-object
+    # hand-offs the configurator still does.
+    _publish_config(
+        testcase,
+        max_total_tokens=None,
+        swa_full_tokens_ratio=swa_full_tokens_ratio,
+        page_size=page_size,
+        disable_radix_cache=disable_radix_cache,
+        chunked_prefill_size=chunked_prefill_size,
+        disable_overlap_schedule=disable_overlap_schedule,
+        speculative_num_draft_tokens=speculative_num_draft_tokens,
+        speculative_algorithm=speculative_algorithm,
+        speculative_num_steps=speculative_num_steps,
+        speculative_eagle_topk=speculative_eagle_topk,
+        disaggregation_mode=disaggregation_mode,
+        max_running_requests=max_running_requests,
+        disaggregation_decode_extra_slots=disaggregation_decode_extra_slots,
+        enable_hisparse=False,
+        enable_dsa_cache_layer_split=False,
+        kv_cache_dtype="auto",
     )
-    sa.speculative_algorithm = speculative_algorithm
-    sa.speculative_num_steps = speculative_num_steps
-    sa.speculative_eagle_topk = speculative_eagle_topk
-    sa.disaggregation_mode = disaggregation_mode
-    sa.max_running_requests = max_running_requests
-    sa.disaggregation_decode_extra_slots = disaggregation_decode_extra_slots
-    sa.enable_hisparse = False
-    sa.enable_dsa_cache_layer_split = False
-    sa.kv_cache_dtype = "auto"
-    mr.server_args = sa
+    mr.server_args = get_server_args()
 
     spec = MagicMock()
     spec.is_eagle.return_value = False
@@ -180,7 +195,7 @@ class TestDefaultConfigurator(unittest.TestCase):
     """Default (MHA): available_bytes -> tokens, memory invariant holds."""
 
     def _run(self, available_bytes, page_size=1, **kwargs):
-        mr = _make_model_runner(page_size=page_size, **kwargs)
+        mr = _make_model_runner(self, page_size=page_size, **kwargs)
         with mock_cpu_env():
             from sglang.srt.model_executor.pool_configurator import (
                 create_memory_pool_configurator,
@@ -238,10 +253,12 @@ class TestDefaultConfigurator(unittest.TestCase):
     ):
         num_layers = 2
         raw = _make_model_runner(
+            self,
             num_layers=num_layers,
             use_mla_backend=True,
         )
         packed = _make_model_runner(
+            self,
             num_layers=num_layers,
             use_mla_backend=True,
         )
@@ -265,6 +282,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
 
     def _make_swa_runner(self, full_layers=16, swa_layers=16, ratio=0.5, page_size=1):
         return _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=list(range(full_layers)),
             swa_attention_layer_ids=list(range(full_layers, full_layers + swa_layers)),
@@ -353,6 +371,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
     def test_chunk_cache_cap_accounts_for_spec_topk_page_rounding(self):
         available = 1_000_000
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
@@ -392,6 +411,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
         # 2*chunk(4) + page(1) = 9; cap = 41 * 2 + 9 = 91.
         available = 1_000_000
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
@@ -422,6 +442,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
     def test_chunk_cache_cap_drops_prefill_for_disagg_decode(self):
         available = 1_000_000
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
@@ -452,6 +473,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
         # under overlap.
         available = 1_000_000
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
@@ -484,6 +506,7 @@ class TestHybridSWAConfigurator(unittest.TestCase):
         # request count (num_reserved_decode_tokens is a full-pool concern, not SWA).
         available = 2_000_000
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[0],
             swa_attention_layer_ids=[1],
@@ -517,6 +540,7 @@ class TestAllSWAConfigurator(unittest.TestCase):
 
     def _run(self, available_bytes, ratio=0.5, page_size=1, **kwargs):
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=[],
             swa_attention_layer_ids=list(range(32)),
@@ -569,7 +593,7 @@ class TestEagleConfigurator(unittest.TestCase):
         num_layers = 32
         eagle_draft_num_layers = 4
 
-        mr = _make_model_runner(num_layers=num_layers)
+        mr = _make_model_runner(self, num_layers=num_layers)
         mr.spec_algorithm.is_eagle.return_value = True
         mr.spec_algorithm.is_standalone.return_value = False
         mr.spec_algorithm.is_none.return_value = False
@@ -591,7 +615,7 @@ class TestEagleConfigurator(unittest.TestCase):
 
 class TestFactory(unittest.TestCase):
     def test_default_for_non_swa(self):
-        mr = _make_model_runner(is_hybrid_swa=False)
+        mr = _make_model_runner(self, is_hybrid_swa=False)
         with mock_cpu_env():
             from sglang.srt.model_executor.pool_configurator import (
                 DefaultPoolConfigurator,
@@ -603,6 +627,7 @@ class TestFactory(unittest.TestCase):
 
     def test_swa_for_hybrid(self):
         mr = _make_model_runner(
+            self,
             is_hybrid_swa=True,
             full_attention_layer_ids=list(range(16)),
             swa_attention_layer_ids=list(range(16, 32)),
@@ -621,6 +646,7 @@ class TestFactory(unittest.TestCase):
         # SWAChunkCapPoolConfigurator is selected only when max_running_requests is set.
         def _cfg(max_running_requests):
             mr = _make_model_runner(
+                self,
                 is_hybrid_swa=True,
                 full_attention_layer_ids=[0],
                 swa_attention_layer_ids=[1],
@@ -681,7 +707,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
     def test_dcp_replication_scales_draft_budget(self):
         """The replicated draft pool spans every DCP virtual location."""
         draft_kv_per_token = 10_240
-        mr = _make_model_runner()
+        mr = _make_model_runner(self)
         mr.spec_algorithm.is_dflash_family.return_value = True
         mr.spec_aux_config = SimpleNamespace(
             eagle_draft_num_layers=None,
@@ -715,6 +741,7 @@ class TestDflashDraftKvBudget(unittest.TestCase):
 
         def _tokens(draft_kv_per_token):
             mr = _make_model_runner(
+                self,
                 is_hybrid_swa=True,
                 full_attention_layer_ids=list(range(16)),
                 swa_attention_layer_ids=list(range(16, 32)),

--- a/test/registered/unit/models/test_draft_entry_hook_parity.py
+++ b/test/registered/unit/models/test_draft_entry_hook_parity.py
@@ -1,0 +1,95 @@
+"""A draft entry class answers the loader's questions exactly when its target does.
+
+The loader asks the *entry class* it instantiates for the shared-experts-fusion
+decision (`install_shared_experts_fusion_decision`). A draft is its own entry
+class -- `...NextN`, `...MTP`, `...DSpark`, `...Eagle3` -- so when the target
+family carries auto-disable conditions and the draft's class does not expose
+them, the draft resolves a *different* decision than the target it drafts for,
+and its weights are laid out for the other layout. That shipped once: the DSV4
+DSpark draft skipped its bundled shared-expert tensors until #33312 gave it the
+gate.
+
+`test_fusion_gate_coverage.py` walks the same registry but asks a different
+question: does this entry class *touch* the decision (read the flag, name a gated
+class)? That catches a class after it starts consuming the decision. It cannot
+catch one that should consume it and does not, which is what the DSpark class
+looked like: it built the family's *layer* classes, so the flag reader lived in
+another module and its own source named no gated class.
+
+This case asks the invariant directly instead: **presence parity between a draft
+entry class and its target**. Identity is deliberately not required -- a draft
+that delegates with adapted arguments (the Qwen3.5 MTP unwraps `text_config` and
+substitutes the MTP quantization config) is exactly right.
+"""
+
+import re
+import unittest
+
+from sglang.srt.models.registry import ModelRegistry
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=60, suite="base-a-test-cpu")
+
+# The hooks the loader resolves on the entry class where a draft/target
+# disagreement is a defect rather than a difference. Weight-name maps
+# (`packed_modules_mapping`, `hf_to_sglang_mapper`) are deliberately absent: a
+# draft's checkpoint has its own names, so those differ by design.
+PARITY_HOOKS = ("shared_experts_fusion_disable_reason",)
+
+# `...Eagle`/`...Eagle3` drafts are standalone checkpoints with their own
+# architecture; the rest mirror a stage of their target.
+DRAFT_SUFFIX = re.compile(r"(NextN|MTP|DSpark|DFlash|Standalone)$")
+
+
+def _target_of(arch: str, archs: dict):
+    """The arch a draft entry class drafts for, if it is named after it."""
+    match = DRAFT_SUFFIX.search(arch)
+    if not match:
+        return None
+    base = arch[: match.start()]
+    for candidate in (base, f"{base}ForCausalLM"):
+        if candidate in archs and candidate != arch:
+            return candidate
+    return None
+
+
+class TestDraftEntryHookParity(CustomTestCase):
+    def test_a_draft_resolves_a_gate_exactly_when_its_target_does(self):
+        archs = {}
+        for arch in sorted(ModelRegistry.get_supported_archs()):
+            try:
+                archs[arch] = ModelRegistry.resolve_model_cls(arch)[0]
+            except Exception:
+                continue  # an arch this environment cannot import
+
+        checked, offenders = 0, []
+        for arch, cls in archs.items():
+            target = _target_of(arch, archs)
+            if target is None:
+                continue
+            for hook in PARITY_HOOKS:
+                checked += 1
+                draft_has = hasattr(cls, hook)
+                target_has = hasattr(archs[target], hook)
+                if draft_has == target_has:
+                    continue
+                which = "the draft" if target_has else "the target"
+                offenders.append(
+                    f"{arch} vs {target}: {hook} missing on {which} "
+                    f"({cls.__module__} / {archs[target].__module__})"
+                )
+
+        self.assertGreater(checked, 10, "the draft/target pairing found nothing")
+        self.assertEqual(
+            [],
+            offenders,
+            "a draft entry class and the target it drafts for must resolve the "
+            "same loader hooks; otherwise the loader installs one decision for "
+            "the target and another for the draft, and the draft's weights are "
+            "laid out for the wrong one:\n  " + "\n  ".join(offenders),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -490,6 +490,13 @@ class TestCudaVmmFeatureTransport(unittest.TestCase):
 
 
 class TestSchedulerMmTransportBoundary(unittest.TestCase):
+    def _publish(self, **fields):
+        from sglang.srt.runtime_context import get_context
+
+        override = get_context().override_server_args(**fields)
+        override.install()
+        self.addCleanup(override.restore)
+
     @staticmethod
     def _prepare_scheduler(scheduler):
         scheduler.session_controller = SimpleNamespace(maybe_reap=MagicMock())
@@ -501,7 +508,9 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
         from sglang.srt.managers import scheduler as scheduler_module
 
         scheduler = object.__new__(scheduler_module.Scheduler)
-        scheduler.server_args = SimpleNamespace(
+        # The transport gate reads the published bags, so the case publishes
+        # the configuration under test.
+        self._publish(
             mm_feature_transport="cuda_vmm",
             enable_broadcast_mm_inputs_process=True,
         )
@@ -548,7 +557,7 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
                 return iter(self.batch)
 
         scheduler = object.__new__(scheduler_module.Scheduler)
-        scheduler.server_args = SimpleNamespace(mm_feature_transport="cuda_vmm")
+        self._publish(mm_feature_transport="cuda_vmm")
         self._prepare_scheduler(scheduler)
         raw_inputs = [object(), object()]
         materialized = [object(), object()]

--- a/test/registered/unit/server_args/test_resolution_is_reproducible.py
+++ b/test/registered/unit/server_args/test_resolution_is_reproducible.py
@@ -402,5 +402,59 @@ class TestResolutionIsReproducible(CustomTestCase):
         self.assertEqual(getattr(first, "_resolved_overrides", None), first_provenance)
 
 
+class TestTheResolutionSeamHasOneCaller(CustomTestCase):
+    """The pipeline is entered from exactly one place.
+
+    Step 12 moves the call from ``__post_init__`` to ``publish`` so the record
+    stays raw; that is a one-line move only while the seam has a single caller.
+    A second entry point would also mean resolution could run twice on one
+    instance, which the strict ``__setattr__`` guard turns into an
+    ``AttributeError`` rather than a silent re-resolve.
+    """
+
+    def test_only_post_init_runs_the_pipeline(self):
+        import ast
+        from pathlib import Path
+
+        import sglang
+
+        package_root = Path(next(iter(sglang.__path__)))
+        callers = []
+        for path in sorted(package_root.rglob("*.py")):
+            try:
+                tree = ast.parse(path.read_text())
+            except SyntaxError:
+                continue
+            # The full (class, function, ...) scope chain, so the assertion can
+            # say "the one caller is ServerArgs.__post_init__" -- not merely
+            # that nothing outside a function named __post_init__ calls it.
+            scopes = {}
+            for node in ast.walk(tree):
+                own = scopes.get(id(node), ())
+                if isinstance(
+                    node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                ):
+                    own = own + (node.name,)
+                for child in ast.iter_child_nodes(node):
+                    scopes[id(child)] = own
+            for node in ast.walk(tree):
+                if (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "_run_resolution_pipeline"
+                ):
+                    rel = path.relative_to(package_root).as_posix()
+                    callers.append((rel, ".".join(scopes.get(id(node), ()))))
+        # Every call, compared whole: a removed call, a duplicate inside
+        # __post_init__, or another class growing a same-named __post_init__
+        # all show up here.
+        self.assertEqual(
+            [("srt/server_args.py", "ServerArgs.__post_init__")],
+            callers,
+            "the resolution pipeline must be entered exactly once, from "
+            f"ServerArgs.__post_init__; found: {callers}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -57,6 +57,12 @@ _CONFIGURED_SIZE_CALL_SITES = {
         "point, since with PP off the group is never touched, which is what lets "
         "the Indexer be constructed before distributed init"
     ),
+    ("srt/managers/scheduler.py", "configured_pp_size"): (
+        "dispatch_event_loop picks the PP event loop; the MLX runner stub never "
+        "initializes torch.distributed, so the live property asserts before the "
+        "MLX loop can start -- the configured leaf answers the same value "
+        "wherever the live groups exist"
+    ),
     ("srt/mem_cache/kv_cache_configurator.py", "configured_pp_size"): (
         "decides whether the token capacity needs a cross-PP all-reduce at all; "
         "asking the configured size keeps that decision independent of whether a "

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -84,12 +84,6 @@ _CONFIGURED_SIZE_CALL_SITES = {
     ),
 }
 
-# A dynamic read whose name is set nowhere in the tree, so the predicate it
-# feeds is inert (the ``getattr`` default decides it). Converting it would mean
-# choosing what it should have named, which is the CP path's call, not this
-# sweep's -- so it is listed here rather than silently counted or "fixed".
-_INERT_DYNAMIC_READS = frozenset({("srt/layers/cp/base.py", "_is_dsa_model_arch")})
-
 _DIRECT_BASELINE = 0
 _ALIAS_BASELINE = 0
 
@@ -105,17 +99,9 @@ def _is_global_call(node) -> bool:
     return isinstance(func, ast.Attribute) and func.attr == "get_server_args"
 
 
-def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
-    """The (direct, alias) field reads in one module.
-
-    ``inert`` names the fields listed in ``_INERT_DYNAMIC_READS`` for this file;
-    they are dropped here, at the point the read is recognized, so the filter
-    matches on the field name rather than on the rendered message.
-    """
+def _collect(rel: str, tree: ast.AST):
+    """The (direct, alias) field reads in one module."""
     direct, alias = [], []
-
-    def counted(attr: str) -> bool:
-        return attr not in inert
 
     def _getattr_name(node):
         """``getattr(<record>, "field")`` names a field just as ``.field`` does;
@@ -132,20 +118,15 @@ def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
         return node.args[1].value
 
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Attribute)
-            and _is_global_call(node.value)
-            and counted(node.attr)
-        ):
+        if isinstance(node, ast.Attribute) and _is_global_call(node.value):
             direct.append(f"{rel}:{node.lineno}: get_server_args().{node.attr}")
 
         name = _getattr_name(node)
-        if name is not None and _is_global_call(node.args[0]) and counted(name):
+        if name is not None and _is_global_call(node.args[0]):
             direct.append(f"{rel}:{node.lineno}: getattr(get_server_args(), {name!r})")
 
         if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
-        params = {a.arg for a in list(node.args.args) + list(node.args.kwonlyargs)}
         bound = {}
         for inner in ast.walk(node):
             # ``sa = get_server_args()`` and its annotated form
@@ -193,7 +174,6 @@ def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
                 and isinstance(inner.value, ast.Name)
                 and inner.value.id in bound
                 and inner.lineno >= bound[inner.value.id]
-                and counted(inner.attr)
             ):
                 alias.append(
                     f"{rel}:{inner.lineno}: {inner.value.id}.{inner.attr} "
@@ -205,7 +185,6 @@ def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
                 and isinstance(inner.args[0], ast.Name)
                 and inner.args[0].id in bound
                 and inner.lineno >= bound[inner.args[0].id]
-                and counted(name)
             ):
                 alias.append(
                     f"{rel}:{inner.lineno}: getattr({inner.args[0].id}, {name!r}) "
@@ -301,7 +280,7 @@ def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
                 ):
                     base, attr = node.args[0].id, attr_name
                     shown = f"getattr({base}, {attr!r})"
-            if base and not _shadowed(node, base) and counted(attr):
+            if base and not _shadowed(node, base):
                 alias.append(
                     f"{rel}:{node.lineno}: {shown} "
                     f"(module-level bind from get_server_args() at line "
@@ -349,13 +328,13 @@ def _collect(rel: str, tree: ast.AST, inert: frozenset = frozenset()):
             key = shown = None
             if isinstance(inner, ast.Attribute):
                 key = _bound_attr(inner.value)
-                if key is not None and counted(inner.attr):
+                if key is not None:
                     shown = f"{key[0]}.{key[1]}.{inner.attr}"
             else:
                 name = _getattr_name(inner)
                 if name is not None:
                     key = _bound_attr(inner.args[0])
-                    if key is not None and counted(name):
+                    if key is not None:
                         shown = f"getattr({key[0]}.{key[1]}, {name!r})"
             if shown is not None:
                 alias.append(
@@ -376,8 +355,7 @@ def _field_reads():
             tree = ast.parse(path.read_text())
         except SyntaxError:
             continue
-        inert = frozenset(name for path_, name in _INERT_DYNAMIC_READS if path_ == rel)
-        module_direct, module_alias = _collect(rel, tree, inert)
+        module_direct, module_alias = _collect(rel, tree)
         direct += module_direct
         alias += module_alias
     return direct, alias

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -401,6 +401,7 @@ class _FakeResolvedArgs:
     max_running_requests: A[int | None, Arg(help="mrr"), NS("schedule")] = None
     chunked_prefill_size: A[int, Arg(help="cps"), NS("schedule")] = -1
     max_prefill_tokens: A[int, Arg(help="mpt"), NS("schedule")] = 16384
+    enable_dynamic_chunking: A[bool, Arg(help="edc"), NS("schedule")] = False
     cuda_graph_config: A[object | None, Arg(help="cgc"), NS("exec.graph")] = None
     tp_size: A[int, Arg(help="tp"), NS("parallel")] = 1
     pp_size: A[int, Arg(help="pp"), NS("parallel")] = 1
@@ -1025,6 +1026,31 @@ class TestDerivedPredicatesAgreeAcrossTiers(_IsolatedServerArgs):
                         ServerArgs.enable_mamba_extra_buffer_lazy(args),
                         mamba_extra_buffer_lazy_enabled(),
                     )
+
+    def test_prefill_buffer_ceiling_matches_the_member(self):
+        from sglang.srt.runtime_context import max_prefill_buffer_tokens
+
+        for chunked in (-1, 0, 1024, 8192):
+            for dynamic in (False, True):
+                for pp in (1, 4):
+                    for max_prefill in (0, 2048, 16384):
+                        with self.subTest(
+                            chunked=chunked,
+                            dynamic=dynamic,
+                            pp=pp,
+                            max_prefill=max_prefill,
+                        ):
+                            args = _FakeResolvedArgs(
+                                chunked_prefill_size=chunked,
+                                enable_dynamic_chunking=dynamic,
+                                pp_size=pp,
+                                max_prefill_tokens=max_prefill,
+                            )
+                            get_context().set_server_args(args)
+                            self.assertEqual(
+                                ServerArgs.max_prefill_buffer_tokens(args),
+                                max_prefill_buffer_tokens(),
+                            )
 
     def test_activation_reserve_matches_the_member(self):
         from types import SimpleNamespace

--- a/test/registered/unit/test_runtime_context.py
+++ b/test/registered/unit/test_runtime_context.py
@@ -391,6 +391,19 @@ class _FakeResolvedArgs:
     speculative_num_draft_tokens: A[int | None, Arg(help="d"), NS("spec")] = None
     speculative_adaptive: A[bool, Arg(help="a"), NS("spec")] = False
     speculative_adaptive_config: A[str | None, Arg(help="c"), NS("spec")] = None
+    load_format: A[str, Arg(help="lf"), NS("model")] = "auto"
+    remote_instance_weight_loader_backend: A[str, Arg(help="rb"), NS("model")] = "nccl"
+    remote_instance_weight_loader_start_seed_via_transfer_engine: A[
+        bool, Arg(help="rs"), NS("model")
+    ] = False
+    modelexpress_config: A[str | None, Arg(help="mx"), NS("model")] = None
+    disaggregation_mode: A[str, Arg(help="dm"), NS("disagg")] = "null"
+    max_running_requests: A[int | None, Arg(help="mrr"), NS("schedule")] = None
+    chunked_prefill_size: A[int, Arg(help="cps"), NS("schedule")] = -1
+    max_prefill_tokens: A[int, Arg(help="mpt"), NS("schedule")] = 16384
+    cuda_graph_config: A[object | None, Arg(help="cgc"), NS("exec.graph")] = None
+    tp_size: A[int, Arg(help="tp"), NS("parallel")] = 1
+    pp_size: A[int, Arg(help="pp"), NS("parallel")] = 1
     _resolved_overrides: list = dataclasses.field(default_factory=list)
 
 
@@ -1012,6 +1025,74 @@ class TestDerivedPredicatesAgreeAcrossTiers(_IsolatedServerArgs):
                         ServerArgs.enable_mamba_extra_buffer_lazy(args),
                         mamba_extra_buffer_lazy_enabled(),
                     )
+
+    def test_activation_reserve_matches_the_member(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.runtime_context import pre_capture_activation_reserve_mb
+
+        graph = SimpleNamespace(decode=SimpleNamespace(max_bs=64))
+        cases = (
+            dict(disaggregation_mode="null", chunked_prefill_size=8192),
+            dict(disaggregation_mode="null", chunked_prefill_size=-1),
+            dict(
+                disaggregation_mode="null",
+                chunked_prefill_size=-1,
+                max_prefill_tokens=1024,
+            ),
+            dict(disaggregation_mode="decode", max_running_requests=32),
+            dict(disaggregation_mode="decode", max_running_requests=None),
+            dict(
+                disaggregation_mode="decode",
+                max_running_requests=None,
+                speculative_num_draft_tokens=4,
+            ),
+            dict(
+                disaggregation_mode="null",
+                chunked_prefill_size=8192,
+                tp_size=8,
+                pp_size=2,
+            ),
+        )
+        for case in cases:
+            for gpu_mem in (None, 20 * 1024, 80 * 1024):
+                with self.subTest(gpu_mem=gpu_mem, **case):
+                    args = _FakeResolvedArgs(cuda_graph_config=graph, **case)
+                    get_context().set_server_args(args)
+                    self.assertEqual(
+                        ServerArgs.pre_capture_activation_reserve_mb(args, gpu_mem),
+                        pre_capture_activation_reserve_mb(gpu_mem),
+                    )
+
+    def test_remote_instance_transfer_engine_matches_the_member(self):
+        from sglang.srt.runtime_context import remote_instance_transfer_engine_enabled
+
+        backends = ("nccl", "transfer_engine", "modelexpress")
+        transports = (None, '{"transport": "transfer_engine"}', '{"transport": "nixl"}')
+        for seed_via_te in (False, True):
+            for load_format in ("auto", "remote_instance"):
+                for backend in backends:
+                    for mx in transports:
+                        with self.subTest(
+                            seed=seed_via_te,
+                            load_format=load_format,
+                            backend=backend,
+                            modelexpress=mx,
+                        ):
+                            args = _FakeResolvedArgs(
+                                load_format=load_format,
+                                remote_instance_weight_loader_backend=backend,
+                                remote_instance_weight_loader_start_seed_via_transfer_engine=seed_via_te,
+                                modelexpress_config=mx,
+                            )
+                            get_context().set_server_args(args)
+                            for override in (None, "remote_instance", "auto"):
+                                self.assertEqual(
+                                    ServerArgs.remote_instance_weight_loader_use_transfer_engine(
+                                        args, override
+                                    ),
+                                    remote_instance_transfer_engine_enabled(override),
+                                )
 
     def test_attention_backends_match_the_member(self):
         from sglang.srt.runtime_context import attention_backends

--- a/test/registered/unit/test_runtime_context_config_bags.py
+++ b/test/registered/unit/test_runtime_context_config_bags.py
@@ -59,6 +59,13 @@ _EXEC_SUBS = (
 
 
 class TestConfigBags(CustomTestCase):
+    def _callTestMethod(self, method):
+        # No retry: CustomTestCase retries once in CI, but `addCleanup` runs
+        # after the last attempt, so a retry of the dual-resolve case would
+        # re-enter with the first attempt's leaked process state instead of
+        # the pristine snapshot the sibling helper restores from.
+        unittest.TestCase._callTestMethod(self, method)
+
     def setUp(self):
         rc.reset_context()
 
@@ -76,14 +83,130 @@ class TestConfigBags(CustomTestCase):
         with self.assertRaises(ValueError):
             rc.get_memory()
 
-    def test_bag_values_match_server_args(self):
-        sa = self._publish()
-        self.assertEqual(rc.get_exec().moe.moe_runner_backend, sa.moe_runner_backend)
-        self.assertEqual(rc.get_exec().kernel.attention_backend, sa.attention_backend)
-        self.assertEqual(rc.get_memory().hicache_ratio, sa.hicache_ratio)
+    def test_the_bags_carry_what_resolution_produced(self):
+        """The projection is faithful: each leaf is the *resolved* value.
+
+        Two requirements the dummy-model shortcut cannot meet: the record must
+        go through the real resolution pipeline (a dummy path returns at the
+        dummy-model boundary with every sampled leaf still raw, so raw==raw
+        would pass vacuously), and the reference must be an independent
+        resolution of the same raw input -- a fresh, never-published record,
+        resolved after restoring the process state (environ and the EnvField
+        none-flags) the first resolution may have written -- so the assertion
+        is "bag == what resolution produces", not "bag == the instance publish
+        copied from". Reproducibility (`test_resolution_is_reproducible`)
+        licenses the sibling as a stand-in for the pipeline's output. The
+        raw-differs guard keeps the comparison meaningful: every sampled leaf
+        must have moved off its dataclass default, so each equality compares a
+        value resolution demonstrably wrote. Supplied construction inputs
+        (`model_path`, `device`, `random_seed`) and leaves resolution leaves
+        alone never enter the sample -- projection coverage for those lives in
+        `test_passthrough_leaves_project_into_their_namespaces`. Step 12 keeps
+        records at the user's raw input; then the sibling goes raw and this
+        assertion starts failing for every sampled leaf, which is the signal
+        the bags became the only home of the effective value.
+        """
+        import dataclasses
+
+        sa, reference = self._resolve_published_and_sibling()
+        defaults = {f.name: f.default for f in dataclasses.fields(ServerArgs)}
+        # Leaves resolution writes on this input on both CI device shapes
+        # (CUDA host and CPU-only runner): each starts at a None default.
+        sampled = (
+            (lambda: rc.get_exec().kernel.attention_backend, "attention_backend"),
+            (lambda: rc.get_schedule().page_size, "page_size"),
+            (lambda: rc.get_schedule().chunked_prefill_size, "chunked_prefill_size"),
+            (lambda: rc.get_schedule().mem_fraction_static, "mem_fraction_static"),
+        )
+        for accessor, leaf in sampled:
+            with self.subTest(leaf=leaf):
+                # The raw-differs guard: a sampled leaf that still sits on its
+                # default (or has none to differ from) proves nothing.
+                self.assertIsNot(defaults[leaf], dataclasses.MISSING)
+                self.assertNotEqual(getattr(reference, leaf), defaults[leaf])
+                self.assertEqual(accessor(), getattr(reference, leaf))
+        # And the record agrees today, which is what step 12 changes: when this
+        # assertion starts failing for a resolution-written leaf, the flip
+        # landed and the bag is the only place the effective value lives.
         self.assertEqual(rc.get_schedule().page_size, sa.page_size)
-        self.assertEqual(rc.get_serving().host, sa.host)
-        self.assertEqual(rc.get_model().model_path, sa.model_path)
+
+    def test_passthrough_leaves_project_into_their_namespaces(self):
+        """Thin projection smoke over leaves resolution does not move.
+
+        `bag == instance` is all these equalities can claim (publish projected
+        an unchanged field into serving/memory/moe/model) -- resolution
+        faithfulness is `test_the_bags_carry_what_resolution_produced`'s job.
+        """
+        sa = self._publish()
+        sampled = (
+            (lambda: rc.get_serving().host, "host"),
+            (lambda: rc.get_memory().hicache_ratio, "hicache_ratio"),
+            (lambda: rc.get_exec().moe.moe_runner_backend, "moe_runner_backend"),
+            (lambda: rc.get_model().model_path, "model_path"),
+        )
+        for accessor, leaf in sampled:
+            with self.subTest(leaf=leaf):
+                self.assertEqual(accessor(), getattr(sa, leaf))
+
+    def _resolve_published_and_sibling(self):
+        """Resolve a real mini config twice from the same pristine process
+        state: publish the first record, hand back the never-published sibling
+        as the reference."""
+        import json
+        import os
+        import shutil
+        import tempfile
+
+        from sglang.srt.environ import EnvField, envs
+
+        config_dir = tempfile.mkdtemp(prefix="bag_contract_")
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        with open(os.path.join(config_dir, "config.json"), "w") as handle:
+            json.dump(
+                {
+                    "architectures": ["LlamaForCausalLM"],
+                    "model_type": "llama",
+                    "hidden_size": 16,
+                    "intermediate_size": 32,
+                    "num_attention_heads": 2,
+                    "num_key_value_heads": 2,
+                    "num_hidden_layers": 2,
+                    "vocab_size": 128,
+                    "max_position_embeddings": 2048,
+                },
+                handle,
+            )
+
+        # Resolution can write process state os.environ does not carry (the
+        # multimodal transport env sticky plus the EnvField descriptor flag
+        # `set()` flips); snapshot both so the sibling resolves the same
+        # pristine input. Walk the MRO: `vars(type(envs))` alone would miss
+        # fields declared on a base class.
+        env_fields = {}
+        for klass in reversed(type(envs).__mro__):
+            for name, field in vars(klass).items():
+                if isinstance(field, EnvField):
+                    env_fields[name] = field
+        environ_before = dict(os.environ)
+        none_flags_before = {
+            name: field._set_to_none for name, field in env_fields.items()
+        }
+
+        def restore_process_state():
+            os.environ.clear()
+            os.environ.update(environ_before)
+            for name, was_none in none_flags_before.items():
+                getattr(type(envs), name)._set_to_none = was_none
+
+        self.addCleanup(restore_process_state)
+
+        def resolve():
+            return ServerArgs(model_path=config_dir, device="cuda", random_seed=42)
+
+        sa = resolve()
+        rc.publish(sa, role="scheduler")
+        restore_process_state()
+        return sa, resolve()
 
     def test_all_accessors_and_exec_subgroups(self):
         self._publish()

--- a/test/registered/unit/test_split_attention_backend_decisions.py
+++ b/test/registered/unit/test_split_attention_backend_decisions.py
@@ -1,0 +1,361 @@
+"""Decisions keyed on the attention backend must read the configured pair.
+
+`--attention-backend` is one of three fields: the base one and the two split
+ones (`--prefill-attention-backend` / `--decode-attention-backend`). A launch
+that sets only a split field leaves the base at `None`, so a decision that reads
+`attention_backend` alone answers from a field the operator never set. What that
+cost, before the sweep these cases guard:
+
+  - a weight sized for the wrong dtype (gpt-oss `sinks` under trtllm_mha; that
+    decision is now gone -- the weight stays bfloat16 and the trtllm backend
+    upcasts at its call site, since at model-build time no config read can say
+    which backend serves this runner's forwards),
+  - a prefill feature switched off (chunked prefix cache),
+  - a triton kernel chosen for a backend that cannot host it (`support_triton(None)`
+    answers True), in mrope and in the req-to-token writer,
+  - a version guard that never fires (flashinfer),
+  - a deterministic-inference knob left unset (prefill truncation align).
+
+`attention_backends()` is the shared answer: the pair with the base-field
+fallback applied. The callable decisions are checked by calling them; the rest
+are pinned statically, since reproducing them means building a model or a
+scheduler.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+from sglang.srt.runtime_context import attention_backends, get_context
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+import sglang
+
+_PACKAGE_ROOT = Path(next(iter(sglang.__path__))) / "srt"
+
+# The decisions this file is about, and which half of the pair each one needs.
+# A base-only read here is the regression; the resolution pipeline and the two
+# modules that own the config are exempt because "did the operator pin the base
+# field?" is a real question *there*.
+_PAIR_READERS = {
+    "models/inkling_common/attn.py": "the half serving the forward (mirrors hybrid dispatch)",
+    "model_executor/model_runner_components/misc_utils.py": "prefill (chunked prefix cache)",
+    "layers/rotary_embedding/mrope.py": "both (triton availability)",
+    "mem_cache/allocation.py": "prefill (req-to-token writer); both (get_last_loc)",
+    "batch_overlap/two_batch_overlap.py": "prefill (extend positions)",
+    "managers/scheduler.py": "prefill (truncation align knobs)",
+    "entrypoints/engine.py": "either half (flashinfer version floor)",
+}
+
+
+class TestSplitBackendsReachTheDecisions(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self._saved = get_context()._server_args
+
+    def tearDown(self):
+        if self._saved is not None:
+            get_context().set_server_args(self._saved)
+        super().tearDown()
+
+    def _publish(self, **fields):
+        override = get_context().override_server_args(**fields)
+        override.install()
+        self.addCleanup(override.restore)
+
+    def test_the_pair_is_what_a_split_only_launch_configures(self):
+        self._publish(
+            attention_backend=None,
+            prefill_attention_backend="triton",
+            decode_attention_backend="trtllm_mha",
+        )
+        self.assertEqual(attention_backends(), ("triton", "trtllm_mha"))
+
+    def test_chunked_prefix_cache_follows_the_prefill_backend(self):
+        from sglang.srt.model_executor.model_runner_components.misc_utils import (
+            maybe_disable_chunked_prefix_cache,
+        )
+        from sglang.srt.runtime_context import get_schedule
+
+        # A prefill backend that supports the feature, configured *only* through
+        # the split field: the gate must leave it on.
+        self._publish(
+            attention_backend=None,
+            prefill_attention_backend="fa3",
+            decode_attention_backend="triton",
+            disable_chunked_prefix_cache=False,
+        )
+        maybe_disable_chunked_prefix_cache(use_mla_backend=True, is_draft_worker=False)
+        self.assertFalse(get_schedule().disable_chunked_prefix_cache)
+
+        # And an unsupported one still switches it off.
+        self._publish(
+            attention_backend=None,
+            prefill_attention_backend="torch_native",
+            decode_attention_backend="fa3",
+            disable_chunked_prefix_cache=False,
+        )
+        maybe_disable_chunked_prefix_cache(use_mla_backend=True, is_draft_worker=False)
+        self.assertTrue(get_schedule().disable_chunked_prefix_cache)
+
+    def test_inkling_selects_the_half_serving_the_forward(self):
+        from types import SimpleNamespace
+
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.model_executor.forward_context import (
+            ForwardContext,
+            forward_context,
+        )
+        from sglang.srt.models.inkling_common.attn import serving_attention_backend
+
+        self._publish(
+            attention_backend=None,
+            prefill_attention_backend="triton",
+            decode_attention_backend="fa4",
+            speculative_attention_mode="prefill",
+        )
+
+        def batch(mode):
+            return SimpleNamespace(forward_mode=mode)
+
+        unstamped = SimpleNamespace(
+            prefill_attention_backend_str=None, decode_attention_backend_str=None
+        )
+        with forward_context(ForwardContext(attn_backend=unstamped)):
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.EXTEND)), "triton"
+            )
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.DECODE)), "fa4"
+            )
+            self.assertEqual(serving_attention_backend(batch(ForwardMode.IDLE)), "fa4")
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.TARGET_VERIFY)), "triton"
+            )
+
+        # Draft-extend routes through the hybrid dispatcher's prefill branch
+        # regardless of the spec mode.
+        with forward_context(ForwardContext(attn_backend=unstamped)):
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.DRAFT_EXTEND_V2)),
+                "triton",
+            )
+
+        self._publish(
+            attention_backend=None,
+            prefill_attention_backend="triton",
+            decode_attention_backend="fa4",
+            speculative_attention_mode="decode",
+        )
+        with forward_context(ForwardContext(attn_backend=unstamped)):
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.TARGET_VERIFY)), "fa4"
+            )
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.DRAFT_EXTEND_V2)),
+                "triton",
+            )
+
+        # The pair the runner stamped on its backend wins over the bags: a
+        # draft runner serves every phase with its own backend.
+        stamped = SimpleNamespace(
+            prefill_attention_backend_str="fa4", decode_attention_backend_str="fa4"
+        )
+        with forward_context(ForwardContext(attn_backend=stamped)):
+            self.assertEqual(
+                serving_attention_backend(batch(ForwardMode.EXTEND)), "fa4"
+            )
+
+    def test_the_flashinfer_version_guard_sees_a_split_launch(self):
+        # The launcher runs before any publish, so it asks the record; the
+        # member and the accessor answer the same pair.
+        args = ServerArgs.__new__(ServerArgs)
+        for name, value in (
+            ("attention_backend", None),
+            ("prefill_attention_backend", None),
+            ("decode_attention_backend", "flashinfer"),
+        ):
+            object.__setattr__(args, name, value)
+        self.assertIn("flashinfer", args.get_attention_backends())
+
+    def test_support_triton_is_the_regression_being_guarded(self):
+        from sglang.srt.utils.common import support_triton
+
+        # This is why a base-only read is not merely imprecise: the unset field
+        # reads as "supported".
+        self.assertTrue(support_triton(None))
+
+    def test_no_listed_decision_reads_the_base_field_alone(self):
+        offenders = []
+        for rel, why in _PAIR_READERS.items():
+            tree = ast.parse((_PACKAGE_ROOT / rel).read_text())
+            for node in ast.walk(tree):
+                # Any attribute read named `attention_backend` is the base
+                # field, whatever the base expression is spelled as -- a bag
+                # chain, a record, or a local alias of either
+                # (`k = get_exec().kernel; k.attention_backend`). The pair
+                # helpers are calls, not attributes, so they never match.
+                if isinstance(node, ast.Attribute) and node.attr == "attention_backend":
+                    offenders.append(f"{rel}:{node.lineno}: base-only read ({why})")
+        self.assertEqual(
+            [],
+            offenders,
+            "these decisions must read attention_backends() (the pair with the "
+            "base-field fallback), not the base field:\n" + "\n".join(offenders),
+        )
+
+
+class TestDraftFactoryStamping(CustomTestCase):
+    """The factory's products carry the stamp `serving_attention_backend`
+    prefers -- removing the child-stamping loop, the `cutedsl_mla` rename, or
+    the wrapper copy goes red here, not only in a spec e2e."""
+
+    def setUp(self):
+        super().setUp()
+        self._saved = get_context()._server_args
+
+    def tearDown(self):
+        if self._saved is not None:
+            get_context().set_server_args(self._saved)
+        super().tearDown()
+
+    def _publish(self, **fields):
+        override = get_context().override_server_args(**fields)
+        override.install()
+        self.addCleanup(override.restore)
+
+    def _factory(self, draft_backend=None):
+        from types import SimpleNamespace
+
+        from sglang.srt.speculative.draft_utils import DraftBackendFactory
+
+        runner = SimpleNamespace(draft_attention_backend=draft_backend)
+        return DraftBackendFactory(runner, topk=1, speculative_num_steps=2)
+
+    def test_a_decode_container_stamps_its_per_step_children(self):
+        from types import SimpleNamespace
+
+        self._publish(attention_backend="triton")
+        children = [SimpleNamespace(), SimpleNamespace()]
+        container = SimpleNamespace(attn_backends=children)
+        product = self._factory()._create_backend(
+            "decode_attention_backend",
+            {"triton": lambda: ("triton", container)},
+            "unsupported {backend_type}",
+            stamps_children=True,
+        )
+        # EAGLE's eager loop puts the children into the ForwardContext
+        # directly, so an unstamped child answers with the target pair.
+        for obj in [product, *children]:
+            self.assertEqual(obj.prefill_attention_backend_str, "triton")
+            self.assertEqual(obj.decode_attention_backend_str, "triton")
+
+    def test_the_draft_override_wins_over_the_published_pair(self):
+        from types import SimpleNamespace
+
+        self._publish(attention_backend="triton")
+        product = self._factory(draft_backend="trtllm_mha")._create_backend(
+            "decode_attention_backend",
+            {"trtllm_mha": lambda: ("trtllm_mha", SimpleNamespace(attn_backends=[]))},
+            "unsupported {backend_type}",
+            stamps_children=True,
+        )
+        self.assertEqual(product.prefill_attention_backend_str, "trtllm_mha")
+
+    def test_cutedsl_draft_extend_stamps_the_effective_kernel(self):
+        # cutedsl_mla only supports decode; the draft-extend map builds the
+        # trtllm-mla backend, and the *constructor* answers the effective
+        # name, so the stamp says what actually runs with no rename table --
+        # and the conv-sidecar wrapper that enters the ForwardContext must
+        # answer with the wrapped backend's stamp.
+        from types import SimpleNamespace
+        from unittest import mock
+
+        from sglang.srt.layers.attention import attention_registry
+
+        self._publish(attention_backend="triton")
+        factory = self._factory(draft_backend="cutedsl_mla")
+        built = SimpleNamespace()
+        factory._create_trtllm_mla_prefill_backend = lambda: ("trtllm_mla", built)
+        wrapper = SimpleNamespace()
+        with mock.patch.object(
+            attention_registry,
+            "attn_backend_wrapper_for_draft_extend",
+            lambda runner, backend: wrapper,
+        ):
+            product = factory.create_draft_extend_backend()
+        self.assertIs(product, wrapper)
+        self.assertEqual(built.prefill_attention_backend_str, "trtllm_mla")
+        self.assertEqual(product.prefill_attention_backend_str, "trtllm_mla")
+        self.assertEqual(product.decode_attention_backend_str, "trtllm_mla")
+
+    def test_a_host_dependent_alias_stamps_the_concrete_kernel(self):
+        # `hybrid_linear_attn` picks fa3/intel_amx/triton by host inside its
+        # constructor, so no static rename can say what it builds -- the
+        # constructor's own answer is the stamp. A stamp that repeats the
+        # alias crashes Inkling's per-forward kwargs assembly, which asserts
+        # the name is a concrete kernel.
+        from types import SimpleNamespace
+
+        self._publish(attention_backend="hybrid_linear_attn")
+        concrete = SimpleNamespace(attn_backends=[SimpleNamespace()])
+        product = self._factory()._create_backend(
+            "decode_attention_backend",
+            {"hybrid_linear_attn": lambda: ("triton", concrete)},
+            "unsupported {backend_type}",
+            stamps_children=True,
+        )
+        self.assertEqual(product.prefill_attention_backend_str, "triton")
+        self.assertEqual(
+            product.attn_backends[0].decode_attention_backend_str, "triton"
+        )
+
+    def test_the_real_map_never_stamps_an_alias(self):
+        # The factory's real constructors each answer their effective name;
+        # this pins that no map key with an aliased or host-dependent
+        # constructor ("nsa", "cutedsl_mla", "hybrid_linear_attn") can leak
+        # its request name into a stamp: whatever the leaf built, the name it
+        # answered is a concrete kernel, never one of the alias keys.
+        import ast as _ast
+        import inspect
+
+        from sglang.srt.speculative import draft_utils
+
+        tree = _ast.parse(inspect.getsource(draft_utils))
+        offenders = []
+        for node in _ast.walk(tree):
+            if not isinstance(node, _ast.FunctionDef):
+                continue
+            if not node.name.startswith("_create_") or "_backend" not in node.name:
+                continue
+            for ret in _ast.walk(node):
+                if not isinstance(ret, _ast.Return) or ret.value is None:
+                    continue
+                # Leaf returns are ("name", ctor(...)); delegations return the
+                # inner call. A bare backend return would silently miss the
+                # stamp contract.
+                if isinstance(ret.value, _ast.Tuple):
+                    name = ret.value.elts[0]
+                    if isinstance(name, _ast.Constant) and name.value in (
+                        "nsa",
+                        "hybrid_linear_attn",
+                    ):
+                        offenders.append(f"{node.name}: stamps alias {name.value!r}")
+                elif isinstance(ret.value, _ast.Call):
+                    fn = ret.value.func
+                    is_delegation = isinstance(
+                        fn, _ast.Attribute
+                    ) and fn.attr.startswith("_create_")
+                    if not is_delegation:
+                        offenders.append(
+                            f"{node.name}: returns a bare backend (no effective name)"
+                        )
+        self.assertEqual([], offenders, "\n".join(offenders))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_supplied_instance_exposure_ratchet.py
+++ b/test/registered/unit/test_supplied_instance_exposure_ratchet.py
@@ -1,0 +1,1165 @@
+"""The supplied-instance surface is measured on two axes, and may only shrink.
+
+A callee that takes ``server_args`` keeps the supplied-instance contract: the
+caller chose the object, so no global-read ratchet counts it. Step 12 changes
+what that object *carries* — the instance stays at the user's raw input — so a
+callee reading a field **resolution fills in** would start seeing the CLI default
+instead of the effective value.
+
+This pins that intersection. Each entry is one (file, field) pair where a
+parameter named ``server_args`` is read for a field resolution writes; the plan
+doc carries the proposed disposition per field
+(``global_context/12-raw-input-config.md``, "the supplied-instance conversion
+list"). New pairs fail: a new one is new step-12 work, and the moment to decide
+where the value should come from is when the read is written, not during the
+flip. Pairs that disappear also fail, with the entry to delete — the list is the
+measurement, not a memory of one.
+
+The written-field set is derived here rather than hardcoded: the
+representative configs in ``_MATRIX`` (one per resolution family it exercises)
+are resolved and compared against the dataclass defaults, the same matrix the
+context repo's audit tool uses. Ambient environment is normalized per entry --
+resolution branches on CI detection and leaves sticky process state, so each
+entry resolves from the pristine snapshot, and the CI shape is an explicit
+entry rather than an accident of the runner. The read scan mirrors that
+tool's three shapes — a parameter attribute, ``getattr(server_args, "literal")``,
+and the parameter parked on ``self`` — because two implementations of one census
+that disagree are worse than either alone.
+
+The second axis is **already wrong today**, not after a flip. Some config is
+decided *after* publish and recorded with ``get_context().override(...)`` —
+elastic-EP resizing `ep_size`, a weight update rewriting `model_path` /
+`load_format`, HiCache attach naming a storage backend, adaptive speculative
+decoding moving `speculative_num_steps`. That write reaches the bags and never
+the record, so a supplied-instance read of one of those fields answers with the
+startup value from the moment the override lands. Whether that is a defect
+depends on ordering — a value copied at construction, before any override, is
+fine — so this axis is pinned as a measurement with the same growth guard rather
+than as a list of bugs. One of them *was* a defect and is fixed at the base of
+this stack: the linear-attn dispatch table rebuilt itself from the record after
+the SM100 GDN prefill decision had been recorded in the bag, so a second runner's
+rebuild dropped it. That choice is a per-runner stamp now and is not recorded
+process-wide at all, so neither the read nor the field is on this axis.
+"""
+
+import ast
+import dataclasses
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+import sglang
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+# Also on a CUDA runner: the written set is derived by resolving on the running
+# host, and `is_cuda()` / capability gates only open on real hardware. The pin
+# is split by host so both registrations stay exact: `_EXPOSED` is asserted
+# everywhere, and a pair whose write only happens on CUDA belongs in
+# `_EXPOSED_CUDA_ONLY` -- pinned on the CUDA runner, invisible to the CPU
+# assertion. Without the split, one shared exact list could not hold such a
+# pair at all: pinning it fails the CPU run as "gone", omitting it fails the
+# CUDA run as "new". (No AMD registration: an `is_hip()`-gated write would
+# shift the exact sets in ways none of the pinning hosts can verify; the ROCm
+# resolution surface is covered by `test_resolution_is_reproducible.py`
+# instead, whose assertion is device-agnostic.)
+register_cuda_ci(est_time=20, stage="base-b", runner_config="1-gpu-small")
+
+_PACKAGE_ROOT = Path(next(iter(sglang.__path__))) / "srt"
+
+# The config the resolution pipeline owns; reading the in-flight record is their
+# job, not a supplied-instance read.
+_OWNERS = ("server_args.py", "runtime_context.py", "arg_groups/")
+
+_MINI_CONFIG = {
+    "architectures": ["LlamaForCausalLM"],
+    "model_type": "llama",
+    "hidden_size": 16,
+    "intermediate_size": 32,
+    "num_attention_heads": 2,
+    "num_key_value_heads": 2,
+    "num_hidden_layers": 2,
+    "vocab_size": 128,
+    "max_position_embeddings": 2048,
+}
+
+# One config resolves only its own decisions, so the written set is a union.
+_MATRIX = (
+    {},
+    {
+        "speculative_algorithm": "EAGLE",
+        "speculative_num_steps": 3,
+        "speculative_eagle_topk": 1,
+        "speculative_num_draft_tokens": 4,
+    },
+    {"dp_size": 2, "tp_size": 2, "enable_dp_attention": True},
+    # DWDP resolves dp_size and enable_dp_attention *itself* -- the plain DP
+    # entry above passes them in, and passed-in fields are excluded from the
+    # written set, so without this entry the dp_size readers would never pin.
+    {"tp_size": 2, "dwdp_size": 2},
+    {"enable_hierarchical_cache": True, "hicache_ratio": 2.0},
+    {"disaggregation_mode": "prefill"},
+    {"tp_size": 2, "attn_cp_size": 2},
+    {"enable_lora": True, "max_lora_rank": 16},
+    {"kv_cache_dtype": "fp8_e4m3", "page_size": 64},
+    # MIS resolves disable_radix_cache (and friends) itself; the backend is
+    # passed in because the handler asserts flashinfer rather than switching.
+    {"enable_mis": True, "attention_backend": "flashinfer"},
+)
+
+# `declare_late_resolution` call sites whose keyword expansion is built
+# dynamically; the written fields are spelled out here and drift-guarded.
+_LATE_RESOLUTION_DYNAMIC_SITES = {
+    "parser/template_detection.py": frozenset({"reasoning_parser", "tool_call_parser"}),
+}
+
+# Resolution also branches on ambient environment; those shapes are explicit
+# entries so the written set is the same on every host. `SGLANG_IS_IN_CI`
+# makes resolution fill `soft_watchdog_timeout`.
+_ENV_MATRIX = (({}, {"SGLANG_IS_IN_CI": "true"}),)
+
+# Only true constructor inputs: `tokenizer_path` / `served_model_name` are
+# resolution-written (filled from `model_path` when unset), so their readers
+# are step-12 exposure like any other pair.
+_PASSED = frozenset({"model_path", "device", "random_seed"})
+
+_EXPOSED = {
+    ("configs/embedding_model_spec.py", "chunked_prefill_size"),
+    ("configs/embedding_model_spec.py", "cuda_graph_config"),
+    ("configs/embedding_model_spec.py", "disable_radix_cache"),
+    ("configs/embedding_model_spec.py", "is_embedding"),
+    ("configs/embedding_model_spec.py", "prefill_only_disable_kv_cache"),
+    ("configs/model_config.py", "_speculative_draft_quantization_explicitly_set"),
+    ("configs/model_config.py", "disable_hybrid_swa_memory"),
+    ("configs/model_config.py", "dtype"),
+    ("configs/model_config.py", "enable_multi_layer_eagle"),
+    ("configs/model_config.py", "is_embedding"),
+    ("configs/model_config.py", "model_path"),
+    ("configs/model_config.py", "quantization"),
+    ("configs/model_config.py", "speculative_algorithm"),
+    ("configs/model_config.py", "speculative_draft_model_quantization"),
+    ("constrained/base_grammar_backend.py", "grammar_backend"),
+    ("constrained/base_grammar_backend.py", "reasoning_parser"),
+    ("disaggregation/common/conn.py", "disaggregation_bootstrap_port"),
+    ("disaggregation/common/conn.py", "pp_size"),
+    ("disaggregation/decode_kvcache_offload_manager.py", "hicache_io_backend"),
+    ("disaggregation/decode_kvcache_offload_manager.py", "hicache_mem_layout"),
+    ("disaggregation/decode_kvcache_offload_manager.py", "served_model_name"),
+    ("disaggregation/encode_receiver.py", "disaggregation_ib_device"),
+    ("disaggregation/encode_receiver.py", "encoder_transfer_backend"),
+    ("disaggregation/encode_receiver.py", "mooncake_ib_device"),
+    ("disaggregation/encode_receiver.py", "tokenizer_path"),
+    ("disaggregation/encode_server.py", "device"),
+    ("disaggregation/encode_server.py", "dp_size"),
+    ("disaggregation/encode_server.py", "encoder_transfer_backend"),
+    ("disaggregation/encode_server.py", "load_format"),
+    ("disaggregation/encode_server.py", "mm_process_config"),
+    ("disaggregation/encode_server.py", "model_path"),
+    ("disaggregation/encode_server.py", "served_model_name"),
+    ("disaggregation/encode_server.py", "tokenizer_path"),
+    ("disaggregation/utils.py", "disaggregation_transfer_backend"),
+    ("distributed/bootstrap.py", "disable_custom_all_reduce"),
+    ("distributed/bootstrap.py", "enable_symm_mem"),
+    ("distributed/bootstrap.py", "enable_torch_symm_mem"),
+    ("distributed/bootstrap.py", "flashinfer_allreduce_fusion_backend"),
+    ("distributed/bootstrap.py", "moe_a2a_backend"),
+    ("distributed/bootstrap.py", "pre_warm_nccl"),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "disaggregation_ib_device",
+    ),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "disaggregation_mode",
+    ),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "disaggregation_transfer_backend",
+    ),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "enable_hierarchical_cache",
+    ),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "encoder_transfer_backend",
+    ),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "mooncake_ib_device",
+    ),
+    ("dllm/config.py", "max_running_requests"),
+    ("dllm/config.py", "model_path"),
+    ("elastic_ep/elastic_ep.py", "elastic_ep_initial_size"),
+    ("elastic_ep/elastic_ep.py", "ep_join_mode"),
+    ("elastic_ep/elastic_ep.py", "moe_a2a_backend"),
+    ("elastic_ep/expert_backup_manager.py", "disaggregation_ib_device"),
+    ("elastic_ep/expert_backup_manager.py", "load_format"),
+    ("elastic_ep/expert_backup_manager.py", "mooncake_ib_device"),
+    ("entrypoints/engine.py", "attn_cp_size"),
+    ("entrypoints/engine.py", "detokenizer_worker_num"),
+    ("entrypoints/engine.py", "dp_size"),
+    ("entrypoints/engine.py", "dtype"),
+    ("entrypoints/engine.py", "enable_dp_attention"),
+    ("entrypoints/engine.py", "enable_symm_mem"),
+    ("entrypoints/engine.py", "ep_join_mode"),
+    ("entrypoints/engine.py", "ep_size"),
+    ("entrypoints/engine.py", "load_format"),
+    ("entrypoints/engine.py", "model_path"),
+    ("entrypoints/engine.py", "moe_dp_size"),
+    ("entrypoints/engine.py", "pp_size"),
+    ("entrypoints/engine.py", "quantization"),
+    ("entrypoints/engine.py", "reasoning_parser"),
+    (
+        "entrypoints/engine.py",
+        "remote_instance_weight_loader_start_seed_via_transfer_engine",
+    ),
+    ("entrypoints/engine.py", "tool_call_parser"),
+    ("entrypoints/http_server.py", "disaggregation_mode"),
+    ("entrypoints/http_server.py", "dp_size"),
+    ("entrypoints/http_server.py", "ep_join_mode"),
+    ("entrypoints/http_server.py", "grpc_port"),
+    ("entrypoints/http_server.py", "model_path"),
+    ("entrypoints/http_server.py", "served_model_name"),
+    ("entrypoints/http_server.py", "skip_server_warmup"),
+    ("entrypoints/sidecar.py", "grpc_port"),
+    ("eplb/eplb_manager.py", "ep_dispatch_algorithm"),
+    ("eplb/eplb_manager.py", "expert_distribution_recorder_buffer_size"),
+    ("eplb/expert_distribution.py", "deepep_mode"),
+    ("eplb/expert_distribution.py", "device"),
+    ("eplb/expert_distribution.py", "expert_distribution_recorder_mode"),
+    ("eplb/expert_distribution.py", "moe_a2a_backend"),
+    ("eplb/expert_location.py", "device"),
+    ("eplb/expert_location.py", "eplb_algorithm"),
+    ("kv_canary/api.py", "disaggregation_mode"),
+    ("kv_canary/api.py", "speculative_num_steps"),
+    ("kv_canary/capacities.py", "chunked_prefill_size"),
+    ("kv_canary/capacities.py", "cuda_graph_config"),
+    ("kv_canary/capacities.py", "speculative_num_draft_tokens"),
+    ("kv_canary/token_oracle/install.py", "sampling_backend"),
+    ("layers/attention/dsa/utils.py", "disaggregation_mode"),
+    ("layers/cp/base.py", "attn_cp_size"),
+    ("layers/cp/base.py", "cp_strategy"),
+    ("layers/cp/base.py", "enable_prefill_cp"),
+    ("layers/cp/bcg.py", "cp_strategy"),
+    ("layers/cp/bcg.py", "enable_prefill_cp"),
+    ("layers/dp_attention.py", "attn_cp_size"),
+    ("layers/dp_attention.py", "device"),
+    ("layers/dp_attention.py", "dp_size"),
+    ("layers/dp_attention.py", "enable_dp_attention"),
+    ("layers/flashinfer_comm_fusion.py", "flashinfer_allreduce_fusion_backend"),
+    ("layers/moe/kt_ep_wrapper.py", "chunked_prefill_size"),
+    ("layers/moe/utils.py", "deepep_mode"),
+    ("layers/moe/utils.py", "moe_a2a_backend"),
+    ("layers/moe/utils.py", "moe_runner_backend"),
+    ("layers/moe/utils.py", "quantization"),
+    ("layers/moe/utils.py", "speculative_moe_runner_backend"),
+    ("layers/quantization/unquant.py", "enable_deterministic_inference"),
+    ("lora/lora_manager.py", "enable_dp_attention"),
+    ("lora/lora_manager.py", "enable_lora_overlap_loading"),
+    ("lora/marlin_lora_temp/policy.py", "enable_lora"),
+    ("lora/marlin_lora_temp/policy.py", "lora_paths"),
+    ("managers/data_parallel_controller.py", "attn_cp_size"),
+    ("managers/data_parallel_controller.py", "disaggregation_mode"),
+    ("managers/data_parallel_controller.py", "dp_size"),
+    ("managers/data_parallel_controller.py", "enable_dp_attention"),
+    (
+        "managers/data_parallel_controller.py",
+        "enable_dp_attention_local_control_broadcast",
+    ),
+    ("managers/data_parallel_controller.py", "ep_size"),
+    ("managers/data_parallel_controller.py", "load_balance_method"),
+    ("managers/data_parallel_controller.py", "moe_dp_size"),
+    ("managers/data_parallel_controller.py", "pp_size"),
+    ("managers/data_parallel_controller.py", "soft_watchdog_timeout"),
+    ("managers/detokenizer_manager.py", "soft_watchdog_timeout"),
+    ("managers/detokenizer_manager.py", "tokenizer_path"),
+    ("managers/detokenizer_manager.py", "tool_call_parser"),
+    ("managers/disagg_service.py", "disaggregation_bootstrap_port"),
+    ("managers/disagg_service.py", "disaggregation_mode"),
+    ("managers/disagg_service.py", "disaggregation_transfer_backend"),
+    ("managers/load_snapshot.py", "dp_size"),
+    ("managers/load_snapshot.py", "enable_dp_attention"),
+    ("managers/load_snapshot.py", "load_balance_method"),
+    ("managers/overlap_utils.py", "speculative_algorithm"),
+    ("managers/prefill_delayer.py", "disable_overlap_schedule"),
+    ("managers/prefill_delayer.py", "enable_dp_attention"),
+    ("managers/rust_server.py", "mm_process_config"),
+    ("managers/schedule_batch.py", "disaggregation_mode"),
+    ("managers/scheduler.py", "attn_cp_size"),
+    ("managers/scheduler.py", "disable_overlap_schedule"),
+    ("managers/scheduler.py", "disaggregation_mode"),
+    ("managers/scheduler.py", "dp_size"),
+    ("managers/scheduler.py", "enable_dp_attention"),
+    ("managers/scheduler.py", "enable_hierarchical_cache"),
+    ("managers/scheduler.py", "enable_lora"),
+    ("managers/scheduler.py", "enable_lora_overlap_loading"),
+    ("managers/scheduler.py", "ep_size"),
+    ("managers/scheduler.py", "moe_dp_size"),
+    ("managers/scheduler.py", "pp_size"),
+    ("managers/scheduler.py", "soft_watchdog_timeout"),
+    ("managers/scheduler.py", "speculative_algorithm"),
+    (
+        "managers/scheduler_components/new_token_ratio_tracker.py",
+        "schedule_conservativeness",
+    ),
+    ("managers/scheduler_components/recv_skipper.py", "enable_dp_attention"),
+    ("managers/tokenizer_control_mixin.py", "dp_size"),
+    ("managers/tokenizer_manager.py", "disable_radix_cache"),
+    ("managers/tokenizer_manager.py", "disaggregation_mode"),
+    ("managers/tokenizer_manager.py", "disaggregation_transfer_backend"),
+    ("managers/tokenizer_manager.py", "dp_size"),
+    ("managers/tokenizer_manager.py", "enable_dp_attention"),
+    ("managers/tokenizer_manager.py", "enable_lora"),
+    ("managers/tokenizer_manager.py", "enable_tokenizer_batch_encode"),
+    ("managers/tokenizer_manager.py", "encoder_transfer_backend"),
+    ("managers/tokenizer_manager.py", "limit_mm_data_per_request"),
+    ("managers/tokenizer_manager.py", "lora_paths"),
+    ("managers/tokenizer_manager.py", "mm_feature_transport"),
+    ("managers/tokenizer_manager.py", "model_path"),
+    ("managers/tokenizer_manager.py", "preferred_sampling_params"),
+    ("managers/tokenizer_manager.py", "return_hidden_states_mode"),
+    ("managers/tokenizer_manager.py", "served_model_name"),
+    ("managers/tokenizer_manager.py", "soft_watchdog_timeout"),
+    ("managers/tokenizer_manager.py", "speculative_algorithm"),
+    ("managers/tokenizer_manager.py", "speculative_num_draft_tokens"),
+    ("managers/tokenizer_manager.py", "tokenizer_path"),
+    ("managers/tp_worker.py", "disable_overlap_schedule"),
+    ("managers/tp_worker.py", "model_path"),
+    ("managers/tp_worker.py", "random_seed"),
+    ("managers/tp_worker.py", "speculative_algorithm"),
+    ("managers/tp_worker.py", "tokenizer_path"),
+    ("managers/utils.py", "speculative_algorithm"),
+    ("managers/utils.py", "speculative_eagle_topk"),
+    ("managers/utils.py", "speculative_num_steps"),
+    ("mem_cache/allocation_sizing.py", "page_size"),
+    ("mem_cache/allocation_sizing.py", "speculative_algorithm"),
+    ("mem_cache/allocation_sizing.py", "speculative_eagle_topk"),
+    ("mem_cache/allocation_sizing.py", "speculative_num_steps"),
+    ("mem_cache/hiradix_cache.py", "hicache_io_backend"),
+    ("mem_cache/hiradix_cache.py", "hicache_mem_layout"),
+    ("mem_cache/hiradix_cache.py", "served_model_name"),
+    ("mem_cache/hybrid_cache/hybrid_pool_assembler.py", "hicache_io_backend"),
+    ("mem_cache/hybrid_cache/hybrid_pool_assembler.py", "hicache_mem_layout"),
+    ("mem_cache/hybrid_cache/hybrid_pool_assembler.py", "served_model_name"),
+    ("mem_cache/kv_cache_builder.py", "disable_radix_cache"),
+    ("mem_cache/kv_cache_builder.py", "disaggregation_mode"),
+    ("mem_cache/kv_cache_builder.py", "enable_dp_attention"),
+    ("mem_cache/kv_cache_builder.py", "hicache_mem_layout"),
+    ("mem_cache/radix_cache_cpp.py", "enable_hierarchical_cache"),
+    ("model_executor/forward_batch_info.py", "enable_return_hidden_states"),
+    ("model_executor/forward_batch_info.py", "return_hidden_states_mode"),
+    ("model_executor/model_runner.py", "device"),
+    ("model_executor/model_runner.py", "speculative_algorithm"),
+    ("model_executor/model_runner.py", "speculative_draft_attention_backend"),
+    ("model_executor/model_runner_components/load_model_utils.py", "load_format"),
+    ("model_executor/model_runner_components/load_model_utils.py", "quantization"),
+    (
+        "model_executor/model_runner_components/spec_aux_hidden_state.py",
+        "speculative_draft_attention_backend",
+    ),
+    (
+        "model_executor/model_runner_components/spec_aux_hidden_state.py",
+        "speculative_draft_model_path",
+    ),
+    (
+        "model_executor/model_runner_components/spec_aux_hidden_state.py",
+        "speculative_draft_model_revision",
+    ),
+    ("model_executor/model_runner_components/startup_weight_load.py", "attn_cp_size"),
+    (
+        "model_executor/model_runner_components/startup_weight_load.py",
+        "cuda_graph_config",
+    ),
+    (
+        "model_executor/model_runner_components/startup_weight_load.py",
+        "custom_weight_loader",
+    ),
+    ("model_executor/model_runner_components/startup_weight_load.py", "device"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "dp_size"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "enable_lora"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "ep_size"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "lora_paths"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "pp_size"),
+    (
+        "model_executor/model_runner_components/startup_weight_load.py",
+        "speculative_algorithm",
+    ),
+    (
+        "model_executor/runner_backend/tc_piecewise_cuda_graph_backend.py",
+        "cuda_graph_config",
+    ),
+    ("models/sarvam_moe.py", "attention_backend"),
+    ("models/sarvam_moe.py", "decode_attention_backend"),
+    ("models/sarvam_moe.py", "prefill_attention_backend"),
+    ("multimodal/cache/identity.py", "mm_process_config"),
+    ("multimodal/processors/base_processor.py", "image_processor_backend"),
+    ("multimodal/processors/base_processor.py", "mm_feature_transport"),
+    ("multimodal/processors/base_processor.py", "mm_process_config"),
+    ("multimodal/processors/mimo_v2.py", "device"),
+    ("observability/metrics_collector.py", "disaggregation_mode"),
+    ("observability/metrics_collector.py", "prefill_delayer_max_delay_passes"),
+    ("observability/metrics_collector.py", "served_model_name"),
+    ("parser/template_detection.py", "model_path"),
+    ("ray/data_parallel_controller.py", "attn_cp_size"),
+    ("ray/data_parallel_controller.py", "dp_size"),
+    ("ray/data_parallel_controller.py", "enable_dp_attention"),
+    ("ray/data_parallel_controller.py", "pp_size"),
+    ("ray/engine.py", "dp_size"),
+    ("ray/engine.py", "enable_dp_attention"),
+    ("ray/engine.py", "pp_size"),
+    ("speculative/adaptive_spec_params.py", "speculative_algorithm"),
+    ("speculative/adaptive_spec_params.py", "speculative_eagle_topk"),
+    ("speculative/dflash_worker_v2.py", "speculative_draft_window_size"),
+    ("speculative/dflash_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/draft_worker_common.py", "speculative_draft_attention_backend"),
+    ("speculative/dspark_components/dspark_config.py", "speculative_draft_model_path"),
+    (
+        "speculative/dspark_components/dspark_config.py",
+        "speculative_draft_model_revision",
+    ),
+    ("speculative/dspark_components/dspark_worker_v2.py", "disable_cuda_graph"),
+    ("speculative/dspark_components/dspark_worker_v2.py", "disaggregation_mode"),
+    ("speculative/dspark_components/dspark_worker_v2.py", "enable_dp_attention"),
+    (
+        "speculative/dspark_components/dspark_worker_v2.py",
+        "speculative_num_draft_tokens",
+    ),
+    ("speculative/eagle_disaggregation.py", "enable_multi_layer_eagle"),
+    ("speculative/eagle_disaggregation.py", "speculative_eagle_topk"),
+    ("speculative/eagle_disaggregation.py", "speculative_num_steps"),
+    ("speculative/eagle_worker_v2.py", "device"),
+    ("speculative/eagle_worker_v2.py", "enable_dp_attention"),
+    ("speculative/eagle_worker_v2.py", "speculative_adaptive"),
+    ("speculative/eagle_worker_v2.py", "speculative_algorithm"),
+    ("speculative/eagle_worker_v2.py", "speculative_eagle_topk"),
+    ("speculative/eagle_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/eagle_worker_v2.py", "speculative_num_steps"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "device"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "enable_dp_attention"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_adaptive"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_algorithm"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_eagle_topk"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_num_steps"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "device"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "enable_dp_attention"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_algorithm"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_eagle_topk"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_num_steps"),
+    ("speculative/ngram_worker.py", "device"),
+    ("speculative/ngram_worker.py", "disable_overlap_schedule"),
+    ("speculative/ngram_worker.py", "speculative_eagle_topk"),
+    ("speculative/ngram_worker.py", "speculative_num_draft_tokens"),
+    ("speculative/ngram_worker.py", "speculative_num_steps"),
+    ("speculative/spec_info.py", "enable_multi_layer_eagle"),
+    ("speculative/spec_info.py", "speculative_eagle_topk"),
+    ("speculative/spec_info.py", "speculative_num_draft_tokens"),
+    ("speculative/spec_info.py", "speculative_num_steps"),
+    ("speculative/spec_registry.py", "disable_overlap_schedule"),
+    ("speculative/spec_utils.py", "speculative_eagle_topk"),
+    ("speculative/spec_utils.py", "speculative_num_draft_tokens"),
+    ("speculative/standalone_worker_v2.py", "device"),
+    ("speculative/standalone_worker_v2.py", "enable_dp_attention"),
+    ("speculative/standalone_worker_v2.py", "speculative_algorithm"),
+    ("speculative/standalone_worker_v2.py", "speculative_eagle_topk"),
+    ("speculative/standalone_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/standalone_worker_v2.py", "speculative_num_steps"),
+    ("utils/common.py", "page_size"),
+    ("utils/common.py", "speculative_eagle_topk"),
+    ("utils/common.py", "speculative_num_draft_tokens"),
+    ("utils/common.py", "speculative_num_steps"),
+    ("utils/cuda_vmm_transport_utils.py", "dp_size"),
+    ("utils/cuda_vmm_transport_utils.py", "enable_dp_attention"),
+    ("utils/cuda_vmm_transport_utils.py", "mm_feature_transport"),
+    ("utils/hf_transformers/processor.py", "image_processor_backend"),
+    ("utils/offloader.py", "dp_size"),
+}
+
+# Pairs whose resolution write only happens on a CUDA host (capability or
+# `is_cuda()` gated): asserted on the CUDA registration, invisible to the CPU
+# one. Empty today -- the current written sets coincide across the two hosts --
+# but this is where a GPU-only write's readers get pinned without breaking the
+# CPU-exact assertion.
+_EXPOSED_CUDA_ONLY: frozenset = frozenset()
+
+
+# Axis two: (file, field) pairs where a supplied-instance read names a field that
+# some code overrides post-publish. Each needs an ordering judgment, not a blanket
+# conversion; the list exists so a new one is a decision made when it is written.
+_OVERRIDDEN_AND_READ = {
+    ("configs/model_config.py", "dtype"),
+    ("configs/model_config.py", "model_path"),
+    ("constrained/base_grammar_backend.py", "grammar_backend"),
+    ("disaggregation/decode_kvcache_offload_manager.py", "hicache_storage_backend"),
+    (
+        "disaggregation/decode_kvcache_offload_manager.py",
+        "hicache_storage_backend_extra_config",
+    ),
+    ("disaggregation/encode_server.py", "dp_size"),
+    ("disaggregation/encode_server.py", "load_format"),
+    ("disaggregation/encode_server.py", "model_path"),
+    (
+        "distributed/device_communicators/mooncake_transfer_engine.py",
+        "hicache_storage_backend",
+    ),
+    ("dllm/config.py", "model_path"),
+    ("elastic_ep/expert_backup_manager.py", "load_format"),
+    ("entrypoints/engine.py", "dp_size"),
+    ("entrypoints/engine.py", "dtype"),
+    ("entrypoints/engine.py", "ep_size"),
+    ("entrypoints/engine.py", "load_format"),
+    ("entrypoints/engine.py", "model_path"),
+    ("entrypoints/http_server.py", "dp_size"),
+    ("entrypoints/http_server.py", "model_path"),
+    ("kv_canary/api.py", "speculative_num_steps"),
+    ("kv_canary/capacities.py", "speculative_num_draft_tokens"),
+    ("layers/dp_attention.py", "dp_size"),
+    ("managers/data_parallel_controller.py", "dp_size"),
+    ("managers/data_parallel_controller.py", "ep_size"),
+    ("managers/load_snapshot.py", "dp_size"),
+    ("managers/scheduler.py", "dp_size"),
+    ("managers/scheduler.py", "ep_size"),
+    ("managers/scheduler.py", "hicache_storage_backend"),
+    ("managers/tokenizer_control_mixin.py", "dp_size"),
+    ("managers/tokenizer_manager.py", "dp_size"),
+    ("managers/tokenizer_manager.py", "model_path"),
+    ("managers/tokenizer_manager.py", "speculative_num_draft_tokens"),
+    ("managers/tp_worker.py", "model_path"),
+    ("managers/utils.py", "speculative_num_steps"),
+    ("mem_cache/allocation_sizing.py", "speculative_num_steps"),
+    ("mem_cache/hiradix_cache.py", "hicache_storage_backend"),
+    ("mem_cache/hiradix_cache.py", "hicache_storage_backend_extra_config"),
+    ("mem_cache/hiradix_cache.py", "hicache_storage_prefetch_policy"),
+    ("mem_cache/hiradix_cache.py", "hicache_write_policy"),
+    ("mem_cache/hybrid_cache/hybrid_pool_assembler.py", "hicache_storage_backend"),
+    ("mem_cache/hybrid_cache/hybrid_pool_assembler.py", "hicache_write_policy"),
+    ("mem_cache/kv_cache_builder.py", "hicache_storage_backend"),
+    ("mem_cache/pool_host/common.py", "hicache_storage_backend"),
+    ("mem_cache/pool_host/common.py", "hicache_storage_backend_extra_config"),
+    ("mem_cache/radix_cache_cpp.py", "hicache_write_policy"),
+    ("mem_cache/unified_radix_cache.py", "hicache_storage_backend"),
+    ("mem_cache/unified_radix_cache.py", "hicache_storage_backend_extra_config"),
+    ("mem_cache/unified_radix_cache.py", "hicache_storage_prefetch_policy"),
+    ("mem_cache/unified_radix_cache.py", "hicache_write_policy"),
+    ("model_executor/model_runner_components/load_model_utils.py", "load_format"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "dp_size"),
+    ("model_executor/model_runner_components/startup_weight_load.py", "ep_size"),
+    ("parser/template_detection.py", "model_path"),
+    ("ray/data_parallel_controller.py", "dp_size"),
+    ("ray/engine.py", "dp_size"),
+    ("speculative/dflash_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/dspark_components/dspark_worker_v2.py", "disable_cuda_graph"),
+    (
+        "speculative/dspark_components/dspark_worker_v2.py",
+        "speculative_num_draft_tokens",
+    ),
+    ("speculative/eagle_disaggregation.py", "speculative_num_steps"),
+    ("speculative/eagle_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/eagle_worker_v2.py", "speculative_num_steps"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/frozen_kv_mtp_worker_v2.py", "speculative_num_steps"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/multi_layer_eagle_worker_v2.py", "speculative_num_steps"),
+    ("speculative/ngram_worker.py", "speculative_num_draft_tokens"),
+    ("speculative/ngram_worker.py", "speculative_num_steps"),
+    ("speculative/spec_info.py", "speculative_num_draft_tokens"),
+    ("speculative/spec_info.py", "speculative_num_steps"),
+    ("speculative/spec_utils.py", "speculative_num_draft_tokens"),
+    ("speculative/standalone_worker_v2.py", "speculative_num_draft_tokens"),
+    ("speculative/standalone_worker_v2.py", "speculative_num_steps"),
+    ("utils/common.py", "speculative_num_draft_tokens"),
+    ("utils/common.py", "speculative_num_steps"),
+    ("utils/cuda_vmm_transport_utils.py", "dp_size"),
+    ("utils/offloader.py", "dp_size"),
+}
+
+
+def _expanded_override_keys(rel, tree, call, kw) -> set:
+    """The statically visible keys behind an ``override(..., **expr)``.
+
+    Handles a dict literal, a conditional between dict literals, and a name
+    bound to a dict literal in the enclosing function (plus constant-subscript
+    stores onto it -- the HiCache attach shape). One expansion is unresolvable
+    by design and exempted by name: ``update_server_args`` forwards
+    operator-chosen fields, so its key set is the API's, not this file's.
+    Anything else unresolvable fails -- a silently skipped expansion would
+    shrink the written set.
+    """
+    for a in call.args:
+        if isinstance(a, ast.Constant) and a.value == "update_server_args":
+            return set()
+    for k in call.keywords:
+        if (
+            k.arg == "source"
+            and isinstance(k.value, ast.Constant)
+            and k.value.value == "update_server_args"
+        ):
+            return set()
+
+    def dict_keys(node) -> set:
+        assert isinstance(node, ast.Dict) and all(
+            isinstance(key, ast.Constant) for key in node.keys
+        ), f"non-literal dict in override expansion at {rel}:{call.lineno}"
+        return {key.value for key in node.keys}
+
+    if isinstance(kw.value, ast.Dict):
+        return dict_keys(kw.value)
+    if isinstance(kw.value, ast.IfExp):
+        keys = set()
+        for branch in (kw.value.body, kw.value.orelse):
+            if isinstance(branch, ast.Dict) and branch.keys:
+                keys |= dict_keys(branch)
+            elif isinstance(branch, ast.Dict):
+                pass
+            else:
+                raise AssertionError(
+                    f"unresolvable override expansion at {rel}:{call.lineno}"
+                )
+        return keys
+    assert isinstance(
+        kw.value, ast.Name
+    ), f"unresolvable override expansion at {rel}:{call.lineno}"
+    name = kw.value.id
+    enclosing = None
+    for fn in ast.walk(tree):
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if (
+                fn.lineno
+                <= call.lineno
+                <= max(getattr(fn, "end_lineno", fn.lineno), fn.lineno)
+            ):
+                if enclosing is None or fn.lineno > enclosing.lineno:
+                    enclosing = fn
+    assert (
+        enclosing is not None
+    ), f"override expansion outside any function at {rel}:{call.lineno}"
+    keys = set()
+    found = False
+    for node in ast.walk(enclosing):
+        if (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+            and node.targets[0].id == name
+            and isinstance(node.value, ast.Dict)
+        ):
+            found = True
+            keys |= dict_keys(node.value)
+        elif (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Subscript)
+            and isinstance(node.targets[0].value, ast.Name)
+            and node.targets[0].value.id == name
+            and isinstance(node.targets[0].slice, ast.Constant)
+        ):
+            keys.add(node.targets[0].slice.value)
+    assert found, (
+        f"override expansion '{name}' at {rel}:{call.lineno} has no "
+        "dict-literal assignment in its function; extend the resolver"
+    )
+    return keys
+
+
+class TestSuppliedInstanceExposure(CustomTestCase):
+    def _callTestMethod(self, method):
+        # No CI retry: a failed first attempt has already resolved the matrix
+        # and mutated process state; a retry against that contamination could
+        # pass on a drifted written set or mask a real drift.
+        return unittest.TestCase._callTestMethod(self, method)
+
+    def setUp(self):
+        # Resolving the matrix writes process state on the way through (the
+        # multimodal transport handler sets SGLANG_USE_CUDA_IPC_TRANSPORT, and
+        # `EnvField.set()` flips a descriptor flag `os.environ` does not carry).
+        # Leaking it makes *later* files in the same worker fail, which is how
+        # this was found -- so the case restores what it touched.
+        super().setUp()
+        state = (dict(os.environ), self._env_field_flags())
+        self.addCleanup(self._restore_process_state, state)
+
+    @staticmethod
+    def _env_field_flags() -> dict:
+        from sglang.srt.environ import EnvField, envs
+
+        flags = {}
+        for klass in reversed(type(envs).__mro__):
+            for name, field in vars(klass).items():
+                if isinstance(field, EnvField):
+                    flags[name] = field._set_to_none
+        return flags
+
+    @staticmethod
+    def _restore_process_state(state) -> None:
+        from sglang.srt.environ import envs
+
+        saved_environ, saved_flags = state
+        os.environ.clear()
+        os.environ.update(saved_environ)
+        for name, was_none in saved_flags.items():
+            getattr(type(envs), name)._set_to_none = was_none
+
+    def _config_dir(self) -> str:
+        config_dir = tempfile.mkdtemp(prefix="supplied_instance_")
+        self.addCleanup(shutil.rmtree, config_dir, ignore_errors=True)
+        with open(os.path.join(config_dir, "config.json"), "w") as handle:
+            json.dump(_MINI_CONFIG, handle)
+        return config_dir
+
+    def _resolution_written_fields(self) -> set:
+        """The union of what resolution fills in across the matrix.
+
+        Every entry must resolve. A silently skipped one would shrink this set,
+        which makes pinned pairs look like they disappeared -- the list would
+        then drift by environment rather than by code, and the failure would
+        point at the wrong thing. Each entry resolves from the pristine
+        process snapshot (resolution writes env and EnvField flags on the way
+        through, and DWDP flips `SGLANG_SCHEDULER_SKIP_ALL_GATHER`), so the
+        union does not depend on matrix order; and the ambient CI marker is
+        cleared, so a runner's identity cannot leak into the measurement --
+        the CI-conditioned writes come from `_ENV_MATRIX`'s explicit entry.
+        Late resolution counts too: `declare_late_resolution` writers run at
+        launcher stage (LoRA normalization, parser auto-detection), so their
+        target fields are collected statically from the call sites -- they are
+        resolution writes by definition, just staged after `__post_init__`.
+        """
+        pristine = (dict(os.environ), self._env_field_flags())
+        written = set()
+
+        def resolve_one(extra, env):
+            self._restore_process_state(pristine)
+            os.environ.pop("SGLANG_IS_IN_CI", None)
+            os.environ.update(env)
+            model_path = self._config_dir()
+            try:
+                resolved = ServerArgs(
+                    model_path=model_path, device="cuda", random_seed=42, **extra
+                )
+            except Exception as exc:
+                self.fail(
+                    f"the matrix entry {extra} (env={env}) did not resolve in "
+                    f"this environment ({type(exc).__name__}: {exc}); the "
+                    "written-field union would be short and the pinned list "
+                    "would drift"
+                )
+            defaults = {}
+            for field in dataclasses.fields(resolved):
+                if field.default is not dataclasses.MISSING:
+                    defaults[field.name] = field.default
+                elif field.default_factory is not dataclasses.MISSING:
+                    defaults[field.name] = field.default_factory()
+            for field_name, default in defaults.items():
+                if field_name in _PASSED or field_name in extra:
+                    continue
+                if getattr(resolved, field_name) != default:
+                    written.add(field_name)
+
+        for extra in _MATRIX:
+            resolve_one(extra, {})
+        for extra, env in _ENV_MATRIX:
+            resolve_one(extra, env)
+        self._restore_process_state(pristine)
+        written |= self._late_resolution_written_fields()
+        written |= self._hook_assignment_targets()
+        written |= self._record_method_assignment_targets()
+        written |= self._declarative_override_fields()
+        return written
+
+    def _hook_assignment_targets(self) -> set:
+        """Fields any resolution hook can write, collected statically.
+
+        The matrix can only enumerate families someone thought to add -- the
+        DFLASH hole (its hook is the sole writer of
+        `speculative_draft_attention_backend`, and no entry ran it) showed
+        that a family nobody listed leaves its readers unpinned. The hook
+        modules under `arg_groups/` are the resolution pipeline's extension
+        points, and their assignment surface (`server_args.field = ...`) is
+        the may-write set, family-blind by construction. Collected like the
+        late-resolution keywords: statically, failing loudly on an
+        unparsable module. Underscore-prefixed targets are pipeline
+        bookkeeping, not config leaves.
+        """
+        targets = set()
+        for path in sorted((_PACKAGE_ROOT / "arg_groups").glob("*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            except SyntaxError:
+                self.fail(f"unparsable hook module in the census: {path.name}")
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Assign):
+                    tgts = node.targets
+                elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                    tgts = [node.target]
+                else:
+                    continue
+                for tgt in tgts:
+                    if (
+                        isinstance(tgt, ast.Attribute)
+                        and isinstance(tgt.value, ast.Name)
+                        and tgt.value.id == "server_args"
+                        and not tgt.attr.startswith("_")
+                    ):
+                        targets.add(tgt.attr)
+        return targets
+
+    def _record_method_assignment_targets(self) -> set:
+        """Fields ``ServerArgs``'s own methods can write, collected statically.
+
+        The record's handlers are as family-conditional as the hooks -- the
+        mooncake/layer_first layout rewrite, the deepseek-EP mode defaults,
+        the seed fill that only runs when the caller did *not* supply one (so
+        construct-and-diff can never see it: measuring requires supplying).
+        A write site that can never fire is a dead branch to delete upstream,
+        not a census exemption. Only names that are declared dataclass fields
+        count; underscore bookkeeping does not.
+        """
+        tree = ast.parse(
+            (_PACKAGE_ROOT / "server_args.py").read_text(encoding="utf-8-sig")
+        )
+        sa_class = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "ServerArgs"
+        )
+        declared = {
+            node.target.id
+            for node in sa_class.body
+            if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name)
+        }
+        targets = set()
+        for node in ast.walk(sa_class):
+            if isinstance(node, ast.Assign):
+                tgts = node.targets
+            elif isinstance(node, (ast.AnnAssign, ast.AugAssign)):
+                tgts = [node.target]
+            else:
+                continue
+            for tgt in tgts:
+                if (
+                    isinstance(tgt, ast.Attribute)
+                    and isinstance(tgt.value, ast.Name)
+                    and tgt.value.id == "self"
+                    and tgt.attr in declared
+                    and not tgt.attr.startswith("_")
+                ):
+                    targets.add(tgt.attr)
+        # The deprecated-alias normalization loop writes through a *name
+        # tuple* (`for attr in (...): setattr(self, attr, "dsv4")`), which no
+        # assignment scan sees; its field set is pinned here with a drift
+        # guard on the tuple itself.
+        alias_fields = {
+            "attention_backend",
+            "decode_attention_backend",
+            "prefill_attention_backend",
+            "speculative_draft_attention_backend",
+        }
+        found_tuples = [
+            {elt.value for elt in node.iter.elts if isinstance(elt, ast.Constant)}
+            for node in ast.walk(sa_class)
+            if isinstance(node, ast.For)
+            and isinstance(node.iter, ast.Tuple)
+            and any(
+                isinstance(inner, ast.Call)
+                and isinstance(inner.func, ast.Name)
+                and inner.func.id == "setattr"
+                for inner in ast.walk(node)
+            )
+        ]
+        self.assertIn(
+            alias_fields,
+            found_tuples,
+            "the deprecated-alias normalization loop moved or changed its "
+            "field tuple; update alias_fields to match",
+        )
+        return targets | alias_fields
+
+    def _declarative_override_fields(self) -> set:
+        """Fields the declarative override registry can write.
+
+        ``MODEL_OVERRIDES`` maps arch -> {field: value}, and the
+        ``@register_model_override``(-``_predicate``) providers return (or
+        build by subscript) {field: value} dicts; ``materialize_declarations``
+        applies them all via setattr, so no assignment scan sees these writes
+        and a llama-only matrix never triggers them. Keys must be
+        string literals; anything else fails loudly.
+        """
+        tree = ast.parse(
+            (_PACKAGE_ROOT / "arg_groups" / "overrides.py").read_text(
+                encoding="utf-8-sig"
+            )
+        )
+        fields = set()
+        for node in tree.body:
+            target = None
+            if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name):
+                target = node.targets[0].id
+            elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+                target = node.target.id
+            if target != "MODEL_OVERRIDES" or node.value is None:
+                continue
+            for inner in ast.walk(node.value):
+                if not isinstance(inner, ast.Dict):
+                    continue
+                for key, value in zip(inner.keys, inner.values):
+                    if isinstance(value, ast.Dict):
+                        continue  # arch -> {…} outer layer
+                    self.assertIsInstance(key, ast.Constant, "non-literal override key")
+                    fields.add(key.value)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if not any(
+                isinstance(dec, ast.Call)
+                and isinstance(dec.func, ast.Name)
+                and dec.func.id.startswith("register_model_override")
+                for dec in node.decorator_list
+            ):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Assign) and isinstance(
+                    inner.targets[0], ast.Subscript
+                ):
+                    key = inner.targets[0].slice
+                    self.assertIsInstance(
+                        key, ast.Constant, f"non-literal override key in {node.name}"
+                    )
+                    fields.add(key.value)
+                if isinstance(inner, ast.Dict):
+                    for key in inner.keys:
+                        self.assertIsInstance(
+                            key,
+                            ast.Constant,
+                            f"non-literal override key in {node.name}",
+                        )
+                        fields.add(key.value)
+        return fields
+
+    def _late_resolution_written_fields(self) -> set:
+        """Fields `declare_late_resolution` writes, collected statically.
+
+        These are resolution's launcher-stage writes (they need a tokenizer or
+        adapter load, so they cannot run in `__post_init__`), which the
+        construct-and-diff pass above never sees. The keywords at the call
+        sites are the written fields; an expansion this cannot resolve fails
+        loudly like the override collector's, except the named dynamic sites
+        below, whose field sets are spelled out and drift-guarded (each name
+        must still appear as a constant in the file)."""
+        written = set()
+        root = _PACKAGE_ROOT
+        for path in sorted(root.rglob("*.py")):
+            rel = path.relative_to(root).as_posix()
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            except SyntaxError:
+                self.fail(f"unparsable module in the census: {rel}")
+            for node in ast.walk(tree):
+                if not (
+                    isinstance(node, ast.Call)
+                    and (
+                        (
+                            isinstance(node.func, ast.Name)
+                            and node.func.id == "declare_late_resolution"
+                        )
+                        or (
+                            isinstance(node.func, ast.Attribute)
+                            and node.func.attr
+                            in ("declare_late_resolution", "_late_resolution")
+                        )
+                    )
+                ):
+                    continue
+                if all(kw.arg is None for kw in node.keywords) and any(
+                    isinstance(kw.value, ast.Name) and kw.value.id == "fields"
+                    for kw in node.keywords
+                ):
+                    # The forwarding shim (`ServerArgs._late_resolution` /
+                    # the helper's own body) re-expands its caller's kwargs;
+                    # the write sites are the callers.
+                    continue
+                for kw in node.keywords:
+                    if kw.arg and kw.arg != "source":
+                        written.add(kw.arg)
+                    elif kw.arg is None:
+                        dynamic = _LATE_RESOLUTION_DYNAMIC_SITES.get(rel)
+                        if dynamic is not None:
+                            constants = {
+                                c.value
+                                for c in ast.walk(tree)
+                                if isinstance(c, ast.Constant)
+                            }
+                            missing = dynamic - constants
+                            self.assertFalse(
+                                missing,
+                                f"{rel}: the declared dynamic field set drifted "
+                                f"from the file ({sorted(missing)} not found)",
+                            )
+                            written |= dynamic
+                        else:
+                            written |= _expanded_override_keys(rel, tree, node, kw)
+        return written
+
+    def _supplied_instance_reads(self) -> set:
+        """Three spellings of the same read: ``server_args.field`` off the
+        parameter, ``getattr(server_args, "field", default)`` with a literal
+        name, and the *parked* form -- ``self.x = server_args`` in a method
+        that takes the parameter, read as ``self.x.field`` anywhere in the
+        class. Parking under a different object, a container, or a computed
+        name stays invisible, like in every census of this family -- the
+        loudest known boundary is the *chain* spelling,
+        ``model_runner.server_args.field`` off some other parameter, which
+        this census does not count (~150 reads tree-wide; extending the pin
+        to that spelling is its own step, not a by-product of this one)."""
+        pairs = set()
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            if rel.startswith(_OWNERS):
+                continue
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            except SyntaxError:
+                # A silently dropped module shrinks `found` and reads as
+                # intentional surface shrinkage under the bidirectional pin.
+                self.fail(f"unparsable module in the census: {rel}")
+            for fn in ast.walk(tree):
+                if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                params = {a.arg for a in list(fn.args.args) + list(fn.args.kwonlyargs)}
+                if "server_args" not in params:
+                    continue
+                for node in ast.walk(fn):
+                    if (
+                        isinstance(node, ast.Attribute)
+                        and isinstance(node.value, ast.Name)
+                        and node.value.id == "server_args"
+                        and isinstance(node.ctx, ast.Load)
+                    ):
+                        pairs.add((rel, node.attr))
+                    elif (
+                        isinstance(node, ast.Call)
+                        and isinstance(node.func, ast.Name)
+                        and node.func.id == "getattr"
+                        and len(node.args) >= 2
+                        and isinstance(node.args[0], ast.Name)
+                        and node.args[0].id == "server_args"
+                        and isinstance(node.args[1], ast.Constant)
+                        and isinstance(node.args[1].value, str)
+                    ):
+                        # The same read in optional clothing. Only a literal
+                        # name is censusable; a computed one is not.
+                        pairs.add((rel, node.args[1].value))
+            for cls in ast.walk(tree):
+                if not isinstance(cls, ast.ClassDef):
+                    continue
+                # Parked: `self.x = server_args` in a method that takes the
+                # parameter, read as `self.x.field` anywhere in the class.
+                parked = set()
+                for fn in cls.body:
+                    if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                        continue
+                    if "server_args" not in {
+                        a.arg for a in list(fn.args.args) + list(fn.args.kwonlyargs)
+                    }:
+                        continue
+                    for node in ast.walk(fn):
+                        if (
+                            isinstance(node, ast.Assign)
+                            and len(node.targets) == 1
+                            and isinstance(node.targets[0], ast.Attribute)
+                            and isinstance(node.targets[0].value, ast.Name)
+                            and node.targets[0].value.id == "self"
+                            and isinstance(node.value, ast.Name)
+                            and node.value.id == "server_args"
+                        ):
+                            parked.add(node.targets[0].attr)
+                for node in ast.walk(cls):
+                    if (
+                        isinstance(node, ast.Attribute)
+                        and isinstance(node.ctx, ast.Load)
+                        and isinstance(node.value, ast.Attribute)
+                        and node.value.attr in parked
+                        and isinstance(node.value.value, ast.Name)
+                        and node.value.value.id == "self"
+                    ):
+                        pairs.add((rel, node.attr))
+        return pairs
+
+    @staticmethod
+    def _override_written_fields() -> set:
+        """Fields written post-publish through ``get_context().override(...)``."""
+        written = set()
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            except SyntaxError:
+                raise AssertionError(f"unparsable module in the census: {rel}")
+            for node in ast.walk(tree):
+                if not (
+                    isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "override"
+                ):
+                    continue
+                base = node.func.value
+                if (
+                    isinstance(base, ast.Call)
+                    and isinstance(base.func, ast.Name)
+                    and base.func.id == "get_context"
+                ):
+                    for kw in node.keywords:
+                        if kw.arg == "source":
+                            # Override metadata, not a config field.
+                            continue
+                        if kw.arg:
+                            written.add(kw.arg)
+                        else:
+                            written |= _expanded_override_keys(rel, tree, node, kw)
+        return written
+
+    def test_the_post_publish_override_surface_matches_the_pinned_list(self):
+        written = self._override_written_fields()
+        self.assertGreater(
+            len(written), 5, "found almost no override targets; the scan broke"
+        )
+        found = {pair for pair in self._supplied_instance_reads() if pair[1] in written}
+        new = sorted(found - _OVERRIDDEN_AND_READ)
+        gone = sorted(_OVERRIDDEN_AND_READ - found)
+        self.assertEqual(
+            ([], []),
+            (new, gone),
+            "the post-publish override surface drifted. A read here answers with "
+            "the startup value once the override lands, so a new pair needs an "
+            "ordering judgment: copied before any override (fine), or read after "
+            "one (then it must come from the bags).\n"
+            f"  new: {new}\n"
+            f"  gone (delete from _OVERRIDDEN_AND_READ): {gone}",
+        )
+
+    def test_the_exposed_set_matches_the_pinned_list(self):
+        import torch
+
+        written = self._resolution_written_fields()
+        found = {pair for pair in self._supplied_instance_reads() if pair[1] in written}
+        expected = set(_EXPOSED)
+        if torch.cuda.is_available():
+            expected |= _EXPOSED_CUDA_ONLY
+        new = sorted(found - expected)
+        gone = sorted(expected - found)
+        self.assertEqual(
+            ([], []),
+            (new, gone),
+            "the supplied-instance step-12 surface drifted.\n"
+            f"  new (decide where the resolved value comes from): {new}\n"
+            f"  gone (delete from _EXPOSED / _EXPOSED_CUDA_ONLY): {gone}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Not for merge.** This branch carries the whole stack so CI runs it as one unit and review comments have one place to land. The members merge individually, in order:

| # | PR | what |
|---|---|---|
| 0 | #34376 | **the stack's base, and a fix for main**: the linear-attn kernel choice becomes a per-runner stamp, plus a direct draft/target loader-hook parity invariant |
| 1 | #34263 | the last runner-side `self.server_args` reads → bags, plus two bag-derived accessors |
| 2 | #34264 | decisions keyed on the attention backend read the configured **pair** (**the only user-visible behaviour change in the stack**; the gpt-oss sinks dtype it originally carried is split out into #34917, which merges independently of this stack) |
| 3 | #34265 | a named entry point for resolution, and the last dynamic config read spelled out |
| 4 | #34266 | the **alias form** of the instance read — 57 sites the earlier grep never saw |
| 5 | #34819 (replaces #34268) | the post-publish consumers of the census's supplied-instance debt read the bags (the page_size / chunked_prefill_size / graph-limit families) — **merges before #34267**, so the pin list lands at its final value with no in-stack churn |
| 6 | #34267 | pin the remaining supplied-instance surface **on two axes**: what a raw record would change (297 pairs over the 125 fields resolution can write; written set = matrix ∪ statically collected may-write surface over every write mechanism) and what a post-publish override already changes today (75 pairs over 18 fields), plus the EPD tripwire |
| 7 | #34269 | the bag contract stated as "what resolution produced", and the matching skill rule |

### What this is for

The configuration tier's end state keeps `ServerArgs` at the user's raw input and puts resolution's output in the context. That flip is only safe once nothing reads the record for an effective value. The global half landed in #34080–#34097; this stack finishes the **instance** half and, for what must stay on an instance, measures and pins the exposure instead of leaving it implicit.

### Why #34376 is underneath (a bug the second axis found)

Measuring the second axis turned up a read that is wrong on main today, independent of step 12: `attn_backend_wrapper` recorded the SM100 GDN prefill auto-default into the process-wide config, while the linear-attn dispatch table rebuilt itself from the `ServerArgs` record — once per runner. A second runner's rebuild therefore replaced the first one's kernel with the base backend (demonstrated in-process: `FLASHINFER`, then `TRITON`). The fix belongs on main rather than in this stack, so it is its own PR and the stack sits on it.

Its shape matters for review here: the choice is now a **per-runner stamp** (`runner.linear_attn_backends`, resolved before the backends that read it are built), like `prefill_attention_backend_str` / `decode_attention_backend_str` — a target and its draft must be able to want different kernels. A per-runner value is also no longer recorded process-wide at all, because that recording *is* the leak: the bag leaf is how the gate asks "did the operator name a backend", so a recorded default reads back as an operator flag and the next runner declines its own. That is why #34266's flip of the gate to the bag leaf is correct as written, and why the second axis no longer lists the site — the ratchet reported it as gone the moment the stack moved onto the fix, which is the two-way pin doing its job.

### Codex round 1 (2026-08-10): 8 comments, 8 real, all folded into their originating members

- **inkling per-mode selection** (P1, #34264): extend under a split pair dispatches to the prefill half; the code always described the decode half. Now `serving_attention_backend()` mirrors `HybridAttnBackend._select_backend` and prefers the runner-stamped pair.
- **gpt-oss sinks dtype** (P1, #34264): float32-for-either-half breaks the FA4 phase of the same launch (FA4 asserts bfloat16). The decision is now removed entirely — bfloat16 unconditionally, the trtllm backend upcasts at its call site (exact).
- **extend writer gate** (P2, carrier): `write_cache_indices` has one caller (`alloc_for_extend`) → prefill half only, so a mixed launch keeps the triton writer.
- **seam test** (P2, #34265): now compares the full caller list against the single expected `ServerArgs.__post_init__` (duplicate / removal / same-named dunder all fail; reverse-verified).
- **census getattr form** (P2, #34267): the exposure census also counts `getattr(server_args, "field", default)` with a literal name — 3 more reads pinned.
- **EPD tripwire raw value** (P2, #34267): pins `"auto"` (the actual argument default), not `None`.
- **standalone runner publish order** (P1, #34268): `python -m sglang.benchmark.one_batch` crashed on the pre-publish bag read (reproduced); the constructor's own publish now precedes its first bag read (one_batch verified green on the new tip).

### Codex round 2 (2026-08-10, after the first repush): 3 comments, 3 real, folded the same way

- **gpt-oss draft-context sinks** (P1, #34264): a STANDALONE gpt-oss draft with a pure-trtllm target and `--speculative-draft-attention-backend fa4` builds its model while the config pair says trtllm — any pair-derived dtype rule picks wrong for some runner, because the draft backend is applied after model construction. Resolution: the dtype rule is gone; sinks are bfloat16 unconditionally and trtllm upcasts (exact) at its call site.
- **GDN auto-default idempotency** (P2, #34266): flipping the SM100 default's guard to the bag leaf made its own recorded default read back as "configured", so the TBO dispatcher's second and third creator calls fell back to the base backend for exactly the children that run the split prefill batches. **Superseded by #34376**: the per-runner stamp replaces the process-wide table, and the recording that made the leaf ambiguous is gone, so the guard's bag read is unambiguous and every runner resolves its own choice.
- **census parked-instance form** (P2, #34267): `self.x = server_args` parked in a ctor and read as `self.x.field` in later methods was the third invisible spelling — 9 more reads / 5 more pairs pinned (encode server, eplb manager, rust server, tokenizer manager, base processor). Reverse-verified with a parked probe.

### Codex round 3 (2026-08-10, after the second repush): 5 comments, 5 real, folded the same way

- **draft-extend dispatch alignment** (P1, carrier): the per-mode helper routed draft-extend by `speculative_attention_mode` (deepseek's idiom), but `HybridAttnBackend._select_backend` routes it through the prefill branch. The helper now mirrors the dispatcher exactly; the callable test pins draft-extend → prefill under both spec modes. (deepseek's own dispatch divergence is pre-existing and untouched.)
- **MLX event-loop dispatch** (P1, #34266): `dispatch_event_loop`'s PP checks read the live topology, which asserts on the MLX stub (no torch.distributed); they now read the configured PP size.
- **trtllm sinks upcast cost** (P2, #34264): the per-call upcast is now cached per source tensor, re-derived on in-place weight updates (version bump), and emitted unconditionally under graph capture so replays keep following weight updates.
- **bag-contract reference independence** (P2, #34269): the test's reference is now an independent resolution of the same raw input (a fresh, never-published record) rather than `resolved_server_args_dict()`, which merely reads `vars(server_args)` back.
- **DWDP written-set shape** (P2, #34267): fields a matrix entry passes in are excluded from the written set, and only DWDP makes resolution write `dp_size`/`enable_dp_attention`/`ep_size` itself — adding `{tp_size: 2, dwdp_size: 2}` surfaced the whole DP/EP topology family: **37 more pairs** (launcher, DP controllers, tokenizer family, spec workers). Totals: 1223 reads / 143 exposed / 82 pairs (65 at the stack tip).

### Codex round 4 (2026-08-11, after the rebase onto #34376): 6 comments — 1 branch lag, 5 real, folded the same way

- **auto-default recorded process-wide** (P1, #34376): true of the stale branch head it reviewed — the branch had not been force-pushed after the fix that deletes the recording; pushed, and the deletion is exactly what removes the leak it describes.
- **unstamped replacement backends** (P1, carrier): the spec workers' factory products carried no stamp, so the per-mode helper fell back to the target pair. `DraftBackendFactory._create_backend` stamps its products (draft override first), and the draft-extend conv-sidecar wrapper copies the wrapped stamp.
- **dummy path bypasses resolution** (P2, #34269): the bag-contract test resolved `model_path="dummy"`, which returns before any resolver pass — raw==raw, vacuous. It now resolves a real mini config through the pipeline and `publish()`.
- **EPD tripwire on fixed doubles** (P2, #34267): a fixed double keeps handing the guard the resolved value by construction, so nothing trips at the flip. The tripwire now resolves a real language-only Kimi-K3 TP2 launch and asserts the guard rejects with what resolution produced.
- **MIS matrix entry** (P2, #34267): only `_handle_multi_item_scoring` writes `disable_radix_cache`; the `{enable_mis, attention_backend=flashinfer}` entry pins the radix-cache builder family.
- **`**kwargs` overrides invisible** (P2, #34267): the second-axis collector statically resolves dict-literal expansions (the HiCache attach shape included) and fails loudly on anything unresolvable — six HiCache pairs surfaced.

### Review round 5 (2026-08-11): 1 Codex + a 27-comment human review, all folded

- **late resolution absent from the written census** (Codex, #34267): `declare_late_resolution` writers run at validation, not construction. Collected statically by keyword (`lora_paths`, `reasoning_parser`, `tool_call_parser`), the one dynamic site table-pinned with a drift guard.
- The human review's items are folded member by member (each thread carries its reply): the container rule (`msgspec.Struct`) and a real-backend unstamped-runner test in #34376; EAGLE's per-step children and the `cutedsl_mla`→`trtllm_mla` stamp rename, the pure-capture bypass scope, the any-attribute AST guard and the typed sink cache in #34264; the SWA chunk-cap sizing through the bags and per-case published test doubles in #34266; the written-set environment axis (`SGLANG_IS_IN_CI` matrix + per-entry pristine state), `tokenizer_path`/`served_model_name` leaving the passed-inputs exemption, `default_factory` materialization, fail-loud parsing (which caught a BOM-carrying file every census had skipped), `source=` exemption, no-CI-retry, CUDA registration (AMD scope documented), and the EPD tripwire's device-stable launch + `EnvField` restore in #34267; the sps-table per-case override and the single `chunked_prefill_size` binding in #34268; the per-leaf raw-differs guard without the `model_path` freebie, the resolution-written/passthrough split, sibling resolution from restored process state, and the whole-object skill rule rewrite (disposition ≠ automatically a bag read; per-instance boundaries exempt) in #34269.
- **CPU CI triage**: the two `base-a-test-cpu` failures were ours and are fixed in place — the EPD tripwire resolved a launch whose hybrid state-cache sizing asserts a GPU stack (now `mamba_radix_cache_strategy="no_buffer"` + overlap off), and the exposure ratchet's written set depended on `SGLANG_IS_IN_CI` (now an explicit matrix axis). The b200 `DSLUserCodeError`/cutlass, NPU, and AMD-extra failures reproduce on main and are not ours.

### Review round 6 (2026-08-12): re-review, 6 inline + 8 review-body items, all folded

Four of the six re-reviews came back clean (#34265–#34268 as units); the open items were folded into their originating members:

- **#34376**: the removed fallback's `logging` import / `logger` binding go with it.
- **#34263** (review-body items): `compute_post_capture_kv_resize` reads the bag-backed reserve accessor like the configurator; the transporter's dead `server_args` field and the draft factory's parked record are gone (parameter dropped at all four call sites).
- **#34264**: `TestDraftFactoryStamping` pins the child stamping, the `cutedsl_mla`→`trtllm_mla` rename and the wrapper copy (reverse-verified — nothing turned red before); the child loop is an explicit `stamps_children` contract instead of a defensive `getattr`; `_version` names its private-API contract; `entrypoints/engine.py` joins the pair-reader ratchet; the trtllm backend's `__init__` reads `speculative_eagle_topk` from the spec bag.
- **#34266** (review-body items): the partially-converted functions stop mixing sources — flash-attention constructor seed reads, the metadata-precompute helper (parameter dropped; its pinned pair reported *gone* by the ratchet, the two-way pin working: 112 → 111), the autotune gates, and the fixture's dead parameter.
- **#34269**: the bag-contract class disables the CI retry like the other dual-resolve harnesses.

**A census boundary, named**: the #34266 items were spelled `model_runner.server_args.leaf` — a *chain* form none of the census's three spellings counts (~150 reads tree-wide). The ratchet's docstring now states that boundary; extending the pin to the chain spelling is its own step.

**Process note**: the review-body "Issues outside the diff" sections sat unhandled for a day because the comment sweep read only inline comments — that channel is now part of the sweep.

### Round 7 (2026-08-13): rebase onto current main + the ratchet grows a family-blind written set

- **Rebased onto main `ebc144ce3f`** (107 commits, zero conflicts). This picks up the CuTeDSL 4.6.2 bump (#34372), which is the upstream fix for the b200 `TYPE_UNSTABLE_JOIN` FA4 compile failure this PR's base-b job kept hitting — that job should go green now. The rebase also brought one new supplied-instance read from main (#34398's processor fingerprint reads `mm_process_config`); the two-way pin reported it as `new` on the first post-rebase run, and it is pinned.
- **The written set stops depending on family enumeration** (review catch, twice — Codex found the DFLASH hole, the human review generalized it): the union now includes every `server_args.field = ...` assignment target under `arg_groups/`, collected statically like the late-resolution keywords. 80 pairs the matrix could never expose enter the pin — DFLASH's three readers, the spec-family normalization writers (which the EAGLE entry *supplies* and therefore excludes from construct-and-diff), the CP/disagg hook writers. Totals move to 192 pairs pinned / 175 at the stack tip.
- **The pin is split by host** (review catch): `_EXPOSED` asserted everywhere, `_EXPOSED_CUDA_ONLY` (empty today) for capability-gated writes' readers — one shared exact list cannot represent such a pair, and the old header comment claimed otherwise.

### Round 9 (2026-08-14): the dispositions move below the pin

A reorder casualty, owned and repaired: pushing the reordered branches before retargeting the PR bases let #34268's head become an ancestor of its old base branch, which GitHub auto-marks as merged (and auto-deleted the branch under `delete_branch_on_merge`). Nothing landed on main; the branch is restored, #34267 is retargeted onto it, and #34819 replaces #34268 with the same branch and content.

Review-order cleanup at the maintainer's call: #34268's conversions now sit **before** #34267's ratchet, so the pin list lands once at its final 297 pairs instead of pinning 314 and deleting 17 one member later — the disposition member's diff is purely production conversions, and future pin-list changes (upstream drift, new families) stop cascading renumber edits through four commit messages. The final tree is byte-identical to the round-8 validated tip (verified), so the round-8 boundary and battery evidence carries over; the two reordered intermediate boundaries are the only positions not re-run.

### Round 8 (2026-08-14): the stamp stops trusting the request, the census stops enumerating mechanisms, and the stack rides current main

- **Stamps come from the constructor** (a Codex P1: on Blackwell the `hybrid_linear_attn` draft entry builds a Triton backend but stamped the alias, and Inkling's kwargs assembly asserts a concrete kernel name — first draft-extend forward crashed). Every factory leaf now answers `("effective_name", backend)`; the static rename table is gone; `"nsa"` (builds dsa) and the decode-side hybrid entry were the same shape, all fixed together. Pinned by unit cases incl. a host-dependent-alias case and a source-walking guard that no leaf answers an alias (reverse-verified).
- **The written set adopts may-write semantics wholesale** (maintainer's ruling: a statically-collected write site that can never fire is a dead branch to delete upstream, not a reason to shrink the census). All write mechanisms are now statically collected — hook assignments, the record's own method assignments, the declarative override registry (a Codex catch: `MODEL_OVERRIDES` forces dtype through a setattr applier no assignment scan sees), the drift-guarded alias-normalization tuple, late-resolution keywords — unioned with the matrix. What only may-write can see is now pinned: the mooncake `hicache_mem_layout` rewrite (four memory-pool builders), the deepseek-EP `deepep_mode` defaults, the `random_seed` fill that only fires when the caller did *not* supply one (invisible to construct-and-diff in principle). Totals: **314 pairs pinned / 297 at the stack tip over 125 may-written fields**.
- **Rebased onto current main** (`463981922c`, twice in one day at the maintainer's ask). Three conflicts, all upstream-evolution shaped: the GDN dispatcher grew a configured-verify third argument (#34592) — our per-runner stamp carries `verify`, so it plugs straight in; the global-config read ratchet moved from a registered test to `scripts/lint/` — our exemption-list removal applied to its new home; the FA `num_splits` block became a runtime-policy hook — our deterministic-gate bag conversion applied inside it. The two-way pin flagged main's brand-new `startup_weight_load.py` reading ten may-written fields (plus two override-written ones on the second axis) the moment the stack sat on it — pinned.

### Round 10 (2026-08-15): comment hygiene before merge

A pass over every comment the stack adds to production code, removing what was written for review rather than for the next reader: wiring narration (how a stamp gets set and who reads it), "not X but Y" justifications, before/after bug history ("used to read as None", "the guard never fired"), comparisons to sibling mechanisms, and roadmap notes about the later step. What stays is the forward-looking constraint, in one or two lines: publish must precede the constructor's first bag read, the live PP property asserts on the MLX stub, the sinks weight is bfloat16 while the kernel consumes float32, `Tensor._version` is the private in-place counter, and which half of the pair each decision needs. Test docstrings (the specification itself) are untouched. Behaviour is unchanged — the diff against the validated tip is comments and docstrings only.

### The gpt-oss sinks dtype is split out (#34917)

The census found `gpt_oss` deriving its `sinks` parameter dtype from the configured backend. Converting that read to the pair does not fix it — a single parameter dtype cannot serve a split launch (FA4 asserts bfloat16, trtllm_mha consumes float32), and a draft runner's backend arrives after model construction, so no config source can answer it at all. Deleting the decision is the right fix, but it is a model behaviour change with its own cost profile (a per-layer cast per graph replay for pure-trtllm launches), so it rides in #34917 against main rather than inside a config refactor. This stack leaves `gpt_oss.py` untouched.

### Verification

- **Per-member boundary**: every test file the stack touches, plus the four guardrails, runs at each of the seven boundaries — 220 / 231 / 232 / 233 / 236 / 236 / 237 passed, **0 failed** (an earlier round saw one failure at every boundary, `test_a_resolution_does_not_leak_into_the_next(intermediate='multimodal')`, which reproduced on plain main and has since been fixed upstream). Files a later member adds are reported as not-yet-present rather than silently skipped. The run predates the members-5-and-6 swap, which moves two boundaries without changing the tip.
- **CPU battery** (round 8, on the current-main base; freshly scanned 520-file common list): tip 6758 cases / 332 bad vs base 6752 / 332 — the name-by-name diff shows 0 tip-only and 0 base-only failures; the single not-rerun case is `test_bag_values_match_server_args`, which #34269 rewrites by design.
- **GPU e2e**: GLM-4.7-Flash + NEXTN (tp2), Qwen3-Next-80B-FP8 + NEXTN, Inkling-Small (tp4) and gpt-oss-20b all byte-identical to base (the mixed-pair gpt-oss launch belongs to #34917 now); `one_batch` green on the tip and reproduces the pre-fix crash on the old tip. The linear-attn kit suites (GDN / KDA / lightning / hybrid-linear) pass on the new base: 50 passed + 145 subtests.
- Every added bag read was checked against `namespace_of(ServerArgs)`; the pipeline extraction is byte-identical; pyflakes / black / isort / pre-commit show no new findings versus main.
- The rebase itself was verified patch-against-patch: of the 61 files the pre-rebase stack touched, 6 are now subsumed by #34376 (the linear-attn projection, the registry call site, three test kits, the linear-attn unit test), 41 are byte-identical, and the remaining 14 differ only in hunk context — except the exposure ratchet, which is where the second axis was folded in.

### Where this deliberately stops

297 pinned pairs remain on the first axis, with a proposed disposition each, and 75 on the second, each needing an ordering judgment rather than a blanket conversion. Several are "should this callee take a config at all?", which is a design call; one (`initialize_moe_config`) has a history of running before publish, so converting its read would crash. The larger remaining work — moving resolution's output off the instance — needs the 155 imperative field writes inside the pipeline plus 58 in `arg_groups/` redirected, which is its own design step.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31871115896](https://github.com/sgl-project/sglang/actions/runs/31871115896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31871115736](https://github.com/sgl-project/sglang/actions/runs/31871115736)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->


