### PR TITLE
Fix flaky decode cache-hit check in Inkling test

### DIFF
--- a/python/sglang/test/kl_test_utils.py
+++ b/python/sglang/test/kl_test_utils.py
@@ -308,6 +308,7 @@ def test_input_output_logprobs_match_decode_cache_hit_helper(
     max_samples=None,
     max_new_tokens=8192,
     trust_remote_code=False,
+    min_cache_hit_ratio=0.5,
 ):
     server_info = requests.get(base_url + "/server_info").json()
     if server_info["disable_radix_cache"]:
@@ -363,7 +364,11 @@ def test_input_output_logprobs_match_decode_cache_hit_helper(
         output_logprobs.append(_extract_output_logprobs(result))
 
     if not os.environ.get("SGLANG_TEST_SKIP_CACHE_HIT_ASSERT"):
-        assert len(new_input_ids) > 0.5 * len(
+        # Whether a prompt hits depends on where its last decode checkpoint falls
+        # relative to the page-aligned window a sliding-window model retains, so the
+        # default only screens out a vacuous run. A caller that makes every prompt
+        # hit by construction raises this to pin that down instead.
+        assert len(new_input_ids) > min_cache_hit_ratio * len(
             second_turn_input_ids
         ), f"Too few decode cache hits: {len(new_input_ids)}/{len(second_turn_input_ids)}"
 

--- a/python/sglang/test/kl_test_utils.py
+++ b/python/sglang/test/kl_test_utils.py
@@ -364,10 +364,9 @@ def test_input_output_logprobs_match_decode_cache_hit_helper(
         output_logprobs.append(_extract_output_logprobs(result))
 
     if not os.environ.get("SGLANG_TEST_SKIP_CACHE_HIT_ASSERT"):
-        # Whether a prompt hits depends on where its last decode checkpoint falls
-        # relative to the page-aligned window a sliding-window model retains, so the
-        # default only screens out a vacuous run. A caller that makes every prompt
-        # hit by construction raises this to pin that down instead.
+        # Page-aligned SWA retention decides which prompts hit at all, so the default
+        # only screens out a vacuous run. A caller whose checkpoint interval makes
+        # every prompt hit raises this to pin that down.
         assert len(new_input_ids) > min_cache_hit_ratio * len(
             second_turn_input_ids
         ), f"Too few decode cache hits: {len(new_input_ids)}/{len(second_turn_input_ids)}"

--- a/test/registered/models_e2e/test_inkling_small_nvfp4.py
+++ b/test/registered/models_e2e/test_inkling_small_nvfp4.py
@@ -58,6 +58,12 @@ KL_DIV_THRESHOLD = 1e-9
 # checkpoint or a mis-restored prefix would surface.
 KL_MAX_NEW_TOKENS = 1024
 
+# Equal to the page size below. Out-of-window SWA slots are freed a page at a
+# time, so only a checkpoint sitting on a page boundary still has a full window
+# of SWA data below it -- at the default 256 half the sequence lengths land off
+# that boundary and lose their decode prefix entirely.
+KL_TRACK_INTERVAL = 128
+
 
 class TestInklingSmallNvfp4(CustomTestCase):
     @classmethod
@@ -162,14 +168,8 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
                 "0.1",
                 "--mem-fraction-static",
                 "0.85",
-                # A decode checkpoint is reusable only when a full sliding window of
-                # live SWA data survives below it, and out-of-window SWA slots are
-                # freed a whole page at a time. Setting the interval to the page size
-                # puts every checkpoint exactly on that boundary; at the default 256
-                # a checkpoint clears it only when the sequence length happens to fall
-                # in the first half of an interval, which halves the hit rate.
                 "--mamba-track-interval",
-                "128",
+                str(KL_TRACK_INTERVAL),
                 "--enable-deterministic-inference",
             ],
             env={**os.environ, "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"},
@@ -198,9 +198,8 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
         self._run(assert_logprobs_match_prefill_cache_hit)
 
     def test_input_output_logprobs_match_decode_cache_hit(self):
-        # The interval set above makes every prompt reuse its decode checkpoint, so
-        # anything short of that is a state-reuse regression rather than a geometry
-        # coincidence.
+        # 0.99 is every prompt: the interval above makes the reuse unconditional, so
+        # a single miss is a state-reuse regression rather than a geometry coincidence.
         self._run(assert_logprobs_match_decode_cache_hit, min_cache_hit_ratio=0.99)
 
 

--- a/test/registered/models_e2e/test_inkling_small_nvfp4.py
+++ b/test/registered/models_e2e/test_inkling_small_nvfp4.py
@@ -162,6 +162,14 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
                 "0.1",
                 "--mem-fraction-static",
                 "0.85",
+                # A decode checkpoint is reusable only when a full sliding window of
+                # live SWA data survives below it, and out-of-window SWA slots are
+                # freed a whole page at a time. Setting the interval to the page size
+                # puts every checkpoint exactly on that boundary; at the default 256
+                # a checkpoint clears it only when the sequence length happens to fall
+                # in the first half of an interval, which halves the hit rate.
+                "--mamba-track-interval",
+                "128",
                 "--enable-deterministic-inference",
             ],
             env={**os.environ, "SGLANG_ENABLE_UNIFIED_RADIX_TREE": "1"},
@@ -172,7 +180,7 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
         if getattr(cls, "process", None) is not None:
             kill_process_tree(cls.process.pid)
 
-    def _run(self, helper):
+    def _run(self, helper, **kwargs):
         helper(
             self.base_url,
             {self.model: {"kl_div": KL_DIV_THRESHOLD}},
@@ -180,6 +188,7 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
             max_samples=32,
             max_new_tokens=KL_MAX_NEW_TOKENS,
             trust_remote_code=True,
+            **kwargs,
         )
 
     def test_input_output_logprobs_match(self):
@@ -189,7 +198,10 @@ class TestInklingSmallNvfp4Deterministic(CustomTestCase):
         self._run(assert_logprobs_match_prefill_cache_hit)
 
     def test_input_output_logprobs_match_decode_cache_hit(self):
-        self._run(assert_logprobs_match_decode_cache_hit)
+        # The interval set above makes every prompt reuse its decode checkpoint, so
+        # anything short of that is a state-reuse regression rather than a geometry
+        # coincidence.
+        self._run(assert_logprobs_match_decode_cache_hit, min_cache_hit_ratio=0.99)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`test_input_output_logprobs_match_decode_cache_hit` on `TestInklingSmallNvfp4Deterministic` reds intermittently with `Too few decode cache hits: 16/32` while `avg_kl_div` stays 0.0. The hit count is not noise. A decode checkpoint is reusable only when a full sliding window of live SWA data survives below it, and out-of-window SWA slots are freed a page at a time, so the deepest reusable position is the last page boundary. With `mamba_track_interval` at its default 256 and `--page-size 128` only every other page boundary carries a checkpoint, so a prompt hits iff `(prompt_len + max_new_tokens) mod 256 < 128`. That is half of them, an expected 16 of 32 against a screen needing 17, so the case has been one prompt away from red since it landed. Per-prompt agreement with that condition is 32/32, including the exact `cached_tokens`.

Matching the interval to the page size makes every page boundary a checkpoint, so the condition becomes an identity in the sequence length: **17/32 to 32/32** decode cache hits. `min_cache_hit_ratio` is then raised to require all 32, which turns a sampling floor into a guard and doubles what the case covers, since half the requests previously never reached decode-region state reuse.

4xB200, tp=4, only the interval changed:

```
test_input_output_logprobs_match ... ok
test_input_output_logprobs_match_decode_cache_hit ... avg_kl_div=0.0 ok
test_input_output_logprobs_match_prefill_cache_hit ... avg_kl_div=0.0 ok

Ran 3 tests in 320.719s

OK
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31481873146](https://github.com/sgl-project/sglang/actions/runs/31481873146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31481987018](https://github.com/sgl-project/sglang/actions/runs/31481987018)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->