### PR TITLE
[Bugfix] Widen flashinfer import guard in token_dispatcher/flashinfer.py

### DIFF
--- a/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py
@@ -39,7 +39,19 @@ try:
     from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
 
     use_flashinfer = True
-except ImportError:
+except (ImportError, AttributeError, AssertionError, OSError):
+    # Broader than plain ImportError on purpose: flashinfer's own module-level
+    # initialization can raise non-ImportError when the underlying runtime is
+    # missing/broken. Observed failure modes:
+    #   * AssertionError from flashinfer.comm.cuda_ipc when libcudart cannot be
+    #     loaded (non-CUDA hosts, e.g. NPU / bare-metal CPU with a leftover
+    #     flashinfer install).
+    #   * OSError from flashinfer / libtorch_cuda.so lookups on ROCm hosts
+    #     (see issue #27519).
+    #   * AttributeError has been used at other module-level flashinfer
+    #     guards in this repo (server_args.py, layernorm.py).
+    # Whatever the reason, the correct behavior at this site is graceful
+    # fallback (use_flashinfer = False), not aborting sglang startup.
     use_flashinfer = False
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Motivation

`python/sglang/srt/layers/moe/token_dispatcher/flashinfer.py:42` catches only `ImportError`, but flashinfer's own module-level init is known to raise non-ImportError exceptions when the underlying runtime is missing:

- `AssertionError` from `flashinfer.comm.cuda_ipc.CudaRTLibrary()` when `libcudart` isn't loadable (non-CUDA hosts: NPU, CPU-only, etc. with a leftover flashinfer install).
- `OSError` from flashinfer / `libtorch_cuda.so` lookups on ROCm hosts (see #27519).
                         
Because the guard misses these, `from sglang.srt.layers.moe.token_dispatcher import flashinfer` aborts sglang startup on affected hosts instead of falling back to `use_flashinfer = False`.                                                                                                                                  
                                        
## Modifications                                                                                                                                                                                             
                                                                                                                                                                                                               
Widen the exception tuple to `(ImportError, AttributeError, AssertionError, OSError)` and add an inline comment explaining why. This matches the precedent already used elsewhere in the repo, e.g.:
                                                                                                                                                                                                      
- `debug_utils/dumper.py:1864,1949` — `(ImportError, AssertionError, AttributeError)`
- `server_args.py:6031`, `layers/layernorm.py:85,95`, `layers/attention/flashinfer_backend.py:2413`, `layers/flashinfer_comm_fusion.py:112` — `(ImportError, AttributeError)`                                                                                                                                                         
                                   
## Reproduction                                                                                                                                                                                              
                                                  
On a non-CUDA host:                                                                                                                                                                                          
  pip install flashinfer-python==0.6.12                   
  python -c "from sglang.srt.layers.moe.token_dispatcher import flashinfer"                                                                                                                                    
                                          
Before: `AssertionError: libcudart is not loaded in the current process` → startup aborts.                                                                                                                   
After: import succeeds, `flashinfer.use_flashinfer == False`.                                                                                                                                                
                                         
## Checklist                                                                                                                                                                                                 
                                           
- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci) — N/A, guard-widening one-liner reproducible per steps above.                                 
- [ ] Update documentation / docstrings if applicable.
- [ ] Provide throughput / latency benchmark results — N/A, no runtime path changes. 

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31413213715](https://github.com/sgl-project/sglang/actions/runs/31413213715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31413212648](https://github.com/sgl-project/sglang/actions/runs/31413212648)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->