### PR TITLE
[Fix][Qwen]: fused shared-expert detection PP-safe protection

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -1961,13 +1961,13 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
         return module_name.startswith("model.layers.")
 
     def _get_num_fused_shared_experts(self):
-        if not (
-            hasattr(self.model, "layers")
-            and len(self.model.layers) > 0
-            and hasattr(self.model.layers[0].mlp, "num_fused_shared_experts")
-        ):
+        if not hasattr(self.model, "layers"):
             return 0
-        return self.model.layers[0].mlp.num_fused_shared_experts
+        for layer_id in range(self.model.start_layer, self.model.end_layer):
+            mlp = getattr(self.model.layers[layer_id], "mlp", None)
+            if hasattr(mlp, "num_fused_shared_experts"):
+                return mlp.num_fused_shared_experts
+        return 0
 
     def get_embed_and_head(self):
         embed = self.model.embed_tokens.weight if self.pp_group.is_first_rank else None

--- a/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
+++ b/test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
@@ -1,0 +1,69 @@
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.layers.utils import PPMissingLayer
+from sglang.srt.models.qwen3_5 import Qwen3_5MoeForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestQwen3_5PipelineParallel(CustomTestCase):
+    @staticmethod
+    def _get_num_fused_shared_experts(layers, start_layer, end_layer):
+        model = SimpleNamespace(
+            model=SimpleNamespace(
+                layers=layers,
+                start_layer=start_layer,
+                end_layer=end_layer,
+            )
+        )
+        return Qwen3_5MoeForConditionalGeneration._get_num_fused_shared_experts(model)
+
+    def test_get_num_fused_shared_experts_returns_zero_without_layers(self):
+        model = SimpleNamespace(model=SimpleNamespace())
+
+        num_fused_shared_experts = (
+            Qwen3_5MoeForConditionalGeneration._get_num_fused_shared_experts(model)
+        )
+
+        self.assertEqual(num_fused_shared_experts, 0)
+
+    def test_get_num_fused_shared_experts_uses_local_pp_layers(self):
+        layers = [
+            PPMissingLayer(),
+            PPMissingLayer(),
+            SimpleNamespace(
+                mlp=SimpleNamespace(num_fused_shared_experts=1),
+            ),
+            SimpleNamespace(
+                mlp=SimpleNamespace(num_fused_shared_experts=1),
+            ),
+        ]
+
+        num_fused_shared_experts = self._get_num_fused_shared_experts(
+            layers,
+            start_layer=2,
+            end_layer=4,
+        )
+
+        self.assertEqual(num_fused_shared_experts, 1)
+
+    def test_get_num_fused_shared_experts_returns_zero_without_local_fusion(self):
+        layers = [
+            PPMissingLayer(),
+            SimpleNamespace(mlp=SimpleNamespace()),
+        ]
+
+        num_fused_shared_experts = self._get_num_fused_shared_experts(
+            layers,
+            start_layer=1,
+            end_layer=2,
+        )
+
+        self.assertEqual(num_fused_shared_experts, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The Qwen MoE fused shared-expert lookup always reads `self.model.layers[0].mlp`. `make_layers()` leaves decoder layers owned by other pipeline stages as `PPMissingLayer` placeholders, so a non-first PP stage fails during model initialization with:

```text
AttributeError: 'PPMissingLayer' object has no attribute 'mlp'
```

## Modifications

- Scan `[self.model.start_layer, self.model.end_layer)` when detecting fused shared experts.
- Read `num_fused_shared_experts` from the first local MLP that exposes it.
- Return zero when the model has no decoder layers or no local layer enables shared-expert fusion.
- Add CPU regression coverage for a nonzero local PP layer range, a local layer without shared-expert fusion, and a model without decoder layers.

This lookup runs once during model initialization. It does not add work to the request or token-forward path.

## Unit Tests

```text
Pre-fix implementation: 3 tests run, 2 errors
Patched implementation: 3 tests run, 3 passed
```

The two pre-fix errors reproduce the expected `AttributeError: 'PPMissingLayer' object has no attribute 'mlp'` on non-first PP stages.

The patched test module was also executed through its `unittest` entry point in the retained rank-0 MI300X container used for the TP8/PP2 validation:

```text
SGLang commit: 3425c93666c39ac6979b2223bca96586a601b377
Image:         rocm/sgl-dev:v0.5.16-rocm720-mi30x-20260805
Result:        Ran 3 tests; OK
```

Canonical CI command and local code-quality checks:

```bash
pytest test/registered/unit/models/test_qwen3_5_pipeline_parallel.py -v
pre-commit run --files \
  python/sglang/srt/models/qwen3_5.py \
  test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
python -m py_compile \
  python/sglang/srt/models/qwen3_5.py \
  test/registered/unit/models/test_qwen3_5_pipeline_parallel.py
git diff --check
```

## Accuracy Tests

Existing manual validation was performed before preparing this PR draft; the accuracy workload was not rerun for this draft.

Environment:

```text
SGLang commit: 3425c93666c39ac6979b2223bca96586a601b377
Hardware:       2 nodes x 8 AMD Instinct MI300X GPUs
Topology:       TP8 / PP2
Model:          Qwen
Attention:      AITER
KV cache:       FP8 E4M3
```

Relevant server arguments on both PP stages:

```bash
python3 -m sglang.launch_server \
  --model-path /path/to/qwen \
  --tp-size 8 \
  --pp-size 2 \
  --nnodes 2 \
  --node-rank <0-or-1> \
  --dist-init-addr <rank0-ip>:25000 \
  --attention-backend aiter \
  --kv-cache-dtype fp8_e4m3 \
  --disable-radix-cache
```

Results:

```text
Both PP stages reached readiness.
lm-eval GSM8K strict-match:      1264 / 1319 = 0.9583017437
lm-eval GSM8K flexible-extract:  1263 / 1319 = 0.9575435936
lm-eval exit code:               0
Server fatal errors:             0
HTTP 4xx/5xx responses:          0
```

Without the fix, the non-first PP stage fails during initialization before an accuracy workload can run.

## Speed Tests and Profiling

Not applicable. The change replaces one initialization-time lookup with a scan over the current PP rank's local decoder layers. It does not change model forward, request scheduling, or kernel execution.

## Checklist

- [x] Format the changed code with pre-commit.
- [x] Add a registered CPU unit test for the bug.
- [x] Documentation is not required because there is no user-facing API or configuration change.
- [x] Provide existing PP2 accuracy evidence; speed testing is not applicable because the change is initialization-only.
- [x] Follow the SGLang code style guidance.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31530320685](https://github.com/sgl-project/sglang/actions/runs/31530320685)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31551049967](https://github.com/sgl-project/sglang/actions/runs/31551049967)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->