### PR TITLE
Muse Glimmer Cookbook: install from the PR branch

### DIFF
--- a/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
+++ b/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
@@ -19,7 +19,11 @@ See the [official SGLang installation guide](../../../docs/get-started/install) 
 ```bash Command
 pip install --upgrade pip
 pip install uv
-uv pip install sglang
+# Muse Glimmer support is not in a release yet -- install from the PR branch:
+# https://github.com/sgl-project/sglang/pull/34262
+git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
+cd sglang
+uv pip install -e "python[all]"
 ```
 
 Run the **Python** output of the command panel below in that environment.

--- a/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
+++ b/docs/cookbook/autoregressive/Meta/MuseGlimmer.mdx
@@ -19,11 +19,9 @@ See the [official SGLang installation guide](../../../docs/get-started/install) 
 ```bash Command
 pip install --upgrade pip
 pip install uv
-# Muse Glimmer support is not in a release yet -- install from the PR branch:
+# Muse Glimmer support is not in a release yet -- install the commit from
 # https://github.com/sgl-project/sglang/pull/34262
-git clone -b muse-glimmer https://github.com/sgl-project/sglang.git
-cd sglang
-uv pip install -e "python[all]"
+uv pip install "sglang[all] @ git+https://github.com/sgl-project/sglang@caa91b7d01ca610bb2e37bc095af6e427aa7e358#subdirectory=python"
 ```
 
 Run the **Python** output of the command panel below in that environment.


### PR DESCRIPTION
Muse Glimmer support is not in a release yet, so `uv pip install sglang` does not work. Points the install step at #34262.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31380663166](https://github.com/sgl-project/sglang/actions/runs/31380663166)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31380663029](https://github.com/sgl-project/sglang/actions/runs/31380663029)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->