### PR TITLE
[draft] feat(cache): add session cache priority control

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -138,6 +138,7 @@ from sglang.srt.managers.io_struct import (
     SendWeightsToRemoteInstanceReqInput,
     SeparateReasoningReqInput,
     SetInternalStateReq,
+    SetSessionCachePriorityReqInput,
     SlowDownReqInput,
     UnloadLoRAAdapterReqInput,
     UpdateWeightFromDiskReqInput,
@@ -1572,6 +1573,36 @@ async def close_session(obj: Annotated[CloseSessionReqInput, Body()], request: R
         return Response(status_code=200)
     except Exception as e:
         return _create_error_response(e)
+
+
+@app.post("/set_session_cache_priority")
+@auth_level(AuthLevel.ADMIN_OPTIONAL)
+async def set_session_cache_priority(
+    obj: Annotated[SetSessionCachePriorityReqInput, Body()],
+):
+    """Change eviction protection for one radix-native session."""
+    try:
+        results = await _global_state.tokenizer_manager.set_session_cache_priority(obj)
+    except ValueError as e:
+        return _create_error_response(e)
+
+    targeted = [result for result in results if result.status != "not_targeted"]
+    success = any(result.success for result in targeted)
+    if success:
+        status_code = HTTPStatus.OK
+    elif any(result.status == "stale_generation" for result in targeted):
+        status_code = HTTPStatus.CONFLICT
+    elif any(result.status == "not_found" for result in targeted):
+        status_code = HTTPStatus.NOT_FOUND
+    else:
+        status_code = HTTPStatus.BAD_REQUEST
+    return ORJSONResponse(
+        {
+            "success": success,
+            "results": [msgspec_to_builtins(result) for result in results],
+        },
+        status_code=status_code,
+    )
 
 
 @app.api_route("/configure_logging", methods=["GET", "POST"])

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2046,6 +2046,31 @@ class CloseSessionReqInput(BaseReq, kw_only=True):
     session_id: str
 
 
+class SetSessionCachePriorityReqInput(BaseReq, kw_only=True):
+    session_id: str
+    cache_priority: Literal["protected", "evictable"]
+    session_generation: Optional[int] = None
+    routed_dp_rank: Optional[int] = None
+
+
+class SetSessionCachePriorityReqOutput(BaseReq, kw_only=True):
+    success: bool
+    status: Literal[
+        "updated",
+        "unchanged",
+        "not_found",
+        "stale_generation",
+        "disabled",
+        "not_targeted",
+    ]
+    session_id: str
+    cache_priority: Literal["protected", "evictable"]
+    dp_rank: int
+    session_generation: Optional[int] = None
+    indexed_component_leaves: int = 0
+    message: str = ""
+
+
 class OpenSessionReqOutput(BaseReq, kw_only=True):
     session_id: Optional[str]
     success: bool

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -160,6 +160,8 @@ from sglang.srt.managers.io_struct import (
     SendWeightsToRemoteInstanceReqOutput,
     SetInternalStateReq,
     SetInternalStateReqOutput,
+    SetSessionCachePriorityReqInput,
+    SetSessionCachePriorityReqOutput,
     ShutdownReq,
     SlowDownReqInput,
     SlowDownReqOutput,
@@ -1524,6 +1526,10 @@ class Scheduler(
                 (AbortReq, self.abort_request),
                 (OpenSessionReqInput, self.open_session),
                 (CloseSessionReqInput, self.close_session),
+                (
+                    SetSessionCachePriorityReqInput,
+                    self.set_session_cache_priority,
+                ),
                 (
                     UpdateWeightFromDiskReqInput,
                     self.weight_updater.update_weights_from_disk,
@@ -4824,6 +4830,56 @@ class Scheduler(
             or not self.enable_session_radix_cache
         ):
             self.session_controller.close(recv_req)
+
+    def set_session_cache_priority(
+        self, recv_req: SetSessionCachePriorityReqInput
+    ) -> SetSessionCachePriorityReqOutput:
+        dp_rank = self.ps.dp_rank if self.ps.dp_rank is not None else 0
+        if recv_req.routed_dp_rank is not None and recv_req.routed_dp_rank != dp_rank:
+            return SetSessionCachePriorityReqOutput(
+                success=True,
+                status="not_targeted",
+                session_id=recv_req.session_id,
+                cache_priority=recv_req.cache_priority,
+                dp_rank=dp_rank,
+            )
+
+        if not self.enable_session_radix_cache:
+            return SetSessionCachePriorityReqOutput(
+                success=False,
+                status="disabled",
+                session_id=recv_req.session_id,
+                cache_priority=recv_req.cache_priority,
+                dp_rank=dp_rank,
+                message="Session radix cache is not enabled.",
+            )
+
+        result = self.tree_cache.set_session_cache_priority(
+            recv_req.session_id,
+            protected=recv_req.cache_priority == "protected",
+            generation=recv_req.session_generation,
+        )
+        success = result.status in ("updated", "unchanged")
+        logger.info(
+            "Set session cache priority session_id=%s cache_priority=%s "
+            "status=%s generation=%s indexed_component_leaves=%s dp_rank=%s",
+            recv_req.session_id,
+            recv_req.cache_priority,
+            result.status,
+            result.generation,
+            result.indexed_component_leaves,
+            dp_rank,
+        )
+        return SetSessionCachePriorityReqOutput(
+            success=success,
+            status=result.status,
+            session_id=recv_req.session_id,
+            cache_priority=recv_req.cache_priority,
+            dp_rank=dp_rank,
+            session_generation=result.generation,
+            indexed_component_leaves=result.indexed_component_leaves,
+            message="" if success else result.status.replace("_", " "),
+        )
 
     def maybe_sleep_on_idle(self):
         if self.idle_sleeper is not None:

--- a/python/sglang/srt/managers/tokenizer_control_mixin.py
+++ b/python/sglang/srt/managers/tokenizer_control_mixin.py
@@ -62,6 +62,8 @@ from sglang.srt.managers.io_struct import (
     SendWeightsToRemoteInstanceReqOutput,
     SetInternalStateReq,
     SetInternalStateReqOutput,
+    SetSessionCachePriorityReqInput,
+    SetSessionCachePriorityReqOutput,
     SlowDownReqInput,
     SlowDownReqOutput,
     UnloadLoRAAdapterReqInput,
@@ -120,6 +122,7 @@ _COMMUNICATOR_SPECS = [
     ("update_lora_adapter", LoRAUpdateOutput),
     ("dumper_control", DumperControlReqOutput),
     ("scale_elastic_ep", ScaleElasticEPReqOutput),
+    ("set_session_cache_priority", SetSessionCachePriorityReqOutput),
 ]
 
 
@@ -914,6 +917,28 @@ class TokenizerControlMixin:
         request: Optional[fastapi.Request] = None,
     ):
         await self._async_dispatch_to_scheduler(obj)
+
+    async def set_session_cache_priority(
+        self: TokenizerManager,
+        obj: SetSessionCachePriorityReqInput,
+    ) -> List[SetSessionCachePriorityReqOutput]:
+        self.auto_create_handle_loop()
+        if obj.routed_dp_rank is not None and not (
+            0 <= obj.routed_dp_rank < self.elastic_worker_count
+        ):
+            raise ValueError(
+                f"routed_dp_rank={obj.routed_dp_rank} out of range "
+                f"[0, {self.elastic_worker_count})"
+            )
+        if (
+            obj.session_generation is not None
+            and obj.routed_dp_rank is None
+            and self.elastic_worker_count > 1
+        ):
+            raise ValueError(
+                "session_generation requires routed_dp_rank when dp_size is greater than 1"
+            )
+        return await self.set_session_cache_priority_communicator(obj)
 
     def _update_weight_version_if_provided(
         self: TokenizerManager, weight_version: Optional[str]

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -149,6 +149,10 @@ class SWAComponent(TreeComponent):
         ct = self.component_type
 
         for session_id, covered_by_leaf in self._session_leaf_covered_len.items():
+            if not self.is_session_protected(session_id):
+                report_error(
+                    f"{ct} demoted session {session_id!r} still has coverage metadata"
+                )
             for leaf, covered_len in covered_by_leaf.items():
                 if leaf not in self._session_leaves.get(session_id, ()):
                     report_error(
@@ -161,6 +165,12 @@ class SWAComponent(TreeComponent):
 
         for session_id, leaves in self._session_leaves.items():
             covered_by_leaf = self._session_leaf_covered_len.get(session_id, {})
+            if not self.is_session_protected(session_id):
+                if covered_by_leaf:
+                    report_error(
+                        f"{ct} demoted session {session_id!r} has covered leaves"
+                    )
+                continue
             for leaf in leaves:
                 if leaf not in covered_by_leaf:
                     report_error(

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -118,12 +118,20 @@ class TreeComponent(ABC):
         # Per-session frontier nodes (the deepest registered node per cached
         # path), not physical tree leaves: a frontier node may have children.
         self._session_leaves: dict[str, set[UnifiedTreeNode]] = defaultdict(set)
+        # A demoted session keeps its frontier index but does not contribute to
+        # session_ref. Keeping the index lets promotion restore protection for
+        # surviving leaves without rebuilding the session from request history.
+        self._demoted_session_ids: set[str] = set()
 
     # Subclasses MUST set this as a class attribute (not @property)
     component_type: ComponentType
 
     def reset_session_state(self) -> None:
         self._session_leaves = defaultdict(set)
+        self._demoted_session_ids = set()
+
+    def is_session_protected(self, session_id: str) -> bool:
+        return session_id not in self._demoted_session_ids
 
     def session_ref(self, node: UnifiedTreeNode) -> int:
         return node.component_data[self.component_type].session_ref
@@ -238,16 +246,38 @@ class TreeComponent(ABC):
             return
 
         old_ancestor = self._nearest_session_ancestor(leaf, current_leaves)
-        self._advance_session_coverage(session_id, leaf, old_ancestor)
+        if self.is_session_protected(session_id):
+            self._advance_session_coverage(session_id, leaf, old_ancestor)
         self._mark_session_leaf(session_id, leaf)
         if old_ancestor is not None:
             self._unmark_session_leaf(session_id, old_ancestor)
 
+    def set_session_protected(
+        self, session_id: str, protected: bool
+    ) -> tuple[bool, int]:
+        """Change one session's eviction protection without dropping its index."""
+        was_protected = self.is_session_protected(session_id)
+        leaves = tuple(self._session_leaves.get(session_id, ()))
+        if protected == was_protected:
+            return False, len(leaves)
+
+        if protected:
+            for leaf in leaves:
+                self._advance_session_coverage(session_id, leaf, None)
+            self._demoted_session_ids.discard(session_id)
+        else:
+            for leaf in leaves:
+                self._dec_session_coverage(session_id, leaf)
+            self._demoted_session_ids.add(session_id)
+        return True, len(leaves)
+
     def release_session(self, session_id: str) -> int:
         leaves = tuple(self._session_leaves.get(session_id, ()))
         for leaf in leaves:
-            self._dec_session_coverage(session_id, leaf)
+            if self.is_session_protected(session_id):
+                self._dec_session_coverage(session_id, leaf)
             self._unmark_session_leaf(session_id, leaf)
+        self._demoted_session_ids.discard(session_id)
         return len(leaves)
 
     def discard_deleted_session_leaf(self, node: UnifiedTreeNode) -> None:
@@ -260,7 +290,8 @@ class TreeComponent(ABC):
                 session_id, ()
             ):
                 fallback = None
-            self._recede_session_coverage(session_id, node, fallback)
+            if self.is_session_protected(session_id):
+                self._recede_session_coverage(session_id, node, fallback)
             self._unmark_session_leaf(session_id, node)
             if fallback is not None:
                 self._mark_session_leaf(session_id, fallback)

--- a/python/sglang/srt/mem_cache/unified_cache/session_ref_tracker.py
+++ b/python/sglang/srt/mem_cache/unified_cache/session_ref_tracker.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Literal, Optional
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
@@ -23,6 +23,17 @@ logger = logging.getLogger(__name__)
 # out of this LRU after 8192 later closes, an extremely late finish can tag
 # again; explicit register_session clears the tombstone for intentional id reuse.
 _CLOSED_SESSION_TOMBSTONE_LIMIT = 8192
+
+SessionCachePriorityStatus = Literal[
+    "updated", "unchanged", "not_found", "stale_generation", "disabled"
+]
+
+
+@dataclass(frozen=True, kw_only=True)
+class SessionCachePriorityResult:
+    status: SessionCachePriorityStatus
+    generation: Optional[int]
+    indexed_component_leaves: int = 0
 
 
 @dataclass(kw_only=True)
@@ -42,6 +53,7 @@ class UnifiedSessionRefTracker:
         self._closed_session_ids: OrderedDict[str, None] = OrderedDict()
         self._session_incarnation_counter: int = 0
         self._session_generations: dict[str, int] = {}
+        self._demoted_session_ids: set[str] = set()
         for component in self.components:
             component.reset_session_state()
 
@@ -86,6 +98,9 @@ class UnifiedSessionRefTracker:
 
     def open_radix_session(self, session_id: str) -> Optional[int]:
         self._closed_session_ids.pop(session_id, None)
+        self._demoted_session_ids.discard(session_id)
+        for component in self.components:
+            component.set_session_protected(session_id, True)
         self._session_incarnation_counter += 1
         self._session_generations[session_id] = self._session_incarnation_counter
         return self._session_incarnation_counter
@@ -96,6 +111,44 @@ class UnifiedSessionRefTracker:
             generation = self.open_radix_session(session_id)
         return generation
 
+    def set_session_cache_priority(
+        self,
+        session_id: str,
+        *,
+        protected: bool,
+        generation: Optional[int] = None,
+    ) -> SessionCachePriorityResult:
+        if not self.enable_session_radix_cache:
+            return SessionCachePriorityResult(status="disabled", generation=None)
+
+        current_generation = self._session_generations.get(session_id)
+        if current_generation is None or session_id in self._closed_session_ids:
+            return SessionCachePriorityResult(status="not_found", generation=None)
+        if generation is not None and generation != current_generation:
+            return SessionCachePriorityResult(
+                status="stale_generation", generation=current_generation
+            )
+
+        was_protected = session_id not in self._demoted_session_ids
+        indexed = 0
+        for component in self.components:
+            changed, component_leaves = component.set_session_protected(
+                session_id, protected
+            )
+            assert changed == (protected != was_protected)
+            indexed += component_leaves
+
+        if protected:
+            self._demoted_session_ids.discard(session_id)
+        else:
+            self._demoted_session_ids.add(session_id)
+
+        return SessionCachePriorityResult(
+            status="updated" if protected != was_protected else "unchanged",
+            generation=current_generation,
+            indexed_component_leaves=indexed,
+        )
+
     def release_radix_session(self, session_id: str) -> int:
         if not self.enable_session_radix_cache or session_id is None:
             return 0
@@ -105,6 +158,7 @@ class UnifiedSessionRefTracker:
 
         self._remember_closed_session(session_id)
         self._session_generations.pop(session_id, None)
+        self._demoted_session_ids.discard(session_id)
 
         indexed = 0
         for component in self.components:

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -55,6 +55,7 @@ from sglang.srt.mem_cache.unified_cache.components import (
     TreeComponent,
 )
 from sglang.srt.mem_cache.unified_cache.session_ref_tracker import (
+    SessionCachePriorityResult,
     UnifiedSessionRefTracker,
 )
 from sglang.srt.mem_cache.unified_cache.tree_core_registry import create_tree_core
@@ -2101,6 +2102,19 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def ensure_session_generation(self, session_id: str) -> int:
         return self.session_refs.ensure_session_generation(session_id)
+
+    def set_session_cache_priority(
+        self,
+        session_id: str,
+        *,
+        protected: bool,
+        generation: Optional[int] = None,
+    ) -> SessionCachePriorityResult:
+        return self.session_refs.set_session_cache_priority(
+            session_id,
+            protected=protected,
+            generation=generation,
+        )
 
     def release_radix_session(self, session_id: str) -> int:
         return self.session_refs.release_radix_session(session_id)

--- a/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
@@ -217,6 +217,117 @@ class TestSessionUnifiedRadixCache(CustomTestCase):
         self.assertEqual(match_len(self.cache, [1, 2, 3, 4]), 4)
         self.assertEqual(self.full.session_ref(referenced), 1)
 
+    def test_demote_and_promote_session_cache_priority(self):
+        leaf = insert(self.cache, [1, 2, 3, 4])
+        generation = self.cache.open_radix_session("s1")
+        register(self.cache, [1, 2, 3, 4], "s1", generation)
+
+        demoted = self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+        self.assertEqual(demoted.status, "updated")
+        self.assertEqual(demoted.indexed_component_leaves, 1)
+        self.assertEqual(self.full.session_ref(leaf), 0)
+
+        unchanged = self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+        self.assertEqual(unchanged.status, "unchanged")
+        self.assertEqual(self.full.session_ref(leaf), 0)
+
+        promoted = self.cache.set_session_cache_priority(
+            "s1", protected=True, generation=generation
+        )
+        self.assertEqual(promoted.status, "updated")
+        self.assertEqual(self.full.session_ref(leaf), 1)
+
+    def test_demoted_session_keeps_future_leaves_evictable(self):
+        generation = self.cache.open_radix_session("s1")
+        self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+        leaf = insert(self.cache, [1, 2, 3, 4])
+
+        register(self.cache, [1, 2, 3, 4], "s1", generation)
+        self.assertEqual(self.full.session_ref(leaf), 0)
+
+        self.cache.set_session_cache_priority(
+            "s1", protected=True, generation=generation
+        )
+        self.assertEqual(self.full.session_ref(leaf), 1)
+
+    def test_session_cache_priority_rejects_stale_generation(self):
+        generation = self.cache.open_radix_session("s1")
+
+        result = self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation + 1
+        )
+
+        self.assertEqual(result.status, "stale_generation")
+        self.assertEqual(result.generation, generation)
+
+    def test_demoting_one_session_keeps_shared_prefix_protected(self):
+        shared_leaf = insert(self.cache, [1, 2, 3, 4])
+        generation_1 = self.cache.open_radix_session("s1")
+        generation_2 = self.cache.open_radix_session("s2")
+        register(self.cache, [1, 2, 3, 4], "s1", generation_1)
+        register(self.cache, [1, 2, 3, 4], "s2", generation_2)
+        self.assertEqual(self.full.session_ref(shared_leaf), 2)
+
+        self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation_1
+        )
+
+        self.assertEqual(self.full.session_ref(shared_leaf), 1)
+
+    def test_close_and_reopen_restore_default_protection(self):
+        leaf = insert(self.cache, [1, 2, 3, 4])
+        generation = self.cache.open_radix_session("s1")
+        register(self.cache, [1, 2, 3, 4], "s1", generation)
+        self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+        self.cache.release_radix_session("s1")
+
+        reopened_generation = self.cache.open_radix_session("s1")
+        register(self.cache, [1, 2, 3, 4], "s1", reopened_generation)
+
+        self.assertEqual(self.full.session_ref(leaf), 1)
+
+    def test_eviction_prefers_demoted_session_over_protected_session(self):
+        demoted_leaf = insert(self.cache, [1, 2, 3])
+        protected_leaf = insert(self.cache, [7, 8, 9])
+        demoted_generation = self.cache.open_radix_session("demoted")
+        protected_generation = self.cache.open_radix_session("protected")
+        register(self.cache, [1, 2, 3], "demoted", demoted_generation)
+        register(self.cache, [7, 8, 9], "protected", protected_generation)
+        self.cache.set_session_cache_priority(
+            "demoted", protected=False, generation=demoted_generation
+        )
+
+        self.cache.evict(EvictParams(num_tokens=3))
+
+        self.assertEqual(match_len(self.cache, [1, 2, 3]), 0)
+        self.assertEqual(match_len(self.cache, [7, 8, 9]), 3)
+        self.assertEqual(self.full.session_ref(demoted_leaf), 0)
+        self.assertEqual(self.full.session_ref(protected_leaf), 1)
+
+    def test_promote_after_demoted_leaf_eviction_is_safe(self):
+        insert(self.cache, [1, 2, 3])
+        generation = self.cache.open_radix_session("s1")
+        register(self.cache, [1, 2, 3], "s1", generation)
+        self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+        self.cache.evict(EvictParams(num_tokens=3))
+
+        result = self.cache.set_session_cache_priority(
+            "s1", protected=True, generation=generation
+        )
+
+        self.assertEqual(result.status, "updated")
+        self.assertEqual(result.indexed_component_leaves, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a DP-aware control endpoint that switches a radix-native session between protected and evictable cache state. This gives external policy engines a reversible pressure-control primitive without deleting the session's KV or rebuilding its cache index.

Related: #27574

Dynamo campaign DEP: https://github.com/ai-dynamo/dynamo/issues/13010

### How This Was Implemented

- Add typed request and per-DP response structs for `POST /set_session_cache_priority`, with optional DP targeting and session-generation fencing.
- Keep a demoted session's component frontier index while removing its `session_ref` contribution; promotion restores protection for every surviving indexed leaf.
- Preserve component-specific coverage rules for Full, SWA, and Mamba cache layouts, including shared-prefix reference counts.
- Return idempotent status values and log the applied state, generation, indexed component-leaf count, and DP rank.

<details>
<summary>Walkthrough</summary>

#### Mental model

`protected` is the default session state. `evictable` keeps the KV and the session-to-leaf index, but removes that session's eviction protection so ordinary cache eviction selects its leaves before protected session leaves.

```mermaid
flowchart LR
    P["Policy client"] -->|"POST session id, state, generation, DP"| T["Tokenizer control fan-out"]
    T --> S["Target DP scheduler"]
    S --> R["UnifiedSessionRefTracker"]
    R --> C["Full / SWA / Mamba components"]
    C -->|"update session_ref, retain leaf index"| E["Existing eviction ordering"]
```

#### State and ordering

The tracker owns the current session generation and logical demotion state. Each tree component keeps its existing session frontier index plus a demoted-session set because component deletion callbacks must know whether coverage exists.

Demotion walks the currently indexed leaves and removes their coverage. Promotion walks the surviving leaves and restores it. A session registered while demoted gets a leaf marker but no coverage, so later completed turns remain evictable until promotion.

Shared prefixes remain safe. If two protected sessions reference the same leaf, its reference count is two; demoting one session changes it to one, so the other session still protects the shared KV.

Full attention protects the path to the root, SWA protects its bounded window, and Mamba protects its reusable state leaf. The control operation delegates to those existing component rules instead of adding a second cache ownership model.

#### Request lifecycle

The tokenizer validates an optional `routed_dp_rank` and fans the command through the existing control communicator. Non-target DP ranks return `not_targeted`; the selected scheduler applies the change on its scheduler thread and returns `updated`, `unchanged`, `not_found`, `stale_generation`, or `disabled`.

Generation fencing prevents a delayed command from changing a closed and reopened session. With DP greater than one, a fenced command must name its DP rank because generation counters are local to each scheduler.

Closing a demoted session removes its retained leaf markers and demotion state. Reopening the same session ID starts a new generation in the default protected state.

#### Boundaries and limitations

This PR changes eviction ordering for the selected session's cached leaves. It does not yet bound a demoted request's admission budget, so a later allocation can still consume protected session leaves when no other capacity is available; priority-bounded admission and an eviction cutoff are the next campaign slice.

This PR does not abort requests, migrate sessions, prefetch from L3, or move KV bytes between tiers. It reuses UnifiedRadixCache only and requires `--enable-session-radix-cache`; other cache implementations return `disabled` through the control path.

</details>

### Validation

- `PYTHONPATH=python .venv/bin/python -m pytest -q test/registered/unit/mem_cache/test_session_unified_radix_cache.py` — 12 passed.
- `PYTHONPATH=python .venv/bin/python -m pytest -q test/registered/unit/mem_cache/test_session_unified_radix_cache.py test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py` — 1,050 passed, 1,030 skipped, 50 subtests passed.
- `ruff check --select E9,F63,F7,F82 <changed Python files>` — passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31470280409](https://github.com/sgl-project/sglang/actions/runs/31470280409)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31470280220](https://github.com/sgl-project/sglang/actions/runs/31470280220)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->