### PR TITLE
[AMD] Install AITER's pinned Triton wheel in the ROCm 7.2 image

### DIFF
--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -656,20 +656,24 @@ else:
 PY
 
 # -----------------------
-# Triton: install AITER's pinned ROCm 3.7 wheel (AMD index), replacing the base
-# image's 3.5.1.
+# Triton: hand the choice to AITER's installer, replacing the base image's Triton
+# with whatever revision AITER is built and tested against. Deliberately no
+# version assertion here — AITER's pin is the source of truth (its installer
+# enforces its own floor), so repeating it would only break this build the day
+# AITER moves. The version lands in the build log below.
 #
 # This MUST stay the last pip step, after the torch-ROCm metadata patch above.
-# The base ROCm Torch wheel declares `Requires-Dist: triton==3.5.1`, so any pip
-# install that resolves torch while Triton 3.7 is present drags in PyPI's CUDA
-# triton 3.5.1 and breaks the ROCm stack. The metadata patch above is what drops
+# The base ROCm Torch wheel pins `triton==3.5.1`, so once a different Triton is
+# installed, any pip install that resolves torch drags in PyPI's CUDA triton and
+# replaces ROCm Torch with a CUDA build. The metadata patch above is what drops
 # that pin (see the `Requires-Dist` rewrite in hack.py) — do not install Triton
-# before it, and do not add pip steps after this one.
+# before it, and do not add pip steps after this one. The Torch check below is
+# what catches it if either rule is broken.
 RUN if [ "$BUILD_TRITON" = "1" ]; then \
         cd /sgl-workspace/aiter \
      && test -f .github/scripts/install_triton.sh \
      && PIP_NO_CACHE_DIR=1 bash .github/scripts/install_triton.sh \
-     && python3 -c "import torch; from importlib.metadata import version; v = version('triton'); k = version('triton-kernels'); assert torch.version.hip is not None, torch.__version__; assert v.startswith('3.7.'), v; print(f'[Triton] ROCm Torch {torch.__version__}, Triton {v}, triton-kernels {k}')"; \
+     && python3 -c "import torch; from importlib.metadata import version; v = version('triton'); k = version('triton-kernels'); assert torch.version.hip is not None, torch.__version__; print(f'[Triton] ROCm Torch {torch.__version__}, Triton {v}, triton-kernels {k}')"; \
     fi
 
 # -----------------------

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -91,9 +91,6 @@ ARG BRANCH_TYPE=remote
 # Version override for setuptools_scm (used in nightly builds)
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=""
 
-ARG TRITON_REPO="https://github.com/triton-lang/triton.git"
-ARG TRITON_COMMIT="42270451990532c67e69d753fbd026f28fcc4840"
-
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
 ARG AITER_COMMIT=""
 ENV AITER_COMMIT="${AITER_COMMIT:-${AITER_COMMIT_DEFAULT}}"
@@ -222,8 +219,8 @@ RUN if [ "$BUILD_LLVM" = "1" ]; then \
 # leak into AITER's version when AITER uses setuptools_scm)
 
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=
-# Keep the base image's Torch-compatible Triton by default. Override with
-# AITER_USE_SYSTEM_TRITON=0 when intentionally testing aiter-managed Triton.
+# Compile AITER against the base image's Triton. ROCm 7.2 swaps in AITER's
+# pinned Triton 3.7 at the very end of this file (see the Triton step below).
 ENV AITER_USE_SYSTEM_TRITON=1
 RUN pip uninstall -y aiter
 # Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
@@ -628,24 +625,6 @@ RUN cd /tmp/whl \
         ;; \
     esac
 
-
-# -----------------------
-# Hot patch: Triton
-# For ROCm 7.2, this custom build breaks pip dependency management,
-# so future `pip install` will break the ROCm stack.
-# A workaround for this is to reinstall the default triton
-# wheel with the `rocm/pytorch` image in the root directory.
-RUN if [ "$BUILD_TRITON" = "1" ]; then \
-        pip uninstall -y triton \
-     && apt install -y cmake \
-     && git clone ${TRITON_REPO} triton-custom \
-     && cd triton-custom \
-     && git checkout ${TRITON_COMMIT} \
-     && pip install -r python/requirements.txt \
-     && pip install -e . \
-     && if [ -d python/triton_kernels ]; then pip install -e python/triton_kernels --no-deps; fi; \
-    fi
-
 # -----------------------
 # Hot patch: transformers dynamic_module_utils symlink bug (v5.12.1).
 # _compute_local_source_files_hash calls Path(...).resolve() on custom-code
