### PR TITLE
[PD] Fix NIXL P/D serving stall after prefill replacement

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -223,13 +223,17 @@ Please be aware that this setting will cause prefill instances to take a longer 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>**`SGLANG_DISAGGREGATION_WAITING_TIMEOUT`**</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Timeout (seconds) for receiving KV Cache after request initialization</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Timeout (seconds) for receiving KV Cache after request initialization; also bounds pre-initialization prefill DP-rank discovery (`/query_dp_ranks`)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`300`</td>
     </tr>
   </tbody>
 </table>
 
 If a greater mean TTFT is acceptable, you can `export SGLANG_DISAGGREGATION_WAITING_TIMEOUT=600` (10 minutes) to relax the timeout condition.
+
+#### Prefill Replacement Detection
+
+Decode workers identify each prefill bootstrap server by a per-process instance id, returned in the `X-SGLang-Disaggregation-Instance-ID` response header. When a prefill is replaced behind a bootstrap address that stays reachable — for example a Kubernetes Service — a heartbeat that observes a changed id evicts the cached prefill connections and fails the affected in-flight requests; subsequent requests, including client retries, bootstrap against the new instance (NIXL, Mooncake, and Ascend backends — nothing is retried automatically). With the NIXL backend, a request that fails on cached connections inside the heartbeat window triggers the same recovery immediately. The bootstrap address must resolve to exactly one live prefill process at a time: replacement — old down, then new up — is the supported pattern, not load-balancing one address across several live prefills. Detection requires the prefill to send the id: rolling a prefill back to a version that predates it (the id disappearing) is not detected as a replacement, so avoid downgrades across that boundary while decodes hold cached connections.
 
 
 ## Heterogeneous TP with GPU Staging Buffer

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -6,7 +6,9 @@ import dataclasses
 import logging
 import threading
 import time
+import uuid
 from collections import defaultdict
+from enum import Enum, auto
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
@@ -50,12 +52,24 @@ from sglang.srt.utils.network import (
 
 logger = logging.getLogger(__name__)
 
+BOOTSTRAP_INSTANCE_ID_HEADER = "X-SGLang-Disaggregation-Instance-ID"
+
+# How long a positive /health instance-id confirmation is trusted before
+# re-probing. Bounds the blocking probes on the scheduler thread; must stay
+# at or below the heartbeat interval (the TTL equals the interval's 2 s
+# floor, so an interval raised via env only widens the safety margin).
+INSTANCE_CONFIRM_TTL_SECONDS = 2.0
+
 
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
 # so we don't open a fresh TCP connection per query (that churns short-lived
 # sockets and can exhaust ephemeral ports under high concurrency). Thread-local
-# because requests.Session is not safe for concurrent cross-thread use.
+# because requests.Session is not safe for concurrent cross-thread use; the
+# shared epoch below lets one thread's drop rotate every thread's session.
 _bootstrap_sessions = threading.local()
+# Keyed by bootstrap_addr, bounded like the session dicts; never pruned.
+_bootstrap_session_epochs: Dict[str, int] = {}
+_bootstrap_session_epoch_lock = threading.Lock()
 
 
 def _get_bootstrap_session(bootstrap_addr: str) -> requests.Session:
@@ -63,16 +77,44 @@ def _get_bootstrap_session(bootstrap_addr: str) -> requests.Session:
     if sessions is None:
         sessions = {}
         _bootstrap_sessions.by_addr = sessions
-    session = sessions.get(bootstrap_addr)
-    if session is None:
-        # Not evicted: the number of bootstrap_addr is bounded (one per prefill
-        # server). Bootstrap is http-only, so only http:// is mounted.
-        session = requests.Session()
-        session.mount(
-            "http://", requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
-        )
-        sessions[bootstrap_addr] = session
+    with _bootstrap_session_epoch_lock:
+        epoch = _bootstrap_session_epochs.get(bootstrap_addr, 0)
+    entry = sessions.get(bootstrap_addr)
+    if entry is not None:
+        session, session_epoch = entry
+        if session_epoch == epoch:
+            return session
+        session.close()
+    # Not evicted: the number of bootstrap_addr is bounded (one per prefill
+    # server). Bootstrap is http-only, so only http:// is mounted.
+    session = requests.Session()
+    session.mount(
+        "http://", requests.adapters.HTTPAdapter(pool_connections=1, pool_maxsize=1)
+    )
+    sessions[bootstrap_addr] = (session, epoch)
     return session
+
+
+def _drop_bootstrap_session(bootstrap_addr: str) -> None:
+    """Close this thread's keep-alive session for bootstrap_addr and mark
+    every thread's session stale via the shared epoch (dp-rank queries also
+    run on executor threads, each with its own session).
+
+    During a draining replacement, a kept-alive socket can keep reaching the
+    replaced process while new connections reach its successor, so the old
+    process can keep answering queries (with its own instance id, or with
+    rooms silently missing). Dropping the session forces the next query to
+    reconnect through current address resolution."""
+    with _bootstrap_session_epoch_lock:
+        _bootstrap_session_epochs[bootstrap_addr] = (
+            _bootstrap_session_epochs.get(bootstrap_addr, 0) + 1
+        )
+    sessions = getattr(_bootstrap_sessions, "by_addr", None)
+    if sessions is None:
+        return
+    entry = sessions.pop(bootstrap_addr, None)
+    if entry is not None:
+        entry[0].close()
 
 
 class KVTransferError(Exception):
@@ -91,6 +133,22 @@ class KVTransferError(Exception):
         return f"KVTransferError(bootstrap_room={self.bootstrap_room}): {self.failure_reason}"
 
 
+class InstanceProbeVerdict(Enum):
+    """Outcome of a /health identity probe against a topology snapshot.
+
+    The two CONFIRMED verdicts carry opposite recovery obligations —
+    CONFIRMED_REPLACED retires the rooms in flight against the snapshot,
+    CONFIRMED_SAME vetoes any eviction — while INCONCLUSIVE (probe error,
+    unhealthy status, or an id disappearing) authorizes at most cache-only
+    invalidation: without a confirmed verdict, retiring every in-flight room
+    at the address would turn an overloaded-but-alive prefill into a mass
+    retry."""
+
+    CONFIRMED_SAME = auto()
+    CONFIRMED_REPLACED = auto()
+    INCONCLUSIVE = auto()
+
+
 @dataclasses.dataclass
 class PrefillServerInfo:
     # Topology fields (fetched from bootstrap server)
@@ -102,6 +160,10 @@ class PrefillServerInfo:
     kv_cache_dtype: Optional[str]
     follow_bootstrap_room: bool
     enable_dsa_cache_layer_split: bool = False
+
+    # Changes when the prefill bootstrap service restarts. Delivered via
+    # response header only: older decodes crash on unknown topology keys.
+    instance_id: Optional[str] = None
 
     # PD true-retraction rebootstrap: the prefill's HTTP API port. The decode
     # already knows the prefill host (the bootstrap_addr host), so it can POST
@@ -131,6 +193,12 @@ class PrefillServerInfo:
         self.prefill_http_port = (
             int(self.prefill_http_port) if self.prefill_http_port is not None else None
         )
+
+
+# Topology keys added by a newer prefill are dropped, not crashed on.
+_PREFILL_SERVER_INFO_FIELDS = frozenset(
+    field.name for field in dataclasses.fields(PrefillServerInfo)
+)
 
 
 @dataclasses.dataclass
@@ -219,6 +287,10 @@ class CommonKVManager(BaseKVManager):
         logger.debug(f"kv manager bind to {self.local_ip}:{self.rank_port}")
 
         self.request_status: Dict[int, KVPoll] = {}
+        # Serializes request_status transitions. Not connection_lock: the
+        # receiver constructor publishes its initial status while already
+        # holding it (non-reentrant).
+        self.status_lock = threading.Lock()
         self._socket_cache: Dict[str, zmq.Socket] = {}
         self._monitor_cache: Dict[str, zmq.Socket] = {}
         self._socket_send_locks: Dict[str, threading.Lock] = {}
@@ -260,8 +332,10 @@ class CommonKVManager(BaseKVManager):
             self.required_prefill_response_num_table: Dict[int, int] = {}
             self.prefill_info_table: Dict[str, PrefillServerInfo] = {}
             self.heartbeat_failures: Dict[str, int] = {}
-            self.session_pool: Dict = defaultdict(requests.Session)
-            self.session_pool_lock = threading.Lock()
+            # bootstrap_addr -> (confirmed instance_id, monotonic deadline).
+            # Scheduler thread inserts (unlocked but safe: entries are keyed
+            # to the confirmed id), eviction pops under connection_lock.
+            self._instance_confirm_cache: Dict[str, Tuple[str, float]] = {}
             self.addr_to_rooms_tracker: Dict[str, Set[int]] = defaultdict(set)
             self.prefill_response_tracker: Dict[int, Set[int]] = defaultdict(set)
             # Deferred KV release: room -> prefill ranks that acked their transfer
@@ -346,21 +420,28 @@ class CommonKVManager(BaseKVManager):
         return self.request_status[bootstrap_room]
 
     def update_status(self, bootstrap_room: int, status: KVPoll):
-        if bootstrap_room not in self.request_status:
-            # Do not resurrect a cleared entry with Failed: once clear() has
-            # popped the room from request_status, any late update_status(Failed)
-            # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
-            # pollute a future request that reuses the same bootstrap_room.
-            if status == KVPoll.Failed:
-                return
-            self.request_status[bootstrap_room] = status
-        else:
-            if status == KVPoll.Failed:
+        # One read under status_lock: a Failed landing between an
+        # unsynchronized check and the max() write would be overwritten
+        # (KVPoll.Failed is 0), resurrecting a retired room against
+        # evicted endpoints.
+        with self.status_lock:
+            current = self.request_status.get(bootstrap_room)
+            if current is None:
+                # Do not resurrect a cleared entry with Failed: once clear() has
+                # popped the room from request_status, any late update_status(Failed)
+                # (e.g. from abort()) must be a no-op. Otherwise a Failed entry could
+                # pollute a future request that reuses the same bootstrap_room.
+                if status == KVPoll.Failed:
+                    return
+                self.request_status[bootstrap_room] = status
+            elif status == KVPoll.Failed:
                 self.request_status[bootstrap_room] = KVPoll.Failed
+            elif current == KVPoll.Failed:
+                # Failed is terminal for a live entry; only clear()'s pop
+                # resets it.
+                return
             else:
-                self.request_status[bootstrap_room] = max(
-                    self.request_status[bootstrap_room], status
-                )
+                self.request_status[bootstrap_room] = max(current, status)
 
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
@@ -614,7 +695,14 @@ class CommonKVManager(BaseKVManager):
             response = requests.get(url, timeout=5)
             if response.status_code == 200:
                 data = response.json()
-                info = PrefillServerInfo(**data)
+                info = PrefillServerInfo(
+                    **{
+                        k: v
+                        for k, v in data.items()
+                        if k in _PREFILL_SERVER_INFO_FIELDS
+                    }
+                )
+                info.instance_id = response.headers.get(BOOTSTRAP_INSTANCE_ID_HEADER)
             else:
                 logger.error(
                     f"Failed to get prefill server info: {response.status_code}, {response.text}"
@@ -654,6 +742,8 @@ class CommonKVManager(BaseKVManager):
                 )
 
         self._resolve_rank_mapping(info)
+        # Unlocked: only this thread writes here. A pop landing mid-fetch at
+        # worst reinstalls the replaced snapshot for one heartbeat tick.
         self.prefill_info_table[bootstrap_addr] = info
         logger.debug(f"Prefill parallel info for [{bootstrap_addr}]: {info}")
         return True
@@ -1071,69 +1161,259 @@ class CommonKVManager(BaseKVManager):
                 time.sleep(self.heartbeat_interval)
                 with self.connection_lock:
                     addresses = list(self.prefill_info_table.keys())
-
                 for bootstrap_addr in addresses:
-                    session = None
-                    try:
-                        with self.session_pool_lock:
-                            session = self.session_pool[bootstrap_addr]
-                        response = session.get(
-                            f"http://{bootstrap_addr}/health",
-                            timeout=(2, 3),
-                            headers={"Connection": "keep-alive"},
-                        )
-                        if response.status_code == 200:
-                            self.heartbeat_failures[bootstrap_addr] = 0
-                            self._on_heartbeat_success(bootstrap_addr)
-                        else:
-                            logger.info(
-                                f"Attempting to reconnect to {bootstrap_addr}..."
-                            )
-                            self.heartbeat_failures[bootstrap_addr] = (
-                                self.heartbeat_failures.get(bootstrap_addr, 0) + 1
-                            )
-                    except Exception:
-                        logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
-                        self.heartbeat_failures[bootstrap_addr] = (
-                            self.heartbeat_failures.get(bootstrap_addr, 0) + 1
-                        )
-
-                    if (
-                        self.heartbeat_failures.get(bootstrap_addr, 0)
-                        >= self.max_failures
-                    ):
-                        self._handle_node_failure(bootstrap_addr)
-                        with self.session_pool_lock:
-                            if bootstrap_addr in self.session_pool:
-                                del self.session_pool[bootstrap_addr]
+                    self._heartbeat_tick(bootstrap_addr)
 
         threading.Thread(target=heartbeat_checker, daemon=True).start()
+
+    def _heartbeat_tick(self, bootstrap_addr: str):
+        """One heartbeat probe of bootstrap_addr. The topology snapshot is
+        captured before the request and every verdict is gated on it: a
+        delayed response or timeout that raced with eviction plus recovery
+        must not indict the freshly installed generation."""
+        with self.connection_lock:
+            prefill_info = self.prefill_info_table.get(bootstrap_addr)
+        try:
+            # Each probe opens a fresh connection: a kept-alive socket keeps
+            # reaching a draining replaced process, which answers with the
+            # expected id and masks the replacement until it exits (see
+            # _drop_bootstrap_session).
+            response = requests.get(
+                f"http://{bootstrap_addr}/health",
+                timeout=(2, 3),
+                headers={"Connection": "close"},
+            )
+            if response.status_code == 200:
+                replaced_info = self._bootstrap_instance_replaced(
+                    prefill_info, response
+                )
+                if replaced_info is not None:
+                    failure_reason = (
+                        "Prefill instance was replaced "
+                        f"(bootstrap_addr: {bootstrap_addr})"
+                    )
+                    logger.warning(
+                        "%s; invalidating cached PD connections", failure_reason
+                    )
+                    self._handle_node_failure(
+                        bootstrap_addr,
+                        failure_reason=failure_reason,
+                        expected_prefill_info=replaced_info,
+                    )
+                    self.heartbeat_failures.pop(bootstrap_addr, None)
+                    return
+                # Success is a verdict too: credit it only while the table
+                # still holds the probed generation.
+                with self.connection_lock:
+                    credited = (
+                        prefill_info is not None
+                        and self.prefill_info_table.get(bootstrap_addr) is prefill_info
+                    )
+                    if credited:
+                        self.heartbeat_failures[bootstrap_addr] = 0
+                        # Hook implementations must stay cheap and lock-free
+                        # (NIXL: no-op; Mooncake: prunes completed rooms).
+                        self._on_heartbeat_success(bootstrap_addr)
+            else:
+                logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
+                self._record_heartbeat_failure(
+                    bootstrap_addr, prefill_info=prefill_info
+                )
+        except Exception:
+            logger.info(f"Attempting to reconnect to {bootstrap_addr}...")
+            self._record_heartbeat_failure(bootstrap_addr, prefill_info=prefill_info)
+
+        if self.heartbeat_failures.get(bootstrap_addr, 0) >= self.max_failures:
+            # With the snapshot gone there is nothing this verdict can indict.
+            if prefill_info is not None:
+                self._handle_node_failure(
+                    bootstrap_addr, expected_prefill_info=prefill_info
+                )
+            self.heartbeat_failures.pop(bootstrap_addr, None)
+
+    def _record_heartbeat_failure(
+        self,
+        bootstrap_addr: str,
+        prefill_info: Optional[PrefillServerInfo],
+    ) -> None:
+        """Charge a failed probe to the generation it was sent to; a miss
+        that raced with eviction plus recovery must not count against the
+        replacement."""
+        with self.connection_lock:
+            if (
+                prefill_info is not None
+                and self.prefill_info_table.get(bootstrap_addr) is prefill_info
+            ):
+                self.heartbeat_failures[bootstrap_addr] = (
+                    self.heartbeat_failures.get(bootstrap_addr, 0) + 1
+                )
 
     def _on_heartbeat_success(self, bootstrap_addr: str):
         """Hook called on successful heartbeat. Override for backend-specific cleanup."""
         pass
 
-    def _handle_node_failure(self, failed_bootstrap_addr: str):
-        """Handle failure of a prefill node."""
-        with self.connection_lock:
-            keys_to_remove = [
-                k for k in self.connection_pool if k.startswith(failed_bootstrap_addr)
-            ]
-            # Collect TCP endpoints from cached bootstrap_infos before deletion
-            stale_endpoints = set()
-            for k in keys_to_remove:
-                for info in self.connection_pool[k]:
-                    ip = info.get("rank_ip")
-                    port = info.get("rank_port")
-                    if ip and port:
-                        na = NetworkAddress(ip, int(port))
-                        stale_endpoints.add(na.to_tcp())
-            for k in keys_to_remove:
-                del self.connection_pool[k]
-            self.prefill_info_table.pop(failed_bootstrap_addr, None)
+    def _bootstrap_instance_replaced(
+        self,
+        prefill_info: Optional[PrefillServerInfo],
+        response: requests.Response,
+    ) -> Optional[PrefillServerInfo]:
+        """When a healthy response presents a different instance than the
+        snapshot captured before the request, return that snapshot (the
+        caller's eviction gate), else None. Compared against the pre-request
+        snapshot, not the live table: a delayed response from a replaced
+        instance must not indict a freshly recovered entry. An id appearing
+        over a headerless baseline is a replacement too (there is no
+        upgrade-in-place); only an id disappearing stays inconclusive."""
+        if prefill_info is None:
+            return None
+        observed_instance_id = response.headers.get(BOOTSTRAP_INSTANCE_ID_HEADER)
+        if observed_instance_id and observed_instance_id != prefill_info.instance_id:
+            return prefill_info
+        return None
 
+    def _probe_bootstrap_instance(
+        self,
+        bootstrap_addr: str,
+        expected_prefill_info: PrefillServerInfo,
+    ) -> InstanceProbeVerdict:
+        """Probe /health and compare the presented identity against the
+        caller's pre-failure topology snapshot (passed in, not re-read from
+        the table: the verdict must anchor to the snapshot the caller's
+        eviction would be gated on). A matching id — including a headerless
+        response over a headerless baseline, the only confirmation such a
+        baseline can ever get — is CONFIRMED_SAME; a healthy response
+        presenting a different id (or an id over a headerless baseline) is
+        CONFIRMED_REPLACED, per _bootstrap_instance_replaced; everything
+        else — probe error, unhealthy status, an id disappearing — is
+        INCONCLUSIVE. CONFIRMED_SAME is cached for
+        INSTANCE_CONFIRM_TTL_SECONDS because the probe blocks the scheduler
+        thread."""
+        expected_instance_id = expected_prefill_info.instance_id
+        cached = self._instance_confirm_cache.get(bootstrap_addr)
+        if (
+            cached is not None
+            and cached[0] == expected_instance_id
+            and time.monotonic() < cached[1]
+        ):
+            return InstanceProbeVerdict.CONFIRMED_SAME
+        try:
+            # Fresh connection on purpose: this must probe current address
+            # resolution, and the pooled sessions belong to the heartbeat
+            # thread.
+            response = requests.get(f"http://{bootstrap_addr}/health", timeout=(2, 3))
+        except Exception:
+            return InstanceProbeVerdict.INCONCLUSIVE
+        if response.status_code != 200:
+            return InstanceProbeVerdict.INCONCLUSIVE
+        if (
+            self._bootstrap_instance_replaced(expected_prefill_info, response)
+            is not None
+        ):
+            return InstanceProbeVerdict.CONFIRMED_REPLACED
+        if response.headers.get(BOOTSTRAP_INSTANCE_ID_HEADER) == expected_instance_id:
+            self._instance_confirm_cache[bootstrap_addr] = (
+                expected_instance_id,
+                time.monotonic() + INSTANCE_CONFIRM_TTL_SECONDS,
+            )
+            return InstanceProbeVerdict.CONFIRMED_SAME
+        return InstanceProbeVerdict.INCONCLUSIVE
+
+    def _evict_connections_locked(self, bootstrap_addr: str) -> set:
+        """Drop the connection_pool entries and topology snapshot for
+        bootstrap_addr. Caller holds connection_lock and disconnects the
+        returned endpoints after releasing it. Keys are
+        "{addr}_{dp}_{cp}_{tp}", hence the "_" delimiter in the prefix match."""
+        keys_to_remove = [
+            key for key in self.connection_pool if key.startswith(f"{bootstrap_addr}_")
+        ]
+        stale_endpoints = set()
+        for key in keys_to_remove:
+            for info in self.connection_pool[key]:
+                ip = info.get("rank_ip")
+                port = info.get("rank_port")
+                if ip and port:
+                    stale_endpoints.add(NetworkAddress(ip, int(port)).to_tcp())
+        for key in keys_to_remove:
+            del self.connection_pool[key]
+        # Per-address verdict state dies with the generation it was
+        # accumulated against.
+        self.prefill_info_table.pop(bootstrap_addr, None)
+        self._instance_confirm_cache.pop(bootstrap_addr, None)
+        self.heartbeat_failures.pop(bootstrap_addr, None)
+        return stale_endpoints
+
+    def invalidate_cached_connections(
+        self,
+        bootstrap_addr: str,
+        expected_prefill_info: Optional[PrefillServerInfo] = None,
+    ) -> None:
+        """Drop cached rank endpoints and the topology snapshot so the next
+        request re-fetches both from the bootstrap server. When
+        expected_prefill_info is given, evict only while the table still holds
+        that exact snapshot: a failure observed against an older generation
+        must not tear down a cache that was already refreshed."""
+        with self.connection_lock:
+            if (
+                expected_prefill_info is not None
+                and self.prefill_info_table.get(bootstrap_addr)
+                is not expected_prefill_info
+            ):
+                return
+            stale_endpoints = self._evict_connections_locked(bootstrap_addr)
+
+        for endpoint in stale_endpoints:
+            CommonKVReceiver.disconnect_endpoint(endpoint)
+
+    def handle_instance_replacement(
+        self,
+        bootstrap_addr: str,
+        expected_prefill_info: Optional[PrefillServerInfo],
+        detected_by: str,
+    ) -> None:
+        """Confirmed-replacement verdict from the query or failure path:
+        evict the cached connections AND retire the rooms in flight against
+        the evicted snapshot, exactly like the heartbeat's replacement
+        verdict. Cache-only invalidation would strand those rooms until the
+        waiting timeout — once the next request publishes the replacement's
+        topology, the heartbeat compares new against new and can never
+        indict them. Only INCONCLUSIVE probe verdicts stay cache-only
+        (see NixlKVReceiver.failure_exception)."""
+        failure_reason = (
+            f"Prefill instance was replaced (bootstrap_addr: {bootstrap_addr}, "
+            f"detected by {detected_by})"
+        )
+        logger.warning("%s; invalidating cached PD connections", failure_reason)
+        self._handle_node_failure(
+            bootstrap_addr,
+            failure_reason=failure_reason,
+            expected_prefill_info=expected_prefill_info,
+        )
+
+    def _handle_node_failure(
+        self,
+        failed_bootstrap_addr: str,
+        failure_reason: Optional[str] = None,
+        expected_prefill_info: Optional[PrefillServerInfo] = None,
+    ):
+        """Handle failure of a prefill node. When expected_prefill_info is
+        given, act only while the table still holds that exact snapshot."""
+        failure_reason = failure_reason or (
+            "Lost connection with prefill instance "
+            f"(bootstrap_addr: {failed_bootstrap_addr})"
+        )
+        with self.connection_lock:
+            if (
+                expected_prefill_info is not None
+                and self.prefill_info_table.get(failed_bootstrap_addr)
+                is not expected_prefill_info
+            ):
+                return
+            stale_endpoints = self._evict_connections_locked(failed_bootstrap_addr)
+
+            # Copy before leaving the lock: other threads mutate these sets,
+            # and set mutation mid-iteration raises RuntimeError.
             possible_affected_rooms = list(
-                self.addr_to_rooms_tracker.get(failed_bootstrap_addr, [])
+                self.addr_to_rooms_tracker.get(failed_bootstrap_addr, ())
             )
             self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)
 
