### PR TITLE
[Bugfix] Soft-import sgl_kernel_npu in layernorm.py

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -170,9 +170,31 @@ if _is_cuda:
 logger = logging.getLogger(__name__)
 
 
+_has_add_gemma_rms_norm = False
 if _is_npu:
     import torch_npu
-    from sgl_kernel_npu.norm.add_rmsnorm_bias import add_gemma_rms_norm
+
+    # `sgl_kernel_npu.norm.add_rmsnorm_bias` pulls
+    # `triton.language.extra.cann.extension`, which only ships with
+    # triton-ascend 3.2.1+ / CANN 9.0.0+. Older combinations (e.g. the
+    # triton-ascend 3.2.0 wheel on pypi, which exposes
+    # `triton.language.extra.ascend` instead) raise ModuleNotFoundError at
+    # import time and abort sglang startup even though
+    # `forward_npu` already has a fully-native fallback keyed off
+    # `SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM`. Degrade gracefully: if the
+    # kernel is unavailable, log once and force that native path.
+    try:
+        from sgl_kernel_npu.norm.add_rmsnorm_bias import add_gemma_rms_norm
+
+        _has_add_gemma_rms_norm = True
+    except (ImportError, AttributeError) as _sgl_kernel_npu_import_err:
+        add_gemma_rms_norm = None  # sentinel; forward_npu won't call it
+        logger.info(
+            "sgl_kernel_npu.norm.add_rmsnorm_bias unavailable (%s); "
+            "GemmaRMSNorm.forward_npu will use the native fallback "
+            "(equivalent to setting SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM=1).",
+            _sgl_kernel_npu_import_err,
+        )
 
 
 @lru_cache(maxsize=1)
@@ -1138,7 +1160,13 @@ class GemmaRMSNorm(BaseFusedOp):
         residual: Optional[torch.Tensor] = None,
         post_residual_addition: Optional[torch.Tensor] = None,
     ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
-        if envs.SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM.get():
+        # Second condition matches the module-level fallback set when
+        # sgl_kernel_npu is missing (e.g. triton-ascend < 3.2.1); both routes
+        # land on forward_native, so behavior is identical to explicit opt-in.
+        if (
+            envs.SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM.get()
+            or not _has_add_gemma_rms_norm
+        ):
             return self.forward_native(x, residual)
         if residual is not None:
             if post_residual_addition is not None:


### PR DESCRIPTION
## Motivation

`python/sglang/srt/layers/layernorm.py:175` unconditionally imports `add_gemma_rms_norm` from `sgl_kernel_npu.norm.add_rmsnorm_bias`, which in turn imports `triton.language.extra.cann.extension`. That submodule only ships with **triton-ascend 3.2.1+ (CANN 9.0.0+)**. On any Ascend host still on triton-ascend 3.2.0 — currently the only version published to pypi, which exposes `triton.language.extra.ascend` instead — this import raises `ModuleNotFoundError` at module load and **aborts sglang startup entirely**:

    File ".../sglang/srt/layers/layernorm.py", line 175, in <module>
        from sgl_kernel_npu.norm.add_rmsnorm_bias import add_gemma_rms_norm
    File ".../sgl_kernel_npu/norm/add_rmsnorm_bias.py", line 4, in <module>
        import triton.language.extra.cann.extension as al
    ModuleNotFoundError: No module named 'triton.language.extra.cann'

The kicker:  `GemmaRMSNorm.forward_npu` **already has a fully-native fallback** keyed off `SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM` (introduced for `test/registered/npu/reward_models/test_npu_gemma_2_27b_v0_2.py:87`). The kernel isn't required — the top-level import guard is just too tight.

## Modifications

Two-touchpoint diff, no behavior change on hosts that have the kernel:

* Wrap the `sgl_kernel_npu` import in `try/except (ImportError, AttributeError)`, set a module-level sentinel `_has_add_gemma_rms_norm` sentinel, and log an INFO line once at import so users know why they landed on the native path.
* Extend the `forward_npu` guard to `envs.SGLANG_NPU_FORWARD_NATIVE_GEMMA_RMS_NORM.get() or not _has_add_gemma_rms_norm`, The `_has_add_gemma_rms_norm` short-circuit takes the *same* code path an explicit opt-in would take.

`torch_npu` remains a hard requirement (also needed for the `residual is None` branch via `torch_npu.npu_gemma_rms_norm`).

## Verification (Ascend 910B2 + CANN 8.5.1 + torch_npu 2.10.0 + triton-ascend 3.2.0)

- **Before:** `python3 -c "import sglang.srt.layers.layernorm"` → aborts at line 175.
- **After:** import succeeds; `_has_add_gemma_rms_norm == False`; `add_gemma_rms_norm is None`; INFO log fires once.
- **`forward_npu` behavior:** manually driven with `residual=None` and `residual=zeros` — both routes invoke `forward_native` as designed.
- **Lint:** `ruff check` clean, `ruff format --check` clean.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-to-ci) — N/A, guard-widening fix with existing native path; reproducible per steps above.
- [ ] Update documentation / docstrings if applicable.
- [ ] Provide throughput / latency benchmark results — N/A, fallback path exists in-tree already.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31453396510](https://github.com/sgl-project/sglang/actions/runs/31453396510)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31453396501](https://github.com/sgl-project/sglang/actions/runs/31453396501)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->