### PR TITLE
[diffusion] fix: nightly diffusion benchmark passes the retired --warmup flag

### DIFF
--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -13,7 +13,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --dit-layerwise-offload false --tp-size 2",
+                    "serve_args": "--warmup-mode server --dit-layerwise-offload false --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -29,7 +29,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --dit-layerwise-offload false --tp-size 2",
+                    "serve_args": "--warmup-mode server --dit-layerwise-offload false --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -45,7 +45,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --tp-size 2",
+                    "serve_args": "--warmup-mode server --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -62,7 +62,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --tp-size 2",
+                    "serve_args": "--warmup-mode server --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -78,7 +78,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --tp-size 2",
+                    "serve_args": "--warmup-mode server --tp-size 2",
                     "extra_env": {}
                 }
             }
@@ -95,7 +95,7 @@
             "num_gpus": 4,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
+                    "serve_args": "--warmup-mode server --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
                     "extra_env": {}
                 }
             }
@@ -113,7 +113,7 @@
             "num_gpus": 1,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup",
+                    "serve_args": "--warmup-mode server",
                     "extra_env": {}
                 }
             }
@@ -131,7 +131,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
+                    "serve_args": "--warmup-mode server --pipeline-class-name LTX2TwoStagePipeline --cfg-parallel-size 2",
                     "extra_env": {}
                 }
             }
@@ -147,7 +147,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --tp-size 2 --attention-backend fa",
+                    "serve_args": "--warmup-mode server --tp-size 2 --attention-backend fa",
                     "extra_env": {}
                 }
             }
@@ -164,7 +164,7 @@
             "num_gpus": 2,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --tp-size 2",
+                    "serve_args": "--warmup-mode server --tp-size 2",
                     "extra_env": {"SGLANG_DISABLE_COSMOS3_GUARDRAILS": "1"}
                 }
             }
@@ -182,7 +182,7 @@
             "num_gpus": 4,
             "frameworks": {
                 "sglang": {
-                    "serve_args": "--warmup --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
+                    "serve_args": "--warmup-mode server --enable-cfg-parallel --ulysses-degree 2 --text-encoder-cpu-offload --pin-cpu-memory",
                     "extra_env": {}
                 }
             }

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -802,9 +802,9 @@ def run_single(
         wait_for_health(base_url, framework)
 
         # No client-side warmup: each framework relies on its own server-side
-        # warmup before traffic. sglang's serve_args pass --warmup, which `serve`
-        # resolves to server-based (synthetic) warmup that primes kernels at
-        # startup, before the health check passes. This goes through the internal
+        # warmup before traffic. sglang's serve_args pass --warmup-mode server,
+        # which primes kernels with a synthetic request at startup, before the
+        # health check passes. This goes through the internal
         # warmup path that bypasses sampling-param preset validation (e.g.
         # Ideogram-4's preset-locked num_inference_steps), so no per-case warmup
         # special-casing is needed here.


### PR DESCRIPTION
## The failure

`nightly-test-diffusion` has been failing on every run. Every sglang server it launches dies at argument parsing:

```
sglang: error: ambiguous option: --warmup could match --warmup-mode, --warmup-resolutions, --warmup-steps
```

`--warmup` was retired in favour of `--warmup-mode {off,request,server}`, but `scripts/ci/utils/diffusion/comparison_configs.json` still passes the bare flag in all 11 of its `serve_args`.

Nothing catches this quickly, which is why it has been expensive: the server exits immediately, the harness then waits out its **full 2400s health timeout** before giving up and moving to the next case. So the job spends ~40 minutes per case producing nothing. Example run: https://github.com/sgl-project/sglang/actions/runs/31331243760/job/93289737137

## The fix

Replaces the flag with `--warmup-mode server` in all 11 entries — **not** a deletion.

`warmup_mode` defaults to `None` and `_adjust_warmup` resolves that to `"off"` unless something else forces it, so simply dropping the flag would have silently turned warmup off for the eager cases and let the measured request absorb cold-start cost. That would have turned a loud failure into a quiet benchmark regression.

`server` is also exactly what the harness already documents as the intent — the comment in `run_comparison.py` describes the flag as resolving to "server-based (synthetic) warmup that primes kernels at startup, before the health check passes". That comment is updated to name the current flag.

## Verification

Parsed all 11 `serve_args` with `ServerArgs.add_cli_args` on an H200 box against this branch:

```
checked 11 sglang nightly serve_args
REJECTED: none — all accepted by the real parser
```

Negative control: re-injecting `--warmup` reproduces the exact error above, so the check is meaningful rather than vacuous.

## Worth considering separately

A pre-merge lint that parses every `serve_args` in this config with `ServerArgs.add_cli_args` would have caught this the day the flag was retired, for roughly no cost. I've kept it out of this PR to keep the fix minimal, but happy to add it here or in a follow-up if you'd like it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31492251482](https://github.com/sgl-project/sglang/actions/runs/31492251482)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31492251217](https://github.com/sgl-project/sglang/actions/runs/31492251217)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->