### PR TITLE
[Fix] Pin `cuda-tile` to 1.6.0rc5 to unblock Python 3.10 x86_64 installs

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
   "build",
   "compressed-tensors",
   "cuda-python>=13.0",
+  # Transitive dep of flashinfer-python, pinned because 1.6.0rc6 shipped no cp310 linux x86_64 wheel.
+  "cuda-tile==1.6.0rc5",
   "datasets",
   "decord2 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "distro",


### PR DESCRIPTION
## Summary
- Pin `cuda-tile==1.6.0rc5` so resolution stops picking the incomplete `1.6.0rc6` prerelease

## Background
- `cuda-tile` is transitive: `sglang` -> `flashinfer_python[cu13]==0.6.15.post1` -> `cuda-tile>=1.4.0`
- On PyPI it is a `wheel_stub` placeholder sdist that fetches the real wheel from `pypi.nvidia.com` at build time
- `1.6.0rc6` was published without `cp310` and `cp313` linux x86_64 wheels, so the stub raises `RuntimeError: Didn't find wheel for cuda-tile 1.6.0rc6`
- CI installs with `--prerelease allow` (`.github/workflows/_pr-test-stage-cpu.yml`), so every CPU shard on Python 3.10 x86_64 died in `Install dependencies` before running a single test

## Fix
- `1.6.0rc5` is the newest version with a complete wheel matrix (cp310-cp314 across linux x86_64/aarch64 and win_amd64) and still satisfies flashinfer's `>=1.4.0` constraint
- The `==` pin needs a manual bump once a complete `1.6.0rcN` is republished

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31436562656](https://github.com/sgl-project/sglang/actions/runs/31436562656)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31436562499](https://github.com/sgl-project/sglang/actions/runs/31436562499)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
