### PR TITLE
fix(speculative): enable EAGLE draft extend graph for HIP DSA backend

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -398,6 +398,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             "musa": EAGLEDraftCudaGraphRunner,
         }
         supports_hip_aiter_draft_extend_graph = False
+        supports_hip_dsa_draft_extend_graph = False
         if _is_hip:
             # Keep import local so non-HIP environments do not require aiter.
             from sglang.srt.layers.attention.aiter_backend import (
@@ -406,6 +407,16 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
             supports_hip_aiter_draft_extend_graph = isinstance(
                 self.draft_attn_backend, AiterMultiStepDraftBackend
+            )
+            # On HIP the DSA backend is already instantiated as the running
+            # attention backend, so the import is safe and does not pull in
+            # the CUDA-only sparse-attention stack at module load time.
+            from sglang.srt.layers.attention.dsa_backend import (
+                DeepseekSparseAttnBackend,
+            )
+
+            supports_hip_dsa_draft_extend_graph = isinstance(
+                self.draft_extend_attn_backend, DeepseekSparseAttnBackend
             )
 
         graph_supported_backend_types = [
@@ -452,6 +463,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 or _is_xpu
                 or supports_cuda_draft_extend_graph
                 or supports_hip_aiter_draft_extend_graph
+                or supports_hip_dsa_draft_extend_graph
             )
         ):
             tic = time.perf_counter()


### PR DESCRIPTION
Running GLM-5.2 with EAGLE MTP on MI308X (gfx942, ROCm 7.x), the draft extend graph was never captured. The server starts fine but the extend graph path is silently skipped, so every draft step goes through the eager path — noticeable throughput hit on decode.

Traced it to the capture condition in `_capture_cuda_graphs`. `DeepseekSparseAttnBackend` is added to `graph_supported_backend_types` only inside the `if _is_cuda or _is_musa:` block. On HIP, the DSA backend is the running attention backend (GLM-5.2 uses DSA for its sparse attention), but there is no HIP-side guard for it. The Aiter multi-step backend already has `supports_hip_aiter_draft_extend_graph` for this exact situation; the DSA backend just does not have an equivalent.

The fix mirrors the Aiter pattern: under `_is_hip`, check whether `draft_extend_attn_backend` is a `DeepseekSparseAttnBackend` and OR it into the capture condition. The DSA backend import is safe here because on HIP it is already instantiated — this is not the same as the CUDA lazy import, which exists to avoid pulling in deep_gemm at module load time on non-CUDA builds.

Tested on MI308X ×8, GLM-5.2-FP8, TP8, EAGLE with `num_steps=3, topk=1, draft_tokens=4`. After the patch, the log shows `Capture draft extend CUDA graph begin/end` (previously absent) and decode throughput improves as expected from graph replay vs. eager execution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31475143111](https://github.com/sgl-project/sglang/actions/runs/31475143111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31475142907](https://github.com/sgl-project/sglang/actions/runs/31475142907)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->