### PR TITLE
Fix default dtype restoration after model loader errors

### DIFF
--- a/python/sglang/srt/model_loader/utils.py
+++ b/python/sglang/srt/model_loader/utils.py
@@ -25,8 +25,10 @@ def set_default_torch_dtype(dtype: torch.dtype):
     """Sets the default torch dtype to the given dtype."""
     old_dtype = torch.get_default_dtype()
     torch.set_default_dtype(dtype)
-    yield
-    torch.set_default_dtype(old_dtype)
+    try:
+        yield
+    finally:
+        torch.set_default_dtype(old_dtype)
 
 
 def _is_moe_model(model_config: ModelConfig, architectures: list[str]) -> bool:


### PR DESCRIPTION
## Summary

Restore the process-wide PyTorch default dtype when model construction exits with an exception. The context manager previously restored it only after a normal exit, so loader errors handled by a caller could leak the model dtype into later work.

## Validation

- Pre-commit hooks for the changed file
- Exception-path restoration check
- Python bytecode compilation

## Original commits

- `c3b8a4093`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31522514032](https://github.com/sgl-project/sglang/actions/runs/31522514032)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31522513670](https://github.com/sgl-project/sglang/actions/runs/31522513670)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->