### PR TITLE
[Scheduler] Fix GPU DP metadata rank ordering under overlap

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -73,6 +73,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import get_forward_context
 from sglang.srt.runtime_context import get_exec, get_forward, get_parallel, get_spec
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.utils import (
@@ -780,13 +781,19 @@ class LayerCommunicator:
         residual: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
-        return self._communicate_summable_tensor_pair_fn(
+        output = self._communicate_summable_tensor_pair_fn(
             hidden_states=hidden_states,
             residual=residual,
             forward_batch=forward_batch,
             context=self._context,
             allow_reduce_scatter=self.allow_reduce_scatter,
         )
+        # Publish after the final layer's rank-coupled communication.
+        if self.is_last_layer:
+            rank_sync_done_event = get_forward_context().rank_sync_done_event
+            if rank_sync_done_event is not None:
+                rank_sync_done_event.record()
+        return output
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
         if not self.allow_reduce_scatter:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2039,6 +2039,7 @@ class Scheduler(
             enable_overlap=self.enable_overlap,
             spec_algorithm=self.spec_algorithm,
             get_require_mlp_sync=lambda: self.require_mlp_sync,
+            rank_sync_runner=self.model_worker.war_fastpath_runner,
         )
 
     def init_pool_stats_observer(self) -> None:

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -39,6 +39,20 @@ if TYPE_CHECKING:
 _ENABLE_METRICS_DP_ATTENTION = envs.SGLANG_ENABLE_METRICS_DP_ATTENTION.get()
 
 
+def _wait_for_rank_sync(runner: Optional[ModelRunner], stream, fallback_stream) -> None:
+    if runner is None or not getattr(
+        runner.model, "requires_dp_attention_rank_sync_ordering", False
+    ):
+        return
+
+    event = runner.rank_sync_done_event
+    runner.rank_sync_done_event = None
+    if event is None:
+        stream.wait_stream(fallback_stream)
+    else:
+        stream.wait_event(event)
+
+
 def _resolve_elastic_world_dp_size(
     dp_size: int,
     *,
@@ -233,6 +247,7 @@ def prepare_mlp_sync_batch_raw(
     require_mlp_tp_gather: bool,
     disable_overlap_schedule: bool,
     offload_tags: set[str],
+    rank_sync_runner: Optional[ModelRunner] = None,
     dwdp: bool = False,
 ):
     # Check if other DP workers have running batches
@@ -311,6 +326,10 @@ def prepare_mlp_sync_batch_raw(
         disable_overlap_schedule
         or envs.SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH.get()
     ):
+        if not disable_overlap_schedule and not skip_all_gather:
+            # Order the GPU metadata rendezvous after the previous rank phase.
+            stream = torch.get_device_module(tp_group.device).current_stream()
+            _wait_for_rank_sync(rank_sync_runner, stream, model_runner.forward_stream)
         group = tp_group.device_group
         device = tp_group.device
     else:
@@ -401,6 +420,7 @@ class SchedulerDPAttnAdapter:
     enable_overlap: bool
     spec_algorithm: SpeculativeAlgorithm
     get_require_mlp_sync: Callable[[], bool]
+    rank_sync_runner: ModelRunner
 
     def prepare_mlp_sync_batch(self, local_batch: ScheduleBatch):
         return prepare_mlp_sync_batch_raw(
@@ -415,6 +435,7 @@ class SchedulerDPAttnAdapter:
             require_mlp_tp_gather=require_mlp_tp_gather(self.server_args),
             disable_overlap_schedule=get_schedule().disable_overlap_schedule,
             offload_tags=self.offload_tags,
+            rank_sync_runner=self.rank_sync_runner,
             dwdp=get_parallel().dwdp_size > 1,
         )
 

--- a/python/sglang/srt/model_executor/forward_context.py
+++ b/python/sglang/srt/model_executor/forward_context.py
@@ -38,6 +38,7 @@ class ForwardContext:
     write time — use dataclasses.replace for per-call overrides."""
 
     attn_backend: AttentionBackend
+    rank_sync_done_event: Optional[object] = None
 
 
 _current: Optional[ForwardContext] = None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -410,6 +410,8 @@ class ModelRunner:
         self.war_read_done_event = make_war_read_done_event(
             torch.get_device_module(self.device)
         )
+        self.rank_sync_done_event: Optional[torch.cuda.Event] = None
+        self.rank_sync_boundary_event: Optional[torch.cuda.Event] = None
 
         # CPU offload
         set_offloader(

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -80,6 +80,8 @@ def _mtp_quant_config(quant_config):
 
 class Qwen3_5ForCausalLMMTP(nn.Module):
 
+    requires_dp_attention_rank_sync_ordering = True
+
     @staticmethod
     def shared_experts_fusion_disable_reason(hf_config, quant_config):
         return Qwen3_5ForCausalLM.shared_experts_fusion_disable_reason(
@@ -137,6 +139,10 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                 )
 
         self.logits_processor = LogitsProcessor(config)
+
+    @property
+    def rank_sync_boundary_after_last_layer_communication(self) -> bool:
+        return not self.logits_processor.do_tensor_parallel_all_gather
 
     @classmethod
     def get_model_config_for_expert_location(cls, config):

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 import torch
 
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
+from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import (
     DpPaddingMode,
     set_dp_buffer_len,
@@ -40,6 +41,7 @@ from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.srt.speculative.eagle_utils import get_draft_input_from_target_hidden_dim
 from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
 from sglang.srt.utils import (
+    is_cuda,
     require_attn_tp_gather,
     require_gathered_buffer,
     require_mlp_sync,
@@ -139,6 +141,26 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         self.draft_extend_attn_backend.init_cuda_graph_state(
             self.max_bs, self.max_num_token
         )
+        can_record_rank_sync = (
+            is_cuda()
+            and not model_runner.server_args.disable_overlap_schedule
+            and envs.SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH.get()
+            and not envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get()
+            and getattr(
+                model_runner.model,
+                "requires_dp_attention_rank_sync_ordering",
+                False,
+            )
+            and getattr(
+                model_runner.model,
+                "rank_sync_boundary_after_last_layer_communication",
+                False,
+            )
+        )
+        if can_record_rank_sync:
+            self.model_runner.rank_sync_boundary_event = self.device_module.Event(
+                external=True
+            )
         self.seq_len_fill_value = (
             self.draft_extend_attn_backend.get_cuda_graph_seq_len_fill_value()
         )
@@ -434,7 +456,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
             return ret
 
         with forward_context(
-            ForwardContext(attn_backend=self.draft_extend_attn_backend)
+            ForwardContext(
+                attn_backend=self.draft_extend_attn_backend,
+                rank_sync_done_event=self.model_runner.rank_sync_boundary_event,
+            )
         ):
             self.draft_extend_attn_backend.init_forward_metadata_out_graph(
                 forward_batch, in_capture=True
@@ -601,6 +626,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             out = self._replay_graph(shape_key, forward_batch)
+        if self.model_runner.rank_sync_boundary_event is not None:
+            self.model_runner.rank_sync_done_event = (
+                self.model_runner.rank_sync_boundary_event
+            )
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -122,6 +122,22 @@ _is_hip = is_hip()
 _is_xpu = is_xpu()
 
 
+@contextlib.contextmanager
+def _draft_extend_rank_sync_context(runner):
+    event = runner.rank_sync_boundary_event
+    if event is None:
+        yield
+        return
+    with forward_context(
+        ForwardContext(
+            attn_backend=runner.attn_backend,
+            rank_sync_done_event=event,
+        )
+    ):
+        yield
+    runner.rank_sync_done_event = event
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -804,7 +820,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             if (c := self.draft_runner.canary_manager) is not None
             else contextlib.nullcontext()
         )
-        with canary_ctx:
+        with canary_ctx, _draft_extend_rank_sync_context(self.draft_runner):
             logits_output = self.draft_runner.forward(forward_batch).logits_output
         maybe_detect_nan(logits_output.next_token_logits, "draft_extend_for_prefill")
         maybe_detect_inf(logits_output.next_token_logits, "draft_extend_for_prefill")
@@ -924,9 +940,10 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     forward_batch
                 )
             else:
-                draft_logits_output = self.draft_runner.forward(
-                    forward_batch
-                ).logits_output
+                with _draft_extend_rank_sync_context(self.draft_runner):
+                    draft_logits_output = self.draft_runner.forward(
+                        forward_batch
+                    ).logits_output
 
         maybe_detect_nan(
             draft_logits_output.next_token_logits,

--- a/test/registered/unit/managers/scheduler_components/test_dp_attn.py
+++ b/test/registered/unit/managers/scheduler_components/test_dp_attn.py
@@ -1,0 +1,124 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.layers.communicator import LayerCommunicator  # noqa: E402
+from sglang.srt.managers.scheduler_components.dp_attn import (  # noqa: E402
+    _wait_for_rank_sync,
+)
+from sglang.srt.model_executor.forward_context import (  # noqa: E402
+    ForwardContext,
+    forward_context,
+    get_forward_context,
+)
+from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP  # noqa: E402
+from sglang.srt.speculative.eagle_worker_v2 import (  # noqa: E402
+    _draft_extend_rank_sync_context,
+)
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _runner(*, event=None, required=True):
+    return SimpleNamespace(
+        model=SimpleNamespace(
+            requires_dp_attention_rank_sync_ordering=required,
+        ),
+        rank_sync_done_event=event,
+        forward_stream=object(),
+    )
+
+
+class TestDPAttnRankSync(CustomTestCase):
+    def test_waits_for_boundary_event(self):
+        event = object()
+        runner = _runner(event=event)
+        stream = MagicMock()
+        fallback_stream = object()
+
+        _wait_for_rank_sync(runner, stream, fallback_stream)
+
+        stream.wait_event.assert_called_once_with(event)
+        stream.wait_stream.assert_not_called()
+        self.assertIsNone(runner.rank_sync_done_event)
+
+    def test_missing_producer_waits_actual_forward_stream(self):
+        runner = _runner()
+        stream = MagicMock()
+        fallback_stream = object()
+        self.assertIsNot(fallback_stream, runner.forward_stream)
+
+        _wait_for_rank_sync(runner, stream, fallback_stream)
+
+        stream.wait_stream.assert_called_once_with(fallback_stream)
+        stream.wait_event.assert_not_called()
+
+    def test_unrelated_model_is_unchanged(self):
+        event = object()
+        runner = _runner(event=event, required=False)
+        stream = MagicMock()
+
+        _wait_for_rank_sync(runner, stream, object())
+
+        stream.wait_event.assert_not_called()
+        stream.wait_stream.assert_not_called()
+        self.assertIs(runner.rank_sync_done_event, event)
+
+
+class TestEagerRankSyncPublish(CustomTestCase):
+    def test_publishes_after_draft_extend_scope(self):
+        event = object()
+        runner = SimpleNamespace(
+            attn_backend=object(),
+            rank_sync_boundary_event=event,
+            rank_sync_done_event=None,
+        )
+
+        with _draft_extend_rank_sync_context(runner):
+            self.assertIs(get_forward_context().rank_sync_done_event, event)
+            self.assertIsNone(runner.rank_sync_done_event)
+
+        self.assertIs(runner.rank_sync_done_event, event)
+
+
+class TestLayerRankSyncBoundary(CustomTestCase):
+    def test_records_after_last_layer_communication(self):
+        order = []
+        event = MagicMock()
+        event.record.side_effect = lambda: order.append("event")
+        communicator = object.__new__(LayerCommunicator)
+        communicator.is_last_layer = True
+        communicator.allow_reduce_scatter = True
+        communicator._context = object()
+        communicator._communicate_summable_tensor_pair_fn = MagicMock(
+            side_effect=lambda **_: order.append("communicate")
+        )
+
+        with forward_context(
+            ForwardContext(
+                attn_backend=object(),
+                rank_sync_done_event=event,
+            )
+        ):
+            communicator.postprocess_layer("hidden-in", "residual-in", object())
+
+        self.assertEqual(order, ["communicate", "event"])
+
+
+class TestQwen35MTPRankSync(CustomTestCase):
+    def test_boundary_excludes_logits_collective(self):
+        model = object.__new__(Qwen3_5ForCausalLMMTP)
+        model.logits_processor = SimpleNamespace(do_tensor_parallel_all_gather=False)
+        self.assertTrue(model.rank_sync_boundary_after_last_layer_communication)
+
+        model.logits_processor.do_tensor_parallel_all_gather = True
+        self.assertFalse(model.rank_sync_boundary_after_last_layer_communication)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This PR fixes a reproducible hang in Qwen3.5 MTP serving with DP attention, overlap scheduling, and GPU/NCCL scheduler metadata sync enabled.

The previous iteration's draft-extend can still be running MoE/DeepEP or output communication on the forward stream when the next iteration starts the DP metadata all-gather on the schedule stream. Without an ordering edge between these two rank-coupled GPU phases, different ranks can enter them in opposite orders and wait for peers that are blocked in the other phase.

As a correctness control, making the schedule stream wait for the whole forward stream removes the hang. However, this also waits for final norm and LM-head work that has no rank-ordering dependency, unnecessarily removing their overlap with the next metadata sync.

The current fix records an event immediately after the previous draft-extend's final rank-coupled communication. The next GPU metadata gather waits for this event rather than for the entire forward stream, preserving overlap with the remaining tail compute.

```text
Unsafe overlap (hang window)

forward stream, step N:   ... -> [MoE/DeepEP + output collective] ------>
schedule stream, step N+1:       CPU planning -> [DP metadata all-gather]
                                                no ordering edge

Different ranks may enter the two bracketed GPU phases in opposite orders.


Whole-stream correctness control

forward stream, step N:   rank communication -> norm / LM head -> done
                                                                  |
schedule stream, step N+1:       CPU planning -------- wait_stream(forward)
                                                                  |
                                                        DP metadata all-gather


Current narrow-event fix

forward stream, step N:   rank communication -> record(event) -> norm / LM head
                                                  |
schedule stream, step N+1:       CPU planning -> wait(event) -> DP metadata all-gather

After record(event), the metadata gather may overlap with norm / LM-head tail compute.
```

## Modifications

- Record an external CUDA event after the final layer communication.
- Publish the event from CUDA graph replay and explicit eager draft-extend scopes.
- Wait for it immediately before the overlap GPU/NCCL metadata gather.
- Keep the draft event owner separate from the scheduler's actual forward stream used by the fallback.
- Scope the ordering to Qwen3.5 MTP; Gloo, non-overlap, skip-all-gather, and other models are unchanged.

This PR builds on the D2H optimization merged in #34338. If #34373 and this PR are merged together, the symmetric-memory path should apply the same dependency to its private stream. That can be adjusted during rebase or as a small follow-up, depending on merge order.

## Accuracy Tests

GSM8K exact-match was evaluated on PR commit `82e6c2b` with the same 44×GB300 7P+1D topology used for the hang reproduction: prefill DP/TP/EP 4, decode DP/TP/EP 16, DP attention, overlap scheduling, NCCL metadata sync, and MTP3 with 4 draft tokens.

- 8-shot, 200 examples, temperature 0, max output 16,384
- score: 0.935 (187 / 200)
- 200 / 200 requests completed, with zero benchmark errors and zero server tracebacks

The serving stress validation also completed without errors:

- concurrency 3072: 30,720 / 30,720 completed, zero errors
- concurrency 4096: 40,960 / 40,960 completed, zero errors

Targeted unit coverage checks the event wait, real forward-stream fallback, unrelated-model isolation, eager producer scope, event placement, and the logits-tail guard.

## Speed Tests and Profiling

Setup: `nvidia/Qwen3.5-397B-A17B-NVFP4-V2`, 44 GB300 GPUs, 7 prefill workers (DP/TP/EP 4), 1 decode worker (TP/DP/EP 16), MTP3 with 4 draft tokens, `trtllm_mha`, DeepEP low-latency, random ISL 8192 / OSL 1024.

| Path | Concurrency | Mean TPOT | Output TPS |
| --- | ---: | ---: | ---: |
| whole-forward `wait_stream` | 3072 | 30.743 ms | 82,243.787 |
| narrow rank event | 3072 | 30.643 ms | 82,476.936 |
| whole-forward `wait_stream` | 4096 | 37.675 ms | 87,041.058 |
| narrow rank event | 4096 | 37.573 ms | 87,409.389 |

Mean TPOT and output TPS were within run-to-run noise. All 16 decode ranks used the event path with no fallback or traceback.

Targeted pre-commit checks passed for all changed files.

## Checklist

- [x] Format code with pre-commit.
- [x] Add targeted unit tests.
- [x] Provide serving correctness and performance results.
- [ ] Documentation update. No user-facing API or configuration changes.
