### PR TITLE
[Fix] Make DeepSeek-V4 reasoning and tool-call streaming parsing chunk-invariant

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -180,7 +180,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                         parameters[param_name] = _partial_json_loads(
                             param_value, Allow.ALL
                         )[0]
-                    except (json.JSONDecodeError, MalformedJSON):
+                    except (json.JSONDecodeError, MalformedJSON, ValueError):
                         parameters[param_name] = param_value.strip()
 
         return json.dumps(parameters, ensure_ascii=False)
@@ -370,10 +370,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
             logger.error(f"Error in parse_streaming_increment: {e}")
             # Re-emit verbatim rather than swallowing the turn; the preamble is
             # still inside current_text unless a completed call advanced past it.
+            # Calls collected in this pass are dropped on purpose: the failure can
+            # land between a tool's name and its arguments, and a named call with
+            # no arguments is worse for the client than none at all.
             self._buffer = ""
             if not current_text.startswith(preamble):
                 current_text = preamble + current_text
-            return StreamingParseResult(normal_text=current_text, calls=all_calls)
+            return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -2,6 +2,7 @@ import json
 import logging
 import re
 
+from partial_json_parser.core.exceptions import MalformedJSON
 from partial_json_parser.core.options import Allow
 
 from sglang.srt.entrypoints.openai.protocol import Tool
@@ -179,7 +180,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                         parameters[param_name] = _partial_json_loads(
                             param_value, Allow.ALL
                         )[0]
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, MalformedJSON):
                         parameters[param_name] = param_value.strip()
 
         return json.dumps(parameters, ensure_ascii=False)
@@ -199,26 +200,27 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         calls = []
         try:
-            # Extract content between function_calls tags
-            function_calls_match = re.search(
-                self.function_calls_regex,
-                text,
-                re.DOTALL,
-            )
-            if not function_calls_match:
+            # Every tool_calls section, not just the first: a turn can contain
+            # several, and the streaming path already parses all of them.
+            sections = re.findall(self.function_calls_regex, text, re.DOTALL)
+            if not sections:
                 return StreamingParseResult(normal_text=normal_text, calls=[])
 
-            function_calls_content = function_calls_match.group(1)
-
             # Find all invoke blocks
-            for invoke_match in re.finditer(
-                self.invoke_regex, function_calls_content, re.DOTALL
-            ):
-                func_name, invoke_content, _ = self._unpack_invoke_match(invoke_match)
-                func_args = self._parse_parameters_from_xml(invoke_content)
-                # construct match_result for parse_base_json
-                match_result = {"name": func_name, "parameters": json.loads(func_args)}
-                calls.extend(self.parse_base_json(match_result, tools))
+            for function_calls_content in sections:
+                for invoke_match in re.finditer(
+                    self.invoke_regex, function_calls_content, re.DOTALL
+                ):
+                    func_name, invoke_content, _ = self._unpack_invoke_match(
+                        invoke_match
+                    )
+                    func_args = self._parse_parameters_from_xml(invoke_content)
+                    # construct match_result for parse_base_json
+                    match_result = {
+                        "name": func_name,
+                        "parameters": json.loads(func_args),
+                    }
+                    calls.extend(self.parse_base_json(match_result, tools))
 
             return StreamingParseResult(normal_text=normal_text, calls=calls)
         except Exception as e:
@@ -259,6 +261,10 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=current_text)
 
         all_calls: list[ToolCallItem] = []
+        # Prose the model emitted before the first tool call. Only recovered for the
+        # first call; prose between or after tool calls stays buffered because the
+        # DSML guard above never releases a buffer that still holds a marker.
+        preamble = ""
         try:
             # Loop to handle multiple consecutive invoke blocks
             while True:
@@ -280,6 +286,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     self.current_tool_id = 0
                     self.prev_tool_call_arr = []
                     self.streamed_args_for_tool = [""]
+                    call_start = invoke_match.start()
+                    bot_pos = current_text.rfind(self.bot_token, 0, call_start)
+                    if bot_pos != -1:
+                        call_start = bot_pos
+                    # Same trailing-newline handling as detect_and_parse, so the
+                    # two paths agree on normal_text.
+                    preamble = current_text[:call_start].removesuffix("\n\n")
 
                 # Ensure arrays are large enough for current tool
                 while len(self.prev_tool_call_arr) <= self.current_tool_id:
@@ -355,11 +368,17 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     break
 
             # No more invoke blocks found
-            return StreamingParseResult(normal_text="", calls=all_calls)
+            return StreamingParseResult(normal_text=preamble, calls=all_calls)
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            return StreamingParseResult(normal_text=current_text)
+            # Drop the buffer so the same bad content is not re-parsed, and
+            # re-emit it verbatim rather than swallowing the turn. The preamble is
+            # still inside current_text unless a completed call advanced past it.
+            self._buffer = ""
+            if not current_text.startswith(preamble):
+                current_text = preamble + current_text
+            return StreamingParseResult(normal_text=current_text, calls=all_calls)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -200,8 +200,6 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         calls = []
         try:
-            # Every tool_calls section, not just the first: a turn can contain
-            # several, and the streaming path already parses all of them.
             sections = re.findall(self.function_calls_regex, text, re.DOTALL)
             if not sections:
                 return StreamingParseResult(normal_text=normal_text, calls=[])
@@ -261,9 +259,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=current_text)
 
         all_calls: list[ToolCallItem] = []
-        # Prose the model emitted before the first tool call. Only recovered for the
-        # first call; prose between or after tool calls stays buffered because the
-        # DSML guard above never releases a buffer that still holds a marker.
+        # Only recovered for the first call: the DSML guard above never releases a
+        # buffer that still holds a marker, so later prose stays buffered.
         preamble = ""
         try:
             # Loop to handle multiple consecutive invoke blocks
@@ -290,8 +287,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     bot_pos = current_text.rfind(self.bot_token, 0, call_start)
                     if bot_pos != -1:
                         call_start = bot_pos
-                    # Same trailing-newline handling as detect_and_parse, so the
-                    # two paths agree on normal_text.
+                    # Same trailing-newline trim as detect_and_parse, so both agree.
                     preamble = current_text[:call_start].removesuffix("\n\n")
 
                 # Ensure arrays are large enough for current tool
@@ -372,8 +368,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            # Drop the buffer so the same bad content is not re-parsed, and
-            # re-emit it verbatim rather than swallowing the turn. The preamble is
+            # Re-emit verbatim rather than swallowing the turn; the preamble is
             # still inside current_text unless a completed call advanced past it.
             self._buffer = ""
             if not current_text.startswith(preamble):

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -370,9 +370,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
             logger.error(f"Error in parse_streaming_increment: {e}")
             # Re-emit verbatim rather than swallowing the turn; the preamble is
             # still inside current_text unless a completed call advanced past it.
-            # Calls collected in this pass are dropped on purpose: the failure can
-            # land between a tool's name and its arguments, and a named call with
-            # no arguments is worse for the client than none at all.
+            # Calls are dropped on purpose: the failure can land between a tool's
+            # name and its arguments, and a half-formed call is worse than none.
             self._buffer = ""
             if not current_text.startswith(preamble):
                 current_text = preamble + current_text

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -215,9 +215,8 @@ class BaseReasoningFormatDetector:
 
         # Continue with reasoning content
         if self._in_reasoning:
