### PR TITLE
Support online NVFP4 for dense linear layers

### DIFF
--- a/python/sglang/srt/layers/quantization/nvfp4_online.py
+++ b/python/sglang/srt/layers/quantization/nvfp4_online.py
@@ -11,6 +11,8 @@ from typing import Any, Callable, Dict, List, Optional
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.layers.parameter import ModelWeightParameter
+from sglang.srt.layers.quantization.base_config import LinearMethodBase
 from sglang.srt.layers.quantization.fp8_utils import (
     block_quant_dequant,
     inverse_transform_scale_ue8m0,
@@ -19,14 +21,35 @@ from sglang.srt.layers.quantization.modelopt_quant import (
     ModelOptFp4Config,
     ModelOptNvFp4FusedMoEMethod,
     ModelOptQuantConfig,
+    fp4_gemm,
 )
 from sglang.srt.layers.quantization.unquant import UnquantizedLinearMethod
 from sglang.srt.layers.quantization.utils import (
     is_layer_skipped,
     per_tensor_dequantize,
 )
+from sglang.srt.layers.utils.common import copy_or_rebind_param
 
 logger = logging.getLogger(__name__)
+
+NVFP4_MAX = float(torch.finfo(torch.float8_e4m3fn).max) * 6.0
+
+
+def exact_nvfp4_quant_math():
+    """Scope exact FP4 quantization math to load-time weight conversion.
+
+    Serving restores the caller's environment, so the runtime activation
+    quantization is unaffected.
+    """
+    from sglang.srt.utils.common import temp_set_env
+
+    return temp_set_env(
+        FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH="1",
+        FLASHINFER_NVFP4_4OVER6="1",
+        FLASHINFER_NVFP4_4OVER6_E4M3_USE_256="0",
+        FLASHINFER_NVFP4_4OVER6_ERR_MODE="MSE",
+        FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH="1",
+    )
 
 
 class NvFp4OnlineConfig(ModelOptQuantConfig):
@@ -35,8 +58,8 @@ class NvFp4OnlineConfig(ModelOptQuantConfig):
     `--quantization nvfp4_online` exclusively means online per-token FP32
     activation scaling. Use `modelopt_fp4` for per-tensor FP32 activation scales
     or serialized NVFP4 checkpoints. This path converts BF16/FP16/FP8 MoE expert
-    weights as they load; dense layers retain their source precision or
-    quantization.
+    weights and BF16/FP16 dense linear weights as they load; dense layers whose
+    shape no FP4 GEMM can serve stay in their source precision.
     """
 
     # Marker consumed by the ModelOpt FP4 layout and the model loader. Serialized
@@ -138,6 +161,14 @@ class NvFp4OnlineConfig(ModelOptQuantConfig):
                 prefix, self.exclude_modules, self.packed_modules_mapping
             ) or self.is_layer_excluded(prefix):
                 return UnquantizedLinearMethod()
+            if is_layer_skipped(
+                prefix, self.fp4_ignored_layers, self.packed_modules_mapping
+            ):
+                if self.is_checkpoint_fp8_serialized:
+                    return Fp8LinearMethod(self)
+                return UnquantizedLinearMethod()
+            if self.use_per_token_activation and not self.is_checkpoint_fp8_serialized:
+                return NvFp4OnlineLinearMethod(self)
             if self.is_checkpoint_fp8_serialized:
                 return Fp8LinearMethod(self)
             return UnquantizedLinearMethod()
@@ -154,6 +185,105 @@ class NvFp4OnlineConfig(ModelOptQuantConfig):
                 return None
             return ModelOptNvFp4OnlineFusedMoEMethod(self, prefix)
         return None
+
+
+class NvFp4OnlineLinearMethod(LinearMethodBase):
+    """Dense linear converted to NVFP4 as the checkpoint loads.
+
+    The weight keeps one FP32 decode scale for the whole shard; activations get
+    one per token, computed each forward. The GEMM alpha is therefore a vector
+    of ``per_token_scale * weight_scale_2``, which only the FlashInfer backends
+    whose epilogue applies a row scale can consume: cute-dsl on SM10X and
+    cutlass on SM12X. Layers the FP4 GEMM cannot serve belong in
+    SGLANG_FP4_IGNORED_LAYERS.
+    """
+
+    def __init__(self, quant_config: NvFp4OnlineConfig) -> None:
+        self.quant_config = quant_config
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: List[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ) -> None:
+        layer.register_parameter(
+            "weight",
+            ModelWeightParameter(
+                data=torch.empty(
+                    sum(output_partition_sizes),
+                    input_size_per_partition,
+                    dtype=params_dtype,
+                ),
+                input_dim=1,
+                output_dim=0,
+                weight_loader=extra_weight_attrs.get("weight_loader"),
+            ),
+        )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        from flashinfer import SfLayout, nvfp4_quantize
+
+        weight = layer.weight.data
+        # The load-time env scope buys ~9% lower weight quantization error.
+        with exact_nvfp4_quant_math():
+            # FlashInfer takes the reciprocal as the encode scale.
+            weight_scale_2 = weight.abs().amax().float() / NVFP4_MAX
+            weight_fp4, weight_scale = nvfp4_quantize(
+                weight,
+                1.0 / weight_scale_2,
+                sfLayout=SfLayout.layout_128x4,
+                backend="cute-dsl",
+            )
+
+        copy_or_rebind_param(layer, "weight", weight_fp4)
+        copy_or_rebind_param(layer, "weight_scale", weight_scale)
+        copy_or_rebind_param(layer, "weight_scale_2", weight_scale_2.reshape(1))
+        # Per-token mode reads this as the base multiplier and folds each row's
+        # own amax into the scale it returns.
+        copy_or_rebind_param(
+            layer,
+            "input_global_scale_inv",
+            torch.full(
+                (1,), 1.0 / NVFP4_MAX, dtype=torch.float32, device=weight.device
+            ),
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        from flashinfer import SfLayout, nvfp4_quantize
+
+        out_features = layer.weight.shape[0]
+        # out_scale folds the weight decode scale into the returned per-token
+        # scales, so `alpha` comes out of the quantize kernel ready for the GEMM.
+        x_fp4, x_scale, alpha = nvfp4_quantize(
+            x.reshape(-1, x.shape[-1]),
+            layer.input_global_scale_inv,
+            sfLayout=SfLayout.layout_128x4,
+            per_token_activation=True,
+            backend="cute-dsl",
+            out_scale=layer.weight_scale_2,
+        )
+        out = fp4_gemm(
+            x_fp4,
+            layer.weight.T,
+            x_scale,
+            layer.weight_scale.T,
+            alpha,
+            x.dtype,
+            out_features,
+        )
+        if bias is not None:
+            out = out + bias
+        return out.view(*x.shape[:-1], out_features)
 
 
 class _ModelOptFp4OnlineConfig(NvFp4OnlineConfig):

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -130,7 +130,6 @@ from sglang.srt.utils import (
     rank0_log,
     set_weight_attrs,
 )
-from sglang.srt.utils.common import temp_set_env
 
 if TYPE_CHECKING:
     from sglang.srt.configs.device_config import DeviceConfig
@@ -861,15 +860,11 @@ class DefaultModelLoader(BaseModelLoader):
             )
 
         if is_nvfp4_online or is_modelopt_fp4_online:
-            # Scope exact FP4 quantization math to load-time conversion only;
-            # restore the original environment before serving starts.
-            with temp_set_env(
-                FLASHINFER_DISABLE_FP4_QUANT_FAST_MATH="1",
-                FLASHINFER_NVFP4_4OVER6="1",
-                FLASHINFER_NVFP4_4OVER6_E4M3_USE_256="0",
-                FLASHINFER_NVFP4_4OVER6_ERR_MODE="MSE",
-                FLASHINFER_NVFP4_4OVER6_ERR_USE_FAST_MATH="1",
-            ):
+            from sglang.srt.layers.quantization.nvfp4_online import (
+                exact_nvfp4_quant_math,
+            )
+
+            with exact_nvfp4_quant_math():
                 model.load_weights(weights)
             if target_device.type == "cuda":
                 torch.cuda.synchronize()

--- a/test/registered/unit/layers/quantization/test_nvfp4_linear_backends.py
+++ b/test/registered/unit/layers/quantization/test_nvfp4_linear_backends.py
@@ -2,18 +2,20 @@
 
 Real layer path (ColumnParallelLinear -> weight_loader -> weight processing
 -> forward) per SM100 backend vs a dequantized-reference matmul; a merged
-two-shard case guards the per-partition scale gathering of fused layers.
+two-shard case guards the per-partition scale gathering of fused layers, and
+an online case guards the per-token activation scales of `nvfp4_online`.
 """
 
 import unittest
 from unittest import mock
 
 import torch
-from flashinfer import fp4_quantize
+from flashinfer import SfLayout, fp4_quantize, nvfp4_quantize
 
 from sglang.srt.layers.quantization import fp4_utils
 from sglang.srt.layers.quantization.fp4_utils import Fp4GemmRunnerBackend
 from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4Config
+from sglang.srt.layers.quantization.nvfp4_online import NVFP4_MAX, NvFp4OnlineConfig
 from sglang.srt.utils import get_device_sm
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.layer_ut_utils import (
@@ -42,6 +44,13 @@ SHAPES = [
 ]
 
 ACT_SCALE = 1.0 / (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
+
+# The online path has no padding step, so K must already suit the FP4 GEMM.
+ONLINE_SHAPES = [
+    (64, 256, 512),
+    (5, 160, 512),
+    (128, 1024, 1024),
+]
 
 
 def _make_quantized_layer(n: int, k: int):
@@ -116,6 +125,35 @@ def _make_merged_layer(n_half: int, k: int):
     return layer, torch.cat(dequants, dim=0)
 
 
+def _make_online_layer(n: int, k: int):
+    """BF16 checkpoint weights, converted to NVFP4 at load time."""
+    layer = make_tp1_column_parallel_linear(NvFp4OnlineConfig(), n, k)
+    w = torch.randn((n, k), device="cuda", dtype=torch.bfloat16) / 10
+    load_linear_weights(layer, weight=w)
+    return layer
+
+
+def _online_reference(layer, x: torch.Tensor) -> torch.Tensor:
+    """Matmul of the same NVFP4 values the layer holds, dequantized in fp32."""
+    x_q, x_sf, per_token_scale = nvfp4_quantize(
+        x,
+        torch.full((1,), 1.0 / NVFP4_MAX, dtype=torch.float32, device=x.device),
+        sfLayout=SfLayout.layout_128x4,
+        per_token_activation=True,
+        backend="cute-dsl",
+    )
+    x_dequant = dequantize_nvfp4_to_dtype(
+        x_q, x_sf, (1.0 / per_token_scale).reshape(-1, 1), torch.float32
+    )
+    w_dequant = dequantize_nvfp4_to_dtype(
+        layer.weight.data,
+        layer.weight_scale.data,
+        1.0 / layer.weight_scale_2.data,
+        torch.float32,
+    )
+    return x_dequant @ w_dequant.T
+
+
 @unittest.skipIf(get_device_sm() < 100, "NVFP4 dense GEMM backends require SM100+")
 class TestNvFp4LinearBackends(CustomTestCase):
     @classmethod
@@ -157,6 +195,34 @@ class TestNvFp4LinearBackends(CustomTestCase):
             x = torch.randn((16, 512), device="cuda", dtype=torch.bfloat16) / 10
             out, _ = layer(x)
             self._assert_matches(layer, x, out, w_dequant)
+
+    def test_online_per_token_activation_scale(self):
+        """`nvfp4_online` gives each activation row its own dequant scale, so
+        the GEMM alpha is a vector. Reusing one row's scale for the batch --
+        a scalar alpha, or a per-row alpha read at the wrong coordinate --
+        rescales every other row by the ratio of their amaxes, which the
+        decade-spread rows below turn into a large per-row error."""
+        torch.manual_seed(7)
+        with mock.patch.object(
+            fp4_utils,
+            "FP4_GEMM_RUNNER_BACKEND",
+            Fp4GemmRunnerBackend("flashinfer_cutedsl"),
+        ):
+            for m, n, k in ONLINE_SHAPES:
+                with self.subTest(shape=(m, n, k)):
+                    layer = _make_online_layer(n, k)
+                    layer.quant_method.process_weights_after_loading(layer)
+
+                    decades = torch.logspace(-2, 2, m, device="cuda")
+                    x = (torch.randn((m, k), device="cuda") / 10 * decades[:, None]).to(
+                        torch.bfloat16
+                    )
+                    out, _ = layer(x)
+
+                    ref = _online_reference(layer, x)
+                    assert_output_close(self, out, ref)
+                    row_err = (out.float() - ref).norm(dim=1) / ref.norm(dim=1)
+                    self.assertLess(row_err.max().item(), 0.02)
 
     def test_flashinfer_cutedsl(self):
         self._run_backend("flashinfer_cutedsl")


### PR DESCRIPTION
## Motivation

`--quantization nvfp4_online` only converted MoE expert weights, so a dense model served every linear in source precision.

## Modifications

Add `NvFp4OnlineLinearMethod`: each linear shard is converted to NVFP4 at load time, activations are quantized per token each forward, and `per_token_scale * weight_scale_2` is passed as the `mm_fp4` alpha vector. That needs a FlashInfer backend whose epilogue applies a per-row alpha (cute-dsl on SM10X, cutlass on SM12X). Layers the FP4 GEMM cannot serve go in `SGLANG_FP4_IGNORED_LAYERS`.

Depends on flashinfer-ai/flashinfer#4441 (per-token alpha for `mm_fp4`), which is not merged yet.

## Accuracy Tests

Servers (B300, 4 GPUs each):

```bash
# nvfp4_online
CUDA_VISIBLE_DEVICES=0,1,2,3 sglang serve --model-path Qwen/Qwen3.6-27B \
  --reasoning-parser qwen3 --tool-call-parser qwen3_coder \
  --mamba-radix-cache-strategy extra_buffer --attention-backend trtllm_mha \
  --mem-fraction-static 0.8 --quantization nvfp4_online --dp-size 4 --port 30000

# bf16 baseline
CUDA_VISIBLE_DEVICES=4,5,6,7 sglang serve --model-path Qwen/Qwen3.6-27B \
  --reasoning-parser qwen3 --tool-call-parser qwen3_coder \
  --mamba-radix-cache-strategy extra_buffer --attention-backend trtllm_mha \
  --mem-fraction-static 0.8 --dp-size 4 --port 30001
```

Eval (`--max-tokens 261632` is the model's 262144 context minus prompt headroom,
so nothing truncates; `top_k=20` comes from the checkpoint's
`generation_config.json` via the default `--sampling-defaults model`):

```bash
sgl-eval run aime26 --base-url http://127.0.0.1:30000/v1 \
  --n-repeats 8 --temperature 1.0 --top-p 0.95 --thinking \
  --max-tokens 261632 --num-threads 240
sgl-eval run aime26 --base-url http://127.0.0.1:30001/v1 \
  --n-repeats 8 --temperature 1.0 --top-p 0.95 --thinking \
  --max-tokens 261632 --num-threads 240
```

AIME26, 30 problems x 8 samples, thinking mode:

| | bf16 | nvfp4_online |
|---|---|---|
| avg@8 | 94.58% (+-0.61) | 94.17% (+-0.83) |
| majority@8 | 96.67% | 96.67% |
| pass@8 | 96.67% | 96.67% |
| truncated | 0.00% | 0.00% |
| completion tokens | 7.87M | 8.74M |
| wall clock | 33.4 min | 25.5 min |

## Speed Tests and Profiling

Same servers without `--dp-size 4`, one model per GPU. Batch size 1 decode,
1024 new tokens, mean of 3 runs:

| | tok/s | latency |
|---|---|---|
| bf16 | 99.99 | 10.241 s |
| nvfp4_online | 182.57 | 5.609 s |

1.83x decode throughput. Weights drop from 51.05 GB to 19.12 GB.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829014756](https://github.com/sgl-project/sglang/actions/runs/34829014756)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829014591](https://github.com/sgl-project/sglang/actions/runs/34829014591)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829014739](https://github.com/sgl-project/sglang/actions/runs/34829014739)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->