### PR TITLE
fix(ci): constrain NeMo Skills evaluator dependencies

### DIFF
--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -212,6 +212,7 @@ def _get_nemo_venv() -> Tuple[str, dict]:
             "--python",
             f"{_nemo_venv_dir}/venv/bin/python",
             f"git+https://github.com/NVIDIA/NeMo-Skills.git@{nemo_skills_ref}",
+            "mcp<2",
         ],
         capture_output=True,
         text=True,

--- a/python/sglang/test/accuracy_test_runner.py
+++ b/python/sglang/test/accuracy_test_runner.py
@@ -213,6 +213,7 @@ def _get_nemo_venv() -> Tuple[str, dict]:
             f"{_nemo_venv_dir}/venv/bin/python",
             f"git+https://github.com/NVIDIA/NeMo-Skills.git@{nemo_skills_ref}",
             "mcp<2",
+            "typer<0.27",
         ],
         capture_output=True,
         text=True,


### PR DESCRIPTION
## Summary

- constrain MCP to `<2` and Typer to `<0.27` when installing the pinned NeMo Skills evaluator
- scope both constraints to the evaluator's temporary virtual environment
- keep the existing NeMo Skills commit and SGLang's global dependencies unchanged

## Root cause

NeMo Skills commit `589294c` imports the deprecated `streamablehttp_client` symbol and declares `mcp` without an upper bound. Fresh resolution installs MCP 2.x, where that symbol was removed, so the accuracy phase fails during import before evaluation requests are issued.

After constraining MCP, the fresh environment resolves Typer 0.27.x. That release generates dash-separated option names such as `--output-dir`, while the pinned NeMo Skills CLI and SGLang invocation use underscore-separated names such as `--output_dir`. The accuracy phase then exits during CLI parsing.

Failures:
- https://github.com/sgl-project/sglang/actions/runs/31317862701/job/93255928833
- https://github.com/sgl-project/sglang/actions/runs/31437695842/job/93615427291

## Validation

- `python3 -m py_compile python/sglang/test/accuracy_test_runner.py`
- fresh Python 3.12 venv resolved `mcp==1.29.0` and `typer==0.26.8`
- verified `from mcp.client.streamable_http import streamablehttp_client`
- verified the pinned NeMo Skills CLI exposes `--output_dir`
- `git diff --check`

The full GB300 nightly evaluation is pending follow-up validation.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31440849228](https://github.com/sgl-project/sglang/actions/runs/31440849228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31440849026](https://github.com/sgl-project/sglang/actions/runs/31440849026)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->