-            # Check for tool_start_token interruption. Unlike detect_and_parse we
-            # cannot see whether a think_end_token follows, so a model that quotes
-            # the tool token inside its reasoning ends the block early here.
+            # Check for tool_start_token interruption. Streaming cannot see a
+            # think_end_token that has not arrived yet; see the chunk_dependent test.
             if self.tool_start_token and self.tool_start_token in current_text:
                 tool_idx = current_text.find(self.tool_start_token)
                 reasoning_text = current_text[:tool_idx]
@@ -241,8 +240,7 @@ class BaseReasoningFormatDetector:
                         ),
                     )
                 if not self.stripped_think_start:
-                    # force_reasoning starts inside the block without having seen
-                    # the opening token, which can still arrive split.
+                    # force_reasoning never saw the opening token; it can still split.
                     holdback = max(
                         holdback,
                         self._ends_with_partial_token(current_text, think_start_text),
@@ -283,9 +281,8 @@ class BaseReasoningFormatDetector:
         stream_reasoning=False, the held-back token suffix under stream_reasoning=True.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
-            # Same reasoning as the reasoning-side flush below: what is left is a
-            # trailing slice held back only because it could still have grown into
-            # a token. The stream ended, so it never did, and it is content.
+            # Same as the reasoning-side flush below: a held-back slice that never
+            # became a token is content.
             leftover = self._buffer
             self._buffer = ""
             return StreamingParseResult(normal_text=leftover)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -283,7 +283,12 @@ class BaseReasoningFormatDetector:
         stream_reasoning=False, the held-back token suffix under stream_reasoning=True.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
-            return StreamingParseResult()
+            # Same reasoning as the reasoning-side flush below: what is left is a
+            # trailing slice held back only because it could still have grown into
+            # a token. The stream ended, so it never did, and it is content.
+            leftover = self._buffer
+            self._buffer = ""
+            return StreamingParseResult(normal_text=leftover)
 
         # Defensive: subclasses that fill _buffer themselves may not have stripped
         # the opening think token that _parse_streaming_increment_impl removes.

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -269,15 +269,18 @@ class BaseReasoningFormatDetector:
 
     @staticmethod
     def _ends_with_partial_token(buffer: str, token: str) -> int:
-        """Length of the trailing slice of `buffer` that is a strict prefix of `token`."""
-        for i in range(1, min(len(buffer) + 1, len(token))):
+        """Length of the longest trailing slice of `buffer` that is a strict prefix
+        of `token`. Longest, so a token whose prefix repeats inside itself does not
+        get cut short and leak the rest of the marker."""
+        for i in range(min(len(buffer), len(token) - 1), 0, -1):
             if token.startswith(buffer[-i:]):
                 return i
         return 0
 
     def finish(self) -> StreamingParseResult:
-        """Flush reasoning buffered under stream_reasoning=False when the stream ends
-        before the end token (e.g. max_tokens cut it short), instead of dropping it.
+        """Flush reasoning still buffered when the stream ends before the end token
+        (e.g. max_tokens cut it short), instead of dropping it: the whole block under
+        stream_reasoning=False, the held-back token suffix under stream_reasoning=True.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
             return StreamingParseResult()
@@ -294,9 +297,7 @@ class BaseReasoningFormatDetector:
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
 
-        # An unfinished end token under stream_reasoning=True is an incomplete
-        # token rather than content, and is dropped (see the test of the same name).
-        if not self.stream_reasoning and buffer:
+        if buffer:
             return StreamingParseResult(reasoning_text=buffer)
 
         return StreamingParseResult()

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -229,22 +229,16 @@ class BaseReasoningFormatDetector:
                 )
             if self.stream_reasoning:
                 # Minus any trailing slice that could be a token split across chunks.
-                holdback = self._ends_with_partial_token(
-                    current_text, self.think_end_token
-                )
+                holdback_tokens = [self.think_end_token]
                 if self.tool_start_token:
-                    holdback = max(
-                        holdback,
-                        self._ends_with_partial_token(
-                            current_text, self.tool_start_token
-                        ),
-                    )
+                    holdback_tokens.append(self.tool_start_token)
                 if not self.stripped_think_start:
                     # force_reasoning never saw the opening token; it can still split.
-                    holdback = max(
-                        holdback,
-                        self._ends_with_partial_token(current_text, think_start_text),
-                    )
+                    holdback_tokens.append(think_start_text)
+                holdback = max(
+                    self._ends_with_partial_token(current_text, token)
+                    for token in holdback_tokens
+                )
                 self._buffer = current_text[len(current_text) - holdback :]
                 return StreamingParseResult(
                     reasoning_text=current_text[: len(current_text) - holdback]

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -144,9 +144,8 @@ class BaseReasoningFormatDetector:
             # Assume reasoning was truncated before end token
             return StreamingParseResult(reasoning_text=processed_text)
 
-        # Extract reasoning content. A turn may hold several reasoning blocks, so
-        # keep alternating instead of splitting once, which would leave the later
-        # blocks (and their tokens) sitting in normal_text.
+        # Extract reasoning content. Alternate rather than split once, or a later
+        # reasoning block and its tokens would be left sitting in normal_text.
         if self.think_end_token in processed_text:
             reasoning_parts = []
             normal_parts = []
@@ -206,9 +205,8 @@ class BaseReasoningFormatDetector:
         if not self.stripped_think_start and think_start_text in current_text:
             start_idx = current_text.find(think_start_text)
             if start_idx > 0:
-                # Anything ahead of the token is normal content, not reasoning.
-                # Emit it and re-enter with the token at the front of the buffer,
-                # so a `replace` here can never pull that text into reasoning.
+                # Emit what precedes the token and re-enter with it at the front,
+                # so a `replace` can never pull that text into reasoning.
                 leading = current_text[:start_idx]
                 self._buffer = current_text[start_idx:]
                 nested = self._parse_streaming_increment_impl("")
@@ -217,8 +215,7 @@ class BaseReasoningFormatDetector:
                     reasoning_text=nested.reasoning_text,
                 )
             current_text = current_text[len(think_start_text) :]
-            # Write back so stream_reasoning=False, which keeps accumulating into
-            # _buffer, does not carry the token into reasoning_text or finish().
+            # Write back, or stream_reasoning=False carries the token into finish().
             self._buffer = current_text
             self.stripped_think_start = True
             self._in_reasoning = True
@@ -232,8 +229,7 @@ class BaseReasoningFormatDetector:
 
             self._buffer = remainder
             self._in_reasoning = False
-            # Arm the detector for a further reasoning block, and re-enter so the
-            # remainder is scanned for one instead of being emitted wholesale.
+            # Re-armed so a further reasoning block in the remainder is still seen.
             self.stripped_think_start = False
             if remainder:
                 nested = self._parse_streaming_increment_impl("")
@@ -258,8 +254,7 @@ class BaseReasoningFormatDetector:
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             if self.stream_reasoning:
-                # Stream the content immediately, minus any trailing slice that
-                # could be the start of think_end/tool_start split across chunks.
+                # Minus any trailing slice that could be a token split across chunks.
                 holdback = self._ends_with_partial_token(
                     current_text, self.think_end_token
                 )
@@ -1182,8 +1177,7 @@ class DeepSeekV4Detector(BaseReasoningFormatDetector):
             dsv4_thinking_start_token,
             dsv4_thinking_end_token,
             think_excluded_tokens=[dsv4_eos_token, dsv4_dsml_token],
