### PR TITLE
Support deferred MoE finalize for MXFP4 and FP8 block-scale

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/moe_finalize_fuse_shared.cu
+++ b/python/sglang/kernels/jit/csrc/moe/moe_finalize_fuse_shared.cu
@@ -43,8 +43,7 @@
  * Expert-weight scale convention: in our target backends
  * (flashinfer trtllm nvfp4 + unquantized), ``apply_routed_scaling_factor_on_output``
  * is True, so the routed scaling factor is already folded into
- * ``expert_weights`` at topk time. This kernel does not apply any
- * additional scale.
+ * ``expert_weights`` at topk time.
  */
 
 #include <cutlass/array.h>
@@ -71,6 +70,7 @@ __global__ void moeFinalizeKernel(
     int hiddenDim,
     int hiddenDimPadded,
     int topK,
+    float routedScale,
     BF16 const* __restrict__ inPtr,
     int const* __restrict__ expandedIdxToPermutedIdx,
     TypeExpW const* __restrict__ expertWeightsPtr,
@@ -90,7 +90,7 @@ __global__ void moeFinalizeKernel(
         if (permutedIdx == -1) {
           continue;
         }
-        float const scale = static_cast<float>(expertWeightsPtr[expandedIdx]);
+        float const scale = static_cast<float>(expertWeightsPtr[expandedIdx]) * routedScale;
         float const val = static_cast<float>(inPtr[permutedIdx * hiddenDimPadded + hiddenIdx]);
         acc += scale * val;
       }
@@ -141,6 +141,7 @@ __global__ void moeFinalizeKernelVecLoad(
     int hiddenDim,
     int hiddenDimPadded,
     int topK,
+    float routedScale,
     BF16 const* __restrict__ inPtr,
     int const* __restrict__ expandedIdxToPermutedIdx,
     TypeExpW const* __restrict__ expertWeightsPtr,
@@ -214,7 +215,7 @@ __global__ void moeFinalizeKernelVecLoad(
         if (permutedIdx == -1) {
           continue;
         }
-        float const scale = static_cast<float>(scaleArr[ki]);
+        float const scale = static_cast<float>(scaleArr[ki]) * routedScale;
         cutlass::NumericArrayConverter<float, BF16, FINALIZE_ELEM_PER_THREAD> toFloat;
         ComputeElem expertResult = toFloat(inputElemArr[ki]);
 #pragma unroll
@@ -253,6 +254,7 @@ void dispatchFinalize(
     int hiddenDim,
     int hiddenDimPadded,
     int topK,
+    float routedScale,
     BF16 const* inPtr,
     int const* expandedIdxPtr,
     void const* weightsPtrVoid,
@@ -283,6 +285,7 @@ void dispatchFinalize(
         hiddenDim,
         hiddenDimPadded,
         topK,
+        routedScale,
         inPtr,
         expandedIdxPtr,
         weightsPtr,
@@ -307,6 +310,7 @@ void dispatchFinalize(
         hiddenDim,
         hiddenDimPadded,
         topK,
+        routedScale,
         inPtr,
         expandedIdxPtr,
         weightsPtr,
@@ -333,7 +337,8 @@ void moe_finalize_fuse_shared(
     TensorView expert_weights,
     TensorView shared_output,
     int64_t top_k,
-    bool enable_pdl) {
+    bool enable_pdl,
+    double routed_scale) {
   TVM_FFI_ICHECK_EQ(out.ndim(), 2) << "out must be 2-D [numTokens, hiddenDim]";
   TVM_FFI_ICHECK_EQ(gemm2_out.ndim(), 2) << "gemm2_out must be 2-D [totalNumPaddedTokens, hiddenDimPadded]";
   TVM_FFI_ICHECK_EQ(expanded_idx_to_permuted_idx.ndim(), 1);
@@ -381,6 +386,7 @@ void moe_finalize_fuse_shared(
         hiddenDim,
         hiddenDimPadded,
         int(top_k),
+        float(routed_scale),
         inPtr,
         expandedIdxPtr,
         expert_weights.data_ptr(),
@@ -396,6 +402,7 @@ void moe_finalize_fuse_shared(
         hiddenDim,
         hiddenDimPadded,
         int(top_k),
+        float(routed_scale),
         inPtr,
         expandedIdxPtr,
         expert_weights.data_ptr(),

--- a/python/sglang/kernels/ops/moe/moe_finalize_fuse_shared.py
+++ b/python/sglang/kernels/ops/moe/moe_finalize_fuse_shared.py
@@ -24,6 +24,7 @@ def moe_finalize_fuse_shared(
     shared_output: Optional[torch.Tensor],
     top_k: int,
     enable_pdl: bool = False,
+    routed_scale: float = 1.0,
 ) -> torch.Tensor:
     assert gemm2_out.dtype == torch.bfloat16
     assert expert_weights.dtype in (torch.float32, torch.bfloat16)
@@ -56,5 +57,6 @@ def moe_finalize_fuse_shared(
         shared_output,
         int(top_k),
         bool(enable_pdl),
+        float(routed_scale),
     )
     return out

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -48,6 +48,7 @@ from sglang.srt.layers.moe.topk import (
     TopKConfig,
     TopKOutput,
     TopKOutputChecker,
+    TopKOutputFormat,
 )
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
@@ -97,6 +98,24 @@ _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 # layers can resolve to different quant methods, so print_info_once (keyed on the
 # full message) would otherwise fire once per distinct quant method.
 _deferred_finalize_info_logged = False
+
+
+def _deferred_finalize_topk_format(quant_method) -> Optional[TopKOutputFormat]:
+    from sglang.srt.layers.quantization.mxfp4_flashinfer_trtllm_moe import (
+        Mxfp4FlashinferTrtllmMoEMethod,
+    )
+
+    backend = get_moe_runner_backend()
+    if backend.is_flashinfer_trtllm():
+        if isinstance(quant_method, ModelOptNvFp4FusedMoEMethod):
+            return TopKOutputFormat.BYPASSED
+        if isinstance(quant_method, Fp8MoEMethod) and quant_method.block_quant:
+            return TopKOutputFormat.BYPASSED
+    if backend.is_flashinfer_mxfp4() and isinstance(
+        quant_method, Mxfp4FlashinferTrtllmMoEMethod
+    ):
+        return TopKOutputFormat.STANDARD
+    return None
 
 
 def _copy_weight_view_before_h2d(loaded_weight: torch.Tensor) -> torch.Tensor:
@@ -381,10 +400,12 @@ class FusedMoE(torch.nn.Module):
                     self.use_deep_gemm,
                 )
         _validate_hpc_ops_quant_method(self.quant_method)
+        self.deferred_finalize_topk_format = _deferred_finalize_topk_format(
+            self.quant_method
+        )
         self.supports_deferred_finalize = (
             envs.SGLANG_ENABLE_MOE_DEFERRED_FINALIZE.get()
-            and get_moe_runner_backend().is_flashinfer_trtllm()
-            and isinstance(self.quant_method, ModelOptNvFp4FusedMoEMethod)
+            and self.deferred_finalize_topk_format is not None
         )
         global _deferred_finalize_info_logged
         if not _deferred_finalize_info_logged:
@@ -392,6 +413,7 @@ class FusedMoE(torch.nn.Module):
             logging.getLogger(__name__).info(
                 "FlashInfer TRTLLM MoE deferred finalize is "
                 f"{'enabled' if self.supports_deferred_finalize else 'disabled'} "
+                f"(topk_format={self.deferred_finalize_topk_format}) "
                 f"(moe_runner_backend={get_exec().moe.moe_runner_backend}, "
                 f"quant_method={type(self.quant_method).__name__})."
             )

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -57,6 +57,7 @@ class FlashInferTrtllmDeferredFinalizeOutput:
     expert_weights: torch.Tensor
     expanded_idx_to_permuted_idx: torch.Tensor
     top_k: int
+    routed_scale: float = 1.0
 
 
 @contextmanager
@@ -84,6 +85,7 @@ def finalize_flashinfer_trtllm_deferred_output(
         shared_output,
         deferred_output.top_k,
         enable_pdl=is_arch_support_pdl(),
+        routed_scale=deferred_output.routed_scale,
     )
 
 
@@ -720,16 +722,24 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
             )
             a_sf_t = a_sf.t()
 
-        # Allocate output inside symmetric memory context
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            symm_output = torch.empty(
-                hidden_states.shape[0],
-                hidden_states.shape[1],
-                dtype=hidden_states.dtype,
-                device=hidden_states.device,
-            )
+        defer_finalize = (
+            _deferred_finalize_enabled.get()
+            and not use_routed_topk
+            and TopKOutputChecker.format_is_bypassed(topk_output)
+        )
+
+        symm_output = None
+        if not defer_finalize:
+            # Allocate output inside symmetric memory context
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                symm_output = torch.empty(
+                    hidden_states.shape[0],
+                    hidden_states.shape[1],
+                    dtype=hidden_states.dtype,
+                    device=hidden_states.device,
+                )
 
         # Move kernel call outside context manager to avoid graph breaks
         # during torch.compile for piecewise cuda graph.
@@ -774,6 +784,46 @@ def fused_experts_none_to_flashinfer_trtllm_fp8(
                 tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
                 fp8_quantization_type=int(fp8_quantization_type),
                 activation_type=quant_info.activation_type,
+            )
+        elif defer_finalize:
+            from flashinfer.fused_moe import trtllm_fp8_block_scale_moe
+
+            deferred = trtllm_fp8_block_scale_moe(
+                routing_logits=router_logits,
+                routing_bias=correction_bias,
+                hidden_states=a_q,
+                hidden_states_scale=a_sf_t,
+                gemm1_weights=quant_info.w13_weight,
+                gemm1_weights_scale=quant_info.w13_weight_scale_inv,
+                gemm2_weights=quant_info.w2_weight,
+                gemm2_weights_scale=quant_info.w2_weight_scale_inv,
+                num_experts=quant_info.global_num_experts,
+                top_k=topk_config.top_k,
+                n_group=topk_config.num_expert_group,
+                topk_group=topk_config.topk_group,
+                intermediate_size=quant_info.intermediate_size,
+                local_expert_offset=quant_info.local_expert_offset,
+                local_num_experts=quant_info.local_num_experts,
+                routed_scaling_factor=(
+                    runner_config.routed_scaling_factor
+                    if runner_config.routed_scaling_factor is not None
+                    else 1.0
+                ),
+                routing_method_type=routing_method_type,
+                use_shuffled_weight=use_shuffled_weight,
+                do_finalize=False,
+                tune_max_num_tokens=next_power_of_2(a_q.shape[0]),
+                fp8_quantization_type=fp8_quantization_type,
+                activation_type=quant_info.activation_type,
+            )
+            gemm2_out, expert_weights, expanded_idx_to_permuted_idx = deferred[:3]
+            return StandardCombineInput(
+                hidden_states=FlashInferTrtllmDeferredFinalizeOutput(
+                    gemm2_out=gemm2_out,
+                    expert_weights=expert_weights,
+                    expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+                    top_k=topk_config.top_k,
+                )
             )
         else:
             assert TopKOutputChecker.format_is_bypassed(topk_output)

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -319,20 +319,32 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         else:
             raise NotImplementedError(f"Unsupported mxfp4 moe precision: {precision}")
 
-        with use_symmetric_memory(
-            get_tp_group(), disabled=not is_allocation_symmetric()
-        ):
-            num_tokens = x_quant.shape[0]
-            out_hidden_size = (
-                x_quant.shape[-1] * 2
-                if x_quant.dtype == torch.uint8
-                else x_quant.shape[-1]
-            )
-            symm_output = torch.empty(
-                num_tokens, out_hidden_size, dtype=torch.bfloat16, device=x_quant.device
-            )
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            FlashInferTrtllmDeferredFinalizeOutput,
+            _deferred_finalize_enabled,
+        )
 
-        output = trtllm_fp4_block_scale_routed_moe(
+        defer_finalize = _deferred_finalize_enabled.get()
+
+        symm_output = None
+        if not defer_finalize:
+            with use_symmetric_memory(
+                get_tp_group(), disabled=not is_allocation_symmetric()
+            ):
+                num_tokens = x_quant.shape[0]
+                out_hidden_size = (
+                    x_quant.shape[-1] * 2
+                    if x_quant.dtype == torch.uint8
+                    else x_quant.shape[-1]
+                )
+                symm_output = torch.empty(
+                    num_tokens,
+                    out_hidden_size,
+                    dtype=torch.bfloat16,
+                    device=x_quant.device,
+                )
+
+        result = trtllm_fp4_block_scale_routed_moe(
             topk_ids=packed_topk,
             routing_bias=None,
             hidden_states=x_quant,
@@ -358,12 +370,28 @@ class Mxfp4FlashinferTrtllmMoEMethod:
             local_num_experts=num_local_experts,
             routed_scaling_factor=1.0,
             routing_method_type=int(RoutingMethodType.TopK),
-            do_finalize=True,
+            do_finalize=not defer_finalize,
             tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
             output=symm_output,
-        )[0]
+        )
 
-        return StandardCombineInput(hidden_states=output)
+        if not defer_finalize:
+            return StandardCombineInput(hidden_states=result[0])
+
+        gemm2_out, expert_weights, expanded_idx_to_permuted_idx = result[:3]
+        routed_scaling_factor = self.moe_runner_config.routed_scaling_factor
+
+        return StandardCombineInput(
+            hidden_states=FlashInferTrtllmDeferredFinalizeOutput(
+                gemm2_out=gemm2_out,
+                expert_weights=expert_weights,
+                expanded_idx_to_permuted_idx=expanded_idx_to_permuted_idx,
+                top_k=packed_topk.shape[1],
+                routed_scale=(
+                    1.0 if routed_scaling_factor is None else routed_scaling_factor
+                ),
+            )
+        )
 
 
 def maybe_fuse_routed_scale_and_shared_add(

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -981,8 +981,8 @@ class DeepseekV2MoE(nn.Module):
         deferred_finalize = (
             has_shared_output
             and not self._shared_expert_tp1
-            and topk_output.format == TopKOutputFormat.BYPASSED
             and self.experts.supports_deferred_finalize
+            and topk_output.format == self.experts.deferred_finalize_topk_format
         )
         if deferred_finalize:
             final_hidden_states = self.experts.forward_deferred_finalize(


### PR DESCRIPTION
## Motivation

The FlashInfer TRT-LLM MoE kernels can return the unweighted expert outputs instead of performing the top-k weighted combine inside the kernel. When the combine is deferred, it is merged with the shared-expert addition into a single kernel, which removes one kernel launch per MoE layer per decode step.

This mode was previously enabled only for the NVFP4 runner. This PR enables it for the MXFP4 runner and for the FP8 block-scale runner. The FP8 per-tensor runner is not changed.

## Modifications

1. The deferred combine is enabled for MXFP4 and FP8 block-scale in addition to NVFP4. Each supported quantization and runner combination accepts the deferred form for exactly one routing format, so the required format is now derived per configuration rather than assumed.

2. The routed scaling factor is handled explicitly. On the MXFP4 path the routing decision is computed in advance, and the MoE kernel therefore does not execute the stage that would apply this factor to the expert weights. The factor is instead passed to the fused combine kernel, which multiplies it into the expert weight already held in a register. No additional kernel is launched. All other callers pass a value of 1.0 and their results are unchanged.

## Accuracy

AIME 2026, 30 problems, 8 repeats, 240 samples per configuration.

| Configuration | pass@1 |
| --- | --- |
| Baseline | 96.67% |
| This PR | 97.08% |

Servers:

```
# baseline
SGLANG_ENABLE_MOE_DEFERRED_FINALIZE=0 sglang serve --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 --tp 4 \
  --moe-runner-backend flashinfer_mxfp4 --swa-full-tokens-ratio 0.1 --port 30001

# this PR
sglang serve --trust-remote-code \
  --model-path deepseek-ai/DeepSeek-V4-Flash-0731 --tp 4 \
  --moe-runner-backend flashinfer_mxfp4 --swa-full-tokens-ratio 0.1 --port 30000
```

Evaluation:

```
sgl-eval run aime26 --base-url http://127.0.0.1:30001/v1 \
  --n-repeats 8 --temperature 1.0 --top-p 0.95 --thinking \
  --num-threads 240 --max-tokens 131072

sgl-eval run aime26 --base-url http://127.0.0.1:30000/v1 \
  --n-repeats 8 --temperature 1.0 --top-p 0.95 --thinking \
  --num-threads 240 --max-tokens 131072
```

## Speed

DeepSeek-V4-Flash-0731, MXFP4 MoE runner, tensor parallel size 4, B300, input length 1024, output length 1024. One measurement per point.

| Batch size | Output tok/s, baseline | Output tok/s, this PR | Change |
| --- | --- | --- | --- |
| 1 | 193.09 | 197.46 | +2.3% |
| 4 | 622.83 | 632.04 | +1.5% |
| 8 | 1163.31 | 1177.10 | +1.2% |
| 16 | 2107.59 | 2105.02 | -0.1% |
| 64 | 6265.74 | 6272.06 | +0.1% |
| 256 | 15597.53 | 15246.44 | -2.3% |

Kernel counts from a decode profile of 20 steps at batch size 1, one tensor parallel rank, 43 MoE layers:

| Kernel | Baseline | This PR |
| --- | --- | --- |
| In-kernel combine | 3.241 ms, 860 launches | not launched |
| Elementwise add for the shared expert | 1.324 ms, 860 launches | not launched |
| Fused combine and shared-expert add | not launched | 3.318 ms, 860 launches |

At batch size 256 the same comparison gives 9.717 ms for the two baseline kernels and 6.604 ms for the single fused kernel, a reduction of 3.11 ms per 20 decode steps.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31550766019](https://github.com/sgl-project/sglang/actions/runs/31550766019)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31550765937](https://github.com/sgl-project/sglang/actions/runs/31550765937)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->