### PR TITLE
Fix tokenizer warning filtering for processors

### DIFF
--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -48,6 +48,7 @@ from .tokenizer import (
     _TOKENIZERS_BACKEND,
     _fix_added_tokens_encoding,
     _fix_special_tokens_pattern,
+    _install_tokenizer_warnings_filter,
 )
 
 _IMAGE_PROCESSOR_BACKENDS = {"auto", "torchvision", "pil"}
@@ -367,6 +368,8 @@ def get_processor(
             processor = tokenizer
         else:
             processor.tokenizer = tokenizer
+
+    _install_tokenizer_warnings_filter(tokenizer)
 
     if tokenizer.chat_template is None:
         local_path = download_from_hf(

--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -132,6 +132,15 @@ class TokenizerWarningsFilter(logging.Filter):
         return "Calling super().encode with" not in record.getMessage()
 
 
+_tokenizer_warnings_filter = TokenizerWarningsFilter()
+
+
+def _install_tokenizer_warnings_filter(tokenizer):
+    logging.getLogger(tokenizer.__class__.__module__).addFilter(
+        _tokenizer_warnings_filter
+    )
+
+
 # ---------------------------------------------------------------------------
 # Helpers for get_tokenizer
 # ---------------------------------------------------------------------------
@@ -168,9 +177,6 @@ def _auto_tokenizer_from_pretrained(tokenizer_name, *args, **common_kwargs):
     try:
         tokenizer = AutoTokenizer.from_pretrained(
             tokenizer_name, *args, **common_kwargs
-        )
-        logging.getLogger(tokenizer.__class__.__module__).addFilter(
-            TokenizerWarningsFilter()
         )
         return tokenizer
     except TypeError as e:
@@ -419,6 +425,7 @@ def _fix_special_tokens_pattern(tokenizer):
 
 def _apply_post_load_fixes(tokenizer, tokenizer_name, revision):
     """Apply all post-load patches and return the final tokenizer."""
+    _install_tokenizer_warnings_filter(tokenizer)
     _fix_v5_tokenizer_components(tokenizer, tokenizer_name, revision)
     _fix_v5_add_bos_eos_token(tokenizer, tokenizer_name, revision)
 


### PR DESCRIPTION
## Summary

- install the existing tokenizer warning filter through a shared helper
- apply it to tokenizers loaded through both `get_tokenizer` and `get_processor`
- reuse one filter instance so repeated loader calls do not accumulate filters

## Motivation

The remote Kimi tokenizer logs `Calling super().encode with {'add_special_tokens': False}` for normal encode calls. The existing suppression was installed only after `AutoTokenizer.from_pretrained`, while multimodal tokenizers loaded through `AutoProcessor` bypassed it.

## Verification

- `python3 -m py_compile python/sglang/srt/utils/hf_transformers/tokenizer.py python/sglang/srt/utils/hf_transformers/processor.py`
- `pre-commit run --files python/sglang/srt/utils/hf_transformers/tokenizer.py python/sglang/srt/utils/hf_transformers/processor.py`
- inline logging check: target warning suppressed, unrelated warning preserved, repeated installation remains idempotent

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31558294748](https://github.com/sgl-project/sglang/actions/runs/31558294748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31558295186](https://github.com/sgl-project/sglang/actions/runs/31558295186)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->