-            # Route DSML blocks out of reasoning so the tool call detector, whose
-            # has_tool_call() matches on "<" + the DSML marker, can see them.
+            # Leading "<" included: has_tool_call() matches on it.
             tool_start_token=f"<{dsv4_dsml_token}",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -144,14 +144,25 @@ class BaseReasoningFormatDetector:
             # Assume reasoning was truncated before end token
             return StreamingParseResult(reasoning_text=processed_text)
 
-        # Extract reasoning content
+        # Extract reasoning content. A turn may hold several reasoning blocks, so
+        # keep alternating instead of splitting once, which would leave the later
+        # blocks (and their tokens) sitting in normal_text.
         if self.think_end_token in processed_text:
-            splits = processed_text.split(self.think_end_token, maxsplit=1)
-            reasoning_text = splits[0]
-            normal_text = splits[1]
+            reasoning_parts = []
+            normal_parts = []
+            rest = processed_text
+            while self.think_end_token in rest:
+                block, rest = rest.split(self.think_end_token, 1)
+                reasoning_parts.append(block)
+                if think_start_text not in rest:
+                    break
+                before, rest = rest.split(think_start_text, 1)
+                normal_parts.append(before)
+            normal_parts.append(rest)
 
             return StreamingParseResult(
-                normal_text=normal_text, reasoning_text=reasoning_text
+                normal_text="".join(normal_parts),
+                reasoning_text="".join(reasoning_parts),
             )
         else:
             # think_end_token is in self.previous_content for continue_final_message=True case
@@ -193,7 +204,22 @@ class BaseReasoningFormatDetector:
 
         # Strip `<think>` token if present
         if not self.stripped_think_start and think_start_text in current_text:
-            current_text = current_text.replace(think_start_text, "", 1)
+            start_idx = current_text.find(think_start_text)
+            if start_idx > 0:
+                # Anything ahead of the token is normal content, not reasoning.
+                # Emit it and re-enter with the token at the front of the buffer,
+                # so a `replace` here can never pull that text into reasoning.
+                leading = current_text[:start_idx]
+                self._buffer = current_text[start_idx:]
+                nested = self._parse_streaming_increment_impl("")
+                return StreamingParseResult(
+                    normal_text=leading + nested.normal_text,
+                    reasoning_text=nested.reasoning_text,
+                )
+            current_text = current_text[len(think_start_text) :]
+            # Write back so stream_reasoning=False, which keeps accumulating into
+            # _buffer, does not carry the token into reasoning_text or finish().
+            self._buffer = current_text
             self.stripped_think_start = True
             self._in_reasoning = True
 
@@ -202,14 +228,21 @@ class BaseReasoningFormatDetector:
             end_idx = current_text.find(self.think_end_token)
 
             reasoning_text = current_text[:end_idx]
+            remainder = current_text[end_idx + len(self.think_end_token) :]
 
-            self._buffer = ""
+            self._buffer = remainder
             self._in_reasoning = False
-            normal_text = current_text[end_idx + len(self.think_end_token) :]
+            # Arm the detector for a further reasoning block, and re-enter so the
+            # remainder is scanned for one instead of being emitted wholesale.
+            self.stripped_think_start = False
+            if remainder:
+                nested = self._parse_streaming_increment_impl("")
+                return StreamingParseResult(
+                    normal_text=nested.normal_text,
+                    reasoning_text=reasoning_text + nested.reasoning_text,
+                )
 
-            return StreamingParseResult(
-                normal_text=normal_text, reasoning_text=reasoning_text
-            )
+            return StreamingParseResult(reasoning_text=reasoning_text)
 
         # Continue with reasoning content
         if self._in_reasoning:
@@ -225,16 +258,37 @@ class BaseReasoningFormatDetector:
                     normal_text=normal_text, reasoning_text=reasoning_text
                 )
             if self.stream_reasoning:
-                # Stream the content immediately
-                self._buffer = ""
-                return StreamingParseResult(reasoning_text=current_text)
+                # Stream the content immediately, minus any trailing slice that
+                # could be the start of think_end/tool_start split across chunks.
+                holdback = self._ends_with_partial_token(
+                    current_text, self.think_end_token
+                )
+                if self.tool_start_token:
+                    holdback = max(
+                        holdback,
+                        self._ends_with_partial_token(
+                            current_text, self.tool_start_token
+                        ),
+                    )
+                self._buffer = current_text[len(current_text) - holdback :]
+                return StreamingParseResult(
+                    reasoning_text=current_text[: len(current_text) - holdback]
+                )
             else:
                 return StreamingParseResult()
 
-        # If we're not in a reasoning block return as normal text
+        # If we're not in a reasoning block return as normal text, holding back a
+        # trailing partial think_start so a later reasoning block is still seen.
         if not self._in_reasoning:
-            self._buffer = ""
-            return StreamingParseResult(normal_text=current_text)
+            holdback = (
+                0
+                if self.stripped_think_start
+                else self._ends_with_partial_token(current_text, think_start_text)
+            )
+            self._buffer = current_text[len(current_text) - holdback :]
+            return StreamingParseResult(
+                normal_text=current_text[: len(current_text) - holdback]
+            )
 
         return StreamingParseResult()
 
@@ -244,15 +298,27 @@ class BaseReasoningFormatDetector:
             return text[len(think_start_text) :]
         return text
 
+    @staticmethod
+    def _ends_with_partial_token(buffer: str, token: str) -> int:
+        """Length of the trailing slice of `buffer` that is a strict prefix of `token`."""
+        for i in range(1, min(len(buffer) + 1, len(token))):
+            if token.startswith(buffer[-i:]):
+                return i
+        return 0
+
     def finish(self) -> StreamingParseResult:
-        """Flush reasoning buffered under stream_reasoning=False when the stream ends
-        before the end token (e.g. max_tokens cut it short), instead of dropping it.
+        """Flush reasoning still buffered when the stream ends before the end token
+        (e.g. max_tokens cut it short), instead of dropping it: the whole block under
+        stream_reasoning=False, a held-back partial token under stream_reasoning=True.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
-            return StreamingParseResult()
+            # A held-back partial think_start that never completed is normal text.
+            leftover = self._buffer
+            self._buffer = ""
+            return StreamingParseResult(normal_text=leftover)
 
-        # stream_reasoning=False never clears _buffer, so the opening think token
-        # (stripped only from the base class's local view) survives here.
+        # Defensive: subclasses that fill _buffer themselves may not have stripped
+        # the opening think token that _parse_streaming_increment_impl removes.
         buffer = self._strip_leading_think_start(self._buffer)
         self._buffer = ""
 
@@ -263,7 +329,7 @@ class BaseReasoningFormatDetector:
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
 
-        if not self.stream_reasoning and buffer:
+        if buffer:
             return StreamingParseResult(reasoning_text=buffer)
 
         return StreamingParseResult()
@@ -1116,6 +1182,9 @@ class DeepSeekV4Detector(BaseReasoningFormatDetector):
             dsv4_thinking_start_token,
             dsv4_thinking_end_token,
             think_excluded_tokens=[dsv4_eos_token, dsv4_dsml_token],
+            # Route DSML blocks out of reasoning so the tool call detector, whose
+            # has_tool_call() matches on "<" + the DSML marker, can see them.
+            tool_start_token=f"<{dsv4_dsml_token}",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,
@@ -1173,13 +1242,6 @@ class Apertus2509Detector(BaseReasoningFormatDetector):
         self._tool_end_token = "<|tools_suffix|>"
         self._reasoning_acc: str = ""
         self._in_inner_tool: bool = False
