### PR TITLE
[Spec] Read the draft checkpoint config with the target's resolution inputs

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import TYPE_CHECKING, Optional
@@ -21,26 +20,45 @@ def _disable_overlap_schedule_for_cpu(server_args: ServerArgs) -> None:
     )
 
 
+# The algorithms whose resolution depends on the draft architecture. Anything
+# else must not pay for the draft config read below, let alone fail on it.
+_GEMMA4_ALIASED_ALGORITHMS = ("NEXTN", "EAGLE", "EAGLE3")
+
+_GEMMA4_ASSISTANT_DRAFT_ARCHS = (
+    "Gemma4AssistantForCausalLM",
+    "Gemma4UnifiedAssistantForCausalLM",
+)
+
+
+def _draft_is_gemma4_assistant(server_args: ServerArgs) -> bool:
+    """Whether the draft checkpoint is a Gemma4 assistant draft.
+
+    Answers False without reading anything unless the configured algorithm
+    actually consumes the answer. The read honors --model-config-parser and a
+    pinned revision, so for every other algorithm -- including the launches
+    that never build a draft worker at all -- it is a failure mode the startup
+    has no reason to take on.
+    """
+    if server_args.speculative_algorithm not in _GEMMA4_ALIASED_ALGORITHMS:
+        return False
+    if not server_args.speculative_draft_model_path:
+        return False
+
+    from sglang.srt.configs.model_config import ModelConfig
+
+    cfg = ModelConfig.get_draft_hf_config(server_args)
+    draft_archs = getattr(cfg, "architectures", None) or []
+    return any(arch in _GEMMA4_ASSISTANT_DRAFT_ARCHS for arch in draft_archs)
+
+
 def _resolve_speculative_algorithm_alias(
-    speculative_algorithm: Optional[str],
-    speculative_draft_model_path: Optional[str],
-    trust_remote_code: bool = False,
-    kwargs: Optional[dict] = {},
+    *, speculative_algorithm: Optional[str], is_gemma4_draft: bool
 ) -> Optional[str]:
-    """Resolve CLI speculative algorithm; NEXTN/EAGLE may become FROZEN_KV_MTP for Gemma4 assistant drafts."""
+    """Resolve the CLI speculative algorithm to the name workers dispatch on.
 
-    is_gemma4_draft = False
-    if speculative_draft_model_path:
-        from sglang.srt.utils.hf_transformers_utils import get_config
-
-        cfg = get_config(
-            speculative_draft_model_path, trust_remote_code=trust_remote_code, **kwargs
-        )
-        draft_archs = getattr(cfg, "architectures", None) or []
-        is_gemma4_draft = any(
-            arch in ("Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM")
-            for arch in draft_archs
-        )
+    NEXTN is an alias for EAGLE. A Gemma4 assistant draft promotes NEXTN/EAGLE
+    to FROZEN_KV_MTP instead, and is rejected outright for EAGLE3.
+    """
 
     if speculative_algorithm == "EAGLE3" and is_gemma4_draft:
         raise ValueError(
@@ -89,17 +107,9 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             "select the non-overlap (synchronous) path."
         )
 
-    kwargs = {}
-
-    override_config_file = server_args.decrypted_draft_config_file
-    if override_config_file and override_config_file.strip():
-        kwargs["_configuration_file"] = override_config_file.strip()
-
     server_args.speculative_algorithm = _resolve_speculative_algorithm_alias(
-        server_args.speculative_algorithm,
-        server_args.speculative_draft_model_path,
-        trust_remote_code=server_args.trust_remote_code,
-        kwargs=kwargs,
+        speculative_algorithm=server_args.speculative_algorithm,
+        is_gemma4_draft=_draft_is_gemma4_assistant(server_args),
     )
 
     # Validate --speculative-draft-window-size once, regardless of algorithm.
@@ -210,30 +220,29 @@ def _handle_dflash(server_args: ServerArgs) -> None:
         )
 
     if server_args.speculative_num_draft_tokens is None:
+        from sglang.srt.configs.model_config import DraftConfigReadError, ModelConfig
         from sglang.srt.speculative.dflash_utils import (
             parse_dflash_draft_config,
         )
 
-        model_override_args = json.loads(server_args.json_model_override_args)
         inferred_block_size = None
+        # Only an unreadable checkpoint falls back. A checkpoint that is
+        # readable but declares a malformed block_size raises out of the parse
+        # below: silently serving it with a different draft window is worse
+        # than refusing to start.
         try:
-            from sglang.srt.utils.hf_transformers_utils import get_config
-
-            draft_hf_config = get_config(
-                server_args.speculative_draft_model_path,
-                trust_remote_code=server_args.trust_remote_code,
-                revision=server_args.speculative_draft_model_revision,
-                model_override_args=model_override_args,
-            )
-            inferred_block_size = parse_dflash_draft_config(
-                draft_hf_config=draft_hf_config
-            ).resolve_block_size(default=None)
-        except Exception as e:
+            draft_hf_config = ModelConfig.get_draft_hf_config(server_args)
+        except DraftConfigReadError as e:
+            draft_hf_config = None
             logger.warning(
                 "Failed to infer DFLASH block_size from draft model config; "
                 "defaulting speculative_num_draft_tokens to 16. Error: %s",
                 e,
             )