@@ -1142,20 +1422,23 @@ class CommonKVManager(BaseKVManager):
 
         affected_rooms = []
         for room in possible_affected_rooms:
-            if (
-                room in self.request_status
-                and self.check_status(room) != KVPoll.Success
-            ):
-                self.record_failure(
-                    room,
-                    f"Lost connection with prefill instance (bootstrap_addr: {failed_bootstrap_addr})",
-                )
-                self.update_status(room, KVPoll.Failed)
-                affected_rooms.append(room)
+            # One status_lock section per room: terminal cleanup pops rooms
+            # concurrently, and a check-then-index here would KeyError and
+            # kill the heartbeat thread. The record lands in the same
+            # section (failure_lock nests inside status_lock) so a racing
+            # cleanup cannot strand it for a reused room id.
+            with self.status_lock:
+                status = self.request_status.get(room)
+                if status is None or status == KVPoll.Success:
+                    continue
+                self.request_status[room] = KVPoll.Failed
+                self.record_failure(room, failure_reason)
+            affected_rooms.append(room)
 
         logger.error(
-            f"Lost connection with prefill instance (bootstrap_addr: {failed_bootstrap_addr}), "
-            f"{len(affected_rooms)} requests affected"
+            "%s, %d requests affected",
+            failure_reason,
+            len(affected_rooms),
         )
 
 
@@ -1321,7 +1604,11 @@ class CommonKVSender(BaseKVSender):
         return KVPoll.Failed
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+        # Locked pop: an unlocked pop can interleave with update_status's
+        # present-check, letting a late Failed write resurrect the entry the
+        # pop just cleared and pollute a reused bootstrap_room.
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
             self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "transfer_infos"):
@@ -1361,11 +1648,27 @@ class CommonKVReceiver(BaseKVReceiver):
         self.init_time: Optional[float] = None
         self.abort_notified: bool = False
         self._connection_pool_entries: Dict[str, List[Dict]] = {}
-        self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
-        self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
+        # True when _setup_bootstrap_infos reused connection_pool entries.
+        self._used_cached_bootstrap_infos: bool = False
+        self._aborted: bool = False
+        # None until init(); the failure path may read it before then.
+        self.prefill_info: Optional[PrefillServerInfo] = None
+        # One locked section for both publications: node-failure handling
+        # snapshots-and-pops this set under connection_lock and skips rooms
+        # absent from request_status, so an unlocked add (or a status write
+        # outside the section) leaves a room no retirement can ever reach.
+        with self.kv_mgr.connection_lock:
+            self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(
+                self.bootstrap_room
+            )
+            self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
 
     def init(self, prefill_dp_rank: int):
-        if self.bootstrap_addr not in self.kv_mgr.prefill_info_table:
+        # Single locked read: the heartbeat thread evicts concurrently. The
+        # snapshot is also what the generation-gated eviction anchors to.
+        with self.kv_mgr.connection_lock:
+            prefill_info = self.kv_mgr.prefill_info_table.get(self.bootstrap_addr)
+        if prefill_info is None:
             self.kv_mgr.record_failure(
                 self.bootstrap_room,
                 f"Prefill server with bootstrap_addr: {self.bootstrap_addr} is healthy before, but now it is down. Request (bootstrap_room: {self.bootstrap_room}) has been marked as failed.",
@@ -1375,7 +1678,7 @@ class CommonKVReceiver(BaseKVReceiver):
             return
 
         # Read pre-computed rank mapping from prefill_info (computed in try_ensure_parallel_info)
-        self.prefill_info = self.kv_mgr.prefill_info_table[self.bootstrap_addr]
+        self.prefill_info = prefill_info
         self.target_tp_rank = self.prefill_info.target_tp_rank
         self.target_tp_ranks = self.prefill_info.target_tp_ranks
         self.target_cp_ranks = self.prefill_info.target_cp_ranks
@@ -1407,6 +1710,7 @@ class CommonKVReceiver(BaseKVReceiver):
         for target_cp_rank in self.target_cp_ranks:
             bootstrap_key = f"{self.bootstrap_addr}_{self.prefill_dp_rank}_{target_cp_rank}_{self.target_tp_rank}"
 
+            # Locked read: the heartbeat thread evicts keys concurrently.
             with self.kv_mgr.connection_lock:
                 cached_bootstrap_infos = self.kv_mgr.connection_pool.get(bootstrap_key)
 
@@ -1458,15 +1762,23 @@ class CommonKVReceiver(BaseKVReceiver):
                     self.invalidate_cached_bootstrap_infos()
                     return
 
+                # Publish under the lock, and only while the table still
+                # holds this receiver's snapshot: a replacement can complete
+                # during the fetch, and publishing then would overwrite the
+                # new generation's endpoints with dead ones. setdefault
+                # adopts the entry a racing same-generation receiver
+                # published first.
                 with self.kv_mgr.connection_lock:
-                    cached_bootstrap_infos = self.kv_mgr.connection_pool.setdefault(
-                        bootstrap_key, self.bootstrap_infos
-                    )
-
-                if cached_bootstrap_infos is not self.bootstrap_infos:
-                    self.bootstrap_infos = cached_bootstrap_infos
+                    if (
+                        self.kv_mgr.prefill_info_table.get(self.bootstrap_addr)
+                        is self.prefill_info
+                    ):
+                        self.bootstrap_infos = self.kv_mgr.connection_pool.setdefault(
+                            bootstrap_key, self.bootstrap_infos
+                        )
             else:
                 self.bootstrap_infos = cached_bootstrap_infos
+                self._used_cached_bootstrap_infos = True
 
             self._connection_pool_entries[bootstrap_key] = self.bootstrap_infos
 
@@ -1485,42 +1797,127 @@ class CommonKVReceiver(BaseKVReceiver):
     def _get_bootstrap_info_from_server(
         self, prefill_dp_rank, prefill_cp_rank, target_tp_rank, target_pp_rank
     ):
-        """Fetch the bootstrap info from the bootstrap server."""
+        """Fetch the bootstrap info from the bootstrap server.
+
+        An instance-id mismatch is ambiguous about which side is stale, the
+        keep-alive socket or the topology snapshot, so retry once on the
+        fresh connection the first mismatch forced open (see
+        _drop_bootstrap_session); a second mismatch means the snapshot is
+        the stale side and it is evicted (generation-gated)."""
+        url = f"http://{self.bootstrap_addr}/route?prefill_dp_rank={prefill_dp_rank}&prefill_cp_rank={prefill_cp_rank}&target_tp_rank={target_tp_rank}&target_pp_rank={target_pp_rank}"
         try:
-            url = f"http://{self.bootstrap_addr}/route?prefill_dp_rank={prefill_dp_rank}&prefill_cp_rank={prefill_cp_rank}&target_tp_rank={target_tp_rank}&target_pp_rank={target_pp_rank}"
             response = _get_bootstrap_session(self.bootstrap_addr).get(url, timeout=5)
             if response.status_code == 200:
-                bootstrap_info = response.json()
-                bootstrap_info["pp_rank"] = int(target_pp_rank)
-                return bootstrap_info
-            else:
-                logger.error(
-                    f"Failed to get prefill server info: {response.status_code}, {response.text}"
+                if self._rank_response_matches_instance(response):
+                    bootstrap_info = response.json()
+                    bootstrap_info["pp_rank"] = int(target_pp_rank)
+                    return bootstrap_info
+                response = _get_bootstrap_session(self.bootstrap_addr).get(
+                    url, timeout=5
                 )
-                return None
+                if response.status_code == 200:
+                    if self._rank_response_matches_instance(response):
+                        bootstrap_info = response.json()
+                        bootstrap_info["pp_rank"] = int(target_pp_rank)
+                        return bootstrap_info
+                    self.kv_mgr.handle_instance_replacement(
+                        self.bootstrap_addr,
+                        expected_prefill_info=self.prefill_info,
+                        detected_by="rank endpoint fetch",
+                    )
+                    return None
+            logger.error(
+                f"Failed to get prefill server info: {response.status_code}, {response.text}"
+            )
+            # A draining replaced process can 404 new-topology ranks forever;
+            # don't pin the socket that produced the error.
+            _drop_bootstrap_session(self.bootstrap_addr)
+            return None
         except Exception as e:
             logger.error(f"Error fetching prefill info from bootstrap: {e}")
             return None
 
+    def _rank_response_matches_instance(self, response: requests.Response) -> bool:
+        """Reject a rank answer whose instance id disagrees with the topology
+        snapshot: accepting one from a draining replaced process would cache
+        dead endpoints under the fresh topology (see _drop_bootstrap_session).
+        Both ids absent is a pre-instance-id server -- nothing to compare."""
+        observed_instance_id = response.headers.get(BOOTSTRAP_INSTANCE_ID_HEADER)
+        if observed_instance_id == self.prefill_info.instance_id:
+            return True
+        logger.warning(
+            "Rank endpoint response from %s presents instance %s but the "
+            "topology snapshot came from instance %s; discarding the fetch "
+            "and the keep-alive connection that produced it.",
+            self.bootstrap_addr,
+            observed_instance_id,
+            self.prefill_info.instance_id,
+        )
+        _drop_bootstrap_session(self.bootstrap_addr)
+        return False
+
+    @staticmethod
+    def _dp_rank_response_matches_instance(
+        response: requests.Response,
+        expected_instance_id: Optional[str],
+        bootstrap_addr: str,
+    ) -> bool:
+        """Same contract as _rank_response_matches_instance."""
+        observed_instance_id = response.headers.get(BOOTSTRAP_INSTANCE_ID_HEADER)
+        if observed_instance_id == expected_instance_id:
+            return True
+        logger.warning(
+            "dp_rank query response from %s presents instance %s but the "
+            "topology snapshot came from instance %s; discarding the answer "
+            "and the keep-alive connection that produced it.",
+            bootstrap_addr,
+            observed_instance_id,
+            expected_instance_id,
+        )
+        _drop_bootstrap_session(bootstrap_addr)
+        return False
+
     @staticmethod
     def query_prefill_dp_ranks(
-        bootstrap_addr: str, bootstrap_rooms: List[int]
-    ) -> Dict[str, int]:
-        """Batch query prefill dp_ranks for given bootstrap_rooms."""
+        bootstrap_addr: str,
+        bootstrap_rooms: List[int],
+        expected_instance_id: Optional[str],
+    ) -> Optional[Dict[str, int]]:
+        """Batch query prefill dp_ranks for given bootstrap_rooms.
+
+        The response must present the topology snapshot's instance id: a
+        draining replaced process omits rooms it never registered, and an
+        accepted empty answer would park those requests with no timeout
+        armed. The first mismatch drops the session and the query retries
+        once on the fresh connection; a second mismatch returns None so the
+        caller evicts the stale snapshot. Transient failures return {} and
+        the rooms keep waiting under the caller's resolution deadline."""
+        url = f"http://{bootstrap_addr}/query_dp_ranks"
+        payload = {"bootstrap_rooms": bootstrap_rooms}
         try:
-            url = f"http://{bootstrap_addr}/query_dp_ranks"
             response = _get_bootstrap_session(bootstrap_addr).post(
-                url,
-                json={"bootstrap_rooms": bootstrap_rooms},
-                timeout=5,
+                url, json=payload, timeout=5
             )
             if response.status_code == 200:
-                return response.json()
-            else:
-                logger.error(
-                    f"Failed to query dp_ranks: {response.status_code}, {response.text}"
+                if CommonKVReceiver._dp_rank_response_matches_instance(
+                    response, expected_instance_id, bootstrap_addr
+                ):
+                    return response.json()
+                response = _get_bootstrap_session(bootstrap_addr).post(
+                    url, json=payload, timeout=5
                 )
-                return {}
+                if response.status_code == 200:
+                    if CommonKVReceiver._dp_rank_response_matches_instance(
+                        response, expected_instance_id, bootstrap_addr
+                    ):
+                        return response.json()
+                    return None
+            logger.error(
+                f"Failed to query dp_ranks: {response.status_code}, {response.text}"
+            )
+            # Don't pin the socket that produced an unusable answer.
+            _drop_bootstrap_session(bootstrap_addr)
+            return {}
         except Exception as e:
             logger.error(f"Error querying dp_ranks from bootstrap: {e}")
             return {}
@@ -1603,11 +2000,28 @@ class CommonKVReceiver(BaseKVReceiver):
         return KVPoll.Failed
 
     def clear(self) -> None:
-        self.kv_mgr.request_status.pop(self.bootstrap_room, None)
+        # Locked pop: an unlocked pop can interleave with update_status's
+        # present-check, letting a late Failed write resurrect the entry the
+        # pop just cleared and pollute a reused bootstrap_room.
+        with self.kv_mgr.status_lock:
+            self.kv_mgr.request_status.pop(self.bootstrap_room, None)
         self.kv_mgr.required_prefill_response_num_table.pop(self.bootstrap_room, None)
         self.kv_mgr.prefill_response_tracker.pop(self.bootstrap_room, None)
+        # Failure records survive this base cleanup: Mooncake and Mori
+        # consume theirs only after clear(), so a pop here would misreport
+        # every local failure as propagated. NIXL pops in its override.
+        # Failed rooms have no other exit from the tracker: the only removals
+        # besides this one are the NIXL success-path discard and the
+        # whole-address pop on node failure, so without this a terminally
+        # failed room stays tracked for the address's lifetime. .get(), not
+        # the defaultdict index: cleanup racing that whole-address pop must
+        # not recreate an empty entry for a retired address.
+        tracked_rooms = self.kv_mgr.addr_to_rooms_tracker.get(self.bootstrap_addr)
+        if tracked_rooms is not None:
+            tracked_rooms.discard(self.bootstrap_room)
 
     def abort(self):
+        self._aborted = True
         self.kv_mgr.record_failure(
             self.bootstrap_room,
             "Aborted by AbortReq.",
@@ -1650,6 +2064,7 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
     def __init__(self, host: str, port: int):
         self.host = host
         self.port = port
+        self.instance_id = uuid.uuid4().hex
         self.app = web.Application()
         self.store = dict()
         self.lock = asyncio.Lock()
@@ -1700,7 +2115,11 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
         self.app.router.add_get("/health", self._handle_health_check)
 
     async def _handle_health_check(self, request):
-        return web.Response(text="OK", status=200)
+        return web.Response(
+            text="OK",
+            status=200,
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: self.instance_id},
+        )
 
     async def _handle_route(self, request: web.Request):
         method = request.method
@@ -1829,7 +2248,13 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 enable_dsa_cache_layer_split=bool(self.enable_dsa_cache_layer_split),
                 prefill_http_port=self.prefill_http_port,
             )
-            return web.json_response(dataclasses.asdict(info), status=200)
+            payload = dataclasses.asdict(info)
+            del payload["instance_id"]
+            return web.json_response(
+                payload,
+                status=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: self.instance_id},
+            )
 
         if not self._is_ready():
             return web.Response(
@@ -1851,7 +2276,11 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 status=404,
             )
 
-        return web.json_response(dataclasses.asdict(bootstrap_info), status=200)
+        return web.json_response(
+            dataclasses.asdict(bootstrap_info),
+            status=200,
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: self.instance_id},
+        )
 
     async def _handle_register_dp_rank(self, request: web.Request):
         data = await request.json()
@@ -1874,7 +2303,11 @@ class CommonKVBootstrapServer(BaseKVBootstrapServer):
                 room_int = int(room)
                 if room_int in self.room_to_dp_rank:
                     result[str(room_int)] = self.room_to_dp_rank[room_int]["dp_rank"]
