### PR TITLE
feat(cache): enforce session priority during allocation

### DIFF
--- a/benchmark/session_cache/README.md
+++ b/benchmark/session_cache/README.md
@@ -1,0 +1,34 @@
+# Session cache priority pressure benchmark
+
+This benchmark measures whether demoting low-value radix-native sessions protects other sessions during severe device-KV pressure on one engine.
+
+Start a fresh server for each arm. Set `--max-total-tokens` low enough to make the working set exceed device KV capacity:
+
+```bash
+python -m sglang.launch_server \
+  --model-path /path/to/model \
+  --tp 4 \
+  --kv-cache-dtype fp8_e4m3 \
+  --enable-session-radix-cache \
+  --radix-eviction-policy priority \
+  --max-total-tokens 131072 \
+  --port 30000
+```
+
+Run the protected control arm:
+
+```bash
+python benchmark/session_cache/bench_priority_pressure.py \
+  --arm protected \
+  --output /tmp/session-priority-protected.json
+```
+
+Restart the server, then run the demoted arm:
+
+```bash
+python benchmark/session_cache/bench_priority_pressure.py \
+  --arm demoted \
+  --output /tmp/session-priority-demoted.json
+```
+
+The default workload primes eight low-value sessions, primes six high-value sessions so they are newer, then grows only the low-value sessions past the configured device-KV capacity. The expected signal is a higher `high_cached_fraction_mean` in the demoted arm with `all_requests_succeeded=true` in both arms. For a stable comparison, run fresh-server A/B and B/A pairs.

