### PR TITLE
[Bugfix] Fall back from unsafe SM100 kernels on SM103

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K3.mdx
@@ -127,7 +127,7 @@ Capacity levers, all in the Playground. Each trades precision or cache behavior 
 
 Speculation: DSPARK holds block size + 1 (= 8) intermediate states per request — the calculator folds this in — and an unset `--max-running-requests` resets to 48 under spec (the command panel reminds you; set it explicitly to raise).
 
-**MoE runner.** Leave `--moe-runner-backend` unset on Blackwell and it resolves to FlashInfer MXFP4 (W4A8, prebuilt trtllm-gen SiTU kernels) when the cubin pool is installed, Marlin (W4A16) otherwise; H100/H200 pin Marlin. The B200 Balanced and High-Throughput cells pin `flashinfer_mxfp4` explicitly because that is the shape they were brought up on — on an install without the pool, drop the flag to fall back to Marlin. The published Docker images already provision the **SiTU cubin pool**; to install it independently, run the same flow as the Dockerfile:
+**MoE runner.** On SM100 (B200/GB200), leaving `--moe-runner-backend` unset selects FlashInfer MXFP4 (W4A8, prebuilt trtllm-gen SiTU kernels) and requires the cubin pool. On SM103 (B300/GB300), auto selects Marlin (W4A16) because the trtllm-gen finalize kernel can hang on B300 ([#34340](https://github.com/sgl-project/sglang/issues/34340)); H100/H200 also pin Marlin. The B200 Balanced and High-Throughput cells pin `flashinfer_mxfp4` explicitly because that is the shape they were brought up on — on an install without the pool, replace that flag with `--moe-runner-backend marlin`. The published Docker images already provision the **SiTU cubin pool**; to install it independently, run the same flow as the Dockerfile:
 
 ```bash
 wget https://github.com/sgl-project/whl/releases/download/trtllm_gen_moe_cubin_20260617/trtllm_gen_moe_cubin_pool_20260617_v0613rc1.zip

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1448,9 +1448,9 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--bf16-gemm-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; selects <code>cutedsl</code> on SM100/SM103 (Blackwell), otherwise uses cuBLAS via `torch.nn.functional.linear`), 'cutedsl' (SGLang JIT CuTe DSL TGV BF16 GEMM on SM10X; dispatches between the CuTe DSL kernel and cuBLAS).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; selects <code>cutedsl</code> on SM100, otherwise uses cuBLAS via <code>torch.nn.functional.linear</code>), 'cutedsl' (SGLang JIT CuTe DSL TGV BF16 GEMM on SM100; dispatches between the CuTe DSL kernel and cuBLAS), 'torch' (always uses cuBLAS via <code>torch.nn.functional.linear</code>).</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`auto`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>cutedsl</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>cutedsl</code>, <code>torch</code></td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--disable-flashinfer-autotune`</td>

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -458,11 +458,12 @@ export const config = {
           // Blackwell-only kernel-fusion path; selecting it reveals the Quantization sub-select.
           { id: "megamoe",          label: "MegaMoE",           flags: ["--moe-a2a-backend megamoe"],
             requiresHw: ["b200", "b300", "gb200", "gb300"] },
-          // Blackwell-only: runs the prebuilt trtllm-gen SiTU cubins; needs the
+          // SM100-only: runs the prebuilt trtllm-gen SiTU cubins; needs the
           // downloadable SiTU cubin pool unpacked and pointed to by the env var.
+          // SM103 uses Marlin because the trtllm-gen finalize kernel can hang.
           { id: "flashinfer_mxfp4", label: "FlashInfer (MXFP4)", flags: ["--moe-runner-backend flashinfer_mxfp4"],
             env: ["SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/path/to/trtllm_gen_moe_cubin_pool"],
-            requiresHw: ["b200", "b300", "gb200", "gb300"] },
+            requiresHw: ["b200", "gb200"] },
           { id: "marlin",           label: "Marlin (W4A16)",    flags: ["--moe-runner-backend marlin"] },
         ],
       },

--- a/python/sglang/kernels/ops/gemm/cutedsl_bf16_gemm.py
+++ b/python/sglang/kernels/ops/gemm/cutedsl_bf16_gemm.py
@@ -7,7 +7,7 @@
 # You may obtain a copy of the License at
 #
 #   http://www.apache.org/licenses/LICENSE-2.0
-"""CuTe DSL TGV BF16 GEMM (low-latency SM10x GEMM).
+"""CuTe DSL TGV BF16 GEMM (low-latency SM100 GEMM).
 
 Computes ``out[M, N] = x[M, K] @ weight[N, K].T (+ bias[N])`` for bf16 inputs,
 fp32 accumulation, bf16 output. The kernel writes M-contiguous output, so the