-        return web.json_response(result, status=200)
+        return web.json_response(
+            result,
+            status=200,
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: self.instance_id},
+        )
 
     async def _cleanup_expired_entries(self):
         """Remove entries older than cleanup interval from room_to_dp_rank."""

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -36,7 +36,12 @@ from sglang.srt.configs.mamba_utils import Mamba2CacheParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.base.conn import StateType
-from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVReceiver
+from sglang.srt.disaggregation.common.conn import (
+    CommonKVManager,
+    CommonKVReceiver,
+    PrefillServerInfo,
+    _drop_bootstrap_session,
+)
 from sglang.srt.disaggregation.decode_hicache_mixin import (
     DecodeHiCachePreallocMixin,
     DecodeHiCacheTransferMixin,
@@ -370,13 +375,33 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.retracted_queue: List[Req] = []
         self.pending_reqs: List[DecodeRequest] = []
         # In-flight authoritative room -> DP-rank lookups, consumed below.
+        # The PrefillServerInfo is the topology snapshot the query was sent
+        # against; a prefetched answer is only consumed under that snapshot.
         self._prefill_dp_rank_queries: Dict[
-            str, Tuple[Tuple[int, ...], Future[Dict[str, int]]]
+            str,
+            Tuple[
+                Tuple[int, ...],
+                Future[Optional[Dict[str, int]]],
+                PrefillServerInfo,
+            ],
         ] = {}
         self._ensure_retry_count: Dict[str, int] = {}
         self._max_ensure_retries: int = 15  # scheduling cycles
         self._ensure_last_attempt_time: Dict[str, float] = {}
         self._ensure_retry_interval: float = 1.0  # seconds
+        # Deadline for /query_dp_ranks resolution, keyed by bootstrap_room:
+        # a room the prefill never registered resolves to nothing on every
+        # query, with no other timeout armed yet (init() has not run).
+        self._dp_rank_query_first_attempt: Dict[int, float] = {}
+        self._dp_rank_query_timeout: float = (
+            envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.get()
+        )
+        # Rooms missing past this grace period force a reconnect through
+        # current address resolution (see _drop_bootstrap_session): a
+        # draining replaced instance presents the expected id with the
+        # replacement's rooms simply absent, so no mismatch ever fires.
+        self._dp_rank_query_fresh_retry_grace: float = self._dp_rank_query_timeout / 2
+        self._dp_rank_query_last_fresh_retry: Dict[str, float] = {}
         # Retracted requests staged for rebootstrap while generation is paused.
         # Enqueued into ``self.queue`` only on ``continue_generation`` so the
         # prefix KV is recomputed under the post-retract (updated) weights.
@@ -953,6 +978,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     # kv_receiver may be None from a prior self.queue cleanup
                     if decode_req.kv_receiver is not None:
                         decode_req.kv_receiver.abort()
+                        # abort() records a generic AbortReq reason; overwrite
+                        # it so the client sees why (same pattern as
+                        # _fail_prefill_recompute).
+                        self.kv_manager.record_failure(
+                            decode_req.req.bootstrap_room, error_msg
+                        )
                 del self._ensure_retry_count[bootstrap_addr]
                 del self._ensure_last_attempt_time[bootstrap_addr]
             else:
@@ -973,13 +1004,18 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             addr_to_reqs.setdefault(addr, []).append(decode_req)
 
         for bootstrap_addr in set(queries) - set(addr_to_reqs):
-            _, stale_future = queries.pop(bootstrap_addr)
+            _, stale_future, _ = queries.pop(bootstrap_addr)
             stale_future.cancel()
 
         for bootstrap_addr, decode_reqs in addr_to_reqs.items():
             if bootstrap_addr in queries:
                 continue
-            if self.kv_manager.prefill_info_table.get(bootstrap_addr) is None:
+            # Locked read: the heartbeat thread evicts concurrently. The
+            # snapshot rides with the future so the consume point can tell
+            # whether the answer still describes the current generation.
+            with self.kv_manager.connection_lock:
+                prefill_info = self.kv_manager.prefill_info_table.get(bootstrap_addr)
+            if prefill_info is None:
                 continue
 
             rooms = tuple(
@@ -994,11 +1030,12 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 CommonKVReceiver.query_prefill_dp_ranks,
                 bootstrap_addr,
                 list(rooms),
+                expected_instance_id=prefill_info.instance_id,
             )
-            queries[bootstrap_addr] = (rooms, future)
+            queries[bootstrap_addr] = (rooms, future, prefill_info)
 
     def _cancel_prefill_dp_rank_queries(self) -> None:
-        for _, future in self._prefill_dp_rank_queries.values():
+        for _, future, _ in self._prefill_dp_rank_queries.values():
             future.cancel()
         self._prefill_dp_rank_queries.clear()
 
@@ -1006,6 +1043,10 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         """Batch-resolve prefill_dp_ranks for pending requests and initialize receivers."""
         if not self.pending_reqs:
             self._cancel_prefill_dp_rank_queries()
+            # This early return must not strand deadline entries for
+            # externally removed requests.
+            self._dp_rank_query_first_attempt = {}
+            self._dp_rank_query_last_fresh_retry = {}
             return
 
         # Group pending requests by bootstrap_addr
@@ -1030,43 +1071,133 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             # Pass 2: resolve dp rank for addrs whose info is available
             if need_query:
                 rooms = [decode_req.req.bootstrap_room for decode_req in need_query]
+                # Locked read: the heartbeat thread evicts concurrently.
+                with self.kv_manager.connection_lock:
+                    prefill_info = self.kv_manager.prefill_info_table.get(
+                        bootstrap_addr
+                    )
+                expected_instance_id = (
+                    prefill_info.instance_id if prefill_info is not None else None
+                )
                 prefetched = self._prefill_dp_rank_queries.pop(bootstrap_addr, None)
                 prefetched_rooms = prefetched[0] if prefetched is not None else ()
                 if (
                     prefetched is not None
+                    # An answer prefetched against an evicted generation must
+                    # not be consumed under the current one.
+                    and prefetched[2] is prefill_info
                     and tuple(rooms[: len(prefetched_rooms)]) == prefetched_rooms
                 ):
                     room_to_rank = prefetched[1].result()
                     remaining_rooms = rooms[len(prefetched_rooms) :]
-                    if remaining_rooms:
-                        room_to_rank.update(
-                            CommonKVReceiver.query_prefill_dp_ranks(
-                                bootstrap_addr, remaining_rooms
-                            )
+                    if room_to_rank is not None and remaining_rooms:
+                        top_up = CommonKVReceiver.query_prefill_dp_ranks(
+                            bootstrap_addr,
+                            remaining_rooms,
+                            expected_instance_id=expected_instance_id,
                         )
+                        if top_up is None:
+                            room_to_rank = None
+                        else:
+                            room_to_rank.update(top_up)
                 else:
                     if prefetched is not None:
                         prefetched[1].cancel()
                     room_to_rank = CommonKVReceiver.query_prefill_dp_ranks(
-                        bootstrap_addr, rooms
+                        bootstrap_addr,
+                        rooms,
+                        expected_instance_id=expected_instance_id,
                     )
+                if room_to_rank is None:
+                    # Persistent id mismatch: the topology snapshot is the
+                    # stale side; evict it — retiring its in-flight rooms,
+                    # which cache-only eviction would leave to the waiting
+                    # timeout — so Pass 1 re-fetches next cycle.
+                    if prefill_info is not None:
+                        self.kv_manager.handle_instance_replacement(
+                            bootstrap_addr,
+                            expected_prefill_info=prefill_info,
+                            detected_by="dp-rank resolution",
+                        )
+                    room_to_rank = {}
+                now = time.monotonic()
+                stale_missing = False
                 for decode_req in need_query:
-                    prefill_dp_rank = room_to_rank.get(
-                        str(decode_req.req.bootstrap_room)
-                    )
+                    room = decode_req.req.bootstrap_room
+                    prefill_dp_rank = room_to_rank.get(str(room))
                     if prefill_dp_rank is not None:
                         resolved.append((decode_req, int(prefill_dp_rank)))
-                    else:
+                        continue
+                    first_attempt = self._dp_rank_query_first_attempt.setdefault(
+                        room, now
+                    )
+                    if now - first_attempt <= self._dp_rank_query_timeout:
+                        if now - first_attempt > self._dp_rank_query_fresh_retry_grace:
+                            stale_missing = True
                         remaining.append(decode_req)
+                        continue
+                    error_msg = (
+                        f"Could not resolve prefill dp_rank for bootstrap_room "
+                        f"{room} from {bootstrap_addr} within "
+                        f"{self._dp_rank_query_timeout:.0f}s; the prefill "
+                        "instance that would have registered it was likely "
+                        "replaced. Failing the request so the client can retry."
+                    )
+                    logger.error(error_msg)
+                    # kv_receiver may be None from a prior self.queue cleanup
+                    if decode_req.kv_receiver is not None:
+                        decode_req.kv_receiver.abort()
+                        # abort() records a generic AbortReq reason; overwrite
+                        # it so the client sees why (same pattern as
+                        # _fail_prefill_recompute).
+                        self.kv_manager.record_failure(room, error_msg)
+
+                if stale_missing:
+                    last = self._dp_rank_query_last_fresh_retry.get(bootstrap_addr)
+                    if (
+                        last is None
+                        or now - last >= self._dp_rank_query_fresh_retry_grace
+                    ):
+                        # Rooms stayed missing from id-matching answers --
+                        # the draining-instance case; force a reconnect (see
+                        # _dp_rank_query_fresh_retry_grace).
+                        self._dp_rank_query_last_fresh_retry[bootstrap_addr] = now
+                        _drop_bootstrap_session(bootstrap_addr)
             else:
                 prefetched = self._prefill_dp_rank_queries.pop(bootstrap_addr, None)
                 if prefetched is not None:
                     prefetched[1].cancel()
 
         self.pending_reqs = remaining
+        # Deadline and rate-limit state live only as long as something pends.
+        pending_rooms = {decode_req.req.bootstrap_room for decode_req in remaining}
+        self._dp_rank_query_first_attempt = {
+            room: first_attempt
+            for room, first_attempt in self._dp_rank_query_first_attempt.items()
+            if room in pending_rooms
+        }
+        pending_addrs = {_bootstrap_addr(decode_req.req) for decode_req in remaining}
+        self._dp_rank_query_last_fresh_retry = {
+            addr: last
+            for addr, last in self._dp_rank_query_last_fresh_retry.items()
+            if addr in pending_addrs
+        }
 
         for decode_req, prefill_dp_rank in resolved:
             decode_req.kv_receiver.init(prefill_dp_rank)
+
+    def _drop_failed_pending_reqs(self, failed_reqs: List[DecodeRequest]) -> None:
+        """Remove externally failed requests together with their resolution
+        deadlines: a request reusing the bootstrap_room before the next
+        resolution pass must not inherit an expired deadline."""
+        failed_ids = {id(r) for r in failed_reqs}
+        self.pending_reqs = [r for r in self.pending_reqs if id(r) not in failed_ids]
+        pending_rooms = {r.req.bootstrap_room for r in self.pending_reqs}
+        self._dp_rank_query_first_attempt = {
+            room: first_attempt
+            for room, first_attempt in self._dp_rank_query_first_attempt.items()
+            if room in pending_rooms
+        }
 
     def pop_preallocated(
         self,
@@ -1143,10 +1274,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         # DecodeRequest is shared between self.queue and self.pending_reqs;
         # drop failed reqs from both
         if failed_reqs:
-            failed_ids = {id(r) for r in failed_reqs}
-            self.pending_reqs = [
-                r for r in self.pending_reqs if id(r) not in failed_ids
-            ]
+            self._drop_failed_pending_reqs(failed_reqs)
 
         # HiSparse physical constraint: max requests by device buffer capacity.
         # Each admitted req needs padded_buffer_size from hisparse device pool.

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -23,6 +23,7 @@ from sglang.srt.disaggregation.common.conn import (
     CommonKVManager,
     CommonKVReceiver,
     CommonKVSender,
+    InstanceProbeVerdict,
     KVTransferError,
 )
 from sglang.srt.disaggregation.common.staging_handler import (
@@ -629,13 +630,21 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             return
 
         room_infos = self.transfer_infos.get(room, {})
-        needs_staging = any(
-            not tinfo.is_dummy()
-            and tinfo.agent_name in self.decode_kv_args_table
-            and self.decode_kv_args_table[tinfo.agent_name].decode_tp_size
-            != self.attn_tp_size
-            for tinfo in room_infos.values()
-        )
+
+        needs_staging = False
+        for tinfo in room_infos.values():
+            if tinfo.is_dummy():
+                continue
+            # Single get(): the bootstrap thread pops entries concurrently.
+            decode_kv_args = self.decode_kv_args_table.get(tinfo.agent_name)
+            if decode_kv_args is None:
+                # Peer mid-re-registration: leave the room unmarked so the
+                # next chunk re-evaluates, instead of concluding "no staging"
+                # and permanently skipping the STAGING_REQ.
+                return
+            if decode_kv_args.decode_tp_size != self.attn_tp_size:
+                needs_staging = True
+
         if not needs_staging:
             # Mark anyway so we don't re-evaluate the predicate every chunk.
             self._staging_ctx.prefetched_rooms.add(room)
@@ -1133,6 +1142,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     if req.is_dummy():
                         continue
 
+                    # Can fire while the bootstrap thread re-registers the
+                    # peer; the worker's blanket handler fails the room and
+                    # the decode's retry re-registers.
                     assert req.agent_name in self.decode_kv_args_table
                     dst_info = self.decode_kv_args_table[req.agent_name]
                     decode_tp_size = dst_info.decode_tp_size
@@ -1366,8 +1378,10 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 self.exceptions[room] = e
                 self.record_failure(room, str(e))
                 self.update_status(room, KVPoll.Failed)
-                # No ack here on purpose: the DONE barrier bails on the first
-                # ERR, so siblings may still be writing; fall back to the timeout.
+                # No ack here on purpose, and the outstanding count survives:
+                # the DONE barrier bails on the first ERR, so siblings may
+                # still be writing, and outstanding == 0 is the abort ack's
+                # quiescence predicate; fall back to the timeout.
 
     def register_buffer_to_engine(self):
         self.kv_descs = []
@@ -1430,15 +1444,46 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
     def _add_remote_peer(self, decode_kv_args: KVArgsRegisterInfo):
         agent_name = decode_kv_args.agent_name
         if agent_name in self.decode_kv_args_table:
-            logger.info(f"Peer {agent_name} was already registered, ignoring.")
-            return
+            if self.agent.check_remote_metadata(agent_name):
+                logger.info(f"Peer {agent_name} was already registered, ignoring.")
+                return
+            # NIXL lost the metadata outside our control; re-register from
+            # scratch rather than keep a dead peer.
+            logger.info(
+                "Peer %s lost its NIXL remote metadata; registering it again.",
+                agent_name,
+            )
+            self._discard_remote_peer(agent_name)
+
         decode_kv_args.requires_dcp_relayout = self.requires_dcp_relayout(
             decode_kv_args.dst_dcp_size, decode_kv_args.dst_dcp_rank
         )
+        try:
+            self.agent.add_remote_agent(decode_kv_args.agent_metadata)
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                self._prepare_payload_xfer(decode_kv_args)
+        except Exception:
+            # Do not publish a half-registered peer: the decode's retry after
+            # eviction must not find a dead entry.
+            self._discard_remote_peer(agent_name)
+            raise
         self.decode_kv_args_table[agent_name] = decode_kv_args
-        self.agent.add_remote_agent(decode_kv_args.agent_metadata)
-        if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            self._prepare_payload_xfer(decode_kv_args)
+
+    def _discard_remote_peer(self, agent_name: str) -> None:
+        """Best-effort cleanup for a failed or invalidated NIXL peer. Not
+        synchronized with the transfer threads: the dict pops do not
+        invalidate references a transfer already holds."""
+        self.decode_kv_args_table.pop(agent_name, None)
+        self.prep_handles.pop(agent_name, None)
+        self.prep_handles_slice_dst.pop(agent_name, None)
+        try:
+            self.agent.remove_remote_agent(agent_name)
+        except Exception:
+            logger.debug(
+                "Failed to remove NIXL remote peer %s during cleanup",
+                agent_name,
+                exc_info=True,
+            )
 
     def _send_kvcache_generic(
         self,
@@ -1946,6 +1991,21 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     f"chunk exceeds ring buffer total size "
                     f"(room={kv_chunk.room}). Increase "
                     f"SGLANG_DISAGG_STAGING_POOL_SIZE_MB."
+                )
+            if (
+                kv_chunk.is_last_chunk
+                and kv_chunk.room not in self._staging_ctx.prefetched_rooms
+            ):
+                # No STAGING_REQ was ever sent (the prefetch bailed while the
+                # peer was re-registering). With the last chunk dequeued
+                # nothing re-runs the prefetch, so re-enqueueing would wait
+                # forever; earlier chunks may still requeue -- a later
+                # chunk's prefetch can cover them.
+                raise RuntimeError(
+                    f"[Staging] No staging request was sent for room "
+                    f"{kv_chunk.room} (the decode peer was re-registering "
+                    "when its chunks were enqueued); failing the room so the "
+                    "retry re-runs the staging prefetch."
                 )
             # Not ready yet: wait (bounded) for a watermark advance, then
             # re-enqueue to retry. A plain block-until-ready would head-of-line
@@ -2656,65 +2716,86 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
         return True
 
+    def _handle_bootstrap_message(self, waiting_req_bytes: List[bytes]) -> None:
+        if not waiting_req_bytes:
+            raise ValueError("Received an empty NIXL bootstrap message")
+
+        logger.debug(
+            "Received multipart with total byte size %d",
+            sum(len(x) for x in waiting_req_bytes),
+        )
+
+        # Staging: decode reports consumption watermark back to prefill
+        if waiting_req_bytes[0] == b"WATERMARK":
+            if self.enable_staging:
+                handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
+            return
+
+        # Staging: decode replies with allocated staging offset
+        if waiting_req_bytes[0] == b"STAGING_RSP":
+            if self.enable_staging:
+                handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+            return
+
+        if self._handle_abort_notification(waiting_req_bytes):
+            return
+
+        if waiting_req_bytes[0] != GUARD:
+            raise ValueError(f"First message should be {GUARD}. Foreign traffic?")
+        waiting_req_bytes = waiting_req_bytes[1:]
+        room = waiting_req_bytes[0].decode("ascii")
+        agent_name = waiting_req_bytes[3].decode("ascii")
+        if room == "None":
+            # Register new peer and save KV base pointers.
+            self._add_remote_peer(KVArgsRegisterInfo.from_zmq(waiting_req_bytes))
+            logger.debug(f"Register KVArgs from {agent_name} successfully")
+            return
+
+        room = int(room)
+        if room not in self.transfer_infos:
+            self.transfer_infos[room] = {}
+        self.transfer_infos[room][agent_name] = TransferInfo.from_zmq(waiting_req_bytes)
+        required_dst_info_num = self.transfer_infos[room][
+            agent_name
+        ].required_dst_info_num
+        logger.debug(f"got info {room=} {agent_name=} {required_dst_info_num=}")
+        if len(self.transfer_infos[room]) == required_dst_info_num:
+            self.resolve_kv_replica_factor(self.transfer_infos[room])
+            self.req_to_decode_prefix_len[room] = next(
+                (
+                    info.decode_prefix_len
+                    for info in self.transfer_infos[room].values()
+                    if info.decode_prefix_len is not None
+                ),
+                0,
+            )
+            logger.debug(f"{room=} is bootstrapped")
+            self.update_status(room, KVPoll.WaitingForInput)
+
     def _start_bootstrap_thread(self):
         def bootstrap_thread():
             """This thread recvs transfer info from the decode engine"""
             while True:
-                waiting_req_bytes = self.server_socket.recv_multipart()
-                logger.debug(
-                    f"Received multipart with total byte size {sum(len(x) for x in waiting_req_bytes)}"
-                )
-
-                # Staging: decode reports consumption watermark back to prefill
-                if waiting_req_bytes[0] == b"WATERMARK":
-                    if self.enable_staging:
-                        handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
+                try:
+                    msg = self.server_socket.recv_multipart()
+                except zmq.ZMQError as e:
+                    if e.errno in (zmq.ETERM, zmq.ENOTSOCK):
+                        # Socket closed during shutdown; exit instead of spinning.
+                        logger.info("NIXL bootstrap socket closed; thread exiting.")
+                        return
+                    # Must not kill the only thread that accepts new peers.
+                    logger.exception("NIXL bootstrap recv failed; retrying.")
+                    time.sleep(0.1)
                     continue
-
-                # Staging: decode replies with allocated staging offset
-                if waiting_req_bytes[0] == b"STAGING_RSP":
-                    if self.enable_staging:
-                        handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
+                except Exception:
+                    logger.exception("NIXL bootstrap recv failed; retrying.")
+                    time.sleep(0.1)
                     continue
-
-                if self._handle_abort_notification(waiting_req_bytes):
-                    continue
-
-                assert (
-                    waiting_req_bytes[0] == GUARD
-                ), f"First message should be {GUARD}. Foreign traffic?"
-                waiting_req_bytes = waiting_req_bytes[1:]
-                room = waiting_req_bytes[0].decode("ascii")
-                agent_name = waiting_req_bytes[3].decode("ascii")
-                if room == "None":
-                    # Register new peer and save KV base pointers.
-                    self._add_remote_peer(
-                        KVArgsRegisterInfo.from_zmq(waiting_req_bytes)
-                    )
-                    logger.debug(f"Register KVArgs from {agent_name} successfully")
-                    continue
-                room = int(room)
-                if room not in self.transfer_infos:
-                    self.transfer_infos[room] = {}
-                self.transfer_infos[room][agent_name] = TransferInfo.from_zmq(
-                    waiting_req_bytes
-                )
-                required_dst_info_num = self.transfer_infos[room][
-                    agent_name
-                ].required_dst_info_num
-                logger.debug(f"got info {room=} {agent_name=} {required_dst_info_num=}")
-                if len(self.transfer_infos[room]) == required_dst_info_num:
-                    self.resolve_kv_replica_factor(self.transfer_infos[room])
-                    self.req_to_decode_prefix_len[room] = next(
-                        (
-                            info.decode_prefix_len
-                            for info in self.transfer_infos[room].values()
-                            if info.decode_prefix_len is not None
-                        ),
-                        0,
-                    )
-                    logger.debug(f"{room=} is bootstrapped")
-                    self.update_status(room, KVPoll.WaitingForInput)
+                try:
+                    self._handle_bootstrap_message(msg)
+                except Exception:
+                    # Must not kill the only thread that accepts new peers.
+                    logger.exception("Failed to process NIXL bootstrap message")
 
         threading.Thread(target=bootstrap_thread).start()
 
@@ -2941,9 +3022,11 @@ class NixlKVReceiver(CommonKVReceiver):
         # deadline would otherwise lose to the timeout purely by poll ordering.
         self.kv_mgr.update_transfer_status()
         if self.kv_mgr.check_transfer_done(self.bootstrap_room):  # type: ignore
-            self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].discard(
-                self.bootstrap_room
-            )
+            # .get(): success racing a whole-address node-failure pop must
+            # not recreate an empty tracker entry for the retired address.
+            tracked_rooms = self.kv_mgr.addr_to_rooms_tracker.get(self.bootstrap_addr)
+            if tracked_rooms is not None:
+                tracked_rooms.discard(self.bootstrap_room)
             self.conclude_state = KVPoll.Success
             del self.kv_mgr.transfer_statuses[self.bootstrap_room]
             return self.conclude_state  # type: ignore
@@ -3045,10 +3128,58 @@ class NixlKVReceiver(CommonKVReceiver):
                 return False
         return True
 
+    def clear(self) -> None:
+        super().clear()
+        # The record must not outlive the room: a confirmed replacement
+        # detected by this room's own probe re-records a failure after
+        # failure_exception consumed the original, and a reused room id
+        # would inherit it. Safe only on NIXL, which consumes the record
+        # before terminal cleanup (Mooncake and Mori consume theirs after).
+        with self.kv_mgr.failure_lock:
+            self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
+
     def failure_exception(self):
         with self.kv_mgr.failure_lock:
             failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
         is_propagated = failure_reason is None
+        # Invalidate only for failures observed on reused endpoints, and let
+        # /health veto first: a healthy-but-slow prefill presenting the same
+        # instance id must not lose sockets shared with in-flight requests.
+        if (
+            self._used_cached_bootstrap_infos
+            and not self._aborted
+            and not is_propagated
+            and self.prefill_info is not None
+        ):
+            # Gate before the probe: the probe blocks the scheduler thread,
+            # and a burst of stale failures must not serialize probes.
+            with self.kv_mgr.connection_lock:
+                is_current_generation = (
+                    self.kv_mgr.prefill_info_table.get(self.bootstrap_addr)
+                    is self.prefill_info
+                )
+            if is_current_generation:
+                verdict = self.kv_mgr._probe_bootstrap_instance(
+                    self.bootstrap_addr,
+                    expected_prefill_info=self.prefill_info,
+                )
+                if verdict is InstanceProbeVerdict.CONFIRMED_REPLACED:
+                    # Confirmed verdict: evict and retire the rooms in
+                    # flight, which cache-only invalidation would strand
+                    # until the waiting timeout.
+                    self.kv_mgr.handle_instance_replacement(
+                        self.bootstrap_addr,
+                        expected_prefill_info=self.prefill_info,
+                        detected_by="failure-path health probe",
+                    )
+                elif verdict is InstanceProbeVerdict.INCONCLUSIVE:
+                    # Unconfirmed: cache-only, since retiring every room at
+                    # the address would turn an overloaded-but-alive
+                    # prefill into a mass retry.
+                    self.kv_mgr.invalidate_cached_connections(
+                        self.bootstrap_addr,
+                        expected_prefill_info=self.prefill_info,
+                    )
         if is_propagated:
             failure_reason = "NIXL KVReceiver Exception"
         raise KVTransferError(

--- a/rust/sglang-server/src/api_server/app.rs
+++ b/rust/sglang-server/src/api_server/app.rs
@@ -51,7 +51,7 @@ pub async fn serve(
     // Each endpoint module registers its own routes and merges here.
     let router = Router::new()
         .merge(common::routes())
-        .merge(native_api::routes())
+        .merge(native_api::routes(server_args.enable_pd_bootstrap()))
         .merge(openai::routes());
 
     // TODO(auth): no API-key boundary yet. Python gates every route (except
@@ -71,6 +71,24 @@ pub async fn serve(
         let (routes, sweeper) = pd_bootstrap::router_and_sweeper();
         tokio::spawn(sweeper); // cancelled with the runtime on shutdown
         app = app.merge(routes);
+        // Stamped on the whole listener, not per handler: the decode reads it
+        // from `/health` (native_api) and `/route` (pd_bootstrap), which live
+        // in different routers with different state types. Keep this layer
+        // below every `.merge()` -- a router merged after it would not be
+        // stamped, and the listener-wide test probes the router fallback, so
+        // it would stay green.
+        let instance_id = pd_bootstrap::new_instance_id();
+        app = app.layer(axum::middleware::map_response(
+            move |mut response: axum::response::Response| {
+                let instance_id = instance_id.clone();
+                async move {
+                    response
+                        .headers_mut()
+                        .insert(pd_bootstrap::INSTANCE_ID_HEADER, instance_id);
+                    response
+                }
+            },
+        ));
         tracing::info!("PD KV bootstrap registry mounted on the api listener");
     }
 

--- a/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
+++ b/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 
 use arc_swap::ArcSwap;
 use axum::extract::{Query, State};
-use axum::http::StatusCode;
+use axum::http::{HeaderName, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{post, put};
 use axum::{Json, Router};
@@ -18,6 +18,21 @@ use serde::{Deserialize, Serialize};
 use crate::utils::environ;
 use crate::utils::response::json_error;
 use crate::utils::serialize::{parse_int, parse_int_opt, parse_int_vec};
+
+/// Response header carrying the serving process's instance id
+/// (`BOOTSTRAP_INSTANCE_ID_HEADER` in disaggregation/common/conn.py). The
+/// decode heartbeat compares it across `/health` polls to detect a prefill
+/// replaced behind a still-healthy bootstrap address, so `api_server::serve`
+/// stamps it on every response of the merged listener.
+pub(crate) const INSTANCE_ID_HEADER: HeaderName =
+    HeaderName::from_static("x-sglang-disaggregation-instance-id");
+
+/// Fresh per-server instance id (Python: `uuid.uuid4().hex` per bootstrap
+/// server); a replacement prefill presents a different value.
+pub(crate) fn new_instance_id() -> HeaderValue {
+    HeaderValue::from_str(&uuid::Uuid::new_v4().simple().to_string())
+        .expect("hex uuid is a valid header value")
+}
 
 /// Python default: `SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL`.
 const ENTRY_CLEANUP_INTERVAL_ENV: &str = "SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL";
@@ -365,13 +380,13 @@ mod tests {
     use std::net::SocketAddr;
 
     /// Minimal HTTP/1.1 client (same style as the `runtime` tests): returns
-    /// `(status, body)`.
-    fn request(
+    /// the raw response text.
+    fn request_raw(
         addr: SocketAddr,
         method: &str,
         path_query: &str,
         body: Option<&serde_json::Value>,
-    ) -> (u16, String) {
+    ) -> String {
         let body = body.map(|b| b.to_string()).unwrap_or_default();
         let mut conn = std::net::TcpStream::connect(addr).expect("connect");
         let req = format!(
@@ -382,6 +397,16 @@ mod tests {
         conn.write_all(req.as_bytes()).unwrap();
         let mut response = String::new();
         conn.read_to_string(&mut response).unwrap();
+        response
+    }
+
+    fn request(
+        addr: SocketAddr,
+        method: &str,
+        path_query: &str,
+        body: Option<&serde_json::Value>,
+    ) -> (u16, String) {
+        let response = request_raw(addr, method, path_query, body);
         let status = response
             .split_whitespace()
             .nth(1)
@@ -393,6 +418,16 @@ mod tests {
             .map(|(_, b)| b.to_string())
             .unwrap_or_default();
         (status, body)
+    }
+
+    /// `INSTANCE_ID_HEADER` value from a raw response, if present.
+    fn instance_id_of(raw: &str) -> Option<String> {
+        let headers = raw.split_once("\r\n\r\n").map(|(h, _)| h).unwrap_or(raw);
+        headers.lines().find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case(INSTANCE_ID_HEADER.as_str())
+                .then(|| value.trim().to_string())
+        })
     }
 
     fn put_route(overrides: serde_json::Value) -> serde_json::Value {
@@ -563,6 +598,54 @@ mod tests {
         assert_eq!(status, 200);
         let rank: serde_json::Value = serde_json::from_str(&body).unwrap();
         assert_eq!(rank["rank_ip"], "10.0.0.2");
+    }
+
+    /// Replacement detection: a pd-bootstrap-enabled listener stamps its
+    /// per-process instance id on every response, and a replacement server
+    /// presents a different one — that inequality is the decode heartbeat's
+    /// detection signal. The decode compares the id it saw on `/route` with
+    /// the one `/health` presents later, so the two must agree; that
+    /// coverage comes from one listener-wide layer, pinned here on `/health`
+    /// itself — mounting the bootstrap registry forces `/health` shallow
+    /// (the decode reads it with short timeouts; the deep generate probe
+    /// would wait out its scheduler deadline on this schedulerless runtime
+    /// and, in production, accumulate heartbeat misses against a
+    /// busy-but-healthy prefill), so the 200 asserted here also pins that
+    /// contract — plus the router fallback (a 404 outside every
+    /// sub-router), which pins the layer as listener-wide.
+    #[test]
+    fn instance_id_stable_per_server_fresh_per_replacement() {
+        let (_rt, addr) = start_on_free_port();
+
+        let unregistered = instance_id_of(&request_raw(addr, "GET", SENTINEL, None))
+            .expect("instance id on a 503 response");
+        let (status, _) = request(
+            addr,
+            "PUT",
+            "/route",
+            Some(&put_route(serde_json::json!({}))),
+        );
+        assert_eq!(status, 200);
+        let health = request_raw(addr, "GET", "/health", None);
+        assert!(
+            health.starts_with("HTTP/1.1 200"),
+            "PD bootstrap /health must answer shallow, got: {}",
+            health.lines().next().unwrap_or("")
+        );
+        let registered = instance_id_of(&health).expect("instance id on the /health response");
+        assert_eq!(unregistered, registered);
+
+        let fallback = request_raw(addr, "GET", "/no-such-route", None);
+        assert!(fallback.starts_with("HTTP/1.1 404"));
+        assert_eq!(
+            instance_id_of(&fallback).expect("instance id on a 404 response"),
+            registered
+        );
+
+        let (_rt2, replacement_addr) = start_on_free_port();
+        let replacement = instance_id_of(&request_raw(replacement_addr, "GET", SENTINEL, None))
+            .expect("instance id on the replacement server");
+        assert_ne!(registered, replacement);
     }
 
     /// The PD router's room→dp-rank side channel: register/query round-trip

--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -79,10 +79,11 @@ impl RequestTiming {
 }
 
 /// The routes this module owns, mounted by `api_server::serve`.
-pub(super) fn routes() -> Router<Arc<AppState>> {
+/// `shallow_health` forces `/health` to a plain 200 (see `health_routes`).
+pub(super) fn routes(shallow_health: bool) -> Router<Arc<AppState>> {
     Router::new()
         .route("/generate", post(generate))
-        .merge(health_routes())
+        .merge(health_routes(shallow_health))
 }
 
 /// native api error response: unary → `code` plus the JSON `body`,
@@ -98,11 +99,22 @@ pub(super) fn native_error(code: StatusCode, message: &str, stream: bool) -> Res
 /// always; `SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION` (default true, mirroring
 /// Python) decides whether `/health` shares it or is a plain 200 (routing the
 /// request already proves the frontend is up).
-fn health_routes() -> Router<Arc<AppState>> {
+///
+/// `shallow_health` (set when the PD bootstrap registry shares this listener)
+/// overrides the env knob and pins `/health` shallow: the decode side
+/// identity-probes bootstrap `/health` with short read timeouts expecting the
+/// bootstrap-server contract — Python's standalone bootstrap server answers a
+/// plain 200 plus the instance-id header — so the deep generate probe's
+/// default 20 s deadline would time those probes out, accumulate heartbeat
+/// misses, and retire a busy-but-healthy prefill as a node failure. The deep
+/// probe stays available on `/health_generate`.
+fn health_routes(shallow_health: bool) -> Router<Arc<AppState>> {
     let timeout =
         std::time::Duration::from_secs(environ::env_u64("SGLANG_HEALTH_CHECK_TIMEOUT", 20));
     let probe = get(move |state: State<Arc<AppState>>| health_generate(state, timeout));
-    let health = if environ::env_bool("SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION", true) {
+    let deep_health =
+        !shallow_health && environ::env_bool("SGLANG_ENABLE_HEALTH_ENDPOINT_GENERATION", true);
+    let health = if deep_health {
         probe.clone()
     } else {
         get(|| async { StatusCode::OK.into_response() })

--- a/test/registered/disaggregation/test_disaggregation_nixl.py
+++ b/test/registered/disaggregation/test_disaggregation_nixl.py
@@ -19,10 +19,12 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     is_in_ci,
     popen_launch_pd_server,
+    start_subprocess_fail_fast_watcher,
+    terminate_and_kill_process_tree,
     try_cached_model,
 )
 
-register_cuda_ci(est_time=700, stage="base-c", runner_config="8-gpu-h20")
+register_cuda_ci(est_time=1000, stage="base-c", runner_config="8-gpu-h20")
 # base-c 8-GPU runner is required for TP4 prefill + TP4 decode.
 
 NIXL_PREFILL_TP_SIZE = 4
@@ -192,6 +194,37 @@ class NixlPDDisaggregationServerBase(PDDisaggregationServerBase):
             ),
         )
 
+    @classmethod
+    def replace_role(cls, role):
+        """Restart one PD role in place while leaving its peer and router alive."""
+        if cls._fail_fast_stop is not None:
+            cls._fail_fast_stop.set()
+            cls._fail_fast_stop = None
+
+        process_attr = f"process_{role}"
+        process = getattr(cls, process_attr)
+        if process is not None:
+            # SIGTERM first: a bare hard kill leaves CUDA context and pinned
+            # memory to kernel reclaim, which can hold GPU memory for minutes
+            # while the replacement launches on the same GPUs (callers may
+            # replace several times in a row). Also matches how Kubernetes
+            # actually replaces a pod.
+            terminate_and_kill_process_tree(process, wait_timeout=60)
+        setattr(cls, process_attr, None)
+
+        getattr(cls, f"start_{role}")()
+        cls.wait_server_ready(
+            getattr(cls, f"{role}_url") + "/health",
+            process=getattr(cls, process_attr),
+        )
+        cls._fail_fast_stop = start_subprocess_fail_fast_watcher(
+            [
+                ("prefill", cls.process_prefill),
+                ("decode", cls.process_decode),
+                ("lb", cls.process_lb),
+            ]
+        )
+
 
 @unittest.skipUnless(
     _HAS_CONFIGURED_NIXL_BACKEND,
@@ -205,6 +238,19 @@ class TestDisaggregationNixlBasic(NixlPDDisaggregationServerBase):
     subset that proves NIXL can launch, transfer KV, serve a request, return
     logprobs, and keep all workers alive.
     """
+
+    # Mask the connection-refused heartbeat path for the replacement test:
+    # with the default 5s interval the heartbeat clears the stale cache while
+    # the prefill is still down, so replacement recovery would pass even
+    # without #33789's failure-driven invalidation. The short waiting timeout
+    # makes each stale-cache request fail fast instead of in 300s.
+    # Class-level on purpose (one 8-GPU launch for the whole class), so the
+    # other tests here also run with the heartbeat masked and a 30s waiting
+    # timeout — if a healthy test flakes on queueing >30s, look here first.
+    extra_decode_env = {
+        "SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL": "3600",
+        "SGLANG_DISAGGREGATION_WAITING_TIMEOUT": "30",
+    }
 
     @classmethod
     def setUpClass(cls):
@@ -255,6 +301,94 @@ class TestDisaggregationNixlBasic(NixlPDDisaggregationServerBase):
 
         self.assertEqual(len(output_logprobs), completion_tokens)
         self.assertGreater(len(input_logprobs), 0)
+
+    def _prefill_rank_endpoints(self):
+        """Per-rank (ip, port) endpoint map from the bootstrap /route table."""
+        endpoints = {}
+        for tp_rank in range(self.prefill_tp_size):
+            response = requests.get(
+                f"http://{self.base_host}:{self.bootstrap_port}/route",
+                params={
+                    "prefill_dp_rank": 0,
+                    "prefill_cp_rank": 0,
+                    "target_tp_rank": tp_rank,
+                    "target_pp_rank": 0,
+                },
+                timeout=30,
+            )
+            self.assertEqual(response.status_code, 200, response.text)
+            info = response.json()
+            endpoints[tp_rank] = (info["rank_ip"], info["rank_port"])
+        return endpoints
+
+    def test_role_replacements_reconnect(self):
+        """#33789: a replaced prefill behind a still-reachable bootstrap
+        address strands the decode's cached rank endpoints. The heartbeat is
+        masked (see extra_decode_env), so recovery must come from the failure
+        path: requests that reuse the stale cache time out and drop it, after
+        which registration happens afresh and serving resumes."""
+
+        def send_request(stage):
+            try:
+                return requests.post(
+                    self.lb_url + "/generate",
+                    json={
+                        "text": f"NIXL replacement check after {stage}",
+                        "sampling_params": {"temperature": 0, "max_new_tokens": 8},
+                    },
+                    timeout=90,
+                )
+            except requests.RequestException:
+                return None
+
+        def assert_request_succeeds(stage):
+            response = send_request(stage)
+            self.assertIsNotNone(response, f"request errored after {stage}")
+            self.assertEqual(response.status_code, 200, response.text)
+            self.assertGreater(len(response.json()["text"]), 0)
+
+        assert_request_succeeds("initial startup")
+
+        self.replace_role("decode")
+        assert_request_succeeds("decode replacement")
+
+        # A replacement that rebinds the exact same rank endpoints would let
+        # the stale cache accidentally target the replacement, and stock code
+        # would pass too. Rank ports are ephemeral, so a full collision is
+        # rare; re-replace until the topology discriminates.
+        stale_endpoints = self._prefill_rank_endpoints()
+        for _ in range(3):
+            self.replace_role("prefill")
+            if self._prefill_rank_endpoints() != stale_endpoints:
+                break
+        else:
+            self.fail(
+                "prefill replacement kept identical rank endpoints three "
+                "times; the test cannot discriminate fixed from stock code"
+            )
+        # Each failed request invalidates the cache on the ranks that timed
+        # out locally (propagated failures do not, see failure_exception), so
+        # full repair can take up to one failed request per decode TP rank.
+        outcomes = []
+        for attempt in range(self.decode_tp_size + 1):
+            response = send_request(f"prefill replacement attempt {attempt}")
+            outcomes.append(response is not None and response.status_code == 200)
+            if outcomes[-1]:
+                break
+        # The first request usually fails on the stale cached endpoints (no
+        # automatic retry today) -- but that is not asserted: a future
+        # automatic re-bootstrap would make it legitimately succeed, and
+        # this test only pins the recovery contract.
+        if outcomes[0]:
+            print(
+                "NOTE: first request after prefill replacement succeeded; "
+                "recovery contract still verified below."
+            )
+        self.assertTrue(
+            outcomes[-1],
+            f"serving did not recover after {len(outcomes)} requests "
+            "following prefill replacement",
+        )
 
 
 @unittest.skipUnless(

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -1,9 +1,11 @@
+import threading
 import unittest
 from concurrent.futures import Future
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.disaggregation.base import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVReceiver
 from sglang.srt.disaggregation.decode import (
     DecodePreallocQueue,
     DecodeTransferQueue,
@@ -104,6 +106,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue.queue = [decode_req]
         queue.pending_reqs = []
         queue.retracted_queue = []
+        queue._dp_rank_query_first_attempt = {}
         queue._resolve_pending_reqs = MagicMock()
         queue._update_handshake_waiters = MagicMock()
         queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
@@ -151,6 +154,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue.queue = [decode_req]
         queue.pending_reqs = [decode_req]  # same object, dual ownership
         queue.retracted_queue = []
+        queue._dp_rank_query_first_attempt = {}
         queue._resolve_pending_reqs = MagicMock()
         queue._update_handshake_waiters = MagicMock()
         queue._uses_swa_tail_prealloc = MagicMock(return_value=False)
@@ -280,8 +284,11 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
         queue.pending_reqs = [first]
         queue._prefill_dp_rank_queries = {}
+        queue._dp_rank_query_first_attempt = {}
+        queue._dp_rank_query_last_fresh_retry = {}
         queue.kv_manager = SimpleNamespace(
-            prefill_info_table={addr: object()},
+            connection_lock=threading.Lock(),
+            prefill_info_table={addr: SimpleNamespace(instance_id="ins")},
             _ensure_prefill_recompute_executor=lambda: executor,
         )
         queue._resolve_prefill_dp_rank = MagicMock(return_value=None)
@@ -299,10 +306,204 @@ class TestDecodeQueueCleanup(CustomTestCase):
 
         _, called_addr, called_rooms = executor.submit.call_args.args
         self.assertEqual((called_addr, called_rooms), (addr, [7]))
-        query.assert_called_once_with(addr, [8])
+        query.assert_called_once_with(addr, [8], expected_instance_id="ins")
         first.kv_receiver.init.assert_called_once_with(1)
         tail.kv_receiver.init.assert_called_once_with(2)
         self.assertEqual(queue.pending_reqs, [])
+
+    def _make_dp_rank_query_queue(self, decode_req, prefill_info):
+        addr = "10.0.0.1:8998"
+        queue = DecodePreallocQueue.__new__(DecodePreallocQueue)
+        queue.pending_reqs = [decode_req]
+        queue._ensure_retry_count = {}
+        queue._ensure_last_attempt_time = {}
+        queue._ensure_retry_interval = 0
+        queue._max_ensure_retries = 15
+        queue.kv_manager = SimpleNamespace(
+            try_ensure_parallel_info=lambda addr: True,
+            connection_lock=threading.Lock(),
+            prefill_info_table={addr: prefill_info},
+            handle_instance_replacement=MagicMock(),
+            record_failure=MagicMock(),
+        )
+        queue._dp_rank_query_first_attempt = {}
+        queue._dp_rank_query_timeout = 300.0
+        queue._dp_rank_query_fresh_retry_grace = 150.0
+        queue._dp_rank_query_last_fresh_retry = {}
+        queue._prefill_dp_rank_queries = {}
+        return queue
+
+    def test_unresolvable_dp_rank_query_fails_request_after_timeout(self):
+        """Regression: a room the current prefill never registered resolved
+        to nothing on every cycle and re-entered pending_reqs with no
+        timeout armed (init() never ran) -- it cycled forever. The pass must
+        arm its own deadline and abort the receiver on expiry."""
+        prefill_info = SimpleNamespace(
+            instance_id="live", dp_size=2, follow_bootstrap_room=False
+        )
+        req = SimpleNamespace(
+            bootstrap_room=7,
+            disagg_prefill_dp_rank=None,
+            bootstrap_host="10.0.0.1",
+            bootstrap_port=8998,
+        )
+        decode_req = SimpleNamespace(req=req, kv_receiver=MagicMock())
+        queue = self._make_dp_rank_query_queue(decode_req, prefill_info)
+
+        with patch.object(
+            CommonKVReceiver, "query_prefill_dp_ranks", return_value={}
+        ) as query:
+            queue._resolve_pending_reqs()
+        query.assert_called_once_with("10.0.0.1:8998", [7], expected_instance_id="live")
+        self.assertEqual(queue.pending_reqs, [decode_req])
+        self.assertIn(7, queue._dp_rank_query_first_attempt)
+        decode_req.kv_receiver.abort.assert_not_called()
+
+        queue._dp_rank_query_first_attempt[7] -= 301.0
+        with patch.object(CommonKVReceiver, "query_prefill_dp_ranks", return_value={}):
+            queue._resolve_pending_reqs()
+        decode_req.kv_receiver.abort.assert_called_once_with()
+        # Regression: abort() records a generic AbortReq reason; the deadline
+        # path must overwrite it so the client sees why the request failed.
+        queue.kv_manager.record_failure.assert_called_once()
+        self.assertIn(
+            "Could not resolve prefill dp_rank",
+            queue.kv_manager.record_failure.call_args.args[1],
+        )
+        self.assertEqual(queue.pending_reqs, [])
+        self.assertEqual(queue._dp_rank_query_first_attempt, {})
+
+        resolved_req = SimpleNamespace(req=req, kv_receiver=MagicMock())
+        queue = self._make_dp_rank_query_queue(resolved_req, prefill_info)
+        with patch.object(
+            CommonKVReceiver, "query_prefill_dp_ranks", return_value={"7": 1}
+        ):
+            queue._resolve_pending_reqs()
+        resolved_req.kv_receiver.init.assert_called_once_with(1)
+        self.assertEqual(queue.pending_reqs, [])
+        self.assertEqual(queue._dp_rank_query_first_attempt, {})
+
+    def test_persistent_dp_rank_query_mismatch_evicts_stale_topology(self):
+        """Regression: on a persistent mismatch (None) the pass re-asked with
+        the same stale expectation until the deadline aborted the rooms --
+        and the abort exempts the receiver from the failure-path repair. The
+        pass must evict the snapshot (generation-gated) and retire the rooms
+        in flight against it instead."""
+        prefill_info = SimpleNamespace(
+            instance_id="stale", dp_size=2, follow_bootstrap_room=False
+        )
+        req = SimpleNamespace(
+            bootstrap_room=7,
+            disagg_prefill_dp_rank=None,
+            bootstrap_host="10.0.0.1",
+            bootstrap_port=8998,
+        )
+        decode_req = SimpleNamespace(req=req, kv_receiver=MagicMock())
+        queue = self._make_dp_rank_query_queue(decode_req, prefill_info)
+
+        with patch.object(
+            CommonKVReceiver, "query_prefill_dp_ranks", return_value=None
+        ):
+            queue._resolve_pending_reqs()
+
+        # Retirement, not cache-only invalidation: in-flight rooms against
+        # the evicted snapshot would otherwise wait out the full timeout
+        # (the heartbeat can no longer indict them once the replacement's
+        # topology is published).
+        queue.kv_manager.handle_instance_replacement.assert_called_once_with(
+            "10.0.0.1:8998",
+            expected_prefill_info=prefill_info,
+            detected_by="dp-rank resolution",
+        )
+        self.assertEqual(queue.pending_reqs, [decode_req])
+        decode_req.kv_receiver.abort.assert_not_called()
+
+    def test_externally_removed_rooms_leave_no_deadline_entry(self):
+        """Regression: the early return on an emptied queue skipped deadline
+        pruning, stranding removed rooms' entries; a reused room id
+        inherited the expired deadline and failed immediately."""
+        prefill_info = SimpleNamespace(
+            instance_id="live", dp_size=2, follow_bootstrap_room=False
+        )
+        req = SimpleNamespace(
+            bootstrap_room=7,
+            disagg_prefill_dp_rank=None,
+            bootstrap_host="10.0.0.1",
+            bootstrap_port=8998,
+        )
+        decode_req = SimpleNamespace(req=req, kv_receiver=MagicMock())
+        queue = self._make_dp_rank_query_queue(decode_req, prefill_info)
+        with patch.object(CommonKVReceiver, "query_prefill_dp_ranks", return_value={}):
+            queue._resolve_pending_reqs()
+        self.assertIn(7, queue._dp_rank_query_first_attempt)
+
+        # pop_preallocated's abort scan drops the request from pending_reqs
+        # without running the resolution pass again.
+        queue.pending_reqs = []
+        queue._resolve_pending_reqs()
+        self.assertEqual(queue._dp_rank_query_first_attempt, {})
+
+    def test_drop_failed_pending_reqs_prunes_deadlines_with_the_requests(self):
+        """Regression: pop_preallocated left removed requests' deadline
+        entries for the next pass to prune; a room reused before then
+        inherited the expired deadline via setdefault and aborted on its
+        first cycle."""
+        prefill_info = SimpleNamespace(
+            instance_id="live", dp_size=2, follow_bootstrap_room=False
+        )
+        failed_req = SimpleNamespace(
+            req=SimpleNamespace(bootstrap_room=7), kv_receiver=None
+        )
+        kept_req = SimpleNamespace(
+            req=SimpleNamespace(bootstrap_room=8), kv_receiver=MagicMock()
+        )
+        queue = self._make_dp_rank_query_queue(failed_req, prefill_info)
+        queue.pending_reqs = [failed_req, kept_req]
+        queue._dp_rank_query_first_attempt = {7: 100.0, 8: 200.0}
+
+        queue._drop_failed_pending_reqs([failed_req])
+
+        self.assertEqual(queue.pending_reqs, [kept_req])
+        self.assertEqual(queue._dp_rank_query_first_attempt, {8: 200.0})
+
+    def test_stale_missing_rooms_force_reconnect_through_address_resolution(self):
+        """Regression: a draining replaced instance presents the expected id
+        with the replacement's rooms simply absent, so neither the mismatch
+        machinery nor the heartbeat ever fired and every request burned its
+        deadline. Rooms missing past the grace period drop the pooled
+        session (rate-limited); a freshly missing room must not force churn."""
+        prefill_info = SimpleNamespace(
+            instance_id="live", dp_size=2, follow_bootstrap_room=False
+        )
+        req = SimpleNamespace(
+            bootstrap_room=7,
+            disagg_prefill_dp_rank=None,
+            bootstrap_host="10.0.0.1",
+            bootstrap_port=8998,
+        )
+        decode_req = SimpleNamespace(req=req, kv_receiver=MagicMock())
+        queue = self._make_dp_rank_query_queue(decode_req, prefill_info)
+
+        with patch.object(
+            CommonKVReceiver, "query_prefill_dp_ranks", return_value={}
+        ), patch(
+            "sglang.srt.disaggregation.decode._drop_bootstrap_session"
+        ) as drop_session:
+            # Freshly missing: within the grace period, no reconnect.
+            queue._resolve_pending_reqs()
+            drop_session.assert_not_called()
+
+            # Past the grace period: drop the pooled session once.
+            queue._dp_rank_query_first_attempt[7] -= 151.0
+            queue._resolve_pending_reqs()
+            drop_session.assert_called_once_with("10.0.0.1:8998")
+
+            # Immediately after: rate-limited, no second drop.
+            queue._resolve_pending_reqs()
+            drop_session.assert_called_once_with("10.0.0.1:8998")
+
+        self.assertEqual(queue.pending_reqs, [decode_req])
+        decode_req.kv_receiver.abort.assert_not_called()
 
     @patch("sglang.srt.disaggregation.decode.release_kv_cache")
     @patch("sglang.srt.disaggregation.decode.prepare_abort")

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -1,5 +1,7 @@
 """Basic CPU unit tests for NIXL disaggregation control paths."""
 
+import asyncio
+import json
 import struct
 import sys
 import threading
@@ -10,9 +12,18 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+import zmq
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.conn import (
+    BOOTSTRAP_INSTANCE_ID_HEADER,
+    CommonKVBootstrapServer,
+    CommonKVManager,
+    CommonKVReceiver,
+    InstanceProbeVerdict,
+    PrefillRankInfo,
+    PrefillServerInfo,
+)
 from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
@@ -24,10 +35,89 @@ from sglang.srt.disaggregation.nixl.conn import (
     TransferKVChunk,
     TransferStatus,
 )
+from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=23, suite="base-a-test-cpu")
+
+
+class TestNixlBootstrapGeneration(CustomTestCase):
+    def test_all_bootstrap_responses_report_same_instance(self):
+        """Completeness contract: the decode validates /health, the topology
+        fetch, the per-rank fetch, and the dp-rank query against one instance
+        id; a handler that stops stamping silently disables that path."""
+        server = object.__new__(CommonKVBootstrapServer)
+        server.instance_id = "prefill-generation"
+        server.attn_tp_size = 1
+        server.attn_cp_size = 1
+        server.dp_size = 1
+        server.pp_size = 1
+        server.page_size = 1
+        server.kv_cache_dtype = "auto"
+        server.follow_bootstrap_room = True
+        server.enable_dsa_cache_layer_split = False
+        server.prefill_http_port = 30000
+        server._registered_count = 1
+
+        health = asyncio.run(server._handle_health_check(None))
+        topology = asyncio.run(
+            server._handle_route_get(
+                SimpleNamespace(
+                    query={
+                        "prefill_dp_rank": "-1",
+                        "prefill_cp_rank": "-1",
+                        "target_tp_rank": "-1",
+                        "target_pp_rank": "-1",
+                    }
+                )
+            )
+        )
+        server.lock = asyncio.Lock()
+        server.prefill_port_table = {
+            0: {0: {0: {0: PrefillRankInfo(rank_ip="10.0.0.1", rank_port=7000)}}}
+        }
+        rank = asyncio.run(
+            server._handle_route_get(
+                SimpleNamespace(
+                    query={
+                        "prefill_dp_rank": "0",
+                        "prefill_cp_rank": "0",
+                        "target_tp_rank": "0",
+                        "target_pp_rank": "0",
+                    }
+                )
+            )
+        )
+
+        self.assertEqual(
+            health.headers[BOOTSTRAP_INSTANCE_ID_HEADER], "prefill-generation"
+        )
+        self.assertEqual(
+            topology.headers[BOOTSTRAP_INSTANCE_ID_HEADER], "prefill-generation"
+        )
+        # asyncio.Lock binds to the loop that first acquires it, and each
+        # asyncio.run above used its own; give the dp-rank handler a fresh one.
+        server.lock = asyncio.Lock()
+        server.room_to_dp_rank = {1: {"dp_rank": 0, "timestamp": 0}}
+
+        async def _query_body():
+            return {"bootstrap_rooms": ["1"]}
+
+        dp_ranks = asyncio.run(
+            server._handle_query_dp_ranks(SimpleNamespace(json=_query_body))
+        )
+
+        self.assertEqual(
+            rank.headers[BOOTSTRAP_INSTANCE_ID_HEADER], "prefill-generation"
+        )
+        self.assertEqual(
+            dp_ranks.headers[BOOTSTRAP_INSTANCE_ID_HEADER], "prefill-generation"
+        )
+        # The id must stay out of the JSON body: decodes predating the field
+        # construct PrefillServerInfo(**json) and crash on unknown keys, so a
+        # body key would break old-decode/new-prefill rolling upgrades.
+        self.assertNotIn("instance_id", json.loads(topology.text))
 
 
 class NotificationFakeAgent:
@@ -344,6 +434,7 @@ class TestNixlAbortHandling(CustomTestCase):
     def _make_manager(self, request_status=None):
         mgr = object.__new__(NixlKVManager)
         mgr.request_status = dict(request_status or {})
+        mgr.status_lock = threading.Lock()
         mgr._connect = MagicMock()
         mgr.failure_lock = threading.Lock()
         mgr.failure_records = {}
@@ -410,6 +501,7 @@ class TestNixlUpdateStatus(CustomTestCase):
     def _make_manager(self, request_status):
         mgr = object.__new__(NixlKVManager)
         mgr.request_status = dict(request_status)
+        mgr.status_lock = threading.Lock()
         return mgr
 
     def test_given_failed_room_when_status_is_promoted_then_failed_is_preserved(self):
@@ -429,6 +521,78 @@ class TestNixlUpdateStatus(CustomTestCase):
         mgr.update_status(18, KVPoll.Failed)
 
         self.assertNotIn(18, mgr.request_status)
+
+    def test_base_manager_keeps_failed_terminal_for_live_room(self):
+        """Regression: KVPoll.Failed is 0 and the base manager resolved
+        non-Failed writes with max(), so a room retired cross-thread (the
+        heartbeat's replacement or max-failures verdict) while its receiver
+        was still inside init() was resurrected by init()'s own
+        WaitingForInput write — the request then ran against evicted
+        endpoints until the waiting timeout. NIXL and Mori pinned Failed
+        sticky in their own overrides; the base manager must enforce it for
+        every backend that inherits the heartbeat's retirement verdicts."""
+        mgr = object.__new__(CommonKVManager)
+        mgr.request_status = {}
+        mgr.status_lock = threading.Lock()
+
+        mgr.update_status(21, KVPoll.Bootstrapping)
+        mgr.update_status(21, KVPoll.Failed)
+        mgr.update_status(21, KVPoll.WaitingForInput)
+
+        self.assertEqual(mgr.request_status[21], KVPoll.Failed)
+
+    def test_concurrent_failed_write_is_not_lost_to_racing_promotion(self):
+        """Regression: update_status resolved the terminal-Failed check and
+        the max() write with separate unsynchronized reads, so a Failed
+        written by another thread (the heartbeat's replacement verdict)
+        between the two landed only in the max() re-read — and
+        KVPoll.Failed is 0, so max() overwrote it with the promotion,
+        resurrecting the retired room against evicted endpoints until the
+        waiting timeout. Reproduces the exact interleaving
+        deterministically: the promoting thread's first status read for
+        the room pauses until a concurrent update_status(Failed) has run
+        to completion (or, once transitions are serialized, until that
+        writer has provably blocked)."""
+        mgr = object.__new__(CommonKVManager)
+        mgr.status_lock = threading.Lock()
+        failed_written = threading.Event()
+
+        def write_failed():
+            mgr.update_status(21, KVPoll.Failed)
+            failed_written.set()
+
+        failed_thread = threading.Thread(target=write_failed, daemon=True)
+
+        class FirstReadYieldsToFailedWriter(dict):
+            """After the first status read for the room completes, lets the
+            concurrent Failed writer run before the reader proceeds."""
+
+            def __init__(self, *args):
+                super().__init__(*args)
+                self._fired = False
+
+            def _yield_to_failed_writer(self):
+                if not self._fired:
+                    self._fired = True
+                    failed_thread.start()
+                    failed_written.wait(timeout=1.0)
+
+            def get(self, key, default=None):
+                value = super().get(key, default)
+                self._yield_to_failed_writer()
+                return value
+
+            def __getitem__(self, key):
+                value = super().__getitem__(key)
+                self._yield_to_failed_writer()
+                return value
+
+        mgr.request_status = FirstReadYieldsToFailedWriter({21: KVPoll.Bootstrapping})
+
+        mgr.update_status(21, KVPoll.WaitingForInput)
+        failed_thread.join(timeout=2.0)
+
+        self.assertEqual(mgr.request_status[21], KVPoll.Failed)
 
 
 class TestNixlTransferWorker(CustomTestCase):
@@ -480,6 +644,7 @@ class TestNixlTransferWorker(CustomTestCase):
         mgr.exceptions = {}
         mgr.failure_lock = threading.Lock()
         mgr.failure_records = {}
+        mgr.status_lock = threading.Lock()
 
         def check_xfer_state(_handle):
             mgr.update_status(room, KVPoll.Failed)
@@ -534,6 +699,23 @@ class TestNixlTransferWorker(CustomTestCase):
         self.assertIn(room, mgr.transfer_infos)
         self.assertIn(room, mgr.req_to_decode_prefix_len)
         mgr.send_kvcache.assert_called_once()
+
+    def test_worker_failure_keeps_room_outstanding_count(self):
+        """Regression: the failure handler cleared _staging_outstanding, but
+        outstanding == 0 is the abort ack's quiescence predicate and an ERR
+        bails on the first failed handle while sibling handles may still be
+        writing -- the ack let the decode release KV pages under those
+        writes. The count must survive the failure path."""
+        room = 23
+        mgr = self._make_manager(room)
+        mgr.send_aux = MagicMock(side_effect=RuntimeError("aux send failed"))
+        chunk = self._make_chunk(room, [], is_last_chunk=True)
+
+        self._run_worker_once(mgr, chunk)
+
+        self.assertEqual(mgr.request_status[room], KVPoll.Failed)
+        self.assertIn(room, mgr.failure_records)
+        self.assertEqual(dict(mgr._staging_outstanding), {room: 1})
 
 
 class TestNixlNotifications(CustomTestCase):
@@ -603,6 +785,9 @@ class TestNixlReceiverPoll(CustomTestCase):
         mgr.transfer_statuses = {}
         mgr.addr_to_rooms_tracker = defaultdict(set)
         mgr.addr_to_rooms_tracker["prefill:8998"].add(11)
+        # "Cannot confirm the prefill either way" — the fail-open default,
+        # authorizing cache-only invalidation but not room retirement.
+        mgr._probe_bootstrap_instance.return_value = InstanceProbeVerdict.INCONCLUSIVE
 
         receiver = object.__new__(NixlKVReceiver)
         receiver.kv_mgr = mgr
@@ -613,6 +798,14 @@ class TestNixlReceiverPoll(CustomTestCase):
         receiver.conclude_state = None
         receiver.abort_notified = False
         receiver._connection_pool_entries = {}
+        receiver._used_cached_bootstrap_infos = True
+        receiver._aborted = False
+        # The topology snapshot this receiver bootstrapped against; eviction
+        # is generation-gated on it. The table holds the same snapshot —
+        # current generation — unless a test replaces it.
+        receiver.prefill_info = object()
+        mgr.connection_lock = threading.Lock()
+        mgr.prefill_info_table = {"prefill:8998": receiver.prefill_info}
         return receiver, mgr
 
     def test_returns_existing_conclude_state_without_polling_manager(self):
@@ -680,8 +873,193 @@ class TestNixlReceiverPoll(CustomTestCase):
 
         self.assertEqual(receiver.poll(), KVPoll.Success)
         self.assertNotIn(11, mgr.transfer_statuses)
-        self.assertNotIn(11, mgr.addr_to_rooms_tracker["prefill:8998"])
+        self.assertNotIn(11, mgr.addr_to_rooms_tracker.get("prefill:8998", set()))
         self.assertEqual(receiver.conclude_state, KVPoll.Success)
+
+    def test_clear_removes_room_from_address_tracker(self):
+        """Regression: rooms enter addr_to_rooms_tracker at receiver
+        construction, but only a successful transfer or a whole-address
+        node failure removed them — a terminally failed room (waiting
+        timeout, abort, dp-rank resolution deadline) stayed tracked for
+        the address's lifetime, growing the set under persistent failing
+        traffic. clear() is the terminal cleanup every pop path runs, so
+        it must drop the room."""
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {}
+        mgr.prefill_response_tracker = {}
+
+        receiver.clear()
+
+        self.assertNotIn(11, mgr.addr_to_rooms_tracker.get("prefill:8998", set()))
+        self.assertNotIn(11, mgr.request_status)
+
+    def test_clear_after_address_pop_does_not_recreate_tracker_entry(self):
+        """Regression: clear() indexed the tracker defaultdict, so terminal
+        cleanup racing a whole-address node-failure pop recreated an empty
+        entry, retaining one tracker key per retired bootstrap address for
+        the manager's lifetime."""
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {}
+        mgr.prefill_response_tracker = {}
+        mgr.addr_to_rooms_tracker.pop("prefill:8998")
+
+        receiver.clear()
+
+        self.assertNotIn("prefill:8998", mgr.addr_to_rooms_tracker)
+
+    def test_clear_removes_room_failure_record(self):
+        """Regression: when a room's own failure probe confirmed a prefill
+        replacement, the retirement it triggered recorded a fresh failure
+        for that same room after failure_exception had already consumed
+        the original, and terminal cleanup never removed it — the record
+        leaked, and a future request reusing the bootstrap_room inherited
+        a stale "instance was replaced" reason, misreporting a propagated
+        failure as a local one."""
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {}
+        mgr.prefill_response_tracker = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.failure_records = {
+            11: "Prefill instance was replaced (bootstrap_addr: prefill:8998)"
+        }
+
+        receiver.clear()
+
+        self.assertNotIn(11, mgr.failure_records)
+
+    def test_base_clear_leaves_failure_record_for_backend_consumption(self):
+        """Regression: the shared terminal cleanup popped the room's failure
+        record, but the Mooncake and Mori receivers consume theirs in
+        failure_exception only AFTER calling clear() — the pop erased the
+        real reason first, so every local failure on those backends was
+        misreported as a propagated one with a generic message. Only NIXL,
+        which consumes the record before terminal cleanup, may pop it (in
+        its own clear() override)."""
+        receiver, mgr = self._make_receiver()
+        mgr.request_status = {11: KVPoll.Failed}
+        mgr.required_prefill_response_num_table = {}
+        mgr.prefill_response_tracker = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.failure_records = {11: "Mooncake transfer engine failed"}
+
+        CommonKVReceiver.clear(receiver)
+
+        self.assertEqual(mgr.failure_records, {11: "Mooncake transfer engine failed"})
+
+    def test_failure_invalidates_cached_registration_for_next_request(self):
+        """#33789: a request that reused cached rank endpoints and then failed
+        locally must drop the cache, or every later request keeps talking to a
+        replaced prefill until a heartbeat tick notices. An inconclusive
+        probe authorizes only the cache-only invalidation — never the
+        evict-and-retire path, which would mass-retry every in-flight room
+        at an overloaded-but-alive prefill."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        mgr.failure_records = {11: "peer registration failed"}
+
+        with self.assertRaisesRegex(Exception, "peer registration failed"):
+            receiver.failure_exception()
+
+        mgr.invalidate_cached_connections.assert_called_once_with(
+            "prefill:8998", expected_prefill_info=receiver.prefill_info
+        )
+        mgr.handle_instance_replacement.assert_not_called()
+
+    def test_confirmed_replacement_on_failure_probe_retires_rooms(self):
+        """Regression: the failure-path probe collapsed a healthy response
+        presenting a different instance id — a confirmed replacement — into
+        the same verdict as a failed probe, so it only invalidated the
+        cache. The rooms already in flight against the evicted snapshot
+        were stranded until the waiting timeout: once the next request
+        published the replacement's topology, the heartbeat compared new
+        against new and could never indict them. A confirmed mismatch must
+        take the same evict-and-retire path as the heartbeat's replacement
+        verdict."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        mgr._probe_bootstrap_instance.return_value = (
+            InstanceProbeVerdict.CONFIRMED_REPLACED
+        )
+        mgr.failure_records = {11: "request timed out"}
+
+        with self.assertRaisesRegex(Exception, "request timed out"):
+            receiver.failure_exception()
+
+        mgr.handle_instance_replacement.assert_called_once_with(
+            "prefill:8998",
+            expected_prefill_info=receiver.prefill_info,
+            detected_by="failure-path health probe",
+        )
+        mgr.invalidate_cached_connections.assert_not_called()
+
+    def test_confirmed_unchanged_prefill_keeps_connection_pool(self):
+        """A slow-but-healthy prefill that still presents the registered
+        instance_id must keep its cache: invalidating would disconnect
+        sockets shared with in-flight rooms."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        mgr._probe_bootstrap_instance.return_value = InstanceProbeVerdict.CONFIRMED_SAME
+        mgr.failure_records = {11: "request timed out"}
+
+        with self.assertRaisesRegex(Exception, "request timed out"):
+            receiver.failure_exception()
+
+        mgr._probe_bootstrap_instance.assert_called_once_with(
+            "prefill:8998", expected_prefill_info=receiver.prefill_info
+        )
+        mgr.invalidate_cached_connections.assert_not_called()
+        mgr.handle_instance_replacement.assert_not_called()
+
+    def test_stale_generation_failure_skips_health_probe(self):
+        """Stale failures burst after a replacement and their evictions no-op
+        anyway; the generation gate must be checked before the blocking
+        /health probe, not after."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        mgr.failure_records = {11: "request timed out"}
+        # The cache was already refreshed past this receiver's snapshot.
+        mgr.prefill_info_table = {"prefill:8998": object()}
+
+        with self.assertRaisesRegex(Exception, "request timed out"):
+            receiver.failure_exception()
+
+        mgr._probe_bootstrap_instance.assert_not_called()
+        mgr.invalidate_cached_connections.assert_not_called()
+
+    def test_abort_does_not_invalidate_cached_registration(self):
+        """A client-side abort says nothing about the prefill's health; it must
+        not churn cached endpoints shared with concurrent requests."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        receiver._aborted = True
+        mgr.failure_records = {11: "Aborted by AbortReq."}
+
+        with self.assertRaisesRegex(Exception, "Aborted by AbortReq."):
+            receiver.failure_exception()
+
+        mgr.invalidate_cached_connections.assert_not_called()
+
+    def test_failure_on_fresh_registration_keeps_connection_pool(self):
+        """A failure on a connection registered within this same request is not
+        evidence of staleness; the just-created pool entry must survive."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        receiver._used_cached_bootstrap_infos = False
+        mgr.failure_records = {11: "transfer timed out"}
+
+        with self.assertRaisesRegex(Exception, "transfer timed out"):
+            receiver.failure_exception()
+
+        mgr.invalidate_cached_connections.assert_not_called()
+
+    def test_propagated_failure_without_local_record_keeps_connection_pool(self):
+        """When the failure detail lives on another rank, this rank observed
+        nothing locally and must not invalidate on hearsay; the detecting rank
+        handles its own cache."""
+        receiver, mgr = self._make_receiver(status=KVPoll.Failed)
+        mgr.failure_records = {}
+
+        with self.assertRaisesRegex(Exception, "NIXL KVReceiver Exception"):
+            receiver.failure_exception()
+
+        mgr.invalidate_cached_connections.assert_not_called()
 
 
 class TestNixlNodeFailure(CustomTestCase):
@@ -698,6 +1076,11 @@ class TestNixlNodeFailure(CustomTestCase):
             "10.0.0.1:8998": object(),
             "10.0.0.2:8998": object(),
         }
+        mgr._instance_confirm_cache = {
+            "10.0.0.1:8998": ("instance-1", float("inf")),
+            "10.0.0.2:8998": ("instance-2", float("inf")),
+        }
+        mgr.heartbeat_failures = {}
         mgr.addr_to_rooms_tracker = defaultdict(set)
         mgr.addr_to_rooms_tracker["10.0.0.1:8998"] = {3, 4, 5}
         mgr.request_status = {
@@ -707,6 +1090,7 @@ class TestNixlNodeFailure(CustomTestCase):
         }
         mgr.failure_records = {}
         mgr.failure_lock = threading.Lock()
+        mgr.status_lock = threading.Lock()
         mgr.update_status = CommonKVManager.update_status.__get__(mgr, CommonKVManager)
         mgr.check_status = CommonKVManager.check_status.__get__(mgr, CommonKVManager)
         mgr.record_failure = CommonKVManager.record_failure.__get__(
@@ -731,13 +1115,1120 @@ class TestNixlNodeFailure(CustomTestCase):
         self.assertIn(4, mgr.failure_records)
         self.assertNotIn(5, mgr.failure_records)
 
+    def test_node_failure_iterates_room_snapshot_not_live_set(self):
+        """Regression: _handle_node_failure iterated the live per-address room
+        set after releasing connection_lock while other threads mutate it;
+        the RuntimeError killed the heartbeat thread. Reproduced by mutating
+        the set from within the first room's failure recording."""
+        mgr = self._make_manager()
+        tracked_rooms = mgr.addr_to_rooms_tracker["10.0.0.1:8998"]
+        real_record_failure = mgr.record_failure
+
+        def record_failure_and_register_new_room(room, failure_reason):
+            tracked_rooms.add(99)
+            real_record_failure(room, failure_reason)
+
+        mgr.record_failure = record_failure_and_register_new_room
+
+        mgr._handle_node_failure("10.0.0.1:8998")
+
+        self.assertEqual(mgr.request_status[3], KVPoll.Failed)
+        self.assertEqual(mgr.request_status[4], KVPoll.Failed)
+        self.assertEqual(mgr.request_status[5], KVPoll.Success)
+
+    def test_node_failure_retirement_survives_concurrent_terminal_cleanup(self):
+        """Regression: the retirement loop resolved each room with an
+        unlocked membership check followed by an indexed status read, so a
+        terminal cleanup popping the room between the two raised KeyError —
+        killing the heartbeat thread, which has no other exception boundary
+        (silently disabling replacement detection for the process lifetime),
+        and leaving the rest of the room snapshot unretired. Reproduces the
+        interleaving: the membership check's success triggers the concurrent
+        pop before the indexed read."""
+        mgr = self._make_manager()
+
+        class PopsRoomAfterMembershipCheck(dict):
+            def __contains__(self, room):
+                present = super().__contains__(room)
+                if present and room == 3:
+                    self.pop(3)
+                return present
+
+        mgr.request_status = PopsRoomAfterMembershipCheck(mgr.request_status)
+
+        mgr._handle_node_failure("10.0.0.1:8998")
+
+        self.assertEqual(mgr.request_status[4], KVPoll.Failed)
+
+    def test_eviction_requires_full_bootstrap_addr_match(self):
+        """Connection keys are "{addr}_{dp}_{cp}_{tp}", so "10.0.0.1:899" is a
+        string prefix of "10.0.0.1:8998" keys; eviction matching on a bare
+        startswith(addr) would tear down an unrelated prefill's connections."""
+        mgr = self._make_manager()
+
+        mgr._handle_node_failure("10.0.0.1:899")
+        mgr.invalidate_cached_connections("10.0.0.1:899")
+
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertIn("10.0.0.1:8998_0_0_1", mgr.connection_pool)
+        self.assertIn("10.0.0.2:8998_0_0_0", mgr.connection_pool)
+
+    def test_reactive_invalidation_refreshes_topology_snapshot(self):
+        """Regression: keeping the prefill_info_table entry left the replaced
+        instance_id as the heartbeat baseline, so the next tick failed the
+        freshly recovered rooms. The confirm-probe cache is baseline state
+        too and is cleared with it."""
+        mgr = self._make_manager()
+
+        mgr.invalidate_cached_connections("10.0.0.1:8998")
+
+        self.assertNotIn("10.0.0.1:8998", mgr.prefill_info_table)
+        self.assertIn("10.0.0.2:8998", mgr.prefill_info_table)
+        self.assertNotIn("10.0.0.1:8998", mgr._instance_confirm_cache)
+        self.assertIn("10.0.0.2:8998", mgr._instance_confirm_cache)
+
+    def test_stale_generation_invalidation_keeps_refreshed_cache(self):
+        """A stale receiver's failure can surface after the cache was already
+        refreshed; unconditional invalidation would tear down the live cache.
+        Stale snapshot no-ops, current still evicts."""
+        mgr = self._make_manager()
+        stale_info = object()
+
+        mgr.invalidate_cached_connections(
+            "10.0.0.1:8998", expected_prefill_info=stale_info
+        )
+
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertIn("10.0.0.1:8998", mgr.prefill_info_table)
+
+        current_info = mgr.prefill_info_table["10.0.0.1:8998"]
+        mgr.invalidate_cached_connections(
+            "10.0.0.1:8998", expected_prefill_info=current_info
+        )
+
+        self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertNotIn("10.0.0.1:8998", mgr.prefill_info_table)
+
     def test_late_failed_update_does_not_resurrect_cleared_room(self):
         mgr = object.__new__(CommonKVManager)
         mgr.request_status = {}
+        mgr.status_lock = threading.Lock()
 
         CommonKVManager.update_status(mgr, 9, KVPoll.Failed)
 
         self.assertNotIn(9, mgr.request_status)
+
+    def test_detects_prefill_replacement_at_same_healthy_address(self):
+        """The detector compares against the snapshot captured before the
+        request, not the live table, and hands that snapshot back as the
+        caller's eviction gate. No snapshot, no verdict."""
+        mgr = self._make_manager()
+        old_info = PrefillServerInfo(
+            attn_tp_size=1,
+            attn_cp_size=1,
+            dp_size=1,
+            pp_size=1,
+            page_size=1,
+            kv_cache_dtype="auto",
+            follow_bootstrap_room=True,
+            instance_id="old-instance",
+        )
+        response = SimpleNamespace(
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: "new-instance"}
+        )
+
+        self.assertIs(mgr._bootstrap_instance_replaced(old_info, response), old_info)
+
+        same_response = SimpleNamespace(
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: "old-instance"}
+        )
+        self.assertIsNone(mgr._bootstrap_instance_replaced(old_info, same_response))
+        self.assertIsNone(mgr._bootstrap_instance_replaced(None, response))
+
+    def test_headerless_baseline_detects_header_emitting_replacement(self):
+        """Regression: requiring both ids reported a headerless baseline as
+        unchanged forever after its prefill was replaced by a stamping
+        version. An id appearing over a headerless baseline is a replacement
+        (no upgrade-in-place); an id disappearing stays inconclusive."""
+        mgr = self._make_manager()
+        headerless_info = SimpleNamespace(instance_id=None)
+        id_response = SimpleNamespace(
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: "new-instance"}
+        )
+
+        self.assertIs(
+            mgr._bootstrap_instance_replaced(headerless_info, id_response),
+            headerless_info,
+        )
+
+        current_info = SimpleNamespace(instance_id="old-instance")
+        no_header_response = SimpleNamespace(headers={})
+        self.assertIsNone(
+            mgr._bootstrap_instance_replaced(current_info, no_header_response)
+        )
+
+    def test_heartbeat_probe_opens_a_fresh_connection_each_tick(self):
+        """Regression: a pooled keep-alive heartbeat socket kept reaching a
+        draining replaced process, which answers with the expected id,
+        masking the replacement until the old process exited. Each probe
+        must resolve the address afresh on a non-reusable connection."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        mgr.prefill_info_table[addr] = SimpleNamespace(instance_id="old-instance")
+        mgr.heartbeat_failures = {}
+        mgr.max_failures = 1
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "old-instance"},
+            ),
+        ) as health_get:
+            mgr._heartbeat_tick(addr)
+            mgr._heartbeat_tick(addr)
+
+        self.assertEqual(health_get.call_count, 2)
+        for probe in health_get.call_args_list:
+            self.assertEqual(probe.kwargs["headers"], {"Connection": "close"})
+        self.assertEqual(mgr.heartbeat_failures, {addr: 0})
+        self.assertIn(addr, mgr.prefill_info_table)
+
+    def test_topology_fetch_captures_header_id_and_drops_unknown_fields(self):
+        """try_ensure_parallel_info bridges the wire contract to the cached
+        baseline: the header id must land on the snapshot and unknown
+        topology keys must be dropped, not crashed on. Every other test
+        injects the id directly, so this is the only guard on the bridge."""
+        mgr = object.__new__(CommonKVManager)
+        mgr.prefill_info_table = {}
+        mgr.kv_args = SimpleNamespace(page_size=1)
+        mgr.kv_cache_dtype_str = "auto"
+        mgr.dcp_size = 1
+        mgr._resolve_rank_mapping = lambda info: None
+        response = SimpleNamespace(
+            status_code=200,
+            headers={BOOTSTRAP_INSTANCE_ID_HEADER: "server-instance"},
+            json=lambda: {
+                "attn_tp_size": 1,
+                "attn_cp_size": 1,
+                "dp_size": 1,
+                "pp_size": 1,
+                "page_size": 1,
+                "kv_cache_dtype": "auto",
+                "follow_bootstrap_room": True,
+                "future_topology_field": 123,
+            },
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=response,
+        ):
+            self.assertTrue(mgr.try_ensure_parallel_info("10.0.0.1:8998"))
+
+        cached = mgr.prefill_info_table["10.0.0.1:8998"]
+        self.assertEqual(cached.instance_id, "server-instance")
+        self.assertEqual(cached.attn_tp_size, 1)
+
+    def _prepare_heartbeat(self, mgr, addr, health_get_side_effect):
+        mgr.prefill_info_table[addr] = SimpleNamespace(instance_id="old-instance")
+        mgr.heartbeat_failures = {}
+        mgr.max_failures = 1
+        patcher = patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            side_effect=health_get_side_effect,
+        )
+        self.health_get = patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_heartbeat_tick_ignores_delayed_response_from_replaced_instance(self):
+        """A delayed /health response from the replaced instance must not be
+        compared against the freshly recovered table entry; the verdict
+        anchors to the snapshot captured before the request was sent."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        new_info = SimpleNamespace(instance_id="new-instance")
+
+        def delayed_response_from_old_instance(url, **kwargs):
+            # Reactive recovery finishes while the request is in flight.
+            mgr.prefill_info_table[addr] = new_info
+            return SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "old-instance"},
+            )
+
+        self._prepare_heartbeat(mgr, addr, delayed_response_from_old_instance)
+
+        mgr._heartbeat_tick(addr)
+
+        self.assertIs(mgr.prefill_info_table[addr], new_info)
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertEqual(mgr.request_status[3], KVPoll.WaitingForInput)
+        self.assertEqual(mgr.failure_records, {})
+
+    def test_heartbeat_tick_timeout_verdict_is_generation_gated(self):
+        """A timeout verdict whose generation was evicted and replaced
+        mid-flight must no-op rather than tear down the new generation's
+        cache; the stale failure count is discarded with it."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        new_info = SimpleNamespace(instance_id="new-instance")
+
+        def timeout_after_replacement(url, **kwargs):
+            mgr.prefill_info_table[addr] = new_info
+            raise OSError("health check timed out")
+
+        self._prepare_heartbeat(mgr, addr, timeout_after_replacement)
+
+        mgr._heartbeat_tick(addr)
+
+        self.assertIs(mgr.prefill_info_table[addr], new_info)
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertEqual(mgr.request_status[3], KVPoll.WaitingForInput)
+        self.assertEqual(mgr.failure_records, {})
+        self.assertEqual(mgr.heartbeat_failures, {})
+
+    def test_heartbeat_miss_racing_recovery_is_not_charged_to_new_generation(self):
+        """A probe miss that raced with eviction plus recovery must not
+        increment the address-keyed failure count: carried over, it would
+        put the new generation one hiccup away from the threshold."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        new_info = SimpleNamespace(instance_id="new-instance")
+
+        def timeout_after_replacement(url, **kwargs):
+            mgr.prefill_info_table[addr] = new_info
+            raise OSError("health check timed out")
+
+        self._prepare_heartbeat(mgr, addr, timeout_after_replacement)
+        mgr.max_failures = 2
+
+        mgr._heartbeat_tick(addr)
+
+        self.assertEqual(mgr.heartbeat_failures, {})
+
+        self.health_get.side_effect = OSError("transient miss")
+
+        mgr._heartbeat_tick(addr)
+
+        self.assertIs(mgr.prefill_info_table[addr], new_info)
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertEqual(mgr.request_status[3], KVPoll.WaitingForInput)
+        self.assertEqual(mgr.heartbeat_failures, {addr: 1})
+
+    def test_eviction_clears_heartbeat_failure_count(self):
+        """Reactive eviction replaces the generation outside the heartbeat
+        thread; a count accrued against the old generation must not survive
+        it, or the replacement starts partway toward the failure threshold."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        mgr.heartbeat_failures = {addr: 1}
+
+        mgr.invalidate_cached_connections(addr)
+
+        self.assertEqual(mgr.heartbeat_failures, {})
+
+    def test_heartbeat_tick_verdicts_still_act_on_unreplaced_generation(self):
+        """The gates exist to stop cross-generation verdicts, not to weaken
+        detection: with no concurrent eviction, a replaced instance id evicts
+        and fails pending rooms, and so does a timeout that reaches the
+        failure threshold."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        self._prepare_heartbeat(
+            mgr,
+            addr,
+            lambda url, **kwargs: SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "new-instance"},
+            ),
+        )
+
+        mgr._heartbeat_tick(addr)
+
+        self.assertNotIn(addr, mgr.prefill_info_table)
+        self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertEqual(mgr.request_status[3], KVPoll.Failed)
+        self.assertIn(3, mgr.failure_records)
+
+        timing_out = self._make_manager()
+
+        def raise_timeout(url, **kwargs):
+            raise OSError("health check timed out")
+
+        self._prepare_heartbeat(timing_out, addr, raise_timeout)
+
+        timing_out._heartbeat_tick(addr)
+
+        self.assertNotIn(addr, timing_out.prefill_info_table)
+        self.assertNotIn("10.0.0.1:8998_0_0_0", timing_out.connection_pool)
+        self.assertEqual(timing_out.request_status[3], KVPoll.Failed)
+        self.assertIn(3, timing_out.failure_records)
+
+    def test_heartbeat_tick_skips_success_bookkeeping_without_snapshot(self):
+        """Regression: a healthy response after the entry was evicted fell
+        through to the success path, resetting the failure count and firing
+        the backend hook for an address the eviction had just cleared."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        self._prepare_heartbeat(
+            mgr,
+            addr,
+            lambda url, **kwargs: SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "new-instance"},
+            ),
+        )
+        # The eviction lands before the tick captures its snapshot.
+        del mgr.prefill_info_table[addr]
+
+        with patch.object(mgr, "_on_heartbeat_success") as on_success:
+            mgr._heartbeat_tick(addr)
+
+        on_success.assert_not_called()
+        self.assertEqual(mgr.heartbeat_failures, {})
+
+    def test_heartbeat_tick_success_verdict_is_generation_gated(self):
+        """Regression: the success path only checked the snapshot was
+        non-None, so a delayed healthy response from an evicted-and-replaced
+        generation credited the replacement (failure-count entry, backend
+        hook). Success must be identity-gated like failure."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        new_info = SimpleNamespace(instance_id="new-instance")
+
+        def delayed_healthy_response_from_old_instance(url, **kwargs):
+            # Reactive recovery evicts the probed generation and installs
+            # its replacement while the /health request is in flight; the
+            # response still presents the probed generation's id, so it
+            # passes the snapshot comparison and reaches the success path.
+            mgr.prefill_info_table[addr] = new_info
+            return SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "old-instance"},
+            )
+
+        self._prepare_heartbeat(mgr, addr, delayed_healthy_response_from_old_instance)
+
+        with patch.object(mgr, "_on_heartbeat_success") as on_success:
+            mgr._heartbeat_tick(addr)
+
+        on_success.assert_not_called()
+        self.assertEqual(mgr.heartbeat_failures, {})
+        self.assertIs(mgr.prefill_info_table[addr], new_info)
+
+    def test_heartbeat_success_hook_runs_under_the_generation_lock(self):
+        """Regression: the backend success hook ran after releasing
+        connection_lock, so an eviction landing in the gap handed the stale
+        verdict's hook the replacement's state. The hook must run inside the
+        critical section that authorized it."""
+        mgr = self._make_manager()
+        addr = "10.0.0.1:8998"
+        self._prepare_heartbeat(
+            mgr,
+            addr,
+            lambda url, **kwargs: SimpleNamespace(
+                status_code=200,
+                headers={BOOTSTRAP_INSTANCE_ID_HEADER: "old-instance"},
+            ),
+        )
+
+        lock_held_during_hook = []
+        with patch.object(
+            mgr,
+            "_on_heartbeat_success",
+            side_effect=lambda a: lock_held_during_hook.append(
+                mgr.connection_lock.locked()
+            ),
+        ):
+            mgr._heartbeat_tick(addr)
+
+        self.assertEqual(lock_held_during_hook, [True])
+        self.assertEqual(mgr.heartbeat_failures, {addr: 0})
+
+    def test_heartbeat_node_failure_is_generation_gated(self):
+        """Between the id comparison and the eviction a request can install a
+        new generation; ungated _handle_node_failure would evict the fresh
+        cache. Stale snapshot no-ops, current still evicts."""
+        mgr = self._make_manager()
+
+        mgr._handle_node_failure("10.0.0.1:8998", expected_prefill_info=object())
+
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertIn("10.0.0.1:8998", mgr.prefill_info_table)
+        self.assertEqual(mgr.request_status[3], KVPoll.WaitingForInput)
+        self.assertEqual(mgr.failure_records, {})
+
+        current_info = mgr.prefill_info_table["10.0.0.1:8998"]
+        mgr._handle_node_failure("10.0.0.1:8998", expected_prefill_info=current_info)
+
+        self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+        self.assertNotIn("10.0.0.1:8998", mgr.prefill_info_table)
+        self.assertEqual(mgr.request_status[3], KVPoll.Failed)
+        self.assertIn(3, mgr.failure_records)
+
+
+class TestBootstrapInstanceProbe(CustomTestCase):
+    ADDR = "10.0.0.1:8998"
+
+    @staticmethod
+    def _make_manager():
+        mgr = object.__new__(NixlKVManager)
+        mgr._instance_confirm_cache = {}
+        return mgr
+
+    @staticmethod
+    def _snapshot(instance_id):
+        return PrefillServerInfo(
+            attn_tp_size=1,
+            attn_cp_size=1,
+            dp_size=1,
+            pp_size=1,
+            page_size=1,
+            kv_cache_dtype="auto",
+            follow_bootstrap_room=True,
+            instance_id=instance_id,
+        )
+
+    @staticmethod
+    def _response(instance_id, status_code=200):
+        headers = {}
+        if instance_id is not None:
+            headers[BOOTSTRAP_INSTANCE_ID_HEADER] = instance_id
+        return SimpleNamespace(status_code=status_code, headers=headers)
+
+    def _probe(self, expected_id, response):
+        mgr = self._make_manager()
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=response,
+        ):
+            return mgr._probe_bootstrap_instance(
+                self.ADDR, expected_prefill_info=self._snapshot(expected_id)
+            )
+
+    def test_matching_health_header_confirms_instance(self):
+        """The only outcome allowed to suppress failure-driven cache recovery
+        is a positive /health match against the registered instance_id."""
+        self.assertIs(
+            self._probe("live", self._response("live")),
+            InstanceProbeVerdict.CONFIRMED_SAME,
+        )
+
+    def test_healthy_mismatch_is_a_confirmed_replacement(self):
+        """Regression: a healthy response presenting a different instance id
+        — a confirmed replacement, by the same rule the heartbeat and the
+        query path apply — was collapsed into the same verdict as a failed
+        probe, so the failure path only invalidated the cache and the rooms
+        in flight against the replaced snapshot waited out their timeout.
+        An id appearing over a headerless baseline is a replacement too:
+        there is no upgrade-in-place."""
+        cases = {
+            "different id": ("old", self._response("new")),
+            "id over headerless baseline": (None, self._response("new")),
+        }
+        for name, (expected_id, response) in cases.items():
+            with self.subTest(name):
+                self.assertIs(
+                    self._probe(expected_id, response),
+                    InstanceProbeVerdict.CONFIRMED_REPLACED,
+                )
+
+    def test_uncertain_probe_outcomes_are_inconclusive(self):
+        """Anything short of a healthy response with a definite identity —
+        an unhealthy status even when it carries the expected id, or an id
+        disappearing — neither confirms the instance (which would suppress
+        recovery) nor convicts it (which would retire every in-flight room
+        at the address on an overload blip)."""
+        cases = {
+            "id disappeared (downgrade or stripped header)": (
+                "old",
+                self._response(None),
+            ),
+            "unhealthy status": ("old", self._response("old", status_code=503)),
+            "unhealthy status with mismatched id": (
+                "old",
+                self._response("new", status_code=503),
+            ),
+        }
+        for name, (expected_id, response) in cases.items():
+            with self.subTest(name):
+                self.assertIs(
+                    self._probe(expected_id, response),
+                    InstanceProbeVerdict.INCONCLUSIVE,
+                )
+
+    def test_headerless_baseline_is_confirmed_by_live_headerless_probe(self):
+        """Regression: any headerless baseline was unconfirmable, so every
+        local failure on a reused connection evicted the pool of a healthy
+        pre-instance-id prefill. A live headerless response is all the
+        confirmation such a baseline can get."""
+        self.assertIs(
+            self._probe(None, self._response(None)),
+            InstanceProbeVerdict.CONFIRMED_SAME,
+        )
+
+    def test_probe_error_is_inconclusive(self):
+        mgr = self._make_manager()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            side_effect=ConnectionError("bootstrap unreachable"),
+        ):
+            self.assertIs(
+                mgr._probe_bootstrap_instance(
+                    self.ADDR, expected_prefill_info=self._snapshot("old")
+                ),
+                InstanceProbeVerdict.INCONCLUSIVE,
+            )
+
+    def test_positive_confirm_is_cached_within_ttl(self):
+        """The probe blocks the scheduler thread and an overloaded prefill
+        fails one local request after another; a just-confirmed instance is
+        trusted for a short window instead of re-probing per failure."""
+        mgr = self._make_manager()
+        snapshot = self._snapshot("same")
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=self._response("same"),
+        ) as mock_get:
+            for _ in range(2):
+                self.assertIs(
+                    mgr._probe_bootstrap_instance(
+                        self.ADDR, expected_prefill_info=snapshot
+                    ),
+                    InstanceProbeVerdict.CONFIRMED_SAME,
+                )
+
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_confirm_cache_is_keyed_to_the_confirmed_instance_id(self):
+        """A cache keyed by address alone would let a confirmation of the old
+        instance suppress the probe after the baseline was refreshed to a new
+        one; the cached entry must only match the instance_id it confirmed."""
+        mgr = self._make_manager()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=self._response("old"),
+        ) as mock_get:
+            self.assertIs(
+                mgr._probe_bootstrap_instance(
+                    self.ADDR, expected_prefill_info=self._snapshot("old")
+                ),
+                InstanceProbeVerdict.CONFIRMED_SAME,
+            )
+        self.assertEqual(mock_get.call_count, 1)
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=self._response("new"),
+        ) as mock_get:
+            self.assertIs(
+                mgr._probe_bootstrap_instance(
+                    self.ADDR, expected_prefill_info=self._snapshot("new")
+                ),
+                InstanceProbeVerdict.CONFIRMED_SAME,
+            )
+        self.assertEqual(mock_get.call_count, 1)
+
+    def test_replacement_verdict_does_not_populate_confirm_cache(self):
+        """A mismatch must leave no trace in the positive-confirmation
+        cache: the entry is keyed to the id it confirmed, and caching
+        anything here could suppress a later probe's verdict."""
+        mgr = self._make_manager()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.requests.get",
+            return_value=self._response("new"),
+        ):
+            mgr._probe_bootstrap_instance(
+                self.ADDR, expected_prefill_info=self._snapshot("old")
+            )
+
+        self.assertEqual(mgr._instance_confirm_cache, {})
+
+
+class TestReceiverTableLocking(CustomTestCase):
+    class _LockAssertingDict(dict):
+        """Shared-table stand-in that rejects any access performed without
+        holding connection_lock."""
+
+        def __init__(self, lock):
+            super().__init__()
+            self._lock = lock
+
+        def _check(self):
+            if not self._lock.locked():
+                raise AssertionError("connection_pool accessed without connection_lock")
+
+        def get(self, key, default=None):
+            self._check()
+            return super().get(key, default)
+
+        def __contains__(self, key):
+            self._check()
+            return super().__contains__(key)
+
+        def __getitem__(self, key):
+            self._check()
+            return super().__getitem__(key)
+
+        def __setitem__(self, key, value):
+            self._check()
+            super().__setitem__(key, value)
+
+    def test_cached_lookup_happens_under_connection_lock(self):
+        """The heartbeat thread evicts pool keys under connection_lock; the
+        cached-path read must be a single locked snapshot or a concurrent
+        eviction turns it into a KeyError."""
+        lock = threading.Lock()
+        mgr = SimpleNamespace(
+            connection_lock=lock,
+            connection_pool=self._LockAssertingDict(lock),
+        )
+        infos = [{"rank_ip": "10.0.0.1", "rank_port": 7000}]
+        with lock:
+            mgr.connection_pool["10.0.0.1:8998_0_0_0"] = infos
+
+        receiver = object.__new__(NixlKVReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_addr = "10.0.0.1:8998"
+        receiver.prefill_dp_rank = 0
+        receiver.target_tp_rank = 0
+        receiver.target_cp_ranks = [0]
+        receiver._used_cached_bootstrap_infos = False
+        receiver._connection_pool_entries = {}
+
+        receiver._setup_bootstrap_infos()
+
+        self.assertEqual(receiver.bootstrap_infos, infos)
+        self.assertTrue(receiver._used_cached_bootstrap_infos)
+
+    def test_init_reads_prefill_info_under_connection_lock(self):
+        """The heartbeat thread pops prefill_info_table entries under
+        connection_lock; init() must take a single locked snapshot, which is
+        also the object the generation-gated eviction anchors to."""
+        lock = threading.Lock()
+        table = self._LockAssertingDict(lock)
+        info = SimpleNamespace(
+            target_tp_rank=0,
+            target_tp_ranks=[0],
+            target_cp_ranks=[0],
+            target_pp_ranks=[0],
+            required_dst_info_num=1,
+            required_prefill_response_num=1,
+        )
+        with lock:
+            table["10.0.0.1:8998"] = info
+        mgr = SimpleNamespace(
+            connection_lock=lock,
+            prefill_info_table=table,
+            required_prefill_response_num_table={},
+            enable_staging=False,
+            update_status=MagicMock(),
+        )
+
+        receiver = object.__new__(NixlKVReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_addr = "10.0.0.1:8998"
+        receiver.bootstrap_room = 7
+        receiver.conclude_state = None
+        receiver._setup_bootstrap_infos = MagicMock()
+
+        receiver.init(prefill_dp_rank=0)
+
+        self.assertIs(receiver.prefill_info, info)
+        self.assertEqual(mgr.required_prefill_response_num_table[7], 1)
+        receiver._setup_bootstrap_infos.assert_called_once_with()
+
+    def test_constructor_publishes_room_and_status_in_one_locked_section(self):
+        """Regression, twice: the constructor's tracker add ran unlocked
+        while node-failure handling snapshots-and-pops the address's set
+        under connection_lock — the add could land on the just-popped
+        (orphaned) set; then the locked add still published the initial
+        Bootstrapping status after releasing the lock, and the node-failure
+        retirement loop skips rooms absent from request_status — a
+        snapshot-and-pop between the two publications dropped the room's
+        tracker membership but skipped retiring it (no status yet), and the
+        late status write then installed Bootstrapping for a permanently
+        untracked room. Both failure modes strand the request until its
+        waiting timeout; both publications must land in one critical
+        section."""
+
+        class _CountingLock:
+            def __init__(inner):
+                inner._lock = threading.Lock()
+                inner.acquisitions = 0
+
+            def __enter__(inner):
+                inner._lock.acquire()
+                inner.acquisitions += 1
+
+            def __exit__(inner, *exc):
+                inner._lock.release()
+
+            def locked(inner):
+                return inner._lock.locked()
+
+        lock = _CountingLock()
+        held_during_add = []
+        status_writes = []
+
+        class _LockCheckedSet(set):
+            def add(inner, room):
+                held_during_add.append(lock.locked())
+                set.add(inner, room)
+
+        mgr = MagicMock()
+        mgr.connection_lock = lock
+        mgr.addr_to_rooms_tracker = defaultdict(_LockCheckedSet)
+        mgr.update_status = MagicMock(
+            side_effect=lambda room, status: status_writes.append(
+                (room, status, lock.locked())
+            )
+        )
+
+        receiver = object.__new__(NixlKVReceiver)
+        CommonKVReceiver.__init__(
+            receiver, mgr, bootstrap_addr="10.0.0.1:8998", bootstrap_room=7
+        )
+
+        self.assertEqual(held_during_add, [True])
+        self.assertEqual(status_writes, [(7, KVPoll.Bootstrapping, True)])
+        self.assertEqual(lock.acquisitions, 1)
+        self.assertIn(7, mgr.addr_to_rooms_tracker["10.0.0.1:8998"])
+
+    def _make_fetching_receiver(self, mgr, prefill_info):
+        receiver = object.__new__(NixlKVReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_addr = "10.0.0.1:8998"
+        receiver.bootstrap_room = 7
+        receiver.prefill_dp_rank = 0
+        receiver.target_tp_rank = 0
+        receiver.target_tp_ranks = [0]
+        receiver.target_cp_ranks = [0]
+        receiver.target_pp_ranks = [0]
+        receiver.prefill_info = prefill_info
+        receiver._used_cached_bootstrap_infos = False
+        receiver._connection_pool_entries = {}
+        receiver._get_bootstrap_info_from_server = MagicMock(
+            return_value={"rank_ip": "10.0.0.1", "rank_port": 7000}
+        )
+        receiver._register_kv_args = MagicMock(return_value=True)
+        return receiver
+
+    def test_stale_receiver_does_not_republish_evicted_endpoints(self):
+        """A replacement can complete inside a cache-miss receiver's fetch
+        window; an unconditional publish would overwrite the new
+        generation's pool entry with dead endpoints. Stale snapshot skips,
+        current publishes."""
+        current_info = object()
+        mgr = SimpleNamespace(
+            connection_lock=threading.Lock(),
+            connection_pool={},
+            prefill_info_table={"10.0.0.1:8998": current_info},
+            is_mla_backend=False,
+        )
+
+        stale = self._make_fetching_receiver(mgr, prefill_info=object())
+        stale._setup_bootstrap_infos()
+
+        self.assertEqual(mgr.connection_pool, {})
+        self.assertIsNotNone(stale.bootstrap_infos)
+
+        fresh = self._make_fetching_receiver(mgr, prefill_info=current_info)
+        fresh._setup_bootstrap_infos()
+
+        self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+
+
+class TestRankEndpointFetchValidation(CustomTestCase):
+    ENDPOINT = {"rank_ip": "10.0.0.1", "rank_port": 7000}
+
+    def _make_receiver(self, instance_id):
+        receiver = object.__new__(NixlKVReceiver)
+        receiver.bootstrap_addr = "10.0.0.1:8998"
+        receiver.prefill_info = SimpleNamespace(instance_id=instance_id)
+        receiver.kv_mgr = MagicMock()
+        return receiver
+
+    def _response(self, instance_id):
+        headers = {}
+        if instance_id is not None:
+            headers[BOOTSTRAP_INSTANCE_ID_HEADER] = instance_id
+        return SimpleNamespace(
+            status_code=200, headers=headers, json=lambda: self.ENDPOINT
+        )
+
+    def _fetch(self, receiver, *responses):
+        session = MagicMock()
+        session.get.side_effect = list(responses)
+        with patch(
+            "sglang.srt.disaggregation.common.conn._get_bootstrap_session",
+            return_value=session,
+        ), patch(
+            "sglang.srt.disaggregation.common.conn._drop_bootstrap_session"
+        ) as drop_session:
+            result = receiver._get_bootstrap_info_from_server(0, 0, 0, 0)
+        return result, drop_session, session
+
+    def test_rank_endpoint_fetch_rejects_persistently_mismatched_instance(self):
+        """Regression: an answer from a draining replaced process cached dead
+        rank endpoints under the fresh topology, and the /health veto made
+        the stall permanent. A second mismatch on the fresh connection
+        indicts the snapshot instead, which is evicted generation-gated;
+        matching and both-headerless pairs keep working."""
+        stale = self._make_receiver(instance_id="new-instance")
+        result, drop_session, session = self._fetch(
+            stale,
+            self._response("old-instance"),
+            self._response("old-instance"),
+        )
+        self.assertIsNone(result)
+        self.assertEqual(session.get.call_count, 2)
+        self.assertEqual(drop_session.call_count, 2)
+        # Retirement, not cache-only invalidation: rooms in flight against
+        # the evicted snapshot would otherwise ride out the waiting timeout
+        # (the heartbeat can no longer indict them once the replacement's
+        # topology is published).
+        stale.kv_mgr.handle_instance_replacement.assert_called_once_with(
+            "10.0.0.1:8998",
+            expected_prefill_info=stale.prefill_info,
+            detected_by="rank endpoint fetch",
+        )
+
+        # An unstamped response against a stamped snapshot is the same
+        # process disagreement in the other direction (a stamped topology
+        # means the server versions its responses).
+        unstamped_rx = self._make_receiver(instance_id="new-instance")
+        unstamped, drop_session, _ = self._fetch(
+            unstamped_rx, self._response(None), self._response(None)
+        )
+        self.assertIsNone(unstamped)
+        unstamped_rx.kv_mgr.handle_instance_replacement.assert_called_once()
+
+        matching_rx = self._make_receiver(instance_id="new-instance")
+        matching, drop_session, _ = self._fetch(
+            matching_rx, self._response("new-instance")
+        )
+        self.assertEqual(matching, self.ENDPOINT)
+        drop_session.assert_not_called()
+        matching_rx.kv_mgr.handle_instance_replacement.assert_not_called()
+
+        headerless, drop_session, _ = self._fetch(
+            self._make_receiver(instance_id=None), self._response(None)
+        )
+        self.assertEqual(headerless, self.ENDPOINT)
+        drop_session.assert_not_called()
+
+    def test_rank_endpoint_fetch_retries_once_on_a_fresh_connection(self):
+        """Regression: a single mismatch failed the whole fetch even though
+        its usual cause is the just-dropped keep-alive socket; one retry on
+        the fresh connection resolves the draining-pod case."""
+        receiver = self._make_receiver(instance_id="new-instance")
+        result, drop_session, session = self._fetch(
+            receiver,
+            self._response("old-instance"),
+            self._response("new-instance"),
+        )
+        self.assertEqual(result, self.ENDPOINT)
+        self.assertEqual(session.get.call_count, 2)
+        drop_session.assert_called_once_with("10.0.0.1:8998")
+        receiver.kv_mgr.handle_instance_replacement.assert_not_called()
+
+    def test_rank_endpoint_fetch_drops_session_on_error_status(self):
+        """Regression: only 200 responses rotated the session, so a draining
+        process 404ing new-topology ranks kept the socket pinned and every
+        later receiver repeated the error."""
+        receiver = self._make_receiver(instance_id="new-instance")
+        error = SimpleNamespace(status_code=404, headers={}, text="not found")
+        result, drop_session, session = self._fetch(receiver, error)
+        self.assertIsNone(result)
+        self.assertEqual(session.get.call_count, 1)
+        drop_session.assert_called_once_with("10.0.0.1:8998")
+        receiver.kv_mgr.handle_instance_replacement.assert_not_called()
+
+
+class TestDpRankQueryValidation(CustomTestCase):
+    ADDR = "10.0.0.1:8998"
+
+    def _query(self, *responses, expected_instance_id):
+        session = MagicMock()
+        session.post.side_effect = list(responses)
+        with patch(
+            "sglang.srt.disaggregation.common.conn._get_bootstrap_session",
+            return_value=session,
+        ), patch(
+            "sglang.srt.disaggregation.common.conn._drop_bootstrap_session"
+        ) as drop_session:
+            result = CommonKVReceiver.query_prefill_dp_ranks(
+                self.ADDR, [7], expected_instance_id=expected_instance_id
+            )
+        return result, drop_session, session
+
+    def _response(self, instance_id, mapping):
+        headers = {}
+        if instance_id is not None:
+            headers[BOOTSTRAP_INSTANCE_ID_HEADER] = instance_id
+        return SimpleNamespace(status_code=200, headers=headers, json=lambda: mapping)
+
+    def test_dp_rank_query_rejects_mismatched_instance(self):
+        """Regression: the dp-rank query was the one bootstrap response
+        accepted without instance validation, and a draining process
+        omitting unregistered rooms parked those requests with no timeout
+        armed. A mismatch discards answer and session; a second mismatch
+        returns None so the caller evicts the snapshot. Matching and
+        both-headerless pairs keep working."""
+        mapping = {"7": 2}
+
+        cases_rejected = {
+            "stale socket answers for the old instance": ("old", "new"),
+            "stamped answer against a headerless snapshot": ("new", None),
+            "headerless answer against a stamped snapshot": (None, "new"),
+        }
+        for name, (observed, expected) in cases_rejected.items():
+            with self.subTest(name):
+                result, drop_session, session = self._query(
+                    self._response(observed, mapping),
+                    self._response(observed, mapping),
+                    expected_instance_id=expected,
+                )
+                self.assertIsNone(result)
+                self.assertEqual(session.post.call_count, 2)
+                self.assertEqual(drop_session.call_count, 2)
+
+        cases_accepted = {
+            "matching instance": ("same", "same"),
+            "both headerless (pre-instance-id server)": (None, None),
+        }
+        for name, (observed, expected) in cases_accepted.items():
+            with self.subTest(name):
+                result, drop_session, session = self._query(
+                    self._response(observed, mapping), expected_instance_id=expected
+                )
+                self.assertEqual(result, mapping)
+                self.assertEqual(session.post.call_count, 1)
+                drop_session.assert_not_called()
+
+    def test_dp_rank_query_retries_once_on_a_fresh_connection(self):
+        """Regression: a single mismatch discarded the answer even though its
+        usual cause is the just-dropped keep-alive socket; only a second
+        mismatch on the fresh connection becomes the evict-the-snapshot
+        signal (None)."""
+        mapping = {"7": 2}
+        result, drop_session, session = self._query(
+            self._response("old", mapping),
+            self._response("new", mapping),
+            expected_instance_id="new",
+        )
+        self.assertEqual(result, mapping)
+        self.assertEqual(session.post.call_count, 2)
+        drop_session.assert_called_once_with(self.ADDR)
+
+
+class TestNixlRemotePeerRegistration(CustomTestCase):
+    def _make_manager(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.agent = MagicMock()
+        mgr.decode_kv_args_table = {}
+        mgr.prep_handles = {}
+        mgr.prep_handles_slice_dst = {}
+        mgr.disaggregation_mode = DisaggregationMode.PREFILL
+        mgr.requires_dcp_relayout = MagicMock(return_value=False)
+        mgr._prepare_payload_xfer = MagicMock()
+        return mgr
+
+    @staticmethod
+    def _peer(agent_name):
+        return SimpleNamespace(
+            agent_name=agent_name,
+            agent_metadata=f"metadata-{agent_name}".encode("ascii"),
+            dst_dcp_size=1,
+            dst_dcp_rank=0,
+        )
+
+    def test_failed_registration_is_atomic_and_retryable(self):
+        mgr = self._make_manager()
+        peer = self._peer("decode-agent")
+        mgr.agent.add_remote_agent.side_effect = [RuntimeError("UCX failed"), None]
+
+        with self.assertRaisesRegex(RuntimeError, "UCX failed"):
+            mgr._add_remote_peer(peer)
+
+        self.assertNotIn(peer.agent_name, mgr.decode_kv_args_table)
+
+        mgr._add_remote_peer(peer)
+
+        self.assertIs(mgr.decode_kv_args_table[peer.agent_name], peer)
+        self.assertEqual(mgr.agent.add_remote_agent.call_count, 2)
+        mgr._prepare_payload_xfer.assert_called_once_with(peer)
+
+    def test_invalidated_remote_metadata_is_registered_again(self):
+        mgr = self._make_manager()
+        old_peer = self._peer("decode-agent")
+        replacement = self._peer("decode-agent")
+        mgr.decode_kv_args_table[old_peer.agent_name] = old_peer
+        mgr.agent.check_remote_metadata.return_value = False
+
+        mgr._add_remote_peer(replacement)
+
+        mgr.agent.remove_remote_agent.assert_called_once_with("decode-agent")
+        mgr.agent.add_remote_agent.assert_called_once_with(replacement.agent_metadata)
+        self.assertIs(mgr.decode_kv_args_table[replacement.agent_name], replacement)
+
+    def test_new_decode_agent_registers_alongside_stale_agent(self):
+        mgr = self._make_manager()
+        old_peer = self._peer("old-decode-agent")
+        replacement = self._peer("new-decode-agent")
+        mgr.decode_kv_args_table[old_peer.agent_name] = old_peer
+
+        mgr._add_remote_peer(replacement)
+
+        self.assertEqual(
+            set(mgr.decode_kv_args_table),
+            {"old-decode-agent", "new-decode-agent"},
+        )
+        mgr.agent.add_remote_agent.assert_called_once_with(replacement.agent_metadata)
+
+
+class TestNixlBootstrapThread(CustomTestCase):
+    def test_bootstrap_thread_survives_recv_errors_and_exits_on_shutdown(self):
+        """The bootstrap thread is the only receiver of peer registrations:
+        recv errors must not kill it, and only ETERM/ENOTSOCK may end it.
+        Drives a non-zmq error, a transient zmq error, one message, and
+        shutdown."""
+        mgr = object.__new__(NixlKVManager)
+        handled = []
+        mgr._handle_bootstrap_message = handled.append
+        mgr.server_socket = MagicMock()
+        mgr.server_socket.recv_multipart.side_effect = [
+            ValueError("malformed frame"),
+            zmq.ZMQError(zmq.EAGAIN),
+            [b"frame"],
+            zmq.ZMQError(zmq.ETERM),
+        ]
+        threads = []
+        real_thread = threading.Thread
+
+        def capture_thread(*args, **kwargs):
+            # Daemonize so a regressed shutdown path (thread never exits)
+            # fails the assertion below instead of wedging the test process.
+            kwargs.setdefault("daemon", True)
+            thread = real_thread(*args, **kwargs)
+            threads.append(thread)
+            return thread
+
+        with patch(
+            "sglang.srt.disaggregation.nixl.conn.threading.Thread",
+            side_effect=capture_thread,
+        ), patch("sglang.srt.disaggregation.nixl.conn.time.sleep"):
+            mgr._start_bootstrap_thread()
+            threads[0].join(timeout=10)
+
+        self.assertFalse(threads[0].is_alive())
+        self.assertEqual(handled, [[b"frame"]])
 
 
 class TestNixlStaging(CustomTestCase):
@@ -837,6 +2328,85 @@ class TestNixlStaging(CustomTestCase):
 
         self.assertIn(3, mgr._staging_ctx.prefetched_rooms)
 
+    def test_prefetch_predicate_survives_concurrent_peer_discard(self):
+        """The staging predicate reads decode_kv_args_table while the
+        bootstrap thread pops entries; check-then-index raced to a KeyError.
+        Reproduced with a table whose membership test discards the entry."""
+
+        class DiscardOnContains(dict):
+            def __contains__(self, key):
+                present = super().__contains__(key)
+                if present:
+                    super().pop(key)
+                return present
+
+        mgr = self._make_manager()
+        mgr.enable_staging = True
+        mgr.kv_buffer_tensors = {"k_buffers": [], "v_buffers": [], "page_size": 1}
+        mgr._staging_ctx = PrefillStagingContext()
+        mgr.transfer_infos = {
+            3: {
+                "agent": TransferInfo(
+                    room=3,
+                    endpoint="127.0.0.1",
+                    dst_port=1000,
+                    agent_name="agent",
+                    dst_kv_indices=np.array([1], dtype=np.int32),
+                    dst_aux_index=0,
+                    required_dst_info_num=1,
+                    dst_state_indices=[],
+                )
+            }
+        }
+        mgr.decode_kv_args_table = DiscardOnContains(
+            {"agent": SimpleNamespace(decode_tp_size=2)}
+        )
+
+        mgr._prefetch_staging_reqs(3)
+
+        self.assertIn(3, mgr._staging_ctx.prefetched_rooms)
+
+    def test_missing_peer_leaves_room_retryable(self):
+        """Regression: classifying a mid-re-registration peer as "no staging
+        needed" permanently marked the room prefetched with no STAGING_REQ
+        ever sent. An unresolved peer leaves the room unmarked; the fan-out
+        must then run."""
+        mgr = self._make_manager()
+        mgr.enable_staging = True
+        mgr.kv_buffer_tensors = {"k_buffers": [], "v_buffers": [], "page_size": 1}
+        mgr._staging_ctx = PrefillStagingContext()
+        mgr.transfer_infos = {
+            3: {
+                "agent": TransferInfo(
+                    room=3,
+                    endpoint="127.0.0.1",
+                    dst_port=1000,
+                    agent_name="agent",
+                    dst_kv_indices=np.array([1], dtype=np.int32),
+                    dst_aux_index=0,
+                    required_dst_info_num=1,
+                    dst_state_indices=[],
+                )
+            }
+        }
+        mgr.decode_kv_args_table = {}
+
+        mgr._prefetch_staging_reqs(3)
+
+        self.assertNotIn(3, mgr._staging_ctx.prefetched_rooms)
+
+        mgr.decode_kv_args_table["agent"] = SimpleNamespace(decode_tp_size=4)
+        with patch(
+            "sglang.srt.disaggregation.nixl.conn.get_schedule",
+            return_value=SimpleNamespace(chunked_prefill_size=4),
+        ), patch(
+            "sglang.srt.disaggregation.common.staging_handler.prefetch_staging_reqs"
+        ) as fan_out:
+            mgr._prefetch_staging_reqs(3)
+
+        fan_out.assert_called_once()
+        self.assertIn(3, mgr._staging_ctx.prefetched_rooms)
+
     def test_do_staging_transfer_requeues_when_allocation_not_ready(self):
         mgr = self._make_manager()
         mgr._staging_ctx = PrefillStagingContext()
@@ -871,6 +2441,72 @@ class TestNixlStaging(CustomTestCase):
                 queue,
             )
 
+        self.assertIsNone(handle)
+        self.assertTrue(deferred)
+        self.assertEqual(queue.items, [kv_chunk])
+
+    def test_last_chunk_of_unprefetched_room_fails_instead_of_spinning(self):
+        """Regression: a last chunk enqueued while the prefetch bailed on a
+        re-registering peer can never become ready, and no later chunk
+        re-runs the prefetch -- requeueing waits forever. It must fail the
+        room so the retry re-runs the prefetch; non-last chunks may requeue."""
+        kv_chunk = TransferKVChunk(
+            room=3,
+            prefill_kv_indices=np.array([10, 11], dtype=np.int32),
+            index_slice=slice(0, 2),
+            is_last_chunk=True,
+            chunk_id=0,
+            prefill_aux_index=0,
+            state_indices=None,
+        )
+        req = SimpleNamespace(room=3, agent_name="decode_agent")
+        strategy = MagicMock()
+        strategy.check_ready.return_value = (False, 0, -1, 0, -1)
+
+        mgr = self._make_manager()
+        mgr._staging_ctx = PrefillStagingContext()  # room 3 never prefetched
+        queue = FakeQueue()
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.disaggregation.common.staging_buffer": (
+                    _fake_staging_buffer_module()
+                )
+            },
+        ):
+            with self.assertRaisesRegex(RuntimeError, "No staging request"):
+                mgr._do_staging_transfer(
+                    strategy,
+                    kv_chunk,
+                    kv_chunk.prefill_kv_indices,
+                    req,
+                    SimpleNamespace(),
+                    queue,
+                )
+        self.assertEqual(queue.items, [])
+
+        # Control: the same last chunk keeps requeueing normally when the
+        # prefetch did run — a pending allocation is legitimately in flight.
+        mgr = self._make_manager()
+        mgr._staging_ctx = PrefillStagingContext()
+        mgr._staging_ctx.prefetched_rooms.add(3)
+        queue = FakeQueue()
+        with patch.dict(
+            sys.modules,
+            {
+                "sglang.srt.disaggregation.common.staging_buffer": (
+                    _fake_staging_buffer_module()
+                )
+            },
+        ):
+            handle, deferred = mgr._do_staging_transfer(
+                strategy,
+                kv_chunk,
+                kv_chunk.prefill_kv_indices,
+                req,
+                SimpleNamespace(),
+                queue,
+            )
         self.assertIsNone(handle)
         self.assertTrue(deferred)
         self.assertEqual(queue.items, [kv_chunk])

