### PR TITLE
Raise PD zmq per-context socket cap via SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -198,7 +198,8 @@ class CommonKVManager(BaseKVManager):
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
-        # Raise libzmq's per-context socket cap before creating any sockets.
+        # Raise libzmq's per-context socket cap because this manager caches two
+        # sockets per decode endpoint, so large fleets can exceed the default.
         self._zmq_ctx.set(
             zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
         )

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -198,6 +198,14 @@ class CommonKVManager(BaseKVManager):
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
+        # Raise libzmq's per-context socket cap (default 1023): this manager
+        # caches 2 sockets per decode endpoint (PUSH + PAIR monitor), so a
+        # large decode fleet exhausts the default regardless of the OS nofile
+        # limit. Must be set before the context creates any socket; the
+        # option is not retroactive.
+        self._zmq_ctx.set(
+            zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
+        )
         self.rank_port, self.server_socket = get_zmq_socket_on_host(
             self._zmq_ctx, zmq.PULL, host=self.local_ip
         )
@@ -1244,6 +1252,9 @@ class CommonKVSender(BaseKVSender):
 
 class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
+    # One PUSH socket per prefill rank endpoint; raise the cap so a large
+    # prefill fleet cannot exhaust the default 1023 either.
+    _ctx.set(zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get())
     _socket_cache = {}
     _socket_locks = {}
     _global_lock = threading.Lock()

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1252,8 +1252,6 @@ class CommonKVSender(BaseKVSender):
 
 class CommonKVReceiver(BaseKVReceiver):
     _ctx = zmq.Context()
-    # One PUSH socket per prefill rank endpoint; raise the cap so a large
-    # prefill fleet cannot exhaust the default 1023 either.
     _ctx.set(zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get())
     _socket_cache = {}
     _socket_locks = {}

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -198,11 +198,7 @@ class CommonKVManager(BaseKVManager):
 
         # bind zmq socket
         self._zmq_ctx = zmq.Context()
-        # Raise libzmq's per-context socket cap (default 1023): this manager
-        # caches 2 sockets per decode endpoint (PUSH + PAIR monitor), so a
-        # large decode fleet exhausts the default regardless of the OS nofile
-        # limit. Must be set before the context creates any socket; the
-        # option is not retroactive.
+        # Raise libzmq's per-context socket cap before creating any sockets.
         self._zmq_ctx.set(
             zmq.MAX_SOCKETS, envs.SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS.get()
         )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -431,10 +431,6 @@ class Envs:
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
     SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX = EnvBool(True)
-    # Per-zmq-context socket cap; libzmq's default is 1023. A prefill rank
-    # holds 2 sockets per decode endpoint (PUSH + PAIR monitor), so a large
-    # decode fleet (replicas x DP ranks) exhausts the default regardless of
-    # the OS nofile limit. Default is ~16x libzmq's.
     SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(16384)
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -431,6 +431,11 @@ class Envs:
     SGLANG_DISAGGREGATION_NIXL_BACKEND = EnvStr("UCX")
     SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS = EnvStr("{}")
     SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX = EnvBool(True)
+    # Per-zmq-context socket cap; libzmq's default is 1023. A prefill rank
+    # holds 2 sockets per decode endpoint (PUSH + PAIR monitor), so a large
+    # decode fleet (replicas x DP ranks) exhausts the default regardless of
+    # the OS nofile limit. Default is ~16x libzmq's.
+    SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS = EnvInt(16384)
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)


### PR DESCRIPTION
## Motivation

Prefill ranks can exhaust the libzmq per-context socket cap (default 1023) even when the OS file-descriptor limit is sufficient. The KV manager caches a PUSH socket and a PAIR monitor socket per decode endpoint, so 16 decode replicas × 32 DP ranks require 1025 sockets and transfer workers begin failing during connect.

## Modifications

- Add `SGLANG_DISAGGREGATION_ZMQ_MAX_SOCKETS` with a default of 16384.
- Apply the configured cap before creating sockets on both the KV manager context and the shared `CommonKVReceiver` context.

## Accuracy Tests

Not applicable; this change does not affect model outputs.

## Speed Tests and Profiling

Not applicable; this is a connection-capacity mitigation.

## Validation

- `git diff --check`
- `python3 -m compileall -q python/sglang/srt/environ.py python/sglang/srt/disaggregation/common/conn.py`
- Runtime ZMQ smoke test not run because `pyzmq` is unavailable in the current environment.

## Checklist

- [x] Code compiles and passes whitespace validation.
- [x] The new SGLang-owned environment variable is defined through `Envs` and read with `.get()`.
- [ ] Unit tests were not added; the change configures a libzmq context option.
- [ ] Documentation was not updated; this is an expert deployment mitigation.
- [ ] Accuracy and speed benchmarks are not applicable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31535898785](https://github.com/sgl-project/sglang/actions/runs/31535898785)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31536003479](https://github.com/sgl-project/sglang/actions/runs/31536003479)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->