### PR TITLE
[Bugfix] Reject unsupported multi-node TP/PP rank layouts

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -123,6 +123,7 @@ from sglang.srt.utils.network import (
     get_zmq_socket,
     is_port_available,
 )
+from sglang.srt.utils.parallel_topology import calculate_rank_ranges
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.watchdog import SubprocessWatchdog
 from sglang.version import __version__
@@ -1790,21 +1791,7 @@ def _calculate_rank_ranges(
         - pp_size_per_node: number of PP ranks per node.
         - tp_size_per_node: number of TP ranks per node.
     """
-    pp_size_per_node = max(pp_size // nnodes, 1)
-    nnodes_per_pp_rank = max(nnodes // pp_size, 1)
-    pp_rank_range = range(
-        pp_size_per_node * (node_rank // nnodes_per_pp_rank),
-        pp_size_per_node * (node_rank // nnodes_per_pp_rank + 1),
-    )
-
-    nnodes_per_tp_group = nnodes_per_pp_rank
-    tp_size_per_node = tp_size // nnodes_per_tp_group
-    tp_rank_range = range(
-        tp_size_per_node * (node_rank % nnodes_per_tp_group),
-        tp_size_per_node * (node_rank % nnodes_per_tp_group + 1),
-    )
-
-    return pp_rank_range, tp_rank_range, pp_size_per_node, tp_size_per_node
+    return calculate_rank_ranges(nnodes, pp_size, tp_size, node_rank)
 
 
 def _compute_parallelism_ranks(

--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -67,6 +67,7 @@ from sglang.srt.utils.network import (
     get_zmq_socket,
     get_zmq_socket_on_host,
 )
+from sglang.srt.utils.parallel_topology import calculate_rank_ranges
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
 from sglang.srt.utils.watchdog import Watchdog
 from sglang.utils import TypeBasedDispatcher, get_exception_traceback
@@ -608,23 +609,27 @@ class DataParallelController:
 
         scheduler_pipe_readers = []
 
-        pp_size_per_node = max(server_args.pp_size // server_args.nnodes, 1)
-        nnodes_per_pp_rank = max(server_args.nnodes // server_args.pp_size, 1)
-        pp_rank_range = range(
-            pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank),
-            pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank + 1),
-        )
-
-        nnodes_per_tp_group = nnodes_per_pp_rank
-        tp_size_per_node = server_args.tp_size // nnodes_per_tp_group
         if server_args.is_ep_scale_joiner:
             # Scale joiners enumerate their full local TP span.
+            pp_size_per_node = max(server_args.pp_size // server_args.nnodes, 1)
+            nnodes_per_pp_rank = max(server_args.nnodes // server_args.pp_size, 1)
+            pp_rank_range = range(
+                pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank),
+                pp_size_per_node * (server_args.node_rank // nnodes_per_pp_rank + 1),
+            )
             tp_rank_range = range(server_args.tp_size)
             tp_size_per_node = server_args.tp_size
         else:
-            tp_rank_range = range(
-                tp_size_per_node * (server_args.node_rank % nnodes_per_tp_group),
-                tp_size_per_node * (server_args.node_rank % nnodes_per_tp_group + 1),
+            (
+                pp_rank_range,
+                tp_rank_range,
+                pp_size_per_node,
+                tp_size_per_node,
+            ) = calculate_rank_ranges(
+                server_args.nnodes,
+                server_args.pp_size,
+                server_args.tp_size,
+                server_args.node_rank,
             )
 
         attn_cp_rank = 0

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -99,6 +99,7 @@ from sglang.srt.utils.common import (
 )
 from sglang.srt.utils.hf_transformers_utils import check_gguf_file
 from sglang.srt.utils.network import NetworkAddress, get_free_port, wait_port_available
+from sglang.srt.utils.parallel_topology import validate_standard_rank_layout
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 from sglang.srt.utils.tensor_bridge import use_mlx
 from sglang.utils import is_in_ci
@@ -8874,6 +8875,8 @@ class ServerArgs:
             assert (
                 self.tp_size * self.pp_size
             ) % self.nnodes == 0, "tp_size must be divisible by number of nodes"
+            if not self.use_ray:
+                validate_standard_rank_layout(self.nnodes, self.pp_size, self.tp_size)
 
         assert (
             self.pp_max_micro_batch_size is None or self.pp_max_micro_batch_size >= 1

--- a/python/sglang/srt/utils/parallel_topology.py
+++ b/python/sglang/srt/utils/parallel_topology.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Rank placement helpers for the standard homogeneous-node launcher."""
+
+from typing import Tuple
+
+
+def validate_standard_rank_layout(nnodes: int, pp_size: int, tp_size: int) -> None:
+    """Validate that the standard launcher can partition TP x PP over nodes.
+
+    The standard launcher supports two rectangular layouts: complete PP stages
+    assigned evenly to nodes, or complete nodes assigned evenly to PP stages.
+    """
+    if nnodes <= 0 or pp_size <= 0 or tp_size <= 0:
+        raise ValueError(
+            "Parallel sizes must be positive: "
+            f"tp_size={tp_size}, pp_size={pp_size}, nnodes={nnodes}."
+        )
+
+    topology = f"tp_size={tp_size}, pp_size={pp_size}, nnodes={nnodes}"
+
+    if pp_size >= nnodes:
+        if pp_size % nnodes != 0:
+            raise ValueError(
+                f"Unsupported standard rank layout ({topology}): pp_size must "
+                "be divisible by nnodes when complete PP stages are assigned "
+                "to each node."
+            )
+        return
+
+    if nnodes % pp_size != 0:
+        raise ValueError(
+            f"Unsupported standard rank layout ({topology}): nnodes must be "
+            "divisible by pp_size when each PP stage spans multiple nodes."
+        )
+
+    nnodes_per_pp_rank = nnodes // pp_size
+    if tp_size % nnodes_per_pp_rank != 0:
+        raise ValueError(
+            f"Unsupported standard rank layout ({topology}): tp_size must be "
+            f"divisible by nnodes / pp_size ({nnodes_per_pp_rank}) when each "
+            "PP stage spans multiple nodes."
+        )
+
+
+def calculate_rank_ranges(
+    nnodes: int, pp_size: int, tp_size: int, node_rank: int
+) -> Tuple[range, range, int, int]:
+    """Calculate the PP and TP rank ranges assigned to one standard node."""
+    validate_standard_rank_layout(nnodes, pp_size, tp_size)
+
+    pp_size_per_node = max(pp_size // nnodes, 1)
+    nnodes_per_pp_rank = max(nnodes // pp_size, 1)
+    pp_rank_range = range(
+        pp_size_per_node * (node_rank // nnodes_per_pp_rank),
+        pp_size_per_node * (node_rank // nnodes_per_pp_rank + 1),
+    )
+
+    tp_size_per_node = tp_size // nnodes_per_pp_rank
+    tp_rank_range = range(
+        tp_size_per_node * (node_rank % nnodes_per_pp_rank),
+        tp_size_per_node * (node_rank % nnodes_per_pp_rank + 1),
+    )
+
+    return pp_rank_range, tp_rank_range, pp_size_per_node, tp_size_per_node

--- a/python/sglang/srt/weight_cache/daemon.py
+++ b/python/sglang/srt/weight_cache/daemon.py
@@ -48,6 +48,7 @@ from sglang.srt.configs.load_config import LoadConfig
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import publish
 from sglang.srt.utils import MultiprocessingSerializer
+from sglang.srt.utils.parallel_topology import calculate_rank_ranges
 
 from .protocol import (
     CacheConfig,
@@ -640,18 +641,8 @@ def launch_weight_cache_daemons(
     import subprocess
     import sys
 
-    # Replicate _calculate_rank_ranges logic from engine.py
-    pp_size_per_node = max(pp_size // nnodes, 1)
-    nnodes_per_pp_rank = max(nnodes // pp_size, 1)
-    pp_rank_range = range(
-        pp_size_per_node * (node_rank // nnodes_per_pp_rank),
-        pp_size_per_node * (node_rank // nnodes_per_pp_rank + 1),
-    )
-    nnodes_per_tp_group = nnodes_per_pp_rank
-    tp_size_per_node = tp_size // nnodes_per_tp_group
-    tp_rank_range = range(
-        tp_size_per_node * (node_rank % nnodes_per_tp_group),
-        tp_size_per_node * (node_rank % nnodes_per_tp_group + 1),
+    pp_rank_range, tp_rank_range, pp_size_per_node, tp_size_per_node = (
+        calculate_rank_ranges(nnodes, pp_size, tp_size, node_rank)
     )
 
     if nnodes > 1 and dist_init_method is None:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2175,5 +2175,21 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestParallelRankLayoutValidation(CustomTestCase):
+    def test_standard_launcher_rejects_unsupported_layout(self):
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=8,
+            pp_size=3,
+            nnodes=4,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "tp_size=8.*pp_size=3.*nnodes=4",
+        ):
+            args.check_server_args()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/utils/test_parallel_topology.py
+++ b/test/registered/unit/utils/test_parallel_topology.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.utils.parallel_topology import (
+    calculate_rank_ranges,
+    validate_standard_rank_layout,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _unchecked_rank_ranges(nnodes, pp_size, tp_size, node_rank):
+    pp_size_per_node = max(pp_size // nnodes, 1)
+    nnodes_per_pp_rank = max(nnodes // pp_size, 1)
+    pp_rank_range = range(
+        pp_size_per_node * (node_rank // nnodes_per_pp_rank),
+        pp_size_per_node * (node_rank // nnodes_per_pp_rank + 1),
+    )
+    tp_size_per_node = tp_size // nnodes_per_pp_rank
+    tp_rank_range = range(
+        tp_size_per_node * (node_rank % nnodes_per_pp_rank),
+        tp_size_per_node * (node_rank % nnodes_per_pp_rank + 1),
+    )
+    return pp_rank_range, tp_rank_range, pp_size_per_node, tp_size_per_node
+
+
+def _expand_global_ranks(calculator, nnodes, pp_size, tp_size):
+    ranks = []
+    for node_rank in range(nnodes):
+        pp_rank_range, tp_rank_range, _, _ = calculator(
+            nnodes, pp_size, tp_size, node_rank
+        )
+        ranks.extend(
+            tp_size * pp_rank + tp_rank
+            for pp_rank in pp_rank_range
+            for tp_rank in tp_rank_range
+        )
+    return sorted(ranks)
+
+
+class TestParallelTopology(unittest.TestCase):
+    def test_rejects_layout_that_generates_out_of_range_ranks(self):
+        with self.assertRaises(ValueError) as context:
+            calculate_rank_ranges(nnodes=4, pp_size=3, tp_size=8, node_rank=0)
+
+        message = str(context.exception)
+        self.assertIn("tp_size=8", message)
+        self.assertIn("pp_size=3", message)
+        self.assertIn("nnodes=4", message)
+
+    def test_rejects_uneven_pp_stages_per_node(self):
+        with self.assertRaisesRegex(ValueError, "pp_size must be divisible"):
+            validate_standard_rank_layout(nnodes=2, pp_size=3, tp_size=2)
+
+    def test_preserves_known_legal_layouts(self):
+        layouts = [
+            (1, 7, 5),
+            (4, 1, 8),
+            (2, 4, 1),
+            (3, 3, 8),
+            (4, 2, 8),
+            (2, 4, 2),
+        ]
+        for nnodes, pp_size, tp_size in layouts:
+            with self.subTest(nnodes=nnodes, pp_size=pp_size, tp_size=tp_size):
+                self.assertEqual(
+                    _expand_global_ranks(
+                        calculate_rank_ranges, nnodes, pp_size, tp_size
+                    ),
+                    list(range(tp_size * pp_size)),
+                )
+
+    def test_validation_matches_rank_coverage_in_small_grid(self):
+        for nnodes in range(1, 9):
+            for pp_size in range(1, 9):
+                for tp_size in range(1, 9):
+                    with self.subTest(nnodes=nnodes, pp_size=pp_size, tp_size=tp_size):
+                        unchecked_ranks = _expand_global_ranks(
+                            _unchecked_rank_ranges, nnodes, pp_size, tp_size
+                        )
+                        expected_ranks = list(range(tp_size * pp_size))
+
+                        if unchecked_ranks == expected_ranks:
+                            self.assertEqual(
+                                _expand_global_ranks(
+                                    calculate_rank_ranges,
+                                    nnodes,
+                                    pp_size,
+                                    tp_size,
+                                ),
+                                expected_ranks,
+                            )
+                        else:
+                            with self.assertRaises(ValueError):
+                                validate_standard_rank_layout(nnodes, pp_size, tp_size)
+
+    def test_weight_cache_rejects_before_spawning_processes(self):
+        from sglang.srt.weight_cache.daemon import launch_weight_cache_daemons
+
+        with patch("subprocess.Popen") as popen:
+            with self.assertRaises(ValueError):
+                launch_weight_cache_daemons(
+                    model_path="dummy",
+                    tp_size=8,
+                    pp_size=3,
+                    nnodes=4,
+                    node_rank=0,
+                    dist_init_method="tcp://127.0.0.1:29500",
+                )
+
+        popen.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The existing `(tp_size * pp_size) % nnodes == 0` check is necessary but not
sufficient for the rectangular rank layout used by the standard multi-node
launcher. For example, `tp_size=8`, `pp_size=3`, and `nnodes=4` passes the
check, but the current mapping emits global ranks `24..31` even though the
valid range is `0..23`.

Rejecting unsupported layouts during argument validation avoids launching a
partially invalid distributed topology and the harder-to-debug failures that
follow.

## Modifications

- Add a shared, pure-Python validator for the two supported rectangular layouts:
  - when `pp_size >= nnodes`, require `pp_size % nnodes == 0`;
  - when `pp_size < nnodes`, require `nnodes % pp_size == 0` and
    `tp_size % (nnodes / pp_size) == 0`.
- Centralize standard PP/TP rank-range calculation in the same utility.
- Apply the validation to the standard launcher, Engine/Ray automatic rank
  placement, data-parallel controller, and weight-cache daemon launch.
- Preserve elastic EP scale-joiner placement and Ray custom placement-group
  behavior, which do not use the standard rectangular planner.
- Add focused and exhaustive CPU tests. The exhaustive test checks all 512
  combinations with `nnodes`, `pp_size`, and `tp_size` in `[1, 8]`
  against exact global-rank coverage.

This is complementary to #15669: that PR improves the message for the existing
product-divisibility check, while this change validates the stronger placement
invariants.

## Accuracy Tests

Not applicable. This changes launch-time topology validation and does not alter
model computation or outputs.

## Speed Tests and Profiling

Not applicable. Validation runs once during startup and performs only constant-
time integer checks.

## Tests

- `190 passed`:
  - `test/registered/unit/utils/test_parallel_topology.py`
  - `test/registered/unit/server_args/test_server_args.py`
  - `test/registered/unit/managers/test_data_parallel_controller.py`
  - `test/registered/unit/model_loader/test_weight_cache_protocol.py`
- All pre-commit hooks passed, including isort, ruff, black, codespell, and CI
  registry validation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required because no user-facing option or supported
  topology changes.
- [x] Accuracy and speed benchmarks are not applicable to launch-time integer
  validation.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31514759503](https://github.com/sgl-project/sglang/actions/runs/31514759503)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31514759255](https://github.com/sgl-project/sglang/actions/runs/31514759255)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->