### PR TITLE
[Constrained] Report the real cause when no grammar backend is available

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -357,8 +357,11 @@ def create_grammar_backend(
                 ) from e
             logger.warning(
                 f"Grammar backend disabled because tokenizer is not supported by XGrammar: {e}. "
-                "Falling back to grammar_backend='none'. "
-                "Structured outputs (JSON schema, regex, EBNF) will not be available."
+                "Falling back to grammar_backend='none'. Requests using json_schema, "
+                "regex, ebnf or structural_tag will be rejected with HTTP 400, and tool "
+                "calls that need a constraint (tool_choice='required'/named, or 'auto' "
+                "with strict tools) will fail the same way. Try --grammar-backend "
+                "llguidance or --grammar-backend outlines."
             )
             get_context().override("grammar.import_fallback", grammar_backend="none")
             return None

--- a/python/sglang/srt/constrained/grammar_manager.py
+++ b/python/sglang/srt/constrained/grammar_manager.py
@@ -14,6 +14,7 @@ from sglang.srt.constrained.base_grammar_backend import (
 from sglang.srt.constrained.reasoner_grammar_backend import ReasonerGrammarObject
 from sglang.srt.distributed.communication_tags import P2PTag
 from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_context
 
 if TYPE_CHECKING:
     from sglang.srt.managers.io_struct import AbortReq
@@ -128,6 +129,33 @@ class GrammarManager:
         if isinstance(req.grammar, ReasonerGrammarObject):
             req.grammar.max_think_tokens = thinking_budget
 
+    def _no_grammar_backend_error(self) -> str:
+        prefix = (
+            "Grammar-based generation (json_schema, regex, ebnf, structural_tag) is "
+        )
+        if self.server_args.skip_tokenizer_init:
+            return prefix + (
+                "unavailable because the server was launched with --skip-tokenizer-init."
+            )
+        # server_args is the pristine startup record, so a backend disabled by the
+        # import fallback still reads as the requested one; the override log is what
+        # distinguishes "operator asked for none" from "backend failed to load".
+        for source, fields in get_context().overrides_log():
+            if (
+                source == "grammar.import_fallback"
+                and fields.get("grammar_backend") == "none"
+            ):
+                return prefix + (
+                    f"unavailable: the '{self.server_args.grammar_backend}' backend "
+                    "failed to initialize for this model's tokenizer and was disabled "
+                    "at startup. Search the server log for 'Grammar backend disabled' "
+                    "for the underlying error, and try --grammar-backend llguidance or "
+                    "--grammar-backend outlines."
+                )
+        return prefix + (
+            "not supported when the server is launched with --grammar-backend none"
+        )
+
     def process_req_with_grammar(self, req: Req) -> bool:
         # Init grammar cache for this request
         add_to_grammar_queue = False
@@ -138,8 +166,7 @@ class GrammarManager:
             or req.sampling_params.structural_tag is not None
         ):
             if self.grammar_backend is None:
-                error_msg = "Grammar-based generation (json_schema, regex, ebnf, structural_tag) is not supported when the server is launched with --grammar-backend none"
-                req.set_finish_with_abort(error_msg)
+                req.set_finish_with_abort(self._no_grammar_backend_error())
             else:
                 if req.sampling_params.json_schema is not None:
                     key = ("json", req.sampling_params.json_schema)

--- a/test/registered/unit/constrained/test_grammar_manager.py
+++ b/test/registered/unit/constrained/test_grammar_manager.py
@@ -233,19 +233,53 @@ class TestProcessReqWithGrammar(unittest.TestCase):
         req.set_finish_with_abort.assert_called_once()
         self.assertIn("bad schema", req.set_finish_with_abort.call_args[0][0])
 
-    def test_no_backend_aborts(self):
-        """No grammar backend should abort request."""
-        scheduler = _make_scheduler()
-        scheduler.server_args.skip_tokenizer_init = True
-        mgr = GrammarManager(scheduler)
+    def _make_no_backend_mgr(self):
+        """Manager with no grammar backend, built with skip-tokenizer-init so that
+        backend creation is bypassed; callers then set the field under test."""
+        mgr = GrammarManager(_make_scheduler(skip_tokenizer=True))
         mgr.grammar_backend = None
+        return mgr
 
+    def _abort_message(self, mgr, overrides=()):
+        """Run a json_schema request through mgr and return the abort message."""
         req = _make_req(json_schema='{"type": "object"}')
-        result = mgr.process_req_with_grammar(req)
+        with patch("sglang.srt.constrained.grammar_manager.get_context") as get_context:
+            get_context.return_value.overrides_log.return_value = list(overrides)
+            result = mgr.process_req_with_grammar(req)
 
         self.assertFalse(result)
         req.set_finish_with_abort.assert_called_once()
-        self.assertIn("not supported", req.set_finish_with_abort.call_args[0][0])
+        return req.set_finish_with_abort.call_args[0][0]
+
+    def test_no_backend_aborts_on_skip_tokenizer_init(self):
+        """No grammar backend should abort, naming skip-tokenizer-init."""
+        self.assertIn(
+            "--skip-tokenizer-init", self._abort_message(self._make_no_backend_mgr())
+        )
+
+    def test_no_backend_aborts_on_explicit_none(self):
+        """An operator-specified grammar_backend='none' keeps the original message."""
+        mgr = self._make_no_backend_mgr()
+        mgr.server_args.skip_tokenizer_init = False
+        mgr.server_args.grammar_backend = "none"
+
+        msg = self._abort_message(mgr)
+
+        self.assertIn("not supported", msg)
+        self.assertIn("--grammar-backend none", msg)
+
+    def test_no_backend_aborts_on_import_fallback(self):
+        """A backend disabled at startup must not be reported as a launch flag."""
+        mgr = self._make_no_backend_mgr()
+        mgr.server_args.skip_tokenizer_init = False
+        mgr.server_args.grammar_backend = "xgrammar"
+
+        msg = self._abort_message(
+            mgr, overrides=[("grammar.import_fallback", {"grammar_backend": "none"})]
+        )
+
+        self.assertIn("failed to initialize", msg)
+        self.assertNotIn("--grammar-backend none", msg)
 
     def test_json_takes_priority_over_other_constraints(self):
         """When json_schema is set, it should be used regardless of other fields."""


### PR DESCRIPTION
When no grammar backend is available, requests using `json_schema`, `regex`, `ebnf` or `structural_tag` are rejected with a message that always blames `--grammar-backend none`. That is only one of three ways to reach that state — the backend is also disabled at startup when it fails to initialize for the model's tokenizer, and it is absent under `--skip-tokenizer-init`. In those cases operators go looking for a flag nobody set.

`server_args` stays the pristine startup record, so the import fallback is not visible there, but it is recorded in the runtime context's override log — enough to name the real cause. The message for an explicitly configured `none` is unchanged.

The startup warning now also says what operators will actually observe: 400s on structured output and on tool calls that need a constraint, plus the alternate backends worth trying.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31486329077](https://github.com/sgl-project/sglang/actions/runs/31486329077)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31486328832](https://github.com/sgl-project/sglang/actions/runs/31486328832)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->