### PR TITLE
[DSV4] Fix DSpark crash with non-none moe_a2a_backend in TP-attn a2a-…

### DIFF
--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1864,8 +1864,8 @@ class DeepseekV4DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         forward_batch: ForwardBatch,
         *,
-        input_ids: torch.Tensor,
-        input_ids_global: torch.Tensor,
+        input_ids: Optional[torch.Tensor],
+        input_ids_global: Optional[torch.Tensor],
     ) -> torch.Tensor:
         _use_cp = self.dsa_enable_prefill_cp and dsa_use_prefill_cp(forward_batch)
         _use_tp_moe_gather = (
@@ -1950,8 +1950,15 @@ class DeepseekV4DecoderLayer(nn.Module):
             s, r = get_parallel().attn_tp_size, get_parallel().attn_tp_rank
             _a2a_scatter_chunks = list(hidden_states.tensor_split(s))
             hidden_states = _a2a_scatter_chunks[r].contiguous()
-            input_ids = input_ids.tensor_split(s)[r].contiguous()
-            input_ids_global = input_ids_global.tensor_split(s)[r].contiguous()
+            # The DSpark draft layer calls this helper with input_ids=None
+            # (deepseek_v4_dspark.py:_run_ffn) because is_hash is False for nextn
+            # layers on DSv4, so it has no ids to route on and none are read
+            # downstream. The target model always passes real tensors and is
+            # unaffected.
+            if input_ids is not None:
+                input_ids = input_ids.tensor_split(s)[r].contiguous()
+            if input_ids_global is not None:
+                input_ids_global = input_ids_global.tensor_split(s)[r].contiguous()
         # Skip the MoE-internal post-experts all_reduce when we will do the
         # reduce via reduce_scatterv/reduce_scatter at the combine below
         # (else double-reduce).


### PR DESCRIPTION
## Motivation

DeepSeek-V4 with `--speculative-algorithm DSPARK` and any non-none
`--moe-a2a-backend` (`megamoe`, `deepep`, ...) dies during draft-verify CUDA graph
capture, on every TP rank:

```
File "srt/models/deepseek_v4.py", in _run_moe_ffn_dp_sync
    input_ids = input_ids.tensor_split(s)[r].contiguous()
AttributeError: 'NoneType' object has no attribute 'tensor_split'
```

The launcher then **exits 0**, so the pod's `lastState` reads `reason: Completed`.
It presents as a clean shutdown rather than a crash, which makes it easy to
misattribute — it was first reported to us as a segfault.

The DSpark draft layer calls the helper with `input_ids=None`, and that is
correct rather than an oversight. `DeepseekV2MoE` sets

```python
self.is_hash = layer_id < n_hash_layers and not (is_deepseek_v4 and is_nextn)
```

so hash routing is disabled for nextn layers on DSv4 and the ids are never read
downstream. `DeepseekV2MoE.forward` already types both parameters as
`Optional[torch.Tensor]` with a `None` default. `_run_moe_ffn_dp_sync` is the only
place on the path that assumes a tensor.

It splits both unconditionally inside the `_use_tp_attn_a2a_scatter` branch:

```python
_use_tp_attn_a2a_scatter = (
    not _use_cp
    and envs.SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER.get()   # default True
    and get_parallel().attn_tp_size > 1
    and not get_moe_a2a_backend().is_none()              # the trigger
)
```

Because that last clause gates the branch, it is dead code for the default a2a
backend and the `None` flows through untouched. Selecting any non-none backend
wakes the branch up and it raises. **This is not a MegaMoE kernel bug**; MegaMoE is
simply the most common way to reach the branch.

## Modifications

Guard both splits on `is not None`, and widen the two annotations from
`torch.Tensor` to `Optional[torch.Tensor]` so the helper's signature matches the
callee it forwards to.

The target model always passes real tensors, so its behaviour is unchanged, and
the branch is untaken entirely for the default `moe_a2a_backend`. Setting
`SGLANG_DSV4_FIX_TP_ATTN_A2A_SCATTER=0` also avoids the crash, but gives up the
scatter on the target model too, so it is a workaround rather than a fix.

## Accuracy Tests

Measured on 2 x `p6-b200.48xlarge` (8 x B200), DeepSeek-V4-Flash-0731, `tp4/ep4`,
`--speculative-algorithm DSPARK`, hierarchical cache on. The equivalent guard was
applied to a v0.5.16 base, since that is the version this configuration runs in
production; the same two-line change applies to `main` unmodified.

Without the guard the server never reaches ready, so the comparison is
MegaMoE-with-guard against the shipped `flashinfer_mxfp4` recipe on identical
hardware, model and flags. gsm8k, 200 requests per arm:

| arm | concurrency | accuracy | output tok/s |
|---|---|---|---|
| flashinfer (shipped) | 8 | 0.975 | 611.6 |
| megamoe (this fix) | 8 | 0.960 | 631.8 |
| flashinfer (shipped) | 64 | 0.955 | 1780.8 |
| megamoe (this fix) | 64 | 0.980 | 2054.6 |

Accuracy differences are within noise at n=200 (standard error is roughly ±1.5
points) and the arms trade places between concurrencies, i.e. no regression.
Speculative acceptance length matched the baseline at 3.852 versus 3.889 over a
15-minute production traffic replay.

## Speed Tests and Profiling

The fix is a `None` check on a control path taken once per MoE layer per forward;
it is not on any kernel path and adds no measurable cost. Its effect is to make
the DSpark + non-none-a2a configuration reachable at all. For reference, that
configuration then measured +3.3% output throughput and −26.3% mean TTFT at
concurrency 8, and +15.4% / −17.6% at concurrency 64, against the shipped
flashinfer recipe.

## Related

- #29534 — closed unmerged draft; touches the same `_use_tp_attn_a2a_scatter`
  branch for the FP4 MegaMoE fallback layout mismatch, but does not address the
  `None`. That fallback is a separate issue and is not fixed here.
- #27416 — MegaMoE over-cap fallback crash, auto-closed by the staleness bot on
  2026-08-06 without a fix. Also independent of this change.

## Checklist

- [x] Format your code according to Format code with pre-commit — full
      `pre-commit run --files python/sglang/srt/models/deepseek_v4.py` passes
      (isort, ruff, black, codespell all clean).
- [ ] Add unit tests — the crash needs 4+ B200 GPUs and a DSv4 checkpoint to
      reproduce, so there is no unit-level harness for it. Happy to add one if a
      maintainer can point at the right multi-GPU test target.
- [ ] Update documentation — not applicable, no user-facing interface changes.
- [x] Provide accuracy and speed benchmark results — see above.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31445543360](https://github.com/sgl-project/sglang/actions/runs/31445543360)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31445543192](https://github.com/sgl-project/sglang/actions/runs/31445543192)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->