### PR TITLE
Update Qwen3.5 B200 NVFP4 MTP config

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -157,7 +157,7 @@ This section provides deployment configurations optimized for different hardware
         - **MI325X (256GB)** runs with tp=2.
         - **MI355X (288GB)** runs with tp=2.
     - **FP4**: The FP4 quantized model requires ~250GB for weights, cutting memory by almost 4x. NVFP4 ([nvidia/Qwen3.5-397B-A17B-NVFP4-V2](https://huggingface.co/nvidia/Qwen3.5-397B-A17B-NVFP4-V2)) requires B200/B300 (Blackwell architecture); AMD provides an MXFP4 checkpoint ([amd/Qwen3.5-397B-A17B-MXFP4](https://huggingface.co/amd/Qwen3.5-397B-A17B-MXFP4)) for MI355X.
-        - **B200 (183GB)** runs with tp=4. (NVFP4)
+        - **B200 (183GB)** runs with tp=4 (tp=2 with expert parallelism 2 when MTP is enabled). (NVFP4)
         - **B300 (275GB)** runs with tp=2. (NVFP4)
         - **MI355X (288GB)** runs with tp=2 (use tp=4 for low concurrency). (MXFP4)
 
@@ -191,7 +191,7 @@ This section provides deployment configurations optimized for different hardware
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>183GB</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>8</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>4</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>4</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>4 / 2 + EP2 (MTP)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>B300</td>

--- a/docs/src/snippets/autoregressive/qwen35-deployment.jsx
+++ b/docs/src/snippets/autoregressive/qwen35-deployment.jsx
@@ -20,7 +20,7 @@ export const Qwen35Deployment = () => {
   //   35B-A3B:   H100 tp=1, H200 tp=1, B200 tp=1, B300 tp=1, MI300X tp=1, MI325X tp=1, MI355X tp=1
   //   27B:       tp=1 on all hardware (including MI300X, MI325X, MI355X)
   //
-  // FP4 (397B only): NVFP4 on Blackwell B200/B300 tp=4; AMD MXFP4 on MI355X tp=2
+  // FP4 (397B only): NVFP4 on Blackwell B200 tp=4 (tp=2 ep=2 w/ MTP) / B300 tp=4; AMD MXFP4 on MI355X tp=2
 
   const MOE_MODELS = new Set(['397b', '122b', '35b']);
   const FP8_MODELS = new Set(['397b', '122b', '35b', '27b']);
@@ -314,6 +314,11 @@ export const Qwen35Deployment = () => {
     // 122B H100 FP8 with MTP: bump TP to 4 and skip --mem-fraction-static.
     if (model === '122b' && hardware === 'h100' && quantization === 'fp8' && speculative === 'enabled') {
       hwConfig = { ...hwConfig, tp: 4, mem: undefined };
+    }
+    // 397B B200 NVFP4 with MTP: tp=2 with expert parallelism 2 (TEP2) beats
+    // tp=4 across the concurrency sweep.
+    if (model === '397b' && hardware === 'b200' && quantization === 'fp4' && speculative === 'enabled') {
+      hwConfig = { ...hwConfig, tp: 2, ep: 2, mem: 0.8 };
     }
 
     let modelName;


### PR DESCRIPTION
Switch the Qwen3.5-397B-A17B NVFP4 B200 recipe to tp=2 with expert parallelism 2 when MTP is enabled, which outperforms the current tp=4 setting across the concurrency sweep. Best configs based on https://github.com/SemiAnalysisAI/InferenceX/pull/2550.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31458614193](https://github.com/sgl-project/sglang/actions/runs/31458614193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31458614104](https://github.com/sgl-project/sglang/actions/runs/31458614104)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->