@@ -39,7 +39,7 @@ from cutlass.cute.nvgpu import tcgen05
 from cutlass.cute.runtime import from_dlpack, make_fake_stream
 
 from sglang.kernel_api_logging import debug_kernel_api
-from sglang.srt.utils import is_sm100_supported
+from sglang.srt.utils import get_device_sm, is_sm100_supported
 from sglang.srt.utils.common import direct_register_custom_op
 
 # Tuple format: (cta_m, cta_n, num_ab_stage, use_2cta); cta_k is fixed at
@@ -1392,8 +1392,8 @@ def _tgv_bf16_gemm_run(
     weight: torch.Tensor,
     bias: Optional[torch.Tensor],
 ) -> torch.Tensor:
-    if not is_sm100_supported():
-        raise RuntimeError("cutedsl_bf16_gemm requires an SM10x GPU")
+    if not (is_sm100_supported() and get_device_sm() == 100):
+        raise RuntimeError("cutedsl_bf16_gemm requires an SM100 GPU")
     assert x.dtype == torch.bfloat16 and weight.dtype == torch.bfloat16
     assert x.stride(-1) == 1, "x must be K-major [M, K]"
     assert weight.stride(-1) == 1, "weight must be K-major [N, K]"
@@ -1420,8 +1420,8 @@ def _tgv_bf16_gemm_out_run(
     out: torch.Tensor,
     bias: Optional[torch.Tensor],
 ) -> None:
-    if not is_sm100_supported():
-        raise RuntimeError("cutedsl_bf16_gemm requires an SM10x GPU")
+    if not (is_sm100_supported() and get_device_sm() == 100):
+        raise RuntimeError("cutedsl_bf16_gemm requires an SM100 GPU")
     assert x.dtype == torch.bfloat16 and weight.dtype == torch.bfloat16
     assert out.dtype in (torch.bfloat16, torch.float32) and out.device == x.device
     assert x.ndim == 2 and weight.ndim == 2 and out.ndim == 2

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -544,17 +544,26 @@ def _is_mxfp4_pack_quantized(hf_config: Any) -> bool:
 @_register_for("KimiK3ForConditionalGeneration")
 def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
     # MoE runner default, independent of the attention-backend gate above.
-    # trtllm-gen fused MoE (flashinfer_mxfp4) beats marlin on both the decode
-    # (M=bs) and the target-verify (M=bs*(gamma+1)) regimes on SM100/SM103;
-    # it hard-requires the SiTU cubin pool on the box (K3's SiTU activation has
-    # no public cubins). Do not silently trade W4A8 for Marlin W4A16 when the
-    # default cannot start; explicit non-FlashInfer runner choices still win.
+    # trtllm-gen fused MoE (flashinfer_mxfp4) beats marlin on SM100, but its
+    # SM103 cubin coverage is incomplete and the finalize kernel can hang on
+    # B300 (#34340). Keep explicit runner choices authoritative, while routing
+    # auto to the safe Marlin fallback on SM103.
     if server_args.moe_runner_backend not in ("auto", "flashinfer_mxfp4"):
         return {}
-    if not (is_sm100_supported() and get_device_sm() in (100, 103)):
+    sm = get_device_sm()
+    if not (is_sm100_supported() and sm in (100, 103)):
         return {}
     if not _is_mxfp4_pack_quantized(hf_config):
         return {}
+    if sm == 103:
+        if server_args.moe_runner_backend == "auto":
+            logger.warning(
+                "Kimi-K3 on SM103: moe_runner_backend=marlin because the "
+                "trtllm-gen MoE finalize kernel can hang on B300 (#34340)."
+            )
+            return {"moe_runner_backend": "marlin"}
+        return {}
+
     from sglang.kernels.ops.moe.trtllm_gen_moe import available as _trtllm_gen_moe_ok
 
     if not _trtllm_gen_moe_ok():
@@ -578,7 +587,7 @@ def _kimi_k3_moe_runner_overrides(server_args: Any, hf_config: Any) -> dict:
 
     if server_args.moe_runner_backend == "auto":
         logger.info(
-            "Kimi-K3 on SM100/SM103: moe_runner_backend=flashinfer_mxfp4 "
+            "Kimi-K3 on SM100: moe_runner_backend=flashinfer_mxfp4 "
             "(trtllm-gen SiTU cubin pool found)."
         )
         return {"moe_runner_backend": "flashinfer_mxfp4"}

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -85,17 +85,18 @@ _use_cutedsl_bf16_gemm = None
 def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
     global _BF16_GEMM_BACKEND, _cutedsl_bf16_gemm, _use_cutedsl_bf16_gemm
 
-    from sglang.srt.utils import is_sm100_supported
+    from sglang.srt.utils import get_device_sm, is_sm100_supported
 
     backend_str = server_args.bf16_gemm_backend
