### PR TITLE
Honor should_apply_lora when wrapping LoRA target modules

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -962,6 +962,15 @@ class LoRAManager:
                 self.lora_modules[layer_id][module_name] = lora_module
                 continue
 
+            # Suffix matching is ambiguous for multimodal models: encoder
+            # towers name their projections the same way the language model
+            # does, so a target such as qkv_proj also selects modules the
+            # adapter carries no weights for. Models narrow the scope by
+            # defining should_apply_lora; those that do not keep the plain
+            # suffix behavior.
+            should_apply_lora = getattr(self.base_model, "should_apply_lora", None)
+            if callable(should_apply_lora) and not should_apply_lora(module_name):
+                continue
             # The module should be converted if it is included in target_names
             parts = module_name.split(".")
             if (

--- a/test/registered/unit/lora/test_should_apply_lora_gate.py
+++ b/test/registered/unit/lora/test_should_apply_lora_gate.py
@@ -1,0 +1,142 @@
+"""Unit tests for the should_apply_lora gate in LoRAManager.init_lora_modules.
+
+Target modules are matched by name suffix, which is ambiguous for multimodal
+models: an audio or vision tower that names its projections the same way as the
+language model gets wrapped by `--lora-target-modules qkv_proj`, even though the
+adapter carries no weights for it. Models veto those modules by defining
+should_apply_lora.
+
+LoRAManager is built through __new__ so the memory pool, adapter download and
+CUDA setup in __init__ stay out of the way; only init_lora_modules runs.
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede the lora_manager import
+
+import re
+import unittest
+from unittest.mock import MagicMock
+
+import torch.nn as nn
+
+from sglang.srt.lora.lora_manager import LoRAManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _Attention(nn.Module):
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.qkv_proj = nn.Linear(dim, dim * 3, bias=False)
+        self.o_proj = nn.Linear(dim, dim, bias=False)
+
+
+class _Layer(nn.Module):
+    def __init__(self, dim: int = 8):
+        super().__init__()
+        self.self_attn = _Attention(dim)
+
+
+class _LayerStack(nn.Module):
+    def __init__(self, n_layers: int = 2, dim: int = 8):
+        super().__init__()
+        self.layers = nn.ModuleList([_Layer(dim) for _ in range(n_layers)])
+
+
+def _make_manager(base_model, target_modules, num_layers: int = 2):
+    manager = LoRAManager.__new__(LoRAManager)
+    manager.base_model = base_model
+    manager.target_modules = set(target_modules)
+    manager.base_hf_config = MagicMock(num_hidden_layers=num_layers)
+    manager.experts_shared_outer_loras = False
+    manager.lora_use_virtual_experts = False
+
+    wrapped: list[str] = []
+    # The real set_lora_module builds a device-bound layer; record the name and
+    # hand back a mock, which tolerates the attribute writes the caller makes.
+    manager.set_lora_module = lambda name, _module: (
+        wrapped.append(name),
+        MagicMock(),
+    )[1]
+    return manager, wrapped
+
+
+class TestShouldApplyLoraGate(CustomTestCase):
+    def test_gate_filters_encoder_tower(self):
+        """A tower sharing the language model's naming must not be wrapped."""
+
+        pattern = re.compile(
+            r"^thinker\.model\.layers\.\d+\.self_attn\.(?:qkv_proj|o_proj)$"
+        )
+
+        class _Thinker(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = _LayerStack()
+                self.audio_tower = _LayerStack()
+
+        class _Multimodal(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.thinker = _Thinker()
+
+            def should_apply_lora(self, module_name: str) -> bool:
+                return bool(pattern.match(module_name))
+
+        manager, wrapped = _make_manager(_Multimodal(), {"qkv_proj", "o_proj"})
+        manager.init_lora_modules()
+
+        self.assertEqual(
+            [name for name in wrapped if "audio_tower" in name],
+            [],
+            msg="audio_tower modules leaked past the gate",
+        )
+        self.assertEqual(
+            set(wrapped),
+            {
+                "thinker.model.layers.0.self_attn.qkv_proj",
+                "thinker.model.layers.0.self_attn.o_proj",
+                "thinker.model.layers.1.self_attn.qkv_proj",
+                "thinker.model.layers.1.self_attn.o_proj",
+            },
+        )
+
+    def test_model_without_hook_keeps_suffix_match(self):
+        """Models that don't define the hook keep the plain suffix behavior."""
+
+        class _Vanilla(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = _LayerStack()
+
+        manager, wrapped = _make_manager(_Vanilla(), {"qkv_proj"})
+        manager.init_lora_modules()
+
+        self.assertEqual(
+            set(wrapped),
+            {
+                "model.layers.0.self_attn.qkv_proj",
+                "model.layers.1.self_attn.qkv_proj",
+            },
+        )
+
+    def test_deny_all_hook_wraps_nothing(self):
+        class _DenyAll(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = _LayerStack()
+
+            def should_apply_lora(self, module_name: str) -> bool:
+                return False
+
+        manager, wrapped = _make_manager(_DenyAll(), {"qkv_proj", "o_proj"})
+        manager.init_lora_modules()
+
+        self.assertEqual(wrapped, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`LoRAManager.init_lora_modules()` decides what to wrap by matching the last one or two components of a module name against `--lora-target-modules`. For multimodal models that is ambiguous: encoder towers name their projections the same way the language model does. `VisionAttention` exposes `qkv_proj` and `proj`, so a target as ordinary as `qkv_proj` selects tower modules the adapter carries no weights for, and `get_layer_id()` files them into `self.lora_modules[<layer>]` next to the language model's modules for that layer.

Models already declare the intended scope through `should_apply_lora`, and several say so explicitly — `mllama4`: *"Skip vision model and multi_modal_projector for LoRA"*, `gemma3_mm`: *"Skip vision tower and multi_modal_projector for LoRA"*, `qwen2_vl`: *"skip visual tower"*, `ernie45_vl`: *"skip vision_model"*. The comment inside `init_lora_modules()` refers to the hook as well:

```python
# Handle embed_tokens and lm_head before the should_apply_lora gate,
# since VL models' should_apply_lora patterns only match language
# model layers and would incorrectly skip these.
```

But there is no call site anywhere in the tree. Thirteen model files define `should_apply_lora` and none of them has any effect: the declared scope is not enforced, and the special-casing of `embed_tokens` / `lm_head` guards against a gate that never runs.

## Modifications

Restore the call between the special-cased modules and the suffix match, which is where the existing comment says it belongs:

```python
should_apply_lora = getattr(self.base_model, "should_apply_lora", None)
if callable(should_apply_lora) and not should_apply_lora(module_name):
    continue
```

Models that do not define the hook keep the plain suffix behavior, so nothing changes for them.

Added `test/registered/unit/lora/test_should_apply_lora_gate.py`, which pins three behaviors: a tower reusing the language model's names stays unwrapped, a model without the hook keeps suffix matching, and a deny-all hook wraps nothing. The tests build `LoRAManager` through `__new__`, so no memory pool, adapter download or CUDA setup is involved. They pass with this change and fail without it.

One behavior change worth flagging: `interns2_mobius` declares `should_apply_lora` as `module_name.startswith("model.layers.")`, so with the gate active its `model.meta_mlp.*` modules are skipped before reaching the `FusedMoE` branch that currently raises a descriptive `ValueError` for them. Targeting those banks becomes a silent no-op instead of a hard error. If keeping the error is preferred, that check can move above the gate — happy to adjust.

## Accuracy Tests

Not applicable: no change to kernels or model forward code. The change only narrows which modules get wrapped, and only for models that already declare a scope.

## Speed Tests and Profiling

Not applicable. Wrapping fewer modules cannot slow anything down; it avoids allocating LoRA slots for modules the adapter never fills.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31498657348](https://github.com/sgl-project/sglang/actions/runs/31498657348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31498657091](https://github.com/sgl-project/sglang/actions/runs/31498657091)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->