### PR TITLE
Fix CI server warmup progress logging

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_warmup.py
+++ b/python/sglang/multimodal_gen/runtime/server_warmup.py
@@ -253,15 +253,16 @@ class SchedulerWarmupMixin:
                 refresh=False,
             )
         self._warmup_progress_bar.update(1)
+        progress_n = self._warmup_processed
         if _is_ci_log_env():
             logger.info(
                 "Warmup requests: %s/%s %s",
-                self._warmup_progress_bar.n,
+                progress_n,
                 self._warmup_progress_bar.total,
                 self._format_warmup_req(req_or_group),
             )
 
-        if self._warmup_progress_bar.n >= self._warmup_progress_bar.total:
+        if progress_n >= self._warmup_progress_bar.total:
             self._warmup_progress_bar.close()
             self._warmup_progress_bar = None
 

--- a/python/sglang/multimodal_gen/test/unit/test_server_warmup_progress.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_warmup_progress.py
@@ -1,0 +1,36 @@
+"""Unit tests for server warmup progress reporting."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
+from sglang.multimodal_gen.runtime.server_warmup import SchedulerWarmupMixin
+
+
+class TestServerWarmupProgress(unittest.TestCase):
+    def test_ci_progress_uses_scheduler_counter_when_tqdm_is_disabled(self):
+        scheduler = SchedulerWarmupMixin()
+        scheduler._show_warmup_progress = True
+        scheduler._warmup_total = 1
+        scheduler._warmup_processed = 1
+        progress_bar = MagicMock(total=1, n=0)
+        scheduler._warmup_progress_bar = progress_bar
+
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.server_warmup._is_ci_log_env",
+                return_value=True,
+            ),
+            patch("sglang.multimodal_gen.runtime.server_warmup.logger") as logger,
+        ):
+            scheduler._advance_warmup_progress_bar(object(), OutputBatch())
+
+        logger.info.assert_called_once_with(
+            "Warmup requests: %s/%s %s", 1, 1, "warmup req"
+        )
+        progress_bar.close.assert_called_once_with()
+        self.assertIsNone(scheduler._warmup_progress_bar)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Report CI warmup progress from the scheduler's processed-request counter.
- Add a regression test for disabled tqdm progress bars.

## Root cause

CI disables tqdm output, but the scheduler still used the disabled tqdm instance's `n` field for completion logging. That field remained zero, so a completed warmup was logged as `0/1`.

## Validation

- Pre-commit hooks passed, including Python AST, ruff, black, codespell, and merge-conflict checks.
- Reproduced the original `0/1` behavior with `CI=true` before the fix on a real Flux.2 TP=2 server.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31401623764](https://github.com/sgl-project/sglang/actions/runs/31401623764)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31401623221](https://github.com/sgl-project/sglang/actions/runs/31401623221)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->