### PR TITLE
[Fix] Read trace level via `get_global_trace_level()` in `trace_async`

### DIFF
--- a/python/sglang/srt/observability/trace_async.py
+++ b/python/sglang/srt/observability/trace_async.py
@@ -555,7 +555,7 @@ class TraceReqContextAsync:
         external_trace_header: Optional[Dict[str, str]] = None,
     ):
         self.rid: str = str(rid)
-        self.trace_level = _trace_mod.global_trace_level
+        self.trace_level = _trace_mod.get_global_trace_level()
         self.tracing_enable: bool = (
             is_async_tracing_available()
             and _trace_mod.opentelemetry_initialized
@@ -976,7 +976,7 @@ class TraceReqContextAsync:
             return
 
         self.rid = state["rid"]
-        self.trace_level = state.get("trace_level", _trace_mod.global_trace_level)
+        self.trace_level = state.get("trace_level", _trace_mod.get_global_trace_level())
         self._init_args = state["init_args"]
         self._operations = []
         self._flush_threshold = envs.SGLANG_TRACE_ASYNC_FLUSH_THRESHOLD.get()


### PR DESCRIPTION
`trace_async.py` reads `_trace_mod.global_trace_level`, but `trace.py` exposes only `get_global_trace_level()` / `set_global_trace_level()`. Any server started with `--enable-trace` raises `AttributeError` on the first request, so warmup fails and the process exits.

Caught by `test/registered/observability/test_tracing.py` in the scheduled run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31442240568](https://github.com/sgl-project/sglang/actions/runs/31442240568)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31442240393](https://github.com/sgl-project/sglang/actions/runs/31442240393)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->