### PR TITLE
fix(speculative): default speculative_eagle_topk to 1 for NEXTN/STANDALONE to prevent NoneType crash

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -551,6 +551,9 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             "speculative decoding."
         )
 
+    if server_args.speculative_eagle_topk is None:
+        server_args.speculative_eagle_topk = 1
+
     if server_args.enable_mixed_chunk:
         server_args.enable_mixed_chunk = False
         logger.warning(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -390,6 +390,6 @@ def compute_num_reserved_tokens(server_args: ServerArgs) -> int:
     if not algorithm.is_eagle():
         return 0
     return max(
-        server_args.speculative_eagle_topk * server_args.speculative_num_steps,
+        (server_args.speculative_eagle_topk or 1) * server_args.speculative_num_steps,
         server_args.max_speculative_num_draft_tokens,
     )


### PR DESCRIPTION
When using speculative decoding algorithms like `NEXTN` (which resolves to EAGLE) or `STANDALONE` without specifying `--speculative-eagle-topk`, SGLang crashes with a `TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'` during tokenizer initialization in `compute_num_reserved_tokens` and in `_handle_eagle_family`.

This PR fixes the issue by defaulting `speculative_eagle_topk` to `1` if it is `None` for these algorithms.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31459875077](https://github.com/sgl-project/sglang/actions/runs/31459875077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31459874927](https://github.com/sgl-project/sglang/actions/runs/31459874927)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->