### PR TITLE
test: extend NVFP4 Marlin tests to SM120

### DIFF
--- a/test/registered/kernels/ops/quantization/test_gptq_marlin.py
+++ b/test/registered/kernels/ops/quantization/test_gptq_marlin.py
@@ -1,5 +1,4 @@
 import sys
-from types import SimpleNamespace
 
 import pytest
 import torch
@@ -7,23 +6,11 @@ from sgl_kernel.scalar_type import scalar_types
 
 from sglang.kernels.ops.quantization.gptq_marlin import gptq_marlin_gemm
 from sglang.srt.layers.quantization.marlin_utils import (
-    check_marlin_supported,
     marlin_make_workspace,
-)
-from sglang.srt.layers.quantization.marlin_utils_fp4 import (
-    apply_fp4_marlin_linear,
-    nvfp4_marlin_process_global_scale,
-    prepare_nvfp4_layer_for_marlin,
-)
-from sglang.srt.utils.common import (
-    is_sm80_supported,
-    is_sm90_supported,
-    is_sm120_supported,
 )
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import (
     awq_marlin_quantize,
-    make_nvfp4_weight_and_ref,
     marlin_quantize,
 )
 
@@ -116,79 +103,6 @@ def test_gptq_marlin_gemm(
         torch.abs(output_ref)
     )
     assert max_diff < 0.04
-
-
-@pytest.mark.skipif(
-    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
-    reason="NVFP4 Marlin fallback tests require CUDA SM8X/SM9X/SM120",
-)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90_sm120(dtype):
-    major, minor = torch.cuda.get_device_capability()
-    capability = major * 10 + minor
-    assert check_marlin_supported(
-        scalar_types.float4_e2m1f,
-        group_size=16,
-        has_zp=False,
-        device_capability=capability,
-    )
-
-    global_scale = torch.tensor(1.0, dtype=dtype, device="cuda")
-    actual_global_scale = nvfp4_marlin_process_global_scale(global_scale)
-    assert actual_global_scale.is_cuda
-    assert actual_global_scale.ndim == 1
-    assert actual_global_scale.numel() == 1
-    if dtype == torch.float16:
-        assert actual_global_scale.item() == 128.0
-    else:
-        assert actual_global_scale.item() == 2.0**119
-
-
-@pytest.mark.skipif(
-    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
-    reason="NVFP4 Marlin dense numeric test requires CUDA SM80, SM86, SM90 or SM120",
-)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_nvfp4_marlin_dense_matches_dequant_reference(dtype):
-    torch.manual_seed(0)
-
-    size_m = 17
-    size_k = 256
-    size_n = 192
-    group_size = 16
-
-    a_input = torch.randn((size_m, size_k), dtype=dtype, device="cuda") / 10
-    fp4_weight, scales, global_scale, weight_ref = make_nvfp4_weight_and_ref(
-        size_n, size_k, dtype, group_size=group_size
-    )
-
-    layer = torch.nn.Module()
-    layer.quant_config = SimpleNamespace(group_size=group_size)
-    layer.output_size_per_partition = size_n
-    layer.input_size_per_partition = size_k
-    layer.params_dtype = dtype
-    layer.weight = torch.nn.Parameter(fp4_weight, requires_grad=False)
-    layer.weight_scale = torch.nn.Parameter(scales, requires_grad=False)
-    layer.weight_global_scale = torch.nn.Parameter(
-        global_scale.reshape(1), requires_grad=False
-    )
-    prepare_nvfp4_layer_for_marlin(layer)
-
-    output = apply_fp4_marlin_linear(
-        a_input,
-        layer.weight,
-        layer.weight_scale,
-        layer.weight_global_scale,
-        layer.workspace,
-        size_n,
-        size_k,
-        use_fp32_reduce=True,
-    )
-
-    output_ref = torch.matmul(a_input, weight_ref.T)
-    torch.cuda.synchronize()
-
-    torch.testing.assert_close(output, output_ref, rtol=0.04, atol=0.04)
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/ops/quantization/test_gptq_marlin.py
+++ b/test/registered/kernels/ops/quantization/test_gptq_marlin.py
@@ -15,7 +15,11 @@ from sglang.srt.layers.quantization.marlin_utils_fp4 import (
     nvfp4_marlin_process_global_scale,
     prepare_nvfp4_layer_for_marlin,
 )
