### PR TITLE
Fix deterministic-mode shared-memory OutOfResources on sm_89: arch-aware persistent matmul configs

### DIFF
--- a/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
+++ b/python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py
@@ -1,9 +1,11 @@
 # Adapted from https://github.com/thinking-machines-lab/batch_invariant_ops/blob/main/batch_invariant_ops/batch_invariant_ops.py
 
 import contextlib
+import functools
+import logging
 from collections import namedtuple
 from collections.abc import Callable
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import torch
 import triton
@@ -17,6 +19,8 @@ from sglang.srt.utils.common import (
     get_device_core_count,
     get_dispatch_device_backend,
 )
+
+logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
 if _is_npu:
@@ -170,6 +174,134 @@ def matmul_kernel_persistent(
         tl.store(c_ptrs, c, mask=c_mask)
 
 
+# Fixed tile configs for the persistent matmul/bmm kernels, keyed by dtype.
+# Shared by matmul_kernel_persistent and bmm_kernel_persistent. Tuned for
+# datacenter parts with >=160KB of per-block shared memory.
+_MATMUL_PERSISTENT_CONFIGS: Dict[torch.dtype, Dict[str, int]] = {
+    torch.bfloat16: {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_stages": 3,
+        "num_warps": 8,
+    },
+    torch.float16: {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 256,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 8,
+        "num_stages": 3,
+        "num_warps": 8,
+    },
+    torch.float32: {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 32,
+        "GROUP_SIZE_M": 8,
+        "num_stages": 3,
+        "num_warps": 8,
+    },
+}
+
+# Shared memory the float16 config above requires when Triton lowers it for
+# sm_8x: 106496 B, measured on L40S and RTX 4060 Laptop (both sm_89, issue
+# #29149), where the per-block limit is 101376 B, so the first launch dies
+# with OutOfResources. The footprint is a property of (config, target arch),
+# not of the config alone: the identical config fits on SM120 under the same
+# 101376 B limit because newer-arch codegen stages the tiles differently.
+# Hence the gate below checks compute capability as well as the limit;
+# gating on the limit alone would wrongly degrade archs where the config
+# fits.
+_SM8X_FP16_SMEM_REQUIRED_BYTES = 106496
+
+# Conservative float16 variant for low-shared-memory sm_8x parts. Only
+# num_stages differs from the default (3 -> 2). num_stages is the depth of
+# Triton's software pipeline (how many K-tiles are prefetched into shared
+# memory in flight); it changes neither the tile shapes, nor the K-loop
+# iteration order, nor the accumulation order inside tl.dot, so the reduction
+# order that batch invariance rests on is unchanged. Bitwise equality against
+# the num_stages=3 lowering is not asserted here and cannot be measured on
+# sm_89, where that config does not fit. Verified to fit and pass health
+# checks on L40S in issue #29149.
+_MATMUL_PERSISTENT_FP16_LOW_SMEM_CONFIG: Dict[str, int] = {
+    "BLOCK_SIZE_M": 128,
+    "BLOCK_SIZE_N": 256,
+    "BLOCK_SIZE_K": 64,
+    "GROUP_SIZE_M": 8,
+    "num_stages": 2,
+    "num_warps": 8,
+}
+
+
+def _select_matmul_persistent_configs(
+    capability: Tuple[int, int], smem_per_block_bytes: Optional[int]
+) -> Dict[torch.dtype, Dict[str, int]]:
+    """Pick the per-dtype persistent-matmul configs for a device arch.
+
+    Pure function of static device properties (compute capability, per-block
+    shared memory limit). It must never depend on tensor shapes or batch
+    size: batch invariance requires the kernel config to stay fixed for the
+    lifetime of the process for a given (device, dtype).
+    """
+    major, _ = capability
+    if (
+        smem_per_block_bytes is not None
+        and major < 9
+        and smem_per_block_bytes < _SM8X_FP16_SMEM_REQUIRED_BYTES
+    ):
+        configs = dict(_MATMUL_PERSISTENT_CONFIGS)
+        configs[torch.float16] = _MATMUL_PERSISTENT_FP16_LOW_SMEM_CONFIG
+        return configs
+    return _MATMUL_PERSISTENT_CONFIGS
+
+
+@functools.lru_cache(maxsize=None)
+def _matmul_persistent_configs_for_device(
+    device_index: int,
+) -> Dict[torch.dtype, Dict[str, int]]:
+    """Config table for a CUDA device, computed once per device index and
+    cached for the lifetime of the process."""
+    try:
+        props = torch.cuda.get_device_properties(device_index)
+        capability = (props.major, props.minor)
+        smem = getattr(props, "shared_memory_per_block_optin", None)
+        if not smem:
+            # Fallback for torch builds without that field: Triton's internal
+            # driver API (subject to change across Triton versions, hence the
+            # broad except). Same probe as the fused-MoE clamp in #28038.
+            smem = triton.runtime.driver.active.utils.get_device_properties(
+                device_index
+            )["max_shared_mem"]
+    except Exception:
+        return _MATMUL_PERSISTENT_CONFIGS
+    configs = _select_matmul_persistent_configs(capability, smem)
+    if configs is not _MATMUL_PERSISTENT_CONFIGS:
+        logger.warning(
+            "Batch-invariant persistent matmul: the default float16 config "
+            "needs %d B of shared memory as lowered for sm_%d%d but device %d "
+            "provides %d B per block; using the num_stages=2 variant instead "
+            "(issue #29149). Results stay batch-invariant.",
+            _SM8X_FP16_SMEM_REQUIRED_BYTES,
+            capability[0],
+            capability[1],
+            device_index,
+            smem,
+        )
+    return configs
+
+
+def _get_matmul_persistent_configs(
+    device: torch.device,
+) -> Dict[torch.dtype, Dict[str, int]]:
+    if device.type != "cuda":
+        return _MATMUL_PERSISTENT_CONFIGS
+    index = device.index
+    if index is None:
+        index = torch.cuda.current_device()
+    return _matmul_persistent_configs_for_device(index)
+
+
 def _matmul_persistent_triton(
     a: torch.Tensor, b: torch.Tensor, bias: torch.Tensor | None = None
 ):
@@ -196,32 +328,7 @@ def _matmul_persistent_triton(
             ),
         )
 
