### PR TITLE
[Bugfix][DSA] Fix num_splits "(b+1)" crash on prefill-CP speculative decode

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -195,7 +195,7 @@ def cal_padded_tokens(forward_batch: "ForwardBatch"):
     # Consistent with the padding calculation logic in ForwardBatch.prepare_mlp_sync_batch,
     # calculate the actual token length after padding when attn_tp_size > 1 or in the MAX_LEN padding mode.
     from sglang.srt.layers.cp.padding import get_cp_padding_align_size
-    from sglang.srt.layers.cp.utils import is_cp_v2_active
+    from sglang.srt.layers.cp.utils import enable_cp_v2, is_cp_v2_active
 
     # CP-v2 already pads each rank-local shard to its physical size
     if is_cp_v2_active(forward_batch):
@@ -206,10 +206,16 @@ def cal_padded_tokens(forward_batch: "ForwardBatch"):
     global_num_tokens = forward_batch.global_num_tokens_cpu.copy()
     sync_group_size = len(global_num_tokens)
     attn_cp_size = get_parallel().attn_cp_size
-    # Must match the CP padding in ForwardBatch.prepare_mlp_sync_batch.
-    cp_align_size = get_cp_padding_align_size()
-    for i in range(sync_group_size):
-        global_num_tokens[i] = ceil_align(global_num_tokens[i], cp_align_size)
+    # Must mirror ForwardBatch.prepare_mlp_sync_batch, which applies cp_align_size only when
+    # CP-v2 is disabled. Under enable_cp_v2() the speculative forwards (TARGET_VERIFY /
+    # DRAFT_EXTEND_V2) reach here with is_cp_v2_active False, and q is padded to attn_tp_size only
+    # (not cp-aligned). Applying cp_align here over-pads the flashmla metadata past q, so
+    # num_splits ends up longer than q -> fwd_kvcache_mla fails "num_splits must have shape (b+1)".
+    # (attn_cp analog of the attn_tp fix in PR #30642 / issue #30296.)
+    if not enable_cp_v2():
+        cp_align_size = get_cp_padding_align_size()
+        for i in range(sync_group_size):
+            global_num_tokens[i] = ceil_align(global_num_tokens[i], cp_align_size)
     # Reuse the mode selected when the DP buffer was prepared.
     dp_padding_mode = forward_batch.dp_padding_mode
     if dp_padding_mode is None:


### PR DESCRIPTION
## Motivation

Fixes #30296. Running a DSA model (GLM-5.x / DeepSeek-V3.2) with `--dsa-prefill-backend flashmla_kv --enable-prefill-cp --cp-strategy interleave` together with EAGLE/MTP speculative decoding crashes at warmup:

```
RuntimeError: num_splits must have shape (b+1)
```

This is a `TORCH_CHECK` inside `torch.ops.sgl_kernel.fwd_kvcache_mla`, which asserts `num_splits.shape[0] == q.shape[0] + 1`.

## Root cause

`cal_padded_tokens` (`python/sglang/srt/layers/attention/dsa/utils.py`) sizes the FlashMLA `num_splits` metadata (via `pad_dsa_cache_seqlens` → `_compute_flashmla_metadata`) and must mirror `ForwardBatch.prepare_mlp_sync_batch`, which sizes `q`. `prepare_mlp_sync_batch` applies `cp_align_size` **only when CP-v2 is disabled**, but `cal_padded_tokens` applied it **unconditionally**.

On the speculative forwards (`TARGET_VERIFY` / `DRAFT_EXTEND_V2`), `enable_cp_v2()` is `True` while `is_cp_v2_active(forward_batch)` is `False` (those modes are not `context_parallel_extend`), so `cal_padded_tokens` falls through past the CP-v2 early-return and `q` is padded to `attn_tp_size` only. The unconditional `cp_align` then over-pads the metadata to a multiple of `attn_cp_size` while `q` is not, so `len(dsa_cache_seqlens_int32)` (= `num_splits.shape[0] - 1`) exceeds `q.shape[0]` whenever `num_draft_tokens * batch_size` isn't a multiple of `attn_cp_size` → the assert fires.

This is the `attn_cp` analog of the `attn_tp` alignment fix in #30642.

## Fix

Guard the `cp_align` loop in `cal_padded_tokens` with `if not enable_cp_v2()` so the DSA metadata padding matches `prepare_mlp_sync_batch` exactly. No numeric effect — it only removes phantom metadata rows that have no corresponding `q` rows (the padded entries are zeroed and their outputs discarded).

- Legacy CP (`enable_cp_v2()` False): `cp_align` still applied — unchanged.
- Plain prefill EXTEND under CP-v2: hits the `is_cp_v2_active` early-return — unchanged.
- Only the crashing `TARGET_VERIFY` / `DRAFT_EXTEND_V2` spec forwards change: metadata length now equals `q.shape[0]`.

## Test

GLM-5-FP8, tp8/ep8, `--attention-backend dsa --dsa-prefill-backend flashmla_kv --enable-prefill-cp --cp-strategy interleave --moe-a2a-backend megamoe` + EAGLE speculative decoding now serves and handles requests (previously crashed deterministically at warmup, ~175s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31526830497](https://github.com/sgl-project/sglang/actions/runs/31526830497)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31526830089](https://github.com/sgl-project/sglang/actions/runs/31526830089)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->