### PR TITLE
[CI] Add a scheduled workflow to close stale PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,317 @@
+name: Close Stale PRs
+
+# Paced deliberately. As of 2026-08-11 the candidate pool is ~1400 PRs (331 from
+# the WIP rule, ~1072 from the 90-day rule) and roughly 12-13 PRs go quiet per
+# day. At 32 per run that is ~19 net per day, so the backlog drains in ~2.5
+# months while staying well ahead of new inflow - and a bad rule shows up in the
+# reopen rate long before it can close a thousand PRs.
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Report only, do not close anything'
+        type: boolean
+        default: true
+      rules:
+        description: 'Comma-separated subset of: wip,quota,stale'
+        default: 'wip,quota,stale'
+      max_actions:
+        description: 'Hard cap on PRs closed in one run'
+        default: '32'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  close-stale-prs:
+    if: github.repository == 'sgl-project/sglang'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Sweep stale PRs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            // Thresholds.
+            const WIP_DAYS = 21;      // rule 1: WIP / do-not-merge / draft title marker
+            const DRAFT_DAYS = 21;    // rule 1: GitHub draft flag
+            const QUOTA = 5;          // rule 2: max open PRs for a non-write author
+            const QUOTA_IDLE = 7;     // rule 2: every one of their PRs must be idle this long
+            const STALE_DAYS = 90;    // rule 3: no updates at all
+
+            // Keep true. PRs with an approving review are almost always blocked on
+            // us, not on the author: of the 43 approved-and-stale PRs as of
+            // 2026-08-11, a manual triage pass had independently marked at least 8
+            // as worth keeping (#22441, #21194, #21153, #20427, #19777, #19857,
+            // #19530, #22178), and every one of those approvals came from a
+            // maintainer with write access. Flipping this to false closes PRs that
+            // our own reviewers signed off on.
+            const SKIP_APPROVED = true;
+
+            // Candidates are enumerated with paginated pulls.list, NOT the search API.
+            // Search caps out at 1000 results, which silently truncates a 4000+ PR
+            // backlog; REST pagination has no such cap. Both agree on the actual
+            // counts, so this is about completeness, not correctness.
+            //
+            // Caveat on updated_at: it is refreshed by some non-substantive events, so
+            // a PR can report a recent updated_at with no commit or comment behind it
+            // (#6722 on 2026-08-11: updated_at yesterday, last commit 14 months old,
+            // last human comment 8 months old). That direction is safe here - such a
+            // PR is skipped, never wrongly closed. If we ever want to catch them too,
+            // the fix is to age off max(last commit, last human comment) instead, at
+            // the cost of two extra API calls per candidate.
+
+            const KEEP_LABELS = new Set([
+              'high priority',
+              'keep-open',
+              'good first issue',
+            ]);
+
+            const WIP_MARKER = /^\s*\[?\s*(wip|do[ _-]?not[ _-]?merge|dnm|draft)\s*\]?/i;
+
+            const DRY = context.eventName !== 'schedule'
+              && String(process.env.DRY_RUN) !== 'false';
+            const RULES = new Set(
+              (process.env.RULES || 'wip,quota,stale').split(',').map(s => s.trim()));
+            const MAX = parseInt(process.env.MAX_ACTIONS || '32', 10);
+
+            const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+            const now = Date.now();
+            const idleDays = ts => (now - new Date(ts).getTime()) / 86400000;
+
+            core.info(`dry_run=${DRY} rules=${[...RULES]} max_actions=${MAX}`);
+
+            // One permission lookup per author, not per PR.
+            const permCache = new Map();
+            async function hasWrite(login) {
+              if (permCache.has(login)) return permCache.get(login);
+              let ok = false;
+              try {
+                const r = await github.rest.repos.getCollaboratorPermissionLevel(
+                  { owner, repo, username: login });
+                ok = ['admin', 'maintain', 'write'].includes(r.data.permission);
+              } catch (e) {
+                ok = false;  // not a collaborator
+              }
+              permCache.set(login, ok);
+              return ok;
+            }
+
+            async function isApproved(number) {
+              try {
+                const revs = await github.paginate(
+                  github.rest.pulls.listReviews,
+                  { owner, repo, pull_number: number, per_page: 100 });
+                return revs.some(r => r.state === 'APPROVED');
+              } catch (e) {
+                return false;
+              }
+            }
+
+            const prs = await github.paginate(
+              github.rest.pulls.list,
+              { owner, repo, state: 'open', sort: 'updated',
+                direction: 'asc', per_page: 100 });
+            core.info(`fetched ${prs.length} open PRs`);
+
+            // Rule 2 operates on the whole author, so pre-compute per-author state:
+            // how many PRs they have open, and how long ALL of them have been idle.
+            const authors = new Map();
+            for (const pr of prs) {
+              const a = authors.get(pr.user.login) || { count: 0, minIdle: Infinity };
+              a.count += 1;
+              a.minIdle = Math.min(a.minIdle, idleDays(pr.updated_at));
+              authors.set(pr.user.login, a);
+            }
+            const overQuota = new Set();
+            for (const [login, a] of authors) {
+              if (a.count <= QUOTA) continue;
+              if (a.minIdle < QUOTA_IDLE) continue;   // any recent activity spares them all
+              if (await hasWrite(login)) continue;
+              overQuota.add(login);
+            }
+            if (overQuota.size) {
+              core.info(`over-quota authors: ${[...overQuota].join(', ')}`);
+            }
+
+            function classify(pr) {
+              const idle = Math.floor(idleDays(pr.updated_at));
+              if (RULES.has('quota') && overQuota.has(pr.user.login)) {
+                const n = authors.get(pr.user.login).count;
+                return { rule: 'quota',
+                  short: `quota: ${n} open PRs, all idle ${idle}d`,
+                  reason: `the author has ${n} open PRs (limit ${QUOTA} for non-collaborators) `
+                        + `and none of them has been updated in ${QUOTA_IDLE} days` };
+              }
+              if (RULES.has('wip') && (WIP_MARKER.test(pr.title) || pr.draft)
+                  && idle > (pr.draft ? DRAFT_DAYS : WIP_DAYS)) {
+                const marked = WIP_MARKER.test(pr.title);
+                const what = marked ? 'marked WIP / do-not-merge' : 'still a draft';
+                return { rule: 'wip',
+                  short: `${marked ? 'WIP' : 'draft'}, idle ${idle}d`,
+                  reason: `it is ${what} and has not been updated in ${idle} days` };
+              }
+              if (RULES.has('stale') && idle > STALE_DAYS) {
+                return { rule: 'stale',
+                  short: `stale, idle ${idle}d`,
+                  reason: `it has had no updates in ${idle} days` };
+              }
+              return null;
+            }
+
+            // Rebasing hint - an old branch is very likely pointing at paths that
+            // have since moved, so save the author the archaeology.
+            const RELOCATIONS = [
+              'If you do come back to it, these directory moves landed recently and are',
+              'the most common reason an older branch no longer applies:',
+              '',
+              '- `sgl-kernel/` -> `python/sglang/kernels/aot/`',
+              '- `python/sglang/jit_kernel/` -> `python/sglang/kernels/jit/` and `kernels/ops/`',
+              '- Sphinx `docs/` -> Mintlify `docs/docs/` (`.md` -> `.mdx`)',
+              '- `python/sglang/bench_serving.py` -> `python/sglang/benchmark/serving.py`',
+              '- `test/srt/` retired; tests now live under `test/registered/`',
+            ];
+
+            function commentBody(pr, verdict) {
+              const who = `@${pr.user.login}`;
+              const idle = Math.floor(idleDays(pr.updated_at));
+              let lead;
+
+              if (verdict.rule === 'wip') {
+                const what = WIP_MARKER.test(pr.title)
+                  ? 'is still marked a work in progress'
+                  : 'is still a draft';
+                lead = [
+                  `Thanks for working on this, ${who}.`,
+                  '',
+                  `This PR ${what} and has not been updated in ${idle} days, so we are`
+                    + ' closing it to keep the review queue current. Reopen it or push to the'
+                    + ' branch whenever you want to pick it back up.',
+                ];
+              } else if (verdict.rule === 'quota') {
+                const n = authors.get(pr.user.login).count;
+                lead = [
+                  `Thanks for the contributions, ${who}.`,
+                  '',
+                  `You have ${n} PRs open and none has been updated in the last`
+                    + ` ${QUOTA_IDLE} days. We cap idle open PRs at ${QUOTA} per contributor`
+                    + ' so review attention stays spread out, so this batch is being closed.',
+                  '',
+                  'Reopen the two or three you most want reviewed - a short active set moves'
+                    + ' faster than a long idle one.',
+                ];
+              } else {
+                lead = [
+                  `This PR has had no updates in ${idle} days, so it is being closed in a`
+                    + ' backlog sweep. That is a queue-hygiene call, not a judgement on the'
+                    + ' change.',
+                  '',
+                  'If it is still relevant, rebase onto current `main` and reopen.',
+                ];
+              }
+
+              return [...lead, '', ...RELOCATIONS].join('\n');
+            }
+
+            const closed = [];
+            const skipped = [];
+
+            for (const pr of prs) {
+              if (closed.length >= MAX) {
+                core.info(`hit max_actions=${MAX}, stopping`);
+                break;
+              }
+
+              const labels = pr.labels.map(l => l.name);
+              if (labels.some(l => KEEP_LABELS.has(l))) continue;
+              if (await hasWrite(pr.user.login)) continue;
+
+              const verdict = classify(pr);
+              if (!verdict) continue;
+
+              if (SKIP_APPROVED && await isApproved(pr.number)) {
+                skipped.push({ pr, why: 'has an approving review' });
+                continue;
+              }
+
+              if (!DRY) {
+                try {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: pr.number,
+                    body: commentBody(pr, verdict),
+                  });
+                  await github.rest.pulls.update({
+                    owner, repo, pull_number: pr.number, state: 'closed',
+                  });
+                } catch (e) {
+                  core.warning(`failed on #${pr.number}: ${e.message}`);
+                  continue;
+                }
+              }
+              closed.push({ pr, ...verdict });
+              core.info(`${DRY ? 'WOULD CLOSE' : 'closed'} #${pr.number} [${verdict.rule}]`);
+            }
+
+            core.summary.addHeading(
+              DRY ? 'Stale PR sweep - DRY RUN' : 'Stale PR sweep', 2);
+            core.summary.addRaw(
+              `Scanned ${prs.length} open PRs. `
+              + `${DRY ? 'Would close' : 'Closed'} ${closed.length}`
+              + (closed.length >= MAX ? ` (capped at ${MAX})` : '')
+              + `. Left open despite matching: ${skipped.length} (approved).\n\n`);
+
+            const tally = {};
+            for (const c of closed) tally[c.rule] = (tally[c.rule] || 0) + 1;
+            core.summary.addRaw(
+              'By rule: '
+              + (Object.entries(tally).map(([k, v]) => `${k}=${v}`).join(', ') || 'none')
+              + '\n\n');
+
+            if (closed.length) {
+              core.summary.addTable([
+                [{ data: 'reason', header: true }, { data: 'author', header: true },
+                 { data: 'title', header: true }, { data: 'link', header: true }],
+                ...closed.map(c => [
+                  c.short,
+                  `@${c.pr.user.login}`,
+                  c.pr.title.length > 80 ? c.pr.title.slice(0, 77) + '...' : c.pr.title,
+                  `<a href="${c.pr.html_url}">#${c.pr.number}</a>`,
+                ]),
+              ]);
+            }
+            // Rollback line. If a run turns out to have closed the wrong things,
+            // this is the one command that undoes exactly that run.
+            if (closed.length && !DRY) {
+              const nums = closed.map(c => c.pr.number).join(' ');
+              core.summary.addRaw('\n**Undo this run**\n\n');
+              core.summary.addCodeBlock(
+                `for n in ${nums}; do gh pr reopen $n --repo ${owner}/${repo}; done`,
+                'bash');
+              core.summary.addRaw(
+                '\nNote: nothing is labelled, so this table is the only record of the '
+                + 'run. Job summaries are retained for 90 days by default - if you want a '
+                + 'history that outlives that, raise the retention setting or archive the '
+                + 'summaries.\n');
+            }
+
+            if (skipped.length) {
+              core.summary.addRaw(
+                '\n**Matched a rule but not closed - has an approving review**\n\n');
+              for (const s of skipped) {
+                core.summary.addRaw(`- #${s.pr.number} @${s.pr.user.login}\n`);
+              }
+            }
+            await core.summary.write();
+        env:
+          # Precedence: manual input > repository variable > built-in default.
+          # The repository variables let the scheduled run be retuned from
+          # Settings -> Actions -> Variables without touching this file:
+          #   STALE_MAX_ACTIONS=64  speed up once the reopen rate looks healthy
+          #   STALE_MAX_ACTIONS=0   kill switch - MAX=0 breaks the loop immediately
+          #   STALE_RULES=wip       temporarily narrow to one rule
+          DRY_RUN: ${{ inputs.dry_run }}
+          RULES: ${{ inputs.rules || vars.STALE_RULES || 'wip,quota,stale' }}
+          MAX_ACTIONS: ${{ inputs.max_actions || vars.STALE_MAX_ACTIONS || '32' }}

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -307,7 +307,7 @@ jobs:
             await core.summary.write();
         env:
           # Precedence: manual input > repository variable > built-in default.
