### PR TITLE
[AMD] Disable PTX-inline-asm diffusion LayerNorm fast path on ROCm (fix FLUX warmup crash)

### DIFF
--- a/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
+++ b/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
@@ -336,8 +336,19 @@ def is_plain_layer_norm(norm: torch.nn.Module, hidden: int) -> bool:
     )
 
 
+# The fused fast paths below reproduce NVIDIA aten LayerNorm bit-for-bit
+# using PTX inline asm (rcp.approx.f32 / div.rn.f32 / rsqrt.approx.f32 with
+# "=f" float-register constraints via tl.inline_asm_elementwise). PTX is
+# CUDA-only: on ROCm the AMDGPU backend cannot allocate the "f" constraint
+# and the Triton JIT aborts at warmup ("couldn't allocate output register
+# for constraint 'f'"), which hangs FLUX/diffusion bring-up. Disable the
+# fused paths on ROCm so callers fall back to the eager aten chain (the
+# module already guarantees bit-exact-or-eager-fallback).
+_IS_ROCM = getattr(torch.version, "hip", None) is not None
+
+
 def _is_bf16_cuda(t: torch.Tensor) -> bool:
-    return t.is_cuda and t.dtype is torch.bfloat16
+    return (not _IS_ROCM) and t.is_cuda and t.dtype is torch.bfloat16
 
 
 def _mod_row_stride(t: torch.Tensor, batch: int, hidden: int) -> int | None:


### PR DESCRIPTION
## Motivation
On ROCm (MI300X gfx942), bringing up **FLUX.1-dev** on the native SGLang diffusion backend crashes during warmup:

```
[aiter] import [module_rmsnorm_quant] ...
error: couldn't allocate output register for constraint 'f'
```

The server never becomes ready (`ready to roll` never prints, `/health_generate` = 503). In CI this is `multimodal-gen-test-1-gpu-amd*` (`flux_image_t2i`) timing out at the 90-min step limit (e.g. run 31327057626, 08/09; run 31415663809, 08/10). Deterministic and chronic. Root-cause detail in #34351.

## Root cause
The diffusion fast-path helpers embed **NVIDIA PTX inline asm** with float-register constraints (`"=f"`) via `tl.inline_asm_elementwise`:
- `numerics.py`: `rcp.approx.f32`, `div.rn.f32`, `rsqrt.approx.f32` / `mul.rn.f32` (all `constraints="=f,..."`)
- `layernorm_modulate.py` `_rcp4`: `rcp.approx.f32 / fma.rn.f32 / sub.ftz.f32`

PTX is CUDA-only; the AMDGPU backend can't allocate the `'f'` constraint, so the Triton JIT aborts at the first warmup forward. These helpers exist to reproduce NVIDIA aten LayerNorm **bit-for-bit** (SASS-level), so porting the PTX would break the documented contract. The module already guarantees *bit-exact-or-eager-fallback* (`torch.equal` gate + `can_use_*`), so the correct AMD behavior is to take the eager path.

## Fix
Gate the fused fast paths off on ROCm: `_is_bf16_cuda()` (used by both `can_use_fused_layernorm_modulate` and `can_use_fused_qk_head_layernorm`) now returns `False` when `torch.version.hip is not None`, so ROCm falls back to the eager aten LayerNorm. CUDA behavior is unchanged.

## Test plan (offline, real hardware)
- HW: MI300X (gfx942), image `rocm/sgl-dev:v0.5.17-rocm720-mi30x-20260809`.
- **Before:** `sglang serve --model-path black-forest-labs/FLUX.1-dev --model-type diffusion --num-gpus 1` → `couldn't allocate output register for constraint 'f'` at warmup, health 503, never ready.
- **After (this patch):** warmup completes (1024x1024 native FLUX denoise), **"The server is fired up and ready to roll!"**, `/health_generate` = 200. No `allocate output register` error.
- CUDA path untouched (guard is ROCm-only).

Fixes #34351

cc @BBuf

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31456475803](https://github.com/sgl-project/sglang/actions/runs/31456475803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31456475694](https://github.com/sgl-project/sglang/actions/runs/31456475694)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->