### PR TITLE
[Diffusion] Support dynamic CPU offload components

### DIFF
--- a/docs/docs/advanced_features/vlm_query.mdx
+++ b/docs/docs/advanced_features/vlm_query.mdx
@@ -89,7 +89,7 @@ Using a HuggingFace processor to preprocess text and images, and passing the `pr
 ```python Example
 from transformers import AutoProcessor
 
-processor = AutoProcessor.from_pretrained(model_path, use_fast=True)
+processor = AutoProcessor.from_pretrained(model_path)
 processor_output = processor(
     images=[image], text=conv.get_prompt(), return_tensors="pt"
 )
@@ -110,7 +110,7 @@ You can pre-calculate image features to avoid repeated visual encoding processes
 from transformers import AutoProcessor
 from transformers import Qwen2_5_VLForConditionalGeneration
 
-processor = AutoProcessor.from_pretrained(model_path, use_fast=True)
+processor = AutoProcessor.from_pretrained(model_path)
 model = Qwen2_5_VLForConditionalGeneration.from_pretrained(model_path).eval()
 vision = model.model.visual.cuda()
 ```
@@ -192,7 +192,7 @@ Using HuggingFace processor to preprocess data can reduce computational overhead
 ```python Example
 from transformers import AutoProcessor
 
-processor = AutoProcessor.from_pretrained(model_path, use_fast=True)
+processor = AutoProcessor.from_pretrained(model_path)
 processor_output = processor(
     images=[image], text=conv.get_prompt(), return_tensors="pt"
 )
@@ -211,7 +211,7 @@ print(out)
 from transformers import AutoProcessor
 from transformers import Llama4ForConditionalGeneration
 
-processor = AutoProcessor.from_pretrained(model_path, use_fast=True)
+processor = AutoProcessor.from_pretrained(model_path)
 model = Llama4ForConditionalGeneration.from_pretrained(
     model_path, torch_dtype="auto"
 ).eval()

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -195,6 +195,19 @@ For supported native pipelines, set `SGLANG_CACHE_DIT_ENABLED=true` to enable Ca
 
 For supported image pipelines, breakable CUDA graph can be enabled with `--enable-breakable-cuda-graph`, but you must declare every served resolution in `--warmup-resolutions` so warmup captures matching graph signatures.
 
