### PR TITLE
[metrics] Fix prefill FLOPs estimate to count prefix and per-request causal pairs

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -453,6 +453,14 @@ class SchedulerMetricsReporter:
             num_attn_heads * head_dim * act_bytes * num_layers
         )
 
+    @staticmethod
+    def _prefill_attention_products(batch) -> Tuple[float, float]:
+        prefix_product = sum(
+            c * p for c, p in zip(batch.extend_lens, batch.prefix_lens)
+        )
+        within_chunk = sum(c * (c + 1) / 2.0 for c in batch.extend_lens)
+        return prefix_product + within_chunk, prefix_product
+
     def _estimate_prefill_perf(self, batch) -> Tuple[float, float, float]:
         if batch is None or batch.extend_lens is None:
             return 0.0, 0.0, 0.0
@@ -460,11 +468,7 @@ class SchedulerMetricsReporter:
         if tokens == 0:
             return 0.0, 0.0, 0.0
 
-        # Causal prefill token-context product.
-        context_product = sum(
-            c * p + c * (c + 1) / 2.0
-            for c, p in zip(batch.extend_lens, batch.prefix_lens)
-        )
+        context_product, prefix_product = self._prefill_attention_products(batch)
         flops = (
             tokens * self._linear_flops_per_token
             + self._attn_dot_flops_coeff * context_product
@@ -474,6 +478,7 @@ class SchedulerMetricsReporter:
             tokens * self._weight_read_bytes_per_token
             + tokens * self._qkv_act_bytes_per_token
             + tokens * self._prefill_attn_act_read_per_token
+            + prefix_product * self._kv_cache_bytes_per_token
         )
         write_bytes = (
             tokens * self._kv_cache_bytes_per_token
@@ -509,8 +514,8 @@ class SchedulerMetricsReporter:
 
     def _prefill_sol_suffix(self, batch, elapsed_s: float) -> str:
         """Hook: model-specific speed-of-light % suffix for the prefill log line.
-        ``batch`` carries the per-request extend/prefix lengths a subclass needs
-        for an exact attention pair-count. No model arch here, so returns "";
+        Call ``_prefill_attention_products(batch)`` for the exact causal
+        attention pair-count. No model arch here, so returns "";
         a subclass may override it."""
         return ""
 

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -461,7 +461,10 @@ class SchedulerMetricsReporter:
             return 0.0, 0.0, 0.0
 
         # Causal prefill token-context product.
-        context_product = tokens * (tokens + 1) / 2.0
+        context_product = sum(
+            c * p + c * (c + 1) / 2.0
+            for c, p in zip(batch.extend_lens, batch.prefix_lens)
+        )
         flops = (
             tokens * self._linear_flops_per_token
             + self._attn_dot_flops_coeff * context_product

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -454,12 +454,12 @@ class SchedulerMetricsReporter:
         )
 
     @staticmethod
-    def _prefill_attention_products(batch) -> Tuple[float, float]:
-        prefix_product = sum(
-            c * p for c, p in zip(batch.extend_lens, batch.prefix_lens)
-        )
-        within_chunk = sum(c * (c + 1) / 2.0 for c in batch.extend_lens)
-        return prefix_product + within_chunk, prefix_product
+    def _prefill_attention_pairs(batch) -> float:
+        """Causal query-key pairs: each chunk against its cached prefix, plus
+        the causal pairs within the chunk itself."""
+        prefix_pairs = sum(c * p for c, p in zip(batch.extend_lens, batch.prefix_lens))
+        within_chunk_pairs = sum(c * (c + 1) / 2.0 for c in batch.extend_lens)
+        return float(prefix_pairs + within_chunk_pairs)
 
     def _estimate_prefill_perf(self, batch) -> Tuple[float, float, float]:
         if batch is None or batch.extend_lens is None:
@@ -468,17 +468,20 @@ class SchedulerMetricsReporter:
         if tokens == 0:
             return 0.0, 0.0, 0.0
 
-        context_product, prefix_product = self._prefill_attention_products(batch)
+        context_product = self._prefill_attention_pairs(batch)
         flops = (
             tokens * self._linear_flops_per_token
             + self._attn_dot_flops_coeff * context_product
         )
 
+        # The chunk's queries share one pass over the cached prefix, so charge the
+        # prefix KV once per chunk -- not once per query-key pair.
+        prefix_kv_tokens = float(sum(batch.prefix_lens))
         read_bytes = (
             tokens * self._weight_read_bytes_per_token
             + tokens * self._qkv_act_bytes_per_token
             + tokens * self._prefill_attn_act_read_per_token
-            + prefix_product * self._kv_cache_bytes_per_token
+            + prefix_kv_tokens * self._kv_cache_bytes_per_token
         )
         write_bytes = (
             tokens * self._kv_cache_bytes_per_token
@@ -514,7 +517,7 @@ class SchedulerMetricsReporter:
 
     def _prefill_sol_suffix(self, batch, elapsed_s: float) -> str:
         """Hook: model-specific speed-of-light % suffix for the prefill log line.
-        Call ``_prefill_attention_products(batch)`` for the exact causal
+        Call ``_prefill_attention_pairs(batch)`` for the exact causal
         attention pair-count. No model arch here, so returns "";
         a subclass may override it."""
         return ""

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -424,25 +424,15 @@ class TestEstimatedPrefillPerf(CustomTestCase):
         return flops
 
     def test_chunk_is_charged_for_its_cached_prefix(self):
-        """A chunk resumed on a cached prefix must be charged for reading it.
-
-        Every token of a new chunk attends to all tokens already in the KV
-        cache, so a 4-token chunk sitting at prefix 3 costs 4*3 pairs against
-        the prefix plus 4*5/2 pairs within the chunk. Scoring the chunk as a
-        fresh 4-token sequence drops the prefix term, and the shortfall grows
-        with the prefix length.
-        """
         self.assertEqual(self._pair_count([4], [3]), 4 * 3 + 4 * 5 / 2)
 
-    def test_requests_in_one_batch_do_not_attend_to_each_other(self):
-        """Requests batched together must be counted as separate sequences.
+    def test_chunk_is_charged_for_prefix_kv_reads(self):
+        self.reporter._kv_cache_bytes_per_token = 1.0
+        batch = types.SimpleNamespace(extend_lens=[4], prefix_lens=[3])
+        _, read_bytes, _ = self.reporter._estimate_prefill_perf(batch)
+        self.assertEqual(read_bytes, 4 * 3)
 
-        A token only attends within its own request, so two 100-token prefills
-        cost 2 * (100*101/2) pairs. Scoring the batch as one 200-token sequence
-        (200*201/2) charges pairs between requests that never attend to each
-        other. This holds with no prefix at all, so it is a defect distinct
-        from the missing prefix term above.
-        """
+    def test_requests_in_one_batch_do_not_attend_to_each_other(self):
         self.assertEqual(self._pair_count([100, 100], [0, 0]), 2 * (100 * 101 / 2))
 
 

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -426,14 +426,24 @@ class TestEstimatedPrefillPerf(CustomTestCase):
     def test_chunk_is_charged_for_its_cached_prefix(self):
         self.assertEqual(self._pair_count([4], [3]), 4 * 3 + 4 * 5 / 2)
 
-    def test_chunk_is_charged_for_prefix_kv_reads(self):
+    def test_prefix_kv_is_read_once_per_chunk(self):
+        # One pass over the prefix per chunk, not one read per query-key pair:
+        # the chunk's queries share the same KV stream.
         self.reporter._kv_cache_bytes_per_token = 1.0
         batch = types.SimpleNamespace(extend_lens=[4], prefix_lens=[3])
         _, read_bytes, _ = self.reporter._estimate_prefill_perf(batch)
-        self.assertEqual(read_bytes, 4 * 3)
+        self.assertEqual(read_bytes, 3)
 
     def test_requests_in_one_batch_do_not_attend_to_each_other(self):
         self.assertEqual(self._pair_count([100, 100], [0, 0]), 2 * (100 * 101 / 2))
+
+    def test_mixed_prefill_and_decode_rows_use_their_own_context(self):
+        # mix_with_running appends running requests as extend_len 1 with their
+        # full context as prefix_len.
+        self.assertEqual(
+            self._pair_count([8, 1, 1], [0, 100, 200]),
+            8 * 9 / 2 + (100 + 1) + (200 + 1),
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -14,6 +14,7 @@ from sglang.srt.managers.scheduler_components.metrics_reporter import (
     PrefillStats,
     SchedulerMetricsReporter,
 )
+from sglang.test.test_utils import CustomTestCase
 
 
 def _make_ps(**overrides) -> ParallelState:
@@ -397,6 +398,52 @@ class TestIdleMetrics(unittest.TestCase):
         self.assertTrue(math.isnan(self.reporter.stats.fwd_occupancy))
         self.assertEqual(self.reporter._device_timer_window_batch_count, 0)
         self.assertEqual(self.published_occupancies, [])
+
+
+class TestEstimatedPrefillPerf(CustomTestCase):
+    """Causal pair count behind ``est. prefill TFLOPS/s`` and ``estimated_flops``."""
+
+    def setUp(self):
+        self.scheduler = types.SimpleNamespace()
+        self.scheduler.waiting_queue = []
+        self.scheduler.disaggregation_mode = DisaggregationMode.NULL
+        self.reporter = _make_reporter(self, self.scheduler)
+        # One unit per query-key pair and nothing else, so the returned FLOPs
+        # are exactly the attention pair count.
+        self.reporter._linear_flops_per_token = 0.0
+        self.reporter._attn_dot_flops_coeff = 1.0
+        self.reporter._weight_read_bytes_per_token = 0.0
+        self.reporter._qkv_act_bytes_per_token = 0.0
+        self.reporter._prefill_attn_act_read_per_token = 0.0
+        self.reporter._kv_cache_bytes_per_token = 0.0
+        self.reporter._ffn_act_bytes_per_token = 0.0
+
+    def _pair_count(self, extend_lens, prefix_lens):
+        batch = types.SimpleNamespace(extend_lens=extend_lens, prefix_lens=prefix_lens)
+        flops, _, _ = self.reporter._estimate_prefill_perf(batch)
+        return flops
+
+    def test_chunk_is_charged_for_its_cached_prefix(self):
+        """A chunk resumed on a cached prefix must be charged for reading it.
+
+        Every token of a new chunk attends to all tokens already in the KV
+        cache, so a 4-token chunk sitting at prefix 3 costs 4*3 pairs against
+        the prefix plus 4*5/2 pairs within the chunk. Scoring the chunk as a
+        fresh 4-token sequence drops the prefix term, and the shortfall grows
+        with the prefix length.
+        """
+        self.assertEqual(self._pair_count([4], [3]), 4 * 3 + 4 * 5 / 2)
+
+    def test_requests_in_one_batch_do_not_attend_to_each_other(self):
+        """Requests batched together must be counted as separate sequences.
+
+        A token only attends within its own request, so two 100-token prefills
+        cost 2 * (100*101/2) pairs. Scoring the batch as one 200-token sequence
+        (200*201/2) charges pairs between requests that never attend to each
+        other. This holds with no prefix at all, so it is a defect distinct
+        from the missing prefix term above.
+        """
+        self.assertEqual(self._pair_count([100, 100], [0, 0]), 2 * (100 * 101 / 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #34298.

`SchedulerMetricsReporter._estimate_prefill_perf` computes the causal attention pair count using only `sum(extend_lens)`. In other words, when a chunk of `c` tokens is resumed at prefix `P`, the estimator scores it as if it were a brand-new sequence of length `c`. This produces two independent errors.

1. Pairs against the cached prefix are dropped
The `c * P` attention pairs between the chunk and its cached prefix are never counted. Because both FLOPs terms depend only on `sum(extend_lens)`, a fixed `--chunked-prefill-size` makes the estimated numerator identical for every chunk of a request. The reported `est. prefill TFLOPS/s` then becomes proportional to `1 / gap_latency` rather than to any real measure of throughput.
Later chunks take longer as their prefix grows, so the number trends down while the GPU is doing more work per chunk, which is the opposite of the intended signal for the metric.

2.  Separate requests are merged into one sequence
The batch is summed before the pair count is computed, which collapses all requests in the batch into a single sequence. But a token only attends within its own request. For example, two 100-token prefills actually cost `2 * (100*101/2) = 10,100` pairs, while scoring them as one 200-token sequence gives `200*201/2 = 20,100` — charging 10,000 pairs between tokens that never attend to each other.

`_estimate_decode_perf` directly below the code already uses the full context for both its FLOPs and its KV read term, so the prefill path is the outlier here rather than a deliberate simplification.

Mixed prefill+decode batches feed the same estimator and are affected too. ScheduleBatch.mix_with_running appends each running request as extend_len = 1 with prefix_len set to its current context length, but that 1 only nudges the batch-wide token count, and the request's actual context never enters the estimate.

## Modifications

Accumulate the token-context product per request, using the `prefix_lens` the batch already carries:

```
context_product = sum(
    c * p + c * (c + 1) / 2.0
    for c, p in zip(batch.extend_lens, batch.prefix_lens)
)
```

c * p covers each new token against every token already in the request's KV cache. c * (c + 1) / 2 covers the causal pairs within the chunk itself.

This PR deliberately omits the `prefix_lens` fallback and the `c <= 0` guard proposed in #34298. The two lists are written together on every code path that touches them (`prepare_for_extend`, `mix_with_running`, `prepare_encoder_info_extend`), so they stay index-aligned, and `c == 0` already contributes zero to the sum.

tokens, read_bytes and write_bytes are unchanged.

Note for reviewers: this raises the absolute value of sglang:estimated_flops_per_gpu_total, potentially by one to two orders of magnitude at long context. Any alerting thresholds calibrated against the current (incorrect) values will need revisiting.

Left open in #34298: 
- @fzyzcjy — one open question on this: read_bytes has no prefix-dependent term, so prefill reports no KV-cache read traffic for a cached prefix. Adding one needs a call on whether estimated_read_bytes_per_gpu_total is meant to represent logical traffic or actual HBM traffic, since the two differ a lot once kernel tiling and reuse are involved.
Update: implemented logical fix as noted.
- The MLA / MoE / sparse-attention constants need architecture-specific modelling.

## Accuracy Tests

Not applicable — observability only

## Speed Tests and Profiling

Not applicable. The estimator runs on the logging path once per prefill batch; the change replaces one sum over a list of ints with one generator over zip of two lists whose length is the batch's request count.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32074920019](https://github.com/sgl-project/sglang/actions/runs/32074920019)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32074919786](https://github.com/sgl-project/sglang/actions/runs/32074919786)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->