-          # The repository variables let the scheduled run be retuned from
+          # The repository variables let the scheduled run be adjusted from
           # Settings -> Actions -> Variables without touching this file:
           #   STALE_MAX_ACTIONS=64  speed up once the reopen rate looks healthy
           #   STALE_MAX_ACTIONS=0   kill switch - MAX=0 breaks the loop immediately

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -21,6 +21,13 @@ on:
         description: 'Hard cap on PRs closed in one run'
         default: '32'
 
+# Two runs must never sweep at once - they would pick the same candidates and
+# double-comment on them. Queue instead of cancelling, so a manual dry-run does
+# not silently kill the scheduled sweep half way through.
+concurrency:
+  group: close-stale-prs
+  cancel-in-progress: false
+
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,29 +1,21 @@
 name: Close Stale PRs
 
-# Paced deliberately. As of 2026-08-11 the candidate pool is ~1400 PRs (331 from
-# the WIP rule, ~1072 from the 90-day rule) and roughly 12-13 PRs go quiet per
-# day. At 32 per run that is ~19 net per day, so the backlog drains in ~2.5
-# months while staying well ahead of new inflow - and a bad rule shows up in the
-# reopen rate long before it can close a thousand PRs.
 on:
   schedule:
     - cron: '0 1 * * *'
   workflow_dispatch:
     inputs:
       dry_run:
