### PR TITLE
[AMD][Perf] Fuse the GDN gate reshape copy into the gated RMSNorm kernel for Qwen3.5-architecture MoE on HIP

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/layernorm_gated.py
+++ b/python/sglang/kernels/ops/attention/fla/layernorm_gated.py
@@ -94,6 +94,7 @@ def _layer_norm_fwd_1pass_kernel(
     IS_RMS_NORM: tl.constexpr,
     ACTIVATION: tl.constexpr,
     USE_GDC: tl.constexpr = False,
+    WEIGHT_PER_GROUP: tl.constexpr = True,
 ):
     if USE_GDC:
         tl.extra.cuda.gdc_wait()
@@ -152,8 +153,14 @@ def _layer_norm_fwd_1pass_kernel(
     rstd_mask = rows < M
     tl.store(Rstd + rstd_offsets, rstd, mask=rstd_mask)
 
-    # Load weights and biases (broadcast across rows)
-    w_offsets = cols + group * N
+    # Load weights and biases (broadcast across rows).
+    # WEIGHT_PER_GROUP=False means one `group_size`-wide weight vector is shared
+    # by every group (used by the head-grouped GDN path, where the H heads of a
+    # token are the groups and all heads share the same per-head-dim weight).
+    if WEIGHT_PER_GROUP:
+        w_offsets = cols + group * N
+    else:
+        w_offsets = cols
     w_mask = cols < N
     w = tl.load(W + w_offsets, mask=w_mask, other=0.0).to(tl.float32)
 
@@ -216,21 +223,25 @@ def _layer_norm_fwd(
     norm_before_gate=True,
     is_rms_norm=False,
     activation: str = "swish",
+    weight_per_group=True,
 ):
     M, N = x.shape
     if group_size is None:
         group_size = N
     assert N % group_size == 0
     ngroups = N // group_size
+    # `weight_per_group=False`: a single `group_size`-wide weight/bias vector is
+    # shared by all `ngroups` groups instead of one `N`-wide vector.
+    w_numel = N if weight_per_group else group_size
     assert x.stride(-1) == 1
     if z is not None:
         assert z.stride(-1) == 1
         assert z.shape == (M, N)
-    assert weight.shape == (N,)
+    assert weight.shape == (w_numel,)
     assert weight.stride(-1) == 1
     if bias is not None:
         assert bias.stride(-1) == 1
-        assert bias.shape == (N,)
+        assert bias.shape == (w_numel,)
     # allocate output
     if out is not None:
         assert out.shape == x.shape
@@ -292,6 +303,7 @@ def _layer_norm_fwd(
             IS_RMS_NORM=is_rms_norm,
             num_warps=num_warps,
             ACTIVATION=activation,
+            WEIGHT_PER_GROUP=weight_per_group,
             **pdl_kwargs,
         )
     return out, mean, rstd
@@ -299,6 +311,87 @@ def _layer_norm_fwd(
 
 if _is_npu:
     from sgl_kernel_npu.fla.layernorm_gated import layer_norm_fwd_npu as _layer_norm_fwd
+
+
+def _flatten_head_dim(t: torch.Tensor):
+    """View a ``(..., H, D)`` tensor as 2D ``(M, H*D)`` **without copying**.
+
+    Returns ``None`` when the layout cannot be expressed with a single row
+    stride (then the caller must fall back to the generic path).
+    """
+    if t.dim() < 3:
+        return None
+    H, D = t.shape[-2], t.shape[-1]
+    # The (H, D) block must be contiguous so it can collapse into one row.
+    if t.stride(-1) != 1 or t.stride(-2) != D:
+        return None
+    # Drop leading singleton dims, e.g. the (1, T, H, D) linear-attention output.
+    while t.dim() > 3 and t.shape[0] == 1:
+        t = t[0]
+    if t.dim() != 3:
+        return None
+    return t.as_strided((t.shape[0], H * D), (t.stride(0), 1), t.storage_offset())
+
+
+def rms_norm_gated_heads(
+    *,
+    x,
+    weight,
+    z,
+    eps=1e-6,
+    norm_before_gate=True,
+    activation: str = "swish",
+):
+    """Gated RMSNorm over the last dim of ``(..., H, D)`` inputs, keeping heads
+    as *groups* rather than folding them into the row dimension.
+
+    The generic :func:`rms_norm_gated` entry point wants 2D ``(M, D)`` inputs, so
+    callers first do ``t.reshape(-1, D)``. For a tensor whose head stride is
+    larger than ``D`` -- e.g. the GDN gate ``z``, which is a trailing column slice
+    of the packed ``qkvz`` projection and therefore has strides ``(qkvz_dim, D, 1)``
+    -- that reshape is not a view and PyTorch materializes a full contiguous copy
+    (an ``elementwise/direct_copy`` kernel over the whole tensor) purely as data
+    movement before the norm.
+
+    Flattening to ``(M, H*D)`` with ``group_size=D`` instead expresses exactly the
+    same computation (``_layer_norm_fwd_1pass_kernel`` normalizes each group
+    independently and the same per-head-dim ``weight`` is shared by every group,
+    hence ``weight_per_group=False``), and it only ever needs *one* row stride per
+    tensor -- so the strided ``z`` is consumed in place and the copy disappears.
+    The launch geometry is unchanged: the grid goes from ``(ceil(M*H/rpb), 1)`` to
+    ``(ceil(M/rpb'), H)`` covering the same blocks.
+
+    Returns ``None`` if the layout/kernel preconditions do not hold, so callers
+    can fall back to :func:`rms_norm_gated`.
+    """
+    if _is_npu or _use_cpu:
+        return None
+    if x.dim() < 3 or z.dim() < 3:
+        return None
+    H, D = x.shape[-2], x.shape[-1]
+    if z.shape[-2:] != x.shape[-2:]:
+        return None
+    if weight.dim() != 1 or weight.shape[0] != D or weight.stride(-1) != 1:
+        return None
+    x_2d = _flatten_head_dim(x)
+    z_2d = _flatten_head_dim(z)
+    if x_2d is None or z_2d is None or x_2d.shape != z_2d.shape:
+        return None
+    out_2d = torch.empty(x_2d.shape, dtype=x.dtype, device=x.device)
+    _layer_norm_fwd(
+        x_2d,
+        weight,
+        None,
+        eps,
+        z=z_2d,
+        out=out_2d,
+        group_size=D,
+        norm_before_gate=norm_before_gate,
+        is_rms_norm=True,
+        activation=activation,
+        weight_per_group=False,
+    )
+    return out_2d.view(-1, H, D)
 
 
 def rms_norm_gated(
@@ -457,6 +550,24 @@ class RMSNorm(torch.nn.Module):
 
     def reset_parameters(self):
         torch.nn.init.ones_(self.weight)
+
+    def forward_heads(self, x, z):
+        """Head-grouped fast path for ``(..., H, D)`` inputs.
+
+        Avoids the contiguous copy that ``x.reshape(-1, D)`` / ``z.reshape(-1, D)``
+        would force when the head stride is larger than ``D``. Returns ``None``
+        when unsupported so the caller falls back to :meth:`forward`.
+        """
+        if self.group_size is not None or self.bias is not None:
+            return None
+        return rms_norm_gated_heads(
+            x=x,
+            weight=self.weight,
+            z=z,
+            eps=self.eps,
+            norm_before_gate=self.norm_before_gate,
+            activation=self.activation,
+        )
 
     def forward(self, x, z=None):
         """If z is not None, we do norm(x) * silu(z) if norm_before_gate, else norm(x * silu(z))"""

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -667,17 +667,35 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         )
 
         z_shape_og = z.shape
-        # reshape input data into 2D tensor
-        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
-        z = z.reshape(-1, z.shape[-1])
 
-        # Add padding for DP-Attn
-        if core_attn_out.shape != z.shape:
-            core_attn_out_pad = torch.zeros_like(z)
-            core_attn_out_pad[: core_attn_out.shape[0], :] = core_attn_out
-            core_attn_out = core_attn_out_pad
+        # Fused data-movement path: keep the (tokens, heads, head_dim) layout and
+        # let the gated-RMSNorm kernel treat the heads as groups. The generic path
+        # below first flattens to 2D, and for `z` -- a trailing column slice of the
+        # packed qkvz projection, so its head stride is the whole qkvz width -- that
+        # flatten is not a view, so PyTorch materializes a full contiguous copy of
+        # `z` (a direct_copy elementwise kernel) purely as data movement before the
+        # norm. The head-grouped form needs only one row stride per tensor, so the
+        # strided `z` is read in place and the copy disappears. Numerically
+        # identical: the same per-head-dim weight normalizes the same head_v_dim
+        # wide groups. Returns None (-> fall back) if the layout is unsupported.
+        fused_out = None
+        if core_attn_out.numel() == z.numel():
+            fused_out = self.norm.forward_heads(core_attn_out, z)
 
-        core_attn_out = self.norm(core_attn_out, z)
+        if fused_out is not None:
+            core_attn_out = fused_out
+        else:
+            # reshape input data into 2D tensor
+            core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+            z = z.reshape(-1, z.shape[-1])
+
+            # Add padding for DP-Attn
+            if core_attn_out.shape != z.shape:
+                core_attn_out_pad = torch.zeros_like(z)
+                core_attn_out_pad[: core_attn_out.shape[0], :] = core_attn_out
+                core_attn_out = core_attn_out_pad
+
+            core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
         core_attn_out = core_attn_out.reshape(*core_attn_out.shape[:-2], -1)
 


### PR DESCRIPTION
## Motivation

In the GatedDeltaNet (linear-attention) layers of the Qwen3.5 architecture, `Qwen3_5GatedDeltaNet.forward`
flattens both the linear-attention output and the gate to 2D before handing them to the gated RMSNorm:

```python
core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
z = z.reshape(-1, z.shape[-1])
core_attn_out = self.norm(core_attn_out, z)
```

`core_attn_out` is contiguous, so its reshape is a free view (`aten::reshape -> aten::view`). `z` is not:
it is the trailing column slice of the packed `qkvz` projection, so its head stride is the full per-rank
`qkvz` width rather than `head_v_dim`. `z.reshape(-1, head_v_dim)` therefore cannot be a view, and PyTorch
materialises a full contiguous copy of `z` before the norm even starts -- visible in the trace as
`aten::reshape -> aten::clone -> aten::copy_` plus one `direct_copy_kernel_cuda` elementwise launch per
GDN layer per forward. Measured on MI355X (TP=8, aiter backend), per GDN layer on the conc4 trace:

| # | Kernel | Source expression | us |
|---|---|---|---:|
| 1 | `elementwise_kernel` / `direct_copy_kernel_cuda` (bf16) | materialising `z` for `z.reshape(-1, head_v_dim)` | 14.8 |
| 2 | `_layer_norm_fwd_1pass_kernel` (RMSNormGated) | `self.norm(core_attn_out, z)` | 17.5 |
| | **Total** | | **32.25** |

That is ~46% of the region spent on a copy that exists only to satisfy a reshape. Whole-trace it is the
single largest contributor to the `cat`/`contiguous`/`reshape` data-movement bucket, which was the
6th-largest kernel category in the baseline profile.

The fix is to stop reshaping into the row dimension at all. Flattening to `(tokens, heads * head_dim)`
with `group_size = head_dim` -- instead of `(tokens * heads, head_dim)` -- expresses exactly the same
computation, because `_layer_norm_fwd_1pass_kernel` already normalises each group independently. That
layout needs only **one** row stride per tensor, so the strided `z` is consumed in place by the norm and
the copy disappears entirely. Launch geometry is unchanged: the grid goes from `(ceil(M*H/rpb), 1)` to
`(ceil(M/rpb), H)`, covering the same 28,448 blocks at the profiled prefill shape.

Result: one `direct_copy` launch removed per GDN layer per forward (23,581 launches over the profiled
run), and the replaced region drops **32.25 us -> 19.40 us per layer (-39.8%)**.

## Modifications

- **python/sglang/kernels/ops/attention/fla/layernorm_gated.py**: add a
  `WEIGHT_PER_GROUP: tl.constexpr = True` flag to `_layer_norm_fwd_1pass_kernel` and a matching
  `weight_per_group=True` argument to `_layer_norm_fwd`. When it is `False`, a single `group_size`-wide
  weight vector is shared across all groups (`w_offsets = cols` instead of `cols + group * N`), which is
  what the head-grouped layout needs -- the heads of a token are the groups and they all share the same
  per-head-dim weight. The default `True` reproduces the existing offset arithmetic exactly, so every
  current caller compiles to identical code and is byte-identical. Also add `rms_norm_gated_heads()`,
  the head-grouped entry point, and the `_flatten_head_dim()` helper, which builds the `(M, H*D)` view
  with `as_strided` and returns `None` whenever the `(H, D)` block is not contiguous (i.e. whenever the
  no-copy view does not exist).

- **python/sglang/srt/models/qwen3_5.py**: `Qwen3_5GatedDeltaNet.forward` now tries
  `self.norm.forward_heads(core_attn_out, z)` first and uses the existing 2D path -- including the
  DP-Attn zero-padding branch -- untouched whenever the fast path is not taken. `RMSNorm.forward_heads`
  (also added in `layernorm_gated.py`) returns `None` for anything it cannot serve: CPU and NPU
  backends, a norm configured with `group_size` or `bias`, a weight that is not a contiguous
  `head_dim`-wide vector, mismatched head shapes, or any layout whose `(heads, head_dim)` block is not
  contiguous. So the fallback is the pre-existing code path, unmodified, and the only behavioural change
  is on the layouts that were paying for the copy.

## Accuracy Tests

Model: a large MoE model with GatedDeltaNet linear-attention layers (MXFP4 weights, TP=8, MI355X),
aiter backend.

| Benchmark | Score | Threshold | Status |
|-----------|:-----:|:---------:|:------:|
| GSM8K (1319 questions, parallel=512, max-tokens 2048) | 0.9787 | 0.900 | PASS |

Run via `sglang.test.run_eval` against a live server with `chat_template_kwargs {"enable_thinking": false}`.

Beyond the served eval, the head-grouped path was checked against the original path in a standalone
equivalence test: **bit-exact** at token counts 1, 2, 3, 4, 7, 64, 133, 7112 and 8192, for both
`norm_before_gate` settings and both `swish` and `sigmoid` activations.

## Speed Tests and Profiling

Workload: canonical-8k, IL=8192 / OL=1024, `num_prompts = concurrency x 10`. Baseline is the same build
with the change reverted; both sides measured on a freshly started server with identical flags and run
ordering. Traces captured on TP rank 0 at the conc4 anchor.

### Kernel-level (per GatedDeltaNet layer)

| Kernel | Before (us) | After (us) | Notes |
|--------|:-:|:-:|-------|
| `elementwise_kernel` / `direct_copy_kernel_cuda` (`z` materialisation for `z.reshape`) | 14.8 | -- | eliminated |
| `_layer_norm_fwd_1pass_kernel` (RMSNormGated) | 17.5 | 19.4 | now reads `z` strided |
| **Replaced region total** | **32.25** | **19.40** | **-12.85 us (-39.8%), 2 kernels -> 1** |

Normalised per GDN-layer invocation over the whole trace, the decode-side balance is **-4.55 us** of
removed copy against **+0.05 us** added to the norm (reading `z` strided is marginally slower than
reading it contiguous), i.e. **-4.50 us net per GDN layer**. Summed over the model's GDN layers that is
**~0.25 ms saved per decode iteration**. The full-attention and MoE layers are untouched (0 us).

Prefill benefits considerably more, because the removed copy scales with token count rather than with
batch size: at the 7112-token prefill chunk the copy alone is 14.5 us per GDN layer, ~0.8 ms per chunk.

### Profiling confirmation

The `direct_copy` elementwise kernel on the gate tensor is **absent** from the after-trace detail sheets
of every profiled GDN layer, and the trace-wide launch counts confirm the new path is live on every
layer of every iteration rather than only on a subset:

| | Before | After | Delta |
|---|:-:|:-:|:-:|
| `direct_copy` elementwise, launches (whole trace) | 75,062 | 51,481 | -23,581 |
| `direct_copy` elementwise, total us (whole trace) | 305,458.8 | 197,149.6 | -108,309 |
| `_layer_norm_fwd_1pass_kernel`, us / launch | 4.601 | 4.650 | +0.049 |

The 23,581 removed launches are exactly one per GDN-layer invocation in the baseline trace. Module
attribution for `_layer_norm_fwd_1pass_kernel` also moves from `RMSNorm` to `Qwen3_5GatedDeltaNet`, and
its recorded source line moves to the new call site, confirming the head-grouped entry point is the one
being executed.

### E2E benchmark

**Concurrency 4** (IL8192 / OL1024, `num_prompts=40`)

| Metric | Before | After | Delta |
|--------|:-:|:-:|:-:|
| Total throughput (tok/s) | 1910.74 | 1939.54 | +1.51% |
| Output throughput (tok/s) | 212.56 | 215.76 | +1.51% |
| Median ITL (ms) | 16.61 | 16.34 | -1.63% |
| Median TPOT (ms) | 17.84 | 17.56 | -1.57% |
| Median E2E latency (ms) | 16676.38 | 16453.33 | -1.34% |
| Median TTFT (ms) | 450.83 | 449.01 | -0.40% |

**Concurrency 64** (IL8192 / OL1024, `num_prompts=640`)

| Metric | Before | After | Delta |
|--------|:-:|:-:|:-:|
| Total throughput (tok/s) | 9975.74 | 10039.94 | +0.64% |
| Output throughput (tok/s) | 1106.72 | 1113.84 | +0.64% |
| Median ITL (ms) | 30.43 | 30.08 | -1.15% |
| Median TPOT (ms) | 56.69 | 56.36 | -0.58% |
| Median E2E latency (ms) | 52959.59 | 52798.55 | -0.30% |
| Median TTFT (ms) | 510.98 | 476.60 | -6.73% |

### Kernel-to-E2E consistency

| Anchor | Saving / iteration | Baseline iteration | Predicted ITL | Observed ITL |
|---|:-:|:-:|:-:|:-:|
| conc4 | ~0.25 ms | 16.61 ms | -1.5% | -1.63% |
| conc64 | ~0.25 ms | 30.43 ms | -0.8% | -1.15% |

Prediction and measurement agree in direction and magnitude at both anchors -- near-exact at conc4 and
within 1.4x at conc64, the residual there being the reduced HBM pressure that the per-kernel accounting
does not capture. Unlike most small fusions this one also shows up in TTFT (-6.73% at conc64), which is
consistent with the copy scaling with token count: it is ~0.8 ms per prefill chunk rather than the
~0.25 ms per decode step. At conc4 TTFT is dominated by a single short prefill and the -0.40% there is
within noise.

### Notes

- One synthetic shape in the equivalence test (M=1024) differs from the original path by 1 bf16 ULP on 8
  of 2,097,152 elements, because `calc_rows_per_block` selects a different rows-per-block at that M and
  therefore a different Triton reduction schedule; the shapes exercised in serving keep the same
  schedule and are bit-exact.
- The change is in device-agnostic Triton/PyTorch code, so the copy is removed on CUDA as well; the
  numbers reported here were measured on MI355X.
- If a fused projection path is enabled that already writes the gate out contiguously, the head-grouped
  norm simply reads the contiguous tensor and the saving does not double-count.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31492197767](https://github.com/sgl-project/sglang/actions/runs/31492197767)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31492496476](https://github.com/sgl-project/sglang/actions/runs/31492496476)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->