### PR TITLE
[Bugfix] Check paged KV capacity before kernel launch

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -190,6 +190,15 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         ):
             self.merge_and_sort_free()
 
+        if num_new_pages is None:
+            num_new_pages = get_num_new_pages(
+                seq_lens=seq_lens_cpu,
+                page_size=self.page_size,
+                prefix_lens=prefix_lens_cpu,
+            )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty(
             (extend_num_tokens,), dtype=torch.int64, device=self.device
         )
@@ -206,15 +215,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        if num_new_pages is None:
-            num_new_pages = get_num_new_pages(
-                seq_lens=seq_lens_cpu,
-                page_size=self.page_size,
-                prefix_lens=prefix_lens_cpu,
-            )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices
@@ -234,6 +234,14 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.need_sort and bs > len(self.free_pages):
             self.merge_and_sort_free()
 
+        num_new_pages = get_num_new_pages(
+            seq_lens=seq_lens_cpu,
+            page_size=self.page_size,
+            decode=True,
+        )
+        if num_new_pages > len(self.free_pages):
+            return None
+
         out_indices = torch.empty((bs,), dtype=torch.int64, device=self.device)
         alloc_decode_kernel[(bs,)](
             seq_lens,
@@ -246,14 +254,6 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         if self.debug_mode:
             assert len(torch.unique(out_indices)) == len(out_indices)
-
-        num_new_pages = get_num_new_pages(
-            seq_lens=seq_lens_cpu,
-            page_size=self.page_size,
-            decode=True,
-        )
-        if num_new_pages > len(self.free_pages):
-            return None
 
         self.free_pages = self.free_pages[num_new_pages:]
         return out_indices

--- a/test/registered/unit/mem_cache/test_paged_allocator_oom.py
+++ b/test/registered/unit/mem_cache/test_paged_allocator_oom.py
@@ -1,0 +1,120 @@
+"""Regression tests for paged allocator out-of-memory handling."""
+
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_allocator(*, need_sort=False, size=8):
+    return PagedTokenToKVPoolAllocator(
+        size=size,
+        page_size=4,
+        dtype=torch.float16,
+        device="cpu",
+        kvcache=None,
+        need_sort=need_sort,
+    )
+
+
+@pytest.mark.parametrize("num_new_pages", [None, 3])
+def test_extend_checks_capacity_before_launching_kernel(num_new_pages):
+    allocator = _make_allocator()
+    free_pages_before = allocator.free_pages.clone()
+    prefix_lens = torch.tensor([0], dtype=torch.int64)
+    seq_lens = torch.tensor([12], dtype=torch.int64)
+    last_loc = torch.tensor([-1], dtype=torch.int64)
+
+    with patch("sglang.srt.mem_cache.allocator.paged.alloc_extend_kernel") as kernel:
+        result = allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens,
+            seq_lens,
+            seq_lens,
+            last_loc,
+            extend_num_tokens=12,
+            num_new_pages=num_new_pages,
+        )
+
+    assert result is None
+    assert torch.equal(allocator.free_pages, free_pages_before)
+    kernel.__getitem__.assert_not_called()
+
+
+def test_decode_checks_capacity_before_launching_kernel():
+    allocator = _make_allocator()
+    free_pages_before = allocator.free_pages.clone()
+    seq_lens = torch.tensor([5, 9, 13], dtype=torch.int64)
+    last_loc = torch.tensor([3, 7, 11], dtype=torch.int64)
+
+    with patch("sglang.srt.mem_cache.allocator.paged.alloc_decode_kernel") as kernel:
+        result = allocator.alloc_decode(seq_lens, seq_lens, last_loc)
+
+    assert result is None
+    assert torch.equal(allocator.free_pages, free_pages_before)
+    kernel.__getitem__.assert_not_called()
+
+
+def test_extend_launches_when_capacity_is_sufficient():
+    allocator = _make_allocator()
+    prefix_lens = torch.tensor([0], dtype=torch.int64)
+    seq_lens = torch.tensor([8], dtype=torch.int64)
+    last_loc = torch.tensor([-1], dtype=torch.int64)
+
+    with patch("sglang.srt.mem_cache.allocator.paged.alloc_extend_kernel") as kernel:
+        result = allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens,
+            seq_lens,
+            seq_lens,
+            last_loc,
+            extend_num_tokens=8,
+        )
+
+    assert result is not None
+    assert result.shape == (8,)
+    assert len(allocator.free_pages) == 0
+    kernel.__getitem__.assert_called_once_with((1,))
+
+
+def test_decode_launches_when_capacity_is_sufficient():
+    allocator = _make_allocator()
+    seq_lens = torch.tensor([5], dtype=torch.int64)
+    last_loc = torch.tensor([3], dtype=torch.int64)
+
+    with patch("sglang.srt.mem_cache.allocator.paged.alloc_decode_kernel") as kernel:
+        result = allocator.alloc_decode(seq_lens, seq_lens, last_loc)
+
+    assert result is not None
+    assert result.shape == (1,)
+    assert len(allocator.free_pages) == 1
+    kernel.__getitem__.assert_called_once_with((1,))
+
+
+def test_capacity_check_happens_after_release_pages_are_merged():
+    allocator = _make_allocator(need_sort=True, size=12)
+    allocated = allocator.alloc(8)
+    allocator.free(allocated[:4])
+
+    prefix_lens = torch.tensor([0], dtype=torch.int64)
+    seq_lens = torch.tensor([8], dtype=torch.int64)
+    last_loc = torch.tensor([-1], dtype=torch.int64)
+
+    with patch("sglang.srt.mem_cache.allocator.paged.alloc_extend_kernel") as kernel:
+        result = allocator.alloc_extend(
+            prefix_lens,
+            prefix_lens,
+            seq_lens,
+            seq_lens,
+            last_loc,
+            extend_num_tokens=8,
+        )
+
+    assert result is not None
+    assert len(allocator.free_pages) == 0
+    kernel.__getitem__.assert_called_once_with((1,))


