### PR TITLE
Revert small-M CuTe DSL routing for MXFP8

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1247,12 +1247,6 @@ def flashinfer_mxfp8_blockscaled_linear(
         else:
             output_dtype = torch.bfloat16
 
-    # At small M the persistent CUTLASS kernel is 2-5x slower than the
-    # CuTe-DSL swap-AB/split-K kernels (both consume the same swizzled
-    # 1D scales).
-    if backend == "cutlass" and q_input.shape[0] <= 64:
-        backend = "cute-dsl"
-
     if backend == "trtllm":
         weight_scale_t = weight_scale.view(-1)
     else:


### PR DESCRIPTION
## Summary

The small-M CuTe DSL routing from #33962 breaks SM120, so rather than add an `is_sm100_supported()` check, this fully reverts it since dedicated `flashinfer_cutedsl` backend support is being worked on separately

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31383994389](https://github.com/sgl-project/sglang/actions/runs/31383994389)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31383994067](https://github.com/sgl-project/sglang/actions/runs/31383994067)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->