### PR TITLE
Fix DSA metadata row count for DP-padded idle speculative batches

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -167,6 +167,25 @@ def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tens
     return seqlens_32.contiguous().view(-1, 1)
 
 
+def _idle_spec_rows_per_seq(forward_batch: ForwardBatch) -> int:
+    """Query rows carried by each padded sequence of an idle DP-attention rank.
+
+    A rank that idles through a speculative round is still padded to the sync
+    group's token count, and ``ForwardBatch.prepare_mlp_sync_batch`` turns that
+    into ``batch_size = num_tokens // spec_info.num_tokens_per_req`` fabricated
+    sequences — so the batch runs that many query rows per sequence while
+    ``seq_lens`` / ``req_pool_indices`` hold only one entry each. Returns 1 for
+    any batch that is not such an idle speculative round.
+    """
+    if not forward_batch.forward_mode.is_idle():
+        return 1
+    spec_info = forward_batch.spec_info
+    if spec_info is None:
+        return 1
+    # -1 means the flow never set a width (see SpecInput.num_tokens_per_req).
+    return max(1, spec_info.num_tokens_per_req)
+
+
 @dataclass(frozen=True)
 class DSAFlashMLAMetadata:
     """Metadata only needed by FlashMLA"""
@@ -829,6 +848,26 @@ class DeepseekSparseAttnBackend(
         indexer_seq_lens = forward_batch.seq_lens
 
         if forward_batch.forward_mode.is_decode_or_idle():
+            # An idle rank padded through a speculative round runs
+            # `rows_per_seq` query rows per fabricated sequence, so metadata
+            # built one-row-per-sequence would be shorter than the rows the
+            # indexer scores (its paged top-k requires one `lengths` entry per
+            # score row). Every row here is discarded padding, so restate the
+            # batch as `batch_size * rows_per_seq` single-token dummy sequences
+            # rather than teaching each consumer about the expansion.
+            rows_per_seq = _idle_spec_rows_per_seq(forward_batch)
+            if rows_per_seq > 1:
+                batch_size = batch_size * rows_per_seq
+                cache_seqlens_int32 = cache_seqlens_int32.repeat_interleave(
+                    rows_per_seq
+                )
+                cu_seqlens_k = compute_cu_seqlens(cache_seqlens_int32)
+                page_table = page_table.repeat_interleave(rows_per_seq, dim=0)
+                indexer_seq_lens = indexer_seq_lens.repeat_interleave(rows_per_seq)
+                if indexer_seq_lens_cpu is not None:
+                    indexer_seq_lens_cpu = indexer_seq_lens_cpu.repeat_interleave(
+                        rows_per_seq
+                    )
             extend_seq_lens_cpu = [1] * batch_size
             max_seqlen_q = 1
             cu_seqlens_q = self.get_device_int32_arange(batch_size + 1)

--- a/test/registered/unit/layers/attention/test_dsa_idle_spec_metadata.py
+++ b/test/registered/unit/layers/attention/test_dsa_idle_spec_metadata.py
@@ -1,0 +1,171 @@
+"""DSA attention metadata for a DP-attention rank that idles through a
+speculative round.
+
+Such a rank is still padded to the sync group's token count, and
+``ForwardBatch.prepare_mlp_sync_batch`` turns that into
+``batch_size = num_tokens // spec_info.num_tokens_per_req`` fabricated
+sequences — so the forward runs ``num_tokens_per_req`` query rows per sequence
+while ``seq_lens`` / ``req_pool_indices`` hold one entry each. The eager
+``init_forward_metadata`` used to build one metadata row per sequence, which
+left the indexer's paged top-k with a ``lengths`` vector shorter than its score
+rows ("Expected lengths.size(0) == B to be true"); on ROCm it is fatal because
+``aiter_paged_mqa_logits`` scores every query row instead of slicing to
+``q_offset`` first.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.environ import envs
+from sglang.srt.layers.attention.dsa.dsa_topk_backend import DSATopKBackend
+from sglang.srt.layers.attention.dsa.utils import cal_padded_tokens
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.layers.dp_attention import DpPaddingMode
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_context, get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+NUM_REQ_SLOTS = 8
+MAX_CONTEXT = 32
+NUM_DRAFT_TOKENS = 4
+DP_SIZE = 2
+
+
+def _make_backend() -> DeepseekSparseAttnBackend:
+    """Backend carrying only the attributes init_forward_metadata reads.
+
+    Building the real one needs a ModelRunner with loaded weights, while the
+    metadata builder itself is pure tensor bookkeeping.
+    """
+    backend = object.__new__(DeepseekSparseAttnBackend)
+    backend.device = torch.device("cpu")
+    backend._arange_buf = torch.arange(8, dtype=torch.int32)
+    backend.speculative_num_draft_tokens = NUM_DRAFT_TOKENS
+    backend.dsa_index_topk = 2048
+    backend.real_page_size = 1
+    backend.dsa_decode_impl = "aiter"
+    backend.dsa_prefill_impl = "aiter"
+    backend.dsa_topk_backend = DSATopKBackend.SGL_KERNEL
+    backend.dsa_kv_cache_store_fp8 = False
+    backend.enable_auto_select_prefill_impl = False
+    backend.use_mha = False
+    backend.hisparse_coordinator = None
+    backend.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.arange(NUM_REQ_SLOTS * MAX_CONTEXT, dtype=torch.int32).view(
+            NUM_REQ_SLOTS, MAX_CONTEXT
+        )
+    )
+    backend.token_to_kv_pool = SimpleNamespace(
+        dtype=torch.bfloat16, size=1024, page_size=1
+    )
+    return backend
+
+
+def _make_batch(
+    *, forward_mode: ForwardMode, batch_size: int, num_tokens_per_req
+) -> SimpleNamespace:
+    """A DP-padded batch shaped the way prepare_mlp_sync_batch leaves one.
+
+    ``num_tokens_per_req=None`` stands for a round with no speculative input at
+    all (``spec_info is None``).
+    """
+    # Padded rows carry the backend's cuda-graph seq-len fill value.
+    seq_lens = torch.ones(batch_size, dtype=torch.int64)
+    width = 1 if num_tokens_per_req is None else max(1, num_tokens_per_req)
+    return SimpleNamespace(
+        batch_size=batch_size,
+        forward_mode=forward_mode,
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens.clone(),
+        seq_lens_sum=int(seq_lens.sum()),
+        req_pool_indices=torch.zeros(batch_size, dtype=torch.int64),
+        spec_info=(
+            None
+            if num_tokens_per_req is None
+            else SimpleNamespace(num_tokens_per_req=num_tokens_per_req)
+        ),
+        global_num_tokens_cpu=[batch_size * width] * DP_SIZE,
+        dp_padding_mode=DpPaddingMode.MAX_LEN,
+        is_extend_in_batch=False,
+        attn_cp_metadata=None,
+    )
+
+
+class TestDSAIdleSpecMetadata(CustomTestCase):
+    def _build_metadata(self, batch):
+        """Return (metadata, query rows this rank actually forwards)."""
+        backend = _make_backend()
+        # The folded top-k v2 plan JIT-compiles a CUDA kernel; the row counts
+        # under test are the same either way.
+        with envs.SGLANG_OPT_USE_TOPK_V2.override(
+            False
+        ), get_context().override_server_args(), get_parallel().override(
+            attn_cp_size=1, attn_dp_rank=0
+        ):
+            backend.init_forward_metadata(batch)
+            # cal_padded_tokens is the padding calculation prepare_mlp_sync_batch
+            # itself follows, so it is an independent statement of the row count.
+            query_rows = cal_padded_tokens(batch)
+        return backend.forward_metadata, query_rows
+
+    def _assert_row_per_query_row(self, batch, expected_query_rows):
+        metadata, query_rows = self._build_metadata(batch)
+        self.assertEqual(query_rows, expected_query_rows)
+
+        # `lengths` for the indexer's paged top-k, which requires one entry per
+        # score row — the vector whose length used to trip the kernel check.
+        self.assertEqual(metadata.dsa_seqlens_expanded.shape[0], query_rows)
+        self.assertEqual(metadata.dsa_cache_seqlens_int32.shape[0], query_rows)
+        # Per-row KV lengths and page tables the indexer reads alongside it.
+        self.assertEqual(metadata.cache_seqlens_int32.shape[0], query_rows)
+        self.assertEqual(metadata.page_table_1.shape[0], query_rows)
+        self.assertEqual(metadata.real_page_table.shape[0], query_rows)
+        self.assertEqual(metadata.cu_seqlens_q.shape[0], query_rows + 1)
+        self.assertEqual(metadata.cu_seqlens_k.shape[0], query_rows + 1)
+        # The indexer takes sum(dsa_extend_seq_lens_list) as the real (unpadded)
+        # query length; a short value makes it score rows the metadata does not
+        # describe.
+        self.assertEqual(sum(metadata.dsa_extend_seq_lens_list), query_rows)
+
+    def test_idle_speculative_round_covers_every_padded_query_row(self):
+        batch = _make_batch(
+            forward_mode=ForwardMode.IDLE,
+            batch_size=3,
+            num_tokens_per_req=NUM_DRAFT_TOKENS,
+        )
+        self._assert_row_per_query_row(batch, 3 * NUM_DRAFT_TOKENS)
+
+    def test_idle_round_without_speculation_keeps_one_row_per_sequence(self):
+        batch = _make_batch(
+            forward_mode=ForwardMode.IDLE, batch_size=3, num_tokens_per_req=None
+        )
+        self._assert_row_per_query_row(batch, 3)
+
+    def test_idle_round_with_unset_spec_width_keeps_one_row_per_sequence(self):
+        # SpecInput.num_tokens_per_req defaults to -1 ("this flow never set a
+        # width"), which must not scale the batch.
+        batch = _make_batch(
+            forward_mode=ForwardMode.IDLE, batch_size=3, num_tokens_per_req=-1
+        )
+        self._assert_row_per_query_row(batch, 3)
+
+    def test_decode_round_is_unchanged(self):
+        # A live decode rank describes its own sequences; only idle padding is
+        # fabricated, so the expansion must not reach this path.
+        batch = _make_batch(
+            forward_mode=ForwardMode.DECODE, batch_size=3, num_tokens_per_req=1
+        )
+        self._assert_row_per_query_row(batch, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

The `glm52-fp4-1k1k-1p1d-dp8ep8-mtp` leg of the [Nightly Test (AMD MI355X 2N 1P1D Disagg)](https://github.com/sgl-project/sglang/actions/workflows/nightly-amd-mi355x-disagg.yml) workflow fails on every run it has ever had — Aug 8/9/10/11 ([31237934560](https://github.com/sgl-project/sglang/actions/runs/31237934560), [31293296203](https://github.com/sgl-project/sglang/actions/runs/31293296203), [31353982481](https://github.com/sgl-project/sglang/actions/runs/31353982481), [31456703725](https://github.com/sgl-project/sglang/actions/runs/31456703725)) — with a byte-identical signature. It is tracked as R336 in the AMD CI monitor.

The decode server's schedulers die a second into the PD-disaggregation fake-bootstrap warmup:

```
[2026-08-11 08:49:28] Start of pd disaggregation warmup ...
[2026-08-11 08:49:29 DP6 TP6 EP6] Scheduler hit an exception: Traceback (most recent call last):
  ...
  File ".../speculative/eagle_worker_v2.py", line 927, in _draft_extend_for_decode
  File ".../model_executor/runner/eager_runner.py", line 204, in execute
    return self._execute_idle(forward_batch, pp_proxy_tensors)
  ...
  File ".../layers/attention/dsa/dsa_indexer.py", line 887, in _get_topk_paged
    topk_result = metadata.topk_transform(logits, self.index_topk)
RuntimeError: Expected lengths.size(0) == B to be true, but got false.
```

With the schedulers gone the warmup request hangs, and 30 minutes later the `SGLANG_WARMUP_TIMEOUT` fallback fires, `_execute_server_warmup` calls `kill_process_tree`, and the leg fails having never served `/health`. That is why the visible symptom is a 28-minute stall rather than a crash.

### Root cause

A DP-attention rank that idles through a speculative round is still padded to the sync group's token count. `ForwardBatch.prepare_mlp_sync_batch` turns that padding into `batch_size = num_tokens // spec_info.num_tokens_per_req` fabricated sequences, so the rank forwards `num_tokens_per_req` query rows per sequence while `seq_lens` / `req_pool_indices` hold one entry each.

`DeepseekSparseAttnBackend.init_forward_metadata` dispatched IDLE through the plain-decode branch, which builds one metadata row per sequence, so the indexer's paged top-k got a `lengths` vector `num_tokens_per_req`× shorter than its score rows.

### When this broke

Not a regression of this leg — it has no green run to bisect to. The recipe landed on top of an already-broken path:

| Date | Commit | What it established |
|---|---|---|
| 2025-10-06 | [`efbc687c28`](https://github.com/sgl-project/sglang/commit/efbc687c28) ([#11061](https://github.com/sgl-project/sglang/pull/11061)) | DSA's eager `init_forward_metadata` folds IDLE into the decode-shaped branch (`is_decode_or_idle()`), one row per sequence. |
| 2026-01-10 | [`2d088b85d9`](https://github.com/sgl-project/sglang/commit/2d088b85d9) ([#15227](https://github.com/sgl-project/sglang/pull/15227)) | `forward_idle` starts rebuilding attention metadata whenever a padded idle batch has `batch_size > 0`, explicitly to fix an NSA-indexer batch-size mismatch. Every shape is derived from `batch_size` alone — right for a plain decode round, `num_tokens_per_req`× short for a speculative one. Before it, a padded idle batch reused the previous forward's metadata, so no revision ever produced correct metadata here. |
| 2026-06-16 | [`063ab89ac1`](https://github.com/sgl-project/sglang/commit/063ab89ac1) ([#26471](https://github.com/sgl-project/sglang/pull/26471)) | The DeepSeek-V4 backend grows `if self.mtp_enabled and logical_forward_mode.is_idle(): return` — the sibling backend fixes this exact class of bug for itself. DSA never got an equivalent. |
| 2026-06-26 | [`9214b9338f`](https://github.com/sgl-project/sglang/commit/9214b9338f) ([#29413](https://github.com/sgl-project/sglang/pull/29413)) | Adds DSA to the draft-extend cuda-graph list, gated `_is_cuda or _is_musa` ("DSA is CUDA-only"). The graph path builds correct `DRAFT_EXTEND_V2`-shaped metadata, so on ROCm the only escape hatch is closed and the eager path is mandatory (`cuda_graph={..., draft_extend=0.00}` in all four decode logs). |
| 2026-08-07 | [`fc9479243e`](https://github.com/sgl-project/sglang/commit/fc9479243e) ([#32120](https://github.com/sgl-project/sglang/pull/32120)) | Adds the GLM-5.2 DP8/EP8 + MTP recipe — the first time all the conditions coexist in CI. |

Why only this leg: the other three GLM-5.2 legs in the same run are green, and they isolate the two factors cleanly — DP8/EP8 without MTP pads one row per sequence (matches the decode shape), and MTP with TP8/DP1 has no MLP sync and therefore no padded idle ranks. The `dsv4*-dp8ep8-mtp` legs run the same ROCm eager path but use `attention_backend: dsv4`, which has the #26471 guard above.

Why only ROCm: on CUDA `deepgemm_paged_mqa_logits_split` slices the query to `q_offset` before scoring and pads the result back, so the short metadata is self-consistent and the discarded padding rows just get `-1`. ROCm's `aiter_paged_mqa_logits` scores the whole query tensor, which is what trips the kernel check.

## Modifications

`init_forward_metadata` now restates a padded idle speculative batch as `batch_size * num_tokens_per_req` single-token dummy sequences — every row there is discarded padding, so repeating `cache_seqlens` / `page_table` is exact, and it keeps every downstream consumer (indexer `lengths`, `q_offset`, page tables, `cu_seqlens_*`, the folded top-k v2 plan) seeing one metadata row per query row without teaching each of them about the expansion.

The expansion is gated on `forward_mode.is_idle()`. A live decode rank describes its own sequences and must not be touched; `_idle_spec_rows_per_seq` returns 1 for every non-idle batch, for an idle batch with no `spec_info`, and for the `num_tokens_per_req == -1` "width never set" default, so those paths are byte-identical to before.

### Relation to the open PRs on this cluster

- [#33059](https://github.com/sgl-project/sglang/pull/33059) (open since 2026-07-31) fixes the same crash from the other side: it slices `q_fp8[:q_offset]` on the aiter path so ROCm matches the CUDA contract. That removes the assertion, and the two changes are complementary rather than conflicting — this PR makes the metadata describe the batch, #33059 makes the aiter kernel agree with the metadata. If #33059 lands first this PR still removes the underlying under-description (the attention metadata, not just the indexer's, is short today).
- [#32209](https://github.com/sgl-project/sglang/pull/32209) (open since 2026-07-23) short-circuits the eager idle indexer, but its guard is `_is_cuda and forward_batch.forward_mode.is_idle()`, so it cannot fix this MI355X leg.
- [#33877](https://github.com/sgl-project/sglang/pull/33877) is a scheduler-side MTP metadata buffer fix and is unrelated to this failure.

## Accuracy Tests

The change only affects metadata for padded idle rows, whose outputs are discarded. Verified on CPU that a plain idle round and a decode round produce identical metadata before and after the change, and that the idle speculative round goes from 3 rows to the 12 the rank actually forwards (bs=3, `num_tokens_per_req=4`).

The nightly leg itself runs a full GSM8K gate (threshold > 0.91) through the PD path before its perf sweep, which will cover the end-to-end accuracy once it gets past server startup.

## Speed Tests and Profiling

No effect on any non-idle path. On an idle rank the added work is two `repeat_interleave` calls on `batch_size`-sized tensors, off the critical path of every rank that has real work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Tests

`test/registered/unit/layers/attention/test_dsa_idle_spec_metadata.py` (CPU, `base-a-test-cpu`) builds the metadata for a padded idle batch and asserts every per-row field matches `cal_padded_tokens` — the same padding calculation `prepare_mlp_sync_batch` follows, so the expected row count is stated independently of the code under test. It fails with `AssertionError: 3 != 12` on the parent commit and passes with the fix; the plain idle / decode cases pass on both.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d8a9f38-b274-402c-ba78-fa2f49a630d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d8a9f38-b274-402c-ba78-fa2f49a630d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829018047](https://github.com/sgl-project/sglang/actions/runs/34829018047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829017827](https://github.com/sgl-project/sglang/actions/runs/34829017827)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829018017](https://github.com/sgl-project/sglang/actions/runs/34829018017)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->