-        description: 'Report only, do not close anything'
+        description: 'Report only, do not close'
         type: boolean
         default: true
       rules:
-        description: 'Comma-separated subset of: wip,quota,stale'
+        description: 'Subset of: wip,quota,stale'
         default: 'wip,quota,stale'
       max_actions:
-        description: 'Hard cap on PRs closed in one run'
+        description: 'Max PRs closed per run'
         default: '32'
 
-# Two runs must never sweep at once - they would pick the same candidates and
-# double-comment on them. Queue instead of cancelling, so a manual dry-run does
-# not silently kill the scheduled sweep half way through.
 concurrency:
   group: close-stale-prs
   cancel-in-progress: false
@@ -37,288 +29,144 @@ jobs:
     if: github.repository == 'sgl-project/sglang'
     runs-on: ubuntu-latest
     steps:
-      - name: Sweep stale PRs
-        uses: actions/github-script@v8
+      - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            // Thresholds.
-            const WIP_DAYS = 21;      // rule 1: WIP / do-not-merge / draft title marker
-            const DRAFT_DAYS = 21;    // rule 1: GitHub draft flag
-            const QUOTA = 5;          // rule 2: max open PRs for a non-write author
-            const QUOTA_IDLE = 7;     // rule 2: every one of their PRs must be idle this long
-            const STALE_DAYS = 90;    // rule 3: no updates at all
+            const WIP_DAYS = 21;
+            const QUOTA = 5;
+            const QUOTA_IDLE = 7;
+            const STALE_DAYS = 90;
 
