### PR TITLE
[Test] Add CPU unit tests for serving_rerank

### DIFF
--- a/test/registered/unit/entrypoints/openai/test_serving_rerank.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_rerank.py
@@ -1,0 +1,355 @@
+"""CPU-only unit tests for the OpenAI rerank serving helpers."""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+import math
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionMessageContentImagePart,
+    ChatCompletionMessageContentTextPart,
+    ChatCompletionMessageContentVideoPart,
+    V1RerankReqInput,
+)
+from sglang.srt.entrypoints.openai.serving_rerank import (
+    OpenAIServingRerank,
+    _detect_rerank_backend,
+    _extract_text_from_content,
+    _get_yes_no_token_ids,
+    _is_qwen3_reranker_template,
+    _is_qwen3_vl_model,
+    _is_qwen3_vl_reranker_template,
+    _qwen3_rerank_score,
+    _render_jinja_chat_template,
+    _render_vl_jinja_template,
+)
+from sglang.srt.managers.io_struct import EmbeddingReqInput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+
+_RERANK_TEMPLATE = 'The answer can only be "yes" or "no".'
+_VL_RERANK_TEMPLATE = _RERANK_TEMPLATE + " <|vision_start|><|image_pad|>"
+
+
+class _Tokenizer:
+    def __init__(self, chat_template=""):
+        self.chat_template = chat_template
+
+    def encode(self, text, add_special_tokens=False):
+        del add_special_tokens
+        return {"yes": [101], "no": [202]}[text]
+
+
+class _ModelConfig:
+    def __init__(self, model_path="test/cross-encoder"):
+        self.model_path = model_path
+        self.is_generation = True
+
+
+class _TokenizerManager:
+    def __init__(self, chat_template="", model_path="test/cross-encoder"):
+        self.server_args = object()
+        self.tokenizer = _Tokenizer(chat_template)
+        self.model_config = _ModelConfig(model_path)
+
+
+def _text_part(text):
+    return ChatCompletionMessageContentTextPart(type="text", text=text)
+
+
+def _image_part(url="data:image/png;base64,image"):
+    return ChatCompletionMessageContentImagePart(
+        type="image_url", image_url={"url": url}
+    )
+
+
+def _video_part(url="data:video/mp4;base64,video"):
+    return ChatCompletionMessageContentVideoPart(
+        type="video_url", video_url={"url": url}
+    )
+
+
+class TestRerankBackendDetection(CustomTestCase):
+    def test_backend_routing_matrix_uses_request_template_and_model(self):
+        text_request = V1RerankReqInput(query="query", documents=["document"])
+        multimodal_request = V1RerankReqInput(
+            query=[_text_part("query"), _image_part()], documents=["document"]
+        )
+        cases = [
+            (text_request, None, "test/cross-encoder", "cross_encoder"),
+            (text_request, _RERANK_TEMPLATE, "Qwen/Qwen3-Reranker", "text_decoder"),
+            (text_request, _VL_RERANK_TEMPLATE, "test/model", "vl_decoder"),
+            (text_request, None, "QWEN/QWEN3VL-8B", "vl_decoder"),
+            (
+                multimodal_request,
+                _RERANK_TEMPLATE,
+                "test/model",
+                "vl_decoder",
+            ),
+        ]
+
+        for request, template, model_path, expected in cases:
+            with self.subTest(expected=expected, model_path=model_path):
+                self.assertEqual(
+                    _detect_rerank_backend(
+                        request=request,
+                        chat_template=template,
+                        model_path=model_path,
+                    ),
+                    expected,
+                )
+
+    def test_template_detectors_require_their_distinguishing_markers(self):
+        text_cases = [
+            (_RERANK_TEMPLATE.upper(), True),
+            ('answer can only be something: "yes" or "no"', True),
+            ('answer can only be "yes"', False),
+            ("ordinary chat template", False),
+            ("", False),
+        ]
+        for template, expected in text_cases:
+            with self.subTest(detector="text", template=template):
+                self.assertEqual(_is_qwen3_reranker_template(template), expected)
+
+        vl_cases = [
+            (_RERANK_TEMPLATE + " <|vision_start|>", True),
+            (_RERANK_TEMPLATE.upper() + " <|IMAGE_PAD|>", True),
+            (_RERANK_TEMPLATE, False),
+            ("<|vision_start|> describe the image", False),
+        ]
+        for template, expected in vl_cases:
+            with self.subTest(detector="vl", template=template):
+                self.assertEqual(_is_qwen3_vl_reranker_template(template), expected)
+
+    def test_vl_model_detector_accepts_supported_spellings_only(self):
+        cases = [
+            ("Qwen/Qwen3-VL-8B", True),
+            ("local/QWEN3VL-reranker", True),
+            ("Qwen/Qwen3-Reranker", False),
+            ("Qwen/Qwen2-VL-7B", False),
+            ("", False),
+        ]
+        for model_path, expected in cases:
+            with self.subTest(model_path=model_path):
+                self.assertEqual(_is_qwen3_vl_model(model_path), expected)
+
+
+class TestRerankHelpers(CustomTestCase):
+    def test_qwen3_score_normalizes_yes_no_mass_and_guards_denominator(self):
+        cases = [
+            (0.8, 0.2, 0.8),
+            (0.0, 0.0, 0.0),
+            (-0.1, 0.05, 0.0),
+        ]
+        for p_yes, p_no, expected in cases:
+            with self.subTest(p_yes=p_yes, p_no=p_no):
+                self.assertAlmostEqual(_qwen3_rerank_score(p_yes, p_no), expected)
+
+    def test_extract_text_preserves_order_and_ignores_media(self):
+        content = [
+            _text_part("first"),
+            _image_part(),
+            {"type": "text", "text": "second"},
+            _video_part(),
+            {"type": "text", "text": "third"},
+        ]
+
+        self.assertEqual(_extract_text_from_content("direct"), "direct")
+        self.assertEqual(_extract_text_from_content(content), "first second third")
+
+    def test_yes_no_token_ids_use_single_token_encoding(self):
+        self.assertEqual(_get_yes_no_token_ids(_Tokenizer()), (101, 202))
+
+    def test_yes_no_token_ids_fall_back_to_token_conversion(self):
+        class MultiTokenTokenizer:
+            def encode(self, _text, add_special_tokens=False):
+                del add_special_tokens
+                return [1, 2]
+
+            def convert_tokens_to_ids(self, text):
+                return {"yes": 303, "no": 404}[text]
+
+        self.assertEqual(_get_yes_no_token_ids(MultiTokenTokenizer()), (303, 404))
+
+    def test_yes_no_token_ids_have_a_final_qwen_fallback(self):
+        class BrokenTokenizer:
+            def encode(self, _text, add_special_tokens=False):
+                del add_special_tokens
+                raise RuntimeError("tokenizer unavailable")
+
+        self.assertEqual(_get_yes_no_token_ids(BrokenTokenizer()), (9693, 2152))
+
+    def test_text_template_rendering_extracts_text_and_defaults_instruction(self):
+        template = (
+            "{{ instruct | default('DEFAULT') }}|"
+            "{{ messages[0].content }}|{{ messages[1].content }}"
+        )
+        query = [_text_part("query text"), _image_part()]
+        document = [_video_part(), _text_part("document text")]
+
+        self.assertEqual(
+            _render_jinja_chat_template(
+                template,
+                query=query,
+                document=document,
+                instruct=None,
+            ),
+            "DEFAULT|query text|document text",
+        )
+        self.assertEqual(
+            _render_jinja_chat_template(
+                template,
+                query="query",
+                document="document",
+                instruct="custom",
+            ),
+            "custom|query|document",
+        )
+
+    def test_vl_template_rendering_receives_content_lists_and_instruction(self):
+        template = (
+            "{{ instruct | default('DEFAULT') }}|"
+            "{{ query[0].text }}|{{ document[0].type }}"
+        )
+        query = [{"type": "text", "text": "query"}]
+        document = [{"type": "image"}]
+
+        self.assertEqual(
+            _render_vl_jinja_template(
+                template,
+                query=query,
+                document=document,
+                instruct="custom",
+            ),
+            "custom|query|image",
+        )
+
+
+class TestOpenAIServingRerank(CustomTestCase):
+    def setUp(self):
+        self.serving = OpenAIServingRerank(_TokenizerManager())
+
+    def test_request_validation_rejects_empty_text_boundaries(self):
+        cases = [
+            (V1RerankReqInput(query="", documents=["document"]), "Query cannot"),
+            (V1RerankReqInput(query="  ", documents=["document"]), "Query cannot"),
+            (V1RerankReqInput(query="query", documents=[]), "Documents cannot"),
+            (
+                V1RerankReqInput(query="query", documents=[""]),
+                "Each document must",
+            ),
+            (
+                V1RerankReqInput(query="query", documents=[" \t"]),
+                "Each document cannot",
+            ),
+        ]
+        for request, message_fragment in cases:
+            with self.subTest(request=request):
+                self.assertIn(message_fragment, self.serving._validate_request(request))
+
+        valid = V1RerankReqInput(query="query", documents=["document"])
+        self.assertIsNone(self.serving._validate_request(valid))
+
+    def test_cross_encoder_conversion_creates_query_document_pairs(self):
+        request = V1RerankReqInput(
+            query="query", documents=["document one", "document two"]
+        )
+
+        adapted, original = self.serving._convert_to_internal_request(request)
+
+        self.assertIsInstance(adapted, EmbeddingReqInput)
+        self.assertTrue(adapted.is_cross_encoder_request)
+        self.assertEqual(
+            adapted.text,
+            [["query", "document one"], ["query", "document two"]],
+        )
+        self.assertIs(original, request)
+
+    def test_cross_encoder_conversion_extracts_multimodal_text(self):
+        request = V1RerankReqInput(
+            query=[_text_part("query"), _image_part()],
+            documents=[
+                [_video_part(), _text_part("first")],
+                [_text_part("second"), _image_part()],
+            ],
+        )
+
+        adapted, _ = self.serving._convert_to_internal_request(request)
+
+        self.assertEqual(adapted.text, [["query", "first"], ["query", "second"]])
+
+    def test_decoder_conversions_preserve_the_original_request(self):
+        request = V1RerankReqInput(query="query", documents=["document"])
+        cases = [
+            (_RERANK_TEMPLATE, "test/model"),
+            ("", "Qwen/Qwen3-VL-8B"),
+        ]
+        for chat_template, model_path in cases:
+            with self.subTest(chat_template=chat_template, model_path=model_path):
+                serving = OpenAIServingRerank(
+                    _TokenizerManager(chat_template, model_path)
+                )
+                adapted, original = serving._convert_to_internal_request(request)
+                self.assertIs(adapted, request)
+                self.assertIs(original, request)
+
+    def test_logprob_score_uses_token_ids_independent_of_entry_order(self):
+        ret = {
+            "meta_info": {
+                "output_top_logprobs": [
+                    [
+                        (math.log(0.1), 999, "other"),
+                        (math.log(0.2), 202, "no"),
+                        (math.log(0.8), 101, "yes"),
+                    ]
+                ]
+            }
+        }
+
+        self.assertAlmostEqual(self.serving._extract_score_from_logprobs(ret), 0.8)
+
+    def test_logprob_score_handles_missing_yes_or_no_entries(self):
+        yes_only = {
+            "meta_info": {"output_top_logprobs": [[(math.log(0.6), 101, "yes")]]}
+        }
+        no_only = {"meta_info": {"output_top_logprobs": [[(math.log(0.6), 202, "no")]]}}
+
+        self.assertEqual(self.serving._extract_score_from_logprobs(yes_only), 1.0)
+        self.assertEqual(self.serving._extract_score_from_logprobs(no_only), 0.0)
+        self.assertEqual(self.serving._extract_score_from_logprobs({}), 0.0)
+
+    def test_response_accepts_scalar_embedding_scores(self):
+        request = V1RerankReqInput(
+            query="query", documents=["low", "high"], return_documents=True
+        )
+        results = [
+            {"embedding": 0.2, "meta_info": {"id": "low"}},
+            {"embedding": 0.9, "meta_info": {"id": "high"}},
+        ]
+
+        responses = self.serving._build_rerank_response(results, request)
+
+        self.assertEqual(
+            [(response.document, response.index) for response in responses],
+            [("high", 1), ("low", 0)],
+        )
+        self.assertEqual(responses[0].meta_info, {"id": "high"})
+
+    def test_response_rejects_malformed_embedding_lists(self):
+        request = V1RerankReqInput(query="query", documents=["document"])
+
+        for embedding in ([], ["not-a-number"]):
+            with self.subTest(embedding=embedding):
+                with self.assertRaisesRegex(ValueError, "Invalid embedding score"):
+                    self.serving._build_rerank_response(
+                        [{"embedding": embedding}], request
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`python/sglang/srt/entrypoints/openai/serving_rerank.py` contains distinct control flow for ordinary cross-encoders, Qwen3 text-decoder rerankers, and Qwen3-VL multimodal rerankers. These paths previously lacked focused coverage in the registered CPU unit-test suite.

This PR adds regression coverage for the routing, request conversion, score normalization, multimodal text extraction, validation, and response behavior without launching a server or loading model weights. It addresses part of #20865.

### Collision check

I found #28488 before submitting. Its `base-a-test-cpu` job was skipped, it has not been updated since June 19, and several assertions no longer match current `main`. This PR is an independently tested current-`main` implementation using real protocol request objects and `CustomTestCase`.

I also claimed the work in #20865 and noted that I am happy to coordinate if maintainers prefer a different approach.

## Modifications

Add `test/registered/unit/entrypoints/openai/test_serving_rerank.py` with CPU-only coverage for:

- backend selection for cross-encoder, Qwen3 text-decoder, and Qwen3-VL decoder requests;
- Qwen3 and Qwen3-VL template/model detection;
- yes/no token lookup through encode, token-conversion, and final fallback paths;
- yes/no probability normalization and missing-logprob behavior;
- ordered text extraction from mixed text/image/video content;
- text and VL Jinja rendering semantics;
- empty and whitespace-only request validation;
- text and multimodal cross-encoder pair construction;
- preservation of decoder rerank requests;
- scalar embedding responses and malformed embedding rejection.

The test file uses `CustomTestCase` and is registered in `base-a-test-cpu`.

No production files or project dependencies are changed. The tests do not launch a server, instantiate an engine, load model weights, require CUDA, or access the network.

## Accuracy Tests

Not applicable. This is a CPU-only unit-test contribution and does not change model execution or outputs.

Unit-test verification:

```text
$ PYTHONPATH=python pytest test/registered/unit/entrypoints/openai/test_serving_rerank.py -v
============= 18 passed, 22 warnings, 31 subtests passed in 12.83s =============

$ PYTHONPATH=python pytest -q test/registered/unit/entrypoints/openai/test_protocol.py test/registered/unit/entrypoints/openai/test_serving_embedding.py
48 passed, 27 warnings, 16 subtests passed in 13.05s

$ PYTHONPATH=python pytest -q test/registered/unit/entrypoints/openai/test_serving_rerank.py --cov=python/sglang/srt/entrypoints/openai --cov-report=term-missing
python/sglang/srt/entrypoints/openai/serving_rerank.py: 61%
18 passed, 23 warnings, 31 subtests passed in 19.92s
```

Formatting and static checks:

```text
python -m isort --check-only test/registered/unit/entrypoints/openai/test_serving_rerank.py
python -m ruff check --select=F401,F821,UP037 test/registered/unit/entrypoints/openai/test_serving_rerank.py
python -m black --check test/registered/unit/entrypoints/openai/test_serving_rerank.py
codespell --config .codespellrc test/registered/unit/entrypoints/openai/test_serving_rerank.py
python -m py_compile test/registered/unit/entrypoints/openai/test_serving_rerank.py
git diff --check origin/main..HEAD
```

All checks passed.

## Speed Tests and Profiling

Not applicable. This test-only PR does not change runtime or performance-sensitive production code.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable: no user-facing behavior or API changes.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable: test-only change with no model-output or performance impact.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31402502233](https://github.com/sgl-project/sglang/actions/runs/31402502233)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31402500743](https://github.com/sgl-project/sglang/actions/runs/31402500743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->