-
-    @staticmethod
-    def _ends_with_partial_token(buffer: str, token: str) -> int:
-        for i in range(1, min(len(buffer) + 1, len(token))):
-            if token.startswith(buffer[-i:]):
-                return i
-        return 0
 
     def detect_and_parse(self, text: str) -> StreamingParseResult:
         blocks = self.detect_and_parse_block_sequence(text)

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -242,7 +242,9 @@ class BaseReasoningFormatDetector:
 
         # Continue with reasoning content
         if self._in_reasoning:
-            # Check for tool_start_token interruption
+            # Check for tool_start_token interruption. Unlike detect_and_parse we
+            # cannot see whether a think_end_token follows, so a model that quotes
+            # the tool token inside its reasoning ends the block early here.
             if self.tool_start_token and self.tool_start_token in current_text:
                 tool_idx = current_text.find(self.tool_start_token)
                 reasoning_text = current_text[:tool_idx]
@@ -302,9 +304,8 @@ class BaseReasoningFormatDetector:
         return 0
 
     def finish(self) -> StreamingParseResult:
-        """Flush reasoning still buffered when the stream ends before the end token
-        (e.g. max_tokens cut it short), instead of dropping it: the whole block under
-        stream_reasoning=False, a held-back partial token under stream_reasoning=True.
+        """Flush reasoning buffered under stream_reasoning=False when the stream ends
+        before the end token (e.g. max_tokens cut it short), instead of dropping it.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
             # A held-back partial think_start that never completed is normal text.
@@ -324,7 +325,9 @@ class BaseReasoningFormatDetector:
                 return StreamingParseResult(normal_text=normal_text)
             return StreamingParseResult()
 
-        if buffer:
+        # An unfinished end token under stream_reasoning=True is an incomplete
+        # token rather than content, and is dropped (see the test of the same name).
+        if not self.stream_reasoning and buffer:
             return StreamingParseResult(reasoning_text=buffer)
 
         return StreamingParseResult()

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -144,24 +144,14 @@ class BaseReasoningFormatDetector:
             # Assume reasoning was truncated before end token
             return StreamingParseResult(reasoning_text=processed_text)
 
-        # Extract reasoning content. Alternate rather than split once, or a later
-        # reasoning block and its tokens would be left sitting in normal_text.
+        # Extract reasoning content
         if self.think_end_token in processed_text:
-            reasoning_parts = []
-            normal_parts = []
-            rest = processed_text
-            while self.think_end_token in rest:
-                block, rest = rest.split(self.think_end_token, 1)
-                reasoning_parts.append(block)
-                if think_start_text not in rest:
-                    break
-                before, rest = rest.split(think_start_text, 1)
-                normal_parts.append(before)
-            normal_parts.append(rest)
+            splits = processed_text.split(self.think_end_token, maxsplit=1)
+            reasoning_text = splits[0]
+            normal_text = splits[1]
 
             return StreamingParseResult(
-                normal_text="".join(normal_parts),
-                reasoning_text="".join(reasoning_parts),
+                normal_text=normal_text, reasoning_text=reasoning_text
             )
         else:
             # think_end_token is in self.previous_content for continue_final_message=True case
@@ -203,18 +193,7 @@ class BaseReasoningFormatDetector:
 
         # Strip `<think>` token if present
         if not self.stripped_think_start and think_start_text in current_text:
-            start_idx = current_text.find(think_start_text)
-            if start_idx > 0:
-                # Emit what precedes the token and re-enter with it at the front,
-                # so a `replace` can never pull that text into reasoning.
-                leading = current_text[:start_idx]
-                self._buffer = current_text[start_idx:]
-                nested = self._parse_streaming_increment_impl("")
-                return StreamingParseResult(
-                    normal_text=leading + nested.normal_text,
-                    reasoning_text=nested.reasoning_text,
-                )
-            current_text = current_text[len(think_start_text) :]
+            current_text = current_text.replace(think_start_text, "", 1)
             # Write back, or stream_reasoning=False carries the token into finish().
             self._buffer = current_text
             self.stripped_think_start = True
@@ -225,20 +204,14 @@ class BaseReasoningFormatDetector:
             end_idx = current_text.find(self.think_end_token)
 
             reasoning_text = current_text[:end_idx]
-            remainder = current_text[end_idx + len(self.think_end_token) :]
 
-            self._buffer = remainder
+            self._buffer = ""
             self._in_reasoning = False
-            # Re-armed so a further reasoning block in the remainder is still seen.
-            self.stripped_think_start = False
-            if remainder:
-                nested = self._parse_streaming_increment_impl("")
-                return StreamingParseResult(
-                    normal_text=nested.normal_text,
-                    reasoning_text=reasoning_text + nested.reasoning_text,
-                )
+            normal_text = current_text[end_idx + len(self.think_end_token) :]
 
-            return StreamingParseResult(reasoning_text=reasoning_text)
+            return StreamingParseResult(
+                normal_text=normal_text, reasoning_text=reasoning_text
+            )
 
         # Continue with reasoning content
         if self._in_reasoning:
@@ -267,6 +240,13 @@ class BaseReasoningFormatDetector:
                             current_text, self.tool_start_token
                         ),
                     )
