### PR TITLE
[Test] Pin DSpark PD decode draft-input handoff regression

### DIFF
--- a/test/registered/spec/dspark/test_dspark_disaggregation.py
+++ b/test/registered/spec/dspark/test_dspark_disaggregation.py
@@ -1,0 +1,91 @@
+"""CPU regression for the DSpark disaggregation-decode draft-input handoff.
+
+Scope is deliberately narrow: this pins the contract of
+``SpeculativeAlgorithm.DSPARK.build_disagg_draft_input()`` at the
+prefill -> decode boundary, i.e. the single point where a PD decode worker
+must already hold a ``SpecInput`` before the first
+``spec_prepare_for_decode()``. It is not a scheduler simulation.
+
+The invariant is worth pinning because the DSPARK branch used to be absent,
+so the call fell through to ``None`` and the first decode step raised
+``'NoneType' object has no attribute 'prepare_for_decode'`` -- while DSpark,
+DP attention and disaggregation each passed CI on their own.
+
+``FutureMap`` is autospecced (not hand-rolled) because ``publish()`` /
+``stash()`` write device-side relay buffers that a CPU job cannot allocate.
+Those two calls are themselves part of the handoff contract, so they are
+asserted rather than skipped.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import create_autospec
+
+import torch
+
+from sglang.srt.managers.overlap_utils import FutureMap
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+# Committed lengths / pool slots / transferred bonus tokens handed over by the
+# prefill instance for a two-request decode batch.
+SEQ_LENS = torch.tensor([11, 23], dtype=torch.int64)
+REQ_POOL_INDICES = torch.tensor([3, 7], dtype=torch.int64)
+LAST_TOKENS = torch.tensor([101, 202], dtype=torch.int64)
+
+
+class TestDSparkDisaggDraftInput(CustomTestCase):
+    def _make_batch(self, *, enable_overlap: bool):
+        # Exactly the three ScheduleBatch fields the builder reads.
+        return SimpleNamespace(
+            seq_lens=SEQ_LENS,
+            req_pool_indices=REQ_POOL_INDICES,
+            enable_overlap=enable_overlap,
+        )
+
+    def _build(self, *, enable_overlap: bool):
+        future_map = create_autospec(FutureMap, instance=True)
+        spec_info = SpeculativeAlgorithm.DSPARK.build_disagg_draft_input(
+            batch=self._make_batch(enable_overlap=enable_overlap),
+            server_args=SimpleNamespace(),
+            last_tokens_tensor=LAST_TOKENS,
+            future_map=future_map,
+        )
+        return spec_info, future_map
+
+    def test_transferred_state_reaches_the_first_decode(self):
+        spec_info, future_map = self._build(enable_overlap=False)
+
+        # Regression: DSPARK must not fall through to None here.
+        self.assertIsNotNone(spec_info)
+        torch.testing.assert_close(spec_info.bonus_tokens, LAST_TOKENS)
+        torch.testing.assert_close(spec_info.new_seq_lens, SEQ_LENS)
+
+        # Without overlap there is no relay to seed.
+        future_map.publish.assert_not_called()
+        future_map.stash.assert_not_called()
+
+    def test_overlap_seeds_the_future_relay_before_the_first_decode(self):
+        spec_info, future_map = self._build(enable_overlap=True)
+
+        self.assertIsNotNone(spec_info)
+        torch.testing.assert_close(spec_info.future_indices, REQ_POOL_INDICES)
+        # No DSA IndexShare seed survives the transfer.
+        self.assertFalse(spec_info.future_dsa_topk_indices_available)
+
+        future_map.publish.assert_called_once()
+        published_indices, published_seq_lens = future_map.publish.call_args.args
+        torch.testing.assert_close(published_indices, REQ_POOL_INDICES)
+        torch.testing.assert_close(published_seq_lens, SEQ_LENS)
+
+        future_map.stash.assert_called_once()
+        stashed_indices, payload = future_map.stash.call_args.args
+        torch.testing.assert_close(stashed_indices, REQ_POOL_INDICES)
+        torch.testing.assert_close(payload.bonus_tokens, LAST_TOKENS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR adds **regression coverage only** for the DSpark disaggregation-decode draft-input handoff. It contains **no production code** — current `main` already has the implementation:

- `SpeculativeAlgorithm.build_disagg_draft_input()` dispatches on `is_dspark()`
- `python/sglang/srt/speculative/dspark_disaggregation.py` builds the draft input and, under overlap, seeds `future_indices` and publishes/stashes the relay state

What is not currently pinned is the invariant that this path must produce a non-`None` `SpecInput` *before* the first decode step. An earlier stack (v0.5.16) lacked the DSPARK branch, so the call fell through to `None` and the first decode step failed with:

```text
spec_prepare_for_decode
  -> batch.spec_info.prepare_for_decode(batch)
AttributeError: 'NoneType' object has no attribute 'prepare_for_decode'
```

DSpark, DP attention and disaggregation each passed independently; only the combination exposed this handoff gap. This PR pins that boundary so a future refactor cannot silently regress to `DSPARK + PD -> first decode -> spec_info == None`.

## Design context / roadmaps

- [DSpark in SGLang](https://www.lmsys.org/blog/2026-07-06-dspark-sglang) — original DSpark design and serving overview.
- #30344 — parent DSpark roadmap.
- #34297 — DSpark CUDA Graph correctness and robustness roadmap; #34410 is tracked there as a **PD-decode integration regression** encountered while bringing up the B300 runtime matrix. It is not another CUDA-Graph root-cause fix.

## What the regression checks

`test/registered/spec/dspark/test_dspark_disaggregation.py` (CPU, `base-a-test-cpu`), scoped strictly to the handoff contract — it is not a scheduler simulation:

1. `build_disagg_draft_input()` returns a non-None draft input for DSPARK
2. transferred bonus tokens are preserved
3. committed sequence lengths are preserved
4. with overlap enabled, `future_indices` is seeded from `req_pool_indices`
5. no stale DSA IndexShare seed is claimed (`future_dsa_topk_indices_available is False`)
6. sequence-length state is published into the `FutureMap`
7. the speculative relay payload carrying the bonus tokens is stashed before decode resumes

`FutureMap` is autospecced because `publish()` / `stash()` write device-side relay buffers that a CPU job cannot allocate; the calls themselves are part of the contract, so they are asserted rather than skipped. As a negative control, stubbing out the `is_dspark()` dispatch makes the builder return `None` and the regression fails at the first invariant.

## Supporting runtime evidence (2026-08-11; not produced by this PR, not current main)

The following is supporting context only. It is an independent B300/B30Z runtime regression on a different stack, not an end-to-end result of this PR's code on current `main`.

Full stack disclosure:

- SGLang v0.5.16-cu130, torch 2.11.0+cu130, flashinfer 0.6.14, sglang-kernel 0.4.5
- source-equivalent backport of the final reviewer-selected **no-init** #32467 patch
- backport of merged #33098 for DSpark DP-attention draft metadata
- backport of #31513 for the historical v0.5.16 DSpark disaggregation-decode handoff; #31513 was open/unmerged during this validation

Current `main` has since evolved a dedicated DSpark disaggregation path, which is why this PR is regression-only.

Hardware/model: 8x NVIDIA B30Z 275GB (B300-class), DeepSeek-V4-Pro-DSpark, `dspark_block_size = 5`.

Decode topology:

```text
--tp-size 8 --dp-size 8 --enable-dp-attention --enable-dp-lm-head
--moe-dense-tp-size 1 --moe-a2a-backend none
--moe-runner-backend flashinfer_mxfp4 --disable-flashinfer-autotune
--speculative-algorithm DSPARK
--disaggregation-mode decode --disaggregation-transfer-backend fake
--disaggregation-bootstrap-port 8200 --load-balance-method follow_bootstrap_room
--mem-fraction-static 0.92 --max-running-requests 1024
--cuda-graph-max-bs-decode 128
env: SGLANG_RAGGED_VERIFY_MODE=compact SGLANG_DSV4_FP4_EXPERTS=1
```

Workload: random input 60000 / output 1000 tokens, no simulated acceptance.

A locally profiled SPS table was used. Its batch-size probes are `[1, 8, 16, 32, 64, 96]`; therefore the C1024 arm, which reaches per-rank batch 128, is out-of-domain and uses clamped interpolation. Its budget estimate should be treated as optimistic.

### Sustained decode-only regression

| concurrency | requests | success | failed | gen tok/s | TTFT (s) | TPOT (s) | per-rank peak running |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 64 | 640 | 640 | 0 | 3638.96 | 0.109 | 0.0132 | 15 |
| 256 | 2560 | 2560 | 0 | 8340.59 | 0.172 | 0.0227 | 46 |
| 512 | 5120 | 5120 | 0 | 13534.73 | 0.234 | 0.0268 | 87 |
| 1024 | 10240 | 10240 | 0 | 24793.49 | 0.423 | 0.0294 | 128 |

Totals: **18560/18560** successful requests, 0 client failures, 0 CUDA illegal-address faults, 0 device assertions, 0 scheduler exceptions, post-run `/health = 200`. CUDA Graph replay was observed throughout; C1024 reached the captured per-rank batch-size 128 tier. Observed acceptance length was ~1.00–1.12.

For compact ragged-verify coverage, the natural workload produced uniform verify lengths, so it does not count as ragged coverage. Using the existing budget control (`dspark_force_budget_frac = 0.5`) produced a genuinely ragged window with verify lengths spanning 1–6; among fully parsed multi-request scheduling blocks, **39/43 = 90.7%** had `min(verify_len) != max(verify_len)` (for example `[4, 3, 3]`). No GPU fault, NaN, or verify-budget violation was observed in that window.

### Follow-up external-concurrency / admission-pressure sweep

Same server limits (`max-running-requests=1024`, per-rank CUDA-Graph max batch 128):

| external concurrency | requests | success | failed | gen tok/s | TTFT (s) | TPOT (s) | per-rank running peak | prealloc peak |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 1280 | 5120 | 5120 | 0 | 20430 | 6.87 | 0.0332 | 128 | 96 |
| 1536 | 6144 | 6144 | 0 | 21877 | 19.09 | 0.0322 | 128 | 121 |
| 2048 | 6144 | 6144 | 0 | 21275 | 35.06 | 0.0320 | 128 | 222 |
| 2560 | 7680 | 7680 | 0 | 23882 | 53.21 | 0.0306 | 128 | 245 |

All four arms completed with zero request failures, zero observed GPU correctness faults/retractions/preallocation warnings, CUDA Graph replay retained, and `/health = 200`.

**Interpretation:** these higher numbers are external concurrency / admission pressure, **not** proof of 1280–2560 simultaneously running requests. `max-running-requests=1024` remains the active-running ceiling and per-rank running peak stays at 128. The next capacity phase must raise MRR / graph tiers and re-profile SPS before claiming a higher true in-flight capacity.

## Scope

This PR does not claim the CPU test replaces PD runtime CI and does not add or change DSpark PD support. It only pins the first-decode handoff invariant that current `main` already implements.

## Related

- [DSpark blog post](https://www.lmsys.org/blog/2026-07-06-dspark-sglang) — design / serving overview
- #30344 — parent DSpark roadmap
- #34297 — DSpark CUDA Graph correctness / robustness source-of-truth roadmap
- #33098 — DSpark DP-attention draft metadata (**merged**)
- #31513 — earlier DSpark/DFlash disaggregation-decode implementation and failure analysis (**open**)
- #32467 / #32470 — independent producer-side ragged-plan correctness bug and issue
- #33795 / #34286 — Full / Breakable CUDA-Graph capture-initialization ordering work
- #33411 / #33204 — later PD + DSPARK integration work / implementation evolution

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34925212412](https://github.com/sgl-project/sglang/actions/runs/34925212412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34925211967](https://github.com/sgl-project/sglang/actions/runs/34925211967)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34925212214](https://github.com/sgl-project/sglang/actions/runs/34925212214)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->