@@ -675,6 +654,23 @@ else:
     path.write_text(patched)
     print("patched transformers dynamic_module_utils.py (symlink hash fix)")
 PY
+
+# -----------------------
+# Triton: install AITER's pinned ROCm 3.7 wheel (AMD index), replacing the base
+# image's 3.5.1.
+#
+# This MUST stay the last pip step, after the torch-ROCm metadata patch above.
+# The base ROCm Torch wheel declares `Requires-Dist: triton==3.5.1`, so any pip
+# install that resolves torch while Triton 3.7 is present drags in PyPI's CUDA
+# triton 3.5.1 and breaks the ROCm stack. The metadata patch above is what drops
+# that pin (see the `Requires-Dist` rewrite in hack.py) — do not install Triton
+# before it, and do not add pip steps after this one.
+RUN if [ "$BUILD_TRITON" = "1" ]; then \
+        cd /sgl-workspace/aiter \
+     && test -f .github/scripts/install_triton.sh \
+     && PIP_NO_CACHE_DIR=1 bash .github/scripts/install_triton.sh \
+     && python3 -c "import torch; from importlib.metadata import version; v = version('triton'); k = version('triton-kernels'); assert torch.version.hip is not None, torch.__version__; assert v.startswith('3.7.'), v; print(f'[Triton] ROCm Torch {torch.__version__}, Triton {v}, triton-kernels {k}')"; \
+    fi
 
 # -----------------------
 # Performance environment variable.

--- a/docker/rocm.Dockerfile
+++ b/docker/rocm.Dockerfile
@@ -219,8 +219,8 @@ RUN if [ "$BUILD_LLVM" = "1" ]; then \
 # leak into AITER's version when AITER uses setuptools_scm)
 
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=
-# Compile AITER against the base image's Triton. ROCm 7.2 swaps in AITER's
-# pinned Triton 3.7 at the very end of this file (see the Triton step below).
+# Compile AITER against the base image's Triton; the Triton step at the end of
+# this file swaps in AITER's own pin afterwards.
 ENV AITER_USE_SYSTEM_TRITON=1
 RUN pip uninstall -y aiter
 # Use `checkout -f` so the smudge-filter-induced "dirty" working tree from
@@ -656,19 +656,12 @@ else:
 PY
 
 # -----------------------
-# Triton: hand the choice to AITER's installer, replacing the base image's Triton
-# with whatever revision AITER is built and tested against. Deliberately no
-# version assertion here — AITER's pin is the source of truth (its installer
-# enforces its own floor), so repeating it would only break this build the day
-# AITER moves. The version lands in the build log below.
+# Install the Triton AITER pins, replacing the base image's. No version check
+# on purpose: the pin is AITER's to move, and its installer enforces a floor.
 #
-# This MUST stay the last pip step, after the torch-ROCm metadata patch above.
-# The base ROCm Torch wheel pins `triton==3.5.1`, so once a different Triton is
-# installed, any pip install that resolves torch drags in PyPI's CUDA triton and
-# replaces ROCm Torch with a CUDA build. The metadata patch above is what drops
-# that pin (see the `Requires-Dist` rewrite in hack.py) — do not install Triton
-# before it, and do not add pip steps after this one. The Torch check below is
-# what catches it if either rule is broken.
+# Keep this last. Base ROCm Torch pins triton==3.5.1 and the torch patch above
+# is what drops that pin, so installing Triton any earlier lets the next pip
+# install pull CUDA torch instead. The hip check below is the tripwire.
 RUN if [ "$BUILD_TRITON" = "1" ]; then \
         cd /sgl-workspace/aiter \
      && test -f .github/scripts/install_triton.sh \


### PR DESCRIPTION
## Motivation

The ROCm 7.2 image builds Triton from source at its own pinned commit, leaving a 9.9GB checkout in the image.

Install AITER pinned Triton during image build.

## Modifications

`docker/rocm.Dockerfile` only, and only the two `-rocm720` stages, so ROCm 7.0 is byte-for-byte unchanged: call AITER's `.github/scripts/install_triton.sh` instead of building from source, so the image follows AITER's pin rather than carrying its own. It has to stay the last pip step, because the base ROCm Torch wheel pins `triton==3.5.1` and the torch metadata patch above it is what drops that pin — installing Triton any earlier lets the next pip install that resolves torch swap ROCm Torch for a CUDA build. Verified with a full nightly image build on this branch, both arches green: [run 31461086924](https://github.com/sgl-project/sglang/actions/runs/31461086924).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31473342852](https://github.com/sgl-project/sglang/actions/runs/31473342852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31473342646](https://github.com/sgl-project/sglang/actions/runs/31473342646)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->