+### Component CPU Offload
+
+Use `--cpu-offload-components` to explicitly select components for coarse CPU offload:
+
+```bash Command
+sglang generate \
+  --model-path Wan-AI/Wan2.1-T2V-1.3B-Diffusers \
+  --cpu-offload-components dit text_encoder \
+  --prompt "A quiet city street after rain"
+```
+
+Supported components are `dit`, `text_encoder`, `image_encoder`, and `vae`. Use `all` to offload all components or `none` to disable coarse component CPU offload. This unified option cannot be combined with the legacy per-component CPU offload flags. Layerwise offload remains independently controlled by `--layerwise-offload-components`.
+
 ### Layerwise Offload
 
 Use layerwise offload when a large component does not fit comfortably in GPU memory. By default, `--dit-layerwise-offload` only applies to legacy DiT components. Use `--layerwise-offload-components` to select pipeline component names explicitly (`--layerwise-offload-modules` is accepted as an alias):

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -206,7 +206,7 @@ sglang generate \
   --prompt "A quiet city street after rain"
 ```
 
-Supported components are `dit`, `text_encoder`, `image_encoder`, and `vae`. Use `all` to offload all components or `none` to disable coarse component CPU offload. This unified option cannot be combined with the legacy per-component CPU offload flags. Layerwise offload remains independently controlled by `--layerwise-offload-components`.
+Component names are matched against the loaded pipeline's component keys from `model_index.json`, so names such as `transformer_2`, `audio_vae`, and `connectors` are supported without adding them to a registry. The group aliases `dit`, `text_encoder`, `image_encoder`, and `vae` remain available. Use `all` to offload every loaded `torch.nn.Module`, or `none` to disable coarse component CPU offload. Non-module components such as tokenizers and schedulers are unaffected. This unified option cannot be combined with the legacy per-component CPU offload flags. Layerwise offload remains independently controlled by `--layerwise-offload-components`.
 
 ### Layerwise Offload
 

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/adapter_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/adapter_loader.py
@@ -1,3 +1,4 @@
+import torch
 from safetensors.torch import load_file as safetensors_load_file
 
 from sglang.multimodal_gen.configs.models.adapter.ltx_2_connector import (
@@ -50,7 +51,13 @@ class AdapterLoader(ComponentLoader):
 
         model_cls, _ = ModelRegistry.resolve_model_cls(cls_name)
 
-        target_device = get_local_torch_device()
+        target_device = (
+            torch.device("cpu")
+            if self._should_offload_component(
+                server_args, "connectors", server_args.dit_cpu_offload
+            )
+            else get_local_torch_device()
+        )
         default_dtype = resolve_precision(
             server_args, "connectors", precision_attr="dit_precision"
         )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/bridge_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/bridge_loader.py
@@ -74,6 +74,10 @@ class BridgeLoader(ComponentLoader):
             default_dtype,
         )
 
+        component_cpu_offload = self._should_offload_component(
+            server_args, component_name, server_args.dit_cpu_offload
+        )
+
         # Use the FSDP loader when FSDP is requested or shard rules are declared.
         fsdp_shard_conditions = getattr(model_cls, "_fsdp_shard_conditions", None)
         if server_args.use_fsdp_inference or (
@@ -88,7 +92,7 @@ class BridgeLoader(ComponentLoader):
                 device=local_torch_device,
                 hsdp_replicate_dim=server_args.hsdp_replicate_dim,
                 hsdp_shard_dim=server_args.hsdp_shard_dim,
-                cpu_offload=server_args.dit_cpu_offload,
+                cpu_offload=component_cpu_offload,
                 pin_cpu_memory=server_args.pin_cpu_memory,
                 fsdp_inference=server_args.use_fsdp_inference,
                 param_dtype=default_dtype,
@@ -104,7 +108,12 @@ class BridgeLoader(ComponentLoader):
             model = model_cls.from_pretrained(
                 component_model_path, torch_dtype=default_dtype
             )
-            model = model.to(device=get_local_torch_device(), dtype=default_dtype)
+            target_device = (
+                torch.device("cpu")
+                if component_cpu_offload
+                else get_local_torch_device()
+            )
+            model = model.to(device=target_device, dtype=default_dtype)
 
         total_params = sum(p.numel() for p in model.parameters())
         logger.info("Loaded bridge model with %.2fM parameters", total_params / 1e6)

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -480,7 +480,9 @@ class ImageProcessorLoader(ComponentLoader):
     def load_customized(
         self, component_model_path: str, server_args: ServerArgs, component_name: str
     ) -> Any:
-        return AutoImageProcessor.from_pretrained(component_model_path, use_fast=True)
+        return AutoImageProcessor.from_pretrained(
+            component_model_path, backend="torchvision"
+        )
 
 
 class AutoProcessorLoader(ComponentLoader):

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -25,6 +25,9 @@ from sglang.multimodal_gen.runtime.loader.utils import (
     component_name_to_loader_cls,
     get_memory_usage_of_component,
 )
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_resident_strategies import (
+    is_fsdp_managed_module,
+)
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     configure_layerwise_offload_modules,
     is_layerwise_offloaded_module,
@@ -92,10 +95,22 @@ class ComponentLoader(ABC):
         self.component_architecture: str | None = None
 
     def should_offload(
-        self, server_args: ServerArgs, model_config: ModelConfig | None = None
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
     ):
-        # not offload by default
-        return False
+        return component_name is not None and self._should_offload_component(
+            server_args, component_name, False
+        )
+
+    @staticmethod
+    def _should_offload_component(
+        server_args: ServerArgs, component_name: str, legacy_value: bool | None
+    ) -> bool:
+        if server_args.cpu_offload_components is not None:
+            return server_args.is_cpu_offload_component_selected(component_name)
+        return bool(legacy_value)
 
     def target_device(self, should_offload):
         if should_offload:
@@ -215,7 +230,7 @@ class ComponentLoader(ABC):
                 transformers_or_diffusers,
                 component_name,
             )
-        should_offload = self.should_offload(server_args)
+        should_offload = self.should_offload(server_args, component_name=component_name)
         target_device = self.target_device(should_offload)
         return component.to(device=target_device)
 
@@ -301,6 +316,12 @@ class ComponentLoader(ABC):
         else:
             if isinstance(component, nn.Module):
                 component = component.eval()
+                if (
+                    server_args.cpu_offload_components is not None
+                    and server_args.is_cpu_offload_component_selected(component_name)
+                    and not is_fsdp_managed_module(component)
+                ):
+                    component = component.to("cpu")
             current_gpu_mem = current_platform.get_available_gpu_memory()
             model_size = get_memory_usage_of_component(component) or "NA"
             consumed = gpu_mem_before_loading - current_gpu_mem

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
@@ -16,8 +16,16 @@ class ImageEncoderLoader(TextEncoderLoader):
     component_names = ["image_encoder"]
     expected_library = "transformers"
 
-    def should_offload(self, server_args, model_config: ModelConfig | None = None):
-        should_offload = server_args.image_encoder_cpu_offload
+    def should_offload(
+        self,
+        server_args,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
+    ):
+        component_name = component_name or "image_encoder"
+        should_offload = self._should_offload_component(
+            server_args, component_name, server_args.image_encoder_cpu_offload
+        )
         if not should_offload:
             return False
         # _fsdp_shard_conditions is in arch_config, not directly on model_config
@@ -66,6 +74,9 @@ class ImageEncoderLoader(TextEncoderLoader):
             cpu_offload_flag=(
                 cpu_offload_flag
                 if cpu_offload_flag is not None
-                else server_args.image_encoder_cpu_offload
+                else self._should_offload_component(
+                    server_args, component_name, server_args.image_encoder_cpu_offload
+                )
             ),
+            component_name=component_name,
         )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/sound_tokenizer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/sound_tokenizer_loader.py
@@ -26,9 +26,16 @@ class SoundTokenizerLoader(ComponentLoader):
     expected_library = "diffusers"
 
     def should_offload(
-        self, server_args: ServerArgs, model_config: ModelConfig | None = None
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
     ) -> bool:
-        return server_args.vae_cpu_offload
+        return self._should_offload_component(
+            server_args,
+            component_name or "sound_tokenizer",
+            server_args.vae_cpu_offload,
+        )
 
     def load_customized(
         self, component_model_path: str, server_args: ServerArgs, component_name: str
@@ -46,7 +53,9 @@ class SoundTokenizerLoader(ComponentLoader):
         except AttributeError:
             precision = "bf16"
         dtype = PRECISION_TO_TYPE[precision]
-        target_device = self.target_device(self.should_offload(server_args))
+        target_device = self.target_device(
+            self.should_offload(server_args, component_name=component_name)
+        )
 
         with set_default_torch_dtype(dtype), skip_init_modules():
             model_cls, _ = ModelRegistry.resolve_model_cls(class_name)

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -80,8 +80,16 @@ class TextEncoderLoader(ComponentLoader):
         allow_patterns_overrides: list[str] | None = None
         """If defined, weights will load exclusively using these patterns."""
 
-    def should_offload(self, server_args, model_config: ModelConfig | None = None):
-        should_offload = server_args.text_encoder_cpu_offload
+    def should_offload(
+        self,
+        server_args,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
+    ):
+        component_name = component_name or "text_encoder"
+        should_offload = self._should_offload_component(
+            server_args, component_name, server_args.text_encoder_cpu_offload
+        )
         if not should_offload:
             return False
         # _fsdp_shard_conditions is in arch_config, not directly on model_config
@@ -369,6 +377,7 @@ class TextEncoderLoader(ComponentLoader):
             server_args,
             encoder_dtype,
             cpu_offload_flag=cpu_offload_flag,
+            component_name=component_name,
         )
 
     @staticmethod
@@ -400,13 +409,16 @@ class TextEncoderLoader(ComponentLoader):
         server_args: ServerArgs,
         dtype: str = "fp16",
         cpu_offload_flag: bool | None = None,
+        component_name: str = "text_encoder",
     ):
         # Determine CPU offload behavior and target device
 
         local_torch_device = get_local_torch_device()
 
         if not current_platform.is_cpu():
-            fsdp_cpu_offload = self.should_offload(server_args, model_config)
+            fsdp_cpu_offload = self.should_offload(
+                server_args, model_config, component_name
+            )
             should_offload = (
                 cpu_offload_flag if cpu_offload_flag is not None else fsdp_cpu_offload
             )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -141,6 +141,11 @@ class TransformerLoader(ComponentLoader):
         component_server_args = _server_args_for_transformer_component(
             server_args, component_name
         )
+        if server_args.cpu_offload_components is not None:
+            component_server_args = copy.copy(component_server_args)
+            component_server_args.dit_cpu_offload = (
+                server_args.is_cpu_offload_component_selected(component_name)
+            )
 
         # 1. hf config
         config = get_diffusers_component_config(component_path=component_model_path)

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
@@ -195,8 +195,17 @@ class UpsamplerLoader(ComponentLoader):
     component_names = ["spatial_upsampler"]
     expected_library = "diffusers"
 
-    def should_offload(self, server_args: ServerArgs, model_config=None):
-        return server_args.vae_cpu_offload
+    def should_offload(
+        self,
+        server_args: ServerArgs,
+        model_config=None,
+        component_name: str | None = None,
+    ):
+        return self._should_offload_component(
+            server_args,
+            component_name or "spatial_upsampler",
+            server_args.vae_cpu_offload,
+        )
 
     def load_customized(
         self,
@@ -210,7 +219,7 @@ class UpsamplerLoader(ComponentLoader):
 
         logger.info("Loading LatentUpsampler with config: %s", config)
 
-        should_offload = self.should_offload(server_args)
+        should_offload = self.should_offload(server_args, component_name=component_name)
         target_device = self.target_device(should_offload)
 
         with torch.device("meta"):

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -100,9 +100,16 @@ class VAELoader(ComponentLoader):
     expected_library = "diffusers"
 
     def should_offload(
-        self, server_args: ServerArgs, model_config: ModelConfig | None = None
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
     ):
-        return server_args.vae_cpu_offload
+        return self._should_offload_component(
+            server_args,
+            component_name or "vae",
+            server_args.vae_cpu_offload,
+        )
 
     def load_customized(
         self, component_model_path: str, server_args: ServerArgs, component_name: str
@@ -139,7 +146,7 @@ class VAELoader(ComponentLoader):
             # NOTE: some post init logics are only available after updated with config
             vae_config.post_init()
 
-        should_offload = self.should_offload(server_args)
+        should_offload = self.should_offload(server_args, component_name=component_name)
         target_device = self.target_device(should_offload)
 
         native_only = component_name in getattr(

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vl_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vl_encoder_loader.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 import requests
+import torch
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
@@ -59,12 +60,21 @@ class VisionLanguageEncoderLoader(ComponentLoader):
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
             )
+            target_device = (
+                torch.device("cpu")
+                if self._should_offload_component(
+                    server_args,
+                    transformers_or_diffusers,
+                    server_args.dit_cpu_offload,
+                )
+                else get_local_torch_device()
+            )
             model = GlmImageForConditionalGeneration.from_pretrained(
                 component_model_path,
                 config=config,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
-            ).to(get_local_torch_device())
+            ).to(target_device)
             return model
         else:
             raise ValueError(

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vocoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vocoder_loader.py
@@ -26,9 +26,16 @@ class VocoderLoader(ComponentLoader):
     expected_library = "diffusers"
 
     def should_offload(
-        self, server_args: ServerArgs, model_config: ModelConfig | None = None
+        self,
+        server_args: ServerArgs,
+        model_config: ModelConfig | None = None,
+        component_name: str | None = None,
     ):
-        return server_args.vae_cpu_offload
+        return self._should_offload_component(
+            server_args,
+            component_name or "vocoder",
+            server_args.vae_cpu_offload,
+        )
 
     def load_customized(
         self, component_model_path: str, server_args: ServerArgs, component_name: str
@@ -55,7 +62,7 @@ class VocoderLoader(ComponentLoader):
             else PRECISION_TO_TYPE["fp32"]
         )
 
-        should_offload = self.should_offload(server_args)
+        should_offload = self.should_offload(server_args, component_name=component_name)
         target_device = self.target_device(should_offload)
 
         with set_default_torch_dtype(vocoder_dtype), skip_init_modules():

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -333,29 +333,25 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
     def _format_offload_disable_suggestions(self, components: List[str]) -> str:
         component_set = set(components)
-        suggestions = []
-        seen_args = set()
+        component_names = []
+        layerwise_suggestions = []
 
         for component in OFFLOAD_DISABLE_RECOMMENDATION_ORDER:
             if component not in component_set:
                 continue
 
-            arg = None
-            if component == "vae":
-                arg = "--cpu-offload-components"
-            elif component == "image_encoder":
-                arg = "--cpu-offload-components"
-            elif component in ("text_encoder", "text_encoder_2"):
-                arg = "--cpu-offload-components"
+            if component in ("vae", "image_encoder", "text_encoder", "text_encoder_2"):
+                component_names.append(component)
             elif component == "transformer":
                 if self.server_args.is_dit_layerwise_offload_selected:
-                    arg = "--dit-layerwise-offload"
+                    layerwise_suggestions.append("--dit-layerwise-offload")
                 elif self.server_args.dit_cpu_offload:
-                    arg = "--cpu-offload-components"
+                    component_names.append(component)
 
-            if arg is not None and arg not in seen_args:
-                suggestions.append(arg)
-                seen_args.add(arg)
+        suggestions = []
+        if component_names:
+            suggestions.append("--cpu-offload-components " + " ".join(component_names))
+        suggestions.extend(layerwise_suggestions)
 
         return ", ".join(suggestions) if suggestions else "None"
 

--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -322,12 +322,13 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
         pool_overhead_gb = peak_reserved_gb - peak_allocated_gb
 
         logger.debug(
-            f"Peak GPU memory: {peak_reserved_gb:.2f} GB, "
-            f"Peak allocated: {peak_allocated_gb:.2f} GB, "
-            f"Memory pool overhead: {pool_overhead_gb:.2f} GB ({pool_overhead_gb / peak_reserved_gb * 100:.1f}%), "
-            f"Remaining GPU memory at peak: {remaining_gpu_mem_gb:.2f} GB. "
-            f"Components that could stay resident (based on the last request workload): {can_stay_resident}. "
-            f"Related offload server args to disable: {suggested_args_str}"
+            f"GPU memory: peak_reserved={peak_reserved_gb:.2f} GB, "
+            f"peak_allocated={peak_allocated_gb:.2f} GB, "
+            f"pool_overhead={pool_overhead_gb:.2f} GB "
+            f"({pool_overhead_gb / peak_reserved_gb * 100:.1f}%), "
+            f"available_at_peak={remaining_gpu_mem_gb:.2f} GB; "
+            f"resident_candidates={can_stay_resident}; "
+            f"offload_control={suggested_args_str}"
         )
 
     def _format_offload_disable_suggestions(self, components: List[str]) -> str:
@@ -341,16 +342,16 @@ class GPUWorker(GPUWorkerPostTrainingMixin):
 
             arg = None
             if component == "vae":
-                arg = "--vae-cpu-offload"
+                arg = "--cpu-offload-components"
             elif component == "image_encoder":
-                arg = "--image-encoder-cpu-offload"
+                arg = "--cpu-offload-components"
             elif component in ("text_encoder", "text_encoder_2"):
-                arg = "--text-encoder-cpu-offload"
+                arg = "--cpu-offload-components"
             elif component == "transformer":
                 if self.server_args.is_dit_layerwise_offload_selected:
                     arg = "--dit-layerwise-offload"
                 elif self.server_args.dit_cpu_offload:
-                    arg = "--dit-cpu-offload"
+                    arg = "--cpu-offload-components"
 
             if arg is not None and arg not in seen_args:
                 suggestions.append(arg)

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -100,6 +100,8 @@ def should_cpu_offload_component(
         return False
     if server_args.use_fsdp_inference or is_fsdp_managed_module(module):
         return False
+    if server_args.cpu_offload_components is not None:
+        return server_args.is_cpu_offload_component_selected(component_name)
     if is_dit_component_name(component_name):
         return bool(server_args.dit_cpu_offload)
     if is_text_encoder_component_name(component_name):

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload_components.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload_components.py
@@ -47,23 +47,7 @@ CPU_OFFLOAD_FLAG_NAMES = (
     "image_encoder_cpu_offload",
     "vae_cpu_offload",
 )
-CPU_OFFLOAD_COMPONENT_NAMES = ("dit", "text_encoder", "image_encoder", "vae")
-CPU_OFFLOAD_COMPONENT_ALIASES = {
-    "dit": "dit",
-    "transformer": "dit",
-    "transformer_2": "dit",
-    "video_dit": "dit",
-    "video_dit_2": "dit",
-    "audio_dit": "dit",
-    "text_encoder": "text_encoder",
-    "text_encoder_2": "text_encoder",
-    "image_encoder": "image_encoder",
-    "condition_image_encoder": "image_encoder",
-    "vae": "vae",
-    "video_vae": "vae",
-    "audio_vae": "vae",
-    "vocoder": "vae",
-}
+CPU_OFFLOAD_ALL_COMPONENTS = "all"
 
 
 def is_dit_component_name(component_name: str) -> bool:
@@ -73,7 +57,7 @@ def is_dit_component_name(component_name: str) -> bool:
 def normalize_cpu_offload_components(
     component_names: str | Sequence[str] | None,
 ) -> list[str] | None:
-    """Normalize component names accepted by ``--cpu-offload-components``."""
+    """Normalize component keys accepted by ``--cpu-offload-components``."""
     if component_names is None:
         return None
 
@@ -92,22 +76,35 @@ def normalize_cpu_offload_components(
                 if len(raw_components) != 1 or normalized_components:
                     raise ValueError("'none' cannot be combined with other components.")
                 return []
-            if component_name == "all":
-                for name in CPU_OFFLOAD_COMPONENT_NAMES:
-                    if name not in normalized_components:
-                        normalized_components.append(name)
+            if component_name == CPU_OFFLOAD_ALL_COMPONENTS:
+                if CPU_OFFLOAD_ALL_COMPONENTS not in normalized_components:
+                    normalized_components.append(CPU_OFFLOAD_ALL_COMPONENTS)
                 continue
-            canonical_name = CPU_OFFLOAD_COMPONENT_ALIASES.get(component_name)
-            if canonical_name is None:
-                valid_names = ", ".join((*CPU_OFFLOAD_COMPONENT_NAMES, "all", "none"))
-                raise ValueError(
-                    f"Invalid CPU offload component name: {component_name!r}. "
-                    f"Expected one of: {valid_names}."
-                )
-            if canonical_name not in normalized_components:
-                normalized_components.append(canonical_name)
+            if component_name not in normalized_components:
+                normalized_components.append(component_name)
 
     return normalized_components or None
+
+
+def cpu_offload_component_matches(
+    component_name: str,
+    selected_component_names: Collection[str] | None,
+) -> bool:
+    if selected_component_names is None:
+        return False
+    if CPU_OFFLOAD_ALL_COMPONENTS in selected_component_names:
+        return True
+    if component_name in selected_component_names:
+        return True
+    if LAYERWISE_OFFLOAD_DIT_GROUP in selected_component_names:
+        return is_dit_component_name(component_name)
+    if LAYERWISE_OFFLOAD_TEXT_ENCODER_GROUP in selected_component_names:
+        return is_text_encoder_component_name(component_name)
+    if LAYERWISE_OFFLOAD_IMAGE_ENCODER_GROUP in selected_component_names:
+        return component_name in ("image_encoder", "condition_image_encoder")
+    if LAYERWISE_OFFLOAD_VAE_GROUP in selected_component_names:
+        return is_vae_component_name(component_name)
+    return False
 
 
 def is_text_encoder_component_name(component_name: str) -> bool:

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload_components.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload_components.py
@@ -47,10 +47,67 @@ CPU_OFFLOAD_FLAG_NAMES = (
     "image_encoder_cpu_offload",
     "vae_cpu_offload",
 )
+CPU_OFFLOAD_COMPONENT_NAMES = ("dit", "text_encoder", "image_encoder", "vae")
+CPU_OFFLOAD_COMPONENT_ALIASES = {
+    "dit": "dit",
+    "transformer": "dit",
+    "transformer_2": "dit",
+    "video_dit": "dit",
+    "video_dit_2": "dit",
+    "audio_dit": "dit",
+    "text_encoder": "text_encoder",
+    "text_encoder_2": "text_encoder",
+    "image_encoder": "image_encoder",
+    "condition_image_encoder": "image_encoder",
+    "vae": "vae",
+    "video_vae": "vae",
+    "audio_vae": "vae",
+    "vocoder": "vae",
+}
 
 
 def is_dit_component_name(component_name: str) -> bool:
     return component_name in DIT_COMPONENT_NAMES
+
+
+def normalize_cpu_offload_components(
+    component_names: str | Sequence[str] | None,
+) -> list[str] | None:
+    """Normalize component names accepted by ``--cpu-offload-components``."""
+    if component_names is None:
+        return None
+
+    raw_components = (
+        [component_names] if isinstance(component_names, str) else component_names
+    )
+    normalized_components: list[str] = []
+    for raw_component in raw_components:
+        if not isinstance(raw_component, str):
+            raise ValueError(f"Invalid CPU offload component name: {raw_component}.")
+        for component_name in raw_component.split(","):
+            component_name = component_name.strip().replace("-", "_").lower()
+            if not component_name:
+                continue
+            if component_name == "none":
+                if len(raw_components) != 1 or normalized_components:
+                    raise ValueError("'none' cannot be combined with other components.")
+                return []
+            if component_name == "all":
+                for name in CPU_OFFLOAD_COMPONENT_NAMES:
+                    if name not in normalized_components:
+                        normalized_components.append(name)
+                continue
+            canonical_name = CPU_OFFLOAD_COMPONENT_ALIASES.get(component_name)
+            if canonical_name is None:
+                valid_names = ", ".join((*CPU_OFFLOAD_COMPONENT_NAMES, "all", "none"))
+                raise ValueError(
+                    f"Invalid CPU offload component name: {component_name!r}. "
+                    f"Expected one of: {valid_names}."
+                )
+            if canonical_name not in normalized_components:
+                normalized_components.append(canonical_name)
+
+    return normalized_components or None
 
 
 def is_text_encoder_component_name(component_name: str) -> bool:

--- a/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/auto_tune.py
@@ -255,6 +255,7 @@ class ServerArgsAutoTuner:
         if (
             args.layerwise_offload_components is not None
             or args.dit_layerwise_offload is True
+            or args.is_arg_explicitly_set("cpu_offload_components")
         ):
             return
         if not current_platform.is_cuda():
@@ -412,6 +413,7 @@ class ServerArgsAutoTuner:
         if (
             args.is_arg_explicitly_set("layerwise_offload_components")
             or args.dit_layerwise_offload is True
+            or args.is_arg_explicitly_set("cpu_offload_components")
         ):
             # The legacy --dit-layerwise-offload flag is a DiT-only selector.
             # Do not merge implicit defaults into that explicit mode.
@@ -480,6 +482,7 @@ class ServerArgsAutoTuner:
             or envs.SGLANG_CACHE_DIT_ENABLED
             or args.use_fsdp_inference
             or args.is_arg_explicitly_set("dit_cpu_offload")
+            or args.is_arg_explicitly_set("cpu_offload_components")
         ):
             return False
 
@@ -547,6 +550,7 @@ class ServerArgsAutoTuner:
                 "dit_cpu_offload",
                 "dit_layerwise_offload",
                 "layerwise_offload_components",
+                "cpu_offload_components",
             )
         )
 
@@ -557,6 +561,7 @@ class ServerArgsAutoTuner:
             for arg_name in (
                 "dit_layerwise_offload",
                 "layerwise_offload_components",
+                "cpu_offload_components",
             )
         )
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -35,6 +35,7 @@ from sglang.multimodal_gen.runtime.loader.utils import BYTES_PER_GB
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_components import (
     LAYERWISE_OFFLOAD_ALL_COMPONENTS,
     LAYERWISE_OFFLOAD_DIT_GROUP,
+    cpu_offload_component_matches,
     cpu_offload_flags_for_layerwise_components,
     layerwise_component_matches_any_selection,
     normalize_cpu_offload_components,
@@ -299,8 +300,7 @@ class ServerArgs(DisaggServerArgsMixin):
     lora_target_modules: list[str] | None = None
 
     # CPU offload parameters
-    # Explicitly selected coarse component offload. When set, this controls all
-    # four legacy *_cpu_offload flags.
+    # Exact component keys from model_index.json, or a legacy component group.
     cpu_offload_components: list[str] | None = None
     dit_cpu_offload: bool | None = None
     # if true, select the DiT layerwise group
@@ -724,12 +724,17 @@ class ServerArgs(DisaggServerArgsMixin):
         selected_components = (
             normalize_cpu_offload_components(self.cpu_offload_components) or []
         )
-        selected = set(selected_components)
         self.cpu_offload_components = selected_components
-        self.dit_cpu_offload = "dit" in selected
-        self.text_encoder_cpu_offload = "text_encoder" in selected
-        self.image_encoder_cpu_offload = "image_encoder" in selected
-        self.vae_cpu_offload = "vae" in selected
+        self.dit_cpu_offload = cpu_offload_component_matches(
+            "transformer", selected_components
+        )
+        self.text_encoder_cpu_offload = cpu_offload_component_matches(
+            "text_encoder", selected_components
+        )
+        self.image_encoder_cpu_offload = cpu_offload_component_matches(
+            "image_encoder", selected_components
+        )
+        self.vae_cpu_offload = cpu_offload_component_matches("vae", selected_components)
 
     def _adjust_ltx2_two_stage_device_mode(self):
         if not self._is_ltx23_two_stage_pipeline():
@@ -1231,6 +1236,11 @@ class ServerArgs(DisaggServerArgsMixin):
 
     def is_arg_explicitly_set(self, arg_name: str) -> bool:
         return arg_name in self._explicit_arg_names
+
+    def is_cpu_offload_component_selected(self, component_name: str) -> bool:
+        return cpu_offload_component_matches(
+            component_name, self.cpu_offload_components
+        )
 
     def should_configure_layerwise_offload_for_lazy_component(
         self, component_name: str
@@ -1777,8 +1787,9 @@ class ServerArgs(DisaggServerArgsMixin):
             nargs="+",
             default=ServerArgs.cpu_offload_components,
             help=(
-                "Select components for coarse CPU offload. Accepted names are "
-                "dit, text_encoder, image_encoder, vae, all, and none. "
+                "Select component keys from model_index.json for coarse CPU offload. "
+                "Use dit, text_encoder, image_encoder, or vae as group aliases; "
+                "all selects every loaded module and none disables component offload. "
                 "This unified option cannot be combined with the legacy "
                 "per-component CPU offload flags."
             ),

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -37,6 +37,7 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_co
     LAYERWISE_OFFLOAD_DIT_GROUP,
     cpu_offload_flags_for_layerwise_components,
     layerwise_component_matches_any_selection,
+    normalize_cpu_offload_components,
     normalize_layerwise_offload_components,
 )
 from sglang.multimodal_gen.runtime.platforms import (
@@ -298,6 +299,9 @@ class ServerArgs(DisaggServerArgsMixin):
     lora_target_modules: list[str] | None = None
 
     # CPU offload parameters
+    # Explicitly selected coarse component offload. When set, this controls all
+    # four legacy *_cpu_offload flags.
+    cpu_offload_components: list[str] | None = None
     dit_cpu_offload: bool | None = None
     # if true, select the DiT layerwise group
     dit_layerwise_offload: bool | None = None
@@ -481,6 +485,7 @@ class ServerArgs(DisaggServerArgsMixin):
         """set defaults and normalize values."""
         auto_tuner = ServerArgsAutoTuner(self)
         auto_tuner.adjust_based_on_performance_mode()
+        self._adjust_cpu_offload_components()
         if auto_tuner.could_override_server_args():
             self._adjust_offload()
             auto_tuner.maybe_adjust_auto_default_layerwise_offload()
@@ -690,6 +695,41 @@ class ServerArgs(DisaggServerArgsMixin):
                 self.text_encoder_cpu_offload = True
             if self.image_encoder_cpu_offload is None:
                 self.image_encoder_cpu_offload = True
+
+    def _adjust_cpu_offload_components(self) -> None:
+        """Apply the unified CPU offload component selector, when provided."""
+        if self.cpu_offload_components is None:
+            return
+
+        legacy_flags = (
+            "dit_cpu_offload",
+            "text_encoder_cpu_offload",
+            "image_encoder_cpu_offload",
+            "vae_cpu_offload",
+        )
+        conflicting_flags = [
+            flag_name
+            for flag_name in legacy_flags
+            if self.is_arg_explicitly_set(flag_name)
+        ]
+        if conflicting_flags:
+            formatted_flags = ", ".join(
+                "--" + flag_name.replace("_", "-") for flag_name in conflicting_flags
+            )
+            raise ValueError(
+                "--cpu-offload-components cannot be combined with the legacy "
+                f"CPU offload flags: {formatted_flags}"
+            )
+
+        selected_components = (
+            normalize_cpu_offload_components(self.cpu_offload_components) or []
+        )
+        selected = set(selected_components)
+        self.cpu_offload_components = selected_components
+        self.dit_cpu_offload = "dit" in selected
+        self.text_encoder_cpu_offload = "text_encoder" in selected
+        self.image_encoder_cpu_offload = "image_encoder" in selected
+        self.vae_cpu_offload = "vae" in selected
 
     def _adjust_ltx2_two_stage_device_mode(self):
         if not self._is_ltx23_two_stage_pipeline():
@@ -1730,6 +1770,18 @@ class ServerArgs(DisaggServerArgsMixin):
             "--dit-cpu-offload",
             action=StoreBoolean,
             help="Use CPU offload for DiT inference. Enable if run out of memory with FSDP.",
+        )
+        parser.add_argument(
+            "--cpu-offload-components",
+            type=str,
+            nargs="+",
+            default=ServerArgs.cpu_offload_components,
+            help=(
+                "Select components for coarse CPU offload. Accepted names are "
+                "dit, text_encoder, image_encoder, vae, all, and none. "
+                "This unified option cannot be combined with the legacy "
+                "per-component CPU offload flags."
+            ),
         )
         parser.add_argument(
             "--dit-layerwise-offload",

--- a/python/sglang/multimodal_gen/test/test_utils.py
+++ b/python/sglang/multimodal_gen/test/test_utils.py
@@ -914,12 +914,11 @@ def get_clip_model() -> tuple[Any, Any]:
             if "RobertaProcessing" not in str(e):
                 raise
             logger.warning(
-                "Fast CLIP processor failed (%s), retrying with use_fast=False", e
+                "CLIP processor failed (%s), retrying with compatibility shim", e
             )
             processor = _load_clip_processor_with_roberta_processing_compat(
                 CLIPProcessor,
                 CLIP_MODEL_NAME,
-                use_fast=False,
             )
         model = CLIPModel.from_pretrained(CLIP_MODEL_NAME)
 

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -366,7 +366,7 @@ class TestServerArgsPathExpansion(unittest.TestCase):
             ):
                 server_args = ServerArgs.from_cli_args(args, unknown_args)
 
-        self.assertEqual(server_args.cpu_offload_components, ["dit", "vae"])
+        self.assertEqual(server_args.cpu_offload_components, ["transformer", "vae"])
         self.assertTrue(server_args.dit_cpu_offload)
         self.assertTrue(server_args.vae_cpu_offload)
         self.assertFalse(server_args.text_encoder_cpu_offload)
@@ -801,11 +801,47 @@ class TestOffloadDefaults(unittest.TestCase):
             },
         )
 
-        self.assertEqual(args.cpu_offload_components, ["dit", "vae"])
+        self.assertEqual(args.cpu_offload_components, ["transformer", "vae"])
         self.assertTrue(args.dit_cpu_offload)
         self.assertFalse(args.text_encoder_cpu_offload)
         self.assertFalse(args.image_encoder_cpu_offload)
         self.assertTrue(args.vae_cpu_offload)
+
+    def test_cpu_offload_components_preserves_model_index_names(self):
+        args = self._from_dict_with_task_type(
+            ModelTaskType.T2V,
+            kwargs={
+                "performance_mode": "manual",
+                "cpu_offload_components": [
+                    "transformer_2",
+                    "audio_vae",
+                    "connectors",
+                ],
+            },
+        )
+
+        self.assertEqual(
+            args.cpu_offload_components,
+            ["transformer_2", "audio_vae", "connectors"],
+        )
+        self.assertTrue(args.is_cpu_offload_component_selected("transformer_2"))
+        self.assertTrue(args.is_cpu_offload_component_selected("audio_vae"))
+        self.assertTrue(args.is_cpu_offload_component_selected("connectors"))
+        self.assertFalse(args.dit_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+
+    def test_cpu_offload_components_all_matches_dynamic_components(self):
+        args = self._from_dict_with_task_type(
+            ModelTaskType.T2V,
+            kwargs={
+                "performance_mode": "manual",
+                "cpu_offload_components": ["all"],
+            },
+        )
+
+        self.assertEqual(args.cpu_offload_components, ["all"])
+        self.assertTrue(args.is_cpu_offload_component_selected("transformer_2"))
+        self.assertTrue(args.is_cpu_offload_component_selected("connectors"))
 
     def test_cpu_offload_components_none_disables_all_legacy_flags(self):
         args = self._from_dict_with_task_type(

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -346,6 +346,32 @@ class TestServerArgsPathExpansion(unittest.TestCase):
             server_args.layerwise_offload_components, ["transformer", "text_encoder"]
         )
 
+    def test_cpu_offload_components_cli_args(self):
+        parser = FlexibleArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        argv = [
+            "--model-path",
+            "/fake",
+            "--performance-mode",
+            "manual",
+            "--cpu-offload-components",
+            "transformer",
+            "vae",
+        ]
+
+        with patch.object(sys, "argv", ["sglang"] + argv):
+            args, unknown_args = parser.parse_known_args(argv)
+            with patch.object(
+                PipelineConfig, "from_kwargs", return_value=QwenImagePipelineConfig()
+            ):
+                server_args = ServerArgs.from_cli_args(args, unknown_args)
+
+        self.assertEqual(server_args.cpu_offload_components, ["dit", "vae"])
+        self.assertTrue(server_args.dit_cpu_offload)
+        self.assertTrue(server_args.vae_cpu_offload)
+        self.assertFalse(server_args.text_encoder_cpu_offload)
+        self.assertFalse(server_args.image_encoder_cpu_offload)
+
     def test_serve_cli_preserves_config_and_dynamic_unknown_args(self):
         from sglang.multimodal_gen.runtime.entrypoints.cli.serve import (
             add_multimodal_gen_serve_args,
@@ -765,6 +791,47 @@ class TestOffloadDefaults(unittest.TestCase):
         args = self._from_dict_with_task_type(ModelTaskType.T2V)
 
         self.assertFalse(args.vae_cpu_offload)
+
+    def test_cpu_offload_components_controls_legacy_flags(self):
+        args = self._from_dict_with_task_type(
+            ModelTaskType.T2V,
+            kwargs={
+                "performance_mode": "manual",
+                "cpu_offload_components": ["transformer", "vae"],
+            },
+        )
+
+        self.assertEqual(args.cpu_offload_components, ["dit", "vae"])
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertFalse(args.text_encoder_cpu_offload)
+        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertTrue(args.vae_cpu_offload)
+
+    def test_cpu_offload_components_none_disables_all_legacy_flags(self):
+        args = self._from_dict_with_task_type(
+            ModelTaskType.T2V,
+            kwargs={
+                "performance_mode": "manual",
+                "cpu_offload_components": ["none"],
+            },
+        )
+
+        self.assertEqual(args.cpu_offload_components, [])
+        self.assertFalse(args.dit_cpu_offload)
+        self.assertFalse(args.text_encoder_cpu_offload)
+        self.assertFalse(args.image_encoder_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+
+    def test_cpu_offload_components_rejects_legacy_flag_conflict(self):
+        with self.assertRaisesRegex(ValueError, "cannot be combined"):
+            self._from_dict_with_task_type(
+                ModelTaskType.T2V,
+                kwargs={
+                    "performance_mode": "manual",
+                    "cpu_offload_components": ["dit"],
+                    "dit_cpu_offload": True,
+                },
+            )
 
     def test_vae_cpu_offload_defaults_false_on_low_memory_gpu(self):
         args = self._from_dict_with_task_type(

--- a/python/sglang/srt/disaggregation/encode_server.py
+++ b/python/sglang/srt/disaggregation/encode_server.py
@@ -595,7 +595,9 @@ class MMEncoder:
                 server_args.tokenizer_path or server_args.model_path,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
-                use_fast=not server_args.disable_fast_image_processor,
+                backend=(
+                    "pil" if server_args.disable_fast_image_processor else "torchvision"
+                ),
             )
         except Exception as e:
             logger.warning(f"Failed to load image processor: {e}")
@@ -606,7 +608,6 @@ class MMEncoder:
                 server_args.tokenizer_path or server_args.model_path,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
-                use_fast=not server_args.disable_fast_image_processor,
             )
         except Exception as e:
             logger.warning(f"Failed to load video processor: {e}")
@@ -618,7 +619,6 @@ class MMEncoder:
                 server_args.tokenizer_path or server_args.model_path,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
-                use_fast=not server_args.disable_fast_image_processor,
             )
             if not hasattr(_audio_proc, "feature_extractor"):
                 logger.warning(

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -188,7 +188,11 @@ def get_processor(
             kwargs["size"] = {"shortest_edge": 3136, "longest_edge": 1003520}
 
     if config.model_type not in {"llava", "clip"}:
-        kwargs["use_fast"] = use_fast
+        if "InternVL3_5" in tokenizer_name:
+            # This path loads a tokenizer rather than an image processor.
+            kwargs["use_fast"] = use_fast
+        elif use_fast is not None:
+            kwargs["backend"] = "torchvision" if use_fast else "pil"
     try:
         if "InternVL3_5" in tokenizer_name:
             processor = AutoTokenizer.from_pretrained(
@@ -223,7 +227,8 @@ def get_processor(
                 "Processor %s does not have a slow version. Automatically use fast version",
                 tokenizer_name,
             )
-            kwargs["use_fast"] = True
+            kwargs.pop("use_fast", None)
+            kwargs["backend"] = "torchvision"
             processor = AutoProcessor.from_pretrained(
                 tokenizer_name,
                 *args,
@@ -249,10 +254,10 @@ def get_processor(
         ):
             logger.info(
                 "AutoProcessor for %s rejected standard kwargs, "
-                "retrying without trust_remote_code/use_fast",
+                "retrying without trust_remote_code/backend",
                 tokenizer_name,
             )
-            kwargs.pop("use_fast", None)
+            kwargs.pop("backend", None)
             kwargs.pop("_from_auto", None)
             processor = AutoProcessor.from_pretrained(
                 tokenizer_name,

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -39,6 +39,52 @@ register_cpu_ci(est_time=6, suite="base-a-test-cpu")
 
 
 class TestGetProcessor(unittest.TestCase):
+    def test_maps_image_processor_backend(self):
+        config = SimpleNamespace(model_type="test_vlm", auto_map={})
+
+        for use_fast, expected_backend in ((True, "torchvision"), (False, "pil")):
+            with self.subTest(use_fast=use_fast):
+                loaded_processor = MagicMock()
+                loaded_processor.tokenizer.chat_template = "template"
+                auto_config = MagicMock()
+                auto_config.from_pretrained.return_value = config
+                auto_processor = MagicMock()
+                auto_processor.from_pretrained.return_value = loaded_processor
+
+                with patch.multiple(
+                    processor_utils,
+                    AutoConfig=auto_config,
+                    AutoProcessor=auto_processor,
+                ):
+                    processor_utils.get_processor("test-model", use_fast=use_fast)
+
+                call_kwargs = auto_processor.from_pretrained.call_args.kwargs
+                self.assertEqual(call_kwargs["backend"], expected_backend)
+                self.assertNotIn("use_fast", call_kwargs)
+
+    def test_retries_with_torchvision_when_pil_is_unavailable(self):
+        config = SimpleNamespace(model_type="test_vlm", auto_map={})
+        loaded_processor = MagicMock()
+        loaded_processor.tokenizer.chat_template = "template"
+        auto_config = MagicMock()
+        auto_config.from_pretrained.return_value = config
+        auto_processor = MagicMock()
+        auto_processor.from_pretrained.side_effect = [
+            ValueError("does not have a slow version"),
+            loaded_processor,
+        ]
+
+        with patch.multiple(
+            processor_utils,
+            AutoConfig=auto_config,
+            AutoProcessor=auto_processor,
+        ):
+            processor_utils.get_processor("test-model", use_fast=False)
+
+        retry_kwargs = auto_processor.from_pretrained.call_args_list[1].kwargs
+        self.assertEqual(retry_kwargs["backend"], "torchvision")
+        self.assertNotIn("use_fast", retry_kwargs)
+
     def test_resolves_model_name_before_loading_config(self):
         remote_model = "s3://bucket/model"
         local_model = "/cache/model"

--- a/test/registered/vlm/test_token_id_retokenize_e2e.py
+++ b/test/registered/vlm/test_token_id_retokenize_e2e.py
@@ -53,9 +53,7 @@ def _build_drift_prompt(model, image_token):
     token), followed by one image placeholder. drift_delta is how many extra
     tokens the non-canonical form carries vs. the canonical re-tokenization.
     """
-    tok = AutoProcessor.from_pretrained(
-        model, trust_remote_code=True, use_fast=True
-    ).tokenizer
+    tok = AutoProcessor.from_pretrained(model, trust_remote_code=True).tokenizer
 
     def enc(text):
         return tok.encode(text, add_special_tokens=False)

--- a/test/registered/vlm/test_vlm_input_format.py
+++ b/test/registered/vlm/test_vlm_input_format.py
@@ -74,7 +74,7 @@ class VLMInputTestBase:
             cls.main_image.append(Image.open(BytesIO(response.content)))
 
         cls.processor = AutoProcessor.from_pretrained(
-            cls.model_path, trust_remote_code=True, use_fast=True
+            cls.model_path, trust_remote_code=True
         )
         _fix_added_tokens_encoding(cls.processor.tokenizer)
         cls._init_visual()


### PR DESCRIPTION
## Summary
- preserve exact pipeline component keys from `model_index.json` for `--cpu-offload-components`
- support dynamic modules such as `transformer_2`, `audio_vae`, and `connectors`, plus `all` and legacy group aliases
- apply the selection consistently during loading and request-time residency management
- emit complete diagnostic commands with component names
- document the model-index-based behavior

## Rationale
The unified CPU offload option should follow the Diffusers pipeline component namespace instead of maintaining a fixed component registry. Non-module components remain unaffected.

## Testing
CI is requested for this PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->_Not run yet_<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: **Not enabled** -- add `run-ci-extra` label to opt in.<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->