### PR TITLE
[Fix] Update multimodal CUDA VMM helper import

### DIFF
--- a/python/sglang/srt/multimodal/transport/memory_pool.py
+++ b/python/sglang/srt/multimodal/transport/memory_pool.py
@@ -21,7 +21,7 @@ def align_up(value: int, alignment: int) -> int:
 def _driver_modules():
     from cuda.bindings import driver as cuda
 
-    from sglang.srt.distributed.device_communicators.vmm_utils import check_drv
+    from sglang.srt.cuda_vmm_utils import check_drv
 
     return cuda, check_drv
 


### PR DESCRIPTION
## Summary

- update the multimodal CUDA IPC pool to import `check_drv` from the consolidated `sglang.srt.cuda_vmm_utils` module
- restore Gemma3 and other multimodal server warmup after #34199 removed the old module path

## Root cause timeline

- At 2026-08-10 04:35 UTC, #34199 Base run [31355967707](https://github.com/sgl-project/sglang/actions/runs/31355967707) tested PR head `9db7e9b3` merged into main at `2969ab3d`. That base did not contain `multimodal/transport/memory_pool.py`.
- `test/registered/vlm/test_vision_openai_server_a.py` ran for 594 seconds and passed on that merge ref; it was not skipped by `bypass-fastfail`.
- At 2026-08-10 10:47 UTC, #33949 added `memory_pool.py` with an import from `sglang.srt.distributed.device_communicators.vmm_utils`, which was still valid on main.
- At 2026-08-11 01:11 UTC, #34199 squash-merged onto main at `ba5183fe`, which already contained #33949. The squash removed the old module and added `sglang.srt.cuda_vmm_utils`, but the newly added `memory_pool.py` import was not updated.
- The #34199 head did not change after #33949 merged, so pull-request CI did not rerun against the final combination. The changes had no textual conflict, leaving a stale import in the merged tree.

## Verification

- `python3 -m py_compile python/sglang/srt/multimodal/transport/memory_pool.py`
- `pre-commit run --files python/sglang/srt/multimodal/transport/memory_pool.py`
- failure reproduced in PR #34309 Base-b: https://github.com/sgl-project/sglang/actions/runs/31457676239/job/93676740246
- isolated `/rerun-test test/registered/vlm/test_vision_openai_server_a.py` passed 69 tests in 513 seconds: https://github.com/sgl-project/sglang/actions/runs/31461215064

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31458956103](https://github.com/sgl-project/sglang/actions/runs/31458956103)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31458964241](https://github.com/sgl-project/sglang/actions/runs/31458964241)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->