### PR TITLE
[Spec] Sync MTP draft model weights on distributed (NCCL) online weight updates

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -141,7 +141,15 @@ class SchedulerWeightUpdaterManager:
     ) -> Tuple[bool, str]:
         """Update the online model parameter."""
         with self._observe_weight_load("distributed"):
-            success, message = self.tp_worker.update_weights_from_distributed(recv_req)
+            draft_model = None
+            if self.draft_worker is not None:
+                draft_runner = _get_draft_model_runner(self.draft_worker)
+                if draft_runner is not None:
+                    draft_model = draft_runner.model
+
+            success, message = self.tp_worker.update_weights_from_distributed(
+                recv_req, draft_model=draft_model
+            )
             if success:
                 self.flush_cache_after_weight_update(recv_req)
             else:

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -182,7 +182,9 @@ class BaseTpWorker(ABC):
         return success, message
 
     def update_weights_from_distributed(
-        self, recv_req: UpdateWeightsFromDistributedReqInput
+        self,
+        recv_req: UpdateWeightsFromDistributedReqInput,
+        draft_model=None,
     ):
         success, message = (
             self.model_runner.weight_updater.update_weights_from_distributed(
@@ -191,6 +193,7 @@ class BaseTpWorker(ABC):
                 recv_req.shapes,
                 recv_req.group_name,
                 recv_req.load_format,
+                draft_model=draft_model,
             )
         )
         return success, message

--- a/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
+++ b/python/sglang/srt/model_executor/model_runner_components/weight_updater.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import inspect
 import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple, Union
@@ -226,15 +227,17 @@ class WeightUpdater:
         shapes,
         group_name,
         load_format: Optional[str] = None,
+        draft_model=None,
     ):
         """
         Update specific parameter in the model weights online
         through `_model_update_group` process group.
 
         Args:
-            name: the name of the parameter to be updated.
-            dtype: the data type of the parameter to be updated.
-            shape: the shape of the parameter to be updated.
+            names: the names of the parameters to be updated.
+            dtypes: the data types of the parameters to be updated.
+            shapes: the shapes of the parameters to be updated.
+            draft_model: optional draft/MTP model to also update.
         """
         self._assert_weight_cache_inactive("update_weights_from_distributed")
         error = _unsupported_derived_weight_cache_error()
@@ -271,6 +274,15 @@ class WeightUpdater:
                 handle.wait()
 
             self.get_model().load_weights(weights)
+
+            if draft_model is not None:
+                if "is_mtp" in inspect.signature(draft_model.load_weights).parameters:
+                    draft_model.load_weights(weights, is_mtp=True)
+                else:
+                    logger.warning(
+                        f"Draft model {type(draft_model).__name__} does not support "
+                        "MTP weight sync; skipping"
+                    )
             return True, "Succeeded to update parameter online."
 
         except Exception as e:


### PR DESCRIPTION
## What

Adds MTP draft-model weight sync to the distributed (NCCL) online weight-update path (`update_weights_from_distributed`), used in RLHF/PPO rollout when the training engine broadcasts updated parameters to the inference engine. The MTP draft model is now updated from the **same broadcast tensors** that update the target model, so the draft stays consistent with the target after every update. The disk / tensor / IPC update paths already sync the draft model; distributed was the only one that did not — and since target-model `load_weights` skips `mtp*` names at `is_mtp=False`, MTP weights in the broadcast were silently dropped and the draft went stale. No-op when no draft model is present or the draft does not support MTP sync (see Design).

## Design

- Draft model resolved once at the scheduler-side manager via the existing `_get_draft_model_runner(draft_worker)` helper and threaded through `tp_worker.update_weights_from_distributed(recv_req, draft_model=...)` down to `WeightUpdater.update_weights_from_distributed(...)`.
- No extra NCCL communication: reuses the already-broadcast tensors — the MTP model shares the target's device, so the received tensors are fed directly into `draft_model.load_weights(weights, is_mtp=True)`.
- Reuses the model's existing checkpoint-loading semantics: MTP `load_weights` with `is_mtp=True` filters non-`mtp` names and remaps `mtp.*` names (`mtp.fc.weight` → `fc.weight`, `mtp.` → `model.`) exactly as on disk load, so passing the full broadcast list is safe — no errors, no cross-writes (qwen3_moe_mtp / qwen3_5_mtp / nemotron_h_mtp / qwen3_next_mtp / exaone_moe_mtp).
- Backward compatible: `draft_model` defaults to `None`, so existing callers (HTTP → engine → tokenizer_manager → scheduler) are unchanged. An `inspect.signature` guard skips drafts whose `load_weights` has no `is_mtp` kwarg (EAGLE, Mimo / Step3.5 MTP variants) with a warning, instead of failing the whole update with `TypeError`.
- Failures stay conservative: a draft-load failure propagates through the existing `try/except` and returns the "partially updated, discard weights" error.

## Config

No new flags or env vars. Sync is enabled whenever an MTP draft is running. It requires the training side to include `mtp*`-prefixed parameter names in the broadcast list; otherwise the sync is a safe no-op.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31561118353](https://github.com/sgl-project/sglang/actions/runs/31561118353)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31561117961](https://github.com/sgl-project/sglang/actions/runs/31561117961)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->