### PR TITLE
Unify the request length validation logic

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -1202,6 +1202,9 @@ class Engine(EngineScoreMixin, EngineBase):
             tokenizer_manager.max_req_input_len = scheduler_init_result.scheduler_infos[
                 0
             ]["max_req_input_len"]
+            tokenizer_manager.max_total_num_tokens = (
+                scheduler_init_result.scheduler_infos[0]["max_total_num_tokens"]
+            )
 
             # Set up subprocess liveness watchdog to detect crashes
             # Note: RayEngine returns scheduler_procs=None as it uses Ray actors instead of mp.Process

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -253,6 +253,7 @@ async def init_multi_tokenizer() -> ServerArgs:
     )
 
     tokenizer_manager.max_req_input_len = scheduler_info["max_req_input_len"]
+    tokenizer_manager.max_total_num_tokens = scheduler_info["max_total_num_tokens"]
     tokenizer_manager.set_startup_time(scheduler_info["startup_time"])
 
     set_global_state(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -260,7 +260,7 @@ from sglang.srt.managers.utils import (
     EmbeddingBatchResult,
     GenerationBatchResult,
     is_health_check_generate_req,
-    validate_input_length,
+    validate_request_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
 from sglang.srt.mem_cache.common import maybe_cache_unfinished_req, release_kv_cache
@@ -2158,7 +2158,7 @@ class Scheduler(
             abort_request=self.abort_request,
         )
 
-    def init_req_max_new_tokens(self, req):
+    def init_req_max_new_tokens(self, req, check: bool = False):
         input_len = len(req.origin_input_ids)
         max_new_tokens = (
             req.sampling_params.max_new_tokens
@@ -2180,17 +2180,17 @@ class Scheduler(
         # into the waiting queue but can never be scheduled, blocking the queue
         # and eventually making health checks fail.
         paged_input_len = -(-input_len // self.page_size) * self.page_size
-        req.sampling_params.max_new_tokens = max(
-            0,
-            min(
-                max_new_tokens,
-                self.max_req_len - input_len - 1,
-                self.max_total_num_tokens * get_parallel().attn_dcp_size
-                - paged_input_len
-                - self.page_size
-                - 1,
-            ),
+        max_new_tokens = min(
+            max_new_tokens,
+            self.max_req_len - input_len - 1,
+            self.max_total_num_tokens * get_parallel().attn_dcp_size
+            - paged_input_len
+            - self.page_size
+            - 1,
         )
+        assert not check or max_new_tokens >= 0
+        req.sampling_params.max_new_tokens = max(0, max_new_tokens)
+
         # Clipping above can push max_new_tokens below min_new_tokens, which
         # would suppress EOS for the whole generation. Restore the invariant.
         if req.sampling_params.min_new_tokens > req.sampling_params.max_new_tokens:
@@ -2582,19 +2582,23 @@ class Scheduler(
                 self._add_request_to_queue(req)
                 return
 
-        # initialize before returning
-        self.init_req_max_new_tokens(req)
-
         # Validate prompt length
-        error_msg = validate_input_length(
-            req,
+        truncated_input_len, _, error_msg = validate_request_input_length(
             self.max_req_input_len,
-            get_serving().allow_auto_truncate,
+            self.max_total_num_tokens,
+            self.page_size,
+            req_input_len=len(req.origin_input_ids),
+            auto_truncate=get_serving().allow_auto_truncate,
         )
         if error_msg:
             req.set_finish_with_abort(error_msg)
             self._add_request_to_queue(req)
             return
+        if truncated_input_len is not None:
+            del req.origin_input_ids[truncated_input_len:]
+
+        # initialize before returning
+        self.init_req_max_new_tokens(req, check=True)
 
         if not recv_req.return_logprob and recv_req.logprob_start_len != -1:
             # When return_logprob is False, logprob_start_len should be ignored
@@ -2882,14 +2886,18 @@ class Scheduler(
                 return
 
         # Validate prompts length
-        error_msg = validate_input_length(
-            req,
+        truncated_input_len, _, error_msg = validate_request_input_length(
             self.max_req_input_len,
-            get_serving().allow_auto_truncate,
+            self.max_total_num_tokens,
+            self.page_size,
+            req_input_len=len(req.origin_input_ids),
+            auto_truncate=get_serving().allow_auto_truncate,
         )
         if error_msg:
             self._add_request_to_queue(req)
             return
+        if truncated_input_len is not None:
+            del req.origin_input_ids[truncated_input_len:]
 
         # Copy more attributes
         req.logprob_start_len = -1

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -101,6 +101,7 @@ from sglang.srt.managers.tokenizer_manager_score_mixin import TokenizerManagerSc
 from sglang.srt.managers.utils import (
     compute_num_reserved_tokens,
     is_health_check_generate_req,
+    validate_request_input_length,
 )
 from sglang.srt.model_executor.forward_batch_info import (
     get_server_return_hidden_states_mode,
@@ -457,6 +458,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.context_len = self.model_config.context_len
         self.image_token_id = self.model_config.image_token_id
         self.max_req_input_len = None  # Will be set later in engine.py
+        self.max_total_num_tokens = None  # Will be set later in engine.py
+        self.page_size = server_args.page_size
         self.enable_priority_scheduling = server_args.enable_priority_scheduling
         self.default_priority_value = server_args.default_priority_value
         self.num_reserved_tokens = compute_num_reserved_tokens(server_args)
@@ -1147,54 +1150,35 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def _validate_one_request(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput], input_ids: List[int]
     ) -> None:
-        """Validates that the input token count and the requested token count doesn't exceed the model's context length."""
-        # FIXME: unify the length validation logic with the one in the scheduler.
-        _max_req_len = self.context_len
-        input_token_num = len(input_ids) if input_ids is not None else 0
-        input_token_num += self.num_reserved_tokens
-
-        # Validate input length
-        if input_token_num >= self.context_len:
-            if self.allow_auto_truncate:
-                logger.warning(
-                    f"The input ({input_token_num} tokens) is longer than the "
-                    f"model's context length ({self.context_len} tokens). "
-                    "Truncating the input."
-                )
-                del input_ids[_max_req_len:]
-                input_token_num = len(input_ids)
-            else:
-                raise ValueError(
-                    f"The input ({input_token_num} tokens) is longer than the "
-                    f"model's context length ({self.context_len} tokens)."
-                )
-
-        # Validate total tokens (input + max_new_tokens)
-        max_new_tokens = obj.sampling_params.get("max_new_tokens")
-        if (
-            self.validate_total_tokens
-            and max_new_tokens is not None
-            and (max_new_tokens + input_token_num) > _max_req_len
-        ):
-            if self.allow_auto_truncate:
-                logger.warning(
-                    f"Requested token count ({input_token_num} input + {max_new_tokens} new) "
-                    f"exceeds the model's context length ({self.context_len} tokens). "
-                    "Truncating max_new_tokens."
-                )
-                obj.sampling_params["max_new_tokens"] = max(
-                    0, _max_req_len - input_token_num
-                )
-            else:
-                total_tokens = max_new_tokens + input_token_num
-                error_msg = (
-                    f"Requested token count exceeds the model's maximum context length "
-                    f"of {self.context_len} tokens. You requested a total of {total_tokens} "
-                    f"tokens: {input_token_num} tokens from the input messages and "
-                    f"{max_new_tokens} tokens for the completion. Please reduce the number "
-                    f"of tokens in the input messages or the completion to fit within the limit."
-                )
-                raise ValueError(error_msg)
+        """Validates that the input token count and the requested token count
+        doesn't exceed the model's context length and KV cache size."""
+        req_max_new_tokens = obj.sampling_params.get("max_new_tokens", 0)
+        truncated_input_len, truncated_new_tokens, error_msg = (
+            validate_request_input_length(
+                self.max_req_input_len,
+                self.max_total_num_tokens,
+                self.page_size,
+                req_input_len=len(input_ids) + self.num_reserved_tokens,
+                req_max_new_tokens=req_max_new_tokens,
+                auto_truncate=self.allow_auto_truncate,
+            )
+        )
+        if error_msg:
+            raise ValueError(error_msg)
+        if truncated_input_len is not None:
+            logger.warning(
+                f"Requested token count ({len(input_ids)} input) "
+                f"exceeds the maximum allowed length. "
+                f"Truncating the input to {truncated_input_len} tokens."
+            )
+            del input_ids[truncated_input_len:]
+        if truncated_new_tokens is not None:
+            logger.warning(
+                f"Requested token count ({len(input_ids)} input + {req_max_new_tokens} new) "
+                f"exceeds the maximum allowed length. "
+                f"Truncating the new to {truncated_new_tokens} tokens."
+            )
+            obj.sampling_params["max_new_tokens"] = truncated_new_tokens
 
         # Validate embedding requests
         if isinstance(obj, EmbeddingReqInput) and self.is_generation:

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -4,7 +4,7 @@ import dataclasses
 import logging
 import re
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple, Union
 
 import msgspec
 import torch
@@ -13,8 +13,8 @@ from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.eplb.expert_distribution import ExpertDistributionMetrics
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.managers import io_struct
-from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.state_capturer.base import TopkCaptureOutput
 
@@ -190,37 +190,101 @@ class GenerationBatchResult:
         )
 
 
-def validate_input_length(
-    req: Req, max_req_input_len: int, allow_auto_truncate: bool
-) -> Optional[str]:
-    """Validate and potentially truncate input length.
+def validate_request_input_length(
+    max_req_input_len: int,
+    max_total_num_tokens: int,
+    page_size: int,
+    req_input_len: int,
+    req_max_new_tokens: int = 0,
+    auto_truncate: bool = False,
+) -> Tuple[Optional[int], Optional[int], Optional[str]]:
+    """Validate the request input length.
 
     Args:
-        req: The request containing input_ids to validate
-        max_req_input_len: Maximum allowed input length
-        allow_auto_truncate: Whether to truncate long inputs
+        max_req_input_len (int): Maximum allowed input length.
+        max_total_num_tokens (int): Maximum allowed total number of tokens.
+        page_size (int): Page size.
+        req_input_len (int): Request input token length.
+        req_max_new_tokens (int, optional): Request maximum allowed new tokens. Defaults to 0.
+        auto_truncate (bool, optional): Whether to auto-truncate the length. Defaults to False.
 
     Returns:
-        Error message if validation fails, None if successful
+        Tuple[Optional[int], Optional[int], Optional[str]): (truncated_input_len, truncated_new_tokens, error_msg)
+        truncated_input_len: Length of the truncated input. None if no truncation is performed.
+        truncated_new_tokens: Number of truncated new tokens. None if no truncation is performed.
+        error_msg: Error message if the input must be rejected. None if the input is valid.
     """
-    if len(req.origin_input_ids) >= max_req_input_len:
-        if allow_auto_truncate:
-            logger.warning(
-                "Request length is longer than the KV cache pool size or "
-                "the max context length. Truncated. "
-                f"{len(req.origin_input_ids)=}, {max_req_input_len=}."
-            )
-            req.origin_input_ids = req.origin_input_ids[:max_req_input_len]
-            return None
-        else:
-            error_msg = (
-                f"Input length ({len(req.origin_input_ids)} tokens) exceeds "
-                f"the maximum allowed length ({max_req_input_len} tokens). "
-                f"Use a shorter input or enable --allow-auto-truncate."
-            )
-            return error_msg
+    if req_input_len <= 0:
+        error_msg = f"Invalid request input length ({req_input_len})."
+        return None, None, error_msg
 
-    return None
+    if req_max_new_tokens < 0:
+        error_msg = (
+            f"Invalid request maximum allowed new tokens ({req_max_new_tokens})."
+        )
+        return None, None, error_msg
+
+    paged_req_input_len = -(-req_input_len // page_size) * page_size
+
+    aggregate_max_total_num_tokens = max_total_num_tokens * get_parallel().attn_dcp_size
+    max_new_tokens = min(
+        max_req_input_len - req_input_len - 1,
+        aggregate_max_total_num_tokens - paged_req_input_len - page_size - 1,
+    )
+
+    # req_input_len exceeds the maximum allowed length
+    if max_new_tokens < 0:
+        if auto_truncate:
+            max_allowed_req_len = max_req_input_len - 1
+            max_allowed_tokens = (
+                (aggregate_max_total_num_tokens - page_size - 1)
+                // page_size
+                * page_size
+            )
+            truncated_input_len = min(max_allowed_req_len, max_allowed_tokens)
+            truncated_new_tokens = 0
+
+            if truncated_input_len <= 0:
+                error_msg = (
+                    f"Origin input length ({req_input_len} tokens) exceeds "
+                    f"the maximum allowed length ({max_req_input_len - 1} tokens), "
+                    f"or page-aligned input length ({paged_req_input_len} tokens) exceeds "
+                    f"the maximum allowed length ({aggregate_max_total_num_tokens - page_size - 1} tokens). "
+                    f"And cannot truncate input length."
+                )
+                return None, None, error_msg
+
+            return truncated_input_len, truncated_new_tokens, None
+
+        error_msg = (
+            f"Origin input length ({req_input_len} tokens) exceeds "
+            f"the maximum allowed length ({max_req_input_len - 1} tokens), "
+            f"or page-aligned input length ({paged_req_input_len} tokens) exceeds "
+            f"the maximum allowed length ({aggregate_max_total_num_tokens - page_size - 1} tokens). "
+            f"Use a shorter input or enable --allow-auto-truncate."
+        )
+        return None, None, error_msg
+
+    # (req_input_len + req_max_new_tokens) exceeds the maximum allowed length
+    if max_new_tokens < req_max_new_tokens:
+        if auto_truncate:
+            truncated_input_len = None
+            truncated_new_tokens = max_new_tokens
+
+            return truncated_input_len, truncated_new_tokens, None
+
+        error_msg = (
+            f"Origin input length ({req_input_len} tokens) "
+            f"+ {req_max_new_tokens} new tokens exceeds "
+            f"the maximum allowed length ({max_req_input_len - 1} tokens), "
+            f"or page-aligned input length ({paged_req_input_len} tokens) "
+            f"+ {req_max_new_tokens} new tokens exceeds "
+            f"the maximum allowed length ({aggregate_max_total_num_tokens - page_size - 1} tokens). "
+            f"Use a shorter input or enable --allow-auto-truncate."
+        )
+        return None, None, error_msg
+
+    return None, None, None
 
 
 def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:


### PR DESCRIPTION
## Motivation

Whether the request length is valid depends on two conditions: the model context length and the kvcache size. We found that in TokenizerManager, only the context length was verified while ignoring the size of the kvcache, and in Scheduler, requests that exceeded the size of the kvcache were ignored. This causes the scheduler to always be fully loaded even if there is nothing in the running batch.

## Modifications

1. `utils.py` rename `validate_input_length` as `validate_request_input_length`, which now supports validating requests based on context length and kvcache size, and also supports truncation operations.
2. The `tokenizer_manager.py` and `scheduler.py` modules verify the length of the request by calling the `validate_request_input_length` function.
3. Remove the logic in 'scheduler.init_req_max_new_tokens' that forces the max_new_tokens parameter to be set to 0 for requests out of range

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31488398842](https://github.com/sgl-project/sglang/actions/runs/31488398842)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31488398584](https://github.com/sgl-project/sglang/actions/runs/31488398584)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->