### PR TITLE
[model_loader] Stream weights over HTTP Range with one NIC per TP rankPr/object store stream

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -958,6 +958,7 @@
               "docs/advanced_features/observability",
               "docs/advanced_features/model_loading",
               "docs/advanced_features/object_storage",
+              "docs/advanced_features/object_storage_http_range",
               "docs/advanced_features/checkpoint_engine",
               "docs/advanced_features/sglang_for_rl"
             ]

--- a/docs/docs/advanced_features/object_storage_http_range.mdx
+++ b/docs/docs/advanced_features/object_storage_http_range.mdx
@@ -1,0 +1,68 @@
+---
+title: "Streaming Weights over HTTP Range (per-NIC)"
+metatags:
+    description: "Stream SGLang model weights straight out of an object store over HTTP GET Range requests, with one endpoint and one NIC per tensor-parallel rank."
+---
+
+The `http-range` connector streams safetensors weights straight out of an object store over HTTP GET Range requests, without a full local download. It is aimed at multi-NIC hosts: unlike a POSIX/FUSE mount, where the kernel routing table funnels every rank onto one egress link, this connector lets each tensor-parallel rank open its own sockets and pin them to a dedicated NIC.
+
+## When to use it
+
+Use it when **all** of the following hold:
+
+- Weights live behind an HTTP/1.1 server that supports byte ranges and keep-alive (an S3-compatible store, or a small range server in front of the checkpoints).
+- The host has several NICs and you want each rank to drive its own, so aggregate read bandwidth scales with NIC count.
+- The checkpoint is in `.safetensors` format.
+
+If you only need to load from S3/GCS/Azure without per-NIC control, prefer the [`runai_streamer` path](object_storage).
+
+## URL format
+
+```
+http-range://<host>:<port>/<prefix>[?<option>=<value>&...]
+```
+
+The authority is the default endpoint, used for metadata objects and for any rank without a dedicated endpoint. Options:
+
+| Option | Meaning | Default |
+|---|---|---|
+| `endpoints` | Comma-separated `host[:port]` list; rank `i` uses entry `i % len`. Bracket IPv6 literals (`[::1]:9000`). | authority only |
+| `nics` | Comma-separated interfaces bound with `SO_BINDTODEVICE` (Linux only), indexed by rank the same way. Empty entry = routing table. | none |
+| `connections` | Parallel connections per object. | 16 |
+| `chunk_size` | Range size in bytes; keep it large (request rate throttles before bandwidth). | 33554432 |
+| `timeout` | Socket timeout, seconds. | 30 |
+| `retries` | Retries per range. | 2 |
+| `metadata` | Extra metadata object names to fetch (custom code / tokenizer files). | none |
+
+## Quick start
+
+```bash
+python3 -m sglang.launch_server \
+  --tp 4 --load-format remote \
+  --served-model-name Qwen3-30B-A3B \
+  --model-path 'http-range://[fd00::1]:9000/models/Qwen3-30B-A3B?endpoints=[fd00::1]:9000,[fd00::2]:9001,[fd00::3]:9002,[fd00::4]:9003&nics=eth0,eth1,eth2,eth3'
+```
+
+`--served-model-name` is required because the URL contains colons, which SGLang otherwise treats as the `model:adapter` LoRA separator.
+
+The model directory needs no local weight bytes: the connector fetches `config.json`, the tokenizer files and `model.safetensors.index.json` from the server, then streams the shards named in the index.
+
+## Server requirements
+
+- **HTTP/1.1 with `Range` and keep-alive.** A server that closes after every response (HTTP/1.0) or ignores `Range` and returns the whole object is rejected with an explicit error.
+- **Per-NIC return path.** To make the *return* traffic use the intended NIC, the server must be split per NIC as well, with `SO_BINDTODEVICE` on its listening socket. Otherwise only the client side is spread out and the routing table still funnels every rank onto one link.
+- `nics` needs `CAP_NET_RAW` (present by default in containers).
+
+## Cost and limitations
+
+- Every rank pulls **all** shards, because `load_weights` narrows per rank on the consumer side. Total network volume is `tp_size × checkpoint_size` — which is exactly why per-rank NIC pinning is worthwhile: the same volume on one shared NIC takes roughly twice as long.
+- Shards are fetched serially; network time is not overlapped with the host-to-device copy.
+- Only `.safetensors` checkpoints are supported.
+
+## Measured numbers
+
+On a 4-NIC host, Qwen3-30B-A3B (57 GiB, 16 shards), TP=4, one range-server endpoint per NIC, objects served from the storage node's RAM:
+
+- ~3.4 s of network time per rank (~17 GB/s per NIC, ~71 GB/s aggregate), **7.6 s** total `Load weight` including header parse, narrow and H2D.
+- Compared with 25 s for the same model read cold from a local NVMe and 42 s over a FUSE-mounted distributed filesystem.
+- Outputs matched the file-based baseline token for token (greedy, 5 prompts, N=3).

--- a/python/sglang/srt/connector/__init__.py
+++ b/python/sglang/srt/connector/__init__.py
@@ -15,6 +15,10 @@ from sglang.srt.utils import parse_connector_type
 
 logger = logging.getLogger(__name__)
 
+# Scheme of HttpRangeConnector, kept here so create_remote_connector can
+# dispatch on it without importing the module.
+HTTP_RANGE_SCHEME = "http-range"
+
 
 class ConnectorType(str, enum.Enum):
     FS = "filesystem"
@@ -41,6 +45,12 @@ def create_remote_connector(url, device=None, **kwargs) -> BaseConnector:
         return S3Connector(url)
     elif connector_type == "instance":
         return RemoteInstanceConnector(url, device)