-            // Keep true. PRs with an approving review are almost always blocked on
-            // us, not on the author: of the 43 approved-and-stale PRs as of
-            // 2026-08-11, a manual triage pass had independently marked at least 8
-            // as worth keeping (#22441, #21194, #21153, #20427, #19777, #19857,
-            // #19530, #22178), and every one of those approvals came from a
-            // maintainer with write access. Flipping this to false closes PRs that
-            // our own reviewers signed off on.
-            const SKIP_APPROVED = true;
-
-            // Candidates are enumerated with paginated pulls.list, NOT the search API.
-            // Search caps out at 1000 results, which silently truncates a 4000+ PR
-            // backlog; REST pagination has no such cap. Both agree on the actual
-            // counts, so this is about completeness, not correctness.
-            //
-            // Caveat on updated_at: it is refreshed by some non-substantive events, so
-            // a PR can report a recent updated_at with no commit or comment behind it
-            // (#6722 on 2026-08-11: updated_at yesterday, last commit 14 months old,
-            // last human comment 8 months old). That direction is safe here - such a
-            // PR is skipped, never wrongly closed. If we ever want to catch them too,
-            // the fix is to age off max(last commit, last human comment) instead, at
-            // the cost of two extra API calls per candidate.
-
-            const KEEP_LABELS = new Set([
-              'high priority',
-              'keep-open',
-              'good first issue',
-            ]);
-
+            const KEEP_LABELS = new Set(['high priority', 'keep-open', 'good first issue']);
             const WIP_MARKER = /^\s*\[?\s*(wip|do[ _-]?not[ _-]?merge|dnm|draft)\s*\]?/i;
 
