### PR TITLE
[Docs] Add Ling-3.0-tiny INT4 recipes

### DIFF
--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-tiny.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-tiny.mdx
@@ -1,6 +1,6 @@
 ---
 title: Ling-3.0-tiny
-description: "Deploy Ling-3.0-tiny with SGLang — a compact ~7.9B total / ~1.2B active hybrid KDA + MLA MoE in BF16 or FP8, with thinking mode and tool calling."
+description: "Deploy Ling-3.0-tiny with SGLang — a compact ~7.9B total / ~1.2B active hybrid KDA + MLA MoE in BF16, FP8, or INT4, with thinking mode and tool calling."
 tag: NEW
 ---
 
@@ -12,9 +12,10 @@ tag: NEW
 
 ```bash Command
 docker pull lmsysorg/sglang:dev-Ling-3.0-tiny
+docker pull lmsysorg/sglang:dev-Ling-3.0-flash
 ```
 
-For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
+The command generator uses the Tiny image for BF16 and FP8, and the PR #33561 runtime image for INT4. For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
 
 </Accordion>
 
@@ -46,6 +47,7 @@ It is a thinking model with chain-of-thought enabled by default, and it supports
 
 - **BF16**: [inclusionAI/Ling-3.0-tiny](https://huggingface.co/inclusionAI/Ling-3.0-tiny) — ~7.9B total / ~1.2B active
 - **FP8** (blockwise E4M3): [inclusionAI/Ling-3.0-tiny-fp8](https://huggingface.co/inclusionAI/Ling-3.0-tiny-fp8)
+- **INT4** (compressed-tensors W4A16): [inclusionAI/Ling-3.0-tiny-int4](https://huggingface.co/inclusionAI/Ling-3.0-tiny-int4)
 
 **License:** MIT
 
@@ -53,9 +55,10 @@ It is a thinking model with chain-of-thought enabled by default, and it supports
 
 ## 2. Configuration Tips
 
-- At ~7.9B total / 15.8 GB in BF16 (~7.9 GB in FP8), a single GPU is plenty on every supported card. Tensor parallelism is only useful to raise aggregate KV-cache capacity for many long-context concurrent requests — add `--tp 2`/`--tp 4` to a multi-GPU serve directly.
-- Use the dedicated `lmsysorg/sglang:dev-Ling-3.0-tiny` runtime image below; it carries the `bailing_hybrid` support Ling-3.0-tiny needs.
+- At ~7.9B total / 15.8 GB in BF16 (~7.9 GB in FP8 and ~5.8 GB in INT4), a single GPU is plenty on every supported card. Tensor parallelism is only useful to raise aggregate KV-cache capacity for many long-context concurrent requests — add `--tp 2`/`--tp 4` to a multi-GPU serve directly.
+- Use `lmsysorg/sglang:dev-Ling-3.0-tiny` for BF16 and FP8. INT4 uses `lmsysorg/sglang:dev-Ling-3.0-flash`, which includes the compressed-tensors Hopper and Blackwell backends from PR #33561.
 - The FP8 checkpoint uses blockwise (128×128) E4M3 weights with dynamic activations, quantized from the BF16 model with attention projections, the dense MoE gate, and the lm_head left in higher precision. SGLang detects the format from the checkpoint's `quantization_config`, so no explicit quantization flag is needed, and the same single-GPU recipe serves it.
+- The INT4 checkpoint uses symmetric group-32 W4A16 routed experts. SGLang selects Marlin on Hopper and Triton WNA16 on Blackwell automatically; no explicit quantization or MoE backend flag is needed.
 - Unlike Ling-3.0-flash (which pairs `--reasoning-parser ling3` / `--tool-call-parser ling3`), Ling-3.0-tiny uses `--reasoning-parser deepseek-r1` and `--tool-call-parser glm45` (its auto-detected template pairing) — the template wraps tool calls in `<tool_call>` blocks and emits an inline `...</think>` chain-of-thought. Toggle them in the **Parsers** card of the [Playground](#playground).
 - Only `--model-path`, `--host`, and `--port` are needed. SGLang auto-resolves the context length (native 128K from `max_position_embeddings`), the attention backend, and `--mem-fraction-static` from the GPU and the CUDA-graph runtime, so the recipes leave them unset.
 - The chat template defaults to thinking on. Turn it off per request with `"chat_template_kwargs": {"enable_thinking": false}` for direct answers without the `...</think>` block.

--- a/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-tiny.mdx
+++ b/docs/cookbook/autoregressive/InclusionAI/Ling-3.0-tiny.mdx
@@ -12,10 +12,9 @@ tag: NEW
 
 ```bash Command
 docker pull lmsysorg/sglang:dev-Ling-3.0-tiny
-docker pull lmsysorg/sglang:dev-Ling-3.0-flash
 ```
 
-The command generator uses the Tiny image for BF16 and FP8, and the PR #33561 runtime image for INT4. For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
+For how to launch the image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with what the command generator below produces.
 
 </Accordion>
 
@@ -56,7 +55,7 @@ It is a thinking model with chain-of-thought enabled by default, and it supports
 ## 2. Configuration Tips
 
 - At ~7.9B total / 15.8 GB in BF16 (~7.9 GB in FP8 and ~5.8 GB in INT4), a single GPU is plenty on every supported card. Tensor parallelism is only useful to raise aggregate KV-cache capacity for many long-context concurrent requests — add `--tp 2`/`--tp 4` to a multi-GPU serve directly.
-- Use `lmsysorg/sglang:dev-Ling-3.0-tiny` for BF16 and FP8. INT4 uses `lmsysorg/sglang:dev-Ling-3.0-flash`, which includes the compressed-tensors Hopper and Blackwell backends from PR #33561.
+- Use the dedicated `lmsysorg/sglang:dev-Ling-3.0-tiny` runtime image; it includes the compressed-tensors Hopper and Blackwell backends that INT4 needs.
 - The FP8 checkpoint uses blockwise (128×128) E4M3 weights with dynamic activations, quantized from the BF16 model with attention projections, the dense MoE gate, and the lm_head left in higher precision. SGLang detects the format from the checkpoint's `quantization_config`, so no explicit quantization flag is needed, and the same single-GPU recipe serves it.
 - The INT4 checkpoint uses symmetric group-32 W4A16 routed experts. SGLang selects Marlin on Hopper and Triton WNA16 on Blackwell automatically; no explicit quantization or MoE backend flag is needed.
 - Unlike Ling-3.0-flash (which pairs `--reasoning-parser ling3` / `--tool-call-parser ling3`), Ling-3.0-tiny uses `--reasoning-parser deepseek-r1` and `--tool-call-parser glm45` (its auto-detected template pairing) — the template wraps tool calls in `<tool_call>` blocks and emits an inline `...</think>` chain-of-thought. Toggle them in the **Parsers** card of the [Playground](#playground).

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny-benchmarks.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny-benchmarks.jsx
@@ -1,7 +1,6 @@
-// Measured on lmsysorg/sglang:dev-Ling-3.0-tiny, 1× H200. TTFT/TPOT are P50
-// (median) from sglang.bench_serving (random ISL 8192 / OSL 1024, --flush-cache);
-// tokens_per_sec_per_gpu = output tok/s × (isl+osl)/osl. Accuracy from sgl-eval
-// full GSM8K (1319).
+// TTFT/TPOT are P50. INT4 uses 80 exact ISL 8192 / OSL 1024 requests with
+// --flush-cache; BF16/FP8 retain their original published measurements.
+// Accuracy is full GSM8K (1319).
 export const benchmarks = [
   {
     match: { hw: "h200", variant: "default", quant: "bf16", strategy: "high-throughput", nodes: "single" },
@@ -24,5 +23,29 @@ export const benchmarks = [
         ttft_ms: 79.50, tpot_ms: 5.57, tokens_per_sec_per_gpu: 23738 },
     ],
     accuracy: { gsm8k_pct: 94.69 },
+  },
+  {
+    match: { hw: "h200", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "PR #33561 @ 8ba213fc",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 90.31, tpot_ms: 1.96, tokens_per_sec_per_gpu: 4398 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 840.04, tpot_ms: 3.55, tokens_per_sec_per_gpu: 32958 },
+    ],
+    accuracy: { gsm8k_pct: 94.54 },
+    notes: "Full GSM8K stop rate 100%; default decode CUDA Graph captured 36 shapes through batch 256.",
+  },
+  {
+    match: { hw: "b200", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+    sglang_version: "PR #33561 @ 8ba213fc",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 305.67, tpot_ms: 6.33, tokens_per_sec_per_gpu: 1359 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 2634.12, tpot_ms: 16.04, tokens_per_sec_per_gpu: 7730 },
+    ],
+    accuracy: { gsm8k_pct: 94.54 },
+    notes: "Full GSM8K stop rate 100%; default decode CUDA Graph captured 52 shapes through batch 512. Triton WNA16 used untuned default E=128,N=256 configs.",
   },
 ];

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny.jsx
@@ -10,6 +10,7 @@ export const config = {
   quantizations: [
     { id: "bf16", label: "BF16" },
     { id: "fp8", label: "FP8" },
+    { id: "int4", label: "INT4" },
   ],
   strategies: [
     { id: "high-throughput", label: "High-Throughput" },
@@ -21,6 +22,7 @@ export const config = {
   modelNames: {
     "default|bf16": "inclusionAI/Ling-3.0-tiny",
     "default|fp8": "inclusionAI/Ling-3.0-tiny-fp8",
+    "default|int4": "inclusionAI/Ling-3.0-tiny-int4",
   },
 
   placeholders: {
@@ -42,6 +44,12 @@ export const config = {
     "h100": "lmsysorg/sglang:dev-Ling-3.0-tiny",
     "b200": "lmsysorg/sglang:dev-Ling-3.0-tiny",
     "gb300": "lmsysorg/sglang:dev-Ling-3.0-tiny",
+    "h20-3e|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "h200|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "h800|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "h100|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "b200|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "gb300|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
   },
 
   benchmarkCommands: {
@@ -51,13 +59,16 @@ export const config = {
   --model {{MODEL_NAME}} \\
   --dataset-name {{DATASET}} \\
   --random-input-len {{ISL}} --random-output-len {{OSL}} \\
+  --random-range-ratio 1 \\
   --num-prompts {{NUM_PROMPTS}} --max-concurrency {{MAX_CONCURRENCY}} \\
   --flush-cache`,
     accuracy: {
       gsm8k_pct: `# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
 sgl-eval run gsm8k \\
   --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1 \\
-  --num-threads 32`,
+  --num-threads 32 \\
+  --temperature 1.0 --top-p 0.95 \\
+  --thinking`,
     },
   },
 
@@ -180,6 +191,60 @@ sgl-eval run gsm8k \\
     },
     {
       match: { hw: "gb300", variant: "default", quant: "fp8", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h20-3e", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h200", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h800", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "h100", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: false,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "b200", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb300", variant: "default", quant: "int4", strategy: "high-throughput", nodes: "single" },
       verified: false,
       flags: [
         "--model-path {{MODEL_NAME}}",

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-tiny.jsx
@@ -44,12 +44,6 @@ export const config = {
     "h100": "lmsysorg/sglang:dev-Ling-3.0-tiny",
     "b200": "lmsysorg/sglang:dev-Ling-3.0-tiny",
     "gb300": "lmsysorg/sglang:dev-Ling-3.0-tiny",
-    "h20-3e|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "h200|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "h800|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "h100|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "b200|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "gb300|int4": "lmsysorg/sglang:dev-Ling-3.0-flash",
   },
 
   benchmarkCommands: {


### PR DESCRIPTION
## Summary

- add the public Ling-3.0-tiny INT4 checkpoint to the cookbook deployment matrix
- add verified single-GPU H200 and B200 recipes with default decode CUDA Graph enabled
- keep launch commands minimal and let SGLang select Marlin on Hopper and Triton WNA16 on Blackwell
- publish full GSM8K accuracy, stop rates, and fixed 8K/1K concurrency 1/16 performance

Runtime support is provided by #33561.

## Results

| GPU | GSM8K | stop rate | throughput/GPU (c1 / c16) | default graph range |
|---|---:|---:|---:|---:|
| H200 | 94.54% | 100% | 4,398 / 32,958 tok/s | through batch 256 |
| B200 | 94.54% | 100% | 1,359 / 7,730 tok/s | through batch 512 |

Performance uses 80 exact-length random requests at ISL/OSL 8192/1024. The benchmark cards include P50 TTFT and TPOT. The B200 run used the default untuned Triton WNA16 configs for the Tiny expert shape; this is recorded in the benchmark note.

No recipe uses --disable-cuda-graph or --cuda-graph-max-bs-decode.

## Validation

- node docs/scripts/check_cookbook_configs.mjs
- matrix completeness and Docker image mapping check
- pre-commit on all changed files
- Mintlify build validation and broken-links
- Playwright H200/B200 INT4 command, Docker image, benchmark, and verified-state checks
- H200 and B200 serving, full GSM8K finish-reason gate, default CUDA Graph capture, and performance gates

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31521200848](https://github.com/sgl-project/sglang/actions/runs/31521200848)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31521200410](https://github.com/sgl-project/sglang/actions/runs/31521200410)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->