### PR TITLE
[AMD][CI] Run MI300 8-GPU stage-C shards two at a time

### DIFF
--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -1082,7 +1082,7 @@ jobs:
       RUNNER_LABELS: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi300') }}
     strategy:
       fail-fast: false
-      max-parallel: 1
+      max-parallel: 2
       matrix:
         part: [0, 1, 2, 3]
     runs-on: ${{ format('linux-{0}-8gpu-sglang', inputs.runner_arch || 'mi300') }}


### PR DESCRIPTION
## Summary
- run `stage-c-test-large-8-gpu-amd` matrix shards two at a time instead of one
- halves the serialized waves on the AMD PR critical path without changing total GPU-hours

## Motivation
The four shards currently use `max-parallel: 1`. Across recent MI300 job snapshots, partition 0 had a 0-minute median pickup wait while partition 3 waited 163 minutes, matching the duration of the preceding serialized waves rather than runner pickup latency.

`max-parallel: 2` takes the suite from four waves to two. This is deliberately conservative: the 8-GPU pool's observed ceiling is 19 runners and has recently dipped to 14-15, so this leaves ample room rather than assuming the full declared capacity.

## Test plan
- [x] Parse `pr-test-amd.yml` as YAML
- [x] Assert the stage-C matrix remains `[0, 1, 2, 3]` with `max-parallel: 2`
- [x] Run `git diff --check`
- [ ] Dispatch `stage-c-test-large-8-gpu-amd` and confirm shards start two per wave
- [ ] Confirm no increase in 8-GPU pool queue wait after merge

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31448963594](https://github.com/sgl-project/sglang/actions/runs/31448963594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31448963468](https://github.com/sgl-project/sglang/actions/runs/31448963468)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->