+                if not self.stripped_think_start:
+                    # force_reasoning starts inside the block without having seen
+                    # the opening token, which can still arrive split.
+                    holdback = max(
+                        holdback,
+                        self._ends_with_partial_token(current_text, think_start_text),
+                    )
                 self._buffer = current_text[len(current_text) - holdback :]
                 return StreamingParseResult(
                     reasoning_text=current_text[: len(current_text) - holdback]
@@ -274,18 +254,10 @@ class BaseReasoningFormatDetector:
             else:
                 return StreamingParseResult()
 
-        # If we're not in a reasoning block return as normal text, holding back a
-        # trailing partial think_start so a later reasoning block is still seen.
+        # If we're not in a reasoning block return as normal text
         if not self._in_reasoning:
-            holdback = (
-                0
-                if self.stripped_think_start
-                else self._ends_with_partial_token(current_text, think_start_text)
-            )
-            self._buffer = current_text[len(current_text) - holdback :]
-            return StreamingParseResult(
-                normal_text=current_text[: len(current_text) - holdback]
-            )
+            self._buffer = ""
+            return StreamingParseResult(normal_text=current_text)
 
         return StreamingParseResult()
 
@@ -308,10 +280,7 @@ class BaseReasoningFormatDetector:
         before the end token (e.g. max_tokens cut it short), instead of dropping it.
         force_nonempty_content emits it as normal_text, else as reasoning_text."""
         if not self._in_reasoning:
-            # A held-back partial think_start that never completed is normal text.
-            leftover = self._buffer
-            self._buffer = ""
-            return StreamingParseResult(normal_text=leftover)
+            return StreamingParseResult()
 
         # Defensive: subclasses that fill _buffer themselves may not have stripped
         # the opening think token that _parse_streaming_increment_impl removes.

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -1,0 +1,151 @@
+"""Unit tests for DeepSeekV4Detector DSML streaming — no server, no model loading."""
+
+import json
+from unittest.mock import patch
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.deepseekv4_detector import DeepSeekV4Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+DSML = "｜DSML｜"
+
+
+def _wrapped(invoke: str) -> str:
+    return f"<{DSML}tool_calls>\n{invoke}\n</{DSML}tool_calls>"
+
+
+def _invoke(name: str, params: str = "") -> str:
+    return f'<{DSML}invoke name="{name}">\n{params}\n</{DSML}invoke>'
+
+
+def _param(name: str, is_string: str, value: str) -> str:
+    return (
+        f'<{DSML}parameter name="{name}" string="{is_string}">{value}</{DSML}parameter>'
+    )
+
+
+def _weather_call(city: str = "SF") -> str:
+    return _wrapped(_invoke("get_weather", _param("city", "true", city)))
+
+
+class TestDeepSeekV4Streaming(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            )
+        ]
+
+    def _feed(self, chunks):
+        """Returns (normal_text, calls) accumulated over the chunks."""
+        detector = DeepSeekV4Detector()
+        normal, calls = "", []
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal += result.normal_text
+            calls.extend(result.calls)
+        return normal, calls
+
+    def test_preamble_in_same_delta_as_tool_call(self):
+        """Prose sharing a delta with the tool call must not be dropped, and the
+        streaming and one-shot paths must agree on it."""
+        text = "Let me check.\n" + _weather_call()
+        normal, calls = self._feed([text])
+
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
+        self.assertEqual(
+            normal, DeepSeekV4Detector().detect_and_parse(text, self.tools).normal_text
+        )
+
+    def test_preamble_in_earlier_delta(self):
+        normal, calls = self._feed(["Let me check.\n", _weather_call()])
+
+        self.assertIn("Let me check.", normal)
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
+
+    def test_preamble_before_bare_invoke_without_wrapper(self):
+        """The bare `<｜DSML｜invoke …>` form has no tool_calls wrapper to walk
+        back to, so the preamble is computed from the invoke itself."""
+        text = "Checking.\n" + _invoke("get_weather", _param("city", "true", "SF"))
+        normal, calls = self._feed([text])
+
+        self.assertIn("Checking.", normal)
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
+
+    def test_no_dsml_markers_leak_into_normal_text(self):
+        text = "Prose.\n" + _weather_call()
+        normal, _ = self._feed([text[i : i + 4] for i in range(0, len(text), 4)])
+
+        self.assertNotIn(DSML, normal)
+
+    def test_arguments_are_streamed(self):
+        _, calls = self._feed([_weather_call()])
+
+        arguments = "".join(c.parameters for c in calls if c.parameters)
+        self.assertEqual(json.loads(arguments), {"city": "SF"})
+
+    def test_malformed_partial_json_falls_back_to_raw_value(self):
+        """A partial non-string parameter must not escape as MalformedJSON."""
+        detector = DeepSeekV4Detector()
+        result = detector.parse_streaming_increment(
+            f'<{DSML}tool_calls>\n<{DSML}invoke name="get_weather">\n'
+            f'<{DSML}parameter name="city" string="false">{{"a"',
+            self.tools,
+        )
+
+        self.assertEqual([c.name for c in result.calls if c.name], ["get_weather"])
+
+    def test_non_streaming_parses_every_tool_calls_section(self):
+        """A turn with two tool_calls sections must yield both calls."""
+        result = DeepSeekV4Detector().detect_and_parse(
+            f"{_weather_call('SF')}\n{_weather_call('NY')}", self.tools
+        )
+
+        self.assertEqual(len(result.calls), 2)
+
+    def test_parse_error_reemits_buffer_instead_of_swallowing_it(self):
+        """On an unexpected parse error the turn must not come back empty."""
+        detector = DeepSeekV4Detector()
+
+        with patch.object(
+            DeepSeekV4Detector,
+            "_parse_parameters_from_xml",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = detector.parse_streaming_increment(_weather_call(), self.tools)
+
+        self.assertIn("get_weather", result.normal_text)
+        self.assertEqual(detector._buffer, "")
+
+    def test_parse_error_does_not_duplicate_on_next_delta(self):
+        """The buffer is dropped on error, so the same text is not re-emitted."""
+        detector = DeepSeekV4Detector()
+
+        with patch.object(
+            DeepSeekV4Detector,
+            "_parse_parameters_from_xml",
+            side_effect=RuntimeError("boom"),
+        ):
+            first = detector.parse_streaming_increment(_weather_call(), self.tools)
+            second = detector.parse_streaming_increment(" tail", self.tools)
+
+        self.assertIn("get_weather", first.normal_text)
+        self.assertNotIn("get_weather", second.normal_text)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -131,6 +131,9 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertIn("get_weather", first.normal_text)
         self.assertNotIn("get_weather", second.normal_text)
+        # No half-formed call: the failure can land between a tool's name and its
+        # arguments, so an argument-less named call must not reach the client.
+        self.assertEqual(first.calls, [])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -1,6 +1,5 @@
 """Unit tests for DeepSeekV4Detector DSML streaming — no server, no model loading."""
 
-import json
 from unittest.mock import patch
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
@@ -69,12 +68,6 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             normal, DeepSeekV4Detector().detect_and_parse(text, self.tools).normal_text
         )
 
-    def test_preamble_in_earlier_delta(self):
-        normal, calls = self._feed(["Let me check.\n", _weather_call()])
-
-        self.assertIn("Let me check.", normal)
-        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
-
     def test_preamble_before_bare_invoke_without_wrapper(self):
         """The bare `<｜DSML｜invoke …>` form has no tool_calls wrapper to walk
         back to, so the preamble is computed from the invoke itself."""
@@ -89,12 +82,6 @@ class TestDeepSeekV4Streaming(CustomTestCase):
         normal, _ = self._feed([text[i : i + 4] for i in range(0, len(text), 4)])
 
         self.assertNotIn(DSML, normal)
-
-    def test_arguments_are_streamed(self):
-        _, calls = self._feed([_weather_call()])
-
-        arguments = "".join(c.parameters for c in calls if c.parameters)
-        self.assertEqual(json.loads(arguments), {"city": "SF"})
 
     def test_malformed_partial_json_falls_back_to_raw_value(self):
         """A partial non-string parameter must not escape as MalformedJSON."""

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -115,22 +115,9 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertEqual(len(result.calls), 2)
 
-    def test_parse_error_reemits_buffer_instead_of_swallowing_it(self):
-        """On an unexpected parse error the turn must not come back empty."""
-        detector = DeepSeekV4Detector()
-
-        with patch.object(
-            DeepSeekV4Detector,
-            "_parse_parameters_from_xml",
-            side_effect=RuntimeError("boom"),
-        ):
-            result = detector.parse_streaming_increment(_weather_call(), self.tools)
-
-        self.assertIn("get_weather", result.normal_text)
-        self.assertEqual(detector._buffer, "")
-
-    def test_parse_error_does_not_duplicate_on_next_delta(self):
-        """The buffer is dropped on error, so the same text is not re-emitted."""
+    def test_parse_error_neither_swallows_nor_duplicates(self):
+        """An unexpected parse error must not empty the turn, and the dropped
+        buffer must not come back on the next delta."""
         detector = DeepSeekV4Detector()
 
         with patch.object(
@@ -139,6 +126,7 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             side_effect=RuntimeError("boom"),
         ):
             first = detector.parse_streaming_increment(_weather_call(), self.tools)
+            self.assertEqual(detector._buffer, "")
             second = detector.parse_streaming_increment(" tail", self.tools)
 
         self.assertIn("get_weather", first.normal_text)

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -972,6 +972,27 @@ class TestBufferLossBugFix(CustomTestCase):
         self.assertTrue(detector._in_reasoning)
         self.assertTrue(detector.stripped_think_start)
 
+    def test_finish_flushes_partial_token_held_outside_reasoning(self):
+        """Detectors hold back a trailing partial start token so it can be
+        recombined with the next chunk. If the stream ends first, finish() must
+        emit those characters as content instead of dropping them.
+
+        Covers the subclasses that manage `_buffer` themselves but inherit
+        `finish()` from the base class.
+        """
+        for detector in (
+            BaseReasoningFormatDetector("<think>", "</think>"),
+            Apertus2509Detector(),
+        ):
+            with self.subTest(detector=type(detector).__name__):
+                token = detector.think_start_token
+                partial = token[: len(token) - 1]
+                emitted = detector.parse_streaming_increment(f"see {partial}")
+                emitted_normal = emitted.normal_text + detector.finish().normal_text
+
+                self.assertFalse(detector._in_reasoning)
+                self.assertEqual(emitted_normal, f"see {partial}")
+
 
 class TestStreamingChunkSizeInvariance(CustomTestCase):
     """Accumulated (reasoning, normal) output must not depend on how the decode
@@ -1026,13 +1047,14 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
         )
 
     def test_reasoning_truncated_mid_partial_token(self):