--- a/benchmark/session_cache/bench_priority_pressure.py
+++ b/benchmark/session_cache/bench_priority_pressure.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+
+"""Measure session-cache demotion under single-engine KV pressure."""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import json
+import math
+import statistics
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import requests
+
+
+@dataclass
+class GenerateResult:
+    phase: str
+    role: str
+    session_id: str
+    round: int
+    input_tokens: int
+    cached_tokens: int
+    latency_ms: float
+    success: bool
+    error: str = ""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare protected and demoted radix-native sessions under device-KV "
+            "pressure. Run each arm against a fresh server."
+        )
+    )
+    parser.add_argument("--arm", choices=("protected", "demoted"), required=True)
+    parser.add_argument("--base-url", default="http://127.0.0.1:30000")
+    parser.add_argument("--high-sessions", type=int, default=6)
+    parser.add_argument("--low-sessions", type=int, default=8)
+    parser.add_argument("--prime-tokens", type=int, default=6144)
+    parser.add_argument("--growth-tokens", type=int, default=2048)
+    parser.add_argument("--pressure-rounds", type=int, default=4)
+    parser.add_argument("--pressure-concurrency", type=int, default=8)
+    parser.add_argument(
+        "--token-base",
+        type=int,
+        default=1000,
+        help="First token ID used for synthetic prompts; override for small vocabularies.",
+    )
+    parser.add_argument("--timeout", type=float, default=900.0)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def request_json(
+    method: str,
+    url: str,
+    *,
+    body: dict[str, Any] | None = None,
+    timeout: float,
+) -> Any:
+    response = requests.request(method, url, json=body, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(
+            f"{method} {url} failed ({response.status_code}): {response.text}"
+        )
+    if not response.content:
+        return None
+    content_type = response.headers.get("content-type", "")
+    return response.json() if "json" in content_type else response.text
+
+
+def percentile(values: list[float], quantile: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(len(ordered) - 1, math.ceil(quantile * len(ordered)) - 1)
+    return ordered[index]
+
+
+def make_prompt(token_id: int, length: int) -> list[int]:
+    return [token_id] * length
+
+
+def generate(
+    base_url: str,
+    session_id: str,
+    input_ids: list[int],
+    *,
+    phase: str,
+    role: str,
+    round_index: int,
+    timeout: float,
+) -> GenerateResult:
+    started = time.perf_counter()
+    try:
+        response = request_json(
+            "POST",
+            base_url + "/generate",
+            body={
+                "input_ids": input_ids,
+                "session_id": session_id,
+                "sampling_params": {
+                    "temperature": 0,
+                    "max_new_tokens": 1,
+                    "ignore_eos": True,
+                },
+            },
+            timeout=timeout,
+        )
+        meta = response["meta_info"]
+        return GenerateResult(
+            phase=phase,
+            role=role,
+            session_id=session_id,
+            round=round_index,
+            input_tokens=len(input_ids),
+            cached_tokens=int(meta.get("cached_tokens", 0)),
+            latency_ms=(time.perf_counter() - started) * 1000,
+            success=True,
+        )
+    except Exception as error:
+        return GenerateResult(
+            phase=phase,
+            role=role,
+            session_id=session_id,
+            round=round_index,
+            input_tokens=len(input_ids),
+            cached_tokens=0,
+            latency_ms=(time.perf_counter() - started) * 1000,
+            success=False,
+            error=str(error),
+        )
+
+
+def run_batch(
+    base_url: str,
+    sessions: list[tuple[str, int]],
+    *,
+    input_tokens: int,
+    phase: str,
+    role: str,
+    round_index: int,
+    concurrency: int,
+    timeout: float,
+) -> list[GenerateResult]:
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(concurrency, len(sessions))
+    ) as executor:
+        futures = [
+            executor.submit(
+                generate,
+                base_url,
+                session_id,
+                make_prompt(token_id, input_tokens),
+                phase=phase,
+                role=role,
+                round_index=round_index,
+                timeout=timeout,
+            )
+            for session_id, token_id in sessions
+        ]
+        return [future.result() for future in futures]
+
+
+def summarize(events: list[GenerateResult], prime_tokens: int) -> dict[str, Any]:
+    high_probes = [event for event in events if event.phase == "probe_high"]
+    low_pressure = [event for event in events if event.phase == "pressure_low"]
+    successful_high = [event for event in high_probes if event.success]
+    successful_low = [event for event in low_pressure if event.success]
+    high_cached = [event.cached_tokens for event in successful_high]
+    high_latencies = [event.latency_ms for event in successful_high]
+    low_latencies = [event.latency_ms for event in successful_low]
+    return {
+        "all_requests_succeeded": all(event.success for event in events),
+        "failed_requests": sum(not event.success for event in events),
+        "low_pressure_completed": len(successful_low),
+        "low_pressure_total": len(low_pressure),
+        "high_probe_completed": len(successful_high),
+        "high_probe_total": len(high_probes),
+        "high_cached_tokens_mean": (
+            statistics.fmean(high_cached) if high_cached else None
+        ),
+        "high_cached_fraction_mean": (
+            statistics.fmean(value / prime_tokens for value in high_cached)
+            if high_cached
+            else None
+        ),
+        "high_cached_fraction_min": (
+            min(value / prime_tokens for value in high_cached) if high_cached else None
+        ),
+        "high_probe_latency_ms_p50": percentile(high_latencies, 0.50),
+        "high_probe_latency_ms_p95": percentile(high_latencies, 0.95),
+        "low_pressure_latency_ms_p50": percentile(low_latencies, 0.50),
+        "low_pressure_latency_ms_p95": percentile(low_latencies, 0.95),
+    }
+
+
+def main() -> None:
+    args = parse_args()
+    base_url = args.base_url.rstrip("/")
+    if (
+        min(
+            args.high_sessions,
+            args.low_sessions,
+            args.prime_tokens,
+            args.growth_tokens,
+            args.pressure_rounds,
+            args.pressure_concurrency,
+        )
+        <= 0
+    ):
+        raise ValueError(
+            "session counts, token counts, rounds, and concurrency must be positive"
+        )
+
+    server_info = request_json("GET", base_url + "/server_info", timeout=args.timeout)
+    if not server_info.get("enable_session_radix_cache"):
+        raise RuntimeError("server must use --enable-session-radix-cache")
+
+    max_total_tokens = int(server_info["max_total_num_tokens"])
+    initial_tokens = (args.high_sessions + args.low_sessions) * args.prime_tokens
+    final_tokens = args.high_sessions * args.prime_tokens + args.low_sessions * (
+        args.prime_tokens + args.pressure_rounds * args.growth_tokens
+    )
+    if initial_tokens >= max_total_tokens:
+        raise ValueError(
+            f"initial working set {initial_tokens} must be below device KV capacity "
+            f"{max_total_tokens}"
+        )
+    if final_tokens <= max_total_tokens:
+        raise ValueError(
+            f"final working set {final_tokens} must exceed device KV capacity "
+            f"{max_total_tokens}"
+        )
+
+    request_json("POST", base_url + "/flush_cache", timeout=args.timeout)
+    run_id = uuid.uuid4().hex[:12]
+    low_sessions = [
+        (f"priority-pressure-{run_id}-low-{index}", args.token_base + index)
+        for index in range(args.low_sessions)
+    ]
+    high_sessions = [
+        (
+            f"priority-pressure-{run_id}-high-{index}",
+            args.token_base + args.low_sessions + index,
+        )
+        for index in range(args.high_sessions)
+    ]
+    opened: list[str] = []
+    events: list[GenerateResult] = []
+    controls: list[dict[str, Any]] = []
+
+    try:
+        capacity = args.prime_tokens + args.pressure_rounds * args.growth_tokens + 1024
+        for session_id, _ in low_sessions + high_sessions:
+            returned_id = request_json(
+                "POST",
+                base_url + "/open_session",
+                body={"session_id": session_id, "capacity_of_str_len": capacity},
+                timeout=args.timeout,
+            )
+            if returned_id != session_id:
+                raise RuntimeError(
+                    f"open_session returned {returned_id!r} for {session_id!r}"
+                )
+            opened.append(session_id)
+
+        events.extend(
+            run_batch(
+                base_url,
+                low_sessions,
+                input_tokens=args.prime_tokens,
+                phase="prime_low",
+                role="low",
+                round_index=0,
+                concurrency=args.pressure_concurrency,
+                timeout=args.timeout,
+            )
+        )
+        if not all(event.success for event in events):
+            raise RuntimeError("low-session priming failed")
+
+        for session_id, _ in low_sessions:
+            result = request_json(
+                "POST",
+                base_url + "/set_session_cache_priority",
+                body={
+                    "session_id": session_id,
+                    "cache_priority": (
+                        "evictable" if args.arm == "demoted" else "protected"
+                    ),
+                },
+                timeout=args.timeout,
+            )
+            controls.append({"session_id": session_id, "response": result})
+            targeted = [item for item in result if item["status"] != "not_targeted"]
+            if not targeted or not all(item["success"] for item in targeted):
+                raise RuntimeError(f"priority update failed for {session_id}: {result}")
+
+        events.extend(
+            run_batch(
+                base_url,
+                high_sessions,
+                input_tokens=args.prime_tokens,
+                phase="prime_high",
+                role="high",
+                round_index=0,
+                concurrency=args.pressure_concurrency,
+                timeout=args.timeout,
+            )
+        )
+        if not all(event.success for event in events):
+            raise RuntimeError("session priming failed")
+
+        for round_index in range(1, args.pressure_rounds + 1):
+            events.extend(
+                run_batch(
+                    base_url,
+                    low_sessions,
+                    input_tokens=args.prime_tokens + round_index * args.growth_tokens,
+                    phase="pressure_low",
+                    role="low",
+                    round_index=round_index,
+                    concurrency=args.pressure_concurrency,
+                    timeout=args.timeout,
+                )
+            )
+
+        events.extend(
+            run_batch(
+                base_url,
+                high_sessions,
+                input_tokens=args.prime_tokens,
+                phase="probe_high",
+                role="high",
+                round_index=args.pressure_rounds + 1,
+                concurrency=args.pressure_concurrency,
+                timeout=args.timeout,
+            )
+        )
+    finally:
+        for session_id in opened:
+            try:
+                request_json(
+                    "POST",
+                    base_url + "/close_session",
+                    body={"session_id": session_id},
+                    timeout=args.timeout,
+                )
+            except Exception as error:
+                controls.append({"session_id": session_id, "close_error": str(error)})
+
+    output = {
+        "run_id": run_id,
+        "arm": args.arm,
+        "config": {
+            key: str(value) if isinstance(value, Path) else value
+            for key, value in vars(args).items()
+        },
+        "server": {
+            "version": server_info.get("version"),
+            "model_path": server_info.get("model_path"),
+            "max_total_num_tokens": max_total_tokens,
+            "radix_eviction_policy": server_info.get("radix_eviction_policy"),
+            "enable_session_radix_cache": server_info.get("enable_session_radix_cache"),
+        },
+        "working_set": {
+            "initial_tokens": initial_tokens,
+            "final_tokens": final_tokens,
+            "capacity_tokens": max_total_tokens,
+            "pressure_tokens": final_tokens - max_total_tokens,
+        },
+        "controls": controls,
+        "events": [asdict(event) for event in events],
+        "summary": summarize(events, args.prime_tokens),
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(output["summary"], indent=2))
+    if not output["summary"]["all_requests_succeeded"]:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_allocator.py
@@ -83,6 +83,7 @@ def alloc_paged_token_slots_reserve_extend(
     req_pool_indices: Optional[torch.Tensor] = None,
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
+    allow_protected_session_cache: bool = True,
 ):
     """Allocate reserved draft slots and update DSV4 per-request tables."""
     if dsv4_state_lens is None and batch is not None:
@@ -106,6 +107,7 @@ def alloc_paged_token_slots_reserve_extend(
         req_pool_indices=req_pool_indices,
         dsv4_state_lens=dsv4_state_lens,
         batch=batch,
+        allow_protected_session_cache=allow_protected_session_cache,
     )
     if batch is not None:
         maybe_write_dsv4_extend(

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1907,6 +1907,7 @@ def release_req(
     tree_cache: BasePrefixCache,
     hisparse_coordinator: Optional[HiSparseCoordinator],
     offload_kv: bool = True,
+    allow_protected_session_cache: bool = True,
 ) -> None:
     if hisparse_coordinator is not None and not req.finished():
         hisparse_coordinator.retract_req(req)
@@ -1921,7 +1922,11 @@ def release_req(
     release_kv_cache(req, tree_cache, is_insert=False)
     # NOTE(lsyin): we should use the newly evictable memory instantly.
     num_tokens = remaing_req_count * envs.SGLANG_RETRACT_DECODE_STEPS.get()
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(
+        tree_cache,
+        num_tokens,
+        allow_protected_session_cache=allow_protected_session_cache,
+    )
 
     req.reset_for_retract()
 
@@ -2759,6 +2764,27 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def new_tokens_required_next_decode(
         self, selected_indices: Optional[List[int]] = None
     ):
+        return sum(
+            new_tokens
+            for _, new_tokens in self._requests_and_tokens_required_next_decode(
+                selected_indices
+            )
+        )
+
+    def requests_requiring_next_decode_allocation(
+        self, selected_indices: Optional[List[int]] = None
+    ) -> List[Req]:
+        return [
+            req
+            for req, new_tokens in self._requests_and_tokens_required_next_decode(
+                selected_indices
+            )
+            if new_tokens > 0
+        ]
+
+    def _requests_and_tokens_required_next_decode(
+        self, selected_indices: Optional[List[int]] = None
+    ) -> List[Tuple[Req, int]]:
         page_size = self.token_to_kv_pool_allocator.page_size
         requests = (
             self.reqs
@@ -2767,27 +2793,41 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         )
 
         if self.spec_algorithm.is_none():
-            new_pages = sum(1 for r in requests if r.kv_committed_len % page_size == 0)
-            return new_pages * page_size
+            return [
+                (r, page_size if r.kv_committed_len % page_size == 0 else 0)
+                for r in requests
+            ]
 
         return self._new_tokens_required_next_decode_spec_v2(requests, page_size)
 
     def _new_tokens_required_next_decode_spec_v2(self, requests, page_size):
         """Tight estimate matching eagle_utils.eagle_prepare_for_decode allocation."""
         reserve = get_alloc_reserve_per_decode()
-        total = 0
+        required = []
         for r in requests:
             x = max(0, r.kv_committed_len + reserve - r.kv.kv_allocated_len)
             cur = r.kv.kv_allocated_len
             nxt = cur + x
-            total += ceil_align(nxt, page_size) - ceil_align(cur, page_size)
-        return total
+            required.append(
+                (r, ceil_align(nxt, page_size) - ceil_align(cur, page_size))
+            )
+        return required
 
     def check_decode_mem(self, selected_indices: Optional[List[int]] = None):
         """Reclaim evictable tree-cache entries (shortfall only), then report
         whether the next decode step fits in the KV pool."""
-        num_tokens = self.new_tokens_required_next_decode(selected_indices)
-        evict_from_tree_cache(self.tree_cache, num_tokens)
+        required = self._requests_and_tokens_required_next_decode(selected_indices)
+        num_tokens = sum(new_tokens for _, new_tokens in required)
+        allocation_reqs = [req for req, new_tokens in required if new_tokens > 0]
+        allow_protected_session_cache = bool(allocation_reqs) and all(
+            self.tree_cache.request_can_evict_protected_session_cache(req)
+            for req in allocation_reqs
+        )
+        evict_from_tree_cache(
+            self.tree_cache,
+            num_tokens,
+            allow_protected_session_cache=allow_protected_session_cache,
+        )
         return self.token_to_kv_pool_allocator.available_size() >= num_tokens
 
     def retract_decode(
@@ -2795,6 +2835,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     ) -> Tuple[List[Req], float, List[Req]]:
         """Retract the decoding requests when there is not enough memory."""
         sorted_indices = self._get_decode_retraction_order(self.reqs, server_args)
+        # A mixed batch may evict protected session KV only after every demoted
+        # requester has been retracted. Keep normal scheduling order within
+        # each partition.
+        sorted_indices = [
+            i
+            for i in sorted_indices
+            if self.tree_cache.request_can_evict_protected_session_cache(self.reqs[i])
+        ] + [
+            i
+            for i in sorted_indices
+            if not self.tree_cache.request_can_evict_protected_session_cache(
+                self.reqs[i]
+            )
+        ]
 
         retracted_reqs = []
         first_iter = True
@@ -2810,7 +2864,20 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req = self.reqs[idx]
             retracted_reqs.append(req)
             # release memory and don't insert into the tree because we need the space instantly
-            self.release_req(idx, len(sorted_indices), server_args)
+            self.release_req(
+                idx,
+                len(sorted_indices),
+                server_args,
+                allow_protected_session_cache=(
+                    bool(sorted_indices)
+                    and all(
+                        self.tree_cache.request_can_evict_protected_session_cache(
+                            self.reqs[remaining_idx]
+                        )
+                        for remaining_idx in sorted_indices
+                    )
+                ),
+            )
 
         reqs_to_abort: List[Req] = []
         if len(sorted_indices) <= 1 and not self.check_decode_mem(
@@ -2881,7 +2948,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         )
         return sorted_indices
 
-    def release_req(self, idx: int, remaing_req_count: int, server_args: ServerArgs):
+    def release_req(
+        self,
+        idx: int,
+        remaing_req_count: int,
+        server_args: ServerArgs,
+        *,
+        allow_protected_session_cache: bool = True,
+    ):
         release_req(
             req=self.reqs[idx],
             remaing_req_count=remaing_req_count,
@@ -2890,6 +2964,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             tree_cache=self.tree_cache,
             hisparse_coordinator=self.hisparse_coordinator,
+            allow_protected_session_cache=allow_protected_session_cache,
         )
 
     def prepare_encoder_info_decode(self):

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -527,6 +527,14 @@ class PrefillAdder:
 
         self.req_states = None
         self.can_run_list = []
+        self._allocation_allows_protected_session_cache = (
+            not num_mixed_decode_tokens
+            or running_batch is None
+            or all(
+                self.tree_cache.request_can_evict_protected_session_cache(req)
+                for req in running_batch.reqs
+            )
+        )
         self.preempt_list = []
         self.new_chunked_req = None
         self.log_hit_tokens = 0
@@ -581,6 +589,7 @@ class PrefillAdder:
         # that mamba-recoverable budget separately or an over-admit hits the
         # fail-loud `RuntimeError`. `None` outside the unified Mamba pool.
         self.rem_mamba_slots = None
+        self.rem_mamba_slot_offset = 0
         if self._mamba_slot_cost:
             self.rem_mamba_slots = (
                 self.token_to_kv_pool_allocator.mamba_allocator.schedulable_available_size()
@@ -670,11 +679,57 @@ class PrefillAdder:
             )
         return available_and_evictable - self.rem_total_token_offset
 
+    def _request_can_evict_protected_session_cache(self, req: Req) -> bool:
+        return (
+            self._allocation_allows_protected_session_cache
+            and self.tree_cache.request_can_evict_protected_session_cache(req)
+        )
+
+    def _append_can_run_req(self, req: Req) -> None:
+        self.can_run_list.append(req)
+        self._allocation_allows_protected_session_cache &= (
+            self.tree_cache.request_can_evict_protected_session_cache(req)
+        )
+
+    def _rem_total_tokens_for_req(self, req: Req) -> int:
+        if self._request_can_evict_protected_session_cache(req):
+            return self.rem_total_tokens
+        if self.is_all_swa:
+            available_and_evictable = (
+                self.token_to_kv_pool_allocator.swa_available_size()
+                + self.tree_cache.swa_evictable_size_without_session_refs()
+            )
+        elif self.is_hybrid_swa:
+            available_and_evictable = (
+                self.token_to_kv_pool_allocator.full_available_size()
+                + self.tree_cache.full_evictable_size_without_session_refs()
+            )
+        elif self.is_hybrid_ssm_cache:
+            available_and_evictable = (
+                self.token_to_kv_pool_allocator.available_size()
+                + self.tree_cache.full_evictable_size_without_session_refs()
+            )
+        else:
+            available_and_evictable = (
+                self.token_to_kv_pool_allocator.available_size()
+                + self.tree_cache.evictable_size_without_session_refs()
+            )
+        return available_and_evictable - self.rem_total_token_offset
+
     @property
     def rem_swa_tokens(self):
         return (
             self.token_to_kv_pool_allocator.swa_available_size()
             + self.tree_cache.swa_evictable_size()
+            - self.rem_swa_token_offset
+        )
+
+    def _rem_swa_tokens_for_req(self, req: Req) -> int:
+        if self._request_can_evict_protected_session_cache(req):
+            return self.rem_swa_tokens
+        return (
+            self.token_to_kv_pool_allocator.swa_available_size()
+            + self.tree_cache.swa_evictable_size_without_session_refs()
             - self.rem_swa_token_offset
         )
 
@@ -702,6 +757,29 @@ class PrefillAdder:
             )
 
         return available_and_evictable - self.cur_rem_token_offset
+
+    def _cur_rem_tokens_for_req(self, req: Req) -> int:
+        return self._rem_total_tokens_for_req(req) + (
+            self.rem_total_token_offset - self.cur_rem_token_offset
+        )
+
+    def _rem_mamba_slots_for_req(self, req: Req) -> Optional[int]:
+        if self.rem_mamba_slots is None:
+            return None
+        if self._request_can_evict_protected_session_cache(req):
+            return self.rem_mamba_slots
+        remaining = (
+            self.token_to_kv_pool_allocator.mamba_allocator.schedulable_available_size()
+        )
+        if self.is_hybrid_ssm_cache:
+            remaining += self.tree_cache.mamba_evictable_size_without_session_refs()
+        return remaining - self.rem_mamba_slot_offset
+
+    def _has_mamba_slot_for_req(self, req: Req) -> bool:
+        if self._mamba_gap_budget_for_req(req) == 0:
+            return True
+        remaining = self._rem_mamba_slots_for_req(req)
+        return remaining is None or remaining > 0
 
     def _swa_budget_for_req(
         self, extend_input_len: int, max_new_tokens: int, swa_host_hit_length: int = 0
@@ -758,7 +836,12 @@ class PrefillAdder:
             CLIP_MAX_NEW_TOKENS,
         )
 
-    def _swa_chunk_cap(self, max_new_tokens: int, swa_host_hit_length: int = 0) -> int:
+    def _swa_chunk_cap(
+        self,
+        max_new_tokens: int,
+        swa_host_hit_length: int = 0,
+        req: Optional[Req] = None,
+    ) -> int:
         """Largest page-aligned extend chunk the SWA pool can admit right now,
         keeping a sliding window of headroom below rem_swa_tokens; 0 if not
         even one page fits. Only valid when is_hybrid_swa is True.
@@ -771,7 +854,10 @@ class PrefillAdder:
         evictable — so each pass's transient footprint fits the pool."""
         # extend_input_len=0: this solves for the extend chunk itself, so the
         # reserved headroom is the post-chunk decode window only.
-        cap = int(self.rem_swa_tokens) - self._swa_reserved_tokens(
+        rem_swa_tokens = (
+            self.rem_swa_tokens if req is None else self._rem_swa_tokens_for_req(req)
+        )
+        cap = int(rem_swa_tokens) - self._swa_reserved_tokens(
             0, max_new_tokens, swa_host_hit_length
         )
         if cap <= 0:
@@ -869,6 +955,7 @@ class PrefillAdder:
         # separately so full_evictable can't cover it — see __init__).
         if mamba_gap_reserve and self.rem_mamba_slots is not None:
             self.rem_mamba_slots -= 1
+            self.rem_mamba_slot_offset += 1
         self.rem_input_tokens -= extend_input_len
 
         if self.is_hybrid_swa:
@@ -898,13 +985,20 @@ class PrefillAdder:
             self.log_host_hit_tokens += host_hit
             self.log_storage_hit_tokens += storage_hit
 
-    def _get_dllm_remain_tokens(self) -> int:
+    def _get_dllm_remain_tokens(self, req: Optional[Req] = None) -> int:
+        rem_total_tokens = (
+            self.rem_total_tokens
+            if req is None
+            else self._rem_total_tokens_for_req(req)
+        )
         _rem_tokens = min(
             self.rem_dllm_tokens,
             self.dllm_block_size,
-            int(self.rem_total_tokens),
+            int(rem_total_tokens),
         )
-        if _rem_tokens <= 0:
+        if _rem_tokens <= 0 and (
+            req is None or self._request_can_evict_protected_session_cache(req)
+        ):
             _rem_tokens = self.rem_dllm_tokens
 
         return _rem_tokens
@@ -921,7 +1015,7 @@ class PrefillAdder:
 
         req.set_extend_range(prefix_len, prefix_len + trunc_len)
 
-        self.can_run_list.append(req)
+        self._append_can_run_req(req)
 
         self._update_prefill_budget(
             prefix_len,
@@ -943,9 +1037,9 @@ class PrefillAdder:
 
     def add_dllm_staging_req(self, req: Req):
         assert self.dllm_config is not None
-        _rem_tokens = self._get_dllm_remain_tokens()
+        _rem_tokens = self._get_dllm_remain_tokens(req)
 
-        if _rem_tokens <= 0:
+        if _rem_tokens <= 0 or not self._has_mamba_slot_for_req(req):
             return AddReqResult.NO_TOKEN
 
         # Truncate input length to available tokens and update request metadata
@@ -957,7 +1051,7 @@ class PrefillAdder:
         truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
-        self.can_run_list.append(req)
+        self._append_can_run_req(req)
 
         # Update budget: reserve max_new_tokens only if not truncated
         max_new_tokens = (
@@ -976,27 +1070,38 @@ class PrefillAdder:
         # Return based on remaining token availability
         return (
             AddReqResult.NO_TOKEN
-            if self._get_dllm_remain_tokens() <= 0
+            if self._get_dllm_remain_tokens(req) <= 0
             else AddReqResult.CONTINUE
         )
 
     def add_chunked_req(self, req: Req):
+        if not self._has_mamba_slot_for_req(req):
+            return req
         if self.dllm_config is not None:
-            _rem_tokens = self._get_dllm_remain_tokens()
+            _rem_tokens = self._get_dllm_remain_tokens(req)
         else:
-            _rem_tokens = min(self.rem_chunk_tokens, int(self.rem_total_tokens))
+            _rem_tokens = min(
+                self.rem_chunk_tokens, int(self._rem_total_tokens_for_req(req))
+            )
             if self.is_hybrid_swa:
                 # alloc_extend needs extend_num_tokens + page_size per request,
                 # so reserve one page here to avoid OOM
                 _rem_tokens = min(
-                    _rem_tokens, int(self.rem_swa_tokens) - self.page_size
+                    _rem_tokens,
+                    int(self._rem_swa_tokens_for_req(req)) - self.page_size,
                 )
             # The chunked_req must be added to the list; otherwise, it will cause a memory leak.
             # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
             if _rem_tokens <= 0:
-                if self.is_hybrid_swa:
+                if (
+                    self.is_hybrid_swa
+                    or not self._request_can_evict_protected_session_cache(req)
+                ):
                     return req
                 _rem_tokens = self.rem_chunk_tokens
+
+        if _rem_tokens <= 0:
+            return req
 
         # A mid-chunk rank prefills this pass regardless of the delayer
         # verdict, so report prefillable=True and ignore the result.
@@ -1015,7 +1120,7 @@ class PrefillAdder:
         truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
-        self.can_run_list.append(req)
+        self._append_can_run_req(req)
         self._update_prefill_budget(
             0,
             req.extend_range.length,
@@ -1056,15 +1161,14 @@ class PrefillAdder:
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into the
         # budget gate so admission can't over-commit (0 for baseline / non-Mamba).
         paged_input += self._mamba_gap_budget_for_req(req)
-        if paged_input > min(self.cur_rem_tokens, self.rem_total_tokens):
+        if paged_input > min(
+            self._cur_rem_tokens_for_req(req), self._rem_total_tokens_for_req(req)
+        ) or not self._has_mamba_slot_for_req(req):
             return AddReqResult.NO_TOKEN
         if self.is_hybrid_swa:
-            if (
-                self._swa_budget_for_req(
-                    cand_extend_input_len, self._swa_new_tokens(req)
-                )
-                > self.rem_swa_tokens
-            ):
+            if self._swa_budget_for_req(
+                cand_extend_input_len, self._swa_new_tokens(req)
+            ) > self._rem_swa_tokens_for_req(req):
                 return AddReqResult.NO_TOKEN
 
         def add_req_state(r, insert_sort=False):
@@ -1103,7 +1207,7 @@ class PrefillAdder:
         if not self.is_hybrid_swa:
             # Skip this logic for swa. The SWA has different memory management, and
             # this mechanism is underestimating the memory usage.
-            cur_rem_tokens = self.cur_rem_tokens - self.ceil_paged_tokens(
+            cur_rem_tokens = self._cur_rem_tokens_for_req(req) - self.ceil_paged_tokens(
                 cand_extend_input_len
             )
             tokens_freed = 0
@@ -1150,7 +1254,7 @@ class PrefillAdder:
             req.set_extend_range(
                 len(req.prefix_indices), len(req.full_untruncated_fill_ids)
             )
-            self.can_run_list.append(req)
+            self._append_can_run_req(req)
             self._update_prefill_budget(
                 0,
                 req.extend_range.length,
@@ -1172,7 +1276,7 @@ class PrefillAdder:
             req.set_extend_range(
                 len(req.prefix_indices), len(req.prefix_indices) + trunc_len
             )
-            self.can_run_list.append(req)
+            self._append_can_run_req(req)
             self.new_chunked_req = req
             self._update_prefill_budget(
                 0,
@@ -1219,7 +1323,9 @@ class PrefillAdder:
         real_input_tokens = self.ceil_paged_tokens(real_input_tokens)
         prefix_len = len(req.prefix_indices)
 
-        if total_tokens >= self.rem_total_tokens:
+        if total_tokens >= self._rem_total_tokens_for_req(
+            req
+        ) or not self._has_mamba_slot_for_req(req):
             return AddReqResult.NO_TOKEN
 
         chunk_tokens_limit = self.rem_chunk_tokens
@@ -1232,7 +1338,7 @@ class PrefillAdder:
                 self._swa_new_tokens(req),
                 swa_host_hit_length=req.swa_host_hit_length,
             )
-            if swa_needed >= self.rem_swa_tokens:
+            if swa_needed >= self._rem_swa_tokens_for_req(req):
                 if not self._swa_req_never_fits(
                     real_input_tokens,
                     self._swa_new_tokens(req),
@@ -1240,7 +1346,7 @@ class PrefillAdder:
                 ):
                     return AddReqResult.NO_TOKEN
                 swa_cap = self._swa_chunk_cap(
-                    self._swa_new_tokens(req), req.swa_host_hit_length
+                    self._swa_new_tokens(req), req.swa_host_hit_length, req
                 )
                 if self.rem_chunk_tokens is None or swa_cap <= 0:
                     return AddReqResult.NO_TOKEN
@@ -1258,7 +1364,7 @@ class PrefillAdder:
 
         with self._lock_node(req.last_node):
             # self.rem_total_tokens may decrease after the lock acquisition
-            if total_tokens >= self.rem_total_tokens:
+            if total_tokens >= self._rem_total_tokens_for_req(req):
                 return AddReqResult.NO_TOKEN
 
             if self.is_hybrid_swa:
@@ -1268,7 +1374,7 @@ class PrefillAdder:
                     self._swa_new_tokens(req),
                     swa_host_hit_length=req.swa_host_hit_length,
                 )
-                if swa_needed >= self.rem_swa_tokens:
+                if swa_needed >= self._rem_swa_tokens_for_req(req):
                     if not self._swa_req_never_fits(
                         real_input_tokens,
                         self._swa_new_tokens(req),
@@ -1276,7 +1382,7 @@ class PrefillAdder:
                     ):
                         return AddReqResult.NO_TOKEN
                     swa_cap = self._swa_chunk_cap(
-                        self._swa_new_tokens(req), req.swa_host_hit_length
+                        self._swa_new_tokens(req), req.swa_host_hit_length, req
                     )
                     if self.rem_chunk_tokens is None or swa_cap <= 0:
                         return AddReqResult.NO_TOKEN
@@ -1347,7 +1453,7 @@ class PrefillAdder:
                 req.set_extend_range(
                     len(req.prefix_indices), len(req.full_untruncated_fill_ids)
                 )
-                self.can_run_list.append(req)
+                self._append_can_run_req(req)
 
                 self._req_inc_lock_ref(req)
                 self._update_prefill_budget(
@@ -1397,7 +1503,7 @@ class PrefillAdder:
                     len(req.prefix_indices), len(req.prefix_indices) + trunc_len
                 )
 
-                self.can_run_list.append(req)
+                self._append_can_run_req(req)
                 self.new_chunked_req = req
 
                 self._req_inc_lock_ref(req)
@@ -1446,7 +1552,7 @@ class PrefillAdder:
             len(req.full_untruncated_fill_ids)
             - len(req.prefix_indices)
             + min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
-            - self.rem_total_tokens
+            - self._rem_total_tokens_for_req(req)
         )
         for running_req in sorted_valid_running_reqs:
             # Priority difference needs to meet the threshold to be preemptible.

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -146,9 +146,15 @@ def get_last_loc_torch(
 def alloc_token_slots(
     tree_cache: BasePrefixCache,
     num_tokens: int,
+    *,
+    allow_protected_session_cache: bool = True,
 ):
     allocator = tree_cache.token_to_kv_pool_allocator
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(
+        tree_cache,
+        num_tokens,
+        allow_protected_session_cache=allow_protected_session_cache,
+    )
 
     out_cache_loc = allocator.alloc(num_tokens)
 
@@ -201,11 +207,16 @@ def alloc_paged_token_slots_extend(
     req_pool_indices: Optional[torch.Tensor] = None,
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
+    allow_protected_session_cache: bool = True,
 ):
     # Over estimate the number of tokens: assume each request needs a new page.
     allocator = tree_cache.token_to_kv_pool_allocator
     num_tokens = extend_num_tokens + len(seq_lens_cpu) * allocator.page_size
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(
+        tree_cache,
+        num_tokens,
+        allow_protected_session_cache=allow_protected_session_cache,
+    )
 
     is_dsv4 = req_pool_indices is not None and hasattr(allocator, "c4_attn_allocator")
     extra_alloc_kwargs = {}
@@ -253,6 +264,8 @@ def alloc_req_slots(
     req_to_token_pool: ReqToTokenPool,
     reqs: list[Req],
     tree_cache: BasePrefixCache | None,
+    *,
+    allow_protected_session_cache: bool = True,
 ) -> list[int]:
     """Allocate request slots from the pool.
 
@@ -280,7 +293,13 @@ def alloc_req_slots(
         if mamba_available_size < mamba_state_needed:
             if tree_cache is not None and tree_cache.supports_mamba():
                 mamba_num = max(0, mamba_state_needed - mamba_available_size)
-                tree_cache.evict(EvictParams(num_tokens=0, mamba_num=mamba_num))
+                tree_cache.evict(
+                    EvictParams(
+                        num_tokens=0,
+                        mamba_num=mamba_num,
+                        allow_protected_session_cache=allow_protected_session_cache,
+                    )
+                )
     req_pool_indices = req_to_token_pool.alloc(reqs)
     if req_pool_indices is None:
         raise RuntimeError(
@@ -300,6 +319,14 @@ def _alloc_page_size(batch: ScheduleBatch) -> int:
     return batch.tree_cache.page_size
 
 
+def _requests_can_evict_protected_session_cache(
+    tree_cache: BasePrefixCache, reqs: list[Req]
+) -> bool:
+    return bool(reqs) and all(
+        tree_cache.request_can_evict_protected_session_cache(req) for req in reqs
+    )
+
+
 def alloc_for_extend(
     batch: ScheduleBatch,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
@@ -314,6 +341,12 @@ def alloc_for_extend(
     batch.maybe_evict_swa()
 
     prefix_tensors = [r.prefix_indices for r in batch.reqs]
+    allocation_reqs = [
+        req for req, extend_len in zip(batch.reqs, batch.extend_lens) if extend_len > 0
+    ]
+    allow_protected_session_cache = _requests_can_evict_protected_session_cache(
+        batch.tree_cache, allocation_reqs
+    )
 
     reuse_kv = None
     if batch.is_dllm():
@@ -329,8 +362,17 @@ def alloc_for_extend(
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
     # Allocate req slots (raises RuntimeError if the pool is exhausted)
+    req_slot_allocation_reqs = [req for req in batch.reqs if req.req_pool_idx is None]
+    req_slots_allow_protected_session_cache = (
+        _requests_can_evict_protected_session_cache(
+            batch.tree_cache, req_slot_allocation_reqs
+        )
+    )
     req_pool_indices = alloc_req_slots(
-        batch.req_to_token_pool, batch.reqs, batch.tree_cache
+        batch.req_to_token_pool,
+        batch.reqs,
+        batch.tree_cache,
+        allow_protected_session_cache=req_slots_allow_protected_session_cache,
     )
     req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
@@ -348,7 +390,11 @@ def alloc_for_extend(
             alloc_page_size,
         )
     elif alloc_page_size == 1:
-        out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
+        out_cache_loc = alloc_token_slots(
+            batch.tree_cache,
+            batch.extend_num_tokens,
+            allow_protected_session_cache=allow_protected_session_cache,
+        )
     else:
         # Paged allocation - build last_loc
         last_loc = [
@@ -366,6 +412,7 @@ def alloc_for_extend(
             req_pool_indices=req_pool_indices_device,
             dsv4_state_lens=_compute_dsv4_state_lens(batch, is_decode=False),
             batch=batch,
+            allow_protected_session_cache=allow_protected_session_cache,
         )
 
     # Write to req_to_token_pool
@@ -433,8 +480,18 @@ def _alloc_extend_loc_with_kv_reuse(
 
     fresh_slots = None
     if alloc_extend_num_tokens > 0:
+        fresh_reqs = [
+            req for req, should_reuse in zip(batch.reqs, reuse_kv) if not should_reuse
+        ]
+        allow_protected_session_cache = _requests_can_evict_protected_session_cache(
+            batch.tree_cache, fresh_reqs
+        )
         if alloc_page_size == 1:
-            fresh_slots = alloc_token_slots(batch.tree_cache, alloc_extend_num_tokens)
+            fresh_slots = alloc_token_slots(
+                batch.tree_cache,
+                alloc_extend_num_tokens,
+                allow_protected_session_cache=allow_protected_session_cache,
+            )
         else:
             alloc_seq_lens_cpu = torch.tensor(
                 [
@@ -462,6 +519,7 @@ def _alloc_extend_loc_with_kv_reuse(
                 req_pool_indices=req_pool_indices_device,
                 dsv4_state_lens=_compute_dsv4_state_lens(batch, is_decode=False),
                 batch=batch,
+                allow_protected_session_cache=allow_protected_session_cache,
             )
 
     reuse_dtype = fresh_slots.dtype if fresh_slots is not None else torch.int64
@@ -493,12 +551,17 @@ def alloc_paged_token_slots_decode(
     req_pool_indices: Optional[torch.Tensor] = None,
     dsv4_state_lens: Optional[DSV4StateLens] = None,
     batch=None,
+    allow_protected_session_cache: bool = True,
 ) -> torch.Tensor:
     """Allocate paged KV cache for decode batch."""
     allocator = tree_cache.token_to_kv_pool_allocator
     # Over estimate the number of tokens: assume each request needs a new page.
     num_tokens = len(seq_lens) * allocator.page_size
-    evict_from_tree_cache(tree_cache, num_tokens)
+    evict_from_tree_cache(
+        tree_cache,
+        num_tokens,
+        allow_protected_session_cache=allow_protected_session_cache,
+    )
 
     # DSV4-NPU allocator also needs req_pool_indices + per-req state lens and
     # returns a DSV4OutCacheLoc bundle; hasattr-gated so others stay unchanged.
@@ -545,13 +608,21 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
     """
 
     batch.maybe_evict_swa()
+    allocation_reqs = batch.requests_requiring_next_decode_allocation()
+    allow_protected_session_cache = _requests_can_evict_protected_session_cache(
+        batch.tree_cache, allocation_reqs
+    )
 
     seq_lens_gpu = batch.seq_lens
     bs = seq_lens_gpu.shape[0]
 
     if _alloc_page_size(batch) == 1:
         # Non-paged allocation
-        out_cache_loc = alloc_token_slots(batch.tree_cache, bs * token_per_req)
+        out_cache_loc = alloc_token_slots(
+            batch.tree_cache,
+            bs * token_per_req,
+            allow_protected_session_cache=allow_protected_session_cache,
+        )
     else:
         # Paged allocation
         last_loc = batch.req_to_token_pool.req_to_token[
@@ -567,6 +638,7 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
             req_pool_indices=batch.req_pool_indices,
             dsv4_state_lens=_compute_dsv4_state_lens(batch, is_decode=True),
             batch=batch,
+            allow_protected_session_cache=allow_protected_session_cache,
         )
 
     # Write to req_to_token_pool
@@ -685,8 +757,20 @@ def alloc_for_spec_decode(
     batch: Optional[ScheduleBatch] = None,
 ) -> None:
     if num_needed_tokens > 0:
+        allocation_reqs = [
+            req
+            for req, cur_len, nxt_len in zip(reqs, cur_kv_lens_cpu, nxt_kv_lens_cpu)
+            if int(nxt_len) > int(cur_len)
+        ]
+        allow_protected_session_cache = _requests_can_evict_protected_session_cache(
+            tree_cache, allocation_reqs
+        )
         if tree_cache.token_to_kv_pool_allocator.page_size == 1:
-            out_cache_loc = alloc_token_slots(tree_cache, num_needed_tokens)
+            out_cache_loc = alloc_token_slots(
+                tree_cache,
+                num_needed_tokens,
+                allow_protected_session_cache=allow_protected_session_cache,
+            )
         else:
             last_loc = get_last_loc(
                 req_to_token_pool.req_to_token, req_pool_indices, cur_kv_lens
@@ -704,6 +788,7 @@ def alloc_for_spec_decode(
                 num_needed_tokens,
                 req_pool_indices=req_pool_indices,
                 batch=batch,
+                allow_protected_session_cache=allow_protected_session_cache,
             )
         # Updating req_to_token is a write to a shared tensor: it must not overlap
         # with the previous batch's forward, which also reads req_to_token.

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -98,6 +98,7 @@ class EvictParams:
     num_tokens: int = 0
     swa_num_tokens: int = 0
     mamba_num: int = 0
+    allow_protected_session_cache: bool = True
 
 
 @dataclasses.dataclass
@@ -334,6 +335,24 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
 
     def swa_evictable_size(self):
         return 0
+
+    def mamba_evictable_size(self):
+        return 0
+
+    def evictable_size_without_session_refs(self):
+        return self.evictable_size()
+
+    def full_evictable_size_without_session_refs(self):
+        return self.full_evictable_size()
+
+    def swa_evictable_size_without_session_refs(self):
+        return self.swa_evictable_size()
+
+    def mamba_evictable_size_without_session_refs(self):
+        return self.mamba_evictable_size()
+
+    def request_can_evict_protected_session_cache(self, req: Req) -> bool:
+        return True
 
     def protected_size(self):
         return 0

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -102,7 +102,12 @@ def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
     tree_cache.cache_unfinished_req(req, **kwargs)
 
 
-def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
+def evict_from_tree_cache(
+    tree_cache: BasePrefixCache | None,
+    num_tokens: int,
+    *,
+    allow_protected_session_cache: bool = True,
+):
     if tree_cache is None:
         return
 
@@ -120,13 +125,22 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):
             full_num_tokens = max(0, num_tokens - full_available_size)
             swa_num_tokens = max(0, num_tokens - swa_available_size)
             tree_cache.evict(
-                EvictParams(num_tokens=full_num_tokens, swa_num_tokens=swa_num_tokens)
+                EvictParams(
+                    num_tokens=full_num_tokens,
+                    swa_num_tokens=swa_num_tokens,
+                    allow_protected_session_cache=allow_protected_session_cache,
+                )
             )
     else:
         # Standard allocator: evict only the shortfall (mirrors the SWA arm)
         available_size = allocator.available_size()
         if available_size < num_tokens:
-            tree_cache.evict(EvictParams(num_tokens=num_tokens - available_size))
+            tree_cache.evict(
+                EvictParams(
+                    num_tokens=num_tokens - available_size,
+                    allow_protected_session_cache=allow_protected_session_cache,
+                )
+            )
 
 
 def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = True):

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -219,6 +219,11 @@ class FullComponent(TreeComponent):
             _, x = heapq.heappop(self._evict_device_heap)
             if x not in self.tree_core.evictable_device_leaves:
                 continue
+            if (
+                not self._allow_protected_session_cache_eviction
+                and self.session_ref(x) > 0
+            ):
+                return None
             self._evict_device_last_node = x
             return x.id
         return None

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -13,6 +13,7 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     InsertResult,
     MatchPrefixParams,
     MatchResult,
+    zero_match_result,
 )
 from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
@@ -199,12 +200,15 @@ class MambaComponent(TreeComponent):
                 # stops at this request's window boundary instead of walking to
                 # root and over-decrementing locks held by other requests.
                 lock_result = self.cache.inc_lock_ref(result.best_match_node)
-                self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+                self._evict_mamba_for_req(req)
                 dst_index = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
                 self.cache.dec_lock_ref(
                     result.best_match_node, lock_result.to_dec_params()
                 )
-                assert dst_index is not None, "Can not alloc mamba cache"
+                if dst_index is None:
+                    return zero_match_result(
+                        self.cache, result, extra_key=params.key.extra_key
+                    )
             req.mamba_pool_idx = dst_index[0]
         req.mamba_cow_src_index = src_index
         req.mamba_needs_clear = False
@@ -390,6 +394,11 @@ class MambaComponent(TreeComponent):
         ):
             x = self._evict_device_cursor
             assert x.component_data[ct].value is not None
+            if (
+                not self._allow_protected_session_cache_eviction
+                and self.session_ref(x) > 0
+            ):
+                return None
             if x in self.tree_core.evictable_device_leaves and (
                 not enabled or self._can_evict_leaf_atomically(x)
             ):
@@ -479,11 +488,23 @@ class MambaComponent(TreeComponent):
                 self.tree_core.component_protected_size_[ct] -= vlen
             cd.lock_ref -= 1
 
-    def _alloc_mamba_slot(self) -> torch.Tensor:
+    def _evict_mamba_for_req(self, req: Optional[Req] = None) -> None:
+        self.cache.evict(
+            EvictParams(
+                num_tokens=0,
+                mamba_num=1,
+                allow_protected_session_cache=(
+                    req is None
+                    or self.cache.request_can_evict_protected_session_cache(req)
+                ),
+            )
+        )
+
+    def _alloc_mamba_slot(self, req: Optional[Req] = None) -> torch.Tensor:
         """Allocate one mamba pool slot, evicting if necessary."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
-            self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+            self._evict_mamba_for_req(req)
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert slot is not None, "Can not alloc mamba cache"
         return slot
@@ -492,16 +513,18 @@ class MambaComponent(TreeComponent):
     def int8_ckpt_pool(self):
         return getattr(self.cache.req_to_token_pool, "mamba_ckpt_pool", None)
 
-    def _alloc_int8_ckpt_slot(self) -> torch.Tensor:
+    def _alloc_int8_ckpt_slot(self, req: Req) -> torch.Tensor:
         slot = self.int8_ckpt_pool.alloc(1)
         if slot is None:
-            self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+            self._evict_mamba_for_req(req)
             slot = self.int8_ckpt_pool.alloc(1)
             assert slot is not None, "Can not alloc int8 mamba checkpoint slot"
         return slot
 
-    def _commit_int8_checkpoint(self, active_slots: torch.Tensor) -> torch.Tensor:
-        ckpt_slot = self._alloc_int8_ckpt_slot()
+    def _commit_int8_checkpoint(
+        self, active_slots: torch.Tensor, req: Req
+    ) -> torch.Tensor:
+        ckpt_slot = self._alloc_int8_ckpt_slot(req)
         self.int8_ckpt_pool.store_from_active(
             self.cache.req_to_token_pool.mamba_pool,
             active_slots.view(-1),
@@ -553,7 +576,9 @@ class MambaComponent(TreeComponent):
             else:
                 active_value = req.mamba_pool_idx.unsqueeze(-1).clone()
             if self.int8_ckpt_pool is not None:
-                insert_params.mamba_value = self._commit_int8_checkpoint(active_value)
+                insert_params.mamba_value = self._commit_int8_checkpoint(
+                    active_value, req
+                )
             else:
                 insert_params.mamba_value = active_value
             return cache_len
@@ -563,27 +588,27 @@ class MambaComponent(TreeComponent):
             # Donate the mamba index to the radix cache instead of copying.
             if self.int8_ckpt_pool is not None:
                 if self.cache.enable_mamba_extra_buffer:
-                    new_slot = self._alloc_mamba_slot()
+                    new_slot = self._alloc_mamba_slot(req)
                     src_active = (
                         self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                             req, new_slot
                         )
                     )
-                    mamba_value_donated = self._commit_int8_checkpoint(src_active)
+                    mamba_value_donated = self._commit_int8_checkpoint(src_active, req)
                     self.cache.req_to_token_pool.mamba_allocator.free(src_active)
                 else:
                     mamba_value_donated = self._commit_int8_checkpoint(
-                        req.mamba_pool_idx.view(-1)
+                        req.mamba_pool_idx.view(-1), req
                     )
             elif self.cache.enable_mamba_extra_buffer:
-                new_slot = self._alloc_mamba_slot()
+                new_slot = self._alloc_mamba_slot(req)
                 mamba_value_donated = (
                     self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                         req, new_slot
                     )
                 )
             else:
-                mamba_value_donated = self._alloc_mamba_slot()
+                mamba_value_donated = self._alloc_mamba_slot(req)
                 # mamba_pool is a pure PHYSICAL store; translate both slot ids
                 # virtual->physical (identity for the non-unified memory pool) first.
                 translate = self.cache.req_to_token_pool.translate_mamba_indices
@@ -656,7 +681,7 @@ class MambaComponent(TreeComponent):
             return PrepareLoadBackResult()
         dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if dst is None:
-            self.cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+            self._evict_mamba_for_req(req)
             dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert dst is not None, "Cannot alloc mamba for load_back"
         req.mamba_pool_idx = dst[0]

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -562,6 +562,11 @@ class SWAComponent(TreeComponent):
         ):
             x = self._evict_device_cursor
             assert x.component_data[ct].value is not None
+            if (
+                not self._allow_protected_session_cache_eviction
+                and self.session_ref(x) > 0
+            ):
+                return None
             if x in self.tree_core.evictable_device_leaves and (
                 not enabled or self._can_evict_leaf_atomically(x)
             ):

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -115,6 +115,7 @@ class TreeComponent(ABC):
         # Populated when the component passed to TreeCore constructor.
         self.tree_core: Optional[UnifiedTreeCore] = None
         self.is_evict_device_ongoing = False
+        self._allow_protected_session_cache_eviction = True
         # Per-session frontier nodes (the deepest registered node per cached
         # path), not physical tree leaves: a frontier node may have children.
         self._session_leaves: dict[str, set[UnifiedTreeNode]] = defaultdict(set)
@@ -524,11 +525,14 @@ class TreeComponent(ABC):
         - Full evict internal: cascades to SWA + Mamba."""
         return 0
 
-    def evict_device_start(self, request_cnt: int) -> None:
+    def evict_device_start(
+        self, request_cnt: int, allow_protected_session_cache: bool = True
+    ) -> None:
         """Begin this component's device-eviction walk (build its cursor/heap)."""
         assert (
             not self.is_evict_device_ongoing
         ), f"{self.component_type} device eviction already in progress"
+        self._allow_protected_session_cache_eviction = allow_protected_session_cache
         self._evict_device_start(request_cnt)
         self.is_evict_device_ongoing = True
 
@@ -552,6 +556,7 @@ class TreeComponent(ABC):
         ), f"{self.component_type} device eviction not started"
         self._evict_device_end()
         self.is_evict_device_ongoing = False
+        self._allow_protected_session_cache_eviction = True
 
     @abstractmethod
     def _evict_device_start(self, request_cnt: int) -> None:

--- a/python/sglang/srt/mem_cache/unified_cache/session_ref_tracker.py
+++ b/python/sglang/srt/mem_cache/unified_cache/session_ref_tracker.py
@@ -149,6 +149,23 @@ class UnifiedSessionRefTracker:
             indexed_component_leaves=indexed,
         )
 
+    def request_can_evict_protected_session_cache(self, req: Req) -> bool:
+        """Only the current, non-demoted session generation has entitlement."""
+        if not self.enable_session_radix_cache:
+            return True
+        session = req.session
+        if session is not None and session.streaming:
+            return True
+        session_id = self.session_id_for_req(req)
+        if session_id is None:
+            return True
+        current_generation = self._session_generations.get(session_id)
+        return (
+            current_generation is not None
+            and req.session_generation == current_generation
+            and session_id not in self._demoted_session_ids
+        )
+
     def release_radix_session(self, session_id: str) -> int:
         if not self.enable_session_radix_cache or session_id is None:
             return 0

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -1188,10 +1188,15 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
                 lru_op(lru, node)
 
     def evict_device_start(
-        self, component_type: ComponentType, request_cnt: int
+        self,
+        component_type: ComponentType,
+        request_cnt: int,
+        allow_protected_session_cache: bool = True,
     ) -> None:
         """Begin a component's device-eviction walk for up to request_cnt tokens."""
-        self.components_by_type[component_type].evict_device_start(request_cnt)
+        self.components_by_type[component_type].evict_device_start(
+            request_cnt, allow_protected_session_cache
+        )
 
     def evict_device_next_node(
         self, component_type: ComponentType, tracker: dict[ComponentType, int]
@@ -2366,6 +2371,25 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     def component_evictable_size(self, component_type: ComponentType) -> int:
         """Evictable token count for one component (0 if the component is absent)."""
         return self.component_evictable_size_.get(component_type, 0)
+
+    def component_evictable_size_without_session_refs(
+        self, component_type: ComponentType
+    ) -> int:
+        """Count unlocked device values not covered by a protected session.
+
+        This scan is only used for explicitly demoted requests. The normal
+        admission path keeps using the incrementally maintained O(1) counter.
+        """
+        if component_type not in self.components_by_type:
+            return 0
+        if not self.enable_session_radix_cache:
+            return self.component_evictable_size(component_type)
+        total = 0
+        for node in self._node_arena.values():
+            cd = node.component_data[component_type]
+            if cd.value is not None and cd.lock_ref == 0 and cd.session_ref == 0:
+                total += len(cd.value)
+        return total
 
     def full_evictable_size(self) -> int:
         return self.evictable_size()

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core_interface.py
@@ -208,7 +208,10 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
 
     @abstractmethod
     def evict_device_start(
-        self, component_type: ComponentType, request_cnt: int
+        self,
+        component_type: ComponentType,
+        request_cnt: int,
+        allow_protected_session_cache: bool = True,
     ) -> None:
         """Begin a device-eviction walk for one component."""
         ...
@@ -266,6 +269,13 @@ class UnifiedTreeCoreInterface(KVCacheEventMixin, ABC):
     @abstractmethod
     def component_evictable_size(self, component_type: ComponentType) -> int:
         """Evictable token count for one component (0 if the component is absent)."""
+        ...
+
+    @abstractmethod
+    def component_evictable_size_without_session_refs(
+        self, component_type: ComponentType
+    ) -> int:
+        """Unlocked device values not covered by a protected session."""
         ...
 
     @abstractmethod

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -456,7 +456,9 @@ class UnifiedRadixCache(BasePrefixCache):
             ComponentType.SWA: params.swa_num_tokens,
             ComponentType.MAMBA: params.mamba_num,
         }
-        self._evict_components(request_by_type, tracker)
+        self._evict_components(
+            request_by_type, tracker, params.allow_protected_session_cache
+        )
 
         if (
             self.cache_controller is not None
@@ -531,13 +533,16 @@ class UnifiedRadixCache(BasePrefixCache):
         self,
         request_by_type: dict[ComponentType, int],
         tracker: dict[ComponentType, int],
+        allow_protected_session_cache: bool,
     ) -> None:
         for ct in self.tree_components:
             request_cnt = request_by_type[ct]
             # Skip eviction walk if request is already met
             if tracker[ct] >= request_cnt:
                 continue
-            self.tree_core.evict_device_start(ct, request_cnt)
+            self.tree_core.evict_device_start(
+                ct, request_cnt, allow_protected_session_cache
+            )
             try:
                 while (
                     node_id := self._evict_device_next_node(ct, tracker)
@@ -1079,7 +1084,15 @@ class UnifiedRadixCache(BasePrefixCache):
             avail = self.token_to_kv_pool_allocator.available_size()
         if avail < kv_tokens:
             needed = kv_tokens - avail
-            result = self.evict(EvictParams(num_tokens=needed))
+            result = self.evict(
+                EvictParams(
+                    num_tokens=needed,
+                    allow_protected_session_cache=(
+                        req is None
+                        or self.request_can_evict_protected_session_cache(req)
+                    ),
+                )
+            )
             if result.num_tokens_evicted < needed:
                 self.dec_lock_ref(node_id, ancestor_lock_params)
                 self.dec_host_lock_ref(node_id, host_anchor_params)
@@ -2116,6 +2129,9 @@ class UnifiedRadixCache(BasePrefixCache):
             generation=generation,
         )
 
+    def request_can_evict_protected_session_cache(self, req: Req) -> bool:
+        return self.session_refs.request_can_evict_protected_session_cache(req)
+
     def release_radix_session(self, session_id: str) -> int:
         return self.session_refs.release_radix_session(session_id)
 
@@ -2145,11 +2161,19 @@ class UnifiedRadixCache(BasePrefixCache):
     def evictable_size(self) -> int:
         return self.tree_core.evictable_size()
 
+    def evictable_size_without_session_refs(self) -> int:
+        return self.tree_core.component_evictable_size_without_session_refs(
+            BASE_COMPONENT_TYPE
+        )
+
     def protected_size(self) -> int:
         return self.tree_core.protected_size()
 
     def full_evictable_size(self) -> int:
         return self.tree_core.full_evictable_size()
+
+    def full_evictable_size_without_session_refs(self) -> int:
+        return self.evictable_size_without_session_refs()
 
     def full_protected_size(self) -> int:
         return self.tree_core.full_protected_size()
@@ -2157,8 +2181,18 @@ class UnifiedRadixCache(BasePrefixCache):
     def swa_evictable_size(self) -> int:
         return self.tree_core.swa_evictable_size()
 
+    def swa_evictable_size_without_session_refs(self) -> int:
+        return self.tree_core.component_evictable_size_without_session_refs(
+            ComponentType.SWA
+        )
+
     def mamba_evictable_size(self) -> int:
         return self.tree_core.mamba_evictable_size()
+
+    def mamba_evictable_size_without_session_refs(self) -> int:
+        return self.tree_core.component_evictable_size_without_session_refs(
+            ComponentType.MAMBA
+        )
 
     def swa_protected_size(self) -> int:
         return self.tree_core.swa_protected_size()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -47,11 +47,27 @@ class TestPrefillAdder(CustomTestCase):
         full_evictable_size: int = 0,
         swa_evictable_size: int = 0,
         evictable_size: int = 0,
+        unreferenced_evictable_size: int | None = None,
     ) -> MagicMock:
         tree_cache = MagicMock()
         tree_cache.full_evictable_size.return_value = full_evictable_size
         tree_cache.swa_evictable_size.return_value = swa_evictable_size
         tree_cache.evictable_size.return_value = evictable_size
+        if unreferenced_evictable_size is None:
+            unreferenced_evictable_size = evictable_size
+        tree_cache.full_evictable_size_without_session_refs.return_value = (
+            unreferenced_evictable_size
+        )
+        tree_cache.swa_evictable_size_without_session_refs.return_value = (
+            unreferenced_evictable_size
+        )
+        tree_cache.evictable_size_without_session_refs.return_value = (
+            unreferenced_evictable_size
+        )
+        tree_cache.mamba_evictable_size_without_session_refs.return_value = 0
+        tree_cache.request_can_evict_protected_session_cache.return_value = True
+        tree_cache.supports_mamba.return_value = False
+        tree_cache.is_tree_cache.return_value = True
         tree_cache.disable = False
         tree_cache.inc_lock_ref.return_value = IncLockRefResult()
         tree_cache.dec_lock_ref.return_value = DecLockRefResult()
@@ -463,6 +479,41 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(len(adder2.can_run_list), 2)
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
+
+    def test_demoted_session_cannot_admit_against_protected_cache(self):
+        self.mock_tree_cache = self.create_tree_cache(
+            evictable_size=100,
+            unreferenced_evictable_size=3,
+        )
+        self.mock_token_allocator.available_size.return_value = 2
+        self.mock_tree_cache.request_can_evict_protected_session_cache.side_effect = (
+            lambda req: req.session_id != "demoted"
+        )
+
+        demoted = self.create_mock_req("demoted", priority=0, max_new_tokens=1)
+        demoted.session_id = "demoted"
+        demoted.full_untruncated_fill_ids = list(range(4))
+        demoted.last_node = MagicMock()
+        demoted.sampling_params.ignore_eos = False
+
+        demoted_result = self.create_adder(self.create_running_batch()).add_one_req(
+            demoted, has_chunked_req=False, truncation_align_size=None
+        )
+        self.mock_tree_cache.evictable_size_without_session_refs.assert_called()
+        self.mock_tree_cache.evictable_size_without_session_refs.reset_mock()
+
+        protected = self.create_mock_req("protected", priority=0, max_new_tokens=1)
+        protected.session_id = "protected"
+        protected.full_untruncated_fill_ids = list(range(4))
+        protected.last_node = MagicMock()
+        protected.sampling_params.ignore_eos = False
+        protected_result = self.create_adder(self.create_running_batch()).add_one_req(
+            protected, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(demoted_result, AddReqResult.NO_TOKEN)
+        self.assertNotEqual(protected_result, AddReqResult.NO_TOKEN)
+        self.mock_tree_cache.evictable_size_without_session_refs.assert_not_called()
 
     def _build_hybrid_swa_chunked_req(
         self,

--- a/test/registered/unit/managers/test_schedule_batch_prepare_for_decode.py
+++ b/test/registered/unit/managers/test_schedule_batch_prepare_for_decode.py
@@ -1,6 +1,6 @@
 import types
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import torch
 
@@ -40,6 +40,29 @@ def _make_decode_batch():
 
 
 class TestPrepareForDecodeSeqLensOwnership(unittest.TestCase):
+    def test_mixed_decode_uses_protected_session_eviction_cutoff(self):
+        protected = types.SimpleNamespace(kv_committed_len=4, demoted=False)
+        demoted = types.SimpleNamespace(kv_committed_len=4, demoted=True)
+        batch = ScheduleBatch(reqs=[protected, demoted])
+        batch.spec_algorithm = types.SimpleNamespace(is_none=lambda: True)
+        batch.token_to_kv_pool_allocator = types.SimpleNamespace(
+            page_size=1,
+            available_size=lambda: 2,
+        )
+        batch.tree_cache = MagicMock()
+        batch.tree_cache.request_can_evict_protected_session_cache.side_effect = (
+            lambda req: not req.demoted
+        )
+
+        with patch("sglang.srt.managers.schedule_batch.evict_from_tree_cache") as evict:
+            self.assertTrue(batch.check_decode_mem())
+
+        evict.assert_called_once_with(
+            batch.tree_cache,
+            2,
+            allow_protected_session_cache=False,
+        )
+
     def test_decode_seq_lens_bump_is_out_of_place(self):
         """Each prepare_for_decode call rebinds seq-lens tensors to new +1 objects without mutating the old ones."""
         batch = _make_decode_batch()

--- a/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
+++ b/test/registered/unit/mem_cache/test_dllm_fdfo_kv_reuse.py
@@ -56,6 +56,9 @@ class _FakeTreeCache:
     def is_chunk_cache(self):
         return True
 
+    def request_can_evict_protected_session_cache(self, req):
+        return True
+
 
 def _make_req(rid, prefix, block_size, *, req_pool_idx=None, reuse=False):
     return SimpleNamespace(

--- a/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
+++ b/test/registered/unit/mem_cache/test_session_unified_radix_cache.py
@@ -217,6 +217,26 @@ class TestSessionUnifiedRadixCache(CustomTestCase):
         self.assertEqual(match_len(self.cache, [1, 2, 3, 4]), 4)
         self.assertEqual(self.full.session_ref(referenced), 1)
 
+    def test_protected_eviction_cutoff_stops_before_session_kv(self):
+        protected = insert(self.cache, [1, 2, 3, 4])
+        insert(self.cache, [7, 8, 9])
+        register(self.cache, [1, 2, 3, 4], "protected")
+
+        self.assertEqual(self.cache.evictable_size(), 7)
+        self.assertEqual(self.cache.evictable_size_without_session_refs(), 3)
+
+        result = self.cache.evict(
+            EvictParams(
+                num_tokens=7,
+                allow_protected_session_cache=False,
+            )
+        )
+
+        self.assertEqual(result.num_tokens_evicted, 3)
+        self.assertEqual(match_len(self.cache, [7, 8, 9]), 0)
+        self.assertEqual(match_len(self.cache, [1, 2, 3, 4]), 4)
+        self.assertEqual(self.full.session_ref(protected), 1)
+
     def test_demote_and_promote_session_cache_priority(self):
         leaf = insert(self.cache, [1, 2, 3, 4])
         generation = self.cache.open_radix_session("s1")
@@ -240,6 +260,35 @@ class TestSessionUnifiedRadixCache(CustomTestCase):
         )
         self.assertEqual(promoted.status, "updated")
         self.assertEqual(self.full.session_ref(leaf), 1)
+
+    def test_demoted_request_cannot_evict_protected_session_cache(self):
+        generation = self.cache.open_radix_session("s1")
+        req = SimpleNamespace(
+            session_id="s1",
+            session_generation=generation,
+            session=None,
+        )
+        self.assertTrue(self.cache.request_can_evict_protected_session_cache(req))
+
+        self.cache.set_session_cache_priority(
+            "s1", protected=False, generation=generation
+        )
+
+        self.assertFalse(self.cache.request_can_evict_protected_session_cache(req))
+
+    def test_stale_session_request_cannot_evict_protected_session_cache(self):
+        stale_generation = self.cache.open_radix_session("s1")
+        self.cache.release_radix_session("s1")
+        self.cache.open_radix_session("s1")
+        stale_req = SimpleNamespace(
+            session_id="s1",
+            session_generation=stale_generation,
+            session=None,
+        )
+
+        self.assertFalse(
+            self.cache.request_can_evict_protected_session_cache(stale_req)
+        )
 
     def test_demoted_session_keeps_future_leaves_evictable(self):
         generation = self.cache.open_radix_session("s1")


### PR DESCRIPTION
## Summary

- Stack on #34382 and make `evictable` session priority an allocation entitlement, not only an eviction-order hint.
- Admit demoted sessions against free plus unreferenced KV capacity. Protected and non-session traffic keeps the existing O(1) admission path.
- Stop Full, SWA, and Mamba device eviction before protected session values when any request in the allocating batch is demoted.
- Apply the same cutoff to prefill, decode, speculative decode, decode retraction, HiCache load-back, and Mamba copy-on-write. A demoted Mamba COW miss falls back to recompute.
- Retract demoted requests before protected requests when a mixed decode batch cannot allocate without protected session KV.

## Semantics

- A current, non-demoted session generation may evict protected session KV.
- An explicitly demoted or stale session generation may use free KV and evictable KV with `session_ref == 0`, but cannot evict protected session-tagged values.
- Non-session requests and deployments without session radix cache keep existing behavior.
- Mixed allocation may reach protected session KV only when every request requiring allocation is entitled. This prevents a protected request from lending eviction authority to a demoted request in the same batch.

## Validation

- `ruff check --select=F401,F821,UP037 <changed files>`
- `python -m compileall` on changed runtime modules
- 1,646 memory-cache tests passed, 1,038 skipped, excluding the NIXL test (NIXL is not installed) and one known CUDA direct-copy environment failure.
- 410 manager tests passed, 4 skipped, excluding `test_customized_info_streaming.py` because the installed FlashInfer is older than the test requirement.
- Focused session, admission, decode, dLLM KV-reuse, and Mamba pressure tests pass.

## Follow-up

- This patch enforces the binary `protected` / `evictable` boundary. Mapping Dynamo's numerical request priorities and pressure policy onto this control is a separate integration.
- Router retry or engine migration after a demoted decode abort remains a Dynamo-side follow-up.
- The exact unreferenced-capacity count scans tree nodes only for demoted admission. An incremental counter can replace this slow path if pressure benchmarks show it is material.

Related: #27574, ai-dynamo/dynamo#13010

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31474592658](https://github.com/sgl-project/sglang/actions/runs/31474592658)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31474592484](https://github.com/sgl-project/sglang/actions/runs/31474592484)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->