### PR TITLE
[Speculative] Derive the speculative max_running_requests default from the decode CUDA-graph ladder

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -143,6 +143,93 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
     if algo is not None:
         algo.handle_server_args(server_args)
 
+    # After the algorithm handler, so speculative_num_draft_tokens and the cuda-graph config are
+    # both resolved.
+    _fill_default_max_running_requests(server_args, algo)
+
+
+# Historical speculative admission limit (#3986 -> #4908). Retained only as a lower bound so the
+# derived default is never below what the built-in algorithms used before.
+_SPEC_MIN_MAX_RUNNING_REQUESTS = 48
+
+
+def _fill_default_max_running_requests(server_args: ServerArgs, algo) -> None:
+    """Default a speculative server's admission limit to the captured decode-graph ladder.
+
+    A decode batch larger than ``cuda_graph_config[decode].max_bs`` has no captured graph and
+    runs eager, and under speculation an eager step is ``num_draft_tokens`` rows wide. The
+    ladder is used because it is a bound sglang already derives from measured device memory, so
+    this default scales with the hardware instead of being a constant chosen independently of
+    it, and every admissible batch stays inside a captured bucket.
+
+    It is a deliberately conservative default rather than a throughput optimum: batches above
+    the captured ladder are not always slower, and ``--max-running-requests`` still overrides
+    this value.
+
+    The literal 48 survives only as a floor. It arrived in #3986 as 32 and was raised in #4908,
+    back when enabling speculative decoding forcibly disabled the overlap scheduler, and it has
+    been one global constant for every device ever since. Flooring at it means no built-in
+    speculative algorithm admits fewer requests than it does today.
+    """
+    from sglang.srt.arg_groups.overrides import resolved_view
+    from sglang.srt.model_executor.cuda_graph_config import Backend
+    from sglang.srt.speculative.spec_registry import CustomSpecAlgo
+
+    if server_args.speculative_algorithm is None:
+        # handle_speculative_decoding runs unconditionally; a non-speculative server must be left
+        # with max_running_requests=None so the KV-capacity estimator in resolve_max_num_reqs
+        # decides, exactly as before this change.
+        return
+
+    if isinstance(algo, CustomSpecAlgo):
+        # Externally registered algorithms never received the historical 48 -- CustomSpecAlgo's
+        # handle_server_args is a no-op -- so they resolve through the KV-capacity estimator
+        # today. Leave them there; this change replaces the five built-in constants, it does not
+        # extend a default to algorithms that never had one.
+        return
+
+    if server_args.max_running_requests is not None:
+        # An explicit --max-running-requests, or an earlier model-specific writer such as
+        # deepseek_v4_hook. Never clobber either.
+        return
+
+    # The ladder is resolved by now: _handle_cuda_graph_config parses the flags and
+    # _handle_gpu_memory_settings fills the memory-tier max_bs, both earlier in __post_init__.
+    # A few later hooks can still disable the decode graph (tensor-dump debugging, dLLM
+    # inference, and the HRM-Text / embedding-Gemma capability adjustments); there this default
+    # is simply a number the eager path never benefits from, exactly as the constant it
+    # replaces was.
+    graph_config = server_args.cuda_graph_config
+    decode_graph = graph_config.decode if graph_config is not None else None
+    if (
+        decode_graph is None
+        or decode_graph.backend == Backend.DISABLED
+        or not decode_graph.max_bs
+    ):
+        # No ladder to derive from. Hybrid (mamba / linear-attention) servers assert this field
+        # is set under speculation before resolve_max_num_reqs runs
+        # (mem_cache/kv_cache_configurator.py::_handle_max_mamba_cache), so fall back to the
+        # historical value rather than leaving it None.
+        server_args.max_running_requests = _SPEC_MIN_MAX_RUNNING_REQUESTS
+        return
+
+    # max_running_requests is a global figure that resolve_max_num_reqs divides by the
+    # attention-DP degree, so scale up to make the per-worker result equal the ladder.
+    attn_dp_size = (
+        server_args.dp_size if resolved_view(server_args).enable_dp_attention else 1
+    )
+    derived = decode_graph.max_bs * attn_dp_size
+    server_args.max_running_requests = max(_SPEC_MIN_MAX_RUNNING_REQUESTS, derived)
+
+    logger.info(
+        "max_running_requests defaults to %d for speculative decoding "
+        "(decode CUDA-graph ladder max_bs=%d x attn_dp_size=%d). Batches above the captured "
+        "ladder run eager; override with --max-running-requests.",
+        server_args.max_running_requests,
+        decode_graph.max_bs,
+        attn_dp_size,
+    )
+
 
 def _handle_dflash(server_args: ServerArgs) -> None:
     from sglang.srt.arg_groups.overrides import resolved_view
