### PR TITLE
[Bugfix] Retain fire-and-forget asyncio tasks

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/http_server.py
@@ -105,6 +105,9 @@ async def _run_server_warmup_after_http_live(
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    from sglang.multimodal_gen.runtime.entrypoints.openai.mesh_api import (
+        shutdown_mesh_jobs,
+    )
     from sglang.multimodal_gen.runtime.entrypoints.openai.video_api import (
         shutdown_video_jobs,
     )
@@ -139,6 +142,7 @@ async def lifespan(app: FastAPI):
 
         # On shutdown
         logger.info("FastAPI app is shutting down...")
+        await shutdown_mesh_jobs()
         await shutdown_video_jobs()
         broker_task.cancel()
         with suppress(asyncio.CancelledError):

--- a/python/sglang/multimodal_gen/runtime/entrypoints/openai/mesh_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/openai/mesh_api.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
 import time
+from collections.abc import Coroutine
+from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 from fastapi import (
@@ -39,6 +41,29 @@ from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
 router = APIRouter(prefix="/v1/meshes", tags=["meshes"])
+_MESH_JOB_TASKS: dict[str, asyncio.Task[None]] = {}
+
+
+def _discard_mesh_job_task(job_id: str, task: asyncio.Task[None]) -> None:
+    if _MESH_JOB_TASKS.get(job_id) is task:
+        del _MESH_JOB_TASKS[job_id]
+
+
+def _start_mesh_job(job_id: str, job: Coroutine[Any, Any, None]) -> asyncio.Task[None]:
+    task = asyncio.create_task(job, name=f"mesh-job-{job_id}")
+    _MESH_JOB_TASKS[job_id] = task
+    task.add_done_callback(lambda completed: _discard_mesh_job_task(job_id, completed))
+    return task
+
+
+async def shutdown_mesh_jobs() -> None:
+    tasks = list(_MESH_JOB_TASKS.values())
+    _MESH_JOB_TASKS.clear()
+    for task in tasks:
+        task.cancel()
+    for task in tasks:
+        with suppress(asyncio.CancelledError):
+            await task
 
 
 def _normalize_format(fmt: Optional[str]) -> str:
@@ -219,7 +244,7 @@ async def create_mesh(
         sampling_params=sampling_params,
     )
 
-    asyncio.create_task(_dispatch_job_async(request_id, batch))
+    _start_mesh_job(request_id, _dispatch_job_async(request_id, batch))
     return MeshResponse(**job)
 
 

--- a/python/sglang/multimodal_gen/test/unit/test_mesh_job_lifecycle.py
+++ b/python/sglang/multimodal_gen/test/unit/test_mesh_job_lifecycle.py
@@ -1,0 +1,47 @@
+import asyncio
+
+from sglang.multimodal_gen.runtime.entrypoints.openai import mesh_api
+
+
+def test_mesh_job_registry_holds_task_until_completion():
+    async def run_test():
+        started = asyncio.Event()
+        finish = asyncio.Event()
+
+        async def job():
+            started.set()
+            await finish.wait()
+
+        task = mesh_api._start_mesh_job("job-id", job())
+        await started.wait()
+        assert mesh_api._MESH_JOB_TASKS["job-id"] is task
+
+        finish.set()
+        await task
+        await asyncio.sleep(0)
+        assert "job-id" not in mesh_api._MESH_JOB_TASKS
+
+    asyncio.run(run_test())
+
+
+def test_shutdown_mesh_jobs_cancels_and_awaits_cleanup():
+    async def run_test():
+        started = asyncio.Event()
+        cleaned_up = asyncio.Event()
+
+        async def job():
+            started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleaned_up.set()
+
+        task = mesh_api._start_mesh_job("job-id", job())
+        await started.wait()
+        await mesh_api.shutdown_mesh_jobs()
+
+        assert task.cancelled()
+        assert cleaned_up.is_set()
+        assert "job-id" not in mesh_api._MESH_JOB_TASKS
+
+    asyncio.run(run_test())

--- a/python/sglang/srt/managers/multi_tokenizer_mixin.py
+++ b/python/sglang/srt/managers/multi_tokenizer_mixin.py
@@ -710,8 +710,7 @@ class TokenizerWorker(TokenizerManager):
 
     def _handle_pause_continue_broadcast(self, obj: PauseContinueBroadcastReq):
         """Called from handle_loop when a broadcast arrives from the router."""
-        loop = asyncio.get_event_loop()
-        loop.create_task(self._apply_pause_continue_broadcast(obj))
+        self._create_background_task(self._apply_pause_continue_broadcast(obj))
 
     async def _apply_pause_continue_broadcast(self, obj: PauseContinueBroadcastReq):
         """Apply pause/continue state under the condition lock."""

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -29,6 +29,7 @@ import threading
 import time
 from array import array
 from collections import deque
+from collections.abc import Coroutine
 from contextlib import nullcontext
 from datetime import datetime
 from enum import Enum
@@ -563,6 +564,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if self.tokenizer_ipc_name is not None:
             stamp_http_worker_ipc(obj, self.tokenizer_ipc_name)
         await async_sock_send(self.send_to_scheduler, obj)
+
+    def _create_background_task(
+        self, coroutine: Coroutine[Any, Any, Any]
+    ) -> asyncio.Task[Any]:
+        """Schedule a task and retain it until it finishes."""
+        task = asyncio.create_task(coroutine)
+        self.asyncio_tasks.add(task)
+        task.add_done_callback(self.asyncio_tasks.discard)
+        return task
 
     def init_running_status(self):
         # Request states
@@ -1757,7 +1767,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 )
 
                 if self.request_metrics_exporter_manager.exporter_enabled():
-                    asyncio.create_task(
+                    self._create_background_task(
                         self.request_metrics_exporter_manager.write_record(obj, out)
                     )
 
@@ -2447,7 +2457,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
                 # Mark ongoing LoRA request as finished.
                 if self.enable_lora and state.obj.lora_path:
-                    asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
+                    self._create_background_task(
+                        self.lora_registry.release(state.obj.lora_id)
+                    )
 
             if out_dict is not None:
                 state.out_list.append(out_dict)
@@ -2963,7 +2975,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     to_dump_with_server_args["resolved_config"] = None
                     pickle.dump(to_dump_with_server_args, f)
 
-        asyncio.create_task(asyncio.to_thread(background_task))
+        self._create_background_task(asyncio.to_thread(background_task))
 
     def dump_requests_before_crash(
         self, hostname: str = os.getenv("HOSTNAME", socket.gethostname())

--- a/test/registered/unit/managers/test_tokenizer_manager_background_tasks.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_background_tasks.py
@@ -1,0 +1,42 @@
+"""Regression tests for TokenizerManager background-task ownership."""
+
+import asyncio
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTokenizerManagerBackgroundTasks(CustomTestCase):
+    def test_task_is_retained_until_completion(self):
+        async def run_test():
+            started = asyncio.Event()
+            finish = asyncio.Event()
+
+            async def background_job():
+                started.set()
+                await finish.wait()
+
+            manager = TokenizerManager.__new__(TokenizerManager)
+            manager.asyncio_tasks = set()
+            task = manager._create_background_task(background_job())
+
+            await started.wait()
+            self.assertIn(task, manager.asyncio_tasks)
+
+            finish.set()
+            await task
+            await asyncio.sleep(0)
+            self.assertNotIn(task, manager.asyncio_tasks)
+
+        asyncio.run(run_test())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_background_task_ownership.py
+++ b/test/registered/unit/test_background_task_ownership.py
@@ -1,0 +1,54 @@
+"""Ratchet against unowned fire-and-forget asyncio tasks.
+
+``asyncio`` only keeps weak references to scheduled tasks.  A bare
+``create_task(...)`` expression can therefore disappear before the coroutine
+finishes.  These modules previously contained the production failures tracked
+by #34434; keep every future task attached to an explicit lifecycle owner.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_OWNERSHIP_RATCHET_PATHS = (
+    "python/sglang/multimodal_gen/runtime/entrypoints/openai/mesh_api.py",
+    "python/sglang/srt/managers/multi_tokenizer_mixin.py",
+    "python/sglang/srt/managers/tokenizer_manager.py",
+)
+
+
+def _bare_task_calls(path: Path) -> list[int]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    return [
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Call)
+        and isinstance(node.value.func, ast.Attribute)
+        and node.value.func.attr in {"create_task", "ensure_future"}
+    ]
+
+
+class TestBackgroundTaskOwnership(CustomTestCase):
+    def test_fire_and_forget_tasks_have_lifecycle_owners(self):
+        offenders = {
+            relative_path: lines
+            for relative_path in _OWNERSHIP_RATCHET_PATHS
+            if (lines := _bare_task_calls(_REPO_ROOT / relative_path))
+        }
+
+        self.assertFalse(
+            offenders,
+            "Bare task creation leaves only asyncio's weak reference; retain each "
+            f"task until completion: {offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`asyncio` keeps only weak references to scheduled tasks. The five bare fire-and-forget task sites identified in #34434 could therefore be garbage-collected before their work completed.

Closes #34434.

## Modifications

- Route TokenizerManager background work through a helper that retains each task until completion.
- Retain mesh generation jobs and cancel and await any outstanding jobs during server shutdown.
- Add CPU lifecycle regressions for task retention and cleanup.
- Add an AST ratchet covering the reported modules so bare task creation does not return unnoticed.

## Accuracy Tests

No model-output behavior changes. The focused CPU lifecycle tests and ownership ratchet pass; the ratchet detects all five original call sites on the upstream version.

## Speed Tests and Profiling

Not applicable. This changes task ownership around asynchronous side work and does not alter model execution or inference kernels.

## Checklist

- [x] Format checked with the repository-pinned Ruff, Black, isort, and codespell versions.
- [x] Added CPU unit tests for task retention and shutdown cleanup.
- [x] Documentation is not required for this internal lifecycle correction.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Followed the SGLang code style guidance.

AI assistance is disclosed in the commit trailer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31549720803](https://github.com/sgl-project/sglang/actions/runs/31549720803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31549720587](https://github.com/sgl-project/sglang/actions/runs/31549720587)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->