### PR TITLE
[Bugfix] Load official Gemma 4 unified config classes

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -191,12 +191,9 @@ except ImportError:
 
 
 try:
-    from transformers import Gemma4Config as _HFGemma4Config
+    from transformers import Gemma4UnifiedConfig
 
-    class _Gemma4UnifiedConfigAlias(_HFGemma4Config):
-        model_type = "gemma4_unified"
-
-    _CONFIG_REGISTRY["gemma4_unified"] = _Gemma4UnifiedConfigAlias
+    _CONFIG_REGISTRY["gemma4_unified"] = Gemma4UnifiedConfig
 except ImportError:
     pass
 

--- a/test/registered/unit/utils/test_hf_transformers.py
+++ b/test/registered/unit/utils/test_hf_transformers.py
@@ -10,12 +10,18 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-from transformers import PretrainedConfig
+from transformers import (
+    Gemma4UnifiedAudioConfig,
+    Gemma4UnifiedConfig,
+    Gemma4UnifiedVisionConfig,
+    PretrainedConfig,
+)
 from transformers.image_processing_utils import BaseImageProcessor
 
 import sglang.srt.utils.hf_transformers.processor as processor_utils
 from sglang.srt.utils import hf_transformers_patches
 from sglang.srt.utils.hf_transformers.common import (
+    _CONFIG_REGISTRY,
     _is_deepseek_ocr2_model,
     _is_deepseek_ocr_model,
     _override_v_head_dim_if_zero,
@@ -31,6 +37,26 @@ from sglang.srt.utils.hf_transformers_patches import normalize_rope_scaling_comp
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class TestGemma4UnifiedConfigRegistration(unittest.TestCase):
+    def test_uses_unified_subconfigs(self):
+        config_cls = _CONFIG_REGISTRY["gemma4_unified"]
+        self.assertIs(config_cls, Gemma4UnifiedConfig)
+
+        config = config_cls(
+            audio_config={"audio_embed_dim": 640},
+            vision_config={
+                "mm_embed_dim": 3840,
+                "patch_size": 16,
+                "pooling_kernel_size": 3,
+            },
+        )
+
+        self.assertIsInstance(config.audio_config, Gemma4UnifiedAudioConfig)
+        self.assertEqual(config.audio_config.output_proj_dims, 640)
+        self.assertIsInstance(config.vision_config, Gemma4UnifiedVisionConfig)
+        self.assertEqual(config.vision_config.model_patch_size, 48)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

Fixes #34392.

`HfModelConfigParser` currently replaces Transformers' official `Gemma4UnifiedConfig` with a `Gemma4Config` alias for `model_type="gemma4_unified"`. That reconstructs the audio and vision sections as the older config classes. For the reported Gemma 4 checkpoint, the audio checkpoint projection is `[3840, 640]`, while the aliased config keeps the older `output_proj_dims=1536` default and creates a `[3840, 1536]` layer.

## Modifications

- Register Transformers' official `Gemma4UnifiedConfig` for `gemma4_unified` checkpoints.
- Add a CPU regression test that checks the official audio/vision subconfig classes, the 640-dimensional audio projection, and the derived vision patch size.

This also removes the need for the issue's manual vision `model_patch_size` workaround because `Gemma4UnifiedVisionConfig` derives it from the checkpoint fields.

## Accuracy Tests

This changes config parsing and layer construction only; no inference kernels or output computation are changed.

- Focused regression: `1 passed`
- Full `test_hf_transformers.py`: `59 passed`; 2 pre-existing Windows-only `NamedTemporaryFile` reopening tests failed with `PermissionError`
- Loading the exact reported checkpoint config now constructs `Gemma4UnifiedMultimodalEmbedder.audio_projection` with shape `(3840, 640)`

## Speed Tests and Profiling

Not applicable; no runtime hot path is changed.

## Checklist

- [x] Format code with the repository tooling (`black`, `isort`, targeted `ruff` checks)
- [x] Add a CPU unit test
- [ ] Update documentation (not needed for this internal config registration fix)
- [ ] Accuracy/speed benchmarks (not applicable; see above)
- [x] Follow the SGLang code style guidance

## AI assistance

OpenAI Codex assisted with root-cause analysis, the regression test, and the patch. I reviewed the final diff and test evidence and understand the change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31490828882](https://github.com/sgl-project/sglang/actions/runs/31490828882)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31490828722](https://github.com/sgl-project/sglang/actions/runs/31490828722)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->