### PR TITLE
[perf] Collapse the DP attention scheduler sync to a single D2H copy

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -447,10 +447,9 @@ class TboDPAttentionPreparer:
 
         return local_can_run_tbo, local_forward_mode
 
-    def compute_output(self, partial_global_info):
-        # Already a host tensor: the caller does the single D2H for all fields.
-        local_can_run_tbo_aggregated = min(partial_global_info[:, 0].tolist())
-        forward_modes = partial_global_info[:, 1].tolist()
+    def compute_output(self, partial_global_info_cpu):
+        local_can_run_tbo_aggregated = min(partial_global_info_cpu[:, 0].tolist())
+        forward_modes = partial_global_info_cpu[:, 1].tolist()
 
         global_forward_mode, forward_mode_agree = self._compute_global_forward_mode(
             forward_modes

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -448,10 +448,9 @@ class TboDPAttentionPreparer:
         return local_can_run_tbo, local_forward_mode
 
     def compute_output(self, partial_global_info):
-        # Perform only one Device-to-Host (D2H) memory copy
-        cpu_data = partial_global_info[:, :2].cpu()
-        local_can_run_tbo_aggregated = min(cpu_data[:, 0].tolist())
-        forward_modes = cpu_data[:, 1].tolist()
+        # Already a host tensor: the caller does the single D2H for all fields.
+        local_can_run_tbo_aggregated = min(partial_global_info[:, 0].tolist())
+        forward_modes = partial_global_info[:, 1].tolist()
 
         global_forward_mode, forward_mode_agree = self._compute_global_forward_mode(
             forward_modes

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -91,7 +91,7 @@ class MLPSyncBatchInfo:
     local_forward_mode: int
 
     # some gathered elements
-    cpu_tp0_info: torch.Tensor = None
+    tp0_info_cpu: torch.Tensor = None
     global_num_tokens: list[int] = None
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
@@ -179,19 +179,22 @@ class MLPSyncBatchInfo:
             )
         tp_info[tp_active_ranks[:num_ranks_in_tp_info] == 0] = fallback_tensor
 
-        # One D2H for every field the scheduler reads. Each further `.item()` /
-        # `.tolist()` on the device tensor is its own stream sync, and the
-        # reductions below cost nothing on host.
-        cpu_tp0_info = global_info_tensor[:, 0, :].cpu()
-        self.cpu_tp0_info = cpu_tp0_info
-        self.global_num_tokens = cpu_tp0_info[:, 0].tolist()
-        self.global_num_tokens_for_logprob = cpu_tp0_info[:, 1].tolist()
-        self.can_run_decode_cuda_graph = bool(cpu_tp0_info[:, 2].min())
-        self.is_extend_in_batch = bool(cpu_tp0_info[:, 3].max())
-        self.can_run_prefill_cuda_graph = bool(cpu_tp0_info[:, 6].min())
+        # One D2H for every field the scheduler reads; each further `.item()` /
+        # `.tolist()` on the device tensor would be its own stream sync, and the
+        # reductions below cost nothing on host. Copy the whole contiguous
+        # tensor rather than the `[:, 0, :]` slice -- that slice is
+        # non-contiguous once attn_tp * attn_cp > 1, which adds a gather kernel
+        # inside the blocking wait.
+        tp0_info_cpu = global_info_tensor.cpu()[:, 0, :]
+        self.tp0_info_cpu = tp0_info_cpu
+        self.global_num_tokens = tp0_info_cpu[:, 0].tolist()
+        self.global_num_tokens_for_logprob = tp0_info_cpu[:, 1].tolist()
+        self.can_run_decode_cuda_graph = bool(tp0_info_cpu[:, 2].min())
+        self.is_extend_in_batch = bool(tp0_info_cpu[:, 3].max())
+        self.can_run_prefill_cuda_graph = bool(tp0_info_cpu[:, 6].min())
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(
-                cpu_tp0_info[:, 5].tolist()
+                tp0_info_cpu[:, 5].tolist()
             )
 
 
@@ -347,7 +350,7 @@ def prepare_mlp_sync_batch_raw(
 
         mlp_sync_info.tbo_split_seq_index, mlp_sync_info.global_forward_mode = (
             tbo_preparer.compute_output(
-                mlp_sync_info.cpu_tp0_info[:, 4:6],
+                mlp_sync_info.tp0_info_cpu[:, 4:6],
             )
         )
 
@@ -376,7 +379,7 @@ def prepare_mlp_sync_batch_raw(
     if local_batch is not None and not skip_all_gather:
         local_batch.recv_skipper_forward_mode = (
             SchedulerRecvSkipper.derive_forward_mode(
-                mlp_sync_info.cpu_tp0_info[:, 5].tolist()
+                mlp_sync_info.tp0_info_cpu[:, 5].tolist()
             )
         )
 

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -91,14 +91,14 @@ class MLPSyncBatchInfo:
     local_forward_mode: int
 
     # some gathered elements
-    tp0_info: torch.Tensor = None
+    cpu_tp0_info: torch.Tensor = None
     global_num_tokens: list[int] = None
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
     global_forward_mode: int = None
     dp_cooperation_info: Optional[DPCooperationInfo] = None
 
-    def _get_local_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
+    def _get_local_tensor(self, device, dtype=torch.int32) -> torch.Tensor:
         return torch.tensor(
             [
                 self.num_tokens,
@@ -113,7 +113,7 @@ class MLPSyncBatchInfo:
             dtype=dtype,
         )
 
-    def _get_fallback_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
+    def _get_fallback_tensor(self, device, dtype=torch.int32) -> torch.Tensor:
         return torch.tensor(
             [
                 0,  # num_tokens
@@ -179,17 +179,20 @@ class MLPSyncBatchInfo:
             )
         tp_info[tp_active_ranks[:num_ranks_in_tp_info] == 0] = fallback_tensor
 
-        tp0_info = global_info_tensor[:, 0, :]
-        self.tp0_info = tp0_info
-        # Perform only one Device-to-Host (D2H) memory copy
-        cpu_data = tp0_info[:, :2].cpu()
-        self.global_num_tokens = cpu_data[:, 0].tolist()
-        self.global_num_tokens_for_logprob = cpu_data[:, 1].tolist()
-        self.can_run_decode_cuda_graph = bool(tp0_info[:, 2].min().item())
-        self.is_extend_in_batch = bool(tp0_info[:, 3].max().item())
-        self.can_run_prefill_cuda_graph = bool(tp0_info[:, 6].min().item())
+        # One D2H for every field the scheduler reads. Each further `.item()` /
+        # `.tolist()` on the device tensor is its own stream sync, and the
+        # reductions below cost nothing on host.
+        cpu_tp0_info = global_info_tensor[:, 0, :].cpu()
+        self.cpu_tp0_info = cpu_tp0_info
+        self.global_num_tokens = cpu_tp0_info[:, 0].tolist()
+        self.global_num_tokens_for_logprob = cpu_tp0_info[:, 1].tolist()
+        self.can_run_decode_cuda_graph = bool(cpu_tp0_info[:, 2].min())
+        self.is_extend_in_batch = bool(cpu_tp0_info[:, 3].max())
+        self.can_run_prefill_cuda_graph = bool(cpu_tp0_info[:, 6].min())
         if _ENABLE_METRICS_DP_ATTENTION:
-            self.dp_cooperation_info = DPCooperationInfo.create(tp0_info[:, 5].tolist())
+            self.dp_cooperation_info = DPCooperationInfo.create(
+                cpu_tp0_info[:, 5].tolist()
+            )
 
 
 def _update_gather_batch(
@@ -344,7 +347,7 @@ def prepare_mlp_sync_batch_raw(
 
         mlp_sync_info.tbo_split_seq_index, mlp_sync_info.global_forward_mode = (
             tbo_preparer.compute_output(
-                mlp_sync_info.tp0_info[:, 4:6],
+                mlp_sync_info.cpu_tp0_info[:, 4:6],
             )
         )
 
@@ -373,7 +376,7 @@ def prepare_mlp_sync_batch_raw(
     if local_batch is not None and not skip_all_gather:
         local_batch.recv_skipper_forward_mode = (
             SchedulerRecvSkipper.derive_forward_mode(
-                mlp_sync_info.tp0_info[:, 5].tolist()
+                mlp_sync_info.cpu_tp0_info[:, 5].tolist()
             )
         )
 

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -179,12 +179,10 @@ class MLPSyncBatchInfo:
             )
         tp_info[tp_active_ranks[:num_ranks_in_tp_info] == 0] = fallback_tensor
 
-        # One D2H for every field the scheduler reads; each further `.item()` /
-        # `.tolist()` on the device tensor would be its own stream sync, and the
-        # reductions below cost nothing on host. Copy the whole contiguous
-        # tensor rather than the `[:, 0, :]` slice -- that slice is
-        # non-contiguous once attn_tp * attn_cp > 1, which adds a gather kernel
-        # inside the blocking wait.
+        # One D2H for every field: each `.item()` / `.tolist()` on a device
+        # tensor is its own stream sync. Copy the whole tensor, not the
+        # `[:, 0, :]` slice -- that slice is non-contiguous once
+        # attn_tp * attn_cp > 1, adding a gather kernel inside the wait.
         tp0_info_cpu = global_info_tensor.cpu()[:, 0, :]
         self.tp0_info_cpu = tp0_info_cpu
         self.global_num_tokens = tp0_info_cpu[:, 0].tolist()

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -98,7 +98,7 @@ class MLPSyncBatchInfo:
     global_forward_mode: int = None
     dp_cooperation_info: Optional[DPCooperationInfo] = None
 
-    def _get_local_tensor(self, device, dtype=torch.int32) -> torch.Tensor:
+    def _get_local_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
         return torch.tensor(
             [
                 self.num_tokens,
@@ -113,7 +113,7 @@ class MLPSyncBatchInfo:
             dtype=dtype,
         )
 
-    def _get_fallback_tensor(self, device, dtype=torch.int32) -> torch.Tensor:
+    def _get_fallback_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
         return torch.tensor(
             [
                 0,  # num_tokens


### PR DESCRIPTION
Supersedes #23011 (stale after the `scheduler_dp_attn_mixin.py` -> `scheduler_components/dp_attn.py` move); co-authored with the original author.

## Summary
- Copy the gathered info tensor to host once, instead of 5 separate device syncs (`.cpu()` on two columns, three `.min()`/`.max()` + `.item()` reductions, one downstream `.tolist()`)
- Copy the whole contiguous tensor and slice on host — `[:, 0, :]` is non-contiguous once `attn_tp * attn_cp > 1`, which would add a gather kernel inside the blocking wait
- `MLPSyncBatchInfo` carries `tp0_info_cpu` instead of the device tensor; every consumer is host-side after this
- `compute_output` takes `partial_global_info_cpu`, putting the host-tensor contract in the signature

## Background
- Each reduction launches a kernel, then blocks the scheduler thread on a full sync round trip
- The payload is a few hundred bytes, so the cost is sync latency, not bandwidth
- NCCL metadata-gather path only — on the default Gloo path the tensor is already on host, so this is a no-op

## Benchmarking
- Microbenchmark (4 DP ranks, interleaved A/B): consuming the gathered tensor drops 454.6 us -> 172.0 us, i.e. **282 us saved per scheduler step**
- Consumption cost by `attn_tp` (single process, so lower absolute numbers): 212 -> 49 us at `attn_tp=1`, 289 -> 62 us at `attn_tp=2`, 256 -> 52 us at `attn_tp=8`. Slicing before the copy would leave ~30 us of gather kernel on the table in the non-contiguous cases
- E2E (DeepSeek-V4-Flash, DP4 + EP + MTP, A/B/A across restarts) at 4 concurrent: **TPOT 7.90 -> 7.63 ms (-2.9%)**, output throughput +3.1%; the repeated base run reproduced the first within 0.5%
- E2E at 64 concurrent: no resolvable effect — machine drift (+5.4%) exceeded the signal. Expected, since the saved cost is fixed per step and only shows when the scheduler CPU is the critical path

## Not carried over from #23011
- `int64` -> `int32` info tensor: measured -1.0 us (noise) — the all-gather is latency-bound at this size, and the narrower dtype adds an overflow edge for future fields
- Pre-allocated buffer singleton: module-level mutable state conflicts with current process-state conventions, and caching `has_inactive_ranks` at first call is unsafe now that ranks change active state at runtime

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31459701322](https://github.com/sgl-project/sglang/actions/runs/31459701322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31459701308](https://github.com/sgl-project/sglang/actions/runs/31459701308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->