-    configs = {
-        torch.bfloat16: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 128,
-            "BLOCK_SIZE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 3,
-            "num_warps": 8,
-        },
-        torch.float16: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 256,
-            "BLOCK_SIZE_K": 64,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 3,
-            "num_warps": 8,
-        },
-        torch.float32: {
-            "BLOCK_SIZE_M": 128,
-            "BLOCK_SIZE_N": 128,
-            "BLOCK_SIZE_K": 32,
-            "GROUP_SIZE_M": 8,
-            "num_stages": 3,
-            "num_warps": 8,
-        },
-    }
+    configs = _get_matmul_persistent_configs(a.device)
     # print(a.device, b.device, c.device)
     matmul_kernel_persistent[grid](
         a,
@@ -746,32 +853,7 @@ def bmm_batch_invariant(a, b, *, out=None):
         NUM_SMS = get_device_core_count()
 
         # Use fixed kernel configuration for determinism
-        configs = {
-            torch.bfloat16: {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 128,
-                "BLOCK_SIZE_K": 64,
-                "GROUP_SIZE_M": 8,
-                "num_stages": 3,
-                "num_warps": 8,
-            },
-            torch.float16: {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 256,
-                "BLOCK_SIZE_K": 64,
-                "GROUP_SIZE_M": 8,
-                "num_stages": 3,
-                "num_warps": 8,
-            },
-            torch.float32: {
-                "BLOCK_SIZE_M": 128,
-                "BLOCK_SIZE_N": 128,
-                "BLOCK_SIZE_K": 32,
-                "GROUP_SIZE_M": 8,
-                "num_stages": 3,
-                "num_warps": 8,
-            },
-        }
+        configs = _get_matmul_persistent_configs(a.device)
 
         config = configs.get(dtype)
         if config is None:

--- a/test/registered/unit/batch_invariant_ops/test_matmul_persistent_smem_config.py
+++ b/test/registered/unit/batch_invariant_ops/test_matmul_persistent_smem_config.py
@@ -1,0 +1,138 @@
+"""Regression tests for issue #29149.
+
+`--enable-deterministic-inference` crashed at startup on sm_89 (L40S,
+RTX 4060 Laptop): the fixed float16 persistent-matmul config
+(128x256x64, num_stages=3, num_warps=8) lowers to a 106496 B shared-memory
+footprint on sm_8x, above the 101376 B per-block limit, so the first launch
+raised ``triton OutOfResources: shared memory, Required: 106496, Hardware
+limit: 101376``. The identical config fits under the identical 101376 B
+limit on SM120, so the selection gates on (compute capability, limit), not
+the limit alone.
+
+Pure config-selection logic; no GPU kernels are launched (device properties
+are mocked), so this runs on CPU-only machines.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.batch_invariant_ops.batch_invariant_ops import (
+    _MATMUL_PERSISTENT_CONFIGS,
+    _MATMUL_PERSISTENT_FP16_LOW_SMEM_CONFIG,
+    _SM8X_FP16_SMEM_REQUIRED_BYTES,
+    _get_matmul_persistent_configs,
+    _matmul_persistent_configs_for_device,
+    _select_matmul_persistent_configs,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+ADA_LIMIT = 101376  # bytes/block on sm_86, sm_89 and, coincidentally, SM120
+A100_LIMIT = 166912
+H100_LIMIT = 232448
+
+_PROPS_PATH = "torch.cuda.get_device_properties"
+
+
+def _props(major, minor, smem):
+    return SimpleNamespace(major=major, minor=minor, shared_memory_per_block_optin=smem)
+
+
+class TestMatmulPersistentSmemConfig(CustomTestCase):
+    def setUp(self):
+        # Clear before as well as after: when this file runs in the same
+        # process as tests that launch the real kernels (e.g. pytest on the
+        # whole directory on a GPU box), the cache may already hold the real
+        # device's configs.
+        _matmul_persistent_configs_for_device.cache_clear()
+
+    def tearDown(self):
+        _matmul_persistent_configs_for_device.cache_clear()
+
+    def test_sm89_fp16_degraded_to_two_stages(self):
+        # The exact crash arch from #29149: L40S / RTX 4060 Laptop.
+        configs = _select_matmul_persistent_configs((8, 9), ADA_LIMIT)
+        self.assertEqual(configs[torch.float16]["num_stages"], 2)
+
+    def test_sm86_fp16_degraded_to_two_stages(self):
+        # Consumer Ampere shares the sm_8x codegen and the 99KB limit.
+        configs = _select_matmul_persistent_configs((8, 6), ADA_LIMIT)
+        self.assertEqual(configs[torch.float16]["num_stages"], 2)
+
+    def test_sm89_bf16_and_fp32_unchanged(self):
+        # Only the fp16 config exceeds the sm_8x limit; the others fit.
+        configs = _select_matmul_persistent_configs((8, 9), ADA_LIMIT)
+        self.assertEqual(
+            configs[torch.bfloat16], _MATMUL_PERSISTENT_CONFIGS[torch.bfloat16]
+        )
+        self.assertEqual(
+            configs[torch.float32], _MATMUL_PERSISTENT_CONFIGS[torch.float32]
+        )
+
+    def test_sm120_same_limit_keeps_default(self):
+        # SM120 exposes the same 101376 B limit but the fp16 config compiles
+        # and runs there (verified on RTX PRO 6000 Blackwell in #29149):
+        # the 106496 B footprint is sm_8x-codegen-specific. Gating on the
+        # limit alone would wrongly degrade SM120.
+        configs = _select_matmul_persistent_configs((12, 0), ADA_LIMIT)
+        self.assertIs(configs, _MATMUL_PERSISTENT_CONFIGS)
+
+    def test_datacenter_parts_keep_default(self):
+        for capability, limit in [((8, 0), A100_LIMIT), ((9, 0), H100_LIMIT)]:
+            with self.subTest(capability=capability):
+                configs = _select_matmul_persistent_configs(capability, limit)
+                self.assertIs(configs, _MATMUL_PERSISTENT_CONFIGS)
+
+    def test_unknown_limit_keeps_default(self):
+        configs = _select_matmul_persistent_configs((8, 9), None)
+        self.assertIs(configs, _MATMUL_PERSISTENT_CONFIGS)
+
+    def test_low_smem_variant_only_changes_num_stages(self):
+        # Batch invariance depends on this: reducing num_stages only changes
+        # Triton's prefetch pipeline depth. Changing any block size could
+        # change the accumulation order and must never happen here.
+        default = _MATMUL_PERSISTENT_CONFIGS[torch.float16]
+        low = _MATMUL_PERSISTENT_FP16_LOW_SMEM_CONFIG
+        self.assertEqual(
+            {k: v for k, v in low.items() if k != "num_stages"},
+            {k: v for k, v in default.items() if k != "num_stages"},
+        )
+        self.assertLess(low["num_stages"], default["num_stages"])
+
+    def test_threshold_matches_triton_reported_requirement(self):
+        # triton reported exactly 106496 bytes in #29149, on two sm_89 parts.
+        self.assertEqual(_SM8X_FP16_SMEM_REQUIRED_BYTES, 106496)
+
+    def test_device_lookup_uses_mocked_props(self):
+        with patch(_PROPS_PATH, return_value=_props(8, 9, ADA_LIMIT)):
+            configs = _get_matmul_persistent_configs(torch.device("cuda", 0))
+        self.assertEqual(configs[torch.float16]["num_stages"], 2)
+
+    def test_device_lookup_cached_per_device(self):
+        # The choice is made once per device index and must stay fixed for
+        # the process lifetime; later calls may not re-query the driver.
+        with patch(_PROPS_PATH, return_value=_props(8, 9, ADA_LIMIT)) as mock:
+            first = _get_matmul_persistent_configs(torch.device("cuda", 0))
+            second = _get_matmul_persistent_configs(torch.device("cuda", 0))
+        self.assertIs(first, second)
+        self.assertEqual(mock.call_count, 1)
+
+    def test_props_query_failure_keeps_default(self):
+        with patch(_PROPS_PATH, side_effect=RuntimeError("no driver")):
+            configs = _get_matmul_persistent_configs(torch.device("cuda", 0))
+        self.assertIs(configs, _MATMUL_PERSISTENT_CONFIGS)
+
+    def test_non_cuda_device_keeps_default(self):
+        self.assertIs(
+            _get_matmul_persistent_configs(torch.device("cpu")),
+            _MATMUL_PERSISTENT_CONFIGS,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #29149. `--enable-deterministic-inference` crashes at startup on sm_89 (L40S, RTX 4060 Laptop): the fixed float16 persistent-matmul config (BLOCK 128x256x64, num_stages=3, num_warps=8) lowers to a 106496 B shared-memory footprint on sm_8x, above the 101376 B per-block limit, so the first launch raises `triton OutOfResources` and the scheduler dies before `/health_generate`. `matmul_kernel_persistent` and `bmm_kernel_persistent` share the config, so the `SGLANG_BATCH_INVARIANT_OPS_ENABLE_MM_FALLBACK_VARIANT=1` einsum path hits the same wall through `bmm_batch_invariant`.

The diagnosis is not mine. @Ningke-Li reported the issue, pinned it to that config, and showed that num_stages 3 -> 2 (or BLOCK_SIZE_N 256 -> 128) lets the same repro reach `/health_generate` on L40S. @ronhuafeng measured the ~106 KiB against the ~99 KiB limit and proposed arch-aware selection. @waynehacking8 supplied the SM120 datapoint that constrains the fix shape. @u7k4rs6 reproduced on a second Ada part. This PR implements the arch-aware selection and adds tests.

## Modifications

- Deduplicate the two inline config tables in `python/sglang/srt/batch_invariant_ops/batch_invariant_ops.py` into one module-level table shared by `_matmul_persistent_triton` and `bmm_batch_invariant`.
- Select configs per device, once, cached: `torch.cuda.get_device_properties` gives compute capability and `shared_memory_per_block_optin`, with the Triton driver API as a fallback for torch builds without that field (that fallback is adapted from @waynehacking8's #28038). When capability major < 9 and the reported limit is below the measured 106496 B requirement, the float16 entry is swapped for a num_stages=2 variant. Non-CUDA devices and failed property queries keep the defaults. A one-time warning logs the degradation.
- `python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe_triton_config.py` already has a smaller version of that lookup (`_get_cuda_shared_memory_per_block_optin`), but it caches one value for whichever device was current at the first call and has no fallback, so this one keys on device index instead. Happy to consolidate into a single shared helper if you prefer.

Why the gate checks capability and not the limit alone: @waynehacking8 ran the same config on RTX PRO 6000 (SM120), which reports the identical 101376 B `sharedMemPerBlockOptin`, and it compiles and runs (#29149). The 106496 B is sm_8x codegen, not a function of the device limit, so limit-only gating would degrade archs where the config fits.

That is also why this is not #28038's mechanism, despite borrowing its driver fallback. #28038 estimates a fused-MoE config's footprint analytically, `(num_stages - 1) * BLOCK_K * (BLOCK_M * a + BLOCK_N * b)`, and clamps against the device limit. For this config that estimate is `2 * 64 * (128 * 2 + 256 * 2) = 98304` B, under the 101376 B limit, so a clamp of that shape would not fire on sm_89 even though the real lowering needs 106496 B. Hence capability plus the measured constant here.

@waynehacking8 argued in the thread against both an arch allowlist and limit gating, and recommended instead catching `triton.runtime.errors.OutOfResources` on the first launch of a given (device, dtype) config and retrying with num_stages=2, or reading the compiled kernel's `metadata.shared` rather than predicting it. I went with the static gate because it resolves before any op runs, is a pure function of device properties, and is testable on CPU with mocked properties, whereas catch-and-retry decides the config inside the op path and can only be exercised on hardware that fails. The `metadata.shared` variant is the strictly more accurate check and I am happy to rewrite it that way if maintainers prefer; it costs compiling the candidate config at init instead of comparing against a constant.

Determinism and batch invariance:

- Selection is a pure function of static device properties, computed once per device index and cached for the process lifetime. It never sees tensor shapes or batch size, so for a given (device, dtype) every call in the process uses the same config at every batch size and batch composition.
- The fallback changes only num_stages (3 -> 2), the depth of Triton's software prefetch pipeline. Tile shapes, the K-loop, and the accumulation order inside `tl.dot` are unchanged, so which values each output element sums, and in what order, does not depend on num_stages. Batch invariance of the num_stages=2 lowering rests on the same property as the num_stages=3 one. I am not claiming bitwise equality with the num_stages=3 lowering: that config cannot launch on sm_89, so there is nothing on the affected hardware to compare it against.
- That property is measurable and I have not measured it. `test/registered/unit/batch_invariant_ops/test_batch_invariant_ops.py` iterates `[torch.float32, torch.bfloat16]` only, and is registered nightly, so it does not cover the float16 path this PR touches. The check that would validate it is that file's own pattern at float16 on sm_89: `torch.mm(a[:1], b)` vs `torch.mm(a, b)[:1]` under `set_batch_invariant_mode(True)`, `diff_range` exactly 0. I can run it on the L40S and add float16 to that suite's dtype list if you want it in this PR.

## Accuracy Tests

- New CPU test `test/registered/unit/batch_invariant_ops/test_matmul_persistent_smem_config.py` (registered `base-a-test-cpu`, mocked device properties): sm_89/sm_86 get the num_stages=2 fp16 variant; SM120 under the same limit, A100, H100, unknown limit, non-CUDA, and driver-failure paths keep the defaults; the variant differs from the default only in num_stages (pins the invariance contract); per-device caching queries the driver once.
- L40S (sm_89, driver 580.126.09), sglang 0.5.17, Qwen3-0.6B, `--dtype float16 --enable-deterministic-inference`. `--dtype float16` is required to reproduce: Qwen3-0.6B loads as bfloat16 by default, which selects the smaller 128x128x64 config and stays under the limit.

  Unfixed (stock 0.5.17, which still ships the 128x256x64 num_stages=3 fp16 entry and no arch-aware selection):

  ```
  OutOfResources: out of resource: shared memory, Required: 106496, Hardware limit: 101376.
  Reducing block sizes or `num_stages` may help.
  ```

  Server exits before `/health_generate`. Same numbers as the issue.

  Patched: server starts and serves. `"The capital of France is"` at temperature 0 generates `" Paris. The capital of Italy is Rome. The capital of Spain i"`, and two identical greedy requests return identical `output_ids`. That last one is repeat-request stability at a single batch shape, not a batch-invariance measurement; the check that would be one is described above.

## Speed Tests and Profiling

The gate (`major < 9 and shared_memory_per_block_optin < 106496`) never fires on sm_90+, and never on a pre-sm_90 part that reports 106496 B or more, so A100 (166912 B) and H100 (232448 B) keep exactly the configs they run today. Datacenter versus consumer is not the split, though: L40S and L4 are sm_89, A10 and A10G are sm_86, all at 101376 B, so they are gated too, including the L40S this was verified on. On sm_89 the num_stages=2 variant replaces a config that cannot launch at all, so there is no before/after to measure there; one prefetch stage less costs some latency against a hypothetical fitting 3-stage config and is strictly better than dying at startup.

The exposure is the parts the gate reaches that nobody has reported failing: sm_86 (A10, A10G, RTX 3090, A6000) at the same 101376 B, and Turing and Volta below it, where a constant named `_SM8X_...` is not the right thing to compare against at all. Every report in #29149 is sm_89 and my verification is L40S only, so whether the default config actually overshoots on sm_86 is unmeasured, and it does not follow from sm_89 given that the footprint is arch-specific codegen. If maintainers would rather not change behavior on untested archs, I will narrow the gate to `major == 8 and minor == 9`. If anyone has an A10G or a 3090, the fp16 repro above settles it in one run.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31552366383](https://github.com/sgl-project/sglang/actions/runs/31552366383)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31552366210](https://github.com/sgl-project/sglang/actions/runs/31552366210)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->