### PR TITLE
fix(nixl): make FILE path-mode devId globally unique

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
@@ -51,6 +51,18 @@ class NixlRegistry:
         # from a single monotonic counter.
         self._obj_devid_lock = threading.Lock()
         self._obj_devid_next = 1
+        # FILE path-mode devIds must also be globally unique across
+        # concurrent storage() calls. nixlBasicDesc matches/sorts by
+        # (devId, addr, len) -- metaInfo (the file path) is NOT part of
+        # the match key. With per-batch devId = i+1, two concurrent
+        # batches that register the same page produce equal descs, and
+        # deregister's lower_bound match hits the first (potentially
+        # in-flight) desc, closing its fd and causing EBADF on the
+        # in-flight AIO. A global monotonic counter (mirroring the OBJ
+        # pattern above) makes every desc unique so deregister always
+        # matches the correct one.
+        self._file_devid_lock = threading.Lock()
+        self._file_devid_next = 1
         self.path_mode = mem_type == "FILE" and self._probe_path_mode()
         if mem_type == "FILE" and self.path_mode:
             logger.info("HiCacheNixl: path-mode FILE registration active.")
@@ -148,8 +160,12 @@ class NixlRegistry:
                 if self.file_manager.use_direct_io:
                     parts.append("direct")
                 spec = ",".join(parts)
+                n = len(keys)
+                with self._file_devid_lock:
+                    base = self._file_devid_next
+                    self._file_devid_next += n
                 tuples = [
-                    (0, sizes[i], i + 1, f"{spec}:{keys[i]}") for i in range(len(keys))
+                    (0, sizes[i], base + i, f"{spec}:{keys[i]}") for i in range(n)
                 ]
                 with self._registered(tuples, "FILE") as reg:
                     if reg is None:

--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
@@ -51,16 +51,10 @@ class NixlRegistry:
         # from a single monotonic counter.
         self._obj_devid_lock = threading.Lock()
         self._obj_devid_next = 1
-        # FILE path-mode devIds must also be globally unique across
-        # concurrent storage() calls. nixlBasicDesc matches/sorts by
-        # (devId, addr, len) -- metaInfo (the file path) is NOT part of
-        # the match key. With per-batch devId = i+1, two concurrent
-        # batches that register the same page produce equal descs, and
-        # deregister's lower_bound match hits the first (potentially
-        # in-flight) desc, closing its fd and causing EBADF on the
-        # in-flight AIO. A global monotonic counter (mirroring the OBJ
-        # pattern above) makes every desc unique so deregister always
-        # matches the correct one.
+        # FILE path-mode devIds must also be globally unique: nixlBasicDesc
+        # matches by (devId, addr, len) and excludes metaInfo (the file path),
+        # so per-batch i+1 collides across concurrent batches and deregister
+        # can close the wrong fd (EBADF). Mirror the OBJ counter above.
         self._file_devid_lock = threading.Lock()
         self._file_devid_next = 1
         self.path_mode = mem_type == "FILE" and self._probe_path_mode()


### PR DESCRIPTION
## Summary

In `NixlRegistry.storage()`, FILE path-mode registrations used `devId = i+1`, which restarts from 1 on every `storage()` call. Since `nixlBasicDesc` matches and sorts by `(devId, addr, len)` — **metaInfo (the file path) is NOT part of the match key** — two concurrent `storage()` calls that register overlapping pages produce **equal descriptors**. When the later-registered batch completes first and deregisters, `getIndex` (lower_bound) matches the first descriptor in the sorted list, which may belong to the still-in-flight batch. This closes the in-flight batch's fd, causing **EBADF** on the in-flight AIO.

The OBJ branch already uses a global monotonic counter (`_obj_devid_next`) for exactly this reason. This PR applies the same pattern to FILE path-mode.

## Root cause (code-level)

```
nixlBasicDesc::operator<  →  compares (devId, addr, len)     — metaInfo NOT in key
nixlBasicDesc::operator== →  compares (addr, len, devId)     — metaInfo NOT in key
nixlSecDescList::getIndex →  std::lower_bound on sorted list  — matches FIRST equal desc
```

With `devId = i+1` per batch:
1. Batch A registers page P → desc = (0, size, 1, "rw:/path/P")
2. Batch B registers page P → desc = (0, size, 1, "rw:/path/P")  ← **equal to A's desc**
3. Batch B completes first, deregisters → `getIndex` lower_bound matches A's desc (first in sorted list)
4. A's fd is closed → A's in-flight AIO gets EBADF

## The fix

```python
# __init__
self._file_devid_lock = threading.Lock()
self._file_devid_next = 1

# storage() path-mode branch
n = len(keys)
with self._file_devid_lock:
    base = self._file_devid_next
    self._file_devid_next += n
tuples = [
    (0, sizes[i], base + i, f"{spec}:{keys[i]}") for i in range(n)
]
```

Every descriptor is now globally unique → deregister always matches the correct one.

## Verification

### A/B test: double-deregister leak detection (deterministic, no IO dependency)

Register two descs → deregister the second → attempt second deregister:

| Mode | Result | Meaning |
|---|---|---|
| legacy (`i+1`) | **5/5 leaks** | First deregister deleted the other desc; this desc leaked (fd leak + in-flight AIO EBADF root cause) |
| fixed (global counter) | **0/5 leaks** (second deregister = NOT_FOUND) | Precise match, no residue |

### Production verification (AMD MI308X, 8-GPU, GLM-5.2)

| Metric | Before fix | After fix |
|---|---|---|
| `aio_error failed` (EBADF) | 72 in 3 min under load | **0** |
| `pages failed` | 31 | **0** |
| SegFault (UAF cascade) | 1 | **0** |
| Prefill batches | — | 652+ (all clean) |

## Notes

- This is a workaround for a NIXL core design issue: `nixlBasicDesc`'s match key should include metaInfo for FILE_SEG, but that's a larger API change. The global counter is the same pattern already used for OBJ mode in this file.
- The fix is complementary to the nixl-side fix (ai-dynamo/nixl) that cleans up io slots on AIO failure. Together they fix the complete EBADF → leak → SegFault chain.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33260188373](https://github.com/sgl-project/sglang/actions/runs/33260188373)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33260188191](https://github.com/sgl-project/sglang/actions/runs/33260188191)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33260188273](https://github.com/sgl-project/sglang/actions/runs/33260188273)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->