### PR TITLE
[Bugfix] HybridAttnBackend declares forward() twice, killing the linear-attention path

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_attn_backend.py
@@ -222,25 +222,3 @@ class HybridAttnBackend(AttentionBackend):
         else:
             backend = self.prefill_backend
         return backend.update_mamba_state_after_mtp_verify(*args, **kwargs)
-
-    def forward(
-        self,
-        q: torch.Tensor = None,
-        k: torch.Tensor = None,
-        v: torch.Tensor = None,
-        layer: RadixAttention = None,
-        forward_batch: ForwardBatch = None,
-        save_kv_cache: bool = True,
-        **kwargs,
-    ):
-        """Delegate forward to the appropriate backend based on forward mode."""
-        backend = self._select_backend(forward_batch.forward_mode)
-        return backend.forward(
-            q=q,
-            k=k,
-            v=v,
-            layer=layer,
-            forward_batch=forward_batch,
-            save_kv_cache=save_kv_cache,
-            **kwargs,
-        )

--- a/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.model_runner_components import (
     attention_backend_setup,
 )
@@ -115,6 +116,71 @@ def test_equal_resolved_backends_ignore_stale_global_backend():
         )
 
     assert result.name == "resolved"
+
+
+def _hybrid_backend(prefill, decode):
+    runner = SimpleNamespace(
+        server_args=SimpleNamespace(speculative_attention_mode="prefill"),
+        model_config=SimpleNamespace(context_len=2048),
+        kv_cache_dtype=None,
+        token_to_kv_pool=object(),
+        req_to_token_pool=object(),
+    )
+    return HybridAttnBackend(
+        model_runner=runner, prefill_backend=prefill, decode_backend=decode
+    )
+
+
+class _RecordingBackend(_FakeBackend):
+    def __init__(self, name):
+        super().__init__(name)
+        self.calls = []
+        self.extend_dummy_seqs_capped_by_req_pool = False
+
+    def forward(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+        return self.name
+
+
+def test_forward_routes_linear_attention_args():
+    """HybridAttnBackend.forward must keep the mixed_qkv/a/b linear-attention path.
+
+    The class used to declare forward() twice; the second definition shadowed the
+    first and silently dropped mixed_qkv/a/b.
+    """
+    prefill = _RecordingBackend("prefill")
+    backend = _hybrid_backend(prefill, _RecordingBackend("decode"))
+
+    result = backend.forward(
+        layer="layer",
+        forward_batch=SimpleNamespace(forward_mode=ForwardMode.EXTEND),
+        mixed_qkv="mixed",
+        a="a",
+        b="b",
+    )
+
+    assert result == "prefill"
+    _, kwargs = prefill.calls[0]
+    assert kwargs["mixed_qkv"] == "mixed"
+    assert kwargs["a"] == "a"
+    assert kwargs["b"] == "b"
+
+
+def test_forward_still_routes_regular_attention_args():
+    prefill = _RecordingBackend("prefill")
+    backend = _hybrid_backend(prefill, _RecordingBackend("decode"))
+
+    backend.forward(
+        "q",
+        "k",
+        "v",
+        "layer",
+        SimpleNamespace(forward_mode=ForwardMode.EXTEND),
+    )
+
+    args, kwargs = prefill.calls[0]
+    assert args[:3] == ("q", "k", "v")
+    assert "mixed_qkv" not in kwargs
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`HybridAttnBackend` declares `forward()` twice. Python binds the later
definition, so the earlier one is dead code:

| line | origin | signature |
|---|---|---|
| 154 | [Kimi] Support kimi-k3 (#32541), 2026-08-04 | `q, k, v, layer, forward_batch, save_kv_cache, *, mixed_qkv, a, b, **kwargs` |
| 224 | [feat] Support different attention backends for prefill and decode, 2025-07-28 | `q, k, v, layer, forward_batch, save_kv_cache, **kwargs` |

#32541 added the linear-attention-aware `forward()` at the top of the class but
did not remove the pre-existing one further down, so the 2025 definition is the
one that is actually bound.

The effect is that the linear-attention dispatch added by #32541 never runs.
A caller passing `mixed_qkv` / `a` / `b` — as
`hybrid_linear_attn_backend.py` does — falls into `**kwargs` on the old
definition and is then handed to `backend.forward()` alongside `q=None, k=None,
v=None`, instead of taking the `if mixed_qkv is not None:` branch.

## Modifications

- Remove the stale 2025 `forward()`. The kimi-k3 one is a strict superset: same
  parameters for the regular path, plus the linear-attention branch.
- Add two unit tests to
  `test/registered/unit/model_executor/model_runner_components/test_attention_backend_setup.py`
  (already a CPU test module, and it already imports `HybridAttnBackend`)
  asserting that `forward()` routes `mixed_qkv`/`a`/`b` to the selected backend
  and that the plain `q`/`k`/`v` path is unchanged. A future duplicate
  definition fails these instead of silently shadowing.

No behaviour change for the regular attention path; the only difference is
positional vs keyword argument passing to `backend.forward()`.

## Accuracy Tests

Not applicable — this restores a dispatch branch that is currently unreachable,
it does not change kernel or model math.

## Verification

`black` and `isort` clean on both touched files.

I was not able to run the full test module locally: importing `sglang.srt` on
this machine fails at `transformers` config registration
(`ValueError: 'qwen3_asr' is already used by a Transformers config`), which is a
version-pinning issue in my environment and unrelated to this change. I
verified the dispatch by executing the real, unmodified `HybridAttnBackend`
class body with stubbed imports:

```
forward definitions in class: 1
linear path  -> prefill {'mixed_qkv': 'mixed', 'a': 'a', 'b': 'b'}
regular path -> ('q', 'k', 'v')
```

Please run the added tests in CI.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [ ] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33099494579](https://github.com/sgl-project/sglang/actions/runs/33099494579)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33099494294](https://github.com/sgl-project/sglang/actions/runs/33099494294)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33099494501](https://github.com/sgl-project/sglang/actions/runs/33099494501)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->