### PR TITLE
[ROCm] Bound the sliding-window prefix loop and the unified-kernel KV loop (bit-identical; no e2e win claimed)

### DIFF
--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -1100,7 +1100,20 @@ def _fwd_kernel_unified(
     e_max = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
 
     # Unified loop: process all KV tokens (prefix + extend)
-    for start_n in range(0, cur_seq_kv_len, BLOCK_N):
+    #
+    # The two-stage kernel's floor. cur_window_start appears on both sides of the
+    # mask below and cancels, so A = cur_seq_prefix_len + cur_block_m * BLOCK_M -
+    # SLIDING_WINDOW_SIZE. This loop spans prefix and extend KV alike, so the one
+    # floor drops the fully-masked tiles of both.
+    unified_start = 0
+    if SLIDING_WINDOW_SIZE > 0:
+        unified_start = (
+            tl.maximum(
+                cur_seq_prefix_len + cur_block_m * BLOCK_M - SLIDING_WINDOW_SIZE, 0
+            )
+            // BLOCK_N
+        ) * BLOCK_N
+    for start_n in range(unified_start, cur_seq_kv_len, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         mask_n = (start_n + offs_n) < cur_seq_kv_len
 

--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -458,7 +458,19 @@ def _fwd_kernel(
     e_max = tl.zeros([BLOCK_M], dtype=tl.float32) - float("inf")
 
     prefix_end = 0 if SKIP_PREFIX else cur_seq_len_prefix
-    for start_n in range(0, prefix_end, BLOCK_N):
+    # The extend stage's floor, with q at its absolute position
+    # (cur_seq_len_prefix + cur_block_m * BLOCK_M) because kv is indexed within the
+    # prefix; tight for any BLOCK_M/BLOCK_N, and SKIP_TILE already made the skipped
+    # tiles no-ops. Past the first window's m-blocks no query reaches the prefix.
+    prefix_start = 0
+    if SLIDING_WINDOW_SIZE > 0:
+        prefix_start = (
+            tl.maximum(
+                cur_seq_len_prefix + cur_block_m * BLOCK_M - SLIDING_WINDOW_SIZE, 0
+            )
+            // BLOCK_N
+        ) * BLOCK_N
+    for start_n in range(prefix_start, prefix_end, BLOCK_N):
         start_n = tl.multiple_of(start_n, BLOCK_N)
         mask_n = (start_n + offs_n) < cur_seq_len_prefix
 


### PR DESCRIPTION
> **Stacked on #34462** (which is itself stacked on #34461). The diff unique to this PR is the last two commits.

## Read this first

**Neither commit here produces a measurable end-to-end improvement, and the first carries a small cost in one regime.** Both are exhaustively proven bit-identical. I am submitting them as correctness-and-efficiency changes with full disclosure, not as a performance claim — a maintainer may reasonably decide the first is not worth its cost.

## Commit 1 — bound the stage-1 prefix loop

#34462 bounded the stage-2 extend loop. Stage 1 has the identical structure: its mask keeps `(q, kv)` iff `Wp + m0 + i <= start_n + j + W`, so the same floor with `cur_seq_len_prefix` added empties the loop once `m0 >= W`.

**Bound verified exhaustively, not sampled.** `A = Wp + m0 - W`, floor `(A // BLOCK_N) * BLOCK_N`; `ceil((A-BN+1)/BN) == A//BN` was checked for every residue class, then the mask *as written* was brute-forced over 8 tilings × 20 windows × 17 prefixes × 10 extend lengths: **794,088 tiles below the floor, zero holding an unmasked element**, with 50,560 tightness witnesses. Extra conjuncts (causal, custom mask) can only empty a tile further, and were checked anyway.

### Isolated kernel

| shape | SWA layers | full-attention layers |
|---|---:|---:|
| prefix 8192 × extend 8192 | **−17.0%** | +0.3% |
| prefix 4096 × extend 4096 | **−17.1%** | −0.4% |
| prefix 7168 × extend 1024 | **−14.7%** | −0.5% |
| unbounded-prefix layout (the repo test's own layout) | **−57.9% to −94.9%** | — |

### In a served profile

gpt-oss-120b TP4, ISL 8192 with `--chunked-prefill-size 4096`, cc8, 216 matched calls per rank:

| measure | before | after | delta |
|---|---:|---:|---:|
| `_fwd_kernel`, SWA layers | 36.5 µs | 34.3 µs | **−5.9%** (per-rank −5.2 to −6.9%) |
| `_fwd_kernel`, full-attention layers | — | — | −0.4% (noise floor) |

Predicted −7.9% from tile arithmetic, so the mechanism behaves as modelled.

### Served: no resolvable change

`run_sweep.sh`, 8k/1k, OSL 1024, arms A → B → A. **All 15 points reported 100% completion; every delta sits inside the base-vs-base spread.** This is exactly what the ~0.1%-of-prefill-GPU prediction requires — the affected regime (prefix > 0, i.e. chunked prefill and radix-cache hits) is not what a flush-between-points sweep measures.

### The cost, stated plainly

**At prefix 0 the loop cannot execute a single iteration, yet SWA layers measure 1.15–1.25% slower.** Confirmed genuine by a same-variant control (the identical file loaded twice reproduced to ±0.2%). The mechanism is visible in the AMDGCN metadata: `sgpr_spill_count` rises **92 → 102**. A clamped reformulation measures the same, so it appears inherent to introducing a runtime lower bound at all.

So commit 1 is a trade: it helps chunked-prefill and cache-hit traffic and costs ~1.2% on prefix-0 traffic.

## Commit 2 — the same bug in `_fwd_kernel_unified`

The unified kernel carries the identical one-sided window mask. `cur_window_start` cancels on both sides, giving the same floor with `cur_seq_prefix_len` added; **4,100,280 tiles checked below it**, zero violations.

Microbench: **−31% to −70%** — larger than commit 1 because the unified loop spans extend KV as well, so this floor also delivers the stage-2 saving that kernel never received.

**No serving evidence exists and none is claimed.** Deterministic mode is off by default, so no deck arm was run. This commit carries **no** prefix-0 cost (`sgpr_spill_count` 95 → 95).

## Numerics

`max_abs` exactly **0.0** — **139 configurations** for commit 1, **68** for commit 2 — each with an independent fp32 torch reference confirming both arms compute real windowed attention (base and candidate both ≤5.2e-3 against tol 2e-2), so this is not equality of degenerate output.

Coverage includes both grid modes, unbounded prefix, non-causal, 6 tilings, head_dim 64/128/256, fp16/bf16, and sinks on/off. Two coverage gaps found and closed during validation: the DCP `skip_prefix`/`skip_extend`/`lse_extend` paths (a runtime lower bound meeting a constant-zero upper bound) and `USE_CUSTOM_MASK` combined with sliding window (the EAGLE target-verify route).

Full-attention layers are identical at the assembly level: **1313 and 939 AMDGCN instruction lines respectively, zero instruction diffs.**

## Coverage gap worth a follow-up

`test_extend_attention_unified_vs_regular` never passes `sliding_window_size`, so the numerics in this PR are currently the only correctness check that path has anywhere in the repo.

Hardware: MI350X (gfx950), ROCm 7.2 userspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32709182831](https://github.com/sgl-project/sglang/actions/runs/32709182831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32709182601](https://github.com/sgl-project/sglang/actions/runs/32709182601)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32709182701](https://github.com/sgl-project/sglang/actions/runs/32709182701)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->