+            // Scheduled runs always act; only manual runs can be dry.
             const DRY = context.eventName !== 'schedule'
               && String(process.env.DRY_RUN) !== 'false';
-            const RULES = new Set(
-              (process.env.RULES || 'wip,quota,stale').split(',').map(s => s.trim()));
-            const MAX = parseInt(process.env.MAX_ACTIONS || '32', 10);
+            const RULES = new Set(process.env.RULES.split(',').map(s => s.trim()));
+            const MAX = parseInt(process.env.MAX_ACTIONS, 10);
 
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
-            const now = Date.now();
-            const idleDays = ts => (now - new Date(ts).getTime()) / 86400000;
+            const idle = ts => Math.floor((Date.now() - new Date(ts)) / 86400000);
 
-            core.info(`dry_run=${DRY} rules=${[...RULES]} max_actions=${MAX}`);
-
-            // One permission lookup per author, not per PR.
-            const permCache = new Map();
+            const perms = new Map();
             async function hasWrite(login) {
-              if (permCache.has(login)) return permCache.get(login);
-              let ok = false;
-              try {
-                const r = await github.rest.repos.getCollaboratorPermissionLevel(
-                  { owner, repo, username: login });
-                ok = ['admin', 'maintain', 'write'].includes(r.data.permission);
-              } catch (e) {
-                ok = false;  // not a collaborator
+              if (!perms.has(login)) {
+                let ok = false;
+                try {
+                  const r = await github.rest.repos.getCollaboratorPermissionLevel(
+                    { owner, repo, username: login });
+                  ok = ['admin', 'maintain', 'write'].includes(r.data.permission);
+                } catch (e) {}
+                perms.set(login, ok);
               }
-              permCache.set(login, ok);
-              return ok;
+              return perms.get(login);
             }
 
-            async function isApproved(number) {
-              try {
-                const revs = await github.paginate(
-                  github.rest.pulls.listReviews,
-                  { owner, repo, pull_number: number, per_page: 100 });
-                return revs.some(r => r.state === 'APPROVED');
-              } catch (e) {
-                return false;
-              }
-            }
+            // Search would cap at 1000 results and truncate a 4000+ PR backlog.
+            const prs = await github.paginate(github.rest.pulls.list,
+              { owner, repo, state: 'open', sort: 'updated', direction: 'asc', per_page: 100 });
 
-            const prs = await github.paginate(
-              github.rest.pulls.list,
-              { owner, repo, state: 'open', sort: 'updated',
-                direction: 'asc', per_page: 100 });
-            core.info(`fetched ${prs.length} open PRs`);
-
-            // Rule 2 operates on the whole author, so pre-compute per-author state:
-            // how many PRs they have open, and how long ALL of them have been idle.
-            const authors = new Map();
+            const counts = new Map();
+            const freshest = new Map();
             for (const pr of prs) {
-              const a = authors.get(pr.user.login) || { count: 0, minIdle: Infinity };
-              a.count += 1;
-              a.minIdle = Math.min(a.minIdle, idleDays(pr.updated_at));
-              authors.set(pr.user.login, a);
+              const l = pr.user.login;
+              counts.set(l, (counts.get(l) || 0) + 1);
+              freshest.set(l, Math.min(freshest.get(l) ?? Infinity, idle(pr.updated_at)));
             }
             const overQuota = new Set();
-            for (const [login, a] of authors) {
-              if (a.count <= QUOTA) continue;
-              if (a.minIdle < QUOTA_IDLE) continue;   // any recent activity spares them all
-              if (await hasWrite(login)) continue;
-              overQuota.add(login);
-            }
-            if (overQuota.size) {
-              core.info(`over-quota authors: ${[...overQuota].join(', ')}`);
+            if (RULES.has('quota')) {
+              for (const [l, n] of counts) {
+                if (n > QUOTA && freshest.get(l) >= QUOTA_IDLE && !(await hasWrite(l))) {
+                  overQuota.add(l);
+                }
+              }
             }
 
             function classify(pr) {
-              const idle = Math.floor(idleDays(pr.updated_at));
-              if (RULES.has('quota') && overQuota.has(pr.user.login)) {
-                const n = authors.get(pr.user.login).count;
-                return { rule: 'quota',
-                  short: `quota: ${n} open PRs, all idle ${idle}d`,
-                  reason: `the author has ${n} open PRs (limit ${QUOTA} for non-collaborators) `
-                        + `and none of them has been updated in ${QUOTA_IDLE} days` };
+              const d = idle(pr.updated_at);
+              const n = counts.get(pr.user.login);
+              if (overQuota.has(pr.user.login)) {
+                return { rule: 'quota', short: `quota: ${n} open PRs`,
+                  reason: `you have ${n} PRs open and none updated in ${QUOTA_IDLE} days,`
+                        + ` over our soft cap of ${QUOTA} for idle PRs` };
               }
-              if (RULES.has('wip') && (WIP_MARKER.test(pr.title) || pr.draft)
-                  && idle > (pr.draft ? DRAFT_DAYS : WIP_DAYS)) {
-                const marked = WIP_MARKER.test(pr.title);
-                const what = marked ? 'marked WIP / do-not-merge' : 'still a draft';
-                return { rule: 'wip',
-                  short: `${marked ? 'WIP' : 'draft'}, idle ${idle}d`,
-                  reason: `it is ${what} and has not been updated in ${idle} days` };
+              if (RULES.has('wip') && (WIP_MARKER.test(pr.title) || pr.draft) && d > WIP_DAYS) {
+                const w = WIP_MARKER.test(pr.title) ? 'marked WIP' : 'still a draft';
+                return { rule: 'wip', short: `${w}, ${d}d`,
+                  reason: `it is ${w} and has not been updated in ${d} days` };
               }
-              if (RULES.has('stale') && idle > STALE_DAYS) {
-                return { rule: 'stale',
-                  short: `stale, idle ${idle}d`,
-                  reason: `it has had no updates in ${idle} days` };
+              if (RULES.has('stale') && d > STALE_DAYS) {
+                return { rule: 'stale', short: `stale, ${d}d`,
+                  reason: `it has had no updates in ${d} days` };
               }
               return null;
             }
 
-            // Rebasing hint - an old branch is very likely pointing at paths that
-            // have since moved, so save the author the archaeology.
-            const RELOCATIONS = [
-              'If you do come back to it, these directory moves landed recently and are',
-              'the most common reason an older branch no longer applies:',
-              '',
-              '- `sgl-kernel/` -> `python/sglang/kernels/aot/`',
-              '- `python/sglang/jit_kernel/` -> `python/sglang/kernels/jit/` and `kernels/ops/`',
-              '- Sphinx `docs/` -> Mintlify `docs/docs/` (`.md` -> `.mdx`)',
-              '- `python/sglang/bench_serving.py` -> `python/sglang/benchmark/serving.py`',
-              '- `test/srt/` retired; tests now live under `test/registered/`',
-            ];
-
-            function commentBody(pr, verdict) {
-              const who = `@${pr.user.login}`;
-              const idle = Math.floor(idleDays(pr.updated_at));
-              let lead;
-
-              if (verdict.rule === 'wip') {
-                const what = WIP_MARKER.test(pr.title)
-                  ? 'is still marked a work in progress'
-                  : 'is still a draft';
-                lead = [
-                  `Thanks for working on this, ${who}.`,
-                  '',
-                  `This PR ${what} and has not been updated in ${idle} days, so we are`
-                    + ' closing it to keep the review queue current. Reopen it or push to the'
-                    + ' branch whenever you want to pick it back up.',
-                ];
-              } else if (verdict.rule === 'quota') {
-                const n = authors.get(pr.user.login).count;
-                lead = [
-                  `Thanks for the contributions, ${who}.`,
-                  '',
-                  `You have ${n} PRs open and none has been updated in the last`
-                    + ` ${QUOTA_IDLE} days. We cap idle open PRs at ${QUOTA} per contributor`
-                    + ' so review attention stays spread out, so this batch is being closed.',
-                  '',
-                  'Reopen the two or three you most want reviewed - a short active set moves'
-                    + ' faster than a long idle one.',
-                ];
-              } else {
-                lead = [
-                  `This PR has had no updates in ${idle} days, so it is being closed in a`
-                    + ' backlog sweep. That is a queue-hygiene call, not a judgement on the'
-                    + ' change.',
-                  '',
-                  'If it is still relevant, rebase onto current `main` and reopen.',
-                ];
-              }
-
-              return [...lead, '', ...RELOCATIONS].join('\n');
+            function body(pr, v) {
+              return [
+                `Thanks @${pr.user.login}. Closing this because ${v.reason}.`,
+                '',
+                v.rule === 'quota'
+                  ? 'Reopen the two or three you most want reviewed - a short active set'
+                    + ' moves faster than a long idle one.'
+                  : 'Reopen it if the work is still relevant.',
+                '',
+                'Some directories moved recently, so an older branch may need retargeting:',
+                '`sgl-kernel/` -> `python/sglang/kernels/aot/`, `python/sglang/jit_kernel/`',
+                '-> `python/sglang/kernels/jit/`, `docs/` -> `docs/docs/` (`.mdx`),',
+                '`bench_serving.py` -> `benchmark/serving.py`, `test/srt/` -> `test/registered/`.',
+              ].join('\n');
             }
 
             const closed = [];
-            const skipped = [];
-
+            let approved = 0;
             for (const pr of prs) {
-              if (closed.length >= MAX) {
-                core.info(`hit max_actions=${MAX}, stopping`);
-                break;
-              }
-
-              const labels = pr.labels.map(l => l.name);
-              if (labels.some(l => KEEP_LABELS.has(l))) continue;
+              if (closed.length >= MAX) break;
+              if (pr.labels.some(l => KEEP_LABELS.has(l.name))) continue;
               if (await hasWrite(pr.user.login)) continue;
+              const v = classify(pr);
+              if (!v) continue;
 
-              const verdict = classify(pr);
-              if (!verdict) continue;
-
-              if (SKIP_APPROVED && await isApproved(pr.number)) {
-                skipped.push({ pr, why: 'has an approving review' });
-                continue;
-              }
+              // An approving review means it is blocked on us, not the author.
+              const revs = await github.paginate(github.rest.pulls.listReviews,
+                { owner, repo, pull_number: pr.number, per_page: 100 });
+              if (revs.some(r => r.state === 'APPROVED')) { approved++; continue; }
 
               if (!DRY) {
-                try {
-                  await github.rest.issues.createComment({
-                    owner, repo, issue_number: pr.number,
-                    body: commentBody(pr, verdict),
-                  });
-                  await github.rest.pulls.update({
-                    owner, repo, pull_number: pr.number, state: 'closed',
-                  });
-                } catch (e) {
-                  core.warning(`failed on #${pr.number}: ${e.message}`);
-                  continue;
-                }
+                await github.rest.issues.createComment(
+                  { owner, repo, issue_number: pr.number, body: body(pr, v) });
+                await github.rest.pulls.update(
+                  { owner, repo, pull_number: pr.number, state: 'closed' });
               }
-              closed.push({ pr, ...verdict });
-              core.info(`${DRY ? 'WOULD CLOSE' : 'closed'} #${pr.number} [${verdict.rule}]`);
+              closed.push({ pr, ...v });
+              core.info(`${DRY ? 'would close' : 'closed'} #${pr.number} [${v.rule}]`);
             }
-
-            core.summary.addHeading(
-              DRY ? 'Stale PR sweep - DRY RUN' : 'Stale PR sweep', 2);
-            core.summary.addRaw(
-              `Scanned ${prs.length} open PRs. `
-              + `${DRY ? 'Would close' : 'Closed'} ${closed.length}`
-              + (closed.length >= MAX ? ` (capped at ${MAX})` : '')
-              + `. Left open despite matching: ${skipped.length} (approved).\n\n`);
 
             const tally = {};
             for (const c of closed) tally[c.rule] = (tally[c.rule] || 0) + 1;
+            core.summary.addHeading(DRY ? 'Stale PR sweep (dry run)' : 'Stale PR sweep', 2);
             core.summary.addRaw(
-              'By rule: '
-              + (Object.entries(tally).map(([k, v]) => `${k}=${v}`).join(', ') || 'none')
-              + '\n\n');
-
+              `Scanned ${prs.length}. ${DRY ? 'Would close' : 'Closed'} ${closed.length}`
+              + `${closed.length >= MAX ? ` (capped at ${MAX})` : ''}: `
+              + `${Object.entries(tally).map(([k, v]) => `${k}=${v}`).join(', ') || 'none'}. `
+              + `Left open despite matching: ${approved} (approved).\n\n`);
             if (closed.length) {
               core.summary.addTable([
-                [{ data: 'reason', header: true }, { data: 'author', header: true },
-                 { data: 'title', header: true }, { data: 'link', header: true }],
-                ...closed.map(c => [
-                  c.short,
-                  `@${c.pr.user.login}`,
-                  c.pr.title.length > 80 ? c.pr.title.slice(0, 77) + '...' : c.pr.title,
-                  `<a href="${c.pr.html_url}">#${c.pr.number}</a>`,
-                ]),
+                ['reason', 'author', 'title', 'link'].map(data => ({ data, header: true })),
+                ...closed.map(c => [c.short, `@${c.pr.user.login}`,
+                  c.pr.title.slice(0, 80), `<a href="${c.pr.html_url}">#${c.pr.number}</a>`]),
               ]);
-            }
-            // Rollback line. If a run turns out to have closed the wrong things,
-            // this is the one command that undoes exactly that run.
-            if (closed.length && !DRY) {
-              const nums = closed.map(c => c.pr.number).join(' ');
-              core.summary.addRaw('\n**Undo this run**\n\n');
-              core.summary.addCodeBlock(
-                `for n in ${nums}; do gh pr reopen $n --repo ${owner}/${repo}; done`,
-                'bash');
-              core.summary.addRaw(
-                '\nNote: nothing is labelled, so this table is the only record of the '
-                + 'run. Job summaries are retained for 90 days by default - if you want a '
-                + 'history that outlives that, raise the retention setting or archive the '
-                + 'summaries.\n');
-            }
-
-            if (skipped.length) {
-              core.summary.addRaw(
-                '\n**Matched a rule but not closed - has an approving review**\n\n');
-              for (const s of skipped) {
-                core.summary.addRaw(`- #${s.pr.number} @${s.pr.user.login}\n`);
+              if (!DRY) {
+                core.summary.addRaw('\nUndo this run:\n');
+                core.summary.addCodeBlock(
+                  `for n in ${closed.map(c => c.pr.number).join(' ')}; do`
+                  + ` gh pr reopen $n --repo ${owner}/${repo}; done`, 'bash');
               }
             }
             await core.summary.write();
         env:
-          # Precedence: manual input > repository variable > built-in default.
-          # The repository variables let the scheduled run be adjusted from
-          # Settings -> Actions -> Variables without touching this file:
-          #   STALE_MAX_ACTIONS=64  speed up once the reopen rate looks healthy
-          #   STALE_MAX_ACTIONS=0   kill switch - MAX=0 breaks the loop immediately
-          #   STALE_RULES=wip       temporarily narrow to one rule
           DRY_RUN: ${{ inputs.dry_run }}
           RULES: ${{ inputs.rules || vars.STALE_RULES || 'wip,quota,stale' }}
           MAX_ACTIONS: ${{ inputs.max_actions || vars.STALE_MAX_ACTIONS || '32' }}


### PR DESCRIPTION
Adds a daily scheduled sweep that closes stale PRs, alongside the existing
`close-inactive-issues.yml`. Three independent rules, each toggleable:

| rule | condition | matches today |
|---|---|---|
| `wip` | title marked WIP/DNM, or draft, idle > 21d | 331 |
| `quota` | non-collaborator, > 5 open PRs, **all** idle > 7d | 0 |
| `stale` | idle > 90d | ~1072 |

Exempt: write+ access, `high priority` / `keep-open` / `good first issue`,
and any PR with an approving review.

**Pacing.** 32 per run. Roughly 12-13 PRs go quiet per day, so this nets
~19/day and drains the ~1400 backlog in about 2.5 months while staying ahead
of inflow. Deliberately slow: a bad rule shows up in the reopen rate long
before it can close a thousand PRs. Tunable without editing this file via
`vars.STALE_MAX_ACTIONS` (`0` acts as a kill switch) and `vars.STALE_RULES`.

**Why `quota` matches nothing right now.** Every non-collaborator with more
than 5 open PRs has had activity within 7 days - the high-count authors are
active multi-track contributors, not spam. The idle condition makes this rule
a gate on future batches rather than a retroactive purge, and it also keeps
stacked/series PRs intact.

**Why approved PRs are exempt.** Of the 43 approved-and-stale PRs, a manual
triage pass had independently judged at least 8 worth keeping (#22441, #21194,
#21153, #20427, #19777, #19857, #19530, #22178), and every one of those
approvals came from a maintainer with write access. Closing those would
override our own reviewers. The exemption costs 43 out of 1115.

**Output.** Each run writes a job summary listing reason / author / title /
link for everything it closed, plus a one-line `gh pr reopen` command that
undoes that run. Nothing is labelled.

Notes for reviewers:
- Candidates come from paginated `pulls.list`, not the search API - search
  caps at 1000 results and would silently truncate a 4000+ PR backlog.
- `updated_at` is refreshed by some non-substantive events, so a PR can look
  recent with no commit or comment behind it. That direction is safe here
  (skipped, never wrongly closed); the comment in the file records the fix if
  we ever want to catch those too.
- `schedule` runs force `dry_run=false`. Before enabling the cron, run it
  manually with `dry_run=true` and check the summary.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31470419250](https://github.com/sgl-project/sglang/actions/runs/31470419250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31470419083](https://github.com/sgl-project/sglang/actions/runs/31470419083)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->