### PR TITLE
Fix PP HiCache prefetch readiness consensus

### DIFF
--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -820,6 +820,34 @@ class SchedulerPPMixin:
             return [[req.rid for req in good_reqs], [req.rid for req in failed_reqs]]
         return None
 
+    def _pp_filter_hicache_ready_rids(
+        self: Scheduler, candidate_rids: List[str]
+    ) -> List[str]:
+        """Keep only requests whose HiCache prefetch is locally ready.
+
+        In PP disaggregated prefill, the existing bootstrap protocol computes a
+        stage-by-stage intersection and then circulates the final result back to
+        every stage. Folding HiCache readiness into that protocol guarantees
+        that a request enters ``waiting_queue`` only after every PP stage is
+        ready, without inserting a barrier-like collective into the skewed PP
+        event loop.
+        """
+        if (
+            not self.enable_hicache_storage
+            or self.ps.pp_size <= 1
+            or not candidate_rids
+        ):
+            return candidate_rids
+
+        candidate_set = set(candidate_rids)
+        locally_ready_rids = {
+            req.rid
+            for req in self.disagg_prefill_bootstrap_queue.queue
+            if req.rid in candidate_set
+            and self.tree_cache.check_prefetch_progress(req.rid)
+        }
+        return [rid for rid in candidate_rids if rid in locally_ready_rids]
+
     def _pp_pd_get_bootstrapped_ids(self: Scheduler):
         # communicate pre-consensus bootstrapp reqs
         if self.pp_group.is_first_rank:
@@ -829,6 +857,9 @@ class SchedulerPPMixin:
                 True,
                 [KVPoll.WaitingForInput],
                 [KVPoll.Failed],
+            )
+            good_bootstrapped_rids = self._pp_filter_hicache_ready_rids(
+                good_bootstrapped_rids
             )
         else:
             # Other ranks, receive the bootstrap reqs info from the previous rank and ensure the consensus
@@ -842,11 +873,17 @@ class SchedulerPPMixin:
                 [KVPoll.WaitingForInput],
                 [KVPoll.Failed],
             )
