### PR TITLE
[Test] Add unit tests for srt/managers/scheduler_components/idle_sleeper.py

### DIFF
--- a/test/registered/unit/managers/scheduler_components/test_idle_sleeper.py
+++ b/test/registered/unit/managers/scheduler_components/test_idle_sleeper.py
@@ -1,0 +1,149 @@
+"""Unit tests for idle_sleeper — no server, no model loading."""
+
+import unittest
+from unittest.mock import MagicMock, call, patch
+
+import zmq
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components import idle_sleeper
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestIdleSleeper(CustomTestCase):
+    def create_sockets(self, count: int = 2) -> list:
+        return [MagicMock() for _ in range(count)]
+
+    def test_init_registers_every_socket_for_pollin(self):
+        sockets = self.create_sockets(3)
+        with (
+            patch.object(idle_sleeper.zmq, "Poller") as mock_poller_cls,
+            patch.object(idle_sleeper, "real_time", return_value=100.0),
+            envs.SGLANG_EMPTY_CACHE_INTERVAL.override(-1),
+        ):
+            sleeper = idle_sleeper.IdleSleeper(sockets)
+
+        mock_poller_cls.return_value.register.assert_has_calls(
+            [call(s, zmq.POLLIN) for s in sockets]
+        )
+        self.assertEqual(mock_poller_cls.return_value.register.call_count, 3)
+        self.assertEqual(sleeper.last_empty_time, 100.0)
+
+    def test_maybe_sleep_polls_fixed_timeout_and_skips_eviction_when_disabled(self):
+        # SGLANG_EMPTY_CACHE_INTERVAL default is -1 (disabled) — the production
+        # default must never trigger eviction, only the 1s poll wakeup.
+        with (
+            patch.object(idle_sleeper.zmq, "Poller") as mock_poller_cls,
+            patch.object(idle_sleeper, "real_time", return_value=100.0),
+            patch.object(idle_sleeper.current_platform, "empty_cache") as empty_cache,
+            envs.SGLANG_EMPTY_CACHE_INTERVAL.override(-1),
+        ):
+            sleeper = idle_sleeper.IdleSleeper(self.create_sockets())
+            sleeper.maybe_sleep()
+
+        mock_poller_cls.return_value.poll.assert_called_once_with(1000)
+        empty_cache.assert_not_called()
+
+    def test_empty_cache_not_called_at_or_below_interval(self):
+        # Guards the strict `>` in maybe_sleep: an elapsed time exactly equal
+        # to the interval must NOT evict (only strictly-greater does).
+        cases = {
+            "elapsed_below_interval": [10.0, 13.0],
+            "elapsed_equal_interval": [10.0, 15.0],
+        }
+        for label, real_time_values in cases.items():
+            with self.subTest(label=label):
+                with (
+                    patch.object(idle_sleeper.zmq, "Poller"),
+                    patch.object(
+                        idle_sleeper, "real_time", side_effect=list(real_time_values)
+                    ),
+                    patch.object(
+                        idle_sleeper.current_platform, "empty_cache"
+                    ) as empty_cache,
+                    envs.SGLANG_EMPTY_CACHE_INTERVAL.override(5),
+                ):
+                    sleeper = idle_sleeper.IdleSleeper(self.create_sockets())
+                    sleeper.maybe_sleep()
+
+                empty_cache.assert_not_called()
+
+    def test_empty_cache_called_once_and_last_empty_time_reset_past_interval(self):
+        with (
+            patch.object(idle_sleeper.zmq, "Poller"),
+            patch.object(idle_sleeper, "real_time", side_effect=[10.0, 15.1, 15.2]),
+            patch.object(idle_sleeper.current_platform, "empty_cache") as empty_cache,
+            envs.SGLANG_EMPTY_CACHE_INTERVAL.override(5),
+        ):
+            sleeper = idle_sleeper.IdleSleeper(self.create_sockets())
+            sleeper.maybe_sleep()
+
+        empty_cache.assert_called_once_with()
+        self.assertEqual(sleeper.last_empty_time, 15.2)
+
+
+class TestRustServerIdleSleeper(CustomTestCase):
+    def test_maybe_sleep_waits_on_ingress_with_configured_timeout(self):
+        rust_server = MagicMock()
+        with (
+            patch.object(idle_sleeper, "real_time", return_value=100.0),
+            patch.object(idle_sleeper.current_platform, "empty_cache") as empty_cache,
+            envs.SGLANG_EMPTY_CACHE_INTERVAL.override(-1),
+        ):
+            default_sleeper = idle_sleeper.RustServerIdleSleeper(rust_server)
+            default_sleeper.maybe_sleep()
+
+            custom_sleeper = idle_sleeper.RustServerIdleSleeper(
+                rust_server, timeout_ms=250
+            )
+            custom_sleeper.maybe_sleep()
+
+        rust_server.wait_ingress.assert_has_calls([call(1000), call(250)])
+        empty_cache.assert_not_called()
+
+    def test_empty_cache_not_called_at_or_below_interval(self):
+        # Rust equivalent of TestIdleSleeper's boundary test — the eviction
+        # bookkeeping is duplicated, not shared, so the strict `>` must be
+        # guarded independently in this class too.
+        cases = {
+            "elapsed_below_interval": [10.0, 13.0],
+            "elapsed_equal_interval": [10.0, 15.0],
+        }
+        for label, real_time_values in cases.items():
+            with self.subTest(label=label):
+                rust_server = MagicMock()
+                with (
+                    patch.object(
+                        idle_sleeper, "real_time", side_effect=list(real_time_values)
+                    ),
+                    patch.object(
+                        idle_sleeper.current_platform, "empty_cache"
+                    ) as empty_cache,
+                    envs.SGLANG_EMPTY_CACHE_INTERVAL.override(5),
+                ):
+                    sleeper = idle_sleeper.RustServerIdleSleeper(rust_server)
+                    sleeper.maybe_sleep()
+
+                empty_cache.assert_not_called()
+
+    def test_empty_cache_called_once_and_last_empty_time_reset_past_interval(self):
+        # RustServerIdleSleeper duplicates IdleSleeper's eviction bookkeeping
+        # rather than sharing it — guard against the two copies drifting apart.
+        rust_server = MagicMock()
+        with (
+            patch.object(idle_sleeper, "real_time", side_effect=[10.0, 15.1, 15.2]),
+            patch.object(idle_sleeper.current_platform, "empty_cache") as empty_cache,
+            envs.SGLANG_EMPTY_CACHE_INTERVAL.override(5),
+        ):
+            sleeper = idle_sleeper.RustServerIdleSleeper(rust_server)
+            sleeper.maybe_sleep()
+
+        empty_cache.assert_called_once_with()
+        self.assertEqual(sleeper.last_empty_time, 15.2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Part of #20865.

`IdleSleeper` and `RustServerIdleSleeper` in
`python/sglang/srt/managers/scheduler_components/idle_sleeper.py` implement
the scheduler idle-wait path and cache-eviction timing bookkeeping. They had
no focused registered unit coverage.

## Modifications

Add CPU-only unit tests in:

```text
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py
```

Coverage includes:

- `IdleSleeper` registration of all supplied ZMQ sockets with `zmq.POLLIN`.
- Fixed 1000 ms ZMQ polling timeout.
- Disabled cache eviction when `SGLANG_EMPTY_CACHE_INTERVAL < 0`.
- Strict `IdleSleeper` eviction-boundary behavior: elapsed time equal to the
  configured interval does not call `empty_cache()`.
- Cache eviction and `last_empty_time` refresh after elapsed time exceeds the
  configured interval for both idle sleeper implementations.
- `RustServerIdleSleeper.wait_ingress()` with both its default 1000 ms timeout
  and an explicit custom timeout.
- Strict cache-eviction boundary behavior for both idle sleepers: elapsed time
  equal to the configured interval does not call `empty_cache()`.

The tests use `CustomTestCase`, are registered with:

```python
register_cpu_ci(est_time=1, suite="base-a-test-cpu")
```

No server is launched, no model weights are loaded, and no GPU is required.
ZMQ polling, wall-clock time, platform cache eviction, and Rust ingress are
mocked.

## Accuracy Tests

N/A — test-only change; no model-output, kernel, or forward-path code is
modified.

## Speed Tests and Profiling

N/A — test-only change; no inference-path code is modified.

## Test Plan

Ran the focused CPU-only test in the `lmsysorg/sglang:dev` container. The
repository was mounted read-only; no server, model weights, or GPU were used.

```bash
docker run --rm \
  -v /home/lily/wsl_git/sglang:/sgl-workspace/sglang-src:ro \
  -w /sgl-workspace/sglang-src \
  -e PYTHONPATH=/sgl-workspace/sglang-src/python \
  lmsysorg/sglang:dev \
  python3 -m pytest \
    test/registered/unit/managers/scheduler_components/test_idle_sleeper.py \
    -v
```

## Local Testing

\`\`\`bash
pytest test/registered/unit/managers/scheduler_components/test_idle_sleeper.py -v
\`\`\`

\`\`\`text
============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
rootdir: /sgl-workspace/sglang-src/test
configfile: pytest.ini
plugins: anyio-4.14.2, typeguard-4.6.0
collecting ... collected 7 items

test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestIdleSleeper::test_empty_cache_called_once_and_last_empty_time_reset_past_interval PASSED [ 14%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestIdleSleeper::test_empty_cache_not_called_at_or_below_interval PASSED [ 28%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestIdleSleeper::test_init_registers_every_socket_for_pollin PASSED [ 42%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestIdleSleeper::test_maybe_sleep_polls_fixed_timeout_and_skips_eviction_when_disabled PASSED [ 57%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestRustServerIdleSleeper::test_empty_cache_called_once_and_last_empty_time_reset_past_interval PASSED [ 71%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestRustServerIdleSleeper::test_empty_cache_not_called_at_or_below_interval PASSED [ 85%]
test/registered/unit/managers/scheduler_components/test_idle_sleeper.py::TestRustServerIdleSleeper::test_maybe_sleep_waits_on_ingress_with_configured_timeout PASSED [100%]

============== 7 passed, 4 subtests passed in 27.52s ==============
\`\`\`



## Checklist

- [ ] Format code with pre-commit.
- [x] Add CPU-only registered unit tests.
- [x] Use `CustomTestCase`.
- [x] Register the test with `register_cpu_ci`.
- [x] Include boundary cases for cache eviction timing.
- [x] No server launch or model-weight loading.
- [x] Accuracy tests are not applicable.
- [x] Speed tests are not applicable.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31445356918](https://github.com/sgl-project/sglang/actions/runs/31445356918)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31445356730](https://github.com/sgl-project/sglang/actions/runs/31445356730)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->