### PR TITLE
[BugFix] Synchronize Breakable CUDA Graph after warmup before capture

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -119,6 +119,12 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             if post_warmup_hook is not None:
                 post_warmup_hook()
 
+        # Drain any work still in flight from the last warmup (and from
+        # ``post_warmup_hook``) before entering capture, then align the TP ranks
+        # so no rank starts capturing while another is still finishing warmup.
+        self._device_module.synchronize()
+        self._tp_group.barrier()
+
         graph = BreakableCUDAGraph(self.deduped_cuda_graph)
         captured_fn = (
             eager_on_graph(True)(forward_fn) if self._debug_eager else forward_fn

--- a/test/registered/unit/model_executor/runner_backend/test_breakable_cuda_graph_backend.py
+++ b/test/registered/unit/model_executor/runner_backend/test_breakable_cuda_graph_backend.py
@@ -1,0 +1,132 @@
+"""Ordering regression for ``BreakableCudaGraphBackend.capture_one`` — CPU-only.
+
+Bug mechanism (black-box): ``capture_one`` runs two eager warmup iterations and,
+on each, calls ``post_warmup_hook`` — the hook the attention backend uses to reset
+state that warmup mutated. It then constructs the ``BreakableCUDAGraph`` and enters
+capture. Between the *final* warmup/hook and that construction there was no
+device synchronize and no TP barrier, so asynchronous work still in flight from the
+last warmup (or from the hook) could straddle the capture boundary, and the TP ranks
+were not aligned before one of them started capturing.
+
+``FullCudaGraphBackend.capture_one`` has the same warmup-to-capture completion gap;
+closing it there is what #33795 proposes. This case pins the invariant for the
+breakable backend, which is the default prefill graph backend on CUDA.
+
+Guarded invariant — after the last ``post_warmup_hook`` and before the
+``BreakableCUDAGraph`` is constructed there must be at least one
+``device_module.synchronize()`` followed by at least one ``tp_group.barrier()``.
+A future diff that drops either call, or reorders them, turns this case red.
+
+The real capture path needs CUDA (breakable graph capture + device graph pool), so
+the graph type and its capture context are mocked; the logic under test (call
+counts and call ordering) is pure Python and runs on CPU.
+"""
+
+import contextlib
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
+from sglang.srt.model_executor.runner_backend import (
+    breakable_cuda_graph_backend as bcg_module,
+)
+from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend import (
+    BreakableCudaGraphBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _make_backend(call_log):
+    """Build a ``BreakableCudaGraphBackend`` without running ``__init__`` (which
+    would touch CUDA), wiring just the attributes ``capture_one`` reads."""
+    backend = BreakableCudaGraphBackend.__new__(BreakableCudaGraphBackend)
+    backend._graphs = {}
+    backend._outputs = {}
+    backend._capture_inputs = {}
+    backend._pool = None
+    backend._capture_stream = None
+    backend._debug_eager = False
+    backend._shared_output_buffer = None
+    backend._memory_saver_adapter = None
+    backend.deduped_cuda_graph = None
+    backend._device_module = SimpleNamespace(
+        synchronize=mock.Mock(side_effect=lambda: call_log.append("synchronize"))
+    )
+    backend._tp_group = SimpleNamespace(
+        barrier=mock.Mock(side_effect=lambda: call_log.append("barrier"))
+    )
+    return backend
+
+
+class TestBreakableCaptureOrdering(CustomTestCase):
+    def test_syncs_after_final_warmup_before_graph_construction(self):
+        call_log = []
+
+        def forward_fn():
+            call_log.append("forward")
+            return None
+
+        def post_warmup_hook():
+            call_log.append("post_warmup_hook")
+
+        class FakeBreakableCUDAGraph:
+            def __init__(self, *args, **kwargs):
+                call_log.append("breakable_cudagraph_create")
+
+        with mock.patch.object(
+            bcg_module, "BreakableCUDAGraph", FakeBreakableCUDAGraph
+        ), mock.patch.object(
+            bcg_module,
+            "BreakableCUDAGraphCapture",
+            side_effect=lambda **kwargs: contextlib.nullcontext(),
+        ):
+            _make_backend(call_log).capture_one(
+                ShapeKey(size=4),
+                forward_fn,
+                post_warmup_hook=post_warmup_hook,
+            )
+
+        # Two warmups plus the captured forward; the hook only runs in the warmups.
+        self.assertEqual(call_log.count("forward"), 3)
+        self.assertEqual(call_log.count("post_warmup_hook"), 2)
+        self.assertEqual(call_log.count("breakable_cudagraph_create"), 1)
+
+        graph_idx = call_log.index("breakable_cudagraph_create")
+        last_hook_idx = max(
+            i
+            for i, value in enumerate(call_log)
+            if value == "post_warmup_hook" and i < graph_idx
+        )
+
+        sync_between = [
+            i
+            for i, value in enumerate(call_log)
+            if value == "synchronize" and last_hook_idx < i < graph_idx
+        ]
+        barrier_between = [
+            i
+            for i, value in enumerate(call_log)
+            if value == "barrier" and last_hook_idx < i < graph_idx
+        ]
+
+        self.assertTrue(
+            sync_between,
+            "No synchronize() after final warmup hook before BCG construction: "
+            f"{call_log}",
+        )
+        self.assertTrue(
+            barrier_between,
+            "No barrier() after final warmup hook before BCG construction: "
+            f"{call_log}",
+        )
+        # The device must be drained before the ranks rendezvous.
+        self.assertLess(sync_between[0], barrier_between[0])
+        self.assertLess(barrier_between[0], graph_idx)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`BreakableCudaGraphBackend.capture_one()` runs two eager warmup iterations, each followed by `post_warmup_hook`, and then immediately constructs `BreakableCUDAGraph` and enters capture.

There is currently no device synchronization or TP-group rendezvous between the **final** warmup/hook and graph construction. That leaves a warmup-to-capture completion gap: asynchronous work triggered by the last warmup or its hook can still be in flight when capture starts, and TP ranks are not explicitly aligned at that boundary.

This is the same warmup-to-capture completion invariant that #33795 proposes to enforce for `FullCudaGraphBackend`; this PR pins the corresponding invariant for `BreakableCudaGraphBackend`.

This PR does **not** claim a natural BCG crash reproducer and does **not** claim to be the primary fix for the B300 DSpark compact-ragged producer failure. That failure class is separately localized to #32467 / #32470. The source-of-truth investigation map is #34297.

## Modifications

- Add a device `synchronize()` after the final BCG warmup/hook.
- Add a TP-group `barrier()` immediately after the device sync and before `BreakableCUDAGraph` construction.
- Add a CPU-only ordering regression for `BreakableCudaGraphBackend.capture_one()`.

The regression records call order and requires:

```text
final post_warmup_hook
  < synchronize
  < barrier
  < BreakableCUDAGraph construction
```

It also checks that `capture_one()` still performs two warmup forwards plus one captured forward, and that `post_warmup_hook` runs only for the two warmups.

## Tests

The regression was first run against the unpatched production code as a negative control. It failed specifically because no `synchronize()` / `barrier()` existed between the final warmup hook and BCG construction; the forward/hook/count assertions had already passed.

After applying the production change, the same targeted test passed.

Final local validation:

```text
runner_backend unit suite: 5 passed
pre-commit: all hooks passed
git diff --check: clean
working tree: clean
```

The CPU regression is registered in `base-a-test-cpu` and does not require CUDA or model weights.

## Scope / performance

The additional sync + barrier run only during one-time graph capture, after warmup for each captured shape. There is no steady-state replay-path change.

No kernel, model-forward, or numerical logic is modified.

## Root-cause map and related work

The B300/DSpark investigation separated multiple correctness layers rather than treating every illegal-memory symptom as one bug:

```text
#31195  cross-TP verify-budget / Graph-tier consistency
#32183  verifier compressed-state rewrite window
#32467  producer-side ragged plan/index correctness
#33795  FullCudaGraphBackend capture-initialization ordering
#34286  BreakableCudaGraphBackend capture-initialization ordering
#32432  shared runtime-contract / observability RFC
#34410  DSpark PD decode handoff regression coverage
```

### Producer-side bug: #32467 / #32470

The primary B300 producer root cause is a **write-write race** in `plan_compress_prefill_kernel0`: redundant initialization of shared `warp_min` / `warp_max` scratch can overwrite a completed per-warp reduction, making ragged input appear uniform. The wrong uniform/MTP fast path can then emit out-of-range `ragged_id`; a downstream kernel merely surfaces the resulting illegal access.

The final reviewer-selected #32467 implementation is the **no-init** formulation: remove the redundant scratch initialization instead of adding an extra barrier. Same-session A/B/C kernel regression:

| Variant | Init | Extra barrier | OOB plans |
|---|:---:|:---:|---:|
| original | ON | OFF | **13111 / 30000** |
| barrier experiment | ON | ON | **0 / 30000** |
| final reviewer-selected no-init | OFF | OFF | **0 / 30000** |

This is intentionally separate from the capture-ordering invariant in this PR.

### 2026-08-11 B300 runtime evidence

An independent TP8/DP8 B30Z runtime regression of the final #32467 no-init implementation was completed on a v0.5.16 stack with the required DSpark DP/disaggregation integration backports (#33098 merged upstream; #31513 open/unmerged at validation time).

Decode-only topology included DP Attention, DSPARK, fake disaggregation transfer, compact ragged verify, `max-running-requests=1024`, and per-rank CUDA-Graph max batch 128.

The sustained sweep completed **18560/18560 requests** across C64/C256/C512/C1024 with zero observed illegal-address faults, device assertions, scheduler exceptions, or client failures; `/health = 200`. C1024 reached per-rank running batch 128 and ~24.8k generated tok/s.

A forced compact-ragged window (`dspark_force_budget_frac=0.5`) produced verify lengths 1–6; 39/43 fully parsed multi-request blocks were truly ragged, with no GPU fault/NaN/budget violation observed.

A subsequent external-concurrency sweep up to C2560 also completed without request failures or observed GPU correctness faults, but `max-running-requests=1024` kept the true running peak at 128 per rank. Those higher external-concurrency points are admission/queue pressure evidence, **not** proof of >1024 simultaneously running requests.

This runtime evidence strengthens the separation of concerns: #32467 is the primary producer-side fix for the tested B300 failure class, while #34286 remains framework hardening for the Breakable capture boundary.

## Related

- [DSpark in SGLang](https://www.lmsys.org/blog/2026-07-06-dspark-sglang)
- #30344 — parent DSpark roadmap
- #34297 — source-of-truth DSpark CUDA Graph correctness / robustness roadmap
- #31023 / #33356 — historical B300 compact-verify investigations
- #31195 — cross-TP verify-budget / target Graph-tier consistency
- #32183 — verifier rewrite correctness
- #32467 / #32470 — producer-side ragged plan/index race and bug report
- #33412 — independent SM120 evidence for #32467
- #33795 — FullCudaGraphBackend warmup-to-capture synchronization
- #32432 — runtime-contract RFC
- #33098 — DSpark DP/EP metadata integration (merged)
- #31513 — earlier DSpark/DFlash disaggregation-decode implementation/failure analysis (open)
- #34410 — PD decode draft-input handoff regression coverage

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34925147699](https://github.com/sgl-project/sglang/actions/runs/34925147699)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34925147675](https://github.com/sgl-project/sglang/actions/runs/34925147675)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34925147711](https://github.com/sgl-project/sglang/actions/runs/34925147711)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->