### PR TITLE
[docs] GLM-5.2 AMD: add the aiter DSA prefill lever and document chunked-prefill behaviour

### DIFF
--- a/docs/src/snippets/configs/zai-org/glm-5.2.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.2.jsx
@@ -239,6 +239,45 @@ sgl-eval run aime25 \\
         { id: "write_back",    label: "Write-back" },
       ],
     },
+
+    // ----- Card 7: "DSA Prefill Backend" (AMD only) -----
+    // Long-context prefill lever, exposed as an opt-in playground select rather
+    // than folded into a cell: it is a real behaviour change and has NOT been
+    // confirmed on MI355X (the hardware these cells pin), so no verified:true
+    // cell may carry it.
+    //
+    // The aiter DSA prefill kernel uses half the launches (390 vs 780 for
+    // 78 layers x 5 passes) with a coarser decomposition: -57.7% DSA attention
+    // time, -24 to -26% p50 TTFT and -28% p99 at ISL 8192, TPOT -8.5% and
+    // throughput +9.8% at ISL 8192 / concurrency 16.
+    //
+    // PREFILL ONLY -- switching decode to aiter as well costs TPOT (43.88 vs
+    // 41.90 ms at cc16), so --dsa-decode-backend stays tilelang.
+    //
+    // NOT a general win: at ISL 1024 it is 10-12% WORSE, because a decode-stage
+    // kernel repurposed for prefill needs enough work per launch to amortize.
+    // Prefer it only for long-context workloads.
+    //
+    // Measured on MI350X (not MI355X) with --random-range-ratio 0.8, so the "8k"
+    // prompts average ~7370 tokens and the numbers above are not comparable to
+    // the published cookbook TTFT figures (which used ratio 1.0). Needs an
+    // MI355X round at ratio 1.0 before this becomes a cell.
+    //
+    // Note the ROCm engine default is already tilelang for both prefill and
+    // decode (arg_groups/overrides.py, fires for any is_hip()), so the AMD cells
+    // are pinning the engine default rather than making a considered choice.
+    flagSelects: [
+      {
+        id: "dsaPrefillBackend",
+        title: "DSA Prefill Backend (experimental)",
+        showWhen: (base) => base.hw === "mi355x" || base.hw === "mi325x" || base.hw === "mi300x",
+        stripPrefixes: ["--dsa-prefill-backend"],
+        options: [
+          { id: "tilelang", label: "tilelang (verified)", flags: ["--dsa-prefill-backend tilelang"] },
+          { id: "aiter",    label: "aiter (long-context, unverified)", flags: ["--dsa-prefill-backend aiter"] },
+        ],
+      },
+    ],
   },
 
   cells: [
@@ -891,6 +930,28 @@ sgl-eval run aime25 \\
     // (MI325X/MI300X) cells stay verified:false (not yet benchmarked, but correct).
     // BF16 (~1.51 TB) only fits single-node on MI325X (2 TB) / MI355X (2.3 TB);
     // MI300X (1.5 TB) needs multi-node, so its BF16 cells are omitted.
+    //
+    // --chunked-prefill-size on these cells is a LONG-CONTEXT lever, not a
+    // batch-shaping one, and it is inert at the benchmarked workload:
+    //   * chunked_prefill_size auto-defaults to 16384 on any >=160 GB GPU
+    //     (server_args.py, the "B200, MI300" arm), and it is the only budget
+    //     that truncates a request: schedule_policy.py sets
+    //     `trunc_len = self.rem_chunk_tokens`.
+    //   * max_prefill_tokens (default 16384) is a SEPARATE budget that only
+    //     caps how many *further* requests join a prefill batch. It never
+    //     truncates a request, and nothing clamps one budget by the other.
+    //   * Every published GLM-5.2 benchmark is ISL 8192 (see
+    //     glm-5.2-benchmarks.jsx). 8192 is below 16384/32768/131072 alike, so
+    //     all three commit the prompt in a single un-chunked forward -- measured
+    //     bit-identical on MI350X TP8 (cc1 494.9/495.6 ms, cc8 2732.3/2738.6,
+    //     cc16 5080.9/5078.0 for 131072 vs 32768).
+    // Above ISL 16384 the flag becomes live: 131072 keeps a 128K prompt in one
+    // forward where the 16384 default would split it into 8 chunks. So it is not
+    // dead code and is kept.
+    // Do NOT "fix" this by adding --max-prefill-tokens 131072: that raises the
+    // multi-request admission budget, which makes mean TTFT ~1.6x worse
+    // (8k->64k budget: mean TTFT 2612->4505 ms, TPOT 33.2->16.9 ms, p99 flat at
+    // ~4650-4840 ms). 16384 is TTFT-optimal for the benchmarked shape.
     // ====================================================================
     {
       match: { hw: "mi355x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },


### PR DESCRIPTION
## Summary

Two additive documentation changes to the GLM-5.2 AMD cookbook cells. **No `verified: true` cell is modified and no existing flag is removed.**

## 1. A long-context prefill lever, added as an unverified option

`--dsa-prefill-backend aiter` (keeping `--dsa-decode-backend tilelang`) is a large win at long context on MI350X:

| workload | cc | tilelang | aiter | delta |
|---|---:|---:|---:|---:|
| 8k/1k p50 TTFT | 1 | 571.8 ms | 422.3 ms | **−26.1%** |
| 8k/1k p50 TTFT | 16 | 600.3 ms | 454.4 ms | **−24.3%** |
| 8k/1k p99 TTFT | 16 | 7497 ms | 5364 ms | **−28.5%** |
| 1k/1k p50 TTFT | 1 | 138.9 ms | 155.8 ms | **+12.2%** |
| 1k/1k p50 TTFT | 16 | 141.0 ms | 155.1 ms | **+10.0%** |

TPOT −8.5% and throughput +9.8% at 8k/1k cc16.

**Mechanism:** the aiter DSA prefill kernel uses **half the launches** (390 vs 780 for 78 layers × 5 passes) with a coarser decomposition — DSA attention time falls 57.7% and total prefill GPU time 28.5%. All non-DSA kernels keep identical call counts, so the swap is cleanly isolated.

**It is explicitly not a general win.** At ISL 1024 it is 10–12% *worse*, because a decode-stage kernel repurposed for prefill needs enough work per launch to amortise. Prefill only — using aiter for decode as well costs TPOT (43.88 vs 41.90 ms at cc16).

Because this changes behaviour it is added as a new **`flagSelects`** axis marked unverified, gated by `showWhen` to the AMD cells, rather than folded into a verified cell. `stripPrefixes: ["--dsa-prefill-backend"]` swaps only the prefill backend and preserves `--dsa-decode-backend tilelang`.

### Caveats carried into the cell comment

- Measured on **MI350X**, while the cell being annotated is MI355X. Both are gfx950 and share the ROCm/AITER profile, but this needs an MI355X run before it could be marked verified.
- Benchmarks used `--random-range-ratio 0.8`, so "8k" prompts average ~7370 tokens. **Not comparable** to the published cookbook TTFT figures, which used 1.0.
- ROCm's engine default is already tilelang for both (`arg_groups/overrides.py:1720-1722`, fires for any `is_hip()`), so the existing cells pin the default rather than making a considered choice.

## 2. A comment documenting what `--chunked-prefill-size` actually does

The AMD cells carry `--chunked-prefill-size 131072` (low-latency) and `32768` (balanced), and those two configurations measure **bit-identical**:

```
131072 vs 32768 → cc1 494.9 / 495.6 ms · cc8 2732.3 / 2738.6 · cc16 5080.9 / 5078.0
```

**The flags are not inert, and this comment exists to stop someone deleting them on that basis** — which is exactly the wrong conclusion, and one I nearly drew.

`max_prefill_tokens` never truncates a request: `schedule_policy.py:1166` sets `trunc_len = self.rem_chunk_tokens`, and `rem_input_tokens` (`:831`) only stops *further* requests joining the batch. Neither budget clamps the other. So for a single request with ISL in (16384, 131072], `131072` keeps it in **one forward pass** where the 16384 default would split it into eight chunks — live behaviour on a 128K-context model.

The measurement above is bit-identical only because **every published GLM-5.2 benchmark row is ISL 8192**, which is below 16384, 32768 and 131072 alike, so all three commit the prompt un-chunked and cannot differ. The `verified: true` marks are therefore sound, but deleting the flags would silently degrade long-context TTFT for anyone following the cookbook.

The comment also records the still-valid warning **not** to raise `--max-prefill-tokens` to match: measured on MI350X TP8, going 8k → 64k moves mean TTFT 2612 → 4505 ms against a flat p99 (~4650–4840 ms), trading TTFT for TPOT (33.2 → 16.9 ms).

## Testing

`docs/scripts/check_cookbook_configs.mjs` could not be run locally (no node available). Its four rules were hand-checked: no cells and no match dimensions were added, so rules 1–3 are untouched, and the new `showWhen` is total — it cannot throw for any `base`, including `{}` — satisfying rule 4. **Someone with node should still run it.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31546078713](https://github.com/sgl-project/sglang/actions/runs/31546078713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31546078556](https://github.com/sgl-project/sglang/actions/runs/31546078556)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->