-        """A stream cut short inside a partial `</think>` must not drop the
-        held-back characters."""
+        """A stream cut short inside a partial `</think>` drops that fragment
+        (see test_finish_drops_partial_end_tag_when_streaming_reasoning), but it
+        must drop exactly the same fragment at every chunk size."""
         for chunk_size in self.CHUNK_SIZES:
             with self.subTest(chunk_size=chunk_size):
                 self.assertEqual(
                     self._feed(DeepSeekR1Detector(), "<think>compare a <", chunk_size),
-                    ("compare a <", ""),
+                    ("compare a ", ""),
                 )
 
     def test_second_reasoning_block_does_not_leak_into_content(self):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -972,31 +972,10 @@ class TestBufferLossBugFix(CustomTestCase):
         self.assertTrue(detector._in_reasoning)
         self.assertTrue(detector.stripped_think_start)
 
-    def test_finish_flushes_partial_token_held_outside_reasoning(self):
-        """Detectors hold back a trailing partial start token so it can be
-        recombined with the next chunk. If the stream ends first, finish() must
-        emit those characters as content instead of dropping them.
-
-        Covers the subclasses that manage `_buffer` themselves but inherit
-        `finish()` from the base class.
-        """
-        for detector in (
-            BaseReasoningFormatDetector("<think>", "</think>"),
-            Apertus2509Detector(),
-        ):
-            with self.subTest(detector=type(detector).__name__):
-                token = detector.think_start_token
-                partial = token[: len(token) - 1]
-                emitted = detector.parse_streaming_increment(f"see {partial}")
-                emitted_normal = emitted.normal_text + detector.finish().normal_text
-
-                self.assertFalse(detector._in_reasoning)
-                self.assertEqual(emitted_normal, f"see {partial}")
-
 
 class TestStreamingChunkSizeInvariance(CustomTestCase):
     """Accumulated (reasoning, normal) output must not depend on how the decode
-    steps happen to batch tokens, and must match one-shot detect_and_parse.
+    steps happen to batch tokens.
 
     Speculative decoding and stream_interval > 1 deliver multiple tokens per
     step, which splits multi-character tokens like `</think>` across chunk
@@ -1044,26 +1023,6 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
             DeepSeekR1Detector,
             "<think>a < b</think>tail",
             ("a < b", "tail"),
-        )
-
-    def test_reasoning_truncated_mid_partial_token(self):
-        """A stream cut short inside a partial `</think>` drops that fragment
-        (see test_finish_drops_partial_end_tag_when_streaming_reasoning), but it
-        must drop exactly the same fragment at every chunk size."""
-        for chunk_size in self.CHUNK_SIZES:
-            with self.subTest(chunk_size=chunk_size):
-                self.assertEqual(
-                    self._feed(DeepSeekR1Detector(), "<think>compare a <", chunk_size),
-                    ("compare a ", ""),
-                )
-
-    def test_second_reasoning_block_does_not_leak_into_content(self):
-        """A further `<think>` block must be routed to reasoning, and the text
-        before it must stay normal content."""
-        self._assert_invariant(
-            DeepSeekR1Detector,
-            "<think>first</think>mid<think>second</think>end",
-            ("firstsecond", "midend"),
         )
 
     def test_dsv4_tool_block_after_think_end(self):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -1057,14 +1057,8 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
                     )
 
     def test_text_before_think_token_is_chunk_dependent(self):
-        """Accepted divergence inherited from main, pinned so a future fix has to
-        update this test rather than silently change behaviour.
-
-        When reasoning is not forced and the model emits text before `<think>`,
-        `replace(think_start, "", 1)` pulls that text into the reasoning branch,
-        while the prefix check may instead flush it as content first. Which one
-        happens depends on where the chunk boundary lands.
-        """
+        """Accepted divergence, inherited from main: text before `<think>` lands
+        in reasoning or content depending on where the chunk boundary falls."""
         text = "lead<think>r</think>tail"
         variants = {
             self._feed(Qwen3Detector(), text, chunk_size)
@@ -1082,14 +1076,9 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
         )
 
     def test_dsv4_reasoning_quoting_dsml_is_chunk_dependent(self):
-        """Accepted divergence, pinned so it is not mistaken for a regression.
-
-        `tool_start_token` ends the reasoning block as soon as the DSML marker
-        appears, but the non-streaming path only does so when no `</think>`
-        follows. Streaming cannot see whether one is still coming, so a model
-        quoting the tool format inside its reasoning splits by chunk size. The
-        DSV4 system prompt shows that marker to the model, so this is reachable.
-        """
+        """Accepted divergence: streaming ends the block at the DSML marker, while
+        one-shot waits to see whether a `</think>` follows. Reachable because the
+        DSV4 system prompt shows that marker to the model."""
         text = f"<think>format is <{self.DSML}tool_calls></think>answer"
         by_output = {}
         for chunk_size in self.CHUNK_SIZES:

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -236,6 +236,18 @@ class TestDeepSeekV4Detector(CustomTestCase):
         self.assertEqual(detector.reasoning_default, "explicit_thinking")
         self.assertTrue(detector.thinks_internally)
 
+    def test_dsml_block_is_routed_out_of_reasoning(self):
+        """Without tool_start_token the DSML block stays in reasoning_content and
+        the tool call detector never sees it."""
+        detector = ReasoningParser(model_type="deepseek-v4").detector
+        self.assertEqual(detector.tool_start_token, "<｜DSML｜")
+
+        result = detector.parse_streaming_increment(
+            '<think>pick a tool<｜DSML｜tool_calls><｜DSML｜invoke name="s">'
+        )
+        self.assertEqual(result.reasoning_text, "pick a tool")
+        self.assertTrue(result.normal_text.startswith("<｜DSML｜tool_calls>"))
+
 
 class TestInklingDetector(CustomTestCase):
     def test_streaming_routes_blocks_across_all_string_boundaries(self):
@@ -959,6 +971,109 @@ class TestBufferLossBugFix(CustomTestCase):
         self.assertEqual(result.reasoning_text, "")
         self.assertTrue(detector._in_reasoning)
         self.assertTrue(detector.stripped_think_start)
+
+
+class TestStreamingChunkSizeInvariance(CustomTestCase):
+    """Accumulated (reasoning, normal) output must not depend on how the decode
+    steps happen to batch tokens, and must match one-shot detect_and_parse.
+
+    Speculative decoding and stream_interval > 1 deliver multiple tokens per
+    step, which splits multi-character tokens like `</think>` across chunk
+    boundaries.
+    """
+
+    CHUNK_SIZES = [1, 2, 3, 5, 7, 11, 23, 1000]
+    DSML = "｜DSML｜"
+
+    def _feed(self, detector, text, chunk_size):
+        reasoning = normal = ""
+        for i in range(0, len(text), chunk_size):
+            result = detector.parse_streaming_increment(text[i : i + chunk_size])
+            reasoning += result.reasoning_text
+            normal += result.normal_text
+        result = detector.finish()
+        return reasoning + result.reasoning_text, normal + result.normal_text
+
+    def _assert_invariant(self, make_detector, text, expected):
+        for chunk_size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(
+                    self._feed(make_detector(), text, chunk_size), expected
+                )
+        one_shot = make_detector().detect_and_parse(text)
+        self.assertEqual((one_shot.reasoning_text, one_shot.normal_text), expected)
+
+    def test_think_end_split_across_chunks(self):
+        """`</think>` straddling a chunk boundary must still end the block."""
+        self._assert_invariant(
+            DeepSeekR1Detector,
+            "<think>abc reasoning</think>normal text",
+            ("abc reasoning", "normal text"),
+        )
+
+    def test_think_end_split_buffered_mode(self):
+        self._assert_invariant(
+            lambda: DeepSeekR1Detector(stream_reasoning=False),
+            "<think>abc reasoning</think>normal text",
+            ("abc reasoning", "normal text"),
+        )
+
+    def test_literal_angle_bracket_in_reasoning_is_not_swallowed(self):
+        self._assert_invariant(
+            DeepSeekR1Detector,
+            "<think>a < b</think>tail",
+            ("a < b", "tail"),
+        )
+
+    def test_reasoning_truncated_mid_partial_token(self):
+        """A stream cut short inside a partial `</think>` must not drop the
+        held-back characters."""
+        for chunk_size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(
+                    self._feed(DeepSeekR1Detector(), "<think>compare a <", chunk_size),
+                    ("compare a <", ""),
+                )
+
+    def test_second_reasoning_block_does_not_leak_into_content(self):
+        """A further `<think>` block must be routed to reasoning, and the text
+        before it must stay normal content."""
+        self._assert_invariant(
+            DeepSeekR1Detector,
+            "<think>first</think>mid<think>second</think>end",
+            ("firstsecond", "midend"),
+        )
+
+    def test_dsv4_tool_block_after_think_end(self):
+        tool_call = (
+            f"<{self.DSML}tool_calls>"
+            f'<{self.DSML}invoke name="s"></{self.DSML}invoke>'
+            f"</{self.DSML}tool_calls>"
+        )
+        self._assert_invariant(
+            DeepSeekV4Detector,
+            f"<think>my reasoning</think>{tool_call}",
+            ("my reasoning", tool_call),
+        )
+
+    def test_dsv4_tool_block_without_think_end(self):
+        """DSML directly after reasoning must still be routed to normal_text so
+        the tool call detector can see it."""
+        tool_call = (
+            f"<{self.DSML}tool_calls>"
+            f'<{self.DSML}invoke name="s"></{self.DSML}invoke>'
+            f"</{self.DSML}tool_calls>"
+        )
+        for chunk_size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(
+                    self._feed(
+                        DeepSeekV4Detector(),
+                        f"<think>my reasoning{tool_call}",
+                        chunk_size,
+                    ),
+                    ("my reasoning", tool_call),
+                )
 
 
 class TestGptOssDetector(CustomTestCase):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -156,11 +156,14 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
         self.assertEqual(detector._buffer, "")
         self.assertEqual(detector.finish().reasoning_text, "")
 
-    def test_finish_drops_partial_end_tag_when_streaming_reasoning(self):
-        """With stream_reasoning=True the reasoning is emitted chunk by chunk, so
-        finish() must not re-emit. Only a partial end-tag fragment can linger in
-        _buffer; that fragment is an incomplete token, not content, and must be
-        dropped rather than surfaced as reasoning."""
+    def test_finish_flushes_partial_end_tag_when_streaming_reasoning(self):
+        """With stream_reasoning=True everything in _buffer at the end of the
+        stream is a trailing slice that was held back precisely because it could
+        still have grown into `</think>`, so it was never emitted. Since the
+        stream ended it never became a token, and dropping it would lose content
+        whose only crime is looking like the start of one -- reasoning ending in
+        a literal `<` is the common case. Flushing matches stream_reasoning=False
+        and the non-streaming path, which both keep it."""
         detector = BaseReasoningFormatDetector(
             "<think>", "</think>", stream_reasoning=True
         )
@@ -170,8 +173,11 @@ class TestBaseReasoningFormatDetector(CustomTestCase):
         )
         self.assertEqual(detector.parse_streaming_increment("</thi").reasoning_text, "")
         end = detector.finish()
-        self.assertEqual(end.reasoning_text, "")
+        self.assertEqual(end.reasoning_text, "</thi")
         self.assertEqual(end.normal_text, "")
+        # State is cleared, so a second finish() is a no-op.
+        self.assertEqual(detector._buffer, "")
+        self.assertEqual(detector.finish().reasoning_text, "")
 
 
 class TestDeepSeekR1Detector(CustomTestCase):
@@ -1024,6 +1030,42 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
             "<think>a < b</think>tail",
             ("a < b", "tail"),
         )
+
+    def test_reasoning_truncated_mid_partial_token(self):
+        """Reasoning that happens to end in a `</think>` prefix must keep those
+        characters: the holdback exists to recombine them with the next chunk, so
+        a stream that ends first must flush rather than swallow them."""
+        for chunk_size in self.CHUNK_SIZES:
+            with self.subTest(chunk_size=chunk_size):
+                self.assertEqual(
+                    self._feed(DeepSeekR1Detector(), "<think>compare a <", chunk_size),
+                    ("compare a <", ""),
+                )
+
+    def test_dsv4_reasoning_quoting_dsml_is_chunk_dependent(self):
+        """Accepted divergence, pinned so it is not mistaken for a regression.
+
+        `tool_start_token` ends the reasoning block as soon as the DSML marker
+        appears, but the non-streaming path only does so when no `</think>`
+        follows. Streaming cannot see whether one is still coming, so a model
+        quoting the tool format inside its reasoning splits by chunk size. The
+        DSV4 system prompt shows that marker to the model, so this is reachable.
+        """
+        text = f"<think>format is <{self.DSML}tool_calls></think>answer"
+        by_output = {}
+        for chunk_size in self.CHUNK_SIZES:
+            by_output.setdefault(
+                self._feed(DeepSeekV4Detector(), text, chunk_size), []
+            ).append(chunk_size)
+
+        self.assertEqual(len(by_output), 2, f"expected two variants, got {by_output}")
+        early_cut = ("format is ", f"<{self.DSML}tool_calls></think>answer")
+        whole_buffer = (f"format is <{self.DSML}tool_calls>", "answer")
+        self.assertIn(early_cut, by_output)
+        self.assertIn(whole_buffer, by_output)
+
+        one_shot = DeepSeekV4Detector().detect_and_parse(text)
+        self.assertEqual((one_shot.reasoning_text, one_shot.normal_text), whole_buffer)
 
     def test_dsv4_tool_block_after_think_end(self):
         tool_call = (

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -981,11 +981,11 @@ class TestBufferLossBugFix(CustomTestCase):
 
 class TestStreamingChunkSizeInvariance(CustomTestCase):
     """Accumulated (reasoning, normal) output must not depend on how the decode
