### PR TITLE
fix(unified-memory): evict the full sub-pool when mamba starves it of shared bytes

### DIFF
--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -257,8 +257,14 @@ def alloc_req_slots(
         if mamba_available_size < mamba_state_needed:
             if tree_cache is not None and tree_cache.supports_mamba():
                 mamba_num = max(0, mamba_state_needed - mamba_available_size)
+                allocator = tree_cache.token_to_kv_pool_allocator
+                # A mamba slot's bytes can only come back from the full side here,
+                # so evict it too instead of asking mamba to free what it lacks.
                 tree_cache.evict_for_alloc(
-                    EvictParams(num_tokens=0, mamba_num=mamba_num)
+                    EvictParams(
+                        num_tokens=allocator.full_tokens_for_mamba_slots(mamba_num),
+                        mamba_num=mamba_num,
+                    )
                 )
     req_pool_indices = req_to_token_pool.alloc(reqs)
     if req_pool_indices is None:

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -90,11 +90,28 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
     def available_size(self):
         return (len(self.free_pages) + len(self.release_pages)) * self.page_size
 
+    def full_tokens_for_mamba_slots(self, slots: int) -> int:
+        """Full-side tokens to evict so `slots` mamba states fit. Zero unless the
+        two pools share one byte buffer, where freeing one is the only way to
+        fund the other."""
+        return 0
+
     def get_kvcache(self):
         return self._kvcache
 
     def free_group_begin(self):
         self.free_group = []
+
+    def flush_deferred_frees(self):
+        """Apply frees queued by the current group without closing it.
+
+        A caller that must observe its own free before the group ends (an
+        evict-then-retry) needs the rows back in the allocator now; keeping
+        the group open lets later batch frees coalesce as before.
+        """
+        if self.free_group:
+            queued, self.free_group = self.free_group, []
+            self.free(torch.cat(queued))
 
     def free_group_end(self):
         pending, self.free_group = self.free_group, None

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -2060,6 +2060,17 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         super().free_group_begin()
         self.free_page_reps_group = []
 
+    def flush_deferred_frees(self) -> None:
+        # Cash in both tiers (tokens in the base class, page reps here) but
+        # leave the group open so later batch frees still coalesce.
+        pending = self.free_page_reps_group
+        if pending:
+            self.free_page_reps_group = []
+        super().flush_deferred_frees()
+        if pending:
+            reps = torch.cat(pending)
+            self.free(reps, _pages=reps // self.page_size)
+
     def free_group_end(self) -> None:
         pending, self.free_page_reps_group = self.free_page_reps_group, None
         super().free_group_end()
@@ -2805,6 +2816,9 @@ class UnifiedMambaTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def full_available_size(self) -> int:
         return self.full_attn_allocator.schedulable_available_size()
 
+    def full_tokens_for_mamba_slots(self, slots: int) -> int:
+        return slots * self.mamba_slot_full_token_cost()
+
     def mamba_slot_full_token_cost(self) -> int:
         """Full-token-equivalents of shared-gap bytes ONE mamba state consumes.
 
@@ -2990,6 +3004,16 @@ class UnifiedMambaTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def free_group_begin(self) -> None:
         super().free_group_begin()
         self.free_page_reps_group = []
+
+    def flush_deferred_frees(self) -> None:
+        # Cash in both tiers (tokens in the base class, page reps here) but
+        # leave the group open so later batch frees still coalesce.
+        pending = self.free_page_reps_group
+        if pending:
+            self.free_page_reps_group = []
+        super().flush_deferred_frees()
+        if pending:
+            self._release_page_reps(pending)
 
     def free_group_end(self) -> None:
         pending, self.free_page_reps_group = self.free_page_reps_group, None
@@ -3581,6 +3605,16 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         super().free_group_begin()
         self.free_page_reps_group = []
 
+    def flush_deferred_frees(self) -> None:
+        # Cash in both tiers (tokens in the base class, page reps here) but
+        # leave the group open so later batch frees still coalesce.
+        pending = self.free_page_reps_group
+        if pending:
+            self.free_page_reps_group = []
+        super().flush_deferred_frees()
+        if pending:
+            self._release_page_reps(pending)
+
     def free_group_end(self) -> None:
         pending, self.free_page_reps_group = self.free_page_reps_group, None
         super().free_group_end()
@@ -3905,6 +3939,9 @@ class UnifiedMambaSWATokenToKVPoolAllocator(UnifiedSWATokenToKVPoolAllocator):
             if isinstance(b, FloatMultiEndedAllocator):
                 flt = b
         _float_open_short_side(flt, demand)
+
+    def full_tokens_for_mamba_slots(self, slots: int) -> int:
+        return slots * self.mamba_slot_full_token_cost()
 
     def mamba_slot_full_token_cost(self) -> int:
         """Full-token-equivalents one mamba/conv slot removes from the shared

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -204,7 +204,7 @@ class MambaComponent(TreeComponent):
                 # stops at this request's window boundary instead of walking to
                 # root and over-decrementing locks held by other requests.
                 lock_result = self.cache.inc_lock_ref(result.best_match_node)
-                self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+                self._evict_for_one_slot()
                 dst_index = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
                 self.cache.dec_lock_ref(
                     result.best_match_node, lock_result.to_dec_params()
@@ -490,11 +490,24 @@ class MambaComponent(TreeComponent):
                 self.tree_core.component_protected_size_[ct] -= vlen
             cd.lock_ref -= 1
 
+    def _evict_for_one_slot(self) -> None:
+        """Free one mamba slot. On a shared byte buffer the full side has to
+        fund it, so it is evicted too."""
+        allocator = self.cache.token_to_kv_pool_allocator
+        self.cache.evict_for_alloc(
+            EvictParams(
+                num_tokens=allocator.full_tokens_for_mamba_slots(1), mamba_num=1
+            )
+        )
+        # Prefill result handling runs inside a batch free group, where a free
+        # is only queued. Cash it in so the retry below can see those bytes.
+        allocator.flush_deferred_frees()
+
     def _alloc_mamba_slot(self) -> torch.Tensor:
         """Allocate one mamba pool slot, evicting if necessary."""
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
-            self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+            self._evict_for_one_slot()
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert slot is not None, "Can not alloc mamba cache"
         return slot
@@ -677,7 +690,7 @@ class MambaComponent(TreeComponent):
             return PrepareLoadBackResult()
         dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if dst is None:
-            self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
+            self._evict_for_one_slot()
             dst = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
             assert dst is not None, "Cannot alloc mamba for load_back"
         req.kv.mamba_pool_idx = dst[0]

--- a/test/registered/unit/mem_cache/test_multi_ended_allocator.py
+++ b/test/registered/unit/mem_cache/test_multi_ended_allocator.py
@@ -1867,7 +1867,72 @@ class TestPagedMultiEndedAllocator(unittest.TestCase):
         # And .size matches this conserved sum.
         self.assertEqual(allocator.size, full_avail_before)
 
-    # 16. REGRESSION: the page-math helper used by
+    def _build_mamba_composite(self):
+        """Minimal full+mamba composite sharing one byte buffer."""
+        from sglang.srt.mem_cache.multi_ended_allocator import (
+            UnifiedMambaTokenToKVPoolAllocator,
+        )
+
+        full_spec = _make_mha_spec("full", "up")
+        mamba_spec = _make_mamba_spec("mamba", "down")
+        pool = UnifiedKVPool(
+            total_bytes=16 * self.PAGE_SIZE * full_spec.entry_bytes()
+            + 8 * mamba_spec.entry_bytes(),
+            sub_pool_specs=[full_spec, mamba_spec],
+            device=_DEV,
+            enable_memory_saver=False,
+        )
+        full_kv = _FakeKVCache(pool.max_slots("full"))
+        full_kv.attach_allocator = lambda allocator: None
+        mamba_kv = _FakeKVCache(pool.max_slots("mamba"))
+        mamba_kv.attach_allocator = lambda allocator: None
+        mamba_kv._copy_from_physical = lambda src, dst: None
+
+        class _FakeHybridLinearKVPool:
+            full_kv_pool = full_kv
+            mamba_pool = mamba_kv
+
+        return UnifiedMambaTokenToKVPoolAllocator(
+            unified_buffer=pool,
+            kvcache=_FakeHybridLinearKVPool(),
+            device=_DEV,
+            page_size=self.PAGE_SIZE,
+            need_sort=False,
+            forward_stream=None,
+        )
+
+    # 16. The mamba-shortfall eviction is sized with
+    # `full_tokens_for_mamba_slots`. It must be non-zero on the shared
+    # composite and 0 on the base class, so pools that do not share bytes keep
+    # evicting exactly as before.
+    def test_full_tokens_for_mamba_slots(self):
+        from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+
+        allocator = self._build_mamba_composite()
+        self.assertGreater(allocator.full_tokens_for_mamba_slots(1), 0)
+        self.assertEqual(
+            BaseTokenToKVPoolAllocator.full_tokens_for_mamba_slots(allocator, 5), 0
+        )
+
+    # 17. REGRESSION: a free issued inside a free group is only QUEUED, so the
+    # mamba-shortfall path must cash those rows in before its retry or it sees
+    # the same gap it just tried to widen.
+    def test_flush_deferred_frees_returns_bytes_without_closing_group(self):
+        allocator = self._build_mamba_composite()
+        loc = allocator.alloc(2 * self.PAGE_SIZE)
+        self.assertIsNotNone(loc)
+        after_alloc = allocator.available_size()
+
+        allocator.free_group_begin()
+        allocator.free(loc)
+        self.assertEqual(allocator.available_size(), after_alloc)
+
+        allocator.flush_deferred_frees()
+        self.assertGreater(allocator.available_size(), after_alloc)
+        # Group stays open so later batch frees keep coalescing.
+        self.assertIsNotNone(allocator.free_group)
+
+    # 18. REGRESSION: the page-math helper used by
     # `UnifiedSWAKVPool.translate_loc_from_full_to_swa`,
     # `UnifiedSWAKVPool.get_cpu_copy`, and `load_cpu_copy` must do
     # `virt_pages = loc // page_size; offsets = loc % page_size;


### PR DESCRIPTION
## Motivation

`--enable-unified-memory` puts the full/KV and mamba sub-pools in one byte buffer, growing toward each other with a shared gap in between. Under load the mamba side dies:

```
AssertionError: Can not alloc mamba cache, try to increase
--mamba-full-memory-ratio or --max-mamba-cache-size
```

on all 8 ranks, reproducibly, while every dashboard number still looks healthy (`mamba usage 0.35`, `token usage 0.33`, `available_size()` reporting hundreds of free slots).

**Root cause.** A mamba slot can only be funded two ways: mamba evicts its own cached states and reuses its own pages (zero-sum, its footprint never grows), or it extends into the shared gap (grows the footprint, but requires the full side to give ground). On shortfall `alloc_req_slots` only ever asked for the first:

```python
tree_cache.evict(EvictParams(num_tokens=0, mamba_num=mamba_num))
#                            ^^^^^^^^^^^^ never ask the full side for anything
```

That is correct under a static split — the pools hold separate bytes, so evicting the peer frees nothing usable. Under a shared buffer it excludes the only side that can pay. Byte-level forensics at the failure:

| | |
|---|---|
| envelope | 56.84 GiB, **100.0% allocated** |
| gap | **21.2 MB**, one mamba slot needs **53.6 MB** |
| free holes / pending reuse | **0 on both sides** (compaction had nothing to return) |
| full side held | 36.94 GiB, **19.07 GiB beyond its nominal share = 364 mamba slots** |
| mamba held | 380 of 745 configured slots (**short by 365**) |

The 364 slots the full side over-borrowed are the 365 slots mamba could not get.

The startup invariant `max_running_requests x slots_per_request <= mamba_pool_size` (here `745 // 5 = 149`) still holds — but it is denominated in *slots*, and under a shared buffer a slot index no longer implies memory behind it. The run died at **96** running requests, 64% of the cap, with 35-61% slot headroom by every slot-based metric.

## Modifications

Four call sites on the mamba-shortfall path now size the full-side eviction with `full_tokens_for_mamba_slots`, the joint currency admission already uses (`mamba_slot_full_token_cost`, 1 slot = 4063 full tokens in this config):

- `BaseTokenToKVPoolAllocator.full_tokens_for_mamba_slots()` returns **0** — pools that do not share bytes keep evicting exactly as before, so nothing outside the unified pool changes.
- `UnifiedMambaTokenToKVPoolAllocator` overrides it with `slots * mamba_slot_full_token_cost()`.
- `alloc_req_slots` (state slot / ping-pong sites) and `MambaComponent` in `unified_cache/components/` (three sites, factored into `_evict_for_one_slot`) pass it instead of `0`.
- `_alloc_int8_ckpt_slot` is deliberately **not** changed: the int8 checkpoint pool does not share the buffer.

Consumption priority is untouched — the allocator still drains its own holes before extending into the gap. Only the *preparation* step changed, from "stock one supply" to "stock both".

## Accuracy Tests

GSM8K, 200 questions, chat + thinking, same feature flags as the perf runs:

| arm | score |
|---|---|
| static | 0.99 |
| unified (unpatched) | 0.99 – 0.995 |
| **this PR** | **0.985** |

## Speed Tests and Profiling

Kimi-K3 (MXFP4 weights, `compressed-tensors`), 2x4 GB300, ISL/OSL 8k/1k, `--max-mamba-cache-size 745 --max-running-requests 149`, all-`trtllm_mla`, fp8 KV, `flashinfer_mxfp4` MoE. **Three repeats per arm, identical client sequence c1..c128.**

Output throughput (tok/s):

| conc | 1 | 16 | 32 | 64 | 96 | 112 | 128 |
|---|---|---|---|---|---|---|---|
| static | 111 | 751 | 1083 | 1327 | 1503 | 1599 | 1676 |
| unified (unpatched) | 110 | 750 | 1116 | 1699 | **CRASH** | **CRASH** | **CRASH** |
| **this PR** | 111 | 749 | 1116 | **1650** | **1741** | **1830** | **1893** |

- Unpatched: **3/3 repeats crash at c96**, 8 ranks each.
- Patched: **3/3 repeats complete all 7 points.**
- vs static: **+13% to +16%** at the concurrencies that used to crash.
- TPOT stays under 50 ms at c96/112/128 (40.1 / 43.7 / 47.9); static breaches it (49.2 / 53.0 / 56.9).
- Repeat spread: patched 0.60% median / 2.36% max; unpatched 1.84% / 4.50%.
- c64 is −2.9% against the unpatched arm, inside that arm's own 4.5% spread — n=3 cannot resolve it as a regression.

**Alternatives measured and rejected** (2 repeats each, same sequence):

| variant | c64 | c96 | c112 | c128 |
|---|---|---|---|---|
| standing gap reserve only | 1712 | 1500 | 1587 | **CRASH** |
| reserve + this PR | 1583 | 1600 | 1729 | 1812 |
| reserve + evict only the deficit | 1716 | 1505 | 1591 | 1671 |
| evict only the deficit | 1653 | 1494 | 1425 | 1198 |
| **this PR** | **1650** | **1741** | **1830** | **1893** |

A reserve only moves the crash from c96 to c128 and costs throughput when stacked on top. Evicting only what mamba cannot cover itself keeps the prefix cache but pins mamba's footprint at the unpatched value (0.35 of pool, identical to unpatched) and cannot fill the offered batch — 96 running requests against 128 offered — so it collapses at high concurrency.

## Notes on scope

- `mamba_radix_cache.py` has the same `EvictParams(num_tokens=0, mamba_num=1)` pattern, but `registry.py` routes every `is_hybrid_ssm` model to `UnifiedRadixCache`, so those sites are not reachable for hybrid models through the default factory. Left alone.
- `_alloc_int8_ckpt_slot` is deliberately not changed: the int8 checkpoint pool does not share the byte buffer.
- `hardware_backend/mlx/.../auxiliary_state.py` has the same pattern on the MLX path, which has no shared byte pool. Left alone.

## Reproduced on upstream

The numbers above come from the Kimi-K3 day-0 fork. To close that gap I ran the
same two arms on a public `lmsysorg/sglang` nightly container (post-K3-merge),
K3 weights, 2x4 GB300, 8k/1k:

| conc | 1 | 16 | 32 | 64 | 96 | 112 | 128 |
|---|---|---|---|---|---|---|---|
| upstream, unpatched | 110 | 688 | 1088 | 1480 | 1500 | **crash** | **crash** |
| upstream, this PR | 115 | 712 | 1101 | 1501 | 1501 | **1602** | **1680** |

Unpatched dies at c112 with `AssertionError: Not enough space for mamba ping
pong idx` on all 8 ranks (16 crash lines); patched completes all seven points
with zero. Note the crash site differs from the fork run (`Can not alloc mamba
cache` at c96 there): the mamba allocator is reached from roughly ten places
and starvation surfaces at whichever one executes first, which is why this
patch covers the call sites rather than any single assert.

## Limitations

- Measured on one model / one topology / one workload shape (Kimi-K3, 2x4 GB300, 8k/1k random). The change lives in the shared allocator rather than model code, so it should be model-independent, but that is an argument, not a measurement.
- The `assert` on allocation failure remains. This PR mobilises the full side's **evictable** bytes; if the full side holds no evictable cache it yields nothing and the assert still fires. A retract tier for the mamba side is the proper backstop and is left for a follow-up.
- The mirror direction is untouched: `evict_from_tree_cache` still passes `mamba_num=0`, so a full-side shortfall never asks mamba to yield either and goes straight to retract. Same defect, opposite direction; also left for a follow-up since no workload here triggers it (retract never fired in any run).

- The added unit tests are verified against a container of the same vintage as
  the code they were written for (unpatched: the deferred-free test fails;
  patched: the file passes). I could not re-run them against a container
  matching today's `main` -- `mem_cache/` has moved 107 commits since the
  newest public image I have, and the dependencies are a web, not a list. CI
  here will cover that.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33555774959](https://github.com/sgl-project/sglang/actions/runs/33555774959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33555774333](https://github.com/sgl-project/sglang/actions/runs/33555774333)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33555774653](https://github.com/sgl-project/sglang/actions/runs/33555774653)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