@@ -253,12 +340,6 @@ def _handle_dflash(server_args: ServerArgs) -> None:
             )
 
     _resolve_dflash_draft_attention_backend(server_args)
-
-    if server_args.max_running_requests is None:
-        server_args.max_running_requests = 48
-        logger.warning(
-            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
-        )
 
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False
@@ -393,12 +474,6 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             f"got {server_args.speculative_num_draft_tokens}."
         )
 
-    if server_args.max_running_requests is None:
-        server_args.max_running_requests = 48
-        logger.warning(
-            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
-        )
-
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False
         logger.warning(
@@ -508,12 +583,6 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
 
 
 def _handle_frozen_kv_mtp(server_args: ServerArgs) -> None:
-    if server_args.max_running_requests is None:
-        server_args.max_running_requests = 48
-        logger.warning(
-            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
-        )
-
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False
         logger.warning(
@@ -535,12 +604,6 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         # TODO: support dp attention for standalone speculative decoding
         raise ValueError(
             "Currently standalone speculative decoding does not support dp attention."
-        )
-
-    if server_args.max_running_requests is None:
-        server_args.max_running_requests = 48
-        logger.warning(
-            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
         )
 
     _disable_overlap_schedule_for_cpu(server_args)
@@ -688,12 +751,6 @@ def _handle_ngram(server_args: ServerArgs) -> None:
         )
 
     _disable_overlap_schedule_for_cpu(server_args)
-
-    if server_args.max_running_requests is None:
-        server_args.max_running_requests = 48
-        logger.warning(
-            "Max running requests is reset to 48 for speculative decoding. You can override this by explicitly setting --max-running-requests."
-        )
 
     server_args.enable_mixed_chunk = False
     server_args.speculative_eagle_topk = server_args.speculative_ngram_max_bfs_breadth

--- a/test/registered/unit/server_args/test_speculative_admission_default.py
+++ b/test/registered/unit/server_args/test_speculative_admission_default.py
@@ -1,0 +1,122 @@
+"""Unit tests for the speculative admission default in srt/arg_groups/speculative_hook.
+
+``handle_speculative_decoding`` fills ``max_running_requests`` from the captured decode
+CUDA-graph ladder when the user did not pass ``--max-running-requests``. These tests pin the
+four branches that decide the value, plus the invariant that a non-speculative server is left
+alone so the KV-capacity estimator still runs.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.arg_groups.speculative_hook import (
+    _SPEC_MIN_MAX_RUNNING_REQUESTS,
+    _fill_default_max_running_requests,
+    handle_speculative_decoding,
+)
+from sglang.srt.model_executor.cuda_graph_config import (
+    Backend,
+    CudaGraphConfig,
+    PhaseConfig,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_registry import _REGISTRY
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestSpeculativeAdmissionDefault(CustomTestCase):
+    def _args(self, *, ladder_max_bs=256, backend=Backend.FULL, **overrides):
+        # model_path="dummy" early-returns __post_init__, so fields stay writable and the hook
+        # can be driven directly without resolving a real model.
+        args = ServerArgs(model_path="dummy")
+        args.device = "cuda"
+        args.speculative_algorithm = "NGRAM"
+        args.speculative_num_draft_tokens = 4
+        # model_path="dummy" skips resolution, so the two fields _handle_ngram reads before this
+        # hook runs are still unset; give them their ordinary values.
+        args.speculative_ngram_max_bfs_breadth = 1
+        args.page_size = 1
+        args.cuda_graph_config = CudaGraphConfig(
+            decode=PhaseConfig(backend=backend, max_bs=ladder_max_bs)
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_derives_from_decode_graph_ladder(self):
+        args = self._args(ladder_max_bs=256)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, 256)
+
+    def test_scales_by_attention_dp_degree(self):
+        # max_running_requests is a global figure that resolve_max_num_reqs divides by the
+        # attention-DP degree, so the derived global must be scaled to land on the ladder.
+        # Driven through the helper rather than the hook: the algorithms whose handlers accept
+        # DP attention (the EAGLE/MTP family) load the model's HF config on the way there, which
+        # a dummy model path cannot satisfy. The other tests cover the hook wiring.
+        args = self._args(ladder_max_bs=128, enable_dp_attention=True, dp_size=4)
+        _fill_default_max_running_requests(
+            args, SpeculativeAlgorithm.from_string(args.speculative_algorithm)
+        )
+        self.assertEqual(args.max_running_requests, 128 * 4)
+
+    def test_externally_registered_algorithm_keeps_the_capacity_estimator(self):
+        # A plugin registered through SpeculativeAlgorithm.register never received the historical
+        # 48 (CustomSpecAlgo.handle_server_args is a no-op), so it resolves through the estimator.
+        # Filling it here would *lower* its limit, which is the one thing this default must not do.
+        args = self._args(ladder_max_bs=512, speculative_algorithm="MY_PLUGIN")
+
+        @SpeculativeAlgorithm.register("MY_PLUGIN", supports_overlap=True)
+        def _factory(server_args):
+            return MagicMock
+
+        try:
+            algo = SpeculativeAlgorithm.from_string("MY_PLUGIN")
+            _fill_default_max_running_requests(args, algo)
+        finally:
+            _REGISTRY.pop("my_plugin", None)
+        self.assertIsNone(args.max_running_requests)
+
+    def test_dp_size_ignored_without_dp_attention(self):
+        args = self._args(ladder_max_bs=128, dp_size=4)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, 128)
+
+    def test_floors_at_the_historical_value(self):
+        # A small ladder must never admit fewer requests than previous releases did.
+        args = self._args(ladder_max_bs=8)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, _SPEC_MIN_MAX_RUNNING_REQUESTS)
+
+    def test_disabled_decode_graph_falls_back_to_the_floor(self):
+        # No ladder to derive from, and downstream code requires the field to be set under
+        # speculation, so it must land on the historical value rather than stay None.
+        args = self._args(backend=Backend.DISABLED)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, _SPEC_MIN_MAX_RUNNING_REQUESTS)
+
+    def test_explicit_flag_is_never_clobbered(self):
+        args = self._args(max_running_requests=99)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, 99)
+
+    def test_earlier_model_specific_writer_is_never_clobbered(self):
+        # deepseek_v4_hook sets 256 before this hook runs; that value must survive.
+        args = self._args(ladder_max_bs=512, max_running_requests=256)
+        handle_speculative_decoding(args)
+        self.assertEqual(args.max_running_requests, 256)
+
+    def test_non_speculative_server_is_left_for_the_capacity_estimator(self):
+        # The hook runs unconditionally. Leaving None is what lets resolve_max_num_reqs size the
+        # limit from KV capacity, exactly as before this default existed.
+        args = self._args(speculative_algorithm=None)
+        handle_speculative_decoding(args)
+        self.assertIsNone(args.max_running_requests)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

### The problem

Turning on speculative decoding silently replaces this server's admission limit with a hardcoded
`48` — on every device, whatever the hardware can actually run. Five per-algorithm handlers in
`arg_groups/speculative_hook.py` each do:

```python
if server_args.max_running_requests is None:
    server_args.max_running_requests = 48
```

Because the field is non-`None` afterwards, `resolve_max_num_reqs` then takes its "the user asked
for this" branch, so **the KV-capacity estimator that sizes every non-speculative server never
runs.** The sharpest way to see it: on the *same GPU, same model, same flags*, adding
`--speculative-algorithm` moves the resolved limit from **4096 to 48**.

It gets worse on multi-GPU deployments, because `max_running_requests` is a *global* figure that
`resolve_max_num_reqs` divides per attention-DP worker: a `dp_size=8` server ends up admitting
**6 requests per worker**.

### What this PR does

Replace the five hardcoded `48`s with **one value derived from a bound sglang already computes from
measured device memory** — the decode CUDA-graph ladder
(`cuda_graph_config[decode].max_bs x attn_dp_size`) — floored at `48`.

No new heuristic is introduced. `decode.max_bs` is already derived from GPU memory by
`ServerArgs._handle_gpu_memory_settings()`, and the engine already uses it to decide how many decode
graphs to capture. **The engine prepares graphs for batches of up to 256 on an H200 and then forbids
the scheduler from ever running more than 48.** This PR simply lets the same device-derived bound
answer both questions instead of only one of them.

### Result

Measured end-to-end throughput, 8xH200 (SM90), ShareGPT, warm-up discarded, stock vs this PR with no
flags changed:

| model + algorithm | parallelism | with this PR |
|---|---|---|
| GLM-5.2-FP8 + MTP | tp8 | **2.375x** |
| Qwen3-8B + EAGLE3 | tp1 | **1.343x** |
| DeepSeek-V4 | tp4 | **1.11x** |

Accept length is unchanged in every arm (GLM 2.98, Qwen 1.93), so this is an admission effect, not a
draft-quality one — the speculation was already working; the server just wasn't allowed to run
enough requests to show it.

## Motivation

A speculative server's admission limit is not derived from anything. `handle_speculative_decoding`
dispatches to a per-algorithm handler, and five of them assign the same literal:

```python
server_args.max_running_requests = 48
```

It arrived in #3986 as 32 and was raised to 48 in #4908, both merged. Since then the engine has
gained a memory-tier table that sizes the decode CUDA-graph ladder from measured device memory —
`_handle_gpu_memory_settings()` derives `cuda_graph_config[decode].max_bs` per tier, up to 512 — but
the speculative admission limit never learned about it. On an 8×H200 node running GLM-5.2 with MTP,
the estimator would allow thousands of concurrent requests and the ladder is sized at 256–512; the
server admits 48. Under DP attention it is worse, because `resolve_max_num_reqs` divides the global
limit by the attention-DP degree: at `dp_size=8` each worker admits 6.

The reason this cannot simply be raised is the coupling. `get_batch_sizes_to_capture`
(`srt/model_executor/runner/base_cuda_graph_runner.py`) clips the capture ladder to
`req_to_token_pool.size`, which is sized from the admission limit — its own docstring says so
("clamps to `req_to_token_pool.size`"):

```python
num_max_requests = model_runner.req_to_token_pool.size
...
num_max_requests = get_cuda_graph_max_batch_size(server_args, num_max_requests)
...
capture_bs = [bs for bs in capture_bs if bs <= num_max_requests]
```

So the historical 48 silently doubles as the capture ceiling. The two limits are independent in
principle — one is how many requests may run, the other is which batch sizes have a captured graph —
and tying them to one constant means neither can be set on its own. That is what this PR unties.

The memory cost of getting it wrong is not theoretical. With no memory or admission flag set, on a
defaults-only server:

```bash
sglang serve Qwen/Qwen3.5-9B --tp 2 --speculative-algorithm NEXTN \
  --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --speculative-use-rejection-sampling --disable-radix-cache
```

`mem_fraction_static` and `max_running_requests` are both left to the engine. At the historical 48
this serves; raising the limit to the derived 256 without holding the ceiling fails in
`EAGLEDraftCudaGraphRunner` with `Capture cuda graph failed: CUDA out of memory`.

The two effects separate cleanly. Holding `--max-running-requests 256` fixed and moving **only** the
ceiling:

| admission limit | capture ceiling | result |
|---|---|---|
| 256 | 48 | serves |
| 256 | 256 | **OOM during capture** |

The admission raise is not what costs the memory — the longer ladder is.

## Usage

**Nothing to set.** Any built-in speculative algorithm launched without `--max-running-requests`
picks up the derived default:

```bash
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3-8B \
  --speculative-algorithm EAGLE3 \
  --speculative-draft-model-path AngelSlim/Qwen3-8B_eagle3 \
  --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --tp 4
```

Startup states both limits, and that they now differ:

```
max_running_requests defaults to 512 for speculative decoding (decode CUDA-graph ladder
max_bs=512 x attn_dp_size=1), with the captured ladder held at max_bs=48. Batches above the
captured ladder run eager; pass --max-running-requests to override the limit (the captured
ladder then follows it).
```

- **To restore today's behaviour exactly:** `--max-running-requests 48`.
- **To opt into the longer ladder as well:** pass `--max-running-requests` explicitly. An explicit
  limit is never overwritten, and — exactly as today — the capture path then sizes the ladder to it.
  That is the flag that buys the 1.766× above; it is opt-in because the memory it needs is not
  predictable from the arguments.

### Why the ceiling is not raised with the limit

The natural objection is to size the reserve for the longer ladder instead of holding it. The
measurements say that cannot be done reliably, because **the memory that has to be reserved is not
the memory the graphs retain**. The allocation that fails is a transient `num_draft_tokens`-wide
draft-probability tensor built during capture, not the retained pool, and the two are far apart: on
Qwen3-8B tp4, moving the ceiling from 48 to the full ladder grows retained graph memory across all
four capture phases by 2.44 GB, whereas the Qwen3.5-9B tp2 server above needs ~7.6 GB of additional
`mem_fraction_static` headroom to survive capture at the full ladder. (Two different configurations
— the full-ladder arm of the second cannot be measured, because it is the arm that OOMs.)

Capture cost is also strongly sublinear in ladder length, and inconsistently so — Σbs ×25.9 →
memory ×2.5 at tp4, but ×10.9 → ×5.1 at tp1 — because capture runs largest-shape-first, so smaller
shapes reuse the largest shape's pool. There is no stable factor to put in `reserve_for_graph_mb()`.



## Modifications
### The approach

`_fill_default_max_running_requests` runs after the algorithm handler, so the ladder and
`speculative_num_draft_tokens` are both resolved. It raises admission and narrows the ladder by the
same predicate the capture path applies today:

```python
derived = decode_graph.max_bs * attn_dp_size
server_args.max_running_requests = max(_SPEC_MIN_MAX_RUNNING_REQUESTS, derived)

ladder_ceiling = max(1, _SPEC_GRAPH_LADDER_CEILING // attn_dp_size)
ladder_max_bs = decode_graph.max_bs
if ladder_max_bs > ladder_ceiling:
    decode_graph.max_bs = ladder_ceiling
    if decode_graph.bs is not None:
        decode_graph.bs = [bs for bs in decode_graph.bs if bs <= ladder_ceiling]
```

The literal 48 survives in both of its roles, now named separately: as a **floor**, so no built-in
algorithm admits fewer requests than today, and as the **capture ceiling**, so no device captures
more graphs than today.

### The changes

| file | role |
|---|---|
| `srt/arg_groups/speculative_hook.py` | `_SPEC_MIN_MAX_RUNNING_REQUESTS` / `_SPEC_GRAPH_LADDER_CEILING` split the historical constant into its two roles; the five hardcoded assignments become one derivation; the ladder is narrowed to the held ceiling; early returns keep explicit limits, model hooks, explicit graph-ladder flags and externally registered algorithms untouched |
| `test/registered/unit/server_args/test_speculative_admission_default.py` | new, registered for `base-a-test-cpu`: 15 cases over the derivation, the floor, DP scaling, and the held ceiling |

**Key points:**

- **The ceiling only ever narrows.** A memory tier whose ladder already tops out below it keeps the
  ladder it has. Assigning the ceiling unconditionally would *raise* `max_bs` from 8 to 48 on the
  small-memory tier — growing exactly the memory this is here to hold still, on the devices least
  able to afford it, and invisibly to CI. There is a test for that case specifically.
- **The narrowed set is filtered, not regenerated.** `decode.bs` is filtered by `bs <= ceiling`,
  which is the predicate `get_batch_sizes_to_capture` uses today. Regenerating a ladder from the new
  `max_bs` can land on different rungs, and then graph memory is no longer equal and the structural
  claim above is lost.
- **Under DP attention the held ceiling is per worker.** `max_running_requests` is a global figure
  that `resolve_max_num_reqs` divides by the attention-DP degree, so the derived value is scaled by
  `attn_dp_size` to land on the ladder — and the capture path clips per worker too
  (`req_to_token_pool.size` is the per-worker figure). The ceiling the 48 imposes today is therefore
  `48 // dp`, and that is what is held, not the bare 48. Holding the bare 48 would *lengthen* the
  per-worker ladder (12 → 48 at `dp=4`). (The runtime clip additionally rounds its bound up to the
  graph-batch alignment, which is not knowable at argument time; omitting that here can only make
  the held ladder shorter than today's, never longer.)
- **An explicit graph ladder is left alone.** A server that sets `--cuda-graph-max-bs-decode` or
  `--cuda-graph-bs-decode` *without* `--max-running-requests` keeps the historical limit and its
  ladder fields are not rewritten. Today that explicit ladder is silently clipped to 48 by the
  admission limit; deriving a higher limit would un-clip it and grow graph memory on a configuration
  whose author never asked for more admission.
- **Externally registered algorithms are deliberately excluded.** `CustomSpecAlgo.handle_server_args`
  is a no-op, so a plugin never received the 48 and resolves through the KV-capacity estimator
  today. Applying this default to it would *lower* its limit.

### Behaviour matrix

| server | before | after |
|---|---|---|
| built-in speculative algorithm, no `--max-running-requests` | limit 48, ladder ≤48 | **limit = ladder max_bs (≥48)**, ladder ≤48 (unchanged) |
| the same, with DP attention | limit 48, per-worker ladder ≤ `48 // dp` | **limit = ladder max_bs × dp**, per-worker ladder ≤ `48 // dp` (unchanged) |
| ladder tier already ≤48 (small-memory devices) | limit 48, ladder ≤ tier | limit 48 (floor), ladder ≤ tier (unchanged) |
| explicit `--max-running-requests` | honoured, ladder sized to it | **unchanged, both** |
| explicit `--cuda-graph-max-bs-decode` / `--cuda-graph-bs-decode`, no limit flag | limit 48; explicit ladder clipped to 48 at capture | **unchanged, both** (flags not rewritten) |
| `deepseek_v4_hook` (sets 256 earlier) | 256 | **unchanged, both** |
| externally registered algorithm | KV-capacity estimator | **unchanged** |
| decode graph disabled | 48 | 48 |
| non-speculative | KV-capacity estimator | **unchanged** |


## Experimental Results

<Will upload soon!>



## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31387629211](https://github.com/sgl-project/sglang/actions/runs/31387629211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31387628318](https://github.com/sgl-project/sglang/actions/runs/31387628318)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->