### PR TITLE
[attention] Default Kimi-K3 DSPARK decode attention backend to cutedsl_mla

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -502,7 +502,7 @@ def _kimi_k3_overrides(server_args: Any, hf_config: Any) -> dict:
     )
     overrides = {}
     if backends_unset:
-        backend = "trtllm_mla"
+        backend = "cutedsl_mla"
         overrides["decode_attention_backend"] = backend
         overrides["prefill_attention_backend"] = "trtllm_mla"
     else:


### PR DESCRIPTION
## Summary

Default Kimi-K3 + DSPARK (pure-TP, SM100/SM103) decode attention backend from `trtllm_mla` to `cutedsl_mla`. Applies only when the user has not explicitly set an attention backend; explicit `--attention-backend` keeps priority. Non-DSPARK default is unchanged (`trtllm_mla`), DCP path already defaults to `cutedsl_mla`.

## Motivation

For MTP/spec verify (q>1), `cute-dsl` is faster than `trtllm-gen` at every context length in CUDA-graph mode, because it folds the verify tokens into the MMA tile (`fold_sq`) instead of re-scanning KV per query row. See flashinfer-ai/flashinfer#4390 (thread + eager/graph comparison table).

## Benchmarks

8x B300 (SM103), 2-node TP8, Kimi-K3 DSPARK (block 7, q=8), bs=1, isl=900k, osl=1024, `bench_one_batch_server`:

| backend | latency | decode throughput | ITL | acc length |
|---|---|---|---|---|
| trtllm_mla (previous default) | 101.31 s | 118.35 tok/s | 8.45 ms | 5.12 |
| cutedsl_mla | 95.11 s | 183.55 tok/s | 5.45 ms | 3.87 |

Note: acc length differs between runs (5.12 vs 3.87) even though the attention backend does not affect verification acceptance — this is run-to-run variance of the benchmark workload, not a backend effect.

Kernel-level (torch profiler, 10 verify steps x 24 MLA layers): the verify attention kernel drops from 1247.6 us/call to 311.3 us/call (~4x), consistent with the 900k-scaled values from flashinfer-ai/flashinfer#4390 (1413/359 us at 1000k).

Verified end-to-end on the devbox: with no `--attention-backend` flag, the server reports `decode/verify attention backend cutedsl_mla (speculative_attention_mode=decode)` and serves normally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31517614146](https://github.com/sgl-project/sglang/actions/runs/31517614146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31517613806](https://github.com/sgl-project/sglang/actions/runs/31517613806)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
