### PR TITLE
[ROCm] Fix AttributeError on PPMissingLayer that blocks pipeline parallelism on gfx95

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2672,10 +2672,14 @@ class DeepseekV2Model(nn.Module):
             self.norm = PPMissingLayer(return_tuple=True)
 
         self.gemm_output_zero_allocator_size = 0
+        # Read hidden_size off the config, not off self.embed_tokens: on every
+        # non-first PP rank embed_tokens is a PPMissingLayer, which has no
+        # embedding_dim. VocabParallelEmbedding above is constructed with
+        # config.hidden_size and stores it verbatim, so the two agree on rank 0.
         if (
             _use_aiter_gfx95
             and config.n_routed_experts == 256
-            and self.embed_tokens.embedding_dim == 7168
+            and config.hidden_size == 7168
         ):
             num_moe_layers = sum(
                 [
@@ -2705,7 +2709,7 @@ class DeepseekV2Model(nn.Module):
                     config.n_routed_experts,
                     num_moe_layers,
                     allocate_size,
-                    self.embed_tokens.embedding_dim,
+                    config.hidden_size,
                 )
             )
         self.layers_to_capture = []


### PR DESCRIPTION
## Summary

`deepseek_v2.py:2678` reads `self.embed_tokens.embedding_dim` on **every** pipeline-parallel rank. On any rank that is not the first, `embed_tokens` is a `PPMissingLayer` (a `torch.nn.Identity` subclass with no such attribute), so this raises `AttributeError` and pipeline parallelism cannot start.

This is **AMD-specific in practice**: the enclosing guard is `_use_aiter_gfx95 and config.n_routed_experts == 256`, and `_use_aiter_gfx95 = _use_aiter and _is_gfx95_supported` (`deepseek_common/utils.py:50`), so it short-circuits on NVIDIA and only the attribute access is reached on gfx95.

## The fix

Read `config.hidden_size` instead of `self.embed_tokens.embedding_dim`. These are exactly equivalent, not merely close:

- `VocabParallelEmbedding` is constructed at `:2606` as `VocabParallelEmbedding(config.vocab_size, config.hidden_size, ...)`, and stores `self.embedding_dim = embedding_dim` verbatim (`vocab_parallel_embedding.py:292`) — only `num_embeddings` is padded.
- `get_dsv3_gemm_output_zero_allocator_size` re-checks `embedding_dim != 7168` internally (`rocm_linear_utils.py:20`), so the substitution changes nothing downstream.
- `PPMissingLayer()` is instantiated at `:2612`.

There is a sibling read at `:2708`, but it sits **inside** the guarded block, so only `:2678` executes on every rank. It is updated for consistency.

## Scope

The claim this PR defends is narrow: **the `AttributeError` is gone and no reachable behaviour changes.** Whether pipeline parallelism then works end-to-end on MI350X is not verified here — that needs a multi-GPU gfx95 run.

Note also that for models whose `hidden_size` is not 7168 the branch is dead code either way; this is about not crashing before reaching that conclusion.

## Testing

`test/registered/pp/*` could not be run locally (no GPU, and no `torch` in the available interpreters). Line references were re-verified against `main` at the time of writing. Pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31545850935](https://github.com/sgl-project/sglang/actions/runs/31545850935)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31545850933](https://github.com/sgl-project/sglang/actions/runs/31545850933)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->