### PR TITLE
[Bugfix] Wait for SGLang generation readiness in serving benchmark

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -169,6 +169,13 @@ def wait_for_endpoint(url: str, timeout_sec: int = 60) -> bool:
         time.sleep(1)
 
 
+def _get_ready_check_url(base_url: str, model_url: str, backend: str) -> str:
+    """Return the endpoint used to decide when a benchmark server is ready."""
+    if backend in ("sglang", "sglang-native", "sglang-oai", "sglang-oai-chat"):
+        return f"{base_url}/health_generate"
+    return model_url if backend not in ("trt", "gserver") else base_url
+
+
 # trt llm does not support ignore_eos
 # https://github.com/triton-inference-server/tensorrtllm_backend/issues/505
 async def async_request_trt_llm(
@@ -2028,7 +2035,7 @@ def run_benchmark(args_: argparse.Namespace):
 
     # Wait for server to be ready
     if args.ready_check_timeout_sec > 0:
-        health_url = model_url if args.backend not in ("trt", "gserver") else base_url
+        health_url = _get_ready_check_url(base_url, model_url, args.backend)
         if not wait_for_endpoint(health_url, args.ready_check_timeout_sec):
             print(f"Server at {health_url} is not ready. Exiting.")
             sys.exit(1)

--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -53,6 +53,7 @@ from sglang.benchmark.serving import (
     _EMBEDDING_BACKENDS,
     ASYNC_REQUEST_FUNCS,
     _finite_positive_float,
+    _get_ready_check_url,
     async_request_openai_embeddings,
     flush_server_cache,
 )
@@ -109,6 +110,31 @@ class TestEmbeddingBenchmarkBackends(CustomTestCase):
             ASYNC_REQUEST_FUNCS["vllm-embedding"], async_request_openai_embeddings
         )
         self.assertEqual(_BACKEND_API_PATHS["vllm-embedding"], "/v1/embeddings")
+
+
+class TestBenchmarkReadinessEndpoint(CustomTestCase):
+    def test_sglang_backends_wait_for_generation_readiness(self):
+        """A SGLang server exposes models before warmup finishes, so benchmarks
+        must wait for the generation probe instead of the model-list endpoint.
+        """
+        base_url = "http://127.0.0.1:30000"
+        model_url = f"{base_url}/v1/models"
+
+        for backend in ("sglang", "sglang-native", "sglang-oai", "sglang-oai-chat"):
+            with self.subTest(backend=backend):
+                self.assertEqual(
+                    _get_ready_check_url(base_url, model_url, backend),
+                    f"{base_url}/health_generate",
+                )
+
+    def test_other_backends_keep_their_existing_readiness_endpoint(self):
+        """Backends without SGLang's generation probe retain their current URL."""
+        base_url = "http://127.0.0.1:8000"
+        model_url = f"{base_url}/v1/models"
+
+        self.assertEqual(_get_ready_check_url(base_url, model_url, "vllm"), model_url)
+        self.assertEqual(_get_ready_check_url(base_url, model_url, "trt"), base_url)
+        self.assertEqual(_get_ready_check_url(base_url, model_url, "gserver"), base_url)
 
 
 class TestBenchmarkCacheFlush(CustomTestCase):


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #33740.

`bench_serving --ready-check-timeout-sec` currently polls `/v1/models` for SGLang backends. The model-list endpoint can return HTTP 200 while a worker is still warming up, so the benchmark may start its warmup request too early and fail even though the configured readiness timeout has not elapsed.

## Modifications

- Poll `/health_generate` for the `sglang`, `sglang-native`, `sglang-oai`, and `sglang-oai-chat` backends.
- Preserve the existing readiness endpoints for all other backends.
- Add regression coverage for both the SGLang mapping and the compatibility behavior.

Before the implementation change, the new regression test failed for all four SGLang backends because they selected `/v1/models`. It passes after the change.

## Accuracy Tests

This change does not modify model execution or output.

Smoke-tested Gemma 2 2B on RTX 3090:

- Single GPU: non-streaming `/generate` returned HTTP 200 with the expected coherent output.
- 1P1D PD disaggregation with `mooncake_tcp` on two RTX 3090s: non-streaming and streaming `/generate` both returned HTTP 200 with matching output tokens.
- Invalid native generation input returned HTTP 400 with the expected validation error.

Environment: CUDA 13.0, PyTorch 2.13.0, `sglang-kernel` 0.4.6.post1, FlashInfer 0.6.15.post1, `sglang-router` 0.3.2.

## Speed Tests and Profiling

The change only affects the pre-benchmark readiness probe and does not alter the inference path.

For the two-GPU PD smoke test, the non-streaming request completed in 0.584 seconds (server-reported E2E latency: 0.555 seconds), and the streaming request completed in 0.467 seconds. Each GPU used approximately 16.41 GiB.

Validation:

- `pytest -q test/registered/bench_fn/test_benchmark_datasets_api.py`: 47 passed, 10 subtests passed.
- `isort 7.0.0 --check-only`: passed.
- `ruff 0.15.1 --select=F401,F821,UP037`: passed.
- `black 26.1.0 --check`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable: no user-facing option or workflow changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31476270334](https://github.com/sgl-project/sglang/actions/runs/31476270334)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31476270200](https://github.com/sgl-project/sglang/actions/runs/31476270200)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->