### PR TITLE
test: isolate metal profiler tests from ambient SGLANG_USE_MLX

### DIFF
--- a/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
+++ b/test/registered/unit/hardware_backend/mlx/test_metal_profiler.py
@@ -185,7 +185,21 @@ class TestMetalCaptureProfilerMPS(unittest.TestCase):
 
 @unittest.skipUnless(_IS_APPLE_SILICON and _HAS_MLX, _SKIP_REASON)
 class TestSchedulerProfilerManagerMPS(unittest.TestCase):
-    """SchedulerProfilerManager._start_profile handles Metal capture failures."""
+    """SchedulerProfilerManager._start_profile handles Metal capture failures.
+
+    apply_metal_profiler_patches() dispatches on use_mlx(), which reads
+    SGLANG_USE_MLX and is cached for the process (tensor_bridge.use_mlx).
+    This class exists to exercise the MPS strategy, so it pins use_mlx at
+    its point of use in profiler.py rather than the ambient environment;
+    an env-only pin would not reliably override an already-cached value.
+    """
+
+    def setUp(self):
+        patcher = patch(
+            "sglang.srt.hardware_backend.mlx.profiler.use_mlx", return_value=False
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
     def _make_manager(self, output_dir):
         from sglang.srt.managers.scheduler_components.profiler_manager import (


### PR DESCRIPTION
## Motivation

Fixes the metal profiler test failure called out as a known CI failure in the #34166 merge comment. `apply_metal_profiler_patches()` chooses its capture strategy with `use_mlx()` and `TestSchedulerProfilerManagerMPS` never controlled the call. The `stage-a-unit-test-mlx` job sets `SGLANG_USE_MLX=1` at the job level, so this class silently ran the MLX strategy instead of the MPS strategy it exists to test, on every run of that lane.

## Modifications

Pin `use_mlx` at its point of use in `profiler.py` for `TestSchedulerProfilerManagerMPS`, via `unittest.mock.patch("sglang.srt.hardware_backend.mlx.profiler.use_mlx", return_value=False)` in `setUp`, rather than pinning the environment. `use_mlx()` is `@lru_cache(maxsize=1)`, so an env pin loses to an already cached value when the directory shares one process.

The sibling `TestMetalCaptureProfilerMLX` needs no pin: it calls `MetalCaptureProfiler.start_mlx` directly and never reaches the `use_mlx()` dispatch.

## Accuracy Tests

Test only change; no model outputs affected. Verification on an Apple M4 Pro, on `test/registered/unit/hardware_backend/mlx/test_metal_profiler.py` alone, four ways:

- `SGLANG_USE_MLX=1 python -m pytest ... -q`: 10 passed
- `SGLANG_USE_MLX` unset: 10 passed
- `SGLANG_USE_MLX=0`: 10 passed
- the lane's own invocation shape, `SGLANG_USE_MLX=1 python3 test_metal_profiler.py -f`: 10 passed

The pre fix code fails under the first condition, so the fix addresses the observed failure rather than passing vacuously. Full MLX unit suite with the fix, no env override: 184 passed, 4 skipped, 0 failed, matching the pre fix baseline.

From the same M4 Pro review pass over #34166: two of the body's claims reproduce independently, the memory bound percentages from stated geometry and bit identical greedy streams against the merged base on a small non SWA model.

## Speed Tests and Profiling

Not applicable; test only change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31400376016](https://github.com/sgl-project/sglang/actions/runs/31400376016)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31400375767](https://github.com/sgl-project/sglang/actions/runs/31400375767)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->