--- a/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
+++ b/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
@@ -31,6 +31,7 @@ class TestNixlSenderFailureCleanup(unittest.TestCase):
             exceptions={room: expected_exc},
             failure_records={room: "transfer failed"},
             failure_lock=threading.Lock(),
+            status_lock=threading.Lock(),
         )
 
         with self.assertRaises(RuntimeError) as cm:

--- a/test/registered/unit/disaggregation/test_receiver_connection_pool.py
+++ b/test/registered/unit/disaggregation/test_receiver_connection_pool.py
@@ -46,10 +46,14 @@ class _FetchingReceiver(_ConcreteReceiver):
 
 def _fetching_receiver(connection_pool):
     receiver = object.__new__(_FetchingReceiver)
+    # The table holds this receiver's snapshot: publishing fetched endpoints
+    # to the pool is generation-gated on it.
+    receiver.prefill_info = object()
     receiver.kv_mgr = SimpleNamespace(
         connection_pool=connection_pool,
         connection_lock=threading.Lock(),
         is_mla_backend=False,
+        prefill_info_table={"prefill:8998": receiver.prefill_info},
     )
     receiver.bootstrap_addr = "prefill:8998"
     receiver.bootstrap_room = 1

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -113,6 +113,9 @@ class TestDecodePreallocQueuePriority(unittest.TestCase):
         queue.pp_size = 1
         queue.queue = list(decode_reqs)
         queue.pending_reqs = []
