### PR TITLE
[Triton] Bound the sliding-window extend-attention KV loop: -86.6% on SWA layers, -9.4% prefill GPU, bit-identical

### DIFF
--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -605,7 +605,16 @@ def _fwd_kernel(
         else tl.minimum(cur_seq_len_extend, (cur_block_m + 1) * BLOCK_M)
     )
     extend_end = 0 if SKIP_EXTEND else cur_block_m_end
-    for start_n in range(0, extend_end, BLOCK_N):
+    # The mask below keeps (q, kv) iff q <= kv + SLIDING_WINDOW_SIZE, so no tile
+    # under this floor can hold an unmasked element -- tight for any BLOCK_M/BLOCK_N.
+    # SKIP_TILE already made those tiles no-ops, so bounding the loop is
+    # bit-identical and drops their cross-wave tl.max reduction.
+    extend_start = 0
+    if SLIDING_WINDOW_SIZE > 0:
+        extend_start = (
+            tl.maximum(cur_block_m * BLOCK_M - SLIDING_WINDOW_SIZE, 0) // BLOCK_N
+        ) * BLOCK_N
+    for start_n in range(extend_start, extend_end, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         mask_n = (start_n + offs_n) < cur_block_m_end
 


### PR DESCRIPTION
> **Stacked on #34461.** That PR is the first commit on this branch; review or merge it first. The diff unique to this PR is the second commit.

## Summary

In the extend-stage KV loop, the causal *upper* bound is computed per m-block but **the lower bound is hardcoded to 0**. A sliding-window layer therefore walks every earlier 64-wide tile of the chunk and relies on

```python
SKIP_TILE = tl.max(tl.max(final_mask, 1), 0) == 0
```

to suppress the MMA — running that cross-wave `tl.max` reduction roughly **3,968 times per workgroup**. This bounds the loop instead.

**The measurement that motivates it:** sliding-window layers cost 507 µs against full-attention layers' 518 µs — only **2.1% cheaper despite needing 21.7× fewer tiles** (192 vs 4,160). Nearly all of the sliding window's structural advantage was being spent iterating and masking tiles that contribute nothing.

## The bound

A tile can hold an unmasked element only if `m0 <= start_n + BLOCK_N - 1 + W`, so the smallest `BLOCK_N`-aligned tile that can contribute is `(A // BLOCK_N) * BLOCK_N` where `A = m0 - W`. This was re-derived independently, verified for every residue class, and holds for any `BLOCK_M`/`BLOCK_N` — it never assumes `BLOCK_M >= BLOCK_N`. The diagonal tile is always retained, and `SKIP_EXTEND` still yields an empty range.

The prefix loop needs no equivalent change: `triton_backend.py` passes `extend_prefix_lens` to `update_sliding_window_buffer`, so `cur_seq_len_prefix = min(prefix_len, W)` and that loop is already bounded at `ceil(W/BLOCK_N)` tiles.

## Before / after — isolated kernel, split by layer type

| shape | layer | before µs | after µs | delta | tiles |
|---|---|---:|---:|---:|---|
| 8×8192 | **SWA** W=128 | 2652.1 | 391.3 | **−85.2%** | 4160 → 254 |
| 8×8192 | full | 2850.4 | 2849.9 | −0.02% | 4160 → 4160 |
| 8×4096 | **SWA** | 757.5 | 193.6 | **−74.4%** | 1056 → 126 |
| 8×2048 | **SWA** | 239.7 | 101.0 | **−57.9%** | 272 → 62 |
| 8×1024 | **SWA** | 87.8 | 54.3 | **−38.2%** | 72 → 30 |
| 1×8192 | **SWA** | 451.2 | 55.3 | **−87.8%** | 4160 → 254 |

Reverse A/B order reproduces every SWA number within 0.5%, so there is no autotune-cache ordering effect. The small measured deltas on full-attention layers are within a ±8% noise floor at the smallest shape and no claim is made from them — see the assembly argument below instead.

## Before / after — in a served profile

gpt-oss-120b TP4, ISL 8192, cc8, all four TP ranks (agreeing within 1.5%):

| measure | before | after | delta |
|---|---:|---:|---:|
| `_fwd_kernel`, **sliding_attention** layers (90 calls) | 725.4 µs | 96.9 µs | **−86.6%** |
| `_fwd_kernel`, **full_attention** layers (90 calls) | 756.3 µs | 757.4 µs | **+0.1%** |
| `_fwd_kernel` total | 133.36 ms | 76.90 ms | **−42.3%** |
| `_fwd_kernel` share of prefill GPU | 24.18% | 15.39% | |
| total prefill GPU | 551.6 ms | 499.5 ms | **−9.4%** |

Corrupt-timestamp guard applied to both arms: 4987 raw events each, 1 and 2 rows dropped, sum/union 1.003 and 1.004. Without the guard the baseline total would have been inflated 1.5% by a single row.

## Before / after — served

`run_sweep.sh`, OSL 1024, arms A → B → A with a replicated baseline. All 30 points reported `Successful requests` equal to `num_prompts`.

| workload | cc | base mean p50 | this PR | Δ p50 | Δ p99 | Δ out tok/s |
|---|---:|---:|---:|---:|---:|---:|
| 8k/1k | 1 | 91.5 | 88.0 | **−3.9%** | −5.9% | −0.4% |
| 8k/1k | 2 | 96.4 | 94.1 | −2.4% | +0.8% | −0.2% |
| 8k/1k | 4 | 95.2 | 92.4 | **−2.9%** | −0.6% | +0.4% |
| 8k/1k | 8 | 99.6 | 95.4 | **−4.2%** | −7.4% | +0.8% |
| 8k/1k | 16 | 104.3 | 98.6 | **−5.5%** | **−11.9%** | **+1.5%** |
| 1k/1k | 1–16 | 46.5–50.0 | — | +1.3, +2.2, −2.6, −0.8, +0.5 | neutral | ±0.4% |

**8k/1k improves monotonically with concurrency** with TPOT flat-to-better — the signature of a prefill-only kernel change. **1k/1k is neutral, not a regression**: deltas flip sign across concurrency with no trend, all within ~2.6%. That is what the mechanism predicts, since wasted tiles scale with chunk length (4160 → 254 at 8k, but only 72 → 30 at 1k). Baseline replicate spread was 0.2–2.8% on p50.

## Numerics

**`max_abs` exactly 0.0 on 91 of 91 configurations.** Coverage: windows 1/15/16/63/64/65/127/128/129/191/192/255/256/257/1023/4096 and W > seq_len; ragged batches; with and without prefix; window-bounded *and* unbounded prefix `kv_indices` (including the repo unit test's own layout, B=19 N_CTX=12331); head_dim 64/128/256; fp16 and bf16; with and without sinks; causal and non-causal; compact *and* legacy tile grids (which also agree bitwise with each other); and the (64,64) (64,128) (128,128) (32,64) (16,64) (32,32) tilings other backends select.

An independent fp32 torch reference (max_abs 2.1e-3 against tol 2e-2) confirms both arms compute real windowed attention, so this is not equality of degenerate output.

**For full-attention layers the guarantee is stronger than bit-identity.** `SLIDING_WINDOW_SIZE` is a `tl.constexpr`, so at W ≤ 0 the new branch folds at trace time: the emitted AMDGCN differs **only in DWARF metadata** — **1305 instruction lines on both sides, zero instruction diffs**.

Hardware: MI350X (gfx950), ROCm 7.2 userspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32703526129](https://github.com/sgl-project/sglang/actions/runs/32703526129)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32703525923](https://github.com/sgl-project/sglang/actions/runs/32703525923)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32703526042](https://github.com/sgl-project/sglang/actions/runs/32703526042)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->