### PR TITLE
[Spec] Support output logprobs with DSpark

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2492,11 +2492,7 @@ class Scheduler(
         self._maybe_namespace_elastic_radix_cache(req)
 
         if self.spec_algorithm.is_dflash_family():
-            error_msg = (
-                "DSpark speculative decoding does not support return_logprob yet."
-                if self.spec_algorithm.is_dspark() and req.return_logprob
-                else validate_dflash_request(req, self.enable_overlap)
-            )
+            error_msg = validate_dflash_request(req, self.enable_overlap)
             if error_msg is not None:
                 req.set_finish_with_abort(error_msg)
                 self.init_req_max_new_tokens(req)

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.logprob_processor import compute_spec_v2_logprobs
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.managers.scheduler import GenerationBatchResult
 from sglang.srt.managers.tp_worker import TpModelWorker
@@ -404,11 +405,6 @@ class DSparkWorkerV2(BaseSpecWorker):
         on_publish=None,
         grammar_barrier=None,
     ) -> GenerationBatchResult:
-        if getattr(batch, "return_logprob", False):
-            raise ValueError(
-                "DSpark speculative decoding does not support return_logprob yet."
-            )
-
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
@@ -701,6 +697,11 @@ class DSparkWorkerV2(BaseSpecWorker):
             prefix_lens=prefix_lens,
             draft_tokens=draft_tokens,
         )
+        self._compute_output_logprobs(
+            batch=batch,
+            logits_output=logits_output,
+            out_tokens=accept.out_tokens,
+        )
         if on_publish is not None:
             if confidence is not None:
                 on_publish(accept.new_seq_lens, confidence=confidence)
@@ -767,6 +768,39 @@ class DSparkWorkerV2(BaseSpecWorker):
             next_draft_input=next_draft_input,
             speculative_num_draft_tokens=int(self.verify_num_draft_tokens),
             new_seq_lens=accept.new_seq_lens,