+        # `pop_preallocated` prunes this map for failed requests; `__new__`
+        # skips the __init__ that seeds it.
+        queue._dp_rank_query_first_attempt = {}
         queue.retracted_queue = []
         queue.num_reserved_decode_tokens = 0
         # `pop_preallocated` credits this counter; `__new__` skips the __init__


### PR DESCRIPTION
## Motivation

Addresses the prefill-replacement stall in #33789. When a prefill is replaced behind a bootstrap address that stays reachable (typically a k8s Service), the decode never notices: its cached rank endpoints still point at the dead process, so every request after the swap dies on the waiting timeout until the decode is restarted.

Reproduced on 2x RTX 3090 (Qwen2.5-0.5B, mini-lb, NIXL). With a direct address and the default 5 s heartbeat, stock recovers on its own, so the repro masks the heartbeat (`SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL=120`) and swaps the prefill inside the window:

| phase | stock v0.5.16 | this PR |
|---|---|---|
| baseline request | pass | pass |
| right after the swap | fails (expected: the first request is the detection signal) | fails (expected) |
| after one heartbeat tick | stuck forever | pass |

Same result on TP=2 (4x RTX 3090), and re-validated against v0.5.17.

## Modifications

The bootstrap server returns a per-process instance id in a `X-SGLang-Disaggregation-Instance-ID` response header. A header rather than a JSON field because old decodes reject unknown topology keys. The decode caches the id it registered against and recovers on two paths:

