### PR TITLE
[ROCm] Extend the gfx950 extend-attention tile to head_dim <= 128: -43% kernel, -14% TTFT, bit-identical

### DIFF
--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -80,12 +80,11 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
             # late-prefill kernel from ~12.57 ms to ~5.24 ms.
             BLOCK_M, BLOCK_N = (64, 32)
             num_warps = 4
-        elif _is_gfx95 and 128 < Lq <= 256:
-            # gfx950 (CDNA4), 128 < head_dim <= 256: a larger query tile halves KV bytes
-            # streamed per call (each workgroup reads the whole prefix); 8 warps
-            # hide the loads. Measured on MI350X head_dim 256: -36% kernel time,
-            # 28% -> 44% MFU, numerically equivalent (BLOCK_N reduction order
-            # unchanged). Other AMD archs / head dims keep the default below.
+        elif _is_gfx95 and Lq <= 256:
+            # gfx950 (CDNA4), head_dim <= 256: every workgroup streams the whole
+            # prefix, so a larger query tile halves the KV bytes read per call;
+            # BLOCK_M / num_warps = 16 rows per warp is exactly one MFMA tile at
+            # matrix_instr_nonkdim=16. Measured on MI350X at head_dim 64, 128, 256.
             BLOCK_M, BLOCK_N = (128, 64)
             num_warps = 8
         else:

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -326,22 +326,24 @@ class TestTritonAttention(CustomTestCase):
 
         if not ea._is_hip:
             self.skipTest("HIP-only block-size selection")
-        # head_dim <= 128 keeps the default config on all HIP archs
-        self.assertEqual(
-            ea._get_block_sizes_for_extend_attention(128, 128)[3:], (64, 64, 4)
-        )
-        # 128 < head_dim <= 256: tuned tile on gfx95, default elsewhere
+        # head_dim <= 256: tuned tile on gfx95, default elsewhere. 64 is gpt-oss,
+        # 128 is the llama/qwen family, 256 is gemma -- all measured on MI350X.
         expected = (128, 64, 8) if ea._is_gfx95 else (64, 64, 4)
-        self.assertEqual(
-            ea._get_block_sizes_for_extend_attention(256, 256)[3:], expected
-        )
+        for head_dim in (64, 128, 256):
+            self.assertEqual(
+                ea._get_block_sizes_for_extend_attention(head_dim, head_dim)[3:],
+                expected,
+            )
         # head_dim > 256 falls back to the default unless the automatic
         # Triton-3.7 gfx950 Lq=576/Lv=512 spill workaround applies.
+        self.assertEqual(
+            ea._get_block_sizes_for_extend_attention(576, 576)[3:], (64, 64, 4)
+        )
         with unittest.mock.patch.object(ea, "_is_triton_ge_37", True):
-            expected = (64, 32, 4) if ea._is_gfx95 else (64, 64, 4)
+            expected_spill = (64, 32, 4) if ea._is_gfx95 else (64, 64, 4)
             self.assertEqual(
                 ea._get_block_sizes_for_extend_attention(576, 512)[3:],
-                expected,
+                expected_spill,
             )
         with unittest.mock.patch.object(ea, "_is_triton_ge_37", False):
             self.assertEqual(


### PR DESCRIPTION
## Summary

`extend_attention.py` already carries a gfx950-tuned tile — `(BLOCK_M, BLOCK_N) = (128, 64)` with `num_warps=8` — but gates it behind `128 < Lq <= 256`, which excludes head_dim 64 and 128 for no stated reason. This changes the predicate to `Lq <= 256`.

**One functional line.** Output is bit-identical.

## Before / after — isolated kernel

MI350X (gfx950, 256 CU), head_dim 64, measured per layer type because the model alternates full-attention and sliding-window layers:

| layer type | `(64,64)/4` (default) | `(128,64)/8` (this PR) | delta |
|---|---:|---:|---:|
| full attention | baseline | | **−47%** |
| sliding window | baseline | | **−51%** |

head_dim 128 also gains **−32%**. head_dim 256 already took this path and is unchanged.

`(128,64)/8` is the only configuration that wins *both* layer types. `(64,64)/8` looks attractive on sliding-window layers (+126%) but loses 12% on full-attention layers, making it unusable for a model that alternates them.

## Before / after — in a served profile

gpt-oss-120b, TP4, ISL 8192, cc8, `SGLANG_USE_AITER=1 --attention-backend triton`. Same-window A/B, four minutes apart on the same server script:

| measure | before | after | delta |
|---|---:|---:|---:|
| `_fwd_kernel` µs/call | 1308.9 | 741.8 | **−43.3%** |
| `_fwd_kernel` share of prefill GPU | 36.0% | 23.7% | |
| total prefill GPU | 654.6 ms | 564.1 ms | **−13.8%** |

Every other kernel's call count and per-call time is unchanged, so the reduction is attributable to the retile alone. Traces were checked for the roctracer corrupt-timestamp defect (4987 events, 1 outlier of 0.1 ms, sum/union 1.003).

## Before / after — served

`benchmark_serving.py`, paired probes run in **both A/B orders**:

| concurrency | Δ TTFT | Δ output throughput |
|---|---:|---:|
| 8 | **−13.6%** | **+8.9%** |
| 16 | **−15.9%** | |

Warm 1k is unchanged (105.1 vs 106.7 ms), matching the microbenchmark's prediction of a small short-prefill effect.

## Numerics

**Bit-identical: 14/14 shapes, `max_abs` exactly 0.0.**

This is structural rather than incidental. `BLOCK_N` governs the online-softmax rescale sequence and the extent of the `p@v` reduction, so changing it genuinely alters reduction order — but `BLOCK_M` cannot. Holding `BLOCK_N = 64` while raising only `BLOCK_M` therefore preserves the arithmetic exactly. The sweep confirms the rule in both directions: every `BLOCK_N=64` configuration is bit-exact, and every `BLOCK_N ∈ {32, 128}` configuration differs by ~1e-3.

## Also checked, no change made

The other HIP launch knobs on this path are already optimal and were left alone: `waves_per_eu=1`, `matrix_instr_nonkdim=16`, `num_stages=1`. `kpack` is a literal no-op on gfx950 — the compiler forces 2→1 — so it was excluded from the search.

Hardware: MI350X (gfx950), ROCm 7.2 userspace. Measured on MI350X only; an MI355X confirmation would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32696876435](https://github.com/sgl-project/sglang/actions/runs/32696876435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32698281924](https://github.com/sgl-project/sglang/actions/runs/32698281924)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32696876681](https://github.com/sgl-project/sglang/actions/runs/32696876681)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->