### PR TITLE
[Kernel] DSv4 Q norm-rope (fp8): block-per-token freq share + vectorized dequant for prefill throughput

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/main_norm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/main_norm_rope.cuh
@@ -76,7 +76,7 @@ struct FusedQNormRopeParams {
   float eps;
 };
 
-template <typename DType, int64_t kHeadDim, int64_t kRopeDim, typename PosT, bool kUsePDL>
+template <typename DType, int64_t kHeadDim, int64_t kRopeDim, typename PosT, bool kUsePDL, bool kBlockPerToken = true>
 Q_KERNEL void fused_q_norm_rope(const __grid_constant__ FusedQNormRopeParams params) {
   using namespace device;
 
@@ -90,95 +90,220 @@ Q_KERNEL void fused_q_norm_rope(const __grid_constant__ FusedQNormRopeParams par
   static_assert(kRopeSize <= kWarpThreads);
   static_assert(kRopeDim == kWarpThreads * 2, "1 (real, imag) pair per lane");
 
+  // fp8: 2 work-items/warp so their loads overlap (latency-bound); bf16: 1
+  // (bandwidth-bound, a 2nd item just adds register pressure). Per-item math is
+  // identical either way -> the output is bitwise-identical for both.
+  constexpr uint32_t kWorkPerWarp = (sizeof(DType) == 1) ? 2u : 1u;
+
   using Storage = AlignedVector<DType, kVecSize>;
+  using DType2 = packed_t<DType>;
+  constexpr bool kVecConvert = (sizeof(DType) == 1);  // fp8 only
+  // fp8 shares one freq row per token across its heads (block-per-token), but
+  // only when the grid fills the SMs; the host picks kBlockPerToken=false at
+  // small N (crossover total_works>=kBPTMinWorks). bf16 never uses it.
+  // Dispatch-only, so the per-work-item math is byte-identical.
+  constexpr bool kUseBPT = kVecConvert && kBlockPerToken;
 
   const auto warp_id = threadIdx.x / kWarpThreads;
   const auto lane_id = threadIdx.x % kWarpThreads;
-  const auto work_id = blockIdx.x * kFusedQNumWarps + warp_id;
-
   const uint32_t total_works = params.batch_size * params.num_q_heads;
-  if (work_id >= total_works) return;
 
-  const uint32_t batch_id = work_id / params.num_q_heads;
-  const uint32_t head_id = work_id % params.num_q_heads;
-  const auto input_ptr =
-      static_cast<const DType*>(params.q_input) + batch_id * params.q_input_stride_batch + head_id * kHeadDim;
-  const auto output_ptr =
-      static_cast<DType*>(params.q_output) + batch_id * params.q_output_stride_batch + head_id * kHeadDim;
-  const auto position = static_cast<int32_t>(static_cast<const PosT*>(params.positions)[batch_id]);
-
+  // rope-tail staging. fp8's part-2 read is 32 lanes x fp8x2 (2B) -> 2 lanes
+  // share a 4B SMEM bank; pad each pair to its own 4B slot to avoid that. bf16
+  // pairs are already 4B, so bf16 keeps the packed layout.
   __shared__ Storage s_rope[kFusedQNumWarps][kRopeSize];
-
-  // Prefetch this lane's freq pair before the PDL gate so the wait happens
-  // outside the dependency chain on `position`.
-  const auto mem_freq = tile::Memory<fp32x2_t>{lane_id, kWarpThreads};
-
-  PDLWaitPrimary<kUsePDL>();
-
-  // part 1: rmsnorm-self (no weight).
+  __shared__ uint32_t s_rope_pad[kFusedQNumWarps][kVecConvert ? kWarpThreads : 1];
+  // fp8 block-per-token: one freq row shared by all heads of the block's token.
+  __shared__ fp32x2_t s_freq[kVecConvert ? kWarpThreads : 1];
   const auto gmem = tile::Memory<Storage>{lane_id, kWarpThreads};
-  Storage input_vec[kLocalSize];
-#pragma unroll
-  for (int i = 0; i < kLocalSize; ++i) {
-    input_vec[i] = gmem.load(input_ptr, i);
-  }
-
-  const auto freq = mem_freq.load(params.freqs_cis + position * kRopeDim);
-
-  float sum_of_squares = 0.0f;
-#pragma unroll
-  for (int i = 0; i < kLocalSize; ++i) {
-#pragma unroll
-    for (int j = 0; j < kVecSize; ++j) {
-      const auto x = cast<float>(input_vec[i][j]);
-      sum_of_squares += x * x;
-    }
-  }
-  sum_of_squares = warp::reduce_sum(sum_of_squares);
-  const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
-
-#pragma unroll
-  for (int i = 0; i < kLocalSize; ++i) {
-#pragma unroll
-    for (int j = 0; j < kVecSize; ++j) {
-      const auto x = cast<float>(input_vec[i][j]);
-      input_vec[i][j] = cast<DType>(x * norm_factor);
-    }
-  }
-
-  // Stash the rope tail (last kRopeSize lanes' last tile) into shared memory;
-  // write nope tiles to gmem directly.
+  const auto mem_freq = tile::Memory<fp32x2_t>{lane_id, kWarpThreads};
   const bool is_rope_lane = lane_id >= kWarpThreads - kRopeSize;
+
+  // Per-work-item context + a hoisted input load (all loads issued first).
+  Storage input_vec[kWorkPerWarp][kLocalSize];
+  const DType* out_ptr[kWorkPerWarp];
+  int32_t position[kWorkPerWarp];  // bf16 path only; fp8 uses shared s_freq
+  uint32_t n_work;
+
+  if constexpr (kUseBPT) {
+    // ---- fp8: block-per-token dispatch. A block is pinned to one token and
+    // covers up to kHeadsPerBlock consecutive heads; the token's freq row is
+    // loaded ONCE into s_freq (warp 0) and reused. freq is exact fp32 so the
+    // shared value is bit-neutral -> the output is unchanged. All warps reach
+    // __syncthreads (no divergent return); out-of-range warps just do zero
+    // work-items.
+    constexpr uint32_t kHeadsPerBlock = kFusedQNumWarps * kWorkPerWarp;
+    const uint32_t blocks_per_token = (params.num_q_heads + kHeadsPerBlock - 1) / kHeadsPerBlock;
+    const uint32_t token = blockIdx.x / blocks_per_token;
+    const uint32_t head_block = blockIdx.x % blocks_per_token;
+    const uint32_t head_base = head_block * kHeadsPerBlock + warp_id * kWorkPerWarp;
+    const int32_t tpos = static_cast<int32_t>(static_cast<const PosT*>(params.positions)[token]);
+
+    PDLWaitPrimary<kUsePDL>();
+
+    if (warp_id == 0) {
+      s_freq[lane_id] = mem_freq.load(params.freqs_cis + tpos * kRopeDim);
+    }
+
+    n_work = (head_base >= params.num_q_heads)
+                 ? 0u
+                 : ((params.num_q_heads - head_base < kWorkPerWarp) ? (params.num_q_heads - head_base) : kWorkPerWarp);
+
 #pragma unroll
-  for (int i = 0; i < kLocalSize; ++i) {
-    if (i == kLocalSize - 1 && is_rope_lane) {
-      const auto rope_id = lane_id - (kWarpThreads - kRopeSize);
-      s_rope[warp_id][rope_id] = input_vec[i];
-    } else {
-      gmem.store(output_ptr, input_vec[i], i);
+    for (uint32_t w = 0; w < kWorkPerWarp; ++w) {
+      const uint32_t head_id = head_base + w;
+      const uint32_t chead = (head_id < params.num_q_heads) ? head_id : (params.num_q_heads - 1);
+      const auto in_ptr =
+          static_cast<const DType*>(params.q_input) + token * params.q_input_stride_batch + chead * kHeadDim;
+      out_ptr[w] = static_cast<DType*>(params.q_output) + token * params.q_output_stride_batch + chead * kHeadDim;
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+        input_vec[w][i] = gmem.load(in_ptr, i);
+      }
+    }
+    __syncthreads();  // s_freq visible to all warps before part 2
+  } else {
+    // ---- warp-per-(token, head) dispatch (bf16 always; fp8 at small N). -----
+    const auto warp_slot = blockIdx.x * kFusedQNumWarps + warp_id;
+    const auto work_base = warp_slot * kWorkPerWarp;
+    if (work_base >= total_works) return;
+
+    PDLWaitPrimary<kUsePDL>();
+
+    n_work = (total_works - work_base < kWorkPerWarp) ? (total_works - work_base) : kWorkPerWarp;
+#pragma unroll
+    for (uint32_t w = 0; w < kWorkPerWarp; ++w) {
+      const uint32_t work_id = work_base + w;
+      const uint32_t clamped = (work_id < total_works) ? work_id : (total_works - 1);
+      const uint32_t batch_id = clamped / params.num_q_heads;
+      const uint32_t head_id = clamped % params.num_q_heads;
+      const auto in_ptr =
+          static_cast<const DType*>(params.q_input) + batch_id * params.q_input_stride_batch + head_id * kHeadDim;
+      out_ptr[w] = static_cast<DType*>(params.q_output) + batch_id * params.q_output_stride_batch + head_id * kHeadDim;
+      position[w] = static_cast<int32_t>(static_cast<const PosT*>(params.positions)[batch_id]);
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+        input_vec[w][i] = gmem.load(in_ptr, i);
+      }
     }
   }
-  __syncwarp();
+
+  // Process each in-range work-item; math identical to the 1-item baseline.
+#pragma unroll
+  for (uint32_t w = 0; w < kWorkPerWarp; ++w) {
+    if (w >= n_work) break;
+    const auto output_ptr = const_cast<DType*>(out_ptr[w]);
+    fp32x2_t freq;
+    if constexpr (kUseBPT) {
+      freq = s_freq[lane_id];
+    } else {
+      freq = mem_freq.load(params.freqs_cis + position[w] * kRopeDim);
+    }
+
+    float sum_of_squares = 0.0f;
+    if constexpr (kVecConvert) {
+      // Vectorized fp8<->fp32: one hardware convert per pair instead of two
+      // scalar ones (fp8 is instruction-issue bound). device::cast<fp32x2_t> and
+      // device::cast<DType2> use the same round as scalar static_cast, and the
+      // accumulation order is preserved (pair p -> elem 2p then 2p+1), so the
+      // output stays bitwise-identical.
+      constexpr int kPairs = kVecSize / 2;
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+        const auto* vp = reinterpret_cast<const DType2*>(input_vec[w][i].data());
+#pragma unroll
+        for (int p = 0; p < kPairs; ++p) {
+          const auto f = cast<fp32x2_t>(vp[p]);
+          sum_of_squares += f.x * f.x;
+          sum_of_squares += f.y * f.y;
+        }
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+#pragma unroll
+        for (int j = 0; j < kVecSize; ++j) {
+          const auto x = cast<float>(input_vec[w][i][j]);
+          sum_of_squares += x * x;
+        }
+      }
+    }
+    sum_of_squares = warp::reduce_sum(sum_of_squares);
+    const auto norm_factor = math::rsqrt(sum_of_squares / kHeadDim + params.eps);
+
+    if constexpr (kVecConvert) {
+      constexpr int kPairs = kVecSize / 2;
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+        auto* vp = reinterpret_cast<DType2*>(input_vec[w][i].data());
+#pragma unroll
+        for (int p = 0; p < kPairs; ++p) {
+          const auto f = cast<fp32x2_t>(vp[p]);
+          vp[p] = cast<DType2>(fp32x2_t{f.x * norm_factor, f.y * norm_factor});
+        }
+      }
+    } else {
+#pragma unroll
+      for (int i = 0; i < kLocalSize; ++i) {
+#pragma unroll
+        for (int j = 0; j < kVecSize; ++j) {
+          const auto x = cast<float>(input_vec[w][i][j]);
+          input_vec[w][i][j] = cast<DType>(x * norm_factor);
+        }
+      }
+    }
+
+    // Streaming store (st.cs) of nope tiles; stash rope tile to shared.
+#pragma unroll
+    for (int i = 0; i < kLocalSize; ++i) {
+      if (i == kLocalSize - 1 && is_rope_lane) {
+        const auto rope_id = lane_id - (kWarpThreads - kRopeSize);
+        if constexpr (kVecConvert) {
+          // fp8: spread this lane's pairs into 4B slots (bank-conflict-free read).
+          const auto* pr = reinterpret_cast<const DType2*>(input_vec[w][i].data());
+#pragma unroll
+          for (int p = 0; p < kVecSize / 2; ++p) {
+            s_rope_pad[warp_id][rope_id * (kVecSize / 2) + p] =
+                static_cast<uint32_t>(*reinterpret_cast<const uint16_t*>(&pr[p]));
+          }
+        } else {
+          s_rope[warp_id][rope_id] = input_vec[w][i];
+        }
+      } else {
+        static_assert(sizeof(Storage) == 16, "expect 128-bit nope tile");
+        __stcs(
+            reinterpret_cast<int4*>(output_ptr) + (lane_id + i * kWarpThreads),
+            *reinterpret_cast<const int4*>(&input_vec[w][i]));
+      }
+    }
+    __syncwarp();
+
+    // part 2: RoPE on all 32 lanes -- one (real, imag) pair per lane.
+    const auto mem_elem = tile::Memory<DType2>{lane_id, kWarpThreads};
+    DType2 elem;
+    if constexpr (kVecConvert) {
+      const uint16_t raw = static_cast<uint16_t>(s_rope_pad[warp_id][lane_id]);
+      elem = *reinterpret_cast<const DType2*>(&raw);
+    } else {
+      elem = mem_elem.load(s_rope[warp_id]);
+    }
+    const auto [x_real, x_imag] = cast<fp32x2_t>(elem);
+    const auto [freq_real, freq_imag] = freq;
+    const fp32x2_t rotated = {
+        x_real * freq_real - x_imag * freq_imag,
+        x_real * freq_imag + x_imag * freq_real,
+    };
+    mem_elem.store(output_ptr + (kHeadDim - kRopeDim), cast<DType2>(rotated));
+    if (w + 1 < n_work) __syncwarp();  // fence only before next item reuses s_rope
+  }
 
   PDLTriggerSecondary<kUsePDL>();