-    if backend_str == "auto" and is_sm100_supported():
-        backend_str = "cutedsl"
+    cutedsl_supported = is_sm100_supported() and get_device_sm() == 100
+    if backend_str == "auto":
+        backend_str = "cutedsl" if cutedsl_supported else "torch"
 
     backend = Bf16GemmBackend(backend_str)
 
     if backend.is_cutedsl():
-        if not is_sm100_supported():
-            raise ValueError("--bf16-gemm-backend cutedsl requires an SM10x GPU")
+        if not cutedsl_supported:
+            raise ValueError("--bf16-gemm-backend cutedsl requires an SM100 GPU")
 
         from sglang.kernels.ops.gemm.cutedsl_bf16_gemm import (
             cutedsl_bf16_gemm,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1753,7 +1753,7 @@ class ServerArgs:
     bf16_gemm_backend: A[
         str,
         Arg(
-            help="Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; selects 'cutedsl' on SM10x GPUs, otherwise uses cuBLAS via torch.nn.functional.linear), 'cutedsl' (SGLang JIT CuTe DSL TGV BF16 GEMM on SM10x; dispatches between the CuTe DSL kernel and cuBLAS), 'torch' (always uses cuBLAS via torch.nn.functional.linear).",
+            help="Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; selects 'cutedsl' on SM100, otherwise uses cuBLAS via torch.nn.functional.linear), 'cutedsl' (SGLang JIT CuTe DSL TGV BF16 GEMM on SM100; dispatches between the CuTe DSL kernel and cuBLAS), 'torch' (always uses cuBLAS via torch.nn.functional.linear).",
             cli_name="--bf16-gemm-backend",
             choices=BF16_GEMM_BACKEND_CHOICES,
         ),

--- a/test/registered/kernels/ops/gemm/test_cutedsl_bf16_gemm.py
+++ b/test/registered/kernels/ops/gemm/test_cutedsl_bf16_gemm.py
@@ -32,8 +32,11 @@ NUM_TOKENS = get_ci_test_range(list(range(1, 33)), [1, 15, 16, 32])
 @pytest.mark.parametrize("n,k", SHAPES)
 @pytest.mark.parametrize("num_tokens", NUM_TOKENS)
 def test_cutedsl_bf16_gemm(num_tokens, k, n, has_bias):
-    if is_hip_runtime() or get_jit_cuda_arch().major != 10:
-        pytest.skip("SM10x required")
+    if is_hip_runtime():
+        pytest.skip("SM100 required")
+    arch = get_jit_cuda_arch()
+    if (arch.major, arch.minor) != (10, 0):
+        pytest.skip("SM100 required")
 
     torch.manual_seed(num_tokens)
     x = torch.randn(num_tokens, k, dtype=torch.bfloat16, device="cuda")
@@ -65,8 +68,11 @@ def test_empty_batch_not_tgv_eligible(n, k):
 def test_cutedsl_bf16_gemm_empty_batch(has_bias):
     """Empty input must yield the empty [0, N] output, mirroring F.linear —
     launching TGV with a 0-CTA grid fails with CUDA_ERROR_INVALID_VALUE."""
-    if is_hip_runtime() or get_jit_cuda_arch().major != 10:
-        pytest.skip("SM10x required")
+    if is_hip_runtime():
+        pytest.skip("SM100 required")
+    arch = get_jit_cuda_arch()
+    if (arch.major, arch.minor) != (10, 0):
+        pytest.skip("SM100 required")
 
     n, k = 6144, 2048
     x = torch.empty(0, k, dtype=torch.bfloat16, device="cuda")

--- a/test/registered/unit/layers/quantization/test_bf16_gemm_backend.py
+++ b/test/registered/unit/layers/quantization/test_bf16_gemm_backend.py
@@ -1,0 +1,56 @@
+"""Unit tests for architecture-aware BF16 GEMM backend selection."""
+
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.layers.quantization import unquant
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestBf16GemmBackend(CustomTestCase):
+    def setUp(self):
+        self._backend = unquant._BF16_GEMM_BACKEND
+        self._gemm = unquant._cutedsl_bf16_gemm
+        self._use_gemm = unquant._use_cutedsl_bf16_gemm
+
+    def tearDown(self):
+        unquant._BF16_GEMM_BACKEND = self._backend
+        unquant._cutedsl_bf16_gemm = self._gemm
+        unquant._use_cutedsl_bf16_gemm = self._use_gemm
+
+    def _initialize(self, backend: str) -> None:
+        cutedsl_module = ModuleType("sglang.kernels.ops.gemm.cutedsl_bf16_gemm")
+        cutedsl_module.cutedsl_bf16_gemm = object()
+        cutedsl_module.use_cutedsl_bf16_gemm = object()
+        with (
+            patch("sglang.srt.utils.is_sm100_supported", return_value=True),
+            patch("sglang.srt.utils.get_device_sm", return_value=103),
+            patch.dict(
+                sys.modules,
+                {
+                    "sglang.kernels.ops.gemm.cutedsl_bf16_gemm": cutedsl_module,
+                },
+            ),
+        ):
+            unquant.initialize_bf16_gemm_config(
+                SimpleNamespace(bf16_gemm_backend=backend)
+            )
+
+    def test_sm103_auto_falls_back_to_torch(self):
+        """SM103 auto selection must avoid the 2-CTA CuTeDSL kernel that raises Xid 13."""
+        self._initialize("auto")
+        self.assertEqual(unquant.get_bf16_gemm_backend(), unquant.Bf16GemmBackend.TORCH)
+
+    def test_sm103_rejects_explicit_cutedsl(self):
+        """Explicit CuTeDSL must fail before an unsupported SM103 kernel can launch."""
+        with self.assertRaisesRegex(ValueError, "requires an SM100 GPU"):
+            self._initialize("cutedsl")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -9,9 +9,10 @@ import dataclasses
 import json
 import os
 import shutil
+import sys
 import tempfile
 import unittest
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 from typing import Optional
 from unittest.mock import patch
 
@@ -1030,6 +1031,30 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             self.assertEqual(_deepseek_v4_sm120_moe(_view(arch="LlamaForCausalLM")), {})
         with patch.object(overrides_module, "is_sm120_supported", return_value=False):
             self.assertEqual(_deepseek_v4_sm120_moe(_view()), {})
+
+    def test_kimi_k3_sm103_auto_moe_uses_marlin(self):
+        """SM103 auto selection must not launch the hanging trtllm-gen finalize kernel."""
+        from sglang.srt.arg_groups.overrides import _kimi_k3_moe_runner_overrides
+
+        server_args = SimpleNamespace(moe_runner_backend="auto")
+        hf_config = SimpleNamespace(
+            quantization_config={"config_groups": {"experts": {"format": "mxfp4"}}}
+        )
+        trtllm_gen_moe = ModuleType("sglang.kernels.ops.moe.trtllm_gen_moe")
+        trtllm_gen_moe.available = lambda: True
+
+        with (
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+            patch.object(overrides_module, "get_device_sm", return_value=103),
+            patch.dict(
+                sys.modules,
+                {"sglang.kernels.ops.moe.trtllm_gen_moe": trtllm_gen_moe},
+            ),
+        ):
+            self.assertEqual(
+                _kimi_k3_moe_runner_overrides(server_args, hf_config),
+                {"moe_runner_backend": "marlin"},
+            )
 
     def test_nemotron_h_overrides_at_callable_level(self):
         from sglang.srt.arg_groups.overrides import _nemotron_h_overrides


### PR DESCRIPTION
## Motivation

Fixes #34340.

`is_sm100_supported()` is a compute-capability-major check, so it also returns true on SM103. That allowed two SM100-specific paths to be selected on B300: the 2-CTA CuTeDSL TGV BF16 GEMM, which can raise Xid 13 (`CTA Not Present`), and Kimi-K3's trtllm-gen MoE path, whose finalize kernel can hang indefinitely.

## Modifications

- Restrict the CuTeDSL TGV BF16 GEMM backend and direct kernel entrypoints to exact SM100.
- Resolve `--bf16-gemm-backend auto` to Torch/cuBLAS on SM103 and reject explicit CuTeDSL there before launch.
- Resolve Kimi-K3's automatic SM103 MoE runner to Marlin while preserving the optimized FlashInfer MXFP4 path on SM100 and explicit user choices.
- Update CLI help, server-argument docs, and the Kimi-K3 deployment guidance/playground hardware choices.
- Add CPU regression coverage for both backend decisions and tighten the kernel test's architecture guard.

## Impact

SM103 favors reliability over the faster trtllm-gen MoE path: Kimi-K3 auto-selection uses Marlin (W4A16), and unquantized BF16 GEMMs use Torch/cuBLAS. Exact SM100 behavior is unchanged.

## Validation

- `python -m compileall -q` on all changed Python files
- `ruff check --ignore E402,F722,F841` on all changed Python files
- `git diff --check`
- Isolated source-level regression harness: both checks fail on `upstream/main` and pass with this commit

The registered SGLang tests could not run locally because this Windows host lacks Python's POSIX `resource` module. No SM100/SM103 GPU was available for hardware validation; the CPU and B200 tests are registered for CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31459314310](https://github.com/sgl-project/sglang/actions/runs/31459314310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31459314216](https://github.com/sgl-project/sglang/actions/runs/31459314216)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->