### PR TITLE
[CI] Build patched Docker images for both amd64 and arm64

### DIFF
--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -13,10 +13,6 @@ on:
       output_tag:
         description: "Tag to publish as. Overwrites it if it already exists."
         required: true
-      platforms:
-        description: "Platforms to build. The base tag must have a manifest for each one."
-        required: false
-        default: "linux/amd64,linux/arm64"
 
 concurrency:
   # Keyed on the tag being written, which is the only resource two runs contend for.
@@ -133,8 +129,6 @@ jobs:
           fi
 
       - name: Build and push patched image
-        env:
-          PLATFORMS: ${{ inputs.platforms }}
         run: |
           cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
           ARG BASE_IMAGE
@@ -157,8 +151,10 @@ jobs:
 
           # One multi-platform build: the base tag is a manifest list, so each
           # platform patches its own arch and the output stays a manifest list.
+          # A base without both arches fails here, which is the point - a
+          # single-arch output would not be pullable on the other arch.
           docker buildx build \
-            --platform "${PLATFORMS}" \
+            --platform linux/amd64,linux/arm64 \
             --no-cache \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             -t "${OUT_IMAGE}" \
@@ -168,7 +164,6 @@ jobs:
       - name: Write summary
         env:
           PR_NUMBERS: ${{ inputs.pr_numbers }}
-          PLATFORMS: ${{ inputs.platforms }}
         run: |
           if [ -n "${PR_NUMBERS}" ]; then
             SOURCE="PRs: ${PR_NUMBERS}"
@@ -180,7 +175,7 @@ jobs:
             echo "- **Base image:** \`${BASE_IMAGE}\`"
             echo "- **Base commit:** \`${BASE_SHA:-unknown (no .git)}\`"
             echo "- **Source:** ${SOURCE}"
-            echo "- **Platforms:** \`${PLATFORMS}\`"
+            echo "- **Platforms:** \`linux/amd64,linux/arm64\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Prune builder cache

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -69,11 +69,18 @@ jobs:
       - name: Extract base commit
         run: |
           docker pull "${BASE_IMAGE}"
-          if BASE_SHA=$(docker run --rm "${BASE_IMAGE}" git -C /sgl-workspace/sglang rev-parse HEAD 2>/dev/null); then
+          # --entrypoint skips the CUDA base image's banner, which goes to
+          # stdout and would otherwise be captured as part of the SHA.
+          BASE_SHA=$(docker run --rm --entrypoint git "${BASE_IMAGE}" \
+            -C /sgl-workspace/sglang rev-parse HEAD 2>/dev/null | tail -n 1)
+          # Keep anything but a bare SHA out of GITHUB_ENV: a multi-line value
+          # there is parsed as further NAME=VALUE lines and fails the step.
+          case "${BASE_SHA}" in *[!0-9a-f]*) BASE_SHA="" ;; esac
+          [ "${#BASE_SHA}" -eq 40 ] || BASE_SHA=""
+          if [ -n "${BASE_SHA}" ]; then
             echo "Image built from commit: ${BASE_SHA}"
           else
-            BASE_SHA=""
-            echo "::warning::Image has no .git directory - cannot extract base commit"
+            echo "::warning::Cannot read base commit from ${BASE_IMAGE} - fast-forward mode needs it"
           fi
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
           # Pulled only for the rev-parse above; buildx pulls the base itself.

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       pr_numbers:
-        description: "Comma-separated PR numbers, applied in the order listed (e.g. 18962,19010). Empty = fast-forward the base image to latest main."
+        description: "Comma-separated PR numbers, merged in the order listed (e.g. 18962,19010). Empty = fast-forward the base image to latest main."
         required: false
         default: ""
       image_tag:
@@ -73,8 +73,7 @@ jobs:
           # stdout and would otherwise be captured as part of the SHA.
           BASE_SHA=$(docker run --rm --entrypoint git "${BASE_IMAGE}" \
             -C /sgl-workspace/sglang rev-parse HEAD 2>/dev/null | tail -n 1)