-from sglang.srt.utils.common import is_sm80_supported, is_sm90_supported
+from sglang.srt.utils.common import (
+    is_sm80_supported,
+    is_sm90_supported,
+    is_sm120_supported,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_marlin_utils import (
     awq_marlin_quantize,
@@ -115,11 +119,11 @@ def test_gptq_marlin_gemm(
 
 
 @pytest.mark.skipif(
-    not (is_sm80_supported() or is_sm90_supported()),
-    reason="NVFP4 Marlin fallback tests require CUDA SM8X/SM9X",
+    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
+    reason="NVFP4 Marlin fallback tests require CUDA SM8X/SM9X/SM120",
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90(dtype):
+def test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90_sm120(dtype):
     major, minor = torch.cuda.get_device_capability()
     capability = major * 10 + minor
     assert check_marlin_supported(
@@ -141,8 +145,8 @@ def test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90(dtype):
 
 
 @pytest.mark.skipif(
-    not (is_sm80_supported() or is_sm90_supported()),
-    reason="NVFP4 Marlin dense numeric test requires CUDA SM80, SM86, or SM90",
+    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
+    reason="NVFP4 Marlin dense numeric test requires CUDA SM80, SM86, SM90 or SM120",
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 def test_nvfp4_marlin_dense_matches_dequant_reference(dtype):

--- a/test/registered/kernels/ops/quantization/test_nvfp4_marlin.py
+++ b/test/registered/kernels/ops/quantization/test_nvfp4_marlin.py
@@ -1,0 +1,100 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+from sgl_kernel.scalar_type import scalar_types
+
+from sglang.srt.layers.quantization.marlin_utils import check_marlin_supported
+from sglang.srt.layers.quantization.marlin_utils_fp4 import (
+    apply_fp4_marlin_linear,
+    nvfp4_marlin_process_global_scale,
+    prepare_nvfp4_layer_for_marlin,
+)
+from sglang.srt.utils.common import (
+    is_sm80_supported,
+    is_sm90_supported,
+    is_sm120_supported,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_marlin_utils import make_nvfp4_weight_and_ref
+
+register_cuda_ci(est_time=6, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=6, stage="base-b", runner_config="1-gpu-small")
+
+
+@pytest.mark.skipif(
+    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
+    reason="NVFP4 Marlin fallback tests require CUDA SM8X/SM9X/SM120",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90_sm120(dtype):
+    major, minor = torch.cuda.get_device_capability()
+    capability = major * 10 + minor
+    assert check_marlin_supported(
+        scalar_types.float4_e2m1f,
+        group_size=16,
+        has_zp=False,
+        device_capability=capability,
+    )
+
+    global_scale = torch.tensor(1.0, dtype=dtype, device="cuda")
+    actual_global_scale = nvfp4_marlin_process_global_scale(global_scale)
+    assert actual_global_scale.is_cuda
+    assert actual_global_scale.ndim == 1
+    assert actual_global_scale.numel() == 1
+    if dtype == torch.float16:
+        assert actual_global_scale.item() == 128.0
+    else:
+        assert actual_global_scale.item() == 2.0**119
+
+
+@pytest.mark.skipif(
+    not (is_sm80_supported() or is_sm90_supported() or is_sm120_supported()),
+    reason="NVFP4 Marlin dense numeric test requires CUDA SM80, SM86, SM90 or SM120",
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_nvfp4_marlin_dense_matches_dequant_reference(dtype):
+    torch.manual_seed(0)
+
+    size_m = 17
+    size_k = 256
+    size_n = 192
+    group_size = 16
+
+    a_input = torch.randn((size_m, size_k), dtype=dtype, device="cuda") / 10
+    fp4_weight, scales, global_scale, weight_ref = make_nvfp4_weight_and_ref(
+        size_n, size_k, dtype, group_size=group_size
+    )
+
+    layer = torch.nn.Module()
+    layer.quant_config = SimpleNamespace(group_size=group_size)
+    layer.output_size_per_partition = size_n
+    layer.input_size_per_partition = size_k
+    layer.params_dtype = dtype
+    layer.weight = torch.nn.Parameter(fp4_weight, requires_grad=False)
+    layer.weight_scale = torch.nn.Parameter(scales, requires_grad=False)
+    layer.weight_global_scale = torch.nn.Parameter(
+        global_scale.reshape(1), requires_grad=False
+    )
+    prepare_nvfp4_layer_for_marlin(layer)
+
+    output = apply_fp4_marlin_linear(
+        a_input,
+        layer.weight,
+        layer.weight_scale,
+        layer.weight_global_scale,
+        layer.workspace,
+        size_n,
+        size_k,
+        use_fp32_reduce=True,
+    )
+
+    output_ref = torch.matmul(a_input, weight_ref.T)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(output, output_ref, rtol=0.04, atol=0.04)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## Motivation

`ModelOptNvFp4A16LinearMethod.apply()` calls `apply_fp4_marlin_linear()` unconditionally, there is no capability branch, so this is the path every dense NVFP4 W4A16 layer takes on SM120 today. But the two NVFP4 Marlin tests in `test_gptq_marlin.py` are skip-gated to SM80/SM86/SM90, so that path has never been asserted correct on Blackwell.

I verified it on an RTX PRO 6000 Blackwell Server Edition (SM120) while benchmarking this path for #33711, and it passes within the test's existing tolerance. This PR widens the gate so the tests actually run there.

The effect is that they no longer silently skip for anyone running on Blackwell hardware.

## Modifications

`test/registered/kernels/ops/quantization/test_gptq_marlin.py`:

- Added `is_sm120_supported` to the existing `sglang.srt.utils.common` import.
- Extended the `skipif` on `test_nvfp4_marlin_support_and_scale_transforms_*` and `test_nvfp4_marlin_dense_matches_dequant_reference` to include SM120, and updated both reason strings.
- Renamed `test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90` to `..._sm80_sm90_sm120` so the name still matches the gate. Happy to drop the arch suffix entirely instead if you'd prefer.

No kernel or production code is touched. `check_marlin_supported()` only floors at capability < 80 and has no upper bound, so SM120 was never excluded at the kernel-selection level,  the test gate was simply narrower than the code it covers.

## Accuracy Tests

Before, on SM120:

```
test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90[dtype0] SKIPPED
test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90[dtype1] SKIPPED
test_nvfp4_marlin_dense_matches_dequant_reference[dtype0] SKIPPED
test_nvfp4_marlin_dense_matches_dequant_reference[dtype1] SKIPPED
```

After:

```
test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90_sm120[dtype0] PASSED
test_nvfp4_marlin_support_and_scale_transforms_sm80_sm90_sm120[dtype1] PASSED
test_nvfp4_marlin_dense_matches_dequant_reference[dtype0] PASSED
test_nvfp4_marlin_dense_matches_dequant_reference[dtype1] PASSED
```

Run in `lmsysorg/sglang:v0.5.17` on an RTX PRO 6000 Blackwell Server Edition (SM120), both fp16 and bf16. 

## Speed Tests and Profiling

Not applicable as the test-gating change only, no kernel or runtime code modified.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31767679213](https://github.com/sgl-project/sglang/actions/runs/31767679213)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31767679212](https://github.com/sgl-project/sglang/actions/runs/31767679212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->