### PR TITLE
[NPU] Add NpuSRTPlatform so current_platform resolves on Ascend

### DIFF
--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -21,6 +21,7 @@ from sglang.srt.environ import envs
 from sglang.srt.platforms.cpu import CpuSRTPlatform
 from sglang.srt.platforms.cuda import CudaSRTPlatform
 from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.npu import NpuSRTPlatform
 from sglang.srt.platforms.rocm import RocmSRTPlatform
 from sglang.srt.platforms.xpu import XpuSRTPlatform
 from sglang.srt.plugins import PLATFORM_PLUGINS_GROUP, load_plugins_by_group
@@ -46,6 +47,16 @@ def _is_xpu_available() -> bool:
     return torch.xpu.is_available()
 
 
+def _is_npu_available() -> bool:
+    # Guard on hasattr because ``torch.npu`` is registered by ``torch_npu``
+    # at import time; environments without torch_npu installed simply won't
+    # have the attribute. We intentionally do NOT call
+    # ``sglang.srt.utils.common.is_npu`` here -- that helper raises when
+    # torch_npu is present but no NPU device is visible, and a boolean
+    # "available" probe must never raise.
+    return hasattr(torch, "npu") and torch.npu.is_available()
+
+
 def _resolve_platform() -> SRTPlatform:
     """
     Discover and instantiate the active platform.
@@ -68,6 +79,7 @@ def _resolve_platform() -> SRTPlatform:
          - 0 activated + CUDA available → fallback CudaSRTPlatform
          - 0 activated + ROCm available → fallback RocmSRTPlatform
          - 0 activated + XPU available  → fallback XpuSRTPlatform
+         - 0 activated + NPU available  → fallback NpuSRTPlatform
          - 0 activated + none of the above → fallback base SRTPlatform
          - 1 activated → use it
          - N activated → RuntimeError (must set SGLANG_PLATFORM)
@@ -135,6 +147,9 @@ def _resolve_platform() -> SRTPlatform:
         if _is_xpu_available():
             logger.debug("No platform plugin detected. Using XPU SRTPlatform defaults.")
             return XpuSRTPlatform()
+        if _is_npu_available():
+            logger.debug("No platform plugin detected. Using NPU SRTPlatform defaults.")
+            return NpuSRTPlatform()
         logger.debug("No platform detected. Using base SRTPlatform.")
         return SRTPlatform()
 

--- a/python/sglang/srt/platforms/npu.py
+++ b/python/sglang/srt/platforms/npu.py
@@ -1,0 +1,135 @@
+"""NPU (Huawei Ascend) device operations for the SRT platform layer."""
+
+import logging
+from typing import Optional
+
+import torch
+
+from sglang.srt.platforms.device_mixin import (
+    DeviceCapability,
+    DeviceMixin,
+    PlatformEnum,
+)
+from sglang.srt.platforms.interface import SRTPlatform
+
+logger = logging.getLogger(__name__)
+
+
+class NpuDeviceMixin(DeviceMixin):
+    """NPU implementation of the shared device operations.
+
+    Requires ``torch_npu`` to be importable so that ``torch.npu`` is populated;
+    the plugin is imported lazily in ``_ensure_torch_npu()``.
+    """
+
+    _enum: PlatformEnum = PlatformEnum.NPU
+    device_name: str = "npu"
+    device_type: str = "npu"
+
+    @staticmethod
+    def _ensure_torch_npu() -> None:
+        # torch_npu registers the ``npu`` device with the torch dispatcher on
+        # import. It's not a hard dependency of sglang, so we import here on
+        # demand and give a friendly error if it's missing.
+        if not hasattr(torch, "npu"):
+            import torch_npu  # noqa: F401  # pylint: disable=import-outside-toplevel
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        self._ensure_torch_npu()
+        return int(torch.npu.get_device_properties(device_id).total_memory)
+
+    def get_current_memory_usage(
+        self, device: Optional["torch.device"] = None
+    ) -> float:
+        self._ensure_torch_npu()
+        return float(torch.npu.max_memory_allocated(device))
+
+    def get_device(self, local_rank: int) -> "torch.device":
+        return torch.device("npu", local_rank)
+
+    def set_device(self, device: "torch.device") -> None:
+        self._ensure_torch_npu()
+        torch.npu.set_device(device)
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        self._ensure_torch_npu()
+        return str(torch.npu.get_device_name(device_id))
+
+    def get_device_uuid(self, device_id: int = 0) -> str:
+        # torch_npu's DeviceProperties does not expose a UUID; the closest
+        # stable identifier is the device name plus the OS-assigned index.
+        self._ensure_torch_npu()
+        return f"{torch.npu.get_device_name(device_id)}:{device_id}"
+
+    def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
+        # Ascend NPUs don't expose a (major, minor) capability tuple the way
+        # NVIDIA / AMD do. Return a fixed (0, 0) so callers get a well-formed
+        # value; consumers that need finer-grained gating should key off
+        # ``torch.npu.get_device_name(device_id)`` (e.g. "Ascend910B2").
+        return DeviceCapability(0, 0)
+
+    def empty_cache(self) -> None:
+        self._ensure_torch_npu()
+        torch.npu.empty_cache()
+
+    def synchronize(self) -> None:
+        self._ensure_torch_npu()
+        torch.npu.synchronize()
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        """Return (free, total) device memory in bytes."""
+        self._ensure_torch_npu()
+        if not (hasattr(torch, "npu") and torch.npu.is_available()):
+            return 0, 0
+        return torch.npu.mem_get_info(device_id)
+
+    def is_pin_memory_available(self, device=None) -> bool:
+        if device is not None and str(device) == "cpu":
+            return False
+        return True
+
+    # ``get_torch_distributed_backend_str`` intentionally not overridden.
+    # ``_DEVICE_TO_DISTRIBUTED_BACKEND`` in device_mixin.py already maps
+    # "npu" -> "hccl" (or "zbal" when SGLANG_ZBAL_LOCAL_MEM_SIZE > 0), and
+    # the base ``DeviceMixin`` implementation looks up ``self.device_type``
+    # in that table -- so plain inheritance gives the right answer.
+
+    @classmethod
+    def seed_everything(cls, seed: int | None = None) -> None:
+        if seed is not None:
+            super().seed_everything(seed)
+            if hasattr(torch, "npu"):
+                torch.npu.manual_seed_all(seed)
+
+
+class NpuSRTPlatform(NpuDeviceMixin, SRTPlatform):
+    """Default in-tree NPU SRT platform (Huawei Ascend 910B / A2)."""
+
+    # In-tree NPU dispatch already flows through ``if _is_npu:`` guards in
+    # ``kv_cache_configurator``, ``cuda_graph_setup`` and elsewhere -- see
+    # ``hardware_backend/npu/`` for the concrete backend classes. Overriding
+    # the ``get_*_cls`` factory methods here is not required for in-tree
+    # dispatch (those factories are only consulted for out-of-tree platforms
+    # via ``current_platform.is_out_of_tree()``); leaving them at the
+    # ``NotImplementedError`` defaults matches ``CudaSRTPlatform``.
+
+    def get_default_attention_backend(self) -> str:
+        return "ascend"
+
+    def get_dispatch_key_name(self) -> str:
+        return "npu"
+
+    def supports_fp8(self) -> bool:
+        # Ascend 910B/A2 supports FP8 via the CANN toolkit + torch_npu ops,
+        # matching the existing NPU quantization backends under
+        # ``hardware_backend/npu/quantization/``.
+        return True
+
+    def support_cuda_graph(self) -> bool:
+        # ``NPUGraphRunner`` in ``hardware_backend/npu/graph_runner/`` uses
+        # torch_npu graph capture for the decode path.
+        return True
+
+    def support_piecewise_cuda_graph(self) -> bool:
+        # Piecewise / prefill-side graph capture is not yet wired for NPU.
+        return False


### PR DESCRIPTION
## Motivation

The `platforms/` subsystem shipped `PlatformEnum.NPU` and the `npu -> hccl` distributed-backend mapping, but the concrete `platforms/npu.py` module and the corresponding fallback branch in `_resolve_platform` were never landed. On an Ascend 910B / A2 host with `torch_npu` installed and no `SGLANG_PLATFORM` set, `sglang.srt.platforms.current_platform` therefore fell back to the base `SRTPlatform` (device_type='cpu', backend='gloo') even though the full `hardware_backend/npu/` stack (ascend attention, NPUMHATokenToKVPool, NPUGraphRunner, ...) was present in the tree.

Related RFC: #20372 ("Introduce hardware plugin system") explicitly calls for `platforms/npu.py`.

## Modifications

This change fills that gap in-tree, matching the design intent already visible in `platforms/device_mixin.py` and mirroring `platforms/xpu.py`:

** New `python/sglang/srt/platforms/npu.py` ** (mirrors `platforms/xpu.py`): 
- `NpuDeviceMixin(DeviceMixin)` overriding the memory / device / seed helpers against `torch.npu.*`, with a lazy `_ensure_torch_npu()` guard so environments that don't have `torch_npu` installed never trigger a hard import at module load time. 
- `NpuSRTPlatform(NpuDeviceMixin, SRTPlatform)` overriding the NPU-specific policy bits:  
      - `get_default_attention_backend()` ->`"ascend"`, 
      - `get_dispatch_key_name()` -> `"npu"`,
      - `supports_fp8()` and `support_cuda_graph()` -> True,
      - `support_piecewise_cuda_graph()` -> False.
- `get_torch_distributed_backend_str` is intentionally  **not** overridden -- `_DEVICE_TO_DISTRIBUTED_BACKEND` in `device_mixin.py` already maps `"npu" -> "hccl"` (or `"zbal"` when `SGLANG_ZBAL_LOCAL_MEM_SIZE > 0`).
- The `get_*_cls` factory methods are left at their base `NotImplementedError` defaults on purpose: in-tree NPU dispatch already flows through `if _is_npu:` guards in `kv_cache_configurator`, `cuda_graph_setup`, etc., and the factories are only consulted for out-of-tree platforms via `current_platform.is_out_of_tree()`. This matches how `CudaSRTPlatform` handles the same set of methods.

** `python/sglang/srt/platforms/__init__.py` **: 
- Import `NpuSRTPlatform`. 
- Add `_is_npu_available()`, which checks `hasattr(torch, "npu") and torch.npu.is_available()`. It deliberately does NOT call `sglang.srt.utils.common.is_npu`, because that helper raises when `torch_npu` is importable but no NPU is visible, and a boolean "available" probe must never raise. 
- Wire a fallback branch in `_resolve_platform` after the XPU branch and before the base fallback, and document the new arm in the discovery-flow docstring.

## Verification

Verified on an 8x Ascend 910B2 host (torch 2.10, torch_npu 2.10.0, CANN 9.0.0). With no `SGLANG_PLATFORM` set and no plugin registered:

```python       
  >>> from sglang.srt.platforms import current_platform
  >>> type(current_platform).__name__                                                                                                                                                                          
  'NpuSRTPlatform'
  >>> current_platform.device_type, current_platform.is_npu()                                                                                                                                                  
  ('npu', True)   
  >>> current_platform.get_torch_distributed_backend_str()
  'hccl'                                                                                                                                                                                                       
  >>> current_platform.get_default_attention_backend()
  'ascend'                                                                                                                                                                                                     
  >>> current_platform.get_device_name(0)
  'Ascend910B2'
  >>> current_platform.get_device_total_memory(0)
  65452113920
```

CUDA / ROCm / XPU / CPU-opt-in fallback paths are unchanged. No existing in-tree file is modified besides platforms/__init__.py, so hardware_backend/npu/* and every is_npu() legacy call site continue to work exactly as before.                                                                                                                                                                                                                                                                          
                                                                                                                                                                                         
## Checklist       
                                                                                                                                                                                                               
- Format your code according to the https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit.                                                              
- Add unit tests as outlined in the https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-to-ci — N/A for a device-registration patch; covered by manual verification above on real 910B2 hardware.
- Update documentation as needed, including docstrings or example tutorials.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31392979514](https://github.com/sgl-project/sglang/actions/runs/31392979514)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31392978004](https://github.com/sgl-project/sglang/actions/runs/31392978004)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->