### PR TITLE
[diffusion] post_training: honor lora_merge_mode in the LoRA IPC weight update

### DIFF
--- a/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
@@ -628,6 +628,13 @@ class WeightsUpdater:
         updated = 0
         skipped = 0
         unknown_layers: list[str] = []
+        # Honor lora_merge_mode instead of always merging: merged (W + s*B*A)x and
+        # PEFT-trainer Wx + s*B(A*x) agree algebraically but not bitwise.
+        merge_mode = lora_pipeline._resolve_lora_merge_mode(None, None)
+        merge_weights = lora_pipeline._should_merge_lora_for_layers(
+            target_module, layer_dict, merge_mode
+        )
+
         with lora_pipeline._temporarily_disable_offload(target=target_module):
             for layer_name, (lora_a, lora_b) in pairs.items():
                 layer, _resolved_key = _resolve_lora_ipc_layer_dict_key(
@@ -654,7 +661,7 @@ class WeightsUpdater:
                 layer.lora_rank = inferred_rank
                 layer.lora_alpha = alpha
                 layer.set_lora_weights(
-                    lora_a, lora_b, merge_weights=True, clear_existing=True
+                    lora_a, lora_b, merge_weights=merge_weights, clear_existing=True
                 )
                 updated += 1
 


### PR DESCRIPTION
## Motivation

`WeightsUpdater._update_lora_from_tensor` has hardcoded `set_lora_weights(..., merge_weights=True, ...)` since #31029, ignoring the engine's `lora_merge_mode` server arg that the disk LoRA-loading path already honors.

The merge policy is a deployment-level choice the training framework makes when it launches the engine (e.g. miles forwards `--sglang-lora-merge-mode` into ServerArgs). Merging folds `B@A` into the base weight, so the engine computes `(W + s*B*A)x` while a PEFT-adapted trainer computes `Wx + s*B(A*x)` — algebraically equal, not bitwise, so RL setups pick dynamic for on-policy parity.

Forced merging is also expensive for RL weight sync: every bucket POST re-merges each target layer — unmerge restores the full base weight from the pinned-CPU snapshot (H2D), adds `B@A`, then re-snapshots (D2H + clone). On Wan2.2-A14B dual-expert LoRA (2 x 400 target layers, tp=4 engines) one `update_weights_from_tensor` cycle costs 26-46 s, dominated by 5-8 s per bucket POST; with the dynamic mode the update swaps two small tensors per layer (~3.5 s steady on a 4-GPU run).

## Modifications

Resolve the merge mode via the existing `_resolve_lora_merge_mode` / `_should_merge_lora_for_layers` helpers inside `_update_lora_from_tensor` and pass it to `set_lora_weights`, instead of hardcoding `merge_weights=True`. `auto` keeps merging for plain-tensor pipelines and picks dynamic where merging would require a full-gather, matching the disk-loading behavior. One file, +9/-1.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31556953315](https://github.com/sgl-project/sglang/actions/runs/31556953315)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31556953213](https://github.com/sgl-project/sglang/actions/runs/31556953213)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->