### PR TITLE
Add distributed exact input logprobs

### DIFF
--- a/benchmark/kernels/bench_distributed_logprob.py
+++ b/benchmark/kernels/bench_distributed_logprob.py
@@ -1,0 +1,272 @@
+"""TP benchmark for exact input logprobs without full-vocab AllGather.
+
+Example:
+
+  torchrun --standalone --nproc-per-node=4 \
+    benchmark/kernels/bench_distributed_logprob.py --rows 2048 8192
+"""
+
+import argparse
+import gc
+import json
+import os
+from dataclasses import asdict, dataclass
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.logprob_processor import (
+    compute_distributed_row_log_normalizer,
+    compute_row_log_normalizer,
+    get_distributed_token_scores,
+)
+
+
+class TorchTpGroup:
+    def __init__(self):
+        self.device_group = dist.group.WORLD
+
+    def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.device_group)
+        return tensor
+
+
+@dataclass
+class BenchResult:
+    rows: int
+    vocab_size: int
+    tp_size: int
+    baseline_ms: float
+    distributed_ms: float
+    speedup: float
+    baseline_peak_mib: float
+    distributed_peak_mib: float
+    peak_reduction: float
+    max_abs_error: float
+    baseline_allgather_receive_mib_per_rank: float
+    distributed_scalar_receive_mib_per_rank: float
+
+
+def shard_bounds(vocab_size: int, rank: int, world_size: int) -> tuple[int, int, int]:
+    padded_vocab = ((vocab_size + 63) // 64) * 64
+    assert padded_vocab % world_size == 0
+    width = padded_vocab // world_size
+    start = rank * width
+    end = min(start + width, vocab_size)
+    return start, end, width
+
+
+def make_local_logits(
+    rows: int,
+    vocab_size: int,
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int, int]:
+    start, end, width = shard_bounds(vocab_size, rank, world_size)
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260809 + rank)
+    logits = torch.randn((rows, width), device="cuda", dtype=dtype, generator=generator)
+    valid_width = end - start
+    if valid_width < width:
+        logits[:, valid_width:] = 1e4
+    return logits, start, end
+
+
+def max_across_ranks(value: float) -> float:
+    tensor = torch.tensor(value, device="cuda", dtype=torch.float64)
+    dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
+    return tensor.item()
+
+
+def time_cuda(fn, warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        output = fn()
+        del output
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        output = fn()
+        del output
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def peak_memory_mib(fn) -> float:
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    base = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    output = fn()
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated()
+    del output
+    return (peak - base) / (1024**2)
+
+
+def run_correctness(group: TorchTpGroup, rank: int, world_size: int) -> dict:
+    rows, vocab_size = 17, 154883
+    start, end, width = shard_bounds(vocab_size, rank, world_size)
+
+    # Every rank constructs the same small reference, then takes its shard.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(1234)
+    full = torch.randn((rows, vocab_size), device="cuda", generator=generator)
+    full = full + 1e4
+    local = torch.empty((rows, width), device="cuda", dtype=torch.float32)
+    local.fill_(1e6)
+    if end > start:
+        local[:, : end - start] = full[:, start:end]
+
+    row_max, row_log_sum = compute_distributed_row_log_normalizer(
+        local, end - start, group
+    )
+    row_indices = torch.arange(rows, device="cuda").repeat_interleave(world_size)
+    owner_tokens = torch.tensor(
+        [min((owner * width) + 3, vocab_size - 1) for owner in range(world_size)],
+        device="cuda",
+    )
+    token_ids = owner_tokens.repeat(rows)
+    raw_scores = get_distributed_token_scores(
+        local, row_indices, token_ids, start, end, group
+    )
+    got = (raw_scores - row_max[row_indices]) - row_log_sum[row_indices]
+    reference = torch.log_softmax(full, dim=-1)[row_indices, token_ids]
+    max_abs_error = max_across_ranks((got - reference).abs().max().item())
+    return {
+        "rows": rows,
+        "vocab_size": vocab_size,
+        "max_abs_error": max_abs_error,
+        "padding_excluded": True,
+        "owners_covered": world_size,
+    }
+
+
+def run_benchmark(
+    group: TorchTpGroup,
+    rank: int,
+    world_size: int,
+    rows: int,
+    vocab_size: int,
+    warmup: int,
+    iterations: int,
+) -> BenchResult:
+    local_logits, vocab_start, vocab_end = make_local_logits(
+        rows, vocab_size, rank, world_size, torch.bfloat16
+    )
+    local_width = local_logits.shape[1]
+    valid_width = vocab_end - vocab_start
+    target_ids = torch.arange(rows, device="cuda", dtype=torch.long) % vocab_size
+    row_indices = torch.arange(rows, device="cuda", dtype=torch.long)
+
+    def baseline():
+        gathered = torch.empty(
+            (world_size * rows, local_width),
+            device="cuda",
+            dtype=local_logits.dtype,
+        )
+        dist.all_gather_into_tensor(gathered, local_logits)
+        full_logits = (
+            gathered.view(world_size, rows, local_width)
+            .permute(1, 0, 2)
+            .reshape(rows, world_size * local_width)[:, :vocab_size]
+            .float()
+        )
+        row_max, row_log_sum = compute_row_log_normalizer(full_logits)
+        raw_scores = full_logits[row_indices, target_ids]
+        return (raw_scores - row_max) - row_log_sum
+
+    def distributed():
+        local_fp32 = local_logits.float()
+        row_max, row_log_sum = compute_distributed_row_log_normalizer(
+            local_fp32, valid_width, group
+        )
+        raw_scores = get_distributed_token_scores(
+            local_fp32,
+            row_indices,
+            target_ids,
+            vocab_start,
+            vocab_end,
+            group,
+        )
+        return (raw_scores - row_max) - row_log_sum
+
+    reference = baseline()
+    candidate = distributed()
+    torch.cuda.synchronize()
+    max_abs_error = max_across_ranks((candidate - reference).abs().max().item())
+    del reference, candidate
+
+    baseline_ms = max_across_ranks(time_cuda(baseline, warmup, iterations))
+    distributed_ms = max_across_ranks(time_cuda(distributed, warmup, iterations))
+    baseline_peak_mib = max_across_ranks(peak_memory_mib(baseline))
+    distributed_peak_mib = max_across_ranks(peak_memory_mib(distributed))
+
+    full_bf16_bytes = rows * vocab_size * 2
+    baseline_receive = full_bf16_bytes * (world_size - 1) / world_size
+    # MAX, SUM, and selected-score SUM. Ring all-reduce receives
+    # 2*(p-1)/p times the tensor size per rank.
+    scalar_receive = 3 * (2 * (world_size - 1) / world_size) * rows * 4
+
+    return BenchResult(
+        rows=rows,
+        vocab_size=vocab_size,
+        tp_size=world_size,
+        baseline_ms=baseline_ms,
+        distributed_ms=distributed_ms,
+        speedup=baseline_ms / distributed_ms,
+        baseline_peak_mib=baseline_peak_mib,
+        distributed_peak_mib=distributed_peak_mib,
+        peak_reduction=baseline_peak_mib / distributed_peak_mib,
+        max_abs_error=max_abs_error,
+        baseline_allgather_receive_mib_per_rank=baseline_receive / (1024**2),
+        distributed_scalar_receive_mib_per_rank=scalar_receive / (1024**2),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, nargs="+", default=[2048, 8192])
+    parser.add_argument("--vocab-size", type=int, default=154880)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    args = parser.parse_args()
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = TorchTpGroup()
+    try:
+        correctness = run_correctness(group, dist.get_rank(), dist.get_world_size())
+        results = [
+            asdict(
+                run_benchmark(
+                    group,
+                    dist.get_rank(),
+                    dist.get_world_size(),
+                    rows,
+                    args.vocab_size,
+                    args.warmup,
+                    args.iterations,
+                )
+            )
+            for rows in args.rows
+        ]
+        if dist.get_rank() == 0:
+            print(
+                json.dumps(
+                    {"correctness": correctness, "benchmarks": results}, indent=2
+                ),
+                flush=True,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1005,6 +1005,10 @@ class Envs:
     # materializing the full-vocab log-softmax. Escape hatch only; the two
     # paths are mathematically identical.
     SGLANG_ENABLE_FAST_INPUT_LOGPROBS = EnvBool(True)
+    # Compute prompt/input logprobs directly from TP-sharded vocabulary logits.
+    # Set to false to retain the gathered fast-input-logprob path for rollout
+    # comparison or as an operational escape hatch.
+    SGLANG_ENABLE_DISTRIBUTED_INPUT_LOGPROBS = EnvBool(True)
 
     # Tool-Call behavior
     SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -40,6 +40,7 @@ from sglang.srt.layers.dp_attention import (
     get_dp_hidden_size,
 )
 from sglang.srt.layers.logprob_processor import (
+    DistributedLogprobContext,
     InputLogprobProcessor,
     LogprobStage,
     get_token_ids_logprobs_raw,
@@ -414,6 +415,9 @@ class LogitsProcessor(nn.Module):
             get_logits_fn=self._get_logits,
             logits_metadata=logits_metadata,
             skip_chunking_for_dp_attn=self.do_tensor_parallel_all_gather_dp_attn,
+            distributed_context=self._get_distributed_logprob_context(
+                lm_head, logits_metadata
+            ),
         )
 
         logits_output = LogitsProcessorOutput(
@@ -688,6 +692,74 @@ class LogitsProcessor(nn.Module):
                     logits / self.final_logit_softcapping
                 )
 
+        return logits
+
+    def _get_distributed_logprob_context(
+        self,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+    ) -> Optional[DistributedLogprobContext]:
+        """Return the narrow sharded prompt-logprob path when layout is safe."""
+        if (
+            not self.input_logprob_processor.enable_fast_input_logprobs
+            or not self.input_logprob_processor.enable_distributed_input_logprobs
+            or not self.do_tensor_parallel_all_gather
+            or self.do_tensor_parallel_all_gather_dp_attn
+            or logits_metadata.extend_return_top_logprob
+            or not isinstance(lm_head, VocabParallelEmbedding)
+            or not lm_head.enable_tp
+            or lm_head.num_added_embeddings != 0
+            or lm_head.org_vocab_size != self.vocab_size
+        ):
+            return None
+
+        tp_group = (
+            get_parallel().attn_tp_group
+            if self.use_attn_tp_group
+            else get_parallel().tp_group
+        )
+        if lm_head.tp_size != tp_group.world_size:
+            return None
+
+        shard = lm_head.shard_indices
+        return DistributedLogprobContext(
+            tp_group=tp_group,
+            vocab_start_index=shard.org_vocab_start_index,
+            vocab_end_index=shard.org_vocab_end_index,
+            vocab_size=self.vocab_size,
+            get_local_logits_fn=self._get_local_logits_for_distributed_logprobs,
+            gather_sampled_logits_fn=self._gather_sampled_logits,
+        )
+
+    def _get_local_logits_for_distributed_logprobs(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+    ) -> torch.Tensor:
+        """Compute transformed fp32 rank-local logits without vocab gather."""
+        assert not self.do_tensor_parallel_all_gather_dp_attn
+        logits = self._compute_lm_head(hidden_states, lm_head)
+        if self.logit_scale is not None:
+            logits.mul_(self.logit_scale)
+        logits = logits.float()
+        if self.final_logit_softcapping:
+            if not (_is_npu or _is_cpu):
+                fused_softcap(logits, self.final_logit_softcapping)
+            else:
+                logits = self.final_logit_softcapping * torch.tanh(
+                    logits / self.final_logit_softcapping
+                )
+        return logits
+
+    def _gather_sampled_logits(self, local_logits: torch.Tensor) -> torch.Tensor:
+        """Preserve the sampler's full-vocab contract for sampled rows only."""
+        if self.use_attn_tp_group:
+            logits = self._gather_attn_tp_logits(local_logits)
+        else:
+            logits = self._logits_gatherer(local_logits)
+        if logits.shape[-1] > self.vocab_size:
+            logits = logits[:, : self.vocab_size]
         return logits
 
     def _compute_lm_head(

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 import torch
 
@@ -62,6 +62,33 @@ class LogprobResult:
             )
 
 
+@dataclasses.dataclass(frozen=True)
+class DistributedLogprobContext:
+    """TP-sharded input-logprob callbacks and contiguous vocab ownership."""
+
+    tp_group: Any
+    vocab_start_index: int
+    vocab_end_index: int
+    vocab_size: int
+    get_local_logits_fn: Callable
+    gather_sampled_logits_fn: Callable
+
+
+@dataclasses.dataclass(frozen=True)
+class _TokenIdsChunkEntry:
+    token_ids: Optional[List[int]]
+    num_rows: int
+    continue_previous: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _TokenIdsChunkPlan:
+    row_indices: torch.Tensor
+    token_ids: torch.Tensor
+    entries: List[_TokenIdsChunkEntry]
+    next_split_pruned_len: int
+
+
 def compute_row_log_normalizer(
     logits: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -80,6 +107,163 @@ def compute_row_log_normalizer(
     row_log_sum = torch.logsumexp(x - row_max[:, None], dim=-1)
     row_log_sum = torch.where(row_max.isinf(), 0.0, row_log_sum)
     return row_max, row_log_sum
+
+
+def compute_distributed_row_log_normalizer(
+    local_logits: torch.Tensor,
+    valid_vocab_size: int,
+    tp_group: Any,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute a global row normalizer without gathering vocab logits.
+
+    ``local_logits`` follows rank-local contiguous vocab order. Columns after
+    ``valid_vocab_size`` are padding and do not participate. The exchanged
+    tensors are one fp32 max and one fp32 exponential sum per row.
+    """
+    if not 0 <= valid_vocab_size <= local_logits.shape[1]:
+        raise ValueError(
+            f"valid_vocab_size={valid_vocab_size} is incompatible with "
+            f"local logits width {local_logits.shape[1]}"
+        )
+
+    if valid_vocab_size == 0:
+        local_max = torch.full(
+            (local_logits.shape[0],),
+            float("-inf"),
+            dtype=torch.float32,
+            device=local_logits.device,
+        )
+        local_log_sum = torch.zeros_like(local_max)
+    else:
+        valid_logits = local_logits[:, :valid_vocab_size]
+        local_max, local_log_sum = compute_row_log_normalizer(valid_logits)
+
+    global_max = local_max.clone()
+    torch.distributed.all_reduce(
+        global_max,
+        op=torch.distributed.ReduceOp.MAX,
+        group=tp_group.device_group,
+    )
+
+    if valid_vocab_size == 0:
+        local_exp_sum = torch.zeros_like(global_max)
+    else:
+        local_exp_sum = torch.exp((local_max - global_max) + local_log_sum)
+    global_exp_sum = tp_group.all_reduce(local_exp_sum)
+    return global_max, torch.log(global_exp_sum)
+
+
+def get_distributed_token_scores(
+    local_logits: torch.Tensor,
+    row_indices: torch.Tensor,
+    token_ids: torch.Tensor,
+    vocab_start_index: int,
+    vocab_end_index: int,
+    tp_group: Any,
+) -> torch.Tensor:
+    """Look up raw token scores from contiguous TP vocab shards.
+
+    Exactly one rank contributes each requested token score; all other ranks
+    contribute zero. A SUM reduction therefore returns the selected score on
+    every rank while exchanging only one fp32 value per request.
+    """
+    if row_indices.ndim != 1 or token_ids.ndim != 1:
+        raise ValueError("row_indices and token_ids must be one-dimensional")
+    if row_indices.shape != token_ids.shape:
+        raise ValueError("row_indices and token_ids must have the same shape")
+    if row_indices.numel() == 0:
+        return local_logits.new_empty(0, dtype=torch.float32)
+
+    owned = (token_ids >= vocab_start_index) & (token_ids < vocab_end_index)
+    local_width = local_logits.shape[1]
+    if local_width == 0:
+        local_scores = local_logits.new_zeros(token_ids.shape, dtype=torch.float32)
+    else:
+        local_indices = (token_ids - vocab_start_index).clamp(
+            min=0, max=local_width - 1
+        )
+        selected = local_logits[row_indices, local_indices].float()
+        local_scores = torch.where(owned, selected, torch.zeros_like(selected))
+    return tp_group.all_reduce(local_scores)
+
+
+def _build_token_ids_chunk_plan(
+    token_ids_logprobs: List[Optional[List[int]]],
+    pruned_lens: List[int],
+    split_pruned_len: int,
+    num_rows: int,
+    device: torch.device,
+) -> _TokenIdsChunkPlan:
+    """Flatten ragged explicit-token probes into one collective request."""
+    request_rows: List[int] = []
+    request_token_ids: List[int] = []
+    entries: List[_TokenIdsChunkEntry] = []
+    pt = 0
+    next_split_pruned_len = 0
+
+    for n, (token_ids, original_pruned_len) in enumerate(
+        zip(token_ids_logprobs, pruned_lens)
+    ):
+        current_split = split_pruned_len if n == 0 else 0
+        pruned_len = original_pruned_len - current_split
+        continue_previous = current_split > 0
+
+        if pruned_len <= 0:
+            entries.append(_TokenIdsChunkEntry(token_ids, 0, False))
+            continue
+
+        available_rows = min(pruned_len, max(num_rows - pt, 0))
+        if available_rows < pruned_len:
+            next_split_pruned_len = current_split + available_rows
+
+        if token_ids:
+            for row in range(pt, pt + available_rows):
+                request_rows.extend([row] * len(token_ids))
+                request_token_ids.extend(token_ids)
+
+        entries.append(
+            _TokenIdsChunkEntry(token_ids, available_rows, continue_previous)
+        )
+        pt += pruned_len
+
+    return _TokenIdsChunkPlan(
+        row_indices=torch.tensor(request_rows, dtype=torch.long, device=device),
+        token_ids=torch.tensor(request_token_ids, dtype=torch.long, device=device),
+        entries=entries,
+        next_split_pruned_len=next_split_pruned_len,
+    )
+
+
+def _append_token_ids_chunk_from_flat_scores(
+    plan: _TokenIdsChunkPlan,
+    flat_scores: torch.Tensor,
+    token_ids_logprobs_val: List,
+    token_ids_logprobs_idx: List,
+) -> None:
+    """Restore the existing per-sequence/per-row response shape."""
+    score_pt = 0
+    for entry in plan.entries:
+        token_ids = entry.token_ids
+        width = len(token_ids) if token_ids else 0
+        count = entry.num_rows * width
+        if width:
+            values = flat_scores[score_pt : score_pt + count].reshape(
+                entry.num_rows, width
+            )
+            val = values.tolist()
+            idx = [token_ids for _ in range(entry.num_rows)]
+        else:
+            val, idx = [], []
+        score_pt += count
+
+        if entry.continue_previous:
+            token_ids_logprobs_val[-1].extend(val)
+            token_ids_logprobs_idx[-1].extend(idx)
+        else:
+            token_ids_logprobs_val.append(val)
+            token_ids_logprobs_idx.append(idx)
+
+    assert score_pt == flat_scores.numel()
 
 
 def get_top_logprobs_raw(
@@ -447,6 +631,9 @@ class InputLogprobProcessor:
             envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
             and not _deterministic_inference_enabled()
         )
+        self.enable_distributed_input_logprobs = (
+            envs.SGLANG_ENABLE_DISTRIBUTED_INPUT_LOGPROBS.get()
+        )
 
     def forward(
         self,
@@ -458,6 +645,7 @@ class InputLogprobProcessor:
         get_logits_fn: Callable,
         logits_metadata: LogitsMetadata,
         skip_chunking_for_dp_attn: bool = False,
+        distributed_context: Optional[DistributedLogprobContext] = None,
     ) -> Tuple[LogprobResult, torch.Tensor]:
         # Non-chunked = one chunk covering every row. DP-attention must stay
         # single-chunk: the collective schedule cannot depend on per-rank rows.
@@ -479,6 +667,7 @@ class InputLogprobProcessor:
             get_logits_fn,
             logits_metadata,
             chunk_size,
+            distributed_context,
         )
 
     def _forward_by_chunk(
@@ -491,6 +680,7 @@ class InputLogprobProcessor:
         get_logits_fn: Callable,
         logits_metadata: LogitsMetadata,
         chunk_size: int,
+        distributed_context: Optional[DistributedLogprobContext] = None,
     ) -> Tuple[LogprobResult, torch.Tensor]:
         """Compute input logprobs chunk by chunk to cap peak memory."""
         total_size = pruned_states.shape[0]
@@ -524,6 +714,12 @@ class InputLogprobProcessor:
 
             fused_kernel, fused_max_k = row_logsumexp_topk, FUSED_TOPK_MAX_K
 
+        use_distributed_logprobs = (
+            distributed_context is not None
+            and self.enable_fast_input_logprobs
+            and not logits_metadata.extend_return_top_logprob
+        )
+
         for i in range(num_chunks):
             start_idx = i * chunk_size
             end_idx = min((i + 1) * chunk_size, total_size)
@@ -548,17 +744,27 @@ class InputLogprobProcessor:
             # writing through the shared graph logits buffer would alias
             # chunks whose shape happens to match the buffer.
             chunk_states = pruned_states[start_idx:end_idx]
-            chunk_logits = get_logits_fn(
-                chunk_states,
-                lm_head,
-                logits_metadata,
-                use_logits_buffer=num_chunks == 1,
-            )
+            if use_distributed_logprobs:
+                chunk_logits = distributed_context.get_local_logits_fn(
+                    chunk_states, lm_head, logits_metadata
+                )
+            else:
+                chunk_logits = get_logits_fn(
+                    chunk_states,
+                    lm_head,
+                    logits_metadata,
+                    use_logits_buffer=num_chunks == 1,
+                )
 
             # Initialize sampled_logits on first chunk
             if i == 0:
+                sampled_vocab_size = (
+                    distributed_context.vocab_size
+                    if use_distributed_logprobs
+                    else chunk_logits.shape[1]
+                )
                 sampled_logits = torch.empty(
-                    (sample_indices.shape[0], chunk_logits.shape[1]),
+                    (sample_indices.shape[0], sampled_vocab_size),
                     dtype=chunk_logits.dtype,
                     device=chunk_logits.device,
                 )
@@ -570,7 +776,12 @@ class InputLogprobProcessor:
             )
             if chunk_sample_mask.any():
                 chunk_sample_indices = sample_indices[chunk_sample_mask] - start_idx
-                sampled_logits[chunk_sample_mask] = chunk_logits[chunk_sample_indices]
+                chunk_sampled_logits = chunk_logits[chunk_sample_indices]
+                if use_distributed_logprobs:
+                    chunk_sampled_logits = distributed_context.gather_sampled_logits_fn(
+                        chunk_sampled_logits
+                    )
+                sampled_logits[chunk_sample_mask] = chunk_sampled_logits
 
             # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
             chunk_logprobs = chunk_logits[chunk_indices]
@@ -581,6 +792,89 @@ class InputLogprobProcessor:
             chunk_slice = slice(
                 token_to_seq_idx[start_idx], token_to_seq_idx[end_idx - 1] + 1
             )
+
+            if use_distributed_logprobs:
+                valid_vocab_size = (
+                    distributed_context.vocab_end_index
+                    - distributed_context.vocab_start_index
+                )
+                if chunk_logprobs.shape[0] > 0:
+                    row_max, row_log_sum = compute_distributed_row_log_normalizer(
+                        chunk_logprobs,
+                        valid_vocab_size,
+                        distributed_context.tp_group,
+                    )
+
+                    target_token_ids = (
+                        logits_metadata.extend_input_logprob_token_ids_gpu[mask_indices]
+                    ).long()
+                    target_rows = torch.arange(
+                        chunk_logprobs.shape[0],
+                        device=chunk_logprobs.device,
+                        dtype=torch.long,
+                    )
+
+                    explicit_plan = None
+                    lookup_rows = target_rows
+                    lookup_token_ids = target_token_ids
+                    if logits_metadata.extend_token_ids_logprob:
+                        explicit_plan = _build_token_ids_chunk_plan(
+                            logits_metadata.token_ids_logprobs[chunk_slice],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
+                            split_len_token_ids,
+                            chunk_logprobs.shape[0],
+                            chunk_logprobs.device,
+                        )
+                        lookup_rows = torch.cat(
+                            (lookup_rows, explicit_plan.row_indices)
+                        )
+                        lookup_token_ids = torch.cat(
+                            (lookup_token_ids, explicit_plan.token_ids)
+                        )
+
+                    raw_scores = get_distributed_token_scores(
+                        chunk_logprobs,
+                        lookup_rows,
+                        lookup_token_ids,
+                        distributed_context.vocab_start_index,
+                        distributed_context.vocab_end_index,
+                        distributed_context.tp_group,
+                    )
+                    normalized_scores = (
+                        raw_scores - row_max[lookup_rows]
+                    ) - row_log_sum[lookup_rows]
+                    num_targets = target_rows.numel()
+                    token_logprobs.append(normalized_scores[:num_targets])
+
+                    if explicit_plan is not None:
+                        _append_token_ids_chunk_from_flat_scores(
+                            explicit_plan,
+                            normalized_scores[num_targets:],
+                            token_ids_logprobs_val,
+                            token_ids_logprobs_idx,
+                        )
+                        split_len_token_ids = explicit_plan.next_split_pruned_len
+                else:
+                    token_logprobs.append(
+                        chunk_logprobs.new_empty(0, dtype=torch.float32)
+                    )
+                    if logits_metadata.extend_token_ids_logprob:
+                        explicit_plan = _build_token_ids_chunk_plan(
+                            logits_metadata.token_ids_logprobs[chunk_slice],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
+                            split_len_token_ids,
+                            0,
+                            chunk_logprobs.device,
+                        )
+                        _append_token_ids_chunk_from_flat_scores(
+                            explicit_plan,
+                            chunk_logprobs.new_empty(0, dtype=torch.float32),
+                            token_ids_logprobs_val,
+                            token_ids_logprobs_idx,
+                        )
+                        split_len_token_ids = explicit_plan.next_split_pruned_len
+                del chunk_logprobs
+                continue
 
             chunk_precomputed_topk = None
             if self.enable_fast_input_logprobs:

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -8,12 +8,16 @@ top-k indices, across chunk splits and heterogeneous per-sequence params.
 """
 
 import itertools
+import tempfile
 import unittest
 from types import SimpleNamespace
 
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from sglang.srt.layers.logprob_processor import (
+    DistributedLogprobContext,
     InputLogprobProcessor,
     compute_row_log_normalizer,
 )
@@ -27,6 +31,116 @@ VOCAB = 11
 TOPK_CYCLE = [2, 0, 3]
 # [] is a valid probe set distinct from None (opt-out).
 TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
+
+
+class _TorchDistributedGroup:
+    def __init__(self):
+        self.device_group = dist.group.WORLD
+
+    def all_reduce(self, tensor):
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.device_group)
+        return tensor
+
+
+def _distributed_input_logprob_worker(rank, world_size, init_file):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        torch.manual_seed(17)
+        rows, vocab, shard_width = 7, 11, 6
+        full_logits = torch.randn(rows, vocab, dtype=torch.float32) * 3
+        if rank == 0:
+            local_logits = full_logits[:, :shard_width].clone()
+            vocab_start, vocab_end = 0, 6
+        else:
+            # A deliberately dominant padding value catches accidental
+            # participation in the distributed normalizer.
+            padding = torch.full((rows, 1), 1e4)
+            local_logits = torch.cat((full_logits[:, 6:], padding), dim=1)
+            vocab_start, vocab_end = 6, vocab
+
+        group = _TorchDistributedGroup()
+
+        def get_local_logits_fn(states, lm_head, logits_metadata):
+            return states
+
+        def gather_sampled_logits_fn(local_sampled):
+            shards = [torch.empty_like(local_sampled) for _ in range(world_size)]
+            dist.all_gather(shards, local_sampled, group=group.device_group)
+            return torch.cat(shards, dim=-1)[:, :vocab]
+
+        context = DistributedLogprobContext(
+            tp_group=group,
+            vocab_start_index=vocab_start,
+            vocab_end_index=vocab_end,
+            vocab_size=vocab,
+            get_local_logits_fn=get_local_logits_fn,
+            gather_sampled_logits_fn=gather_sampled_logits_fn,
+        )
+        sample_indices = torch.tensor([2, 5, 6], dtype=torch.long)
+        input_indices = torch.arange(6, dtype=torch.long)
+        target_ids = torch.tensor([0, 6, 10, 1, 7, 9], dtype=torch.long)
+        metadata = SimpleNamespace(
+            extend_return_top_logprob=False,
+            extend_token_ids_logprob=True,
+            top_logprobs_nums=[0, 0, 0],
+            extend_logprob_pruned_lens_cpu=[3, 3, 0],
+            extend_input_logprob_token_ids_gpu=target_ids,
+            token_ids_logprobs=[[0, 6, 10], [2, 7], None],
+        )
+
+        proc = InputLogprobProcessor()
+        proc.enable_fast_input_logprobs = True
+        proc.enable_logprobs_chunk = True
+        proc.logprobs_chunk_size = 2
+
+        def unused_gathered_logits(*args, **kwargs):
+            raise AssertionError("distributed path unexpectedly gathered prompt rows")
+
+        result, sampled_logits = proc.forward(
+            pruned_states=local_logits,
+            sample_indices=sample_indices,
+            input_logprob_indices=input_indices,
+            token_to_seq_idx=[0, 0, 0, 1, 1, 1, 2],
+            lm_head=None,
+            get_logits_fn=unused_gathered_logits,
+            logits_metadata=metadata,
+            distributed_context=context,
+        )
+
+        reference = torch.log_softmax(full_logits, dim=-1)
+        expected_targets = reference[input_indices, target_ids]
+        torch.testing.assert_close(
+            result.token_logprobs, expected_targets, rtol=1e-5, atol=1e-5
+        )
+        torch.testing.assert_close(
+            sampled_logits, full_logits[sample_indices], rtol=0, atol=0
+        )
+
+        expected_explicit = [
+            reference[:3, [0, 6, 10]].tolist(),
+            reference[3:6, [2, 7]].tolist(),
+            [],
+        ]
+        _assert_nested_close(
+            unittest.TestCase(),
+            expected_explicit,
+            result.token_ids_logprobs_val,
+            "distributed explicit token IDs",
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        assert result.token_ids_logprobs_idx == [
+            [[0, 6, 10]] * 3,
+            [[2, 7]] * 3,
+            [],
+        ]
+    finally:
+        dist.destroy_process_group()
 
 
 def _build_batch(seq_specs, dtype, vocab=VOCAB):
@@ -118,6 +232,54 @@ def _shape_of(nested):
 
 
 class TestFastInputLogprobs(CustomTestCase):
+    def test_distributed_path_falls_back_for_prompt_topk(self):
+        batch = _build_batch([(4, 1), (3, 0)], torch.float32)
+        proc = InputLogprobProcessor()
+        reference, reference_sampled = _run(proc, batch, True, None)
+
+        def unexpected_distributed_call(*args, **kwargs):
+            raise AssertionError("prompt top-k must retain the gathered path")
+
+        context = DistributedLogprobContext(
+            tp_group=None,
+            vocab_start_index=0,
+            vocab_end_index=VOCAB,
+            vocab_size=VOCAB,
+            get_local_logits_fn=unexpected_distributed_call,
+            gather_sampled_logits_fn=unexpected_distributed_call,
+        )
+        pruned_states, sample_indices, input_indices, token_to_seq, metadata = batch
+
+        def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
+            return states
+
+        got, got_sampled = proc.forward(
+            pruned_states=pruned_states,
+            sample_indices=sample_indices,
+            input_logprob_indices=input_indices,
+            token_to_seq_idx=token_to_seq,
+            lm_head=None,
+            get_logits_fn=get_logits_fn,
+            logits_metadata=metadata,
+            distributed_context=context,
+        )
+        self.assertEqual(reference.top_logprobs_idx, got.top_logprobs_idx)
+        self.assertEqual(reference.token_ids_logprobs_idx, got.token_ids_logprobs_idx)
+        torch.testing.assert_close(reference.token_logprobs, got.token_logprobs)
+        torch.testing.assert_close(reference_sampled, got_sampled)
+
+    def test_distributed_exact_input_logprobs_cpu(self):
+        # Real collectives, but Gloo/CPU only: validates TP=2 normalization,
+        # padding exclusion, local/remote token ownership, ragged explicit
+        # probes, chunk stitching, and sampled-row-only vocab gathering.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mp.spawn(
+                _distributed_input_logprob_worker,
+                args=(2, f"{tmp_dir}/init"),
+                nprocs=2,
+                join=True,
+            )
+
     def _sweep(self, dtype, rtol, atol):
         torch.manual_seed(0)
         proc = InputLogprobProcessor()


### PR DESCRIPTION
# Compute exact input logprobs from TP-sharded vocab logits without full-vocabulary TP gather

## Summary

This change adds an opt-in-safe distributed path for prompt/input logprobs.
Each tensor-parallel rank keeps its vocabulary-sharded logits and contributes:

- one row maximum;
- one rescaled exponential sum;
- selected scores for requested target and explicit token IDs.

The ranks exchange these compact values with NCCL reductions instead of
materializing and all-gathering `[rows, vocab_size]` logits. Sampled rows still
use the existing full-vocabulary gather so general sampling semantics are
unchanged.

AS-IS (gather the vocabulary before normalizing):

```text
TP rank 0: [rows, V/TP] logits   \
TP rank 1: [rows, V/TP] logits    +-- vocab AllGather --> [rows, V]
TP rank 2: [rows, V/TP] logits   /
TP rank 3: [rows, V/TP] logits
                                      |
                              log_softmax + token picks
                                      |
                                input logprob
```

PR (normalize while logits remain sharded):

```text
TP rank r: [rows, V/TP] logits
                 |
       local row max, exp sum, owned token scores
                 |
       MAX/SUM/SCORE reductions (compact per-row data)
                 |
           x_t - m - log(s) for each requested token
                 |
             input logprob (exact, no V-sized gather)
```

The sampled-row path intentionally retains its existing vocabulary gather.

## Performance evidence

Controlled TP4 GLM-5.2 tests used the supported runtime (Torch 2.13/CUDA 13,
`sglang-kernel 0.4.6.post1`, sm100), fixed raw input IDs, one full-workload warmup per
server, and interleaved A-B-B-A ordering with five measured requests per
server.

### Consolidated results

Each row uses N=10 measured requests per path under the same controlled TP4
A-B-B-A protocol. Each request generated one output token and the server ran at
concurrency 1 (`max-running-requests=1`). Values are client-observed
whole-request E2E times.

| Input length | Output tokens | Concurrency | Gathered median | Distributed median | Median saved | Speedup | Gathered mean | Distributed mean |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4K | 1 | 1 | 0.910 s | 0.481 s | 0.429 s (47.2%) | 1.89x | 0.911 s | 0.481 s |
| 8K | 1 | 1 | 1.608 s | 0.727 s | 0.882 s (54.8%) | 2.21x | 1.608 s | 0.727 s |
| 1M | 1 | 1 | 144.064 s | 143.303 s | 0.761 s (0.529%) | 1.005x | 144.063 s | 143.294 s |

The timer covers the complete client request/response path; the GPU interval
from local stat production to logprob readiness was not separately
instrumented.

## Scope

Included:

- prompt/input logprobs;
- explicit `token_ids_logprob` probes;
- chunked prompt-logprob processing;
- contiguous TP vocabulary ownership and padded-shard handling;
- model logit scaling and final logit softcapping;
- fallback guards for unsupported layouts and prompt top-k requests.

Not included:

- prompt top-k logprobs;
- general sampling changes;
- direct-read or producer-fanout memory-semantic transport.

## Rollout and fallback

`SGLANG_ENABLE_DISTRIBUTED_INPUT_LOGPROBS` controls the path and defaults to
enabled. Setting it to `0` restores the gathered fast-input-logprob path for
rollout comparison or operational rollback.

## Correctness validation

- Focused unit suite: 14 passed.
- Coverage includes TP2 Gloo distributed normalization, padded vocabularies,
  owner-shard token lookup, explicit IDs, chunk stitching, and fallback guards.
- Existing deterministic fixed-vector production comparison remains the
  correctness reference.

Long random GLM-5.2 DSA prompts were numerically nondeterministic after the
first 2,048-token region even on an unchanged server, so full-response digests
from those requests are not used as an A/B correctness oracle.

## Review notes

The implementation uses MAX and SUM reductions for the row normalizer and a
compact SUM reduction for requested scores. The sampled-row vocabulary gather
is intentionally preserved. The E2E result demonstrates benefit from the
current NCCL implementation; it is not a claim for the future direct-read or
producer-fanout designs.

## Reproduction artifacts

- Controlled 1M analysis: `artifacts/glm52_tp4_controlled_1m_20260811/analysis.json`
- Controlled 1M raw summary: `artifacts/glm52_tp4_controlled_1m_20260811/summary.json`
- Controlled 8K raw summary: `artifacts/glm52_tp4_controlled_8k_20260810_retry1/summary.json`
- Controlled 4K raw summary: `artifacts/glm52_tp4_controlled_4k_20260811/summary.json`
- Benchmark harness: `experiments/run_controlled_ab.py`
- Research journal: `DISTRIBUTED_LOGPROB_JOURNAL.md`

## Community reproduction

The harness requires four GPUs with the same TP4 GLM-5.2/ModelOpt runtime used
for the numbers above. From this checkout:

```bash
cd <repo-root>

# Focused unit coverage (no GPU required).
PYTHONPATH=sglang_worktree/python \
  python -m pytest -q \
  sglang_worktree/test/registered/unit/layers/test_logprob_fast_input.py

# Controlled 8K A-B-B-A comparison (requires model access and 4 GPUs).
./.venv-current/bin/python \
  experiments/run_controlled_ab.py \
  --length 8192 --warmups 1 --samples 5 --explicit \
  --mem-fraction 0.92 \
  --artifact-dir artifacts/glm52_tp4_controlled_8k_<date>

# Controlled 4K A-B-B-A comparison.
./.venv-current/bin/python \
  experiments/run_controlled_ab.py \
  --length 4096 --warmups 1 --samples 5 --explicit \
  --mem-fraction 0.92 \
  --artifact-dir artifacts/glm52_tp4_controlled_4k_<date>

# Optional long-context appendix run.
./.venv-current/bin/python \
  experiments/run_controlled_ab.py \
  --length 1000000 --warmups 1 --samples 5 --explicit \
  --mem-fraction 0.92 \
  --artifact-dir artifacts/glm52_tp4_controlled_1m_<date>
```

Set the harness model path, GPU list, and runtime constants for your machine.
The exact server flags and runtime versions are recorded in each artifact's
`summary.json`.

This is an open GitHub PR; it has not been merged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31692955531](https://github.com/sgl-project/sglang/actions/runs/31692955531)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31692955322](https://github.com/sgl-project/sglang/actions/runs/31692955322)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