+        if draft_hf_config is not None:
+            inferred_block_size = parse_dflash_draft_config(
+                draft_hf_config=draft_hf_config
+            ).resolve_block_size(default=None)
 
         if inferred_block_size is None:
             inferred_block_size = 16
@@ -367,14 +376,17 @@ def _handle_dspark(server_args: ServerArgs) -> None:
             )
         gamma = int(server_args.speculative_dspark_block_size)
     else:
+        from sglang.srt.configs.model_config import DraftConfigReadError
         from sglang.srt.speculative.dspark_components.dspark_config import (
             DEFAULT_DSPARK_GAMMA,
             read_draft_checkpoint_gamma,
         )
 
+        # As in _handle_dflash: only an unreadable checkpoint falls back to the
+        # default gamma; a malformed one raises.
         try:
             gamma = read_draft_checkpoint_gamma(server_args=server_args)
-        except Exception as e:
+        except DraftConfigReadError as e:
             logger.warning(
                 "Failed to read DSpark gamma from draft model config; "
                 "cannot cross-check --speculative-num-draft-tokens. Error: %s",
@@ -480,15 +492,10 @@ def _resolve_dflash_draft_attention_backend(server_args: ServerArgs) -> None:
     if draft_backend is None:
         draft_backend = fallback_backend
     elif draft_backend == "trtllm_mha":
+        from sglang.srt.configs.model_config import ModelConfig
         from sglang.srt.speculative.dflash_utils import get_dflash_layer_types
-        from sglang.srt.utils.hf_transformers_utils import get_config
 
-        draft_hf_config = get_config(
-            server_args.speculative_draft_model_path,
-            trust_remote_code=server_args.trust_remote_code,
-            revision=server_args.speculative_draft_model_revision,
-            model_override_args=json.loads(server_args.json_model_override_args),
-        )
+        draft_hf_config = ModelConfig.get_draft_hf_config(server_args)
         draft_text_config = (
             getattr(draft_hf_config, "text_config", None) or draft_hf_config
         )

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -18,9 +18,9 @@ import logging
 import math
 import os
 from enum import Enum, IntEnum, auto
-from functools import cached_property
+from functools import cached_property, lru_cache
 from pathlib import Path
-from typing import Any, List, Optional, Set, Union
+from typing import Any, List, Optional, Set, Tuple, Union
 
 import torch
 from transformers import PretrainedConfig
@@ -42,6 +42,18 @@ from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
+
+
+class DraftConfigReadError(Exception):
+    """The speculative draft checkpoint's hf config could not be read.
+
+    Its own type so that callers which fall back to a default on an unreadable
+    checkpoint catch exactly that, and unrelated failures raised on the same
+    line -- a malformed --json-model-override-args, a bug inside a registered
+    config parser -- stay fatal instead of being logged as a warning and
+    replaced with a default draft window.
+    """
+
 
 MIMO_V2_MODEL_ARCHS = (
     "MiMoV2ForCausalLM",
@@ -298,24 +310,20 @@ class ModelConfig:
         self._validate_quantize_and_serve_config()
 
         # Get hf config
-        self._maybe_pull_model_for_runai(self.model_path)
-        self._maybe_pull_model_tokenizer_from_remote()
+        self.model_path, model_weights = self._resolve_hf_config_path(self.model_path)
+        if model_weights is not None:
+            # model_loader/loader.py probes this with hasattr(), so it stays
+            # unset for local paths rather than being set to None.
+            self.model_weights = model_weights
         self.model_override_args = json.loads(model_override_args)
-        kwargs = {}
-        if override_config_file and override_config_file.strip():
-            kwargs["_configuration_file"] = override_config_file.strip()
-        # get_config() is cached. ModelConfig mutates hf_config for draft-model
-        # remapping and architecture-specific normalization, so each instance
-        # must own an isolated copy.
-        self.hf_config = copy.deepcopy(
-            get_config(
-                self.model_path,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-                model_override_args=self.model_override_args,
-                model_config_parser=model_config_parser,
-                **kwargs,
-            )
+        kwargs = self._configuration_file_kwargs(override_config_file)
+        self.hf_config = self._read_hf_config(
+            self.model_path,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            model_override_args=self.model_override_args,
+            model_config_parser=model_config_parser,
+            override_config_file=override_config_file,
         )
         self.hf_text_config = get_hf_text_config(self.hf_config)
         self.is_embedding_gemma = is_embedding_gemma(self.hf_text_config)
@@ -614,6 +622,133 @@ class ModelConfig:
             speculative_algorithm=server_args.speculative_algorithm,
             **kwargs,
         )
+
+    @staticmethod
+    def _configuration_file_kwargs(override_config_file: Optional[str]) -> dict:
+        """`_configuration_file` kwarg naming a decrypted config, or `{}`."""
+        if override_config_file and override_config_file.strip():
+            return {"_configuration_file": override_config_file.strip()}
+        return {}
+
+    @staticmethod
+    @lru_cache(maxsize=None)
+    def _resolve_hf_config_path(model_path: str) -> Tuple[str, Optional[str]]:
+        """Where the hf config is readable from, plus a remote weights URI.
+
+        The hf parsers open local directories, so an object-store URI or a
+        remote URL is resolved to a local copy of the config first and the
+        original is handed back for the weight loader. Returns the path
+        unchanged, and no weights URI, for an ordinary local checkpoint.
+
+        Memoized because it sits outside get_config()'s own cache, so without
+        it every repeated read of one checkpoint re-resolves the path: a
+        remote URL is re-pulled over the network, and each pull strands a
+        tempdir and another link on the signal-handler chain that pins it
+        (see BaseConnector.__init__). Argument resolution reads the draft
+        checkpoint several times before any ModelConfig exists, and each
+        worker reads it again. All three branches are deterministic in
+        model_path, so one resolution per path per process is equivalent.
+        """
+        from sglang.srt.connector import create_remote_connector
+        from sglang.srt.utils import is_remote_url
+
+        if is_runai_obj_uri(model_path):
+            return ObjectStorageModel.get_path(model_path), model_path
+        if is_remote_url(model_path):
+            logger.info("Pulling model configs from remote...")
+            # The pulled config files have to outlive this call, so the client
+            # is deliberately not closed via a `with` block; it owns the
+            # returned local dir for the rest of the process.
+            client = create_remote_connector(model_path)
+            client.pull_files(allow_pattern=["*config.json"])
+            return client.get_local_dir(), model_path
+        return model_path, None
+
+    @staticmethod
+    def _read_hf_config(
+        model_path: str,
+        *,
+        trust_remote_code: bool,
+        revision: Optional[str],
+        model_override_args: dict,
+        model_config_parser: str,
+        override_config_file: Optional[str],
+    ) -> PretrainedConfig:
+        """The single hf config read, shared by the target and the draft.
+
+        Both must resolve a checkpoint the same way. An input dropped on one
+        side makes a checkpoint the other reads fine fail, or resolve
+        different override values: the reported bug was a hand-rolled draft
+        read that omitted model_config_parser, so a checkpoint whose config
+        comes from a registered parser died in the hf parser's Hub lookup.
+        Pass `model_path` through `_resolve_hf_config_path` first.
+
+        get_config() memoizes process-wide and callers mutate what they get
+        back (draft-model remapping, architecture normalization), so each one
+        is handed an isolated copy.
+        """
+        return copy.deepcopy(
+            get_config(
+                model_path,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                model_override_args=model_override_args,
+                model_config_parser=model_config_parser,
+                **ModelConfig._configuration_file_kwargs(override_config_file),
+            )
+        )
+
+    @staticmethod
+    def get_draft_hf_config(server_args: ServerArgs) -> PretrainedConfig:
+        """Read the speculative draft checkpoint's hf config.
+
+        Goes through `_read_hf_config` with the inputs `from_server_args(...,
+        is_draft_model=True)` selects for a draft ModelConfig, so the draft
+        resolves exactly as the target does. Argument resolution needs draft
+        config fields before it is correct to build that ModelConfig --
+        `_config_draft_model` rewrites `architectures[0]` off a
+        speculative_algorithm that is itself still resolving -- so only the
+        read is shared.
+
+        Raises DraftConfigReadError when the checkpoint cannot be read. A
+        malformed --json-model-override-args and a failure inside a
+        registered config parser propagate as themselves, so callers that
+        fall back to a default on an unreadable draft do not swallow them.
+        """
+        revision = server_args.speculative_draft_model_revision or server_args.revision
+        # Parsed outside the read: a malformed override string is a
+        # target-side argument error, not an unreadable draft checkpoint.
+        model_override_args = json.loads(server_args.json_model_override_args)
+        try:
+            model_path, _ = ModelConfig._resolve_hf_config_path(
+                server_args.speculative_draft_model_path
+            )
+            return ModelConfig._read_hf_config(
+                model_path,
+                trust_remote_code=server_args.trust_remote_code,
+                revision=revision,
+                model_override_args=model_override_args,
+                model_config_parser=server_args.model_config_parser,
+                override_config_file=server_args.decrypted_draft_config_file,
+            )
+        except (OSError, ValueError, KeyError, ImportError) as e:
+            # Most of these reads happen while parsing CLI args, where a bare
+            # transformers/hub traceback names neither the draft nor the flag.
+            # The cause goes in the text because callers that swallow this log
+            # it with %s, which never formats __cause__.
+            decrypted = (
+                "<set>" if server_args.decrypted_draft_config_file else "<unset>"
+            )
+            raise DraftConfigReadError(
+                "Failed to read the speculative draft checkpoint config: "
+                f"--speculative-draft-model-path={server_args.speculative_draft_model_path!r} "
+                f"(revision={revision!r}, "
+                f"model_config_parser={server_args.model_config_parser!r}, "
+                # The path locates decrypted plaintext on disk and this message
+                # reaches warning-level logs, so only its presence is reported.
+                f"decrypted_draft_config_file={decrypted}): "
+                f"{type(e).__name__}: {e}"
+            ) from e
 
     def _config_draft_model(self):
         is_draft_model = self.is_draft_model
@@ -1674,36 +1809,6 @@ class ModelConfig:
         }
 
         return default_sampling_params
-
-    def _maybe_pull_model_for_runai(self, model: str) -> None:
-        if is_runai_obj_uri(model):
-            # local path for loading the config
-            self.model_path = ObjectStorageModel.get_path(model)
-            # remote path for loading the weights
-            self.model_weights = model
-
-    def _maybe_pull_model_tokenizer_from_remote(self) -> None:
-        """
-        Pull the model config files to a temporary
-        directory in case of remote.
-
-        Args:
-            model: The model name or path.
-
-        """
-        from sglang.srt.connector import create_remote_connector
-        from sglang.srt.utils import is_remote_url
-
-        if is_remote_url(self.model_path):
-            logger.info("Pulling model configs from remote...")
-            # BaseConnector implements __del__() to clean up the local dir.
-            # Since config files need to exist all the time, so we DO NOT use
-            # with statement to avoid closing the client.
-            client = create_remote_connector(self.model_path)
-            if is_remote_url(self.model_path):
-                client.pull_files(allow_pattern=["*config.json"])
-                self.model_weights = self.model_path
-                self.model_path = client.get_local_dir()
 
 
 # adapted from https://github.com/vllm-project/vllm/blob/v0.6.4.post1/vllm/config.py

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import logging
 from typing import TYPE_CHECKING, Any, List, Optional
 
@@ -22,19 +21,11 @@ DSV4_DRAFT_ATTENTION_BACKEND = "dsv4"
 
 
 def draft_is_deepseek_v4(*, server_args: ServerArgs) -> bool:
-    from sglang.srt.configs.model_config import is_deepseek_v4
-    from sglang.srt.utils.hf_transformers_utils import get_config
+    from sglang.srt.configs.model_config import ModelConfig, is_deepseek_v4
 
-    draft_model_path = server_args.speculative_draft_model_path
-    if not draft_model_path:
+    if not server_args.speculative_draft_model_path:
         return False
-    draft_hf_config = get_config(
-        draft_model_path,
-        trust_remote_code=server_args.trust_remote_code,
-        revision=server_args.speculative_draft_model_revision,
-        model_override_args=json.loads(server_args.json_model_override_args),
-        model_config_parser=server_args.model_config_parser,
-    )
+    draft_hf_config = ModelConfig.get_draft_hf_config(server_args)
     return draft_hf_config is not None and is_deepseek_v4(draft_hf_config)
 
 
@@ -126,15 +117,12 @@ def resolve_runtime_config(
 
 def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
     """Load the draft checkpoint's hf config and read its DSpark gamma
-    (block_size). Raises on config-load failure; callers pick the fallback."""
-    from sglang.srt.utils.hf_transformers_utils import get_config
+    (block_size). Raises DraftConfigReadError when the checkpoint cannot be
+    read -- callers pick the fallback for that; a malformed gamma raises out
+    of the parse instead."""
+    from sglang.srt.configs.model_config import ModelConfig
 
-    draft_hf_config = get_config(
-        server_args.speculative_draft_model_path,
-        trust_remote_code=server_args.trust_remote_code,
-        revision=server_args.speculative_draft_model_revision,
-        model_override_args=json.loads(server_args.json_model_override_args),
-    )
+    draft_hf_config = ModelConfig.get_draft_hf_config(server_args)
     return parse_dspark_draft_config(draft_hf_config=draft_hf_config).resolve_gamma(
         default=None
     )

--- a/test/registered/unit/configs/test_draft_hf_config_resolution.py
+++ b/test/registered/unit/configs/test_draft_hf_config_resolution.py
@@ -1,0 +1,353 @@
+"""Unit tests for ModelConfig.get_draft_hf_config — draft/target read parity.
+
+The draft checkpoint's hf config must be read exactly as the target's is. A
+draft read that drops one of the inputs fails, or resolves different values,
+only on the draft side: the reported bug was the Gemma4 alias probe dropping
+model_config_parser, so a checkpoint whose target config comes from a
+registered plugin parser died in the hf parser's Hub lookup instead.
+
+Parity is structural -- both reads go through ModelConfig._read_hf_config --
+so what is tested here is the other half: that each server_args input reaches
+that helper the way from_server_args would select it for a draft ModelConfig,
+and that a failure is attributed to the right cause.
+"""
+
+import json
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from transformers import PretrainedConfig
+
+from sglang.srt.arg_groups.speculative_hook import (
+    _draft_is_gemma4_assistant,
+    _handle_dflash,
+    _resolve_speculative_algorithm_alias,
+)
+from sglang.srt.configs.model_config import DraftConfigReadError, ModelConfig
+from sglang.srt.configs.model_config_parser_registry import (
+    _MODEL_CONFIG_PARSER_REGISTRY,
+    ModelConfigParserBase,
+    register_model_config_parser,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _draft_server_args(**overrides) -> ServerArgs:
+    # model_path="dummy" short-circuits ServerArgs.__post_init__; the fields
+    # below are set directly (same pattern as unit/spec/test_spec_*.py). Using a
+    # real ServerArgs makes field renames break these tests instead of leaving
+    # them green while get_draft_hf_config raises AttributeError at startup.
+    server_args = ServerArgs(model_path="dummy")
+    fields = dict(
+        # model_path="dummy" returns from __post_init__ before
+        # _handle_missing_default_values auto-detects a device, so device stays
+        # None and any handler that inspects it raises AttributeError.
+        device="cuda",
+        speculative_draft_model_path="/models/draft",
+        speculative_draft_model_revision="main",
+        revision=None,
+        trust_remote_code=True,
+        json_model_override_args='{"num_hidden_layers": 2}',
+        model_config_parser="my_plugin_parser",
+        decrypted_draft_config_file=None,
+    )
+    fields.update(overrides)
+    for key, value in fields.items():
+        setattr(server_args, key, value)
+    return server_args
+
+
+class TestDraftHfConfigResolution(CustomTestCase):
+    def setUp(self):
+        # _resolve_hf_config_path memoizes per process, and the patches below
+        # only take effect on a miss, so a leftover entry for one of these
+        # paths would silently make the resolution assertions vacuous.
+        ModelConfig._resolve_hf_config_path.cache_clear()
+
+    def _captured_call(self, **overrides):
+        """(args, kwargs) get_config saw, for one get_draft_hf_config call."""
+        with patch("sglang.srt.configs.model_config.get_config") as mock_get_config:
+            mock_get_config.return_value = PretrainedConfig(architectures=["Probe"])
+            result = ModelConfig.get_draft_hf_config(_draft_server_args(**overrides))
+        mock_get_config.assert_called_once()
+        self.assertEqual(result.architectures, ["Probe"])
+        return mock_get_config.call_args
+
+    def test_forwards_the_target_read_inputs(self):
+        args, kwargs = self._captured_call()
+        self.assertEqual(args, ("/models/draft",))
+        self.assertEqual(kwargs["trust_remote_code"], True)
+        self.assertEqual(kwargs["revision"], "main")
+        # Passed as a parsed dict, as ModelConfig.__init__ does.
+        self.assertEqual(kwargs["model_override_args"], {"num_hidden_layers": 2})
+        # The dropped input behind the reported bug: without it, get_config
+        # re-resolves model_config_parser="auto", which never routes to a
+        # plugin parser.
+        self.assertEqual(kwargs["model_config_parser"], "my_plugin_parser")
+
+    def test_returns_an_isolated_copy_of_the_cached_config(self):
+        # get_config memoizes process-wide, and consumers reach into nested
+        # dicts (dspark_config/dflash_config are returned by reference), so a
+        # caller normalizing one field must not corrupt every later read.
+        cached = PretrainedConfig(architectures=["Probe"])
+        with patch(
+            "sglang.srt.configs.model_config.get_config", return_value=cached
+        ) as mock_get_config:
+            first = ModelConfig.get_draft_hf_config(_draft_server_args())
+            second = ModelConfig.get_draft_hf_config(_draft_server_args())
+        self.assertEqual(mock_get_config.call_count, 2)
+        for result in (first, second):
+            self.assertIsNot(result, cached)
+        self.assertIsNot(first, second)
+
+    def test_revision_falls_back_to_the_target_revision(self):
+        # Mirrors from_server_args' `model_revision or server_args.revision`.
+        # handle_speculative_decoding pins the draft revision to "main" only
+        # when --speculative-draft-model-path was given; the bundled DSpark and
+        # DeepSeek/GLM MTP paths default that path later, so they reach every
+        # subsequent read with the fallback live.
+        _, kwargs = self._captured_call(
+            speculative_draft_model_revision=None, revision="abc123"
+        )
+        self.assertEqual(kwargs["revision"], "abc123")
+
+    def test_decrypted_draft_config_becomes_the_configuration_file(self):
+        _, kwargs = self._captured_call(
+            decrypted_draft_config_file="  /tmp/decrypted/config.json  "
+        )
+        self.assertEqual(kwargs["_configuration_file"], "/tmp/decrypted/config.json")
+
+    def test_no_configuration_file_when_undecrypted(self):
+        for value in (None, "", "   "):
+            with self.subTest(decrypted_draft_config_file=value):
+                _, kwargs = self._captured_call(decrypted_draft_config_file=value)
+                self.assertNotIn("_configuration_file", kwargs)
+
+    def test_object_store_draft_path_is_resolved_before_the_read(self):
+        # ModelConfig.__init__ normalizes the path before reading; a draft read
+        # that skips it hands an s3:// URI to the hf parsers and lands on a
+        # different cache key than the draft ModelConfig built later.
+        with patch(
+            "sglang.srt.configs.model_config.is_runai_obj_uri", return_value=True
+        ), patch(
+            "sglang.srt.configs.model_config.ObjectStorageModel.get_path",
+            return_value="/local/pulled/draft",
+        ):
+            args, _ = self._captured_call(
+                speculative_draft_model_path="s3://bucket/draft"
+            )
+        self.assertEqual(args, ("/local/pulled/draft",))
+
+    def test_remote_draft_path_is_pulled_once_per_process(self):
+        # The resolution sits outside get_config's cache, so an unmemoized
+        # helper re-pulls the config over the network on every read. Each pull
+        # also strands a tempdir and another link on the signal-handler chain
+        # that pins it, and argument resolution reads the draft several times
+        # before any ModelConfig exists.
+        client = MagicMock()
+        client.get_local_dir.return_value = "/local/remote-pull"
+        with patch(
+            "sglang.srt.configs.model_config.is_runai_obj_uri", return_value=False
+        ), patch("sglang.srt.utils.is_remote_url", return_value=True), patch(
+            "sglang.srt.connector.create_remote_connector", return_value=client
+        ) as create_connector:
+            for _ in range(3):
+                args, _ = self._captured_call(
+                    speculative_draft_model_path="remote://bucket/draft"
+                )
+        # Every read still gets the pulled local dir...
+        self.assertEqual(args, ("/local/remote-pull",))
+        # ...but only the first one paid for it.
+        create_connector.assert_called_once()
+        client.pull_files.assert_called_once()
+
+
+class TestDraftReadFailureAttribution(CustomTestCase):
+    def test_read_failure_names_the_draft_path_and_keeps_the_cause(self):
+        cause = OSError(
+            "Repo id must be in the form 'repo_name' or 'namespace/repo_name'"
+        )
+        with patch(
+            "sglang.srt.configs.model_config.get_config", side_effect=cause
+        ), self.assertRaises(DraftConfigReadError) as ctx:
+            ModelConfig.get_draft_hf_config(_draft_server_args())
+        message = str(ctx.exception)
+        self.assertIn("speculative-draft-model-path", message)
+        self.assertIn("/models/draft", message)
+        # Callers that swallow this log it with %s, which drops __cause__, so
+        # the cause has to survive in the message text itself.
+        self.assertIn("Repo id must be in the form", message)
+        self.assertIs(ctx.exception.__cause__, cause)
+
+    def test_read_failure_does_not_name_the_decrypted_config_path(self):
+        # The message reaches warning-level logs, and the path locates
+        # decrypted plaintext on disk.
+        path = "/tmp/decrypted/secret-config.json"
+        with patch(
+            "sglang.srt.configs.model_config.get_config", side_effect=OSError("boom")
+        ), self.assertRaises(DraftConfigReadError) as ctx:
+            ModelConfig.get_draft_hf_config(
+                _draft_server_args(decrypted_draft_config_file=path)
+            )
+        message = str(ctx.exception)
+        self.assertNotIn(path, message)
+        self.assertIn("decrypted_draft_config_file=<set>", message)
+
+    def test_malformed_model_override_args_is_not_a_draft_read_failure(self):
+        with patch("sglang.srt.configs.model_config.get_config") as mock_get_config:
+            with self.assertRaises(json.JSONDecodeError):
+                ModelConfig.get_draft_hf_config(
+                    _draft_server_args(json_model_override_args="{not json")
+                )
+        mock_get_config.assert_not_called()
+
+    def test_a_broken_config_parser_is_not_reported_as_an_unreadable_draft(self):
+        # A bug inside a registered parser must not be laundered into
+        # "checkpoint unreadable", which callers downgrade to a warning.
+        with patch(
+            "sglang.srt.configs.model_config.get_config",
+            side_effect=TypeError("parse() got an unexpected keyword argument"),
+        ), self.assertRaises(TypeError):
+            ModelConfig.get_draft_hf_config(_draft_server_args())
+
+
+class TestDflashBlockSizeFallback(CustomTestCase):
+    """Which failures _handle_dflash may downgrade to a default draft window."""
+
+    def _dflash_server_args(self, **overrides):
+        return _draft_server_args(
+            speculative_algorithm="DFLASH",
+            speculative_num_draft_tokens=None,
+            speculative_dflash_block_size=None,
+            # Pinned so _resolve_dflash_draft_attention_backend takes its
+            # no-op path: its trtllm_mha branch reads the draft config again,
+            # which is not what these tests are about.
+            speculative_draft_attention_backend="triton",
+            **overrides,
+        )
+
+    def test_unreadable_draft_falls_back_to_the_default_block_size(self):
+        server_args = self._dflash_server_args()
+        with patch(
+            "sglang.srt.configs.model_config.get_config",
+            side_effect=OSError("no such checkpoint"),
+        ):
+            _handle_dflash(server_args)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 16)
+
+    def test_malformed_model_override_args_is_fatal(self):
+        # Regression: the parse used to sit above this try block. Moving it
+        # into the read put it back under `except`, so a quoting error in
+        # --json-model-override-args was reported as an unreadable draft
+        # checkpoint and the launch continued with a 16-token window before
+        # dying later inside ModelConfig.__init__'s own json.loads.
+        server_args = self._dflash_server_args(json_model_override_args="{not json")
+        with patch("sglang.srt.configs.model_config.get_config") as mock_get_config:
+            with self.assertRaises(json.JSONDecodeError):
+                _handle_dflash(server_args)
+        mock_get_config.assert_not_called()
+
+
+class TestGemma4DraftAliasResolution(CustomTestCase):
+    """The reported bug as behavior: a draft only the plugin parser can read.
+
+    The draft paths below do not exist on disk, so any read that reaches the hf
+    parser raises. Each test uses a distinct path because get_config is
+    memoized process-wide.
+    """
+
+    def setUp(self):
+        self._saved_registry = dict(_MODEL_CONFIG_PARSER_REGISTRY)
+
+    def tearDown(self):
+        _MODEL_CONFIG_PARSER_REGISTRY.clear()
+        _MODEL_CONFIG_PARSER_REGISTRY.update(self._saved_registry)
+
+    def _server_args_with_parsed_draft(self, *, draft_path, architecture, algorithm):
+        parser_name = f"fake_parser_{Path(draft_path).name}"
+
+        @register_model_config_parser(parser_name)
+        class _FakeParser(ModelConfigParserBase):
+            def parse(self, model, trust_remote_code, revision=None, **kwargs):
+                return PretrainedConfig(architectures=[architecture])
+
+        return _draft_server_args(
+            speculative_draft_model_path=draft_path,
+            model_config_parser=parser_name,
+            speculative_algorithm=algorithm,
+            json_model_override_args="{}",
+        )
+
+    def test_gemma4_assistant_draft_is_detected_through_the_plugin_parser(self):
+        server_args = self._server_args_with_parsed_draft(
+            draft_path="/nonexistent/gemma4-assistant-draft",
+            architecture="Gemma4AssistantForCausalLM",
+            algorithm="NEXTN",
+        )
+        self.assertTrue(_draft_is_gemma4_assistant(server_args))
+
+    def test_non_gemma4_draft_is_not_detected(self):
+        server_args = self._server_args_with_parsed_draft(
+            draft_path="/nonexistent/llama-draft",
+            architecture="LlamaForCausalLM",
+            algorithm="NEXTN",
+        )
+        self.assertFalse(_draft_is_gemma4_assistant(server_args))
+
+    def test_no_draft_read_for_algorithms_that_ignore_the_answer(self):
+        # The probe used to read the draft config for every algorithm. Now that
+        # the read honors --model-config-parser, a target-only parser would
+        # turn an unused answer into a fatal startup error.
+        server_args = _draft_server_args(speculative_algorithm="DSPARK")
+        with patch("sglang.srt.configs.model_config.get_config") as mock_get_config:
+            self.assertFalse(_draft_is_gemma4_assistant(server_args))
+        mock_get_config.assert_not_called()
+
+    def test_no_draft_read_without_a_draft_path(self):
+        server_args = _draft_server_args(
+            speculative_algorithm="EAGLE", speculative_draft_model_path=None
+        )
+        with patch("sglang.srt.configs.model_config.get_config") as mock_get_config:
+            self.assertFalse(_draft_is_gemma4_assistant(server_args))
+        mock_get_config.assert_not_called()
+
+    def test_gemma4_draft_promotes_nextn_to_frozen_kv_mtp(self):
+        for algorithm in ("NEXTN", "EAGLE"):
+            with self.subTest(algorithm=algorithm):
+                self.assertEqual(
+                    _resolve_speculative_algorithm_alias(
+                        speculative_algorithm=algorithm, is_gemma4_draft=True
+                    ),
+                    "FROZEN_KV_MTP",
+                )
+
+    def test_gemma4_draft_rejects_eagle3(self):
+        with self.assertRaisesRegex(ValueError, "EAGLE3 is"):
+            _resolve_speculative_algorithm_alias(
+                speculative_algorithm="EAGLE3", is_gemma4_draft=True
+            )
+
+    def test_non_gemma4_draft_keeps_the_nextn_to_eagle_alias(self):
+        self.assertEqual(
+            _resolve_speculative_algorithm_alias(
+                speculative_algorithm="NEXTN", is_gemma4_draft=False
+            ),
+            "EAGLE",
+        )
+
+    def test_other_algorithms_pass_through(self):
+        self.assertEqual(
+            _resolve_speculative_algorithm_alias(
+                speculative_algorithm="DSPARK", is_gemma4_draft=False
+            ),
+            "DSPARK",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Five call sites read the **draft** checkpoint's HF config while `ServerArgs.__post_init__` resolves arguments, and each one hand-rolls its own subset of `get_config()` arguments. They disagree with each other and with the target's loader:

| call site | `revision` | `model_override_args` | `model_config_parser` | decrypted config |
|---|---|---|---|---|
| target: `ModelConfig.__init__` | yes | yes | yes | yes |
| `_resolve_speculative_algorithm_alias` (Gemma4 alias probe) | no | no | **no** | yes |
| `_handle_dflash` (block-size inference) | yes | yes | **no** | no |
| `_resolve_dflash_draft_attention_backend` | yes | yes | **no** | no |
| `read_draft_checkpoint_gamma` (DSpark) | yes | yes | **no** | no |
| `draft_is_deepseek_v4` | yes | yes | yes | no |

The alias probe is the worst case: with `model_config_parser` dropped, `get_config` re-resolves `"auto"` → the `hf` parser → `transformers` → the HF Hub. A checkpoint whose target config resolves through a parser registered via `@register_model_config_parser` therefore dies at CLI-parse time:

```
File "python/sglang/srt/arg_groups/speculative_hook.py", line 36, in _resolve_speculative_algorithm_alias
    cfg = get_config(
File "python/sglang/srt/utils/hf_transformers/config.py", line 63, in _try_load_longcat_config
    config_dict, _ = PretrainedConfig.get_config_dict(
huggingface_hub.errors.HFValidationError: Repo id must be in the form 'repo_name' or
'namespace/repo_name': '/.../models--Org--Model/snapshots/<sha>/'. Use `repo_type` argument if needed.
```

The traceback names neither the draft nor the flag that supplied the path, because these reads happen before any model config exists.

## Modifications

- **`ModelConfig.get_draft_hf_config(server_args)`** — one loader for the draft checkpoint's HF config, whose inputs mirror the ones `from_server_args(..., is_draft_model=True)` feeds `ModelConfig`: `trust_remote_code`, the draft revision (falling back to `--revision`, as `from_server_args` does), parsed `--json-model-override-args`, `--model-config-parser`, and `--decrypted-draft-config-file` as `_configuration_file`.
- **All five reads go through it**, so argument resolution and the draft worker's own load (`tp_worker._init_model_config`, already on `from_server_args`) now resolve the same config. Side effect: the five reads collapse onto one `get_config` lru entry instead of up to four distinct ones.
- A read failure is re-raised naming `--speculative-draft-model-path`, the revision and the parser, with the cause both chained and in the message text — the two callers that swallow it log with `"Error: %s"`, which never formats `__cause__`.
- `--json-model-override-args` is parsed *before* the read, so a quoting error in that flag is not reported as an unreadable draft checkpoint.

### Tests

- `test/registered/unit/configs/test_draft_hf_config_resolution.py` — the read inputs (including the `model_override_args`-as-dict conversion and the `_configuration_file` whitespace handling), the error message and cause, and an `ast` parity check comparing the keyword sets of *both* `get_config` call sites in `ModelConfig`, so a new input on the target read that never reaches the draft read fails the suite. Plus the bug as behavior: a draft served by a registered plugin parser at a path the `hf` parser cannot read, covering the `FROZEN_KV_MTP` promotion, the `EAGLE3` rejection and the plain `NEXTN` alias — none of which had coverage before.
- `test/registered/unit/test_draft_config_read_ratchet.py` — asserts no raw `get_config(` call remains under `srt/arg_groups/` or `srt/speculative/`, matched by `ast` (a comment naming `get_config()` must not fail CI) and self-checking that it actually scanned files.

A full draft `ModelConfig` cannot be built during argument resolution: `_config_draft_model` rewrites `hf_config.architectures[0]` for drafts, and its DeepseekV4 branch is gated on the `speculative_algorithm` that the alias probe is still resolving. Only the config read is shared; the docstring records that invariant.

## Deliberately out of scope

Unifying the read *inputs* leaves the read's *failure policy* split across the five sites: fatal at the alias probe and at `_resolve_dflash_draft_attention_backend`, swallowed-and-defaulted at `_handle_dflash` (`speculative_num_draft_tokens = 16`) and at the DSpark gamma read. Those two swallows are now weaker than they look: before this change the arg-resolution read used a *narrower* argument set than the draft `ModelConfig` load, so a failure there could be a false alarm the load would survive; now the two reads are identical and hit the same `get_config` cache entry, so a failed read recurs verbatim at load time. The fallback mostly relocates the crash into the scheduler subprocess, and in the transient-failure case DFLASH boots with a guessed block size that `dflash_worker_v2` only warns about. Changing that is a behavior change for DFLASH users and belongs in its own PR; this one keeps the policy as-is and makes the swallowed warning carry the root cause.

## Accuracy Tests

Not applicable — argument resolution only; no kernel or model forward code is touched. The resolved `hf_config` is unchanged for any launch that already passed the same inputs at both layers.

## Speed Tests and Profiling

Not applicable. Startup-only path; strictly fewer config reads than before.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32403698111](https://github.com/sgl-project/sglang/actions/runs/32403698111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32403697915](https://github.com/sgl-project/sglang/actions/runs/32403697915)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32403698251](https://github.com/sgl-project/sglang/actions/runs/32403698251)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->