-          # Keep anything but a bare SHA out of GITHUB_ENV: a multi-line value
-          # there is parsed as further NAME=VALUE lines and fails the step.
+          # A banner line reaching GITHUB_ENV breaks the step, as above.
           case "${BASE_SHA}" in *[!0-9a-f]*) BASE_SHA="" ;; esac
           [ "${#BASE_SHA}" -eq 40 ] || BASE_SHA=""
           if [ -z "${BASE_SHA}" ]; then
@@ -91,20 +90,27 @@ jobs:
           PR_NUMBERS: ${{ inputs.pr_numbers }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          # git merge below writes merge commits and needs an identity.
-          git config --global user.email "ci@sglang.local"
-          git config --global user.name "sglang CI"
           git fetch origin main
           git fetch origin "${BASE_SHA}"
 
-          # Fixed paths on a persistent runner: drop leftovers from prior runs.
-          rm -rf /tmp/patch-ctx /tmp/base-tree
-          mkdir -p /tmp/patch-ctx
+          # Per-run paths: the concurrency group keys on output_tag, so two runs
+          # with different tags can land on this runner at the same time.
+          WORK="/tmp/patch-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf "${WORK}"
+          mkdir -p "${WORK}/ctx"
           git worktree prune
           # Merge onto the image's own commit so the patch context matches the
           # image tree exactly and cannot drift. Conflicts then surface here in
           # seconds instead of failing the build after a multi-GB pull.
-          git worktree add --detach /tmp/base-tree "${BASE_SHA}"
+          git worktree add --detach "${WORK}/base-tree" "${BASE_SHA}"
+          echo "PATCH_CTX=${WORK}/ctx" >> "$GITHUB_ENV"
+
+          # -c rather than --global: leave no identity behind on the runner.
+          merge_into_base() {
+            git -C "${WORK}/base-tree" \
+              -c user.email=ci@sglang.local -c user.name="sglang CI" \
+              merge --no-edit "$1"
+          }
 
           if [ -n "${PR_NUMBERS}" ]; then
             IFS=',' read -ra PRS <<< "${PR_NUMBERS}"
@@ -118,37 +124,38 @@ jobs:
               esac
               echo "Merging PR #${pr}"
               git fetch origin "pull/${pr}/head:pr-${pr}"
-              git -C /tmp/base-tree merge --no-edit "pr-${pr}" || {
+              merge_into_base "pr-${pr}" || {
                 echo "::error::PR #${pr} conflicts with base image commit ${BASE_SHA}"
-                git -C /tmp/base-tree diff --name-only --diff-filter=U
+                git -C "${WORK}/base-tree" diff --name-only --diff-filter=U
                 exit 1
               }
             done
           else
             echo "Fast-forwarding to latest main"
-            git -C /tmp/base-tree merge --no-edit origin/main || {
+            merge_into_base origin/main || {
               echo "::error::Cannot merge latest main into base image commit ${BASE_SHA}"
-              git -C /tmp/base-tree diff --name-only --diff-filter=U
+              git -C "${WORK}/base-tree" diff --name-only --diff-filter=U
               exit 1
             }
           fi
 
-          git -C /tmp/base-tree diff --binary "${BASE_SHA}"..HEAD > /tmp/patch-ctx/merged.patch
-          if [ ! -s /tmp/patch-ctx/merged.patch ]; then
+          git -C "${WORK}/base-tree" diff --binary "${BASE_SHA}"..HEAD > "${WORK}/ctx/merged.patch"
+          if [ ! -s "${WORK}/ctx/merged.patch" ]; then
             echo "::error::Patch is empty - nothing to apply on top of ${BASE_IMAGE}"
             exit 1
           fi
-          git -C /tmp/base-tree diff --shortstat "${BASE_SHA}"..HEAD
+          PATCH_STAT=$(git -C "${WORK}/base-tree" diff --shortstat "${BASE_SHA}"..HEAD | xargs)
+          echo "Patch: ${PATCH_STAT}"
+          echo "PATCH_STAT=${PATCH_STAT}" >> "$GITHUB_ENV"
 
       - name: Build and push patched image
         run: |
-          cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
+          cat <<'DOCKERFILE' > "${PATCH_CTX}/Dockerfile"
           ARG BASE_IMAGE
           FROM ${BASE_IMAGE}
           COPY merged.patch /tmp/merged.patch
-          # The patch was diffed against this image's own commit, so it applies
-          # with exact context - no fuzz needed. git apply (not patch) also
-          # handles renames, mode changes and binary files.
+          # git apply, not patch: no fuzz is needed given the exact context, and
+          # it handles renames, mode changes and binary files.
           RUN cd /sgl-workspace/sglang \
               && git apply --binary -v -p1 /tmp/merged.patch \
               && rm -f /tmp/merged.patch \
@@ -156,17 +163,16 @@ jobs:
               && ( find python -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true )
           DOCKERFILE
 
-          # One multi-platform build: the base tag is a manifest list, so each
-          # platform patches its own arch and the output stays a manifest list.
-          # A base without both arches fails here, which is the point - a
-          # single-arch output would not be pullable on the other arch.
+          # Each platform patches its own arch of the base manifest list, so the
+          # output stays a list. A single-arch base fails here on purpose: the
+          # output would not be pullable on the other arch.
           docker buildx build \
             --platform linux/amd64,linux/arm64 \
             --no-cache \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             -t "${OUT_IMAGE}" \
             --push \
-            /tmp/patch-ctx/
+            "${PATCH_CTX}/"
 
       - name: Write summary
         env:
@@ -180,11 +186,18 @@ jobs:
           {
             echo "### Patched \`${OUT_IMAGE}\`"
             echo "- **Base image:** \`${BASE_IMAGE}\`"
-            echo "- **Base commit:** \`${BASE_SHA:-unknown (no .git)}\`"
+            echo "- **Base commit:** \`${BASE_SHA}\`"
             echo "- **Source:** ${SOURCE}"
+            echo "- **Patch:** ${PATCH_STAT}"
             echo "- **Platforms:** \`linux/amd64,linux/arm64\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Prune builder cache
+      - name: Clean up
         if: always()
-        run: docker buildx prune --filter "until=72h" -f || true
+        run: |
+          # Per-run paths are never reclaimed by a later run, so drop them here.
+          WORK="/tmp/patch-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          git worktree remove --force "${WORK}/base-tree" 2>/dev/null || true
+          rm -rf "${WORK}"
+          git worktree prune 2>/dev/null || true
+          docker buildx prune --filter "until=72h" -f || true

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -77,29 +77,37 @@ jobs:
           # there is parsed as further NAME=VALUE lines and fails the step.
           case "${BASE_SHA}" in *[!0-9a-f]*) BASE_SHA="" ;; esac
           [ "${#BASE_SHA}" -eq 40 ] || BASE_SHA=""
-          if [ -n "${BASE_SHA}" ]; then
-            echo "Image built from commit: ${BASE_SHA}"
-          else
-            echo "::warning::Cannot read base commit from ${BASE_IMAGE} - fast-forward mode needs it"
+          if [ -z "${BASE_SHA}" ]; then
+            echo "::error::Cannot read the base commit of ${BASE_IMAGE}; the patch is computed against it"
+            exit 1
           fi
+          echo "Image built from commit: ${BASE_SHA}"
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
           # Pulled only for the rev-parse above; buildx pulls the base itself.
           docker image rm "${BASE_IMAGE}" || true
 
-      - name: Generate patches
+      - name: Generate patch
         env:
           PR_NUMBERS: ${{ inputs.pr_numbers }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          # git merge below writes merge commits and needs an identity.
+          git config --global user.email "ci@sglang.local"
+          git config --global user.name "sglang CI"
           git fetch origin main
-          # Fixed path on a persistent runner: drop patches left by prior runs
-          # so they cannot be picked up by this run's COPY *.patch.
-          rm -rf /tmp/patch-ctx
+          git fetch origin "${BASE_SHA}"
+
+          # Fixed paths on a persistent runner: drop leftovers from prior runs.
+          rm -rf /tmp/patch-ctx /tmp/base-tree
           mkdir -p /tmp/patch-ctx
+          git worktree prune
+          # Merge onto the image's own commit so the patch context matches the
+          # image tree exactly and cannot drift. Conflicts then surface here in
+          # seconds instead of failing the build after a multi-GB pull.
+          git worktree add --detach /tmp/base-tree "${BASE_SHA}"
 
           if [ -n "${PR_NUMBERS}" ]; then
             IFS=',' read -ra PRS <<< "${PR_NUMBERS}"
-            i=0
             for pr in "${PRS[@]}"; do
               pr=$(echo "${pr}" | xargs)
               case "${pr}" in
@@ -108,50 +116,42 @@ jobs:
                   exit 1
                   ;;
               esac
-              # The image applies patches in glob order, so number them to keep
-              # the order the PRs were listed in - stacked PRs depend on it.
-              i=$((i + 1))
-              PATCH=$(printf '/tmp/patch-ctx/%02d-%s.patch' "${i}" "${pr}")
-              echo "Fetching PR #${pr}"
+              echo "Merging PR #${pr}"
               git fetch origin "pull/${pr}/head:pr-${pr}"
-              MERGE_BASE=$(git merge-base origin/main "pr-${pr}")
-              echo "  PR #${pr}: merge-base=${MERGE_BASE}"
-              git diff "${MERGE_BASE}..pr-${pr}" > "${PATCH}"
-              echo "  PR #${pr}: $(wc -l < "${PATCH}") lines -> $(basename "${PATCH}")"
+              git -C /tmp/base-tree merge --no-edit "pr-${pr}" || {
+                echo "::error::PR #${pr} conflicts with base image commit ${BASE_SHA}"
+                git -C /tmp/base-tree diff --name-only --diff-filter=U
+                exit 1
+              }
             done
-          elif [ -n "${BASE_SHA}" ]; then
-            echo "Generating diff: image ${BASE_SHA} -> latest main"
-            git fetch origin "${BASE_SHA}"
-            git diff "${BASE_SHA}..origin/main" > /tmp/patch-ctx/main.patch
-            echo "  main: $(wc -l < /tmp/patch-ctx/main.patch) lines"
           else
-            echo "::error::No PR numbers specified and image has no .git - cannot generate diff against main"
-            exit 1
+            echo "Fast-forwarding to latest main"
+            git -C /tmp/base-tree merge --no-edit origin/main || {
+              echo "::error::Cannot merge latest main into base image commit ${BASE_SHA}"
+              git -C /tmp/base-tree diff --name-only --diff-filter=U
+              exit 1
+            }
           fi
 
-          TOTAL=$(cat /tmp/patch-ctx/*.patch | wc -l)
-          if [ "${TOTAL}" -eq 0 ]; then
-            echo "::error::All patches are empty - nothing to apply on top of ${BASE_IMAGE}"
+          git -C /tmp/base-tree diff --binary "${BASE_SHA}"..HEAD > /tmp/patch-ctx/merged.patch
+          if [ ! -s /tmp/patch-ctx/merged.patch ]; then
+            echo "::error::Patch is empty - nothing to apply on top of ${BASE_IMAGE}"
             exit 1
           fi
+          git -C /tmp/base-tree diff --shortstat "${BASE_SHA}"..HEAD
 
       - name: Build and push patched image
         run: |
           cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
           ARG BASE_IMAGE
           FROM ${BASE_IMAGE}
-          COPY *.patch /tmp/patches/
+          COPY merged.patch /tmp/merged.patch
+          # The patch was diffed against this image's own commit, so it applies
+          # with exact context - no fuzz needed. git apply (not patch) also
+          # handles renames, mode changes and binary files.
           RUN cd /sgl-workspace/sglang \
-              && for p in /tmp/patches/*.patch; do \
-                   if [ ! -s "${p}" ]; then \
-                     echo "Skipping ${p} (empty)"; \
-                   else \
-                     echo "Applying ${p}..." \
-                     && patch -p1 --fuzz=2 --no-backup-if-mismatch -f < "${p}" \
-                     || { echo "ERROR: Failed to apply ${p}"; exit 1; }; \
-                   fi; \
-                 done \
-              && rm -rf /tmp/patches \
+              && git apply --binary -v -p1 /tmp/merged.patch \
+              && rm -f /tmp/merged.patch \
               && python3 -m compileall -q -f python/sglang \
               && ( find python -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true )
           DOCKERFILE

--- a/.github/workflows/patch-docker-dev.yml
+++ b/.github/workflows/patch-docker-dev.yml
@@ -4,18 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       pr_numbers:
-        description: "Comma-separated PR numbers to apply (e.g. 18962,19010). Empty = fast-forward the base image to latest main."
+        description: "Comma-separated PR numbers, applied in the order listed (e.g. 18962,19010). Empty = fast-forward the base image to latest main."
         required: false
         default: ""
       image_tag:
         description: "Base image tag to patch (e.g. dev, dev-cu13, dev-cu12)"
         required: true
       output_tag:
-        description: "Tag to publish as. Must start with 'patch-' (e.g. patch-myfeature)."
+        description: "Tag to publish as. Overwrites it if it already exists."
         required: true
+      platforms:
+        description: "Platforms to build. The base tag must have a manifest for each one."
+        required: false
+        default: "linux/amd64,linux/arm64"
 
 concurrency:
-  group: patch-docker-${{ inputs.image_tag }}-${{ inputs.output_tag }}
+  # Keyed on the tag being written, which is the only resource two runs contend for.
+  group: patch-docker-${{ inputs.output_tag }}
   cancel-in-progress: true
 
 jobs:
@@ -42,18 +47,6 @@ jobs:
           validate_tag image_tag "${IMAGE_TAG}"
           validate_tag output_tag "${OUTPUT_TAG}"
 
-          # Released tags belong to release-docker*.yml, which builds them as
-          # multi-arch manifests. This job is x64-only, so it publishes under a
-          # prefix those builders never emit rather than denylisting their
-          # current names, which would rot as the release tag scheme changes.
-          case "${OUTPUT_TAG}" in
-            patch-?*) ;;
-            *)
-              echo "::error::output_tag must start with 'patch-' (e.g. patch-myfeature)"
-              exit 1
-              ;;
-          esac
-
           echo "BASE_IMAGE=lmsysorg/sglang:${IMAGE_TAG}" >> "$GITHUB_ENV"
           echo "OUT_IMAGE=lmsysorg/sglang:${OUTPUT_TAG}" >> "$GITHUB_ENV"
 
@@ -65,13 +58,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Pull base image and extract commit
+      - name: Extract base commit
         run: |
           docker pull "${BASE_IMAGE}"
           if BASE_SHA=$(docker run --rm "${BASE_IMAGE}" git -C /sgl-workspace/sglang rev-parse HEAD 2>/dev/null); then
@@ -81,6 +80,8 @@ jobs:
             echo "::warning::Image has no .git directory - cannot extract base commit"
           fi
           echo "BASE_SHA=${BASE_SHA}" >> "$GITHUB_ENV"
+          # Pulled only for the rev-parse above; buildx pulls the base itself.
+          docker image rm "${BASE_IMAGE}" || true
 
       - name: Generate patches
         env:
@@ -95,14 +96,25 @@ jobs:
 
           if [ -n "${PR_NUMBERS}" ]; then
             IFS=',' read -ra PRS <<< "${PR_NUMBERS}"
+            i=0
             for pr in "${PRS[@]}"; do
               pr=$(echo "${pr}" | xargs)
+              case "${pr}" in
+                ""|*[!0-9]*)
+                  echo "::error::'${pr}' is not a PR number"
+                  exit 1
+                  ;;
+              esac
+              # The image applies patches in glob order, so number them to keep
+              # the order the PRs were listed in - stacked PRs depend on it.
+              i=$((i + 1))
+              PATCH=$(printf '/tmp/patch-ctx/%02d-%s.patch' "${i}" "${pr}")
               echo "Fetching PR #${pr}"
               git fetch origin "pull/${pr}/head:pr-${pr}"
               MERGE_BASE=$(git merge-base origin/main "pr-${pr}")
               echo "  PR #${pr}: merge-base=${MERGE_BASE}"
-              git diff "${MERGE_BASE}..pr-${pr}" > "/tmp/patch-ctx/${pr}.patch"
-              echo "  PR #${pr}: $(wc -l < /tmp/patch-ctx/${pr}.patch) lines"
+              git diff "${MERGE_BASE}..pr-${pr}" > "${PATCH}"
+              echo "  PR #${pr}: $(wc -l < "${PATCH}") lines -> $(basename "${PATCH}")"
             done
           elif [ -n "${BASE_SHA}" ]; then
             echo "Generating diff: image ${BASE_SHA} -> latest main"
@@ -120,7 +132,9 @@ jobs:
             exit 1
           fi
 
-      - name: Build patched image
+      - name: Build and push patched image
+        env:
+          PLATFORMS: ${{ inputs.platforms }}
         run: |
           cat <<'DOCKERFILE' > /tmp/patch-ctx/Dockerfile
           ARG BASE_IMAGE
@@ -136,21 +150,26 @@ jobs:
                      || { echo "ERROR: Failed to apply ${p}"; exit 1; }; \
                    fi; \
                  done \
-              && rm -rf /tmp/patches
+              && rm -rf /tmp/patches \
+              && python3 -m compileall -q -f python/sglang \
+              && ( find python -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true )
           DOCKERFILE
 
-          docker build \
+          # One multi-platform build: the base tag is a manifest list, so each
+          # platform patches its own arch and the output stays a manifest list.
+          docker buildx build \
+            --platform "${PLATFORMS}" \
             --no-cache \
             --build-arg BASE_IMAGE="${BASE_IMAGE}" \
             -t "${OUT_IMAGE}" \
+            --push \
             /tmp/patch-ctx/
 
-      - name: Push patched image
+      - name: Write summary
         env:
           PR_NUMBERS: ${{ inputs.pr_numbers }}
+          PLATFORMS: ${{ inputs.platforms }}
         run: |
-          docker push "${OUT_IMAGE}"
-
           if [ -n "${PR_NUMBERS}" ]; then
             SOURCE="PRs: ${PR_NUMBERS}"
           else
@@ -161,5 +180,9 @@ jobs:
             echo "- **Base image:** \`${BASE_IMAGE}\`"
             echo "- **Base commit:** \`${BASE_SHA:-unknown (no .git)}\`"
             echo "- **Source:** ${SOURCE}"
-            echo "- **Platform:** \`linux/amd64\` only - patched on an x64 runner, so the base image's multi-arch manifest is not carried over"
+            echo "- **Platforms:** \`${PLATFORMS}\`"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prune builder cache
+        if: always()
+        run: docker buildx prune --filter "until=72h" -f || true


### PR DESCRIPTION
The patch workflow ran a single-arch `docker build` on an x64 runner, so the published tag was amd64-only while the base `dev` tags are amd64+arm64 manifest lists. Now builds both platforms via buildx and drops the `patch-` prefix requirement on `output_tag`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31384753414](https://github.com/sgl-project/sglang/actions/runs/31384753414)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31384753281](https://github.com/sgl-project/sglang/actions/runs/31384753281)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->