-    steps happen to batch tokens.
+    steps happen to batch tokens, and must match one-shot detect_and_parse.
 
     Speculative decoding and stream_interval > 1 deliver multiple tokens per
     step, which splits multi-character tokens like `</think>` across chunk
-    boundaries.
+    boundaries. The two `_is_chunk_dependent` tests pin known exceptions.
     """
 
     CHUNK_SIZES = [1, 2, 3, 5, 7, 11, 23, 1000]
@@ -1041,6 +1041,45 @@ class TestStreamingChunkSizeInvariance(CustomTestCase):
                     self._feed(DeepSeekR1Detector(), "<think>compare a <", chunk_size),
                     ("compare a <", ""),
                 )
+
+    def test_normal_text_ending_in_token_prefix_survives(self):
+        """Content after the reasoning block that happens to end in a `</think>`
+        prefix is buffered by the prefix check; the stream ending must flush it."""
+        for text in ("<think>a</think>b<", "<think>a</think>b</thi"):
+            expected = (
+                text.split("</think>", 1)[0].removeprefix("<think>"),
+                text.split("</think>", 1)[1],
+            )
+            for chunk_size in self.CHUNK_SIZES:
+                with self.subTest(text=text, chunk_size=chunk_size):
+                    self.assertEqual(
+                        self._feed(DeepSeekR1Detector(), text, chunk_size), expected
+                    )
+
+    def test_text_before_think_token_is_chunk_dependent(self):
+        """Accepted divergence inherited from main, pinned so a future fix has to
+        update this test rather than silently change behaviour.
+
+        When reasoning is not forced and the model emits text before `<think>`,
+        `replace(think_start, "", 1)` pulls that text into the reasoning branch,
+        while the prefix check may instead flush it as content first. Which one
+        happens depends on where the chunk boundary lands.
+        """
+        text = "lead<think>r</think>tail"
+        variants = {
+            self._feed(Qwen3Detector(), text, chunk_size)
+            for chunk_size in self.CHUNK_SIZES
+        }
+
+        self.assertEqual(
+            variants,
+            {("r", "leadtail"), ("", text), ("leadr", "tail")},
+        )
+        # And the non-streaming path produces yet a fourth split.
+        one_shot = Qwen3Detector().detect_and_parse(text)
+        self.assertEqual(
+            (one_shot.reasoning_text, one_shot.normal_text), ("lead<think>r", "tail")
+        )
 
     def test_dsv4_reasoning_quoting_dsml_is_chunk_dependent(self):
         """Accepted divergence, pinned so it is not mistaken for a regression.

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -434,13 +434,12 @@ class TestGlm45Detector(CustomTestCase):
         self.assertEqual(result.reasoning_text, "")
         self.assertEqual(result.normal_text, "")
 
