### PR TITLE
feat: skip multimodal IPC memory pool in --language-only mode

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -340,10 +340,11 @@ class BaseMultimodalProcessor(ABC):
             "input_features",
         ]
 
-        if self.use_cuda_ipc and not skip_mm_pool:
+        if self.use_cuda_ipc and not skip_mm_pool and not self.server_args.language_only:
             # SGLANG_MM_FEATURE_CACHE_MB is the total pool budget across all
             # tokenizer workers. Each worker gets an equal share so that adding
             # workers doesn't multiply the GPU-side footprint.
+            # Skip in language-only mode to save ~1GB VRAM (pool is unused without multimodal).
             worker_num = self.server_args.tokenizer_worker_num
             per_worker_pool_size = get_mm_feature_pool_size_per_worker(
                 MM_FEATURE_CACHE_SIZE, worker_num


### PR DESCRIPTION
## Problem

When using `--language-only` flag with multimodal models (e.g., Qwen3-VL series), the `MmItemMemoryPool` (~1GB on RTX 4090D) was still allocated even though no multimodal features would be processed.

This wastes VRAM in text-only inference scenarios where visual components are not used.

## Solution

Check `server_args.language_only` before initializing `MmItemMemoryPool` in `base_processor.py`. When language-only mode is active, skip the pool allocation entirely.

## Test Environment

- **Hardware**: Single RTX 4090D 48GB
- **Model**: Qwen3.6-27B-Fable-711-FP8-KV (FP8 quantized multimodal model)
- **Before patch**: MmItemMemoryPool allocated ~1GB despite `language_only=True`
- **After patch**: Pool not created, VRAM saved

## Use Case

Running text-only inference on multimodal models without wasting VRAM on unused visual components. Common in resource-constrained deployments (single 48GB GPU) where every GB counts.

## Note

Upstream already has partial fixes for language-only mode:
- `qwen3_vl.py`: `self.visual = None` when `language_model_only=True`
- `qwen3_5.py`: None check for `self.visual.deepstack_visual_indexes`
- `tokenizer_manager.py`: `language_only` checks for AutoProcessor

This PR completes the fix by also skipping the multimodal IPC memory pool.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31466183908](https://github.com/sgl-project/sglang/actions/runs/31466183908)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31466183653](https://github.com/sgl-project/sglang/actions/runs/31466183653)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->