- Heartbeat: each tick probes `/health` on a fresh connection (a kept-alive socket would keep reaching the draining old process). A healthy answer with a different id evicts the cached connections and fails the in-flight rooms, so retries re-bootstrap against the new instance.
- Failure backstop (NIXL): a request that fails on reused cached endpoints re-probes `/health`. A healthy answer with a different id gets the same treatment; an inconclusive probe (error, non-200, id missing) only invalidates the cache, so a slow-but-alive prefill is not mass-retried.

Per-rank and dp-rank query responses are validated against the cached id too, since a kept-alive socket to a draining process could otherwise repopulate a fresh cache with dead endpoints. Every verdict is anchored to the topology snapshot captured before the network call that produced it, so a verdict racing a replacement plus recovery can never tear down a freshly recovered cache. The concurrency reasoning is in comments next to each gate.

While testing this path I hit and fixed several adjacent bugs: connection eviction matched addresses by string prefix; unlocked reads and writes of the shared tables could kill the heartbeat thread (KeyError/RuntimeError); a concurrent `max()`-based status write could resurrect an already-failed room; failed rooms leaked staging counts, tracker entries, dp-rank deadlines and failure records; and the NIXL bootstrap thread died on any exception. Each fix has a regression test that was verified to fail on the pre-fix code.