-        # Tool interruption should still work - flushes buffered reasoning.
-        # Note: when stream_reasoning=False, the <think> tag is stripped from the
-        # local `current_text` variable but NOT from `self._buffer` (which is never
-        # cleared in the non-streaming path). So the flushed reasoning content
-        # includes the raw <think> tag.
+        # Tool interruption should still work - flushes buffered reasoning. The
+        # opening tag is stripped from `self._buffer` as well as from the local
+        # view, so the flush matches detect_and_parse instead of carrying the raw
+        # <think> tag into reasoning_content.
         result = detector.parse_streaming_increment("<tool_call>tool call")
-        self.assertEqual(result.reasoning_text, "<think>thinking")
+        self.assertEqual(result.reasoning_text, "thinking")
         self.assertEqual(result.normal_text, "<tool_call>tool call")
 
     def test_streaming_empty_reasoning_with_tool(self):


### PR DESCRIPTION
## Summary
- Hold back a trailing partial `</think>` / tool marker in `BaseReasoningFormatDetector`, so streaming output no longer depends on how decode steps batch tokens (supersedes #31009, #21179)
- Fix five further DSV4 reasoning + DSML tool-call streaming bugs, each covered by a test that fails on `main`

## Background
- Speculative decoding and `stream_interval > 1` deliver several tokens per step, splitting multi-character markers across chunk boundaries
- `_parse_streaming_increment_impl` cleared `_buffer` after every emission and destroyed the fragment, so the end token was never recognised and the rest of the turn leaked into `reasoning_content`
- On `main`, `<think>abc</think>normal` at chunk size 3 already yields `reasoning='abc</think>normal'`, `normal=''`
- This affects every detector sharing the base implementation, not only DSV4

## Changes
**Reasoning parser**
- Hold back the longest trailing slice that is a proper prefix of `think_end_token` / `tool_start_token` / `think_start_token`, and flush it in `finish()` when the stream ends first
- Move `_ends_with_partial_token` to `BaseReasoningFormatDetector`, replacing the copy in `Apertus2509Detector`
- `DeepSeekV4Detector` passes `tool_start_token`, so a DSML block that follows reasoning without a `</think>` reaches the tool-call detector instead of staying in `reasoning_content` (supersedes #32539)
- Write the stripped buffer back after removing `think_start_token`, so `stream_reasoning=False` no longer carries the token into `reasoning_content`

**Tool-call detector**
- Catch `MalformedJSON` from `_partial_json_loads` instead of letting it escape to the outer handler (supersedes #32332, #28684)
- Preserve prose emitted before a tool call, for both wrapped and bare invoke forms (supersedes #31786, #33813, #34244)
- On a parse error, drop the buffer and re-emit its text instead of re-parsing it on every later chunk; discard collected calls so a named call with no arguments never reaches the client
- `detect_and_parse` parses every `tool_calls` section, not only the first (supersedes #23786)

## Known divergences
- Streaming cannot see whether a `</think>` still follows, so two inputs split differently from `detect_and_parse`: a model quoting the DSML marker inside its reasoning, and (pre-existing on `main`) text emitted before `<think>` when reasoning is not forced
- Both are pinned by `*_is_chunk_dependent` tests so a future fix has to update them rather than change behaviour silently

## Test plan
- `test_reasoning_parser.py`: `TestStreamingChunkSizeInvariance` feeds each case at chunk sizes `[1, 2, 3, 5, 7, 11, 23, 1000]` and compares against `detect_and_parse` (supersedes #34157)
- `test_deepseekv4_detector.py`: preamble across delta splits, `MalformedJSON` fallback, error-path recovery, multi-section parsing
- Two existing assertions are intentionally flipped, both because they pinned behaviour this PR fixes:
  - `test_finish_drops_partial_end_tag_when_streaming_reasoning` becomes `..._flushes_...`. Its premise was that anything left in `_buffer` had already been emitted chunk by chunk; with holdback that text has never been emitted, and dropping it loses content whose only fault is resembling the start of a token
  - `TestGlm45Detector.test_streaming_no_stream_reasoning` no longer expects the raw `<think>` tag inside `reasoning_content`. Its comment described the leak it was pinning ("stripped from the local `current_text` variable but NOT from `self._buffer`"); `stream_reasoning=False` now matches `detect_and_parse`
- Supersedes #34178, which reported the buffer-clearing bug this PR fixes

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31546554111](https://github.com/sgl-project/sglang/actions/runs/31546554111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31546553893](https://github.com/sgl-project/sglang/actions/runs/31546553893)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
