### PR TITLE
[CPU] Fold the MXFP4 block scale in 2 instructions instead of 4

### DIFF
--- a/python/sglang/kernels/aot/csrc/cpu/vec.h
+++ b/python/sglang/kernels/aot/csrc/cpu/vec.h
@@ -202,11 +202,12 @@ inline std::tuple<__m512bh, __m512bh> cvt_mxfp4_e2m1_bf16_intrinsic_lut(__m256i 
   // Emulate the bf16 multiply by the E8M0 scale as an integer add on the
   // exponent field, forcing zeros to stay zero.
   //
-  // vptestmw sets a lane's mask bit when (x & 0x7FFF) != 0, i.e. exactly for
-  // the lanes that are not +0.0 or -0.0, and the zero-masking form of vpaddw
-  // writes 0 to the lanes the mask leaves clear. That is the same predicate as
-  // the previous and/cmp/add/blend sequence and the same result on every lane,
-  // including the LUT's -0.0 entry, which both versions turn into +0.0.
+  // vptestmw sets a lane's mask bit when (x & 0x7FFF) != 0, i.e. for the lanes
+  // that are not +0.0 or -0.0. That is the *complement* of the mask the old
+  // and/cmp/add/blend sequence built, which selected the zero lanes; the
+  // zero-masking form of vpaddw then writes 0 where the mask is clear, so the
+  // two agree lane by lane. That includes the LUT's -0.0 entry, which both
+  // versions turn into +0.0.
   //
   // 2 instructions per vector instead of 4, no extra ISA requirement:
   // vptestmw is AVX512BW, which vpermw above already needs.

--- a/python/sglang/kernels/aot/csrc/cpu/vec.h
+++ b/python/sglang/kernels/aot/csrc/cpu/vec.h
@@ -190,7 +190,6 @@ inline std::tuple<__m512bh, __m512bh> cvt_mxfp4_e2m1_bf16_intrinsic_lut(__m256i 
   const __m512i lut = (__m512i)(_mm512_cvtne2ps_pbh(values, values));
 
   const __m512i abs_mask = _mm512_set1_epi16(0x7FFF);
-  const __m512i zero = _mm512_setzero_si512();
 
   // expand values to 16-bit integers
   __m512i x0 = _mm512_cvtepu8_epi16(a);
@@ -200,17 +199,22 @@ inline std::tuple<__m512bh, __m512bh> cvt_mxfp4_e2m1_bf16_intrinsic_lut(__m256i 
   x0 = _mm512_permutexvar_epi16(x0, lut);
   x1 = _mm512_permutexvar_epi16(x1, lut);
 
-  // check for zeros
-  __mmask32 mask0 = _mm512_cmp_epi16_mask(_mm512_and_si512(x0, abs_mask), zero, _MM_CMPINT_EQ);
-  __mmask32 mask1 = _mm512_cmp_epi16_mask(_mm512_and_si512(x1, abs_mask), zero, _MM_CMPINT_EQ);
+  // Emulate the bf16 multiply by the E8M0 scale as an integer add on the
+  // exponent field, forcing zeros to stay zero.
+  //
+  // vptestmw sets a lane's mask bit when (x & 0x7FFF) != 0, i.e. exactly for
+  // the lanes that are not +0.0 or -0.0, and the zero-masking form of vpaddw
+  // writes 0 to the lanes the mask leaves clear. That is the same predicate as
+  // the previous and/cmp/add/blend sequence and the same result on every lane,
+  // including the LUT's -0.0 entry, which both versions turn into +0.0.
+  //
+  // 2 instructions per vector instead of 4, no extra ISA requirement:
+  // vptestmw is AVX512BW, which vpermw above already needs.
+  __mmask32 mask0 = _mm512_test_epi16_mask(x0, abs_mask);
+  __mmask32 mask1 = _mm512_test_epi16_mask(x1, abs_mask);
 
-  // emulate bf16 mul with scale factor
-  x0 = _mm512_add_epi16(x0, s0);
-  x1 = _mm512_add_epi16(x1, s1);
-
-  // blend with zero
-  x0 = _mm512_mask_blend_epi16(mask0, x0, zero);
-  x1 = _mm512_mask_blend_epi16(mask1, x1, zero);
+  x0 = _mm512_maskz_add_epi16(mask0, x0, s0);
+  x1 = _mm512_maskz_add_epi16(mask1, x1, s1);
 
   return std::make_tuple(__m512bh(x0), __m512bh(x1));
 }

--- a/test/registered/cpu/test_moe.py
+++ b/test/registered/cpu/test_moe.py
@@ -452,6 +452,53 @@ class TestFusedExperts:
             f"max |out| = {out.abs().max().item()}"
         )
 
+    # Moderate exponents only: 6.0 * 2**(255-127) is not representable in bf16
+    # and the comparison would be inf against inf.
+    @pytest.mark.parametrize("e8m0", [120, 127, 134])
+    def test_mxfp4_moe_zero_codes_mixed_with_nonzero(self, e8m0):
+        """Zeros and non-zeros inside the same 32-element scale block.
+
+        test_mxfp4_moe_zero_codes_stay_zero sets every weight to a zero code, so
+        it passes even if the zero check is done once per block. This one mixes
+        both kinds inside every block, so the check has to be per lane. A single
+        shared exponent keeps the reference a plain power of two.
+        """
+        M, N, K, E = 4, 64, 64, 2
+
+        a = torch.randn(M, K, dtype=dtype) / 10
+        # Alternate a zero byte and a non-zero one along K, so every scale block
+        # holds both kinds.
+        pattern = torch.tensor([0x88, 0x21], dtype=torch.uint8).repeat(K // 4)
+        w1q = pattern.view(1, 1, -1).expand(E, 2 * N, K // 2).contiguous()
+        w1s = torch.full((E, 2 * N, K // 32), e8m0, dtype=torch.uint8)
+        w1dq = MXFP4QuantizeUtil.dequantize(w1q, dtype, w1s)
+        w1_packed = kernel.convert_weight_packed(w1q)
+        w1s_packed = kernel.convert_scale_packed(w1s)
+
+        w2dq, w2_packed, w2s_packed = make_mxfp4_weights(E, K, N, dtype=dtype)
+
+        topk_weight = torch.ones((M, 1), dtype=torch.float32)
+        topk_ids = torch.zeros((M, 1), dtype=torch.int32)
+
+        ref_out = native_fp8_fused_moe(
+            a, w1dq.float(), w2dq.float(), topk_weight, topk_ids, 1
+        )
+        out = run_fused_experts(
+            a,
+            w1_packed,
+            w2_packed,
+            topk_weight,
+            topk_ids,
+            quant=CPUQuantMethod.MXFP4,
+            w1_scale=w1s_packed,
+            w2_scale=w2s_packed,
+            is_vnni=True,
+            inplace=False,
+        )
+
+        atol = rtol = precision[dtype]
+        torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
+
     @pytest.mark.parametrize("m", [1, 32])
     @pytest.mark.parametrize("n", [128, 64])
     @pytest.mark.parametrize("k", [128, 64])

--- a/test/registered/cpu/test_moe.py
+++ b/test/registered/cpu/test_moe.py
@@ -400,6 +400,58 @@ class TestFusedExperts:
         atol = rtol = precision[dtype]
         torch.testing.assert_close(ref_out.bfloat16(), out, atol=atol, rtol=rtol)
 
+    # Both E2M1 zero codes, 0b0000 (+0.0) and 0b1000 (-0.0), in both nibbles.
+    @pytest.mark.parametrize("zero_byte", [0x00, 0x88, 0x08, 0x80])
+    # 0 and 255 are the ends of the E8M0 range; 127 is the identity scale.
+    @pytest.mark.parametrize("e8m0", [0, 1, 127, 200, 254, 255])
+    def test_mxfp4_moe_zero_codes_stay_zero(self, zero_byte, e8m0):
+        """A zero E2M1 code stays zero for every E8M0 exponent.
+
+        The unpack applies the block scale as an integer add on the bf16
+        exponent field, which is exact for every value in the E2M1 codebook
+        except the two zeros: 0x0000 and 0x8000 have no exponent to shift, so
+        adding to them produces a small finite number instead of zero. Both are
+        special-cased, and this is the invariant that special case exists for.
+
+        Worth pinning separately from test_mxfp4_moe: there the zero codes are a
+        small fraction of random weights and a broken special case would stay
+        inside the bf16 tolerance for the low exponents. Here every weight is a
+        zero, so the output is exactly zero or it is not.
+        """
+        M, N, K, E = 4, 64, 64, 2
+
+        a = torch.randn(M, K, dtype=dtype)
+        w1q = torch.full((E, 2 * N, K // 2), zero_byte, dtype=torch.uint8)
+        w1s = torch.full((E, 2 * N, K // 32), e8m0, dtype=torch.uint8)
+        w1_packed = kernel.convert_weight_packed(w1q)
+        w1s_packed = kernel.convert_scale_packed(w1s)
+        # w2 is ordinary: the zeros have to survive the first GEMM and the
+        # activation, and a nonzero w2 is what would expose it if they did not.
+        _, w2_packed, w2s_packed = make_mxfp4_weights(E, K, N, dtype=dtype)
+
+        topk_weight = torch.ones((M, 1), dtype=torch.float32)
+        topk_ids = torch.zeros((M, 1), dtype=torch.int32)
+
+        out = run_fused_experts(
+            a,
+            w1_packed,
+            w2_packed,
+            topk_weight,
+            topk_ids,
+            quant=CPUQuantMethod.MXFP4,
+            w1_scale=w1s_packed,
+            w2_scale=w2s_packed,
+            is_vnni=True,
+            inplace=False,
+        )
+
+        # silu(0) * 0 = 0, so the whole layer collapses to exactly zero. Not
+        # assert_close: any nonzero output here is a wrong unpack, not rounding.
+        assert torch.equal(out, torch.zeros_like(out)), (
+            f"zero code 0x{zero_byte:02x} with e8m0={e8m0} produced "
+            f"max |out| = {out.abs().max().item()}"
+        )
+
     @pytest.mark.parametrize("m", [1, 32])
     @pytest.mark.parametrize("n", [128, 64])
     @pytest.mark.parametrize("k", [128, 64])


### PR DESCRIPTION
## Motivation

The AVX-512 MXFP4 unpack (`cvt_mxfp4_e2m1_bf16_intrinsic_lut` in `python/sglang/kernels/aot/csrc/cpu/vec.h`) applies the E8M0 block scale as an integer add on the bf16 exponent field. That works for every value in the E2M1 codebook — `0, ±0.5, ±1, ±1.5, ±2, ±3, ±4, ±6` all need ≤2 mantissa bits, so they are exact in bf16 and the scale is pure exponent — except for the two zero codes, which have no exponent to shift. Adding to `0x0000` or `0x8000` would produce a small finite number instead of zero, so they are special-cased.

That special case is currently four instructions per vector: `and` + `cmpeq` + `add` + `blend`. It can be two, with the complementary predicate and the same result on every lane.

This is the unpack that feeds the MXFP4 CPU MoE GEMM, and it is per-byte work rather than per-FLOP, so it is a meaningful share of that kernel rather than a rounding error.

## Modifications

```c
-  const __m512i zero = _mm512_setzero_si512();
...
-  __mmask32 mask0 = _mm512_cmp_epi16_mask(_mm512_and_si512(x0, abs_mask), zero, _MM_CMPINT_EQ);
-  x0 = _mm512_add_epi16(x0, s0);
-  x0 = _mm512_mask_blend_epi16(mask0, x0, zero);
+  __mmask32 mask0 = _mm512_test_epi16_mask(x0, abs_mask);
+  x0 = _mm512_maskz_add_epi16(mask0, x0, s0);
```

`vptestmw` sets a lane's mask bit for exactly the lanes where `(x & 0x7FFF) != 0`, which is the complement of the old predicate, and the zero-masking form of `vpaddw` writes `0` to the lanes the mask leaves clear.

**No new ISA requirement**: `vptestmw` is AVX512BW, which the `vpermw` lookup immediately above already needs.

Two tests are added to `test/registered/cpu/test_moe.py` for the invariant the special case exists for (see below). No registry change was needed — the file is already registered.

## Accuracy Tests

**The output is bit-identical, not merely close.** Both sequences were compiled into one binary in separate namespaces and exhaustively compared:

| | lanes | differences |
|---|---|---|
| all 256 packed byte values × all 256 E8M0 exponents | 4,194,304 | **0** |
| 20k random vectors with a **per-lane** exponent | 1,280,000 | **0** |
| the codebook's `-0.0` entry × all 256 exponents | 16,384 | `+0.0` from both |

The per-lane case matters because the 32 lanes of a vector do not share a scale in the real kernel (`transpose_2x32_16bit` in `gemm_fp8.cpp`), and a uniform-scale test cannot tell a per-lane mask from a per-vector one. The `-0.0` row confirms the new version preserves the old one's flush of `-0.0` to `+0.0` — that behaviour is unchanged, not newly introduced.

The two new tests cover the same invariant through the public op:

- `test_mxfp4_moe_zero_codes_stay_zero` — every weight set to a zero code (`0x00`, `0x88`, `0x08`, `0x80`) across exponents `0, 1, 127, 200, 254, 255`; the output must be **exactly** zero (`torch.equal`, not `assert_close`), since `silu(0) * 0 = 0` collapses the whole layer.
- `test_mxfp4_moe_zero_codes_mixed_with_nonzero` — zeros and non-zeros in the same block of 32, so the check has to be per-lane rather than per-block. Moderate exponents only: `6.0 × 2^(255-127)` is not representable in bf16 and would compare `inf` against `inf`.

These are separate from the existing `test_mxfp4_moe` rather than another parametrization of it: there the zero codes are a small fraction of random weights, and at low exponents a broken special case stays inside that test's bf16 tolerance.

`pre-commit run --files python/sglang/kernels/aot/csrc/cpu/vec.h test/registered/cpu/test_moe.py` is clean, including `clang-format` and `check-registered-tests`.

**What I could and could not run.** The exhaustive bit-exactness above was run against this exact header, and the equivalent pair of tests passes on the vLLM copy of this change (`48 passed`, built from source with `torch 2.13.0+cpu`) — the function is byte-for-byte identical between the two trees. **The two tests in this PR are ported to this repo's harness but not executed**: building the CPU kernels here needs Docker/buildx and submodules, which I do not have on the benchmark machine. They reuse only helpers this file already imports (`make_mxfp4_weights`, `native_fp8_fused_moe`, `MXFP4QuantizeUtil`, `precision`) and follow `test_mxfp4_moe` directly, but please run CI on them rather than take my word for it.

## Speed Tests and Profiling

Measured on 2× Xeon Platinum 8592V (Emerald Rapids), gcc 14.2:

| | before | after | |
|---|---|---|---|
| vector instructions in the function, compiled in isolation | 16 | **12** | **−4** |
| MXFP4 MoE expert GEMM built on this header, 64 threads, 7 GB weight pool | 10.9 tok/s | **12.5 tok/s** | **1.15×** |

The instructions that disappear are `vpandd` ×2, `vpcmpeqw` ×2 and the `vmovdqu16` ×2 that materialized the blend; `vptestmw` ×2 come in.

The second row is from an out-of-tree kernel built on this same header rather than from SGLang's own MoE path, so please read it as indicative. It is the measurement I can make repeatably: it reproduces to three significant figures across runs, and a sweep over topk is monotone and consistent with the instruction counts of the alternative unpack variants (`vpermb` 0.88×, `pshufb` 0.66×).

**A note on a number I withdrew.** An earlier draft reported 11.58 → 13.01 GB/s (1.12×) for the `unpack_B` loop in `gemm_fp8.cpp` measured on its own. It does not reproduce: the same binary pinned to the same core gives 1.006–1.014× on most runs and 1.117–1.167× on the rest, and with ASLR disabled it can come out at 0.963×. At K=3584 that loop reads ~57 kB and writes ~229 kB, so it fits in L2 and is store-bound rather than issue-bound, and removing 4 of 16 instructions does not show above the run-to-run spread. The claims I stand behind are the bit-exactness and the instruction count.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation — n/a, no user-facing behaviour changes.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Note on vLLM

vLLM vendors this file (`csrc/cpu/sgl-kernels/vec.h`, header: *"Adapted from sgl-project/sglang"*) and the block is still identical byte for byte there, so the same change is going to both trees: **vllm-project/vllm#51583**. Sending it here as well so a future re-vendor does not revert it.

I do not have an AVX-512 CI runner beyond the machine above, so the measurements are single-platform; the correctness argument does not depend on the platform.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31488463465](https://github.com/sgl-project/sglang/actions/runs/31488463465)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31488463279](https://github.com/sgl-project/sglang/actions/runs/31488463279)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->