The second commit adds the same header to `rust/sglang-server` and pins its `/health` shallow when the bootstrap registry is mounted (the deep probe stays on `/health_generate`): the decode reads bootstrap `/health` with short timeouts, and the default 20 s generation probe would count as heartbeat misses and retire a healthy prefill. Happy to drop this commit and take Rust parity as a follow-up if preferred.

The PD disaggregation guide gains a short section on replacement detection.

Known limitations, kept out of scope on purpose:

- The decode-replacement direction of #33789 is unchanged: replaced decodes still leave stale peer registrations on the prefill.
- Decode-to-prefill registration stays a one-way ZMQ send, as today; a lost registration is not retried until the next eviction.
- Replacements between two pre-instance-id prefills stay undetectable (nothing to compare), same as stock.

## Testing

`test/registered/unit/disaggregation/` plus the priority-scheduling suite: 213 tests + 31 subtests, all bug-regression cases red-verified on pre-fix code. `cargo test -p sglang-server --lib` for the Rust side. E2E `test_disaggregation_nixl.py::test_role_replacements_reconnect` masks the heartbeat, replaces the prefill (SIGTERM before SIGKILL, matching how k8s replaces a pod) and asserts recovery; on stock code that assertion is the one that fails, matching the table above.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32989262235](https://github.com/sgl-project/sglang/actions/runs/32989262235)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32989261289](https://github.com/sgl-project/sglang/actions/runs/32989261289)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32989262496](https://github.com/sgl-project/sglang/actions/runs/32989262496)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->