### PR TITLE
[CI] Fix GSM8K floating-point tolerance boundary

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_nightly.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_nightly.py
@@ -104,7 +104,8 @@ class AccuracyTwoPassMixin:
             )
             self.assertLessEqual(
                 diff,
-                self.max_accuracy_diff,
+                # Allow floating-point noise at the exact threshold (e.g. 0.98 - 0.96).
+                self.max_accuracy_diff + 1e-12,
                 f"{name} accuracy diff {diff:.3f} exceeds max {self.max_accuracy_diff} "
                 f"(pass1={acc1:.3f}, pass2={acc2:.3f})",
             )


### PR DESCRIPTION
## Summary

Fix the GSM8K two-pass test so an exact 2% accuracy difference doesn’t fail because of floating-point rounding

Sample failure: https://github.com/sgl-project/sglang/actions/runs/31372264761/job/93403825005#step:15:1873

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31378609922](https://github.com/sgl-project/sglang/actions/runs/31378609922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31378609053](https://github.com/sgl-project/sglang/actions/runs/31378609053)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->