### PR TITLE
[Scheduler] Add a one-sided symmetric-memory path for the DP metadata gather

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
@@ -49,6 +49,12 @@ class SymmMemGather:
         self._world_size = world_size
         self._width = width
         self._slot = 0
+        # Private stream: this exchange depends only on peer stores, never on
+        # the forward, so it must not inherit the schedule stream's WAR fence.
+        self._stream = torch.cuda.Stream(device=device)
+        self._staging = torch.zeros(width, dtype=dtype, device=device)
+        self._host_in = torch.zeros(width, dtype=dtype).pin_memory()
+        self._host_out = torch.zeros(world_size, width, dtype=dtype).pin_memory()
         rank = self._handle.rank
         # A peer row is a tensor view of that peer's memory; writing it is a
         # store that never blocks on the peer.
@@ -68,14 +74,19 @@ class SymmMemGather:
             _NUM_SLOTS,
         )
 
-    def gather(self, local_row: torch.Tensor) -> torch.Tensor:
-        """Return the (world_size, width) gathered rows for this round."""
+    def gather(self, local_row_cpu: torch.Tensor) -> torch.Tensor:
+        """Host row in, (world_size, width) host rows out."""
         slot = self._slot
         self._slot = (slot + 1) % _NUM_SLOTS
-        for row in self._peer_rows[slot]:
-            row.copy_(local_row)
-        self._handle.barrier(0, _BARRIER_TIMEOUT_MS)
-        return self._region[slot]
+        self._host_in.copy_(local_row_cpu)
+        with torch.cuda.stream(self._stream):
+            self._staging.copy_(self._host_in, non_blocking=True)
+            for row in self._peer_rows[slot]:
+                row.copy_(self._staging)
+            self._handle.barrier(0, _BARRIER_TIMEOUT_MS)
+            self._host_out.copy_(self._region[slot], non_blocking=True)
+        self._stream.synchronize()
+        return self._host_out
 
 
 def maybe_create_symm_mem_gather(

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
@@ -1,0 +1,103 @@
+"""One-sided fixed-shape gather over torch symmetric memory.
+
+Each rank stores its row directly into every peer's buffer and then waits on a
+barrier. No NCCL communicator takes part, so this cannot contend with the
+forward's collectives for cross-communicator ordering -- the reason the
+scheduler's metadata gather can deadlock against draft-model collectives when
+it runs as an NCCL all-gather on a second communicator.
+"""
+
+import logging
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# A stuck peer raises instead of spinning forever.
+_BARRIER_TIMEOUT_MS = 10_000
+# Rows are read after the barrier while peers may already be storing the next
+# round; alternating regions gives the one round of slack that bounds it.
+_NUM_SLOTS = 2
+
+
+class SymmMemGather:
+    """Fixed-shape all-gather over a persistent symmetric region.
+
+    The region is allocated once and rendezvoused once: a symmetric operand
+    must keep its address for its whole lifetime and resolve to the same
+    (region, offset) on every rank, which a per-forward pool allocation does
+    not satisfy.
+    """
+
+    def __init__(
+        self,
+        world_size: int,
+        width: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        group_name: str,
+    ):
+        from torch._C._distributed_c10d import _SymmetricMemory
+
+        # Outside inference mode on purpose: a region created inside it is an
+        # inference tensor and rejects the in-place peer stores below.
+        with torch.inference_mode(False):
+            region = _SymmetricMemory.empty_strided_p2p(
+                (_NUM_SLOTS * world_size * width,),
+                [1],
+                dtype,
+                device,
+                group_name,
+            ).view(_NUM_SLOTS, world_size, width)
+        self._handle = _SymmetricMemory.rendezvous(region)
+        self._region = region
+        self._world_size = world_size
+        self._width = width
+        self._slot = 0
+        rank = self._handle.rank
+        # A peer row is a plain tensor view of that peer's memory; writing it is
+        # a store over NVLink, which never blocks on the peer.
+        self._peer_rows = [
+            [
+                self._handle.get_buffer(peer, (_NUM_SLOTS, world_size, width), dtype)[
+                    slot
+                ][rank]
+                for peer in range(world_size)
+            ]
+            for slot in range(_NUM_SLOTS)
+        ]
+        logger.info(
+            "Symmetric-memory DP gather active: world=%d width=%d slots=%d",
+            world_size,
+            width,
+            _NUM_SLOTS,
+        )
+
+    def gather(self, local_row: torch.Tensor) -> torch.Tensor:
+        """Return the (world_size, width) gathered rows for this round."""
+        slot = self._slot
+        self._slot = (slot + 1) % _NUM_SLOTS
+        for row in self._peer_rows[slot]:
+            row.copy_(local_row)
+        self._handle.barrier(0, _BARRIER_TIMEOUT_MS)
+        return self._region[slot]
+
+
+def maybe_create_symm_mem_gather(
+    world_size: int,
+    width: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    group_name: str,
+) -> Optional[SymmMemGather]:
+    """Build a gatherer, or return None when symmetric memory is unusable."""
+    try:
+        return SymmMemGather(world_size, width, dtype, device, group_name)
+    except Exception as e:
+        logger.warning(
+            "Symmetric-memory DP gather unavailable (%s: %s); falling back.",
+            type(e).__name__,
+            e,
+        )
+        return None

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
@@ -1,10 +1,8 @@
 """One-sided fixed-shape gather over torch symmetric memory.
 
-Each rank stores its row directly into every peer's buffer and then waits on a
-barrier. No NCCL communicator takes part, so this cannot contend with the
-forward's collectives for cross-communicator ordering -- the reason the
-scheduler's metadata gather can deadlock against draft-model collectives when
-it runs as an NCCL all-gather on a second communicator.
+Each rank stores its row into every peer's buffer, then waits on a barrier. No
+communicator takes part, so unlike an all-gather this needs no ordering against
+the forward's collectives.
 """
 
 import logging
@@ -16,19 +14,15 @@ logger = logging.getLogger(__name__)
 
 # A stuck peer raises instead of spinning forever.
 _BARRIER_TIMEOUT_MS = 10_000
-# Rows are read after the barrier while peers may already be storing the next
-# round; alternating regions gives the one round of slack that bounds it.
+# A peer's stores for round N+1 land before its barrier(N+1) returns, so one
+# region would be overwritten while a slower rank still reads round N.
 _NUM_SLOTS = 2
 
 
 class SymmMemGather:
-    """Fixed-shape all-gather over a persistent symmetric region.
-
-    The region is allocated once and rendezvoused once: a symmetric operand
-    must keep its address for its whole lifetime and resolve to the same
-    (region, offset) on every rank, which a per-forward pool allocation does
-    not satisfy.
-    """
+    """Allocated and rendezvoused once: a symmetric operand must keep its
+    address for its whole lifetime and resolve to the same (region, offset) on
+    every rank, which a per-forward pool allocation does not satisfy."""
 
     def __init__(
         self,
@@ -56,8 +50,8 @@ class SymmMemGather:
         self._width = width
         self._slot = 0
         rank = self._handle.rank
-        # A peer row is a plain tensor view of that peer's memory; writing it is
-        # a store over NVLink, which never blocks on the peer.
+        # A peer row is a tensor view of that peer's memory; writing it is a
+        # store that never blocks on the peer.
         self._peer_rows = [
             [
                 self._handle.get_buffer(peer, (_NUM_SLOTS, world_size, width), dtype)[

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -463,6 +463,7 @@ class Envs:
     SGLANG_DATA_PARALLEL_BUDGET_INTERVAL = EnvInt(1)
     SGLANG_REQ_WAITING_TIMEOUT = EnvFloat(-1)  # in seconds
     SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH = EnvBool(False)
+    SGLANG_USE_SYMM_MEM_DP_SYNC = EnvBool(False)
     SGLANG_REQ_RUNNING_TIMEOUT = EnvFloat(-1)  # in seconds
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Decode batches between SWA out-of-window evictions.

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -157,9 +157,23 @@ class MLPSyncBatchInfo:
         group: torch.distributed.ProcessGroup,
         use_all_reduce: bool = False,
     ):
-        local_info_tensor = self._get_local_tensor(device=device)
+        # Build on host first: it is cheap, it gives info_width, and it lets the
+        # transport be chosen before anything lands on a device. The symmetric
+        # path then keeps every staging tensor on the host, so none of them sync
+        # the schedule stream -- which the WAR barrier has fenced behind the
+        # in-flight forward.
+        local_info_cpu = self._get_local_tensor(device="cpu")
+        info_width = local_info_cpu.numel()
+        gatherer = (
+            None if use_all_reduce else _maybe_symm_gatherer(group, device, info_width)
+        )
+        if gatherer is not None:
+            device = "cpu"
+
+        local_info_tensor = (
+            local_info_cpu if device == "cpu" else local_info_cpu.to(device)
+        )
         fallback_tensor = self._get_fallback_tensor(device=device)
-        info_width = local_info_tensor.numel()
         # Inactive max_world_size slots must decode as IDLE.
         global_info_tensor = fallback_tensor.expand(
             self.dp_size, self.tp_size * self.cp_size, info_width
@@ -179,7 +193,7 @@ class MLPSyncBatchInfo:
             )
             missing = flat_info.abs().sum(dim=1) == 0
             flat_info[missing] = fallback_tensor
-        elif (gatherer := _maybe_symm_gatherer(group, device, info_width)) is not None:
+        elif gatherer is not None:
             global_info_tensor = gatherer.gather(local_info_tensor).view(
                 self.dp_size, self.tp_size * self.cp_size, info_width
             )

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -38,6 +38,30 @@ if TYPE_CHECKING:
 
 _ENABLE_METRICS_DP_ATTENTION = envs.SGLANG_ENABLE_METRICS_DP_ATTENTION.get()
 
+# Keyed by group so a process holding several groups gets one region each; the
+# region must persist for the process lifetime (see symm_mem_gather).
+_SYMM_GATHERERS: dict = {}
+
+
+def _maybe_symm_gatherer(group, device, width: int):
+    """Symmetric-memory gatherer for this group, or None to use the collective."""
+    if not envs.SGLANG_USE_SYMM_MEM_DP_SYNC.get() or device == "cpu":
+        return None
+    key = id(group)
+    if key not in _SYMM_GATHERERS:
+        from sglang.srt.distributed.device_communicators.symm_mem_gather import (
+            maybe_create_symm_mem_gather,
+        )
+
+        _SYMM_GATHERERS[key] = maybe_create_symm_mem_gather(
+            world_size=torch.distributed.get_world_size(group),
+            width=width,
+            dtype=torch.int64,
+            device=device,
+            group_name=group.group_name,
+        )
+    return _SYMM_GATHERERS[key]
+
 
 def _resolve_elastic_world_dp_size(
     dp_size: int,
@@ -156,6 +180,10 @@ class MLPSyncBatchInfo:
             )
             missing = flat_info.abs().sum(dim=1) == 0
             flat_info[missing] = fallback_tensor
+        elif (gatherer := _maybe_symm_gatherer(group, device, info_width)) is not None:
+            global_info_tensor = gatherer.gather(local_info_tensor).view(
+                self.dp_size, self.tp_size * self.cp_size, info_width
+            )
         else:
             torch.distributed.all_gather_into_tensor(
                 global_info_tensor.flatten(),

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -38,8 +38,7 @@ if TYPE_CHECKING:
 
 _ENABLE_METRICS_DP_ATTENTION = envs.SGLANG_ENABLE_METRICS_DP_ATTENTION.get()
 
-# Keyed by group so a process holding several groups gets one region each; the
-# region must persist for the process lifetime (see symm_mem_gather).
+# Keyed by group: one region per group, kept for the process lifetime.
 _SYMM_GATHERERS: dict = {}
 
 


### PR DESCRIPTION
Opt-in via `SGLANG_USE_SYMM_MEM_DP_SYNC=1`; default off, and the NCCL/gloo paths are untouched.

**Read the benchmark section before reviewing: this measures level with the default gloo path, not better than it.** It is posted for the diagnosis it carries and for the deadlock argument, not as a throughput win.

## Summary
- Exchange the DP-attention metadata by storing each rank's row into every peer's buffer and waiting on a barrier, instead of an all-gather collective
- Persistent symmetric region allocated once via `empty_strided_p2p` + a single `rendezvous`; double-buffered, since a peer's stores for round N+1 land before its barrier(N+1) returns
- Keep every staging tensor on the host and run the exchange on a private stream, so nothing on this path syncs the schedule stream
- `barrier(timeout_ms)` watchdog, and a warn-and-fall-back path when symmetric memory is unavailable

## What this measured, and the part worth keeping

Transport latency alone, 4 DP ranks, 300 iters, median: gloo 390.7us, NCCL all-gather 156.8us, one-sided 81.5us.

End-to-end on a 4-GPU DP + EP + MTP MoE serving config (A/B/A across restarts, 1 warmup + 3 rounds, median):

| DP metadata transport | median TPOT | median tok/s |
| --- | ---: | ---: |
| gloo (default) | 6.65 ms | 562.13 |
| this PR | 6.67 ms | 563.90 |
| this PR, staging on the schedule stream | 7.56 ms | 501.11 |
| NCCL all-gather | 7.62 ms | 497.97 |
| NCCL ordered behind the forward | 7.85 ms | 483.35 |

A 4.8x faster transport buys nothing end to end, because the transport latency was never the cost. The cost is whether the path forces a host-blocking CUDA operation on the schedule stream, which the WAR barrier has fenced behind the in-flight forward: the pageable H2D that builds the staging tensors then waits for the previous forward's read-done and destroys the scheduler's run-ahead. A profile puts `all_gather` at 2.4-2.8 ms per call with device-side staging, against 0.36-0.40 ms for the exchange itself.

That is also why the last two rows are slow, and why moving only the exchange to a private stream (row 3) recovers nothing: the staging tensors were still on the fenced stream.

## Correctness
- 200 rounds per transport with a payload that changes every round, compared against the analytic answer: gloo, NCCL and symmetric memory all match
- Double buffering is pinned by a differential test: under induced rank skew a single region mismatches on 199 of 200 rounds, two regions on 0

## What is not claimed
The motivation for a communicator-free exchange is that a second-communicator all-gather concurrent with the forward's collectives can deadlock. That argument is mechanical, not measured here: forcing two concurrent NCCL communicators into opposite per-rank orders did not reproduce a hang on an otherwise idle 4-GPU box, so deadlock avoidance is offered as a property of the mechanism rather than an experimental result.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31470524778](https://github.com/sgl-project/sglang/actions/runs/31470524778)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31470524333](https://github.com/sgl-project/sglang/actions/runs/31470524333)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