### PR DESCRIPTION
## Summary

- Check paged KV capacity before launching the extend/decode Triton allocator
  kernels.
- Preserve the existing release-page merge behavior before the capacity check.
- Add regression tests covering OOM, successful allocation, and release-page
  merging.

## Motivation

The old implementation launched the allocation kernel and only then checked
whether enough free pages were available. On an A100 with two free pages, a
prefill or decode request requiring three pages returned `None` but still
launched the kernel once. The kernel could read beyond the logical free-page
list.

This is reachable in normal serving when the KV cache is full and no more
evictable pages are available. See issue #34399 for the reproducible
online path and evidence.

## Validation

### Unit and allocator tests

```text
138 passed, 2 warnings, 33 subtests passed in 29.19s
```

The test command covered the new paged allocator regression tests,
multi-ended allocator, paged free, SWA, HiSparse, DCP layout, KV page
invariants, and decode bookkeeping tests.

### A100 validation

With `NVIDIA A100-PCIE-40GB`, PyTorch `2.9.1+cu128`, and
`CUDA_LAUNCH_BLOCKING=1`:

```text
extend_oom= True kernel_launches= 0 free_unchanged= True
decode_oom= True kernel_launches= 0 free_unchanged= True
```

The same unmodified-mainline inputs launched one kernel in each path.

### OOM-path microbenchmark

After warming the successful kernel path, 100 synchronous prefill OOM calls
measured:

```text
main:  126.14 us/call
patch:  59.37 us/call
```

This is a single local failure-path measurement, not an end-to-end throughput
benchmark. Successful allocation behavior is unchanged.

## Scope

This patch is intentionally limited to the paged allocator capacity-check
ordering. It does not change the Triton kernel interface, page numbering, or
normal successful allocation behavior.

Fixes #34399

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32484222870](https://github.com/sgl-project/sglang/actions/runs/32484222870)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32484222812](https://github.com/sgl-project/sglang/actions/runs/32484222812)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32484222848](https://github.com/sgl-project/sglang/actions/runs/32484222848)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