+    elif connector_type == HTTP_RANGE_SCHEME:
+        # Imported lazily to keep the HTTP streaming machinery out of the
+        # import path of every other connector.
+        from sglang.srt.connector.http_range import HttpRangeConnector
+
+        return HttpRangeConnector(url)
     elif _is_azure_blob_url(url, connector_type):
         # Imported lazily so the optional ``blobfile`` dependency is only
         # required when an Azure URL is actually used.
@@ -70,6 +80,7 @@ __all__ = [
     "RemoteInstanceConnector",
     "S3Connector",
     "ConnectorType",
+    "HTTP_RANGE_SCHEME",
     "create_remote_connector",
     "get_connector_type",
 ]

--- a/python/sglang/srt/connector/http_range.py
+++ b/python/sglang/srt/connector/http_range.py
@@ -1,0 +1,582 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Connector that streams safetensors weights over HTTP GET Range requests.
+
+Motivation: on a host with several NICs, remote weights can be read faster than
+local disk, but only if (a) many connections are in flight and (b) each TP rank
+drives its own NIC. Neither is reachable through a POSIX/FUSE mount, because the
+kernel picks the egress NIC from the routing table and all ranks end up sharing
+one link. Fetching objects over HTTP moves that decision into user space: every
+rank opens its own sockets and can pin them to a NIC with ``SO_BINDTODEVICE``.
+
+URL format::
+
+    http-range://<host>:<port>/<prefix>[?<option>=<value>&...]
+
+The authority is the default endpoint, used for metadata objects and for any
+rank without a dedicated endpoint. Supported options:
+
+``endpoints``
+    Comma separated ``host[:port]`` list; TP rank ``i`` uses entry
+    ``i % len(endpoints)``. IPv6 literals must be bracketed (``[::1]:9000``).
+``nics``
+    Comma separated interface list bound with ``SO_BINDTODEVICE`` (Linux only),
+    indexed by TP rank the same way. An empty entry leaves the egress NIC to the
+    routing table.
+``connections``
+    Parallel connections per object (default 16). Object stores usually cap a
+    single connection well below link speed.
+``chunk_size``
+    Range size in bytes (default 32 MiB). Keep it large: request rate, not
+    bandwidth, is what object stores throttle first.
+``timeout``, ``retries``
+    Socket timeout in seconds (default 30) and retries per range (default 2).
+``metadata``
+    Extra metadata object names to fetch alongside the well-known set, for
+    repositories that ship custom code or tokenizer files.
+
+Server requirements: HTTP/1.1 with byte ranges and keep-alive. A server that
+closes the connection after every response, or that ignores ``Range`` and
+returns the whole object, is rejected with an explicit error. To make the
+*return* path use the intended NIC the server must be split per NIC as well,
+with ``SO_BINDTODEVICE`` on its listening socket -- otherwise only the client
+side is spread out and the routing table still funnels every rank onto one link.
+
+Example::
+
+    python3 -m sglang.launch_server --tp 4 --load-format remote --model-path \\
+      'http-range://[fd00::1]:9000/models/Qwen3-30B-A3B?endpoints=[fd00::1]:9000,[fd00::2]:9001,[fd00::3]:9002,[fd00::4]:9003&nics=bond0,bond1,bond2,bond3'
+"""
+
+import fnmatch
+import itertools
+import json
+import logging
+import os
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Generator, Optional, Tuple
+from urllib.parse import parse_qsl, quote, urlparse
+
+import numpy as np
+import torch
+
+from sglang.srt.connector import HTTP_RANGE_SCHEME, BaseFileConnector
+
+logger = logging.getLogger(__name__)
+
+SCHEME = HTTP_RANGE_SCHEME
+
+_DEFAULT_PORT = 80
+_DEFAULT_CONNECTIONS = 16
+_DEFAULT_CHUNK_SIZE = 32 << 20
+_DEFAULT_TIMEOUT = 30.0
+_DEFAULT_RETRIES = 2
+
+_SAFETENSORS_INDEX = "model.safetensors.index.json"
+_SINGLE_SHARD = "model.safetensors"
+
+# Metadata objects fetched by pull_files(). A plain Range server cannot be
+# listed, so the well-known HuggingFace metadata set is probed by name and
+# missing objects are skipped. Use the ``metadata`` URL option to add more.
+_METADATA_OBJECTS = (
+    "config.json",
+    "generation_config.json",
+    "preprocessor_config.json",
+    "processor_config.json",
+    "tokenizer_config.json",
+    "tokenizer.json",
+    "tokenizer.model",
+    "special_tokens_map.json",
+    "added_tokens.json",
+    "vocab.json",
+    "merges.txt",
+    "chat_template.json",
+    "chat_template.jinja",
+    _SAFETENSORS_INDEX,
+)
+
+# safetensors dtype tag -> torch dtype attribute name.
+_SAFETENSORS_DTYPES = {
+    "BOOL": "bool",
+    "U8": "uint8",
+    "I8": "int8",
+    "F8_E4M3": "float8_e4m3fn",
+    "F8_E5M2": "float8_e5m2",
+    "F8_E8M0": "float8_e8m0fnu",
+    "I16": "int16",
+    "U16": "uint16",
+    "F16": "float16",
+    "BF16": "bfloat16",
+    "I32": "int32",
+    "U32": "uint32",
+    "F32": "float32",
+    "I64": "int64",
+    "U64": "uint64",
+    "F64": "float64",
+}
+
+Endpoint = Tuple[str, int, Optional[str]]
+
+
+def parse_endpoint(spec: str, default_port: int) -> Tuple[str, int]:
+    """Split ``host``, ``host:port`` or ``[v6addr]:port`` into host and port."""
+    spec = spec.strip()
+    if spec.startswith("["):
+        host, sep, rest = spec[1:].partition("]")
+        if not sep:
+            raise ValueError(f"unbalanced brackets in endpoint {spec!r}")
+        port = rest[1:] if rest.startswith(":") else ""
+    elif spec.count(":") == 1:
+        host, _, port = spec.partition(":")
+    else:
+        # Bare hostname, IPv4, or unbracketed IPv6 literal.
+        host, port = spec, ""
+    if not host:
+        raise ValueError(f"missing host in endpoint {spec!r}")
+    return host, int(port) if port else default_port
+
+
+def _torch_dtype(tag: str) -> torch.dtype:
+    name = _SAFETENSORS_DTYPES.get(tag)
+    dtype = getattr(torch, name) if name else None
+    if not isinstance(dtype, torch.dtype):
+        raise ValueError(
+            f"safetensors dtype {tag!r} is not supported by this torch build "
+            f"({torch.__version__})"
+        )
+    return dtype
+
+
+def iter_safetensors(
+    buf: np.ndarray,
+) -> Generator[Tuple[str, torch.Tensor], None, None]:
+    """Yield ``(name, tensor)`` from an in-memory safetensors image.
+
+    Tensors are ``torch.frombuffer`` views onto ``buf``, so the caller must keep
+    it alive while they are in use. ``safetensors.torch.load()`` would copy the
+    whole image once more, which is several GB per shard at these sizes.
+    """
+    view = memoryview(buf.data).cast("B")
+    total = len(view)
+    if total < 8:
+        raise ValueError(f"safetensors image is {total} bytes, too short for a header")
+    header_len = int.from_bytes(bytes(view[:8]), "little")
+    data_start = 8 + header_len
+    if data_start > total:
+        raise ValueError(
+            f"safetensors header claims {header_len} bytes but the image is {total}"
+        )
+    header = json.loads(bytes(view[8:data_start]))
+    for name, meta in header.items():
+        if name == "__metadata__":
+            continue
+        start, end = meta["data_offsets"]
+        if data_start + end > total:
+            raise ValueError(
+                f"tensor {name!r} ends at {data_start + end} past the {total}-byte image"
+            )
+        dtype = _torch_dtype(meta["dtype"])
+        if end == start:
+            tensor = torch.empty(0, dtype=dtype)
+        else:
+            chunk = view[data_start + start : data_start + end]
+            itemsize = torch.empty(0, dtype=dtype).element_size()
+            if (data_start + start) % itemsize:
+                # torch.frombuffer requires an aligned address; safetensors does
+                # not guarantee one for every dtype, so copy in that rare case.
+                chunk = bytearray(chunk)
+            tensor = torch.frombuffer(chunk, dtype=dtype)
+        yield name, tensor.reshape(meta["shape"])
+
+
+class HttpRangeConnector(BaseFileConnector):
+    """Streams weights straight out of an object store, one shard at a time.
+
+    Peak host memory is one shard: the buffer is released as soon as the
+    consumer has walked its tensors. Weight bytes never touch local storage --
+    only metadata objects are materialized, under :meth:`get_local_dir`.
+
+    Every rank pulls all shards, because ``load_weights`` narrows per rank on
+    the consumer side; total network volume is therefore ``tp_size`` times the
+    checkpoint size, which is what makes per-rank NIC pinning worthwhile here.
+    """
+
+    def __init__(self, url: str) -> None:
+        super().__init__(url)
+        parsed = urlparse(url)
+        if parsed.scheme != SCHEME:
+            raise ValueError(f"expected a {SCHEME}:// url, got {url!r}")
+        if not parsed.hostname:
+            raise ValueError(f"missing host in {url!r}")
+        options = dict(parse_qsl(parsed.query, keep_blank_values=True))
+        unknown = set(options) - {
+            "endpoints",
+            "nics",
+            "connections",
+            "chunk_size",
+            "timeout",
+            "retries",
+            "metadata",
+        }
+        if unknown:
+            raise ValueError(f"unknown {SCHEME} options: {sorted(unknown)}")
+
+        self.default_endpoint = (parsed.hostname, parsed.port or _DEFAULT_PORT)
+        self.prefix = parsed.path.rstrip("/")
+        self.endpoints = [
+            parse_endpoint(entry, self.default_endpoint[1])
+            for entry in options.get("endpoints", "").split(",")
+            if entry.strip()
+        ] or [self.default_endpoint]
+        self.nics = [
+            entry.strip() or None for entry in options.get("nics", "").split(",")
+        ]
+        self.connections = int(options.get("connections", _DEFAULT_CONNECTIONS))
+        self.chunk_size = int(options.get("chunk_size", _DEFAULT_CHUNK_SIZE))
+        self.timeout = float(options.get("timeout", _DEFAULT_TIMEOUT))
+        self.retries = int(options.get("retries", _DEFAULT_RETRIES))
+        if self.connections < 1 or self.chunk_size < 1 or self.retries < 0:
+            raise ValueError(
+                "connections and chunk_size must be positive and retries non-negative"
+            )
+        self.metadata_objects = list(_METADATA_OBJECTS) + [
+            entry.strip()
+            for entry in options.get("metadata", "").split(",")
+            if entry.strip()
+        ]
+        self._shards: Optional[list[str]] = None
+
+    # -- endpoints and sockets ----------------------------------------------
+
+    def endpoint_for_rank(self, rank: int) -> Endpoint:
+        host, port = self.endpoints[rank % len(self.endpoints)]
+        return host, port, self.nics[rank % len(self.nics)]
+
+    def _bind_to_device(self, sock: socket.socket, nic: str) -> None:
+        if not sys.platform.startswith("linux"):
+            raise RuntimeError(
+                f"the nics option needs SO_BINDTODEVICE, unavailable on {sys.platform}"
+            )
+        option = getattr(socket, "SO_BINDTODEVICE", 25)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, option, nic.encode() + b"\0")
+        except PermissionError as e:
+            raise PermissionError(
+                f"binding a socket to {nic!r} requires CAP_NET_RAW"
+            ) from e
+
+    def _connect(self, endpoint: Endpoint) -> socket.socket:
+        host, port, nic = endpoint
+        last_error: Optional[OSError] = None
+        for family, kind, proto, _, address in socket.getaddrinfo(
+            host, port, type=socket.SOCK_STREAM
+        ):
+            sock = socket.socket(family, kind, proto)
+            try:
+                if nic:
+                    self._bind_to_device(sock, nic)
+                sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                sock.settimeout(self.timeout)
+                sock.connect(address)
+                return sock
+            except OSError as e:
+                sock.close()
+                last_error = e
+        raise last_error or OSError(f"cannot resolve {host}:{port}")
+
+    # -- HTTP ---------------------------------------------------------------
+
+    def _object_path(self, name: str) -> str:
+        if any(c in name for c in "\r\n") or not name:
+            raise ValueError(f"illegal object name {name!r}")
+        return quote(f"{self.prefix}/{name}")
+
+    def _send_request(
+        self, sock: socket.socket, name: str, byte_range: Optional[Tuple[int, int]]
+    ) -> None:
+        lines = [
+            f"GET {self._object_path(name)} HTTP/1.1",
+            f"Host: {self.default_endpoint[0]}",
+            "Connection: keep-alive",
+        ]
+        if byte_range is not None:
+            offset, length = byte_range
+            lines.append(f"Range: bytes={offset}-{offset + length - 1}")
+        sock.sendall(("\r\n".join(lines) + "\r\n\r\n").encode())
+
+    def _read_response_head(
+        self, sock: socket.socket, pending: bytes
+    ) -> Tuple[int, int, bytes, dict]:
+        """Return ``(status, content_length, leftover_body_bytes, headers)``.
+
+        ``pending`` carries bytes already read past the previous response on a
+        keep-alive connection.
+        """
+        buf = pending
+        while b"\r\n\r\n" not in buf:
+            chunk = sock.recv(65536)
+            if not chunk:
+                raise ConnectionError(
+                    "connection closed while reading response headers"
+                )
+            buf += chunk
+        head, rest = buf.split(b"\r\n\r\n", 1)
+        lines = head.split(b"\r\n")
+        fields = lines[0].split(None, 2)
+        if len(fields) < 2 or not fields[1].isdigit():
+            raise ConnectionError(f"malformed HTTP status line: {lines[0]!r}")
+        headers = {}
+        for line in lines[1:]:
+            key, sep, value = line.partition(b":")
+            if sep:
+                headers[key.strip().lower()] = value.strip()
+        if b"transfer-encoding" in headers:
+            raise ConnectionError(
+                f"{SCHEME} needs Content-Length responses, got "
+                f"Transfer-Encoding: {headers[b'transfer-encoding']!r}"
+            )
+        if headers.get(b"connection", b"").lower() == b"close":
+            raise ConnectionError(
+                f"{SCHEME} needs HTTP/1.1 keep-alive, server asked to close"
+            )
+        if b"content-length" not in headers:
+            raise ConnectionError("HTTP response without Content-Length")
+        return int(fields[1]), int(headers[b"content-length"]), rest, headers
+
+    def _recv_body(
+        self,
+        sock: socket.socket,
+        destination: memoryview,
+        expected: int,
+        pending: bytes,
+    ) -> bytes:
+        got = 0
+        if pending:
+            take = min(len(pending), expected)
+            destination[:take] = pending[:take]
+            got = take
+            pending = pending[take:]
+        while got < expected:
+            read = sock.recv_into(destination[got:])
+            if read == 0:
+                raise ConnectionError(
+                    f"connection closed after {got} of {expected} body bytes"
+                )
+            got += read
+        return pending
+
+    def _get_object(self, name: str) -> Optional[bytes]:
+        """Fetch a whole (small) object, or None when the server reports 404."""
+        sock = self._connect((*self.default_endpoint, None))
+        try:
+            self._send_request(sock, name, None)
+            status, length, pending, _ = self._read_response_head(sock, b"")
+            if status == 404:
+                return None
+            if status != 200:
+                raise ConnectionError(f"GET {name} returned HTTP {status}")
+            body = bytearray(length)
+            self._recv_body(sock, memoryview(body), length, pending)
+            return bytes(body)
+        finally:
+            sock.close()
+
+    def _object_size(self, endpoint: Endpoint, name: str) -> int:
+        """Probe an object's size, and confirm the server honours Range."""
+        sock = self._connect(endpoint)
+        try:
+            self._send_request(sock, name, (0, 1))
+            status, length, _, headers = self._read_response_head(sock, b"")
+            if status == 404:
+                raise FileNotFoundError(f"object {name!r} not found at {endpoint}")
+            if status == 200:
+                raise ConnectionError(
+                    f"server ignored the Range header for {name!r} and returned the "
+                    f"whole object; {SCHEME} requires byte-range support"
+                )
+            if status != 206 or length != 1:
+                raise ConnectionError(
+                    f"unexpected range response for {name!r}: HTTP {status}, "
+                    f"{length} bytes"
+                )
+            # "Content-Range: bytes 0-0/<total>" is the only place a range
+            # response states the object size.
+            content_range = headers.get(b"content-range", b"")
+            total = content_range.rpartition(b"/")[2]
+            if not total.isdigit():
+                raise ConnectionError(
+                    f"range response for {name!r} has no usable Content-Range: "
+                    f"{content_range!r}"
+                )
+            return int(total)
+        finally:
+            sock.close()
+
+    def _fetch_object(self, endpoint: Endpoint, name: str, size: int) -> np.ndarray:
+        """Pull one object into a uint8 array with parallel keep-alive readers.
+
+        Ranges are handed out from a shared cursor rather than split per worker,
+        so every connection stays busy even though shards differ in size.
+        """
+        out = np.empty(size, dtype=np.uint8)
+        view = memoryview(out.data).cast("B")
+        ranges = [
+            (offset, min(self.chunk_size, size - offset))
+            for offset in range(0, size, self.chunk_size)
+        ]
+        cursor = itertools.count()
+        stop = threading.Event()
+        errors: list[BaseException] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            sock = None
+            pending = b""
+            try:
+                for index in cursor:
+                    if index >= len(ranges) or stop.is_set():
+                        return
+                    offset, length = ranges[index]
+                    for attempt in range(self.retries + 1):
+                        try:
+                            if sock is None:
+                                sock = self._connect(endpoint)
+                                pending = b""
+                            self._send_request(sock, name, (offset, length))
+                            status, expected, pending, _ = self._read_response_head(
+                                sock, pending
+                            )
+                            if status != 206 or expected != length:
+                                raise ConnectionError(
+                                    f"range {offset}+{length} of {name!r} answered "
+                                    f"with HTTP {status} and {expected} bytes"
+                                )
+                            pending = self._recv_body(
+                                sock, view[offset : offset + length], length, pending
+                            )
+                            break
+                        except OSError as e:
+                            if sock is not None:
+                                sock.close()
+                                sock = None
+                            if attempt == self.retries:
+                                raise
+                            logger.warning(
+                                "retrying range %d+%d of %s after %s",
+                                offset,
+                                length,
+                                name,
+                                e,
+                            )
+                            time.sleep(0.1 * (attempt + 1))
+            except BaseException as e:  # noqa: BLE001 - re-raised by the caller
+                stop.set()
+                with lock:
+                    errors.append(e)
+            finally:
+                if sock is not None:
+                    sock.close()
+
+        threads = [
+            threading.Thread(target=worker, daemon=True)
+            for _ in range(max(1, min(self.connections, len(ranges))))
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        if errors:
+            raise errors[0]
+        return out
+
+    # -- BaseFileConnector --------------------------------------------------
+
+    def shard_names(self) -> list[str]:
+        if self._shards is not None:
+            return self._shards
+        index = self._get_object(_SAFETENSORS_INDEX)
+        if index is not None:
+            weight_map = json.loads(index)["weight_map"]
+            self._shards = sorted(set(weight_map.values()))
+        elif self._get_object(_SINGLE_SHARD) is not None:
+            self._shards = [_SINGLE_SHARD]
+        else:
+            raise FileNotFoundError(
+                f"neither {_SAFETENSORS_INDEX} nor {_SINGLE_SHARD} found under "
+                f"{self.prefix!r}; only safetensors checkpoints are supported"
+            )
+        return self._shards
+
+    def glob(self, allow_pattern: Optional[list[str]] = None) -> list[str]:
+        host, port = self.default_endpoint
+        names = self.shard_names()
+        if allow_pattern is not None:
+            names = [
+                name
+                for name in names
+                if any(fnmatch.fnmatch(name, pattern) for pattern in allow_pattern)
+            ]
+        return [f"{SCHEME}://{host}:{port}{self.prefix}/{name}" for name in names]
+
+    def pull_files(
+        self,
+        allow_pattern: Optional[list[str]] = None,
+        ignore_pattern: Optional[list[str]] = None,
+    ) -> None:
+        """Materialize metadata objects into the connector's local directory.
+
+        Weight shards are never pulled: they are streamed by
+        :meth:`weight_iterator`. Objects the store does not have are skipped, so
+        the well-known metadata set can be probed without listing support.
+        """
+        for name in self.metadata_objects:
+            if allow_pattern is not None and not any(
+                fnmatch.fnmatch(name, pattern) for pattern in allow_pattern
+            ):
+                continue
+            if ignore_pattern is not None and any(
+                fnmatch.fnmatch(name, pattern) for pattern in ignore_pattern
+            ):
+                continue
+            body = self._get_object(name)
+            if body is None:
+                continue
+            destination = os.path.join(self.local_dir, name)
+            os.makedirs(Path(destination).parent, exist_ok=True)
+            with open(destination, "wb") as f:
+                f.write(body)
+
+    def weight_iterator(
+        self, rank: int = 0
+    ) -> Generator[Tuple[str, torch.Tensor], None, None]:
+        endpoint = self.endpoint_for_rank(rank)
+        shards = self.shard_names()
+        logger.info(
+            "Streaming %d shards from %s over %d connections (rank %d, nic %s)",
+            len(shards),
+            f"[{endpoint[0]}]:{endpoint[1]}{self.prefix}",
+            self.connections,
+            rank,
+            endpoint[2] or "routing table",
+        )
+        fetched = 0
+        seconds = 0.0
+        for name in shards:
+            start = time.perf_counter()
+            size = self._object_size(endpoint, name)
+            buf = self._fetch_object(endpoint, name, size)
+            seconds += time.perf_counter() - start
+            fetched += size
+            yield from iter_safetensors(buf)
+            del buf
+        logger.info(
+            "Streamed %.2f GB in %.2f s (%.2f GB/s) for rank %d on nic %s",
+            fetched / 1e9,
+            seconds,
+            fetched / max(seconds, 1e-9) / 1e9,
+            rank,
+            endpoint[2] or "routing table",
+        )

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -3338,7 +3338,9 @@ class RemoteModelLoader(BaseModelLoader):
     ) -> Generator[Tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights from remote storage."""
         assert get_connector_type(client) == ConnectorType.FS
-        return client.weight_iterator()
+        # Connectors that shard the transfer per rank (e.g. one endpoint or NIC
+        # per rank) need the rank; the others ignore the argument.
+        return client.weight_iterator(get_parallel().tp_rank)
 
     def download_model(self, model_config: ModelConfig) -> None:
         pass

--- a/test/registered/model_loading/test_http_range_connector.py
+++ b/test/registered/model_loading/test_http_range_connector.py
@@ -1,0 +1,357 @@
+import json
+import os
+import struct
+import sys
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import unquote
+
+import numpy as np
+import torch
+from safetensors.torch import load_file, save_file
+
+from sglang.srt.connector import create_remote_connector
+from sglang.srt.connector.http_range import (
+    HttpRangeConnector,
+    iter_safetensors,
+    parse_endpoint,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+SHARDS = {
+    "model-00001-of-00002.safetensors": {
+        "model.embed_tokens.weight": torch.randn(128, 64).to(torch.bfloat16),
+        "model.layers.0.self_attn.q_proj.weight": torch.randn(32, 16),
+    },
+    "model-00002-of-00002.safetensors": {
+        "model.layers.0.self_attn.k_proj.weight": torch.randn(16, 64).to(
+            torch.bfloat16
+        ),
+        "model.layers.0.input_layernorm.weight": torch.randn(64).to(torch.float16),
+        "model.layers.0.self_attn.q_proj.weight_scale": torch.tensor(0.5),
+    },
+}
+
+
+class _RangeHandler(BaseHTTPRequestHandler):
+    """Minimal HTTP/1.1 object server with byte ranges and keep-alive."""
+
+    protocol_version = "HTTP/1.1"
+    root = ""
+    ignore_range = False
+    close_every_response = False
+
+    def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler API
+        path = os.path.join(self.root, unquote(self.path).lstrip("/"))
+        if not os.path.isfile(path):
+            self._respond(404, b"not found\n")
+            return
+        with open(path, "rb") as f:
+            body = f.read()
+        header_range = self.headers.get("Range")
+        if header_range and not self.ignore_range:
+            start, _, end = header_range.split("=", 1)[1].partition("-")
+            first = int(start)
+            last = int(end) if end else len(body) - 1
+            self._respond(
+                206,
+                body[first : last + 1],
+                {"Content-Range": f"bytes {first}-{last}/{len(body)}"},
+            )
+        else:
+            self._respond(200, body)
+
+    def _respond(self, status, body, extra=None):
+        self.send_response(status)
+        for key, value in (extra or {}).items():
+            self.send_header(key, value)
+        self.send_header("Content-Length", str(len(body)))
+        if self.close_every_response:
+            self.send_header("Connection", "close")
+            self.close_connection = True
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args):
+        pass
+
+
+class _Server:
+    """Serves ``root`` on an ephemeral localhost port for the test duration."""
+
+    def __init__(self, root, **handler_attrs):
+        handler = type("_Handler", (_RangeHandler,), {"root": root, **handler_attrs})
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+        self.host, self.port = self.server.server_address[:2]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        self.thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+    def url(self, prefix="/models/tiny", query=""):
+        base = f"http-range://{self.host}:{self.port}{prefix}"
+        return f"{base}?{query}" if query else base
+
+
+def _write_model(root, with_index=True):
+    model_dir = os.path.join(root, "models", "tiny")
+    os.makedirs(model_dir)
+    for name, tensors in SHARDS.items():
+        save_file(tensors, os.path.join(model_dir, name), metadata={"format": "pt"})
+    with open(os.path.join(model_dir, "config.json"), "w") as f:
+        json.dump({"model_type": "qwen3"}, f)
+    with open(os.path.join(model_dir, "tokenizer_config.json"), "w") as f:
+        json.dump({"model_max_length": 8}, f)
+    if with_index:
+        weight_map = {
+            key: shard for shard, tensors in SHARDS.items() for key in tensors
+        }
+        with open(os.path.join(model_dir, "model.safetensors.index.json"), "w") as f:
+            json.dump({"metadata": {}, "weight_map": weight_map}, f)
+    return model_dir
+
+
+class TestHttpRangeUrl(CustomTestCase):
+    def test_parse_endpoint(self):
+        self.assertEqual(parse_endpoint("host", 80), ("host", 80))
+        self.assertEqual(parse_endpoint("host:9000", 80), ("host", 9000))
+        self.assertEqual(parse_endpoint("[fd00::1]:9000", 80), ("fd00::1", 9000))
+        self.assertEqual(parse_endpoint("[fd00::1]", 80), ("fd00::1", 80))
+        # An unbracketed IPv6 literal has no port to split off.
+        self.assertEqual(parse_endpoint("fd00::1", 80), ("fd00::1", 80))
+        with self.assertRaises(ValueError):
+            parse_endpoint("[fd00::1:9000", 80)
+
+    def test_endpoint_per_rank(self):
+        client = HttpRangeConnector(
+            "http-range://h0:9000/bucket/model"
+            "?endpoints=[fd00::1]:9100,[fd00::2]:9101&nics=bond0,,bond2"
+        )
+        try:
+            self.assertEqual(client.endpoint_for_rank(0), ("fd00::1", 9100, "bond0"))
+            self.assertEqual(client.endpoint_for_rank(1), ("fd00::2", 9101, None))
+            # Lists wrap independently: endpoints has 2 entries, nics has 3.
+            self.assertEqual(client.endpoint_for_rank(2), ("fd00::1", 9100, "bond2"))
+            self.assertEqual(client.endpoint_for_rank(3), ("fd00::2", 9101, "bond0"))
+        finally:
+            client.close()
+
+    def test_defaults_and_validation(self):
+        client = HttpRangeConnector("http-range://h0:9000/bucket/model")
+        try:
+            self.assertEqual(client.endpoint_for_rank(7), ("h0", 9000, None))
+            self.assertEqual(client.connections, 16)
+        finally:
+            client.close()
+        with self.assertRaisesRegex(ValueError, "unknown http-range options"):
+            HttpRangeConnector("http-range://h0:9000/m?nic=bond0")
+        with self.assertRaisesRegex(ValueError, "expected a http-range"):
+            HttpRangeConnector("s3://bucket/model")
+
+    def test_created_through_factory(self):
+        client = create_remote_connector("http-range://h0:9000/bucket/model")
+        try:
+            self.assertIsInstance(client, HttpRangeConnector)
+        finally:
+            client.close()
+
+
+class TestHttpRangeConnector(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp = tempfile.TemporaryDirectory()
+        cls.model_dir = _write_model(cls.tmp.name)
+        cls.expected = {
+            name: load_file(os.path.join(cls.model_dir, name)) for name in SHARDS
+        }
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.tmp.cleanup()
+
+    def test_glob_lists_shards_from_index(self):
+        with _Server(self.tmp.name) as server:
+            with create_remote_connector(server.url()) as client:
+                self.assertEqual(
+                    client.glob(),
+                    [f"{server.url()}/{name}" for name in sorted(SHARDS)],
+                )
+                self.assertEqual(
+                    client.glob(allow_pattern=["*-00002-*"]),
+                    [f"{server.url()}/model-00002-of-00002.safetensors"],
+                )
+
+    def test_single_shard_without_index(self):
+        with tempfile.TemporaryDirectory() as root:
+            model_dir = os.path.join(root, "models", "tiny")
+            os.makedirs(model_dir)
+            save_file(
+                SHARDS["model-00001-of-00002.safetensors"],
+                os.path.join(model_dir, "model.safetensors"),
+            )
+            with _Server(root) as server:
+                with create_remote_connector(server.url()) as client:
+                    self.assertEqual(client.shard_names(), ["model.safetensors"])
+
+    def test_no_safetensors_at_all(self):
+        with tempfile.TemporaryDirectory() as root:
+            os.makedirs(os.path.join(root, "models", "tiny"))
+            with _Server(root) as server:
+                with create_remote_connector(server.url()) as client:
+                    with self.assertRaisesRegex(FileNotFoundError, "only safetensors"):
+                        client.shard_names()
+
+    def test_pull_files_fetches_only_metadata(self):
+        with _Server(self.tmp.name) as server:
+            with create_remote_connector(server.url()) as client:
+                client.pull_files(ignore_pattern=["*.safetensors"])
+                pulled = sorted(os.listdir(client.get_local_dir()))
+            self.assertEqual(
+                pulled,
+                [
+                    "config.json",
+                    "model.safetensors.index.json",
+                    "tokenizer_config.json",
+                ],
+            )
+
+    def test_pull_files_honours_allow_pattern(self):
+        # This is the pattern ModelConfig uses to bootstrap a remote model.
+        with _Server(self.tmp.name) as server:
+            with create_remote_connector(server.url()) as client:
+                client.pull_files(allow_pattern=["*config.json"])
+                pulled = sorted(os.listdir(client.get_local_dir()))
+            self.assertEqual(pulled, ["config.json", "tokenizer_config.json"])
+
+    def test_weight_iterator_matches_local_read(self):
+        expected = {
+            name: tensor
+            for tensors in self.expected.values()
+            for name, tensor in tensors.items()
+        }
+        # A chunk smaller than a tensor, one straddling shard boundaries and one
+        # larger than the whole object all have to produce identical bytes.
+        for connections, chunk_size in ((1, 1 << 20), (4, 1024), (8, 97)):
+            with self.subTest(connections=connections, chunk_size=chunk_size):
+                with _Server(self.tmp.name) as server:
+                    url = server.url(
+                        query=f"connections={connections}&chunk_size={chunk_size}"
+                    )
+                    with create_remote_connector(url) as client:
+                        streamed = dict(client.weight_iterator())
+                self.assertEqual(sorted(streamed), sorted(expected))
+                for name, tensor in expected.items():
+                    self.assertEqual(streamed[name].dtype, tensor.dtype)
+                    self.assertEqual(streamed[name].shape, tensor.shape)
+                    self.assertTrue(
+                        torch.equal(
+                            streamed[name].reshape(-1).view(torch.uint8),
+                            tensor.reshape(-1).view(torch.uint8),
+                        ),
+                        f"{name} differs",
+                    )
+
+    def test_rank_selects_its_own_endpoint(self):
+        with _Server(self.tmp.name) as server:
+            # Rank 1 points at a dead port: reaching it proves the rank is used
+            # to pick the endpoint rather than being ignored.
+            query = f"endpoints={server.host}:{server.port},{server.host}:1"
+            with create_remote_connector(server.url(query=query)) as client:
+                self.assertEqual(len(list(client.weight_iterator(0))), 5)
+                with self.assertRaises(OSError):
+                    list(client.weight_iterator(1))
+
+    def test_missing_shard_reports_the_object(self):
+        with tempfile.TemporaryDirectory() as root:
+            model_dir = os.path.join(root, "models", "tiny")
+            os.makedirs(model_dir)
+            with open(
+                os.path.join(model_dir, "model.safetensors.index.json"), "w"
+            ) as f:
+                json.dump({"weight_map": {"a": "gone.safetensors"}}, f)
+            with _Server(root) as server:
+                with create_remote_connector(server.url()) as client:
+                    with self.assertRaisesRegex(FileNotFoundError, "gone.safetensors"):
+                        list(client.weight_iterator())
+
+    def test_server_ignoring_range_is_rejected(self):
+        with _Server(self.tmp.name, ignore_range=True) as server:
+            with create_remote_connector(server.url()) as client:
+                with self.assertRaisesRegex(ConnectionError, "ignored the Range"):
+                    list(client.weight_iterator())
+
+    def test_server_without_keepalive_is_rejected(self):
+        with _Server(self.tmp.name, close_every_response=True) as server:
+            with create_remote_connector(server.url()) as client:
+                with self.assertRaisesRegex(ConnectionError, "keep-alive"):
+                    client.shard_names()
+
+    @unittest.skipIf(sys.platform.startswith("linux"), "SO_BINDTODEVICE exists")
+    def test_nics_need_linux(self):
+        with _Server(self.tmp.name) as server:
+            with create_remote_connector(server.url(query="nics=bond0")) as client:
+                with self.assertRaisesRegex(RuntimeError, "SO_BINDTODEVICE"):
+                    list(client.weight_iterator())
+
+
+class TestIterSafetensors(CustomTestCase):
+    @staticmethod
+    def _image(header, blob=b""):
+        raw = json.dumps(header).encode()
+        return struct.pack("<Q", len(raw)) + raw + blob
+
+    def _as_buffer(self, data):
+        return np.frombuffer(bytearray(data), dtype=np.uint8)
+
+    def test_metadata_entry_is_skipped(self):
+        image = self._image(
+            {
+                "__metadata__": {"format": "pt"},
+                "w": {"dtype": "F32", "shape": [2], "data_offsets": [0, 8]},
+            },
+            struct.pack("<2f", 1.0, 2.0),
+        )
+        tensors = dict(iter_safetensors(self._as_buffer(image)))
+        self.assertEqual(list(tensors), ["w"])
+        self.assertTrue(torch.equal(tensors["w"], torch.tensor([1.0, 2.0])))
+
+    def test_empty_tensor(self):
+        image = self._image(
+            {"w": {"dtype": "F32", "shape": [0], "data_offsets": [0, 0]}}
+        )
+        tensors = dict(iter_safetensors(self._as_buffer(image)))
+        self.assertEqual(tensors["w"].numel(), 0)
+
+    def test_unsupported_dtype(self):
+        image = self._image(
+            {"w": {"dtype": "F4", "shape": [2], "data_offsets": [0, 1]}}, b"\x00"
+        )
+        with self.assertRaisesRegex(ValueError, "F4"):
+            dict(iter_safetensors(self._as_buffer(image)))
+
+    def test_truncated_image(self):
+        image = self._image(
+            {"w": {"dtype": "F32", "shape": [4], "data_offsets": [0, 16]}}, b"\x00" * 4
+        )
+        with self.assertRaisesRegex(ValueError, "past the"):
+            dict(iter_safetensors(self._as_buffer(image)))
+
+    def test_truncated_header(self):
+        with self.assertRaisesRegex(ValueError, "header claims"):
+            dict(iter_safetensors(self._as_buffer(struct.pack("<Q", 4096))))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

On a multi-NIC host, remote weights can be read faster than local disk, but
only if (a) many connections are in flight and (b) each TP rank drives its own
NIC. A POSIX/FUSE mount gives neither: the kernel picks the egress NIC from the
routing table, so every rank shares one link. An object store moves that
decision into user space — each rank opens its own sockets and pins them with
SO_BINDTODEVICE.

## What this adds

An `http-range://` file connector that streams safetensors weights straight out
of an object store over HTTP GET Range requests, so no weight byte lands on
local storage. It plugs into the existing remote-loading path
(`LoadFormat.REMOTE` → `RemoteModelLoader` → `BaseFileConnector`), so
weight_loader narrowing and every layer implementation are reused unchanged;
semantics match `--load-format auto`.

- URL: `http-range://host:port/prefix?endpoints=...&nics=...`, with per-rank
  endpoint/NIC lists plus `connections`/`chunk_size`/`timeout`/`retries`.
- Object sizes learned from the first range response's `Content-Range`; ranges
  handed out from a shared cursor across keep-alive connections; tensors are
  zero-copy `torch.frombuffer` views over one in-flight shard (peak host RAM =
  one shard).
- Servers without Range or keep-alive, and unknown safetensors dtypes, are
  rejected with explicit errors.

## Usage

    python3 -m sglang.launch_server \
      --tp 4 --load-format remote --served-model-name Qwen3-30B-A3B \
      --model-path 'http-range://[fd00::1]:9000/models/Qwen3-30B-A3B?endpoints=[fd00::1]:9000,[fd00::2]:9001,[fd00::3]:9002,[fd00::4]:9003&nics=eth0,eth1,eth2,eth3'

## Testing

- CPU unit test (registered to `base-a-test-cpu`) with a stdlib HTTP/1.1 range
  server: URL/endpoint parsing, per-rank rotation, shard discovery, metadata-only
  pull_files, byte-exact streaming across 1/4/8 connections × 1MB/1KB/97B chunks,
  rejection of missing objects / Range-ignoring / connection-closing servers,
  safetensors offset/empty/unknown-dtype/truncated-header. 20 tests pass.
- End-to-end on a 4-NIC host, Qwen3-30B-A3B (57 GiB, 16 shards), TP=4, one
  endpoint per NIC: ~7.6 s `Load weight` (~17 GB/s per NIC, ~71 GB/s aggregate)
  vs 25 s local NVMe cold read and 42 s over FUSE; outputs match the file-based
  baseline token for token (greedy, 5 prompts, N=3).

## Cost / limitations

- Every rank pulls all shards (auto semantics narrow on the consumer side), so
  total network volume is `tp_size × checkpoint_size` — which is exactly why
  per-rank NIC pinning matters. Shards fetched serially (no H2D overlap).
  `.safetensors` only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31463975846](https://github.com/sgl-project/sglang/actions/runs/31463975846)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31463975773](https://github.com/sgl-project/sglang/actions/runs/31463975773)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->