-            good_bootstrapped_rids = list(
-                set(prev_good_bootstrapped_rids) & set(curr_good_bootstrapped_rids)
+            curr_good_bootstrapped_rids = self._pp_filter_hicache_ready_rids(
+                curr_good_bootstrapped_rids
             )
+            curr_good_bootstrapped_rid_set = set(curr_good_bootstrapped_rids)
+            good_bootstrapped_rids = [
+                rid
+                for rid in prev_good_bootstrapped_rids
+                if rid in curr_good_bootstrapped_rid_set
+            ]
             bad_bootstrapped_rids = list(
-                set(prev_bad_bootstrapped_rids) | set(curr_bad_bootstrapped_rids)
+                dict.fromkeys(prev_bad_bootstrapped_rids + curr_bad_bootstrapped_rids)
             )
         # Route locally-aborted reqs through the bad-union consensus so every PP
         # rank flushes them in the same consensus round, regardless of when the

--- a/test/registered/unit/managers/test_pp_hicache_prefetch_consensus.py
+++ b/test/registered/unit/managers/test_pp_hicache_prefetch_consensus.py
@@ -1,0 +1,91 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.managers.scheduler_pp_mixin import SchedulerPPMixin
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestPPHiCachePrefetchConsensus(unittest.TestCase):
+    def _make_scheduler(self, *, pp_rank: int, readiness: dict[str, bool]):
+        reqs = [SimpleNamespace(rid=rid, finished_reason=None) for rid in readiness]
+        scheduler = SchedulerPPMixin()
+        scheduler.ps = SimpleNamespace(pp_rank=pp_rank, pp_size=8)
+        scheduler.pp_group = SimpleNamespace(is_first_rank=pp_rank == 0)
+        scheduler.enable_hicache_storage = True
+        scheduler.disagg_prefill_bootstrap_queue = SimpleNamespace(queue=reqs)
+        scheduler.tree_cache = SimpleNamespace(
+            check_prefetch_progress=MagicMock(side_effect=lambda rid: readiness[rid])
+        )
+        return scheduler
+
+    def test_local_filter_checks_all_candidates_and_preserves_order(self):
+        scheduler = self._make_scheduler(
+            pp_rank=3,
+            readiness={"req-a": True, "req-b": False, "req-c": True},
+        )
+
+        ready_rids = scheduler._pp_filter_hicache_ready_rids(
+            ["req-c", "req-b", "req-a"]
+        )
+
+        self.assertEqual(ready_rids, ["req-c", "req-a"])
+        self.assertEqual(
+            scheduler.tree_cache.check_prefetch_progress.call_count,
+            3,
+        )
+
+    def test_first_stage_withholds_locally_unready_request(self):
+        scheduler = self._make_scheduler(
+            pp_rank=0,
+            readiness={"req-ready": True, "req-wait": False},
+        )
+        scheduler.get_rids = MagicMock(return_value=(["req-ready", "req-wait"], []))
+
+        good_rids, bad_rids = scheduler._pp_pd_get_bootstrapped_ids()
+
+        self.assertEqual(good_rids, ["req-ready"])
+        self.assertEqual(bad_rids, [])
+
+    def test_later_stage_intersects_previous_and_local_readiness(self):
+        scheduler = self._make_scheduler(
+            pp_rank=5,
+            readiness={
+                "req-a": True,
+                "req-b": False,
+                "req-c": True,
+                "req-local-only": True,
+            },
+        )
+        scheduler._pp_recv_pyobj_from_prev_stage = MagicMock(
+            return_value=[["req-c", "req-b", "req-a"], ["bad-prev"]]
+        )
+        scheduler.get_rids = MagicMock(
+            return_value=(
+                ["req-a", "req-b", "req-c", "req-local-only"],
+                ["bad-local", "bad-prev"],
+            )
+        )
+
+        good_rids, bad_rids = scheduler._pp_pd_get_bootstrapped_ids()
+
+        self.assertEqual(good_rids, ["req-c", "req-a"])
+        self.assertEqual(bad_rids, ["bad-prev", "bad-local"])
+
+    def test_non_pp_path_keeps_existing_scheduler_behavior(self):
+        scheduler = self._make_scheduler(
+            pp_rank=0,
+            readiness={"req": False},
+        )
+        scheduler.ps.pp_size = 1
+
+        ready_rids = scheduler._pp_filter_hicache_ready_rids(["req"])
+
+        self.assertEqual(ready_rids, ["req"])
+        scheduler.tree_cache.check_prefetch_progress.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Gate PD-prefill bootstrap admission on local HiCache storage-prefetch readiness at every pipeline stage.
- Reuse the existing stage-by-stage bootstrap consensus, avoiding a blocking PP collective in the skewed pipeline event loop.
- Preserve RID order while intersecting ready requests and de-duplicating failed requests.
- Add CPU unit coverage for first-stage filtering, downstream consensus, ordering, and the non-PP path.

## Root cause

Each PP stage can independently call `check_prefetch_progress()` before building a new prefill batch. After KV bootstrap completed, a request could enter `waiting_queue` before every PP stage's asynchronous storage prefetch was ready. One stage could then admit the request while another skipped it, allowing the stages to choose different logical batches and desynchronize PP proxy tensors.

This change folds each stage's local HiCache readiness into the existing bootstrap RID consensus. A request is circulated back as ready only after every PP stage has included it.

## Validation

- `python3 -m py_compile python/sglang/srt/managers/scheduler_pp_mixin.py test/registered/unit/managers/test_pp_hicache_prefetch_consensus.py`
- `git diff --check origin/main...HEAD`
- `uvx ruff check --select F401,F821,UP037 python/sglang/srt/managers/scheduler_pp_mixin.py test/registered/unit/managers/test_pp_hicache_prefetch_consensus.py`
- `uvx ruff format --check python/sglang/srt/managers/scheduler_pp_mixin.py test/registered/unit/managers/test_pp_hicache_prefetch_consensus.py`

The targeted pytest module could not be collected in the current local environment because it has `transformers==4.57.6`, while this checkout requires `transformers==5.12.1`. The test is registered in the CPU CI suite.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31386370479](https://github.com/sgl-project/sglang/actions/runs/31386370479)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31386370489](https://github.com/sgl-project/sglang/actions/runs/31386370489)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->