+        )
+
+    def _compute_output_logprobs(
+        self,
+        *,
+        batch: ScheduleBatch,
+        logits_output,
+        out_tokens: torch.Tensor,
+    ) -> None:
+        if not batch.return_logprob:
+            return
+
+        stride = int(self.verify_num_draft_tokens)
+        count = int(out_tokens.shape[0]) * stride
+        output_indices = self._linear_accept_index_cache
+        if (
+            output_indices is None
+            or output_indices.numel() < count
+            or output_indices.device != out_tokens.device
+        ):
+            output_indices = torch.arange(
+                count,
+                dtype=torch.int64,
+                device=out_tokens.device,
+            )
+            self._linear_accept_index_cache = output_indices
+
+        compute_spec_v2_logprobs(
+            batch,
+            logits_output,
+            out_tokens.reshape(-1),
+            output_indices[:count].view(-1, stride),
+            stride - 1,
         )
 
     def _commit_target_mamba_states_after_verify(

--- a/test/registered/spec/dspark/test_dspark_logprobs.py
+++ b/test/registered/spec/dspark/test_dspark_logprobs.py
@@ -1,0 +1,152 @@
+import types
+import unittest
+
+import torch
+
+from sglang.srt.speculative.dspark_components.dspark_worker_v2 import DSparkWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestDSparkLogprobs(CustomTestCase):
+    def _worker(self, stride: int) -> DSparkWorkerV2:
+        worker = object.__new__(DSparkWorkerV2)
+        worker.verify_num_draft_tokens = stride
+        worker._linear_accept_index_cache = None
+        return worker
+
+    def _batch(
+        self,
+        *,
+        bs: int,
+        return_logprob: bool = True,
+        temperatures: torch.Tensor | None = None,
+        top_logprobs_nums=None,
+        token_ids_logprobs=None,
+    ):
+        if temperatures is None:
+            temperatures = torch.ones((bs, 1), dtype=torch.float32)
+        return types.SimpleNamespace(
+            return_logprob=return_logprob,
+            seq_lens=torch.ones(bs, dtype=torch.int64),
+            sampling_info=types.SimpleNamespace(
+                is_all_greedy=bool(torch.all(temperatures == 1)),
+                temperatures=temperatures,
+            ),
+            top_logprobs_nums=top_logprobs_nums,
+            token_ids_logprobs=token_ids_logprobs,
+        )
+
+    @staticmethod
+    def _logits(rows: int, vocab: int):
+        values = torch.arange(rows * vocab, dtype=torch.float32)
+        return types.SimpleNamespace(next_token_logits=values.view(rows, vocab) / 10)
+
+    def test_greedy_logprobs_follow_strided_verify_rows(self):
+        bs, stride, vocab = 2, 4, 7
+        out_tokens = torch.tensor([[1, 3, 5, 0], [6, 4, 2, 1]], dtype=torch.int64)
+        logits_output = self._logits(bs * stride, vocab)
+
+        self._worker(stride)._compute_output_logprobs(
+            batch=self._batch(bs=bs),
+            logits_output=logits_output,
+            out_tokens=out_tokens,
+        )
+
+        logprobs = torch.log_softmax(logits_output.next_token_logits, dim=-1)
+        expected = logprobs[torch.arange(bs * stride), out_tokens.reshape(-1)].view(
+            bs, stride
+        )
+        torch.testing.assert_close(logits_output.next_token_logprobs, expected)
+
+    def test_sampling_logprobs_apply_per_request_temperature(self):
+        bs, stride, vocab = 2, 3, 5
+        temperatures = torch.tensor([[0.5], [2.0]], dtype=torch.float32)
+        out_tokens = torch.tensor([[0, 1, 2], [2, 3, 4]], dtype=torch.int64)
+        logits_output = self._logits(bs * stride, vocab)
+
+        self._worker(stride)._compute_output_logprobs(
+            batch=self._batch(bs=bs, temperatures=temperatures),
+            logits_output=logits_output,
+            out_tokens=out_tokens,
+        )
+
+        scaled = logits_output.next_token_logits / torch.repeat_interleave(
+            temperatures, stride, dim=0
+        )
+        expected_all = torch.log_softmax(scaled, dim=-1)
+        expected = expected_all[torch.arange(bs * stride), out_tokens.reshape(-1)].view(
+            bs, stride
+        )
+        torch.testing.assert_close(logits_output.next_token_logprobs, expected)
+
+    def test_optional_logprob_outputs_cover_every_verify_row(self):
+        bs, stride, vocab = 2, 3, 6
+        out_tokens = torch.tensor([[0, 1, 2], [3, 4, 5]], dtype=torch.int64)
+        logits_output = self._logits(bs * stride, vocab)
+
+        self._worker(stride)._compute_output_logprobs(
+            batch=self._batch(
+                bs=bs,
+                top_logprobs_nums=[2, 1],
+                token_ids_logprobs=[[0, 5], [1]],
+            ),
+            logits_output=logits_output,
+            out_tokens=out_tokens,
+        )
+
+        self.assertEqual(len(logits_output.next_token_top_logprobs_val), bs * stride)
+        self.assertEqual(len(logits_output.next_token_top_logprobs_idx), bs * stride)
+        self.assertEqual(
+            len(logits_output.next_token_token_ids_logprobs_val), bs * stride
+        )
+        self.assertEqual(
+            len(logits_output.next_token_token_ids_logprobs_idx), bs * stride
+        )
+
+    def test_index_cache_reuses_and_resizes_storage(self):
+        stride, vocab = 3, 5
+        worker = self._worker(stride)
+
+        worker._compute_output_logprobs(
+            batch=self._batch(bs=2),
+            logits_output=self._logits(2 * stride, vocab),
+            out_tokens=torch.zeros((2, stride), dtype=torch.int64),
+        )
+        initial_cache = worker._linear_accept_index_cache
+
+        worker._compute_output_logprobs(
+            batch=self._batch(bs=1),
+            logits_output=self._logits(stride, vocab),
+            out_tokens=torch.zeros((1, stride), dtype=torch.int64),
+        )
+        self.assertIs(worker._linear_accept_index_cache, initial_cache)
+
+        worker._compute_output_logprobs(
+            batch=self._batch(bs=3),
+            logits_output=self._logits(3 * stride, vocab),
+            out_tokens=torch.zeros((3, stride), dtype=torch.int64),
+        )
+        self.assertIsNot(worker._linear_accept_index_cache, initial_cache)
+        torch.testing.assert_close(
+            worker._linear_accept_index_cache,
+            torch.arange(3 * stride, dtype=torch.int64),
+        )
+
+    def test_disabled_logprobs_do_not_modify_logits_output(self):
+        bs, stride, vocab = 2, 3, 5
+        logits_output = self._logits(bs * stride, vocab)
+
+        self._worker(stride)._compute_output_logprobs(
+            batch=self._batch(bs=bs, return_logprob=False),
+            logits_output=logits_output,
+            out_tokens=torch.zeros((bs, stride), dtype=torch.int64),
+        )
+
+        self.assertFalse(hasattr(logits_output, "next_token_logprobs"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enable `return_logprob` requests for DSpark
- reuse the Spec v2 logprob processor on accepted target tokens
- cover greedy, sampled, top-k, and token-ID logprob outputs

## Tests
- `test_dspark_logprobs.py`: 5 passed
- `test_dspark_scheduler.py`: 25 passed, 18 subtests passed

## Original commits
- `b4fb3df52`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31470262145](https://github.com/sgl-project/sglang/actions/runs/31470262145)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31470261920](https://github.com/sgl-project/sglang/actions/runs/31470261920)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->