-
-  // part 2: RoPE on all 32 lanes -- one (real, imag) bf16x2 pair per lane.
-  using DType2 = packed_t<DType>;
-  const auto mem_elem = tile::Memory<DType2>{lane_id, kWarpThreads};
-  const auto elem = mem_elem.load(s_rope[warp_id]);
-  const auto [x_real, x_imag] = cast<fp32x2_t>(elem);
-  const auto [freq_real, freq_imag] = freq;
-  const fp32x2_t rotated = {
-      x_real * freq_real - x_imag * freq_imag,
-      x_real * freq_imag + x_imag * freq_real,
-  };
-  mem_elem.store(output_ptr + (kHeadDim - kRopeDim), cast<DType2>(rotated));
 }
 
 template <typename DType, int64_t kHeadDim, int64_t kRopeDim, bool kUsePDL>
 struct FusedQNormRopeKernel {
-  template <typename PosT>
-  static constexpr auto kernel = fused_q_norm_rope<DType, kHeadDim, kRopeDim, PosT, kUsePDL>;
+  template <typename PosT, bool kBlockPerToken>
+  static constexpr auto kernel = fused_q_norm_rope<DType, kHeadDim, kRopeDim, PosT, kUsePDL, kBlockPerToken>;
 
   static void forward(
       const tvm::ffi::TensorView q_input,
@@ -229,10 +354,22 @@ struct FusedQNormRopeKernel {
         .eps = eps,
     };
     const auto total_works = batch_size * num_q_heads;
-    const auto num_blocks = div_ceil(total_works, kFusedQNumWarps);
-    const auto k_int32 = kernel<int32_t>;
-    const auto k_int64 = kernel<int64_t>;
-    const auto k = pos_dtype.is_type<int32_t>() ? k_int32 : k_int64;
+    constexpr uint32_t kWorkPerWarp = (sizeof(DType) == 1) ? 2u : 1u;
+    constexpr bool kVecConvert = (sizeof(DType) == 1);
+    constexpr uint32_t kHeadsPerBlock = kFusedQNumWarps * kWorkPerWarp;
+    // Shape dispatch (fp8 only): block-per-token wins once the grid fills the
+    // SMs but loses to warp-per-work at small N (crossover total_works~4096).
+    constexpr uint32_t kBPTMinWorks = 4096;
+    const bool use_bpt = kVecConvert && (total_works >= kBPTMinWorks);
+
+    uint32_t num_blocks;
+    if (use_bpt) {
+      num_blocks = batch_size * div_ceil(num_q_heads, kHeadsPerBlock);
+    } else {
+      num_blocks = div_ceil(total_works, kFusedQNumWarps * kWorkPerWarp);
+    }
+    const auto k = pos_dtype.is_type<int32_t>() ? (use_bpt ? kernel<int32_t, true> : kernel<int32_t, false>)
+                                                : (use_bpt ? kernel<int64_t, true> : kernel<int64_t, false>);
     LaunchKernel(num_blocks, kFusedQBlockSize, device_.unwrap())  //
         .enable_pdl(kUsePDL)(k, params);
   }

--- a/test/registered/kernels/ops/attention/test_dsv4_q_norm_rope.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_q_norm_rope.py
@@ -1,0 +1,121 @@
+"""Registered CI test for the DSv4 fused Q norm+RoPE kernel (fp8 + bf16).
+
+Covers the fp8 optimization of `fused_q_norm_rope` (block-per-token freq
+sharing + shape dispatch). Validates against a pure-torch fp32 reference with
+per-dtype tolerances, exercising BOTH launcher dispatch paths (small-N
+warp-per-work and large-N block-per-token, crossover at total_works=4096) and
+the block-per-token remainder-block boundary (num_q_heads not a multiple of 8).
+
+Run:
+    export PYTHONPATH=<repo>/python:$PYTHONPATH
+    python -m pytest test/registered/kernels/ops/attention/test_dsv4_q_norm_rope.py -v
+"""
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import fused_q_norm_rope
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+HEAD_DIM = 512
+ROPE_DIM = 64
+NOPE_DIM = HEAD_DIM - ROPE_DIM
+EPS = 1e-6
+MAX_POS = 4096
+
+# Per-dtype tolerance. bf16: 8-bit mantissa -> 2e-2 (project parity tol).
+# fp8_e4m3: 3-bit mantissa -> golden<->kernel disagree by up to ~1 ULP, whose
+# relative step near magnitude 1 is 2^-3; 1e-1 covers it. NaN/Inf checked
+# separately. These are the same tolerances the kernel's own harness uses.
+_TOL = {torch.bfloat16: (2e-2, 2e-2), torch.float8_e4m3fn: (1e-1, 1e-1)}
+
+
+def _golden(q_input, freqs_real, positions, tdt):
+    """Pure-torch fp32 reference, matching the kernel's two-round behavior:
+    normalize + round to DType (incl. rope tile), then rotate the rope tail and
+    round again. RMSNorm-self over 512 dims, NO weight vector."""
+    x = q_input.float()
+    ss = (x * x).sum(-1, keepdim=True)
+    norm = torch.rsqrt(ss / HEAD_DIM + EPS)
+    xn = (x * norm).to(tdt).float()  # round every element (rope tile included)
+
+    pos = positions.long()
+    freqs = freqs_real.index_select(0, pos)  # [B,64] interleaved (re,im,...)
+    cos = freqs[:, 0::2][:, None, :]
+    sin = freqs[:, 1::2][:, None, :]
+    tail = xn[:, :, NOPE_DIM:]
+    re, im = tail[:, :, 0::2], tail[:, :, 1::2]
+    nr = re * cos - im * sin
+    ni = re * sin + im * cos
+    ntail = torch.stack([nr, ni], dim=-1).flatten(-2)
+    y = torch.cat([xn[:, :, :NOPE_DIM], ntail], dim=-1)
+    return y.to(tdt)
+
+
+def _run_case(num_tokens, num_q_heads, dtype, pos_dtype):
+    torch.manual_seed(0)
+    dev = "cuda"
+    q_input = torch.randn(
+        num_tokens, num_q_heads, HEAD_DIM, dtype=torch.float32, device=dev
+    ).to(dtype)
+    q_output = torch.empty_like(q_input)
+
+    angles = torch.rand(MAX_POS, ROPE_DIM // 2, device=dev) * 6.2831853
+    freqs_cis = torch.polar(torch.ones_like(angles), angles)  # complex64
+    freqs_real = torch.view_as_real(freqs_cis).flatten(-2).contiguous()
+
+    positions = torch.randint(0, MAX_POS, (num_tokens,), dtype=pos_dtype, device=dev)
+
+    fused_q_norm_rope(q_input, q_output, EPS, freqs_cis, positions)
+    torch.cuda.synchronize()
+
+    got = q_output.float()
+    exp = _golden(q_input, freqs_real, positions, dtype).float()
+
+    n_nan = torch.isnan(got).sum().item()
+    n_inf = torch.isinf(got).sum().item()
+    assert n_nan == 0 and n_inf == 0, f"NaN={n_nan} Inf={n_inf}"
+
+    rtol, atol = _TOL[dtype]
+    torch.testing.assert_close(got, exp, rtol=rtol, atol=atol)
+
+
+# (num_tokens, num_q_heads) chosen to cover both dispatch paths + boundaries.
+# total_works = N*H; fp8 block-per-token when total_works >= 4096.
+_SHAPES = [
+    (17, 17),  # 289  : warp-per-work, total_works%4=1 tail warp
+    (256, 64),  # 16384: block-per-token
+    (1024, 64),  # 65536: block-per-token (perf sweet spot)
+    (4096, 64),  # big  : block-per-token
+    (63, 64),  # 4032 : just below threshold -> warp-per-work
+    (64, 64),  # 4096 : exactly at threshold -> block-per-token
+    (
+        1024,
+        17,
+    ),  # H%8!=0: block-per-token remainder block (ceil(17/8)=3, last covers 1 head)
+    (256, 32),  # TP=2 tier
+    (512, 16),  # TP=4 tier
+    (8, 64),  # 512  : small-N decode, warp-per-work
+]
+
+
+class TestDSv4QNormRope(CustomTestCase):
+    def test_fp8_correctness(self):
+        for n, h in _SHAPES:
+            for pos_dtype in (torch.int32, torch.int64):
+                with self.subTest(N=n, H=h, pos=str(pos_dtype)):
+                    _run_case(n, h, torch.float8_e4m3fn, pos_dtype)
+
+    def test_bf16_correctness(self):
+        for n, h in _SHAPES:
+            for pos_dtype in (torch.int32, torch.int64):
+                with self.subTest(N=n, H=h, pos=str(pos_dtype)):
+                    _run_case(n, h, torch.bfloat16, pos_dtype)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

`fused_q_norm_rope` is the DSv4 MLA main-path Q kernel: RMSNorm-self over
`head_dim=512` (no weight vector) + RoPE on the trailing 64 dims, writing a dense
`q_output`, dispatched warp-per-(token, head).

On the fp8_e4m3 path it is **not** bandwidth-bound but instruction-issue /
load-latency bound. NCU on `main` shows the ALU pipe at ~66% with `not_selected`
as the top stall, then `long_scoreboard` (load latency) once issue pressure is
relieved, and achieved occupancy stuck near ~54%. A large share of the fp8 loads
is also redundant: every head of a token re-loads the same 256 B RoPE freq row,
which alone accounts for ~11.7% of L2 traffic.

The bf16 path is already at the DRAM bandwidth wall (memSOL ~77.5%,
`long_scoreboard` waiting on DRAM, stores 32/32, loads near-optimally coalesced),
so it has no parity-safe headroom and is deliberately left unchanged.

## Modifications

All changes are in the Q kernel `fused_q_norm_rope` and its
`FusedQNormRopeKernel::forward` launcher. The RMSNorm fp32 accumulation order,
element→lane mapping, warp-reduction tree and RoPE complex-multiply are
untouched, so every (token, head) produces the same output bits as before.

Six stacked changes, each arithmetic-neutral, fp8-gated unless noted:

1. **`q_output` streaming store (`st.cs`).** `q_output` is written once and never
   re-read in-kernel, so the nope tiles now use `__stcs` (128-bit
   `st.global.cs`) to bypass L1 write-allocate and keep the cache clean for the
   latency-critical loads. The stored 16 bytes are unchanged.
2. **Vectorized fp8↔fp32 conversion (packed x2).** The sum-of-squares and
   normalize loops convert an `fp8x2_e4m3` pair per hardware `cvt` instead of two
   scalar casts, halving conversion issues on the issue-bound path. Uses
   `device::cast<fp32x2_t>` / `device::cast<fp8x2_e4m3_t>`, which round the same
   way as scalar `static_cast` (round-to-nearest, satfinite); accumulation order
   (pair p → element 2p then 2p+1) is preserved. bf16 keeps the scalar path.
3. **2 work-items per warp on fp8.** An fp8 warp processes 2 consecutive
   work-items, issuing both input loads before consuming either so the load
   latencies overlap and hide `long_scoreboard`. bf16 stays at 1 — a 2nd item
   would double register pressure and cost occupancy on the bandwidth-bound
   path. Per-item math is unchanged.
4. **`s_rope` padding on fp8.** The part-2 RoPE read is 32 lanes × `fp8x2` (2 B),
   so two lanes share a 4 B SMEM bank; padding each pair to its own 4 B slot
   removes the sharing. Only the low 16 bits carry the `fp8x2` and the read masks
   them back, so padding never reaches the output. bf16 pairs are already 4 B and
   keep the packed layout.
5. **Block-per-token freq sharing on fp8 (the main win).** An fp8 block is pinned
   to one token and covers up to 8 consecutive heads; the token's freq row is
   loaded **once** into `__shared__ s_freq` by warp 0 and reused by all heads
   behind a single `__syncthreads`, cutting freq LDGs 8× (262144 → 32768) and
   easing both issue pressure and L2 traffic. freq is exact fp32, so reading it
   from shared is bit-neutral. All warps reach the barrier (no divergent return);
   out-of-range warps run zero work-items and remainder blocks clamp head
   indices, so they neither read nor write out of bounds.
6. **Shape dispatch.** Block-per-token loses at small N (decode), where it
   grid-starves the SMs; warp-per-work does not. A host-side threshold
   (`total_works >= kBPTMinWorks`) selects between the two via a
   `kBlockPerToken` template bool: small N falls back to warp-per-work, large N
   uses block-per-token. bf16 is always warp-per-work. Both instantiations are
   arithmetic-neutral.

`kBPTMinWorks = 4096` is an sm_100 (B200) autotune value, kept as a kernel-side
`constexpr` so it is easy to retune for other SM counts.

The DType template parameterization is preserved — bf16 and fp8_e4m3 both compile
and pass all correctness checks.

## Accuracy Tests

Verified against a pure-PyTorch fp32 reference (RMSNorm-self over 512 dims with
no weight, trailing-64 RoPE, rounded back to DType) and, as supporting evidence,
byte-compared against the pre-change kernel:

- **allclose vs golden**: bf16/fp16 `rtol=atol=2e-2`, fp8_e4m3
  `rtol=atol=1e-1`; no NaN/Inf. The pre-change kernel reports the same max error.
- **bit parity vs the pre-change kernel: 0 mismatches** (uint8 byte compare, both
  dtypes), across N ∈ {17, 256, 1024, 4096} × H ∈ {17, 64} × positions {int32,
  int64}, including `total_works % 4 != 0` tail-warp shapes and both sides of the
  dispatch threshold.
- **Out-of-bounds guard**: `q_output` over-allocated with a sentinel-filled
  region past the logical tensor; the sentinel bytes are unchanged after the run,
  confirming early-return and remainder warps never write out of bounds.

fp8 golden max abs error grows with magnitude (1.25e-1 at N=4096, H=64). That is
the single-ULP e4m3 (3 mantissa bits) divergence between the golden reference and
the kernel — the pre-change kernel reports the same value and byte parity is
exact, so the 1e-1 tolerance is not loosened relative to the existing kernel.

## Speed Tests and Profiling

CUDA-event median on B200 (sm_100). Baseline is the current `main` kernel
(`kFusedQBlockSize=128`, 4 warps/block); ratio = this PR / baseline, so <1 is
faster. fp8_e4m3, H=64 (TP=1):

| N (tokens) | HOT ratio | COLD ratio | path |
|---:|:---:|:---:|:---|
| 1     | 0.99 | 1.06 | warp-per-work (launch-bound, parity) |
| 8     | 0.96 | 1.15 | warp-per-work (launch-bound, parity) |
| 256   | 0.86 | 0.84 | block-per-token |
| 1024  | 0.79 | 0.84 | block-per-token (**~1.27×**) |
| 4096  | 0.70 | 0.70 | block-per-token (**~1.43×**) |
| 16384 | 0.65 | 0.65 | block-per-token (**~1.54×**) |

Small N stays at parity: the grid cannot fill the SMs there, and the dispatch
avoids the block-per-token slowdown. The COLD >1 at tiny N is L2-flush plus
launch overhead on a ~7 µs kernel — HOT is neutral, so it is not a real
regression. The gain grows once there is enough work to fill the GPU. Measured
against a block=256 baseline as well, with the same pattern (1.28× @1024,
1.39× @4096), so the optimization is block-size-agnostic.

**bf16 is neutral (~1.00) by design** — it is at the DRAM bandwidth wall and all
fp8-only changes are gated off for it.

## Unit test

`test/registered/kernels/ops/attention/test_dsv4_q_norm_rope.py` asserts this op
against a pure-torch fp32 reference with per-dtype tolerance (bf16 2e-2,
fp8_e4m3 1e-1) plus NaN/Inf checks, over 10 shapes × {bf16, fp8} × {int32,
int64} positions = 40 cases. Shapes are chosen to hit both launcher paths and
their boundaries: either side of the dispatch threshold (N63·H64=4032
warp-per-work, N64·H64=4096 block-per-token), block-per-token remainder blocks
where H is not a multiple of 8 (N17·H17, N1024·H17), a `total_works % 4 != 0`
tail warp (N17·H17), TP tiers (H=16/32/64), and small-N decode shapes. All 40
cases pass.

This closes real gaps in coverage for this op: fp8_e4m3, `head_dim=512`, and the
block-per-token path were previously untested.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31464605819](https://github.com/sgl-project/sglang/actions/runs/31464605819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31464605638](https://github.com/sgl-project/sglang/actions/runs/31464605638)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->