### PR TITLE
Support sglang-kernel on Windows ARM64

### DIFF
--- a/python/sglang/kernels/aot/CMakeLists.txt
+++ b/python/sglang/kernels/aot/CMakeLists.txt
@@ -13,6 +13,58 @@ set(CMAKE_VERBOSE_MAKEFILE ON CACHE BOOL "ON")
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_SHARED_LIBRARY_PREFIX "")
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" SGL_KERNEL_SYSTEM_PROCESSOR)
+set(SGL_KERNEL_IS_ARM64 OFF)
+if(SGL_KERNEL_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+    set(SGL_KERNEL_IS_ARM64 ON)
+endif()
+
+set(DEFAULT_SGL_KERNEL_BUILD_SM90 ON)
+set(DEFAULT_SGL_KERNEL_BUILD_INFLLM ON)
+set(DEFAULT_SGL_KERNEL_BUILD_SPATIAL ON)
+set(DEFAULT_SGL_KERNEL_BUILD_FLASHMLA ON)
+set(DEFAULT_SGL_KERNEL_INSTALL_TRITON_KERNELS ON)
+set(DEFAULT_SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN ON)
+set(DEFAULT_SGL_KERNEL_ENABLE_CUTLASS_MLA ON)
+set(DEFAULT_SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS ON)
+if(WIN32)
+    set(DEFAULT_SGL_KERNEL_BUILD_SM90 OFF)
+    set(DEFAULT_SGL_KERNEL_BUILD_INFLLM OFF)
+    set(DEFAULT_SGL_KERNEL_BUILD_SPATIAL OFF)
+    set(DEFAULT_SGL_KERNEL_BUILD_FLASHMLA OFF)
+    set(DEFAULT_SGL_KERNEL_INSTALL_TRITON_KERNELS OFF)
+    set(DEFAULT_SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN OFF)
+    set(DEFAULT_SGL_KERNEL_ENABLE_CUTLASS_MLA OFF)
+    set(DEFAULT_SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS OFF)
+endif()
+
+option(SGL_KERNEL_BUILD_SM90 "Build the SM90 fast-math common_ops variant" ${DEFAULT_SGL_KERNEL_BUILD_SM90})
+option(SGL_KERNEL_BUILD_INFLLM "Build the optional InfLLM-V2 extension" ${DEFAULT_SGL_KERNEL_BUILD_INFLLM})
+option(SGL_KERNEL_BUILD_SPATIAL "Build the optional spatial extension" ${DEFAULT_SGL_KERNEL_BUILD_SPATIAL})
+option(SGL_KERNEL_BUILD_FLASHMLA "Build the optional FlashMLA extension" ${DEFAULT_SGL_KERNEL_BUILD_FLASHMLA})
+option(SGL_KERNEL_INSTALL_TRITON_KERNELS "Bundle triton_kernels in the wheel" ${DEFAULT_SGL_KERNEL_INSTALL_TRITON_KERNELS})
+option(
+    SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN
+    "Build the sparse FlashAttention operators in common_ops"
+    ${DEFAULT_SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN}
+)
+option(
+    SGL_KERNEL_ENABLE_CUTLASS_MLA
+    "Build the AOT CUTLASS MLA decode operators"
+    ${DEFAULT_SGL_KERNEL_ENABLE_CUTLASS_MLA}
+)
+option(
+    SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
+    "Build optional CUTLASS, expert-specialization, AWQ, GPTQ, and legacy FP8 GEMM operators"
+    ${DEFAULT_SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS}
+)
+set(
+    SGL_KERNEL_CUDA_ARCHITECTURES
+    ""
+    CACHE STRING
+    "Optional semicolon/comma-separated CUDA architecture suffixes (for example 121a)"
+)
+
 # GitHub Artifactory
 set(GITHUB_ARTIFACTORY "github.com" CACHE STRING "GitHub mirror URL")
 
@@ -20,29 +72,49 @@ set(GITHUB_ARTIFACTORY "github.com" CACHE STRING "GitHub mirror URL")
 find_package(Python COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT} REQUIRED)
 
 # CXX
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+set(SGL_KERNEL_CXX_STANDARD 17)
+if(MSVC)
+    # Current Windows ARM64 PyTorch headers use C++20 features.
+    set(SGL_KERNEL_CXX_STANDARD 20)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/O2>)
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+endif()
+set(CMAKE_CXX_STANDARD ${SGL_KERNEL_CXX_STANDARD})
+set(CMAKE_CUDA_STANDARD ${SGL_KERNEL_CXX_STANDARD})
 
 # CUDA
 enable_language(CUDA)
 find_package(CUDAToolkit REQUIRED)
+set(SGL_KERNEL_CUDA_VERSION "${CUDAToolkit_VERSION}")
 set_property(GLOBAL PROPERTY CUDA_SEPARABLE_COMPILATION ON)
 
-message(STATUS "Detected CUDA_VERSION=${CUDA_VERSION}")
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
-    message("CUDA_VERSION ${CUDA_VERSION} >= 13.0")
-elseif ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8")
-    message("CUDA_VERSION ${CUDA_VERSION} >= 12.8")
-elseif ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4")
-    message("CUDA_VERSION ${CUDA_VERSION} >= 12.4")
-elseif ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.1")
-    message("CUDA_VERSION ${CUDA_VERSION} >= 12.1")
-elseif ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "11.8")
-    message("CUDA_VERSION ${CUDA_VERSION} >= 11.8")
+message(STATUS "Detected CUDA_VERSION=${SGL_KERNEL_CUDA_VERSION}")
+if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
+    message("CUDA_VERSION ${SGL_KERNEL_CUDA_VERSION} >= 13.0")
+elseif ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8")
+    message("CUDA_VERSION ${SGL_KERNEL_CUDA_VERSION} >= 12.8")
+elseif ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4")
+    message("CUDA_VERSION ${SGL_KERNEL_CUDA_VERSION} >= 12.4")
+elseif ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.1")
+    message("CUDA_VERSION ${SGL_KERNEL_CUDA_VERSION} >= 12.1")
+elseif ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "11.8")
+    message("CUDA_VERSION ${SGL_KERNEL_CUDA_VERSION} >= 11.8")
 endif()
 
 # Torch
 find_package(Torch REQUIRED)
+if(MSVC)
+    # CUTLASS uses host/device facade functions whose host branch calls host-only
+    # helpers. PyTorch promotes NVCC's cross-execution-space diagnostic to an
+    # error globally, even though the device branch is discarded.
+    string(REPLACE
+        "--Werror cross-execution-space-call"
+        ""
+        CMAKE_CUDA_FLAGS
+        "${CMAKE_CUDA_FLAGS}"
+    )
+endif()
 clear_cuda_arches(CMAKE_FLAG)
 
 # Third Party repos
@@ -63,12 +135,14 @@ FetchContent_Declare(
 FetchContent_Populate(repo-fmt)
 
 # Triton kernel
-FetchContent_Declare(
-    repo-triton
-    URL      https://${GITHUB_ARTIFACTORY}/triton-lang/triton/archive/v3.7.1.tar.gz
-    URL_HASH SHA256=7d998625d1035ac496d06a81117727647169422ee67b8889609f06fd5367c491
-)
-FetchContent_Populate(repo-triton)
+if(SGL_KERNEL_INSTALL_TRITON_KERNELS)
+    FetchContent_Declare(
+        repo-triton
+        URL      https://${GITHUB_ARTIFACTORY}/triton-lang/triton/archive/v3.7.1.tar.gz
+        URL_HASH SHA256=7d998625d1035ac496d06a81117727647169422ee67b8889609f06fd5367c491
+    )
+    FetchContent_Populate(repo-triton)
+endif()
 
 # flashinfer
 FetchContent_Declare(
@@ -77,6 +151,37 @@ FetchContent_Declare(
     URL_HASH SHA256=931dfd118f4b6de8c7d98702153c7c03840139170af21a07607693bd9749744d
 )
 FetchContent_Populate(repo-flashinfer)
+if(MSVC)
+    set(FLASHINFER_VEC_DTYPES "${repo-flashinfer_SOURCE_DIR}/include/flashinfer/vec_dtypes.cuh")
+    file(READ "${FLASHINFER_VEC_DTYPES}" FLASHINFER_VEC_DTYPES_CONTENT)
+    string(REPLACE
+        "#define FLASHINFER_INLINE inline __attribute__((always_inline)) __device__"
+        "#define FLASHINFER_INLINE __forceinline__ __device__"
+        FLASHINFER_VEC_DTYPES_CONTENT
+        "${FLASHINFER_VEC_DTYPES_CONTENT}"
+    )
+    file(WRITE "${FLASHINFER_VEC_DTYPES}" "${FLASHINFER_VEC_DTYPES_CONTENT}")
+
+    set(FLASHINFER_MATH "${repo-flashinfer_SOURCE_DIR}/include/flashinfer/math.cuh")
+    file(READ "${FLASHINFER_MATH}" FLASHINFER_MATH_CONTENT)
+    string(REPLACE
+        "ushort y_u16;"
+        "unsigned short y_u16;"
+        FLASHINFER_MATH_CONTENT
+        "${FLASHINFER_MATH_CONTENT}"
+    )
+    file(WRITE "${FLASHINFER_MATH}" "${FLASHINFER_MATH_CONTENT}")
+
+    set(FLASHINFER_PYTORCH_UTILS "${repo-flashinfer_SOURCE_DIR}/csrc/pytorch_extension_utils.h")
+    file(READ "${FLASHINFER_PYTORCH_UTILS}" FLASHINFER_PYTORCH_UTILS_CONTENT)
+    string(REPLACE
+        "FLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)"
+        "#if !defined(_MSC_VER)\nFLASHINFER_EXT_MODULE_INIT_EXPAND(TORCH_EXTENSION_NAME)\n#endif"
+        FLASHINFER_PYTORCH_UTILS_CONTENT
+        "${FLASHINFER_PYTORCH_UTILS_CONTENT}"
+    )
+    file(WRITE "${FLASHINFER_PYTORCH_UTILS}" "${FLASHINFER_PYTORCH_UTILS_CONTENT}")
+endif()
 
 # flash-attention
 FetchContent_Declare(
@@ -96,7 +201,7 @@ if(CCACHE_FOUND AND ENABLE_CCACHE AND DEFINED ENV{CCACHE_DIR})
 endif()
 
 # Configure gencode below SM90
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+if(SGL_KERNEL_IS_ARM64)
     set(DEFAULT_ENABLE_BELOW_SM90 OFF)
     message(STATUS "For aarch64, disable gencode below SM90 by default")
 else()
@@ -106,10 +211,10 @@ endif()
 option(ENABLE_BELOW_SM90 "Enable gencode below SM90" ${DEFAULT_ENABLE_BELOW_SM90})
 
 set(DEFAULT_SGL_KERNEL_ENABLE_FA3 OFF)
-if (CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+if (SGL_KERNEL_IS_ARM64)
     message(STATUS "For aarch64, disable FA3 by default")
 endif()
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4" AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4" AND NOT SGL_KERNEL_IS_ARM64)
     set(DEFAULT_SGL_KERNEL_ENABLE_FA3 ON)
 endif()
 
@@ -122,10 +227,7 @@ set(SGL_KERNEL_CUDA_FLAGS
     "-DNDEBUG"
     "-DOPERATOR_NAMESPACE=sgl-kernel"
     "-O3"
-    "-Xcompiler"
-    "-fPIC"
-    "-gencode=arch=compute_90,code=sm_90"
-    "-std=c++17"
+    "-std=c++${SGL_KERNEL_CXX_STANDARD}"
     "-DFLASHINFER_ENABLE_F16"
     "-DCUTE_USE_PACKED_TUPLE=1"
     "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1"
@@ -141,13 +243,6 @@ set(SGL_KERNEL_CUDA_FLAGS
     # option named SGL_KERNEL_COMPILE_THREADS, default value 32.
     # "--threads=32"
 
-    # Supress warnings
-    "-Xcompiler=-Wno-clang-format-violations"
-    "-Xcompiler=-Wno-conversion"
-    "-Xcompiler=-Wno-deprecated-declarations"
-    "-Xcompiler=-Wno-terminate"
-    "-Xcompiler=-Wfatal-errors"
-    "-Xcompiler=-ftemplate-backtrace-limit=1"
     "-Xcudafe=--diag_suppress=177"   # variable was declared but never referenced
     "-Xcudafe=--diag_suppress=2361"  # invalid narrowing conversion from "char" to "signed char"
 
@@ -155,6 +250,25 @@ set(SGL_KERNEL_CUDA_FLAGS
     # "--ptxas-options=-v"
     # "--ptxas-options=--verbose,--register-usage-level=10,--warn-on-local-memory-usage"
 )
+
+if(MSVC)
+    list(APPEND SGL_KERNEL_CUDA_FLAGS
+        "-Xcompiler=/O2"
+        "-Xcompiler=/EHsc"
+        "-Xcompiler=/DNOMINMAX"
+        "-Xcompiler=/Zc:preprocessor"
+    )
+else()
+    list(APPEND SGL_KERNEL_CUDA_FLAGS
+        "-Xcompiler=-fPIC"
+        "-Xcompiler=-Wno-clang-format-violations"
+        "-Xcompiler=-Wno-conversion"
+        "-Xcompiler=-Wno-deprecated-declarations"
+        "-Xcompiler=-Wno-terminate"
+        "-Xcompiler=-Wfatal-errors"
+        "-Xcompiler=-ftemplate-backtrace-limit=1"
+    )
+endif()
 
 set(SGL_KERNEL_COMPILE_THREADS 32 CACHE STRING "Set compilation threads, default 32")
 
@@ -178,6 +292,22 @@ option(SGL_KERNEL_ENABLE_FA3_SPARSE_MASK  "Enable FA3 sparse mask kernels" OFF)
 option(SGL_KERNEL_ENABLE_SM90A            "Enable SM90A"            OFF)
 option(SGL_KERNEL_ENABLE_SM100A           "Enable SM100A"           OFF)
 
+if(SGL_KERNEL_CUDA_ARCHITECTURES)
+    string(REPLACE "," ";" SGL_KERNEL_CUDA_ARCH_LIST "${SGL_KERNEL_CUDA_ARCHITECTURES}")
+    foreach(SGL_KERNEL_CUDA_ARCH IN LISTS SGL_KERNEL_CUDA_ARCH_LIST)
+        string(STRIP "${SGL_KERNEL_CUDA_ARCH}" SGL_KERNEL_CUDA_ARCH)
+        if(NOT SGL_KERNEL_CUDA_ARCH MATCHES "^[0-9]+[af]?$")
+            message(FATAL_ERROR "Invalid CUDA architecture '${SGL_KERNEL_CUDA_ARCH}'")
+        endif()
+        list(APPEND SGL_KERNEL_CUDA_FLAGS
+            "-gencode=arch=compute_${SGL_KERNEL_CUDA_ARCH},code=sm_${SGL_KERNEL_CUDA_ARCH}"
+        )
+    endforeach()
+    message(STATUS "Using explicit CUDA architectures: ${SGL_KERNEL_CUDA_ARCH_LIST}")
+else()
+    list(APPEND SGL_KERNEL_CUDA_FLAGS "-gencode=arch=compute_90,code=sm_90")
+endif()
+
 if (SGL_KERNEL_ENABLE_BF16)
     list(APPEND SGL_KERNEL_CUDA_FLAGS
         "-DFLASHINFER_ENABLE_BF16"
@@ -192,12 +322,12 @@ if (SGL_KERNEL_ENABLE_FP8)
     )
 endif()
 
-if (ENABLE_BELOW_SM90)
+if (NOT SGL_KERNEL_CUDA_ARCHITECTURES AND ENABLE_BELOW_SM90)
     list(APPEND SGL_KERNEL_CUDA_FLAGS
         "-gencode=arch=compute_80,code=sm_80"
         "-gencode=arch=compute_89,code=sm_89"
     )
-    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    if (SGL_KERNEL_IS_ARM64)
         list(APPEND SGL_KERNEL_CUDA_FLAGS
             "-gencode=arch=compute_87,code=sm_87"
         )
@@ -205,9 +335,9 @@ if (ENABLE_BELOW_SM90)
 
 endif()
 
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
+if (NOT SGL_KERNEL_CUDA_ARCHITECTURES AND ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A))
     # sm_100f is available in CUDA 12.9+ and covers all sm_100, sm_103, sm_107, sm_10x
-    if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.9")
+    if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.9")
         list(APPEND SGL_KERNEL_CUDA_FLAGS
             "-gencode=arch=compute_100f,code=sm_100f"
         )
@@ -220,18 +350,18 @@ if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
         "-gencode=arch=compute_120a,code=sm_120a"
     )
     # refer sm_121, sm_110 and sm_101 description  https://github.com/pytorch/pytorch/pull/156176
-    if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
+    if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "13.0")
         list(APPEND SGL_KERNEL_CUDA_FLAGS
             "--compress-mode=size"
         )
-        if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        if (SGL_KERNEL_IS_ARM64)
             list(APPEND SGL_KERNEL_CUDA_FLAGS
                 "-gencode=arch=compute_110a,code=sm_110a"
                 "-gencode=arch=compute_121a,code=sm_121a"
             )
         endif()
     else()
-        if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+        if (SGL_KERNEL_IS_ARM64)
             list(APPEND SGL_KERNEL_CUDA_FLAGS
                 "-gencode=arch=compute_101a,code=sm_101a"
             )
@@ -239,13 +369,13 @@ if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
     endif()
 endif()
 
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4" AND SGL_KERNEL_ENABLE_FA3)
+if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.4" AND SGL_KERNEL_ENABLE_FA3)
     list(APPEND SGL_KERNEL_CUDA_FLAGS
         "-gencode=arch=compute_90a,code=sm_90a"
     )
 endif()
 
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
+if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_FP4)
     list(APPEND SGL_KERNEL_CUDA_FLAGS
         "-DENABLE_NVFP4=1"
     )
@@ -255,7 +385,6 @@ endif()
 # NOTE: Please sort the filenames alphabetically
 set(SOURCES
     "csrc/allreduce/custom_all_reduce.cu"
-    "csrc/attention/cutlass_mla_kernel.cu"
     "csrc/attention/merge_attn_states.cu"
     "csrc/attention/vertical_slash_index.cu"
     "csrc/common_extension.cc"
@@ -266,35 +395,22 @@ set(SOURCES
     "csrc/elementwise/fused_add_rms_norm_kernel.cu"
     "csrc/elementwise/pos_enc.cu"
     "csrc/elementwise/topk.cu"
-    "csrc/expert_specialization/es_fp8_blockwise.cu"
-    "csrc/expert_specialization/es_sm100_mxfp8_blockscaled.cu"
-    "csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cu"
-
-    "csrc/gemm/awq_kernel.cu"
-    "csrc/gemm/fp8_gemm_kernel.cu"
-    "csrc/gemm/int8_gemm_kernel.cu"
     "csrc/gemm/per_token_group_quant_8bit.cu"
     "csrc/gemm/per_token_group_quant_8bit_v2.cu"
     "csrc/gemm/per_token_quant_fp8.cu"
-    "csrc/gemm/gptq/gptq_kernel.cu"
     "csrc/grammar/apply_token_bitmask_inplace_cuda.cu"
 
     "csrc/infllm_v2/max_pooling.cu"
 
     "csrc/kvcacheio/transfer.cu"
-    "csrc/mamba/causal_conv1d.cu"
     "csrc/memory/weak_ref_tensor.cpp"
 
-    "csrc/moe/cutlass_moe/w4a8/scaled_mm_entry.cu"
-    "csrc/moe/cutlass_moe/w4a8/w4a8_moe_data.cu"
-    "csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu"
     "csrc/moe/moe_align_kernel.cu"
     "csrc/moe/fused_qknorm_rope_kernel.cu"
     "csrc/moe/moe_sum.cu"
     "csrc/moe/moe_sum_reduce.cu"
     "csrc/moe/moe_topk_softmax_kernels.cu"
     "csrc/moe/moe_topk_sigmoid_kernels.cu"
-    "csrc/moe/fp8_blockwise_moe_kernel.cu"
     "csrc/moe/prepare_moe_input.cu"
 
     "csrc/quantization/gguf/gguf_kernel.cu"
@@ -305,14 +421,38 @@ set(SOURCES
 
     "${repo-flashinfer_SOURCE_DIR}/csrc/norm.cu"
     "${repo-flashinfer_SOURCE_DIR}/csrc/renorm.cu"
-
-    "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_bf16_causal_sm80.cu"
-    "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_bf16_sm80.cu"
-    "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_fp16_causal_sm80.cu"
-    "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_fp16_sm80.cu"
-    "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/flash_sparse_api.cpp"
 )
 
+if(SGL_KERNEL_ENABLE_CUTLASS_MLA)
+    list(APPEND SOURCES "csrc/attention/cutlass_mla_kernel.cu")
+endif()
+
+if(SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS)
+    list(APPEND SOURCES
+        "csrc/expert_specialization/es_fp8_blockwise.cu"
+        "csrc/expert_specialization/es_sm100_mxfp8_blockscaled.cu"
+        "csrc/expert_specialization/es_sm100_mxfp8_blockscaled_group_quant.cu"
+        "csrc/gemm/awq_kernel.cu"
+        "csrc/gemm/fp8_gemm_kernel.cu"
+        "csrc/gemm/int8_gemm_kernel.cu"
+        "csrc/gemm/gptq/gptq_kernel.cu"
+        "csrc/mamba/causal_conv1d.cu"
+        "csrc/moe/cutlass_moe/w4a8/scaled_mm_entry.cu"
+        "csrc/moe/cutlass_moe/w4a8/w4a8_moe_data.cu"
+        "csrc/moe/cutlass_moe/w4a8/w4a8_grouped_mm_c3x.cu"
+        "csrc/moe/fp8_blockwise_moe_kernel.cu"
+    )
+endif()
+
+if(SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN)
+    list(APPEND SOURCES
+        "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_bf16_causal_sm80.cu"
+        "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_bf16_sm80.cu"
+        "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_fp16_causal_sm80.cu"
+        "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/src/flash_fwd_sparse_hdim128_fp16_sm80.cu"
+        "${repo-flash-attention_SOURCE_DIR}/csrc/flash_attn/flash_sparse_api.cpp"
+    )
+endif()
 set(INCLUDES
     ${repo-cutlass_SOURCE_DIR}/include
     ${repo-cutlass_SOURCE_DIR}/tools/util/include
@@ -325,17 +465,20 @@ set(INCLUDES
 
 # =========================== Common SM90 Build ============================= #
 # Build SM90 library with fast math optimization (same namespace, different directory)
-Python_add_library(common_ops_sm90_build MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SOURCES})
-
-target_compile_options(common_ops_sm90_build PRIVATE
-    $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS} -use_fast_math>
-)
-target_include_directories(common_ops_sm90_build PRIVATE ${INCLUDES})
-# Set output name and separate build directory to avoid conflicts
-set_target_properties(common_ops_sm90_build PROPERTIES
-    OUTPUT_NAME "common_ops"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm90"
-)
+set(SGL_KERNEL_COMMON_TARGETS)
+if(SGL_KERNEL_BUILD_SM90)
+    Python_add_library(common_ops_sm90_build MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SOURCES})
+    target_compile_options(common_ops_sm90_build PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS} -use_fast_math>
+    )
+    target_include_directories(common_ops_sm90_build PRIVATE ${INCLUDES})
+    set_target_properties(common_ops_sm90_build PROPERTIES
+        OUTPUT_NAME "common_ops"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm90"
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm90"
+    )
+    list(APPEND SGL_KERNEL_COMMON_TARGETS common_ops_sm90_build)
+endif()
 
 # =========================== Common SM100+ Build ============================= #
 # Build SM100+ library with precise math (same namespace, different directory)
@@ -349,44 +492,85 @@ target_include_directories(common_ops_sm100_build PRIVATE ${INCLUDES})
 set_target_properties(common_ops_sm100_build PROPERTIES
     OUTPUT_NAME "common_ops"
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm100"
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/sm100"
 )
+list(APPEND SGL_KERNEL_COMMON_TARGETS common_ops_sm100_build)
 
-find_package(Python3 COMPONENTS Interpreter REQUIRED)
-execute_process(
-    COMMAND ${Python3_EXECUTABLE} -c "import torch; print(int(torch._C._GLIBCXX_USE_CXX11_ABI))"
-    OUTPUT_VARIABLE TORCH_CXX11_ABI
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-if(TORCH_CXX11_ABI STREQUAL "0")
-    message(STATUS "Using old C++ ABI (-D_GLIBCXX_USE_CXX11_ABI=0)")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
-else()
-    message(STATUS "Using new C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI=1)")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
-    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+if(NOT MSVC)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    execute_process(
+        COMMAND ${Python3_EXECUTABLE} -c "import torch; print(int(torch._C._GLIBCXX_USE_CXX11_ABI))"
+        OUTPUT_VARIABLE TORCH_CXX11_ABI
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(TORCH_CXX11_ABI STREQUAL "0")
+        message(STATUS "Using old C++ ABI (-D_GLIBCXX_USE_CXX11_ABI=0)")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=0")
+    else()
+        message(STATUS "Using new C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI=1)")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+        set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -D_GLIBCXX_USE_CXX11_ABI=1")
+    endif()
 endif()
 
-target_link_libraries(common_ops_sm90_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt)
-target_link_libraries(common_ops_sm100_build PRIVATE ${TORCH_LIBRARIES} c10 cuda cublas cublasLt)
+foreach(SGL_KERNEL_COMMON_TARGET IN LISTS SGL_KERNEL_COMMON_TARGETS)
+    target_link_libraries(
+        ${SGL_KERNEL_COMMON_TARGET}
+        PRIVATE
+        ${TORCH_LIBRARIES}
+        c10
+        CUDA::cuda_driver
+        CUDA::cudart
+        CUDA::cublas
+        CUDA::cublasLt
+    )
+    target_compile_definitions(
+        ${SGL_KERNEL_COMMON_TARGET}
+        PRIVATE
+        FLASHATTENTION_DISABLE_BACKWARD
+        FLASHATTENTION_DISABLE_DROPOUT
+        FLASHATTENTION_DISABLE_UNEVEN_K
+    )
+    if(SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN)
+        target_compile_definitions(
+            ${SGL_KERNEL_COMMON_TARGET}
+            PRIVATE
+            SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN
+        )
+    endif()
+    if(SGL_KERNEL_ENABLE_CUTLASS_MLA)
+        target_compile_definitions(
+            ${SGL_KERNEL_COMMON_TARGET}
+            PRIVATE
+            SGL_KERNEL_ENABLE_CUTLASS_MLA
+        )
+    endif()
+    if(SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS)
+        target_compile_definitions(
+            ${SGL_KERNEL_COMMON_TARGET}
+            PRIVATE
+            SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
+        )
+    endif()
+endforeach()
 
 # sparse flash attention
-target_compile_definitions(common_ops_sm90_build PRIVATE
-    FLASHATTENTION_DISABLE_BACKWARD
-    FLASHATTENTION_DISABLE_DROPOUT
-    FLASHATTENTION_DISABLE_UNEVEN_K
-)
-target_compile_definitions(common_ops_sm100_build PRIVATE
-    FLASHATTENTION_DISABLE_BACKWARD
-    FLASHATTENTION_DISABLE_DROPOUT
-    FLASHATTENTION_DISABLE_UNEVEN_K
-)
-
 # Install to different subdirectories
 # CMake will find the built libraries in their respective LIBRARY_OUTPUT_DIRECTORY locations
 # and install them to the specified destinations
-install(TARGETS common_ops_sm90_build LIBRARY DESTINATION sgl_kernel/sm90)
-install(TARGETS common_ops_sm100_build LIBRARY DESTINATION sgl_kernel/sm100)
+if(SGL_KERNEL_BUILD_SM90)
+    install(
+        TARGETS common_ops_sm90_build
+        LIBRARY DESTINATION sgl_kernel/sm90
+        RUNTIME DESTINATION sgl_kernel/sm90
+    )
+endif()
+install(
+    TARGETS common_ops_sm100_build
+    LIBRARY DESTINATION sgl_kernel/sm100
+    RUNTIME DESTINATION sgl_kernel/sm100
+)
 
 # ============================ Optional Install: FA3 ============================= #
 # set flash-attention sources file
@@ -490,6 +674,7 @@ endif()
 # vendored static_switch.h forces bf16 and dispatches headdim to {64, 128}
 # only). Backward kernels are intentionally omitted because SGLang only uses
 # these ops for inference.
+if(SGL_KERNEL_BUILD_INFLLM)
 set(INFLLM_FLASH_CUDA_FLAGS
     "-DNDEBUG"
     "-O3"
@@ -517,7 +702,7 @@ if (ENABLE_BELOW_SM90)
     list(APPEND INFLLM_FLASH_CUDA_FLAGS "-gencode=arch=compute_80,code=sm_80")
 endif()
 list(APPEND INFLLM_FLASH_CUDA_FLAGS "-gencode=arch=compute_90,code=sm_90")
-if ("${CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
+if ("${SGL_KERNEL_CUDA_VERSION}" VERSION_GREATER_EQUAL "12.8" OR SGL_KERNEL_ENABLE_SM100A)
     list(APPEND INFLLM_FLASH_CUDA_FLAGS "-gencode=arch=compute_120a,code=sm_120a")
 endif()
 
@@ -542,9 +727,15 @@ target_include_directories(infllm_ops PRIVATE
 # THPGeneratorClass from libtorch_python (not part of TORCH_LIBRARIES).
 find_library(TORCH_PYTHON_LIBRARY torch_python PATHS "${TORCH_INSTALL_PREFIX}/lib" REQUIRED)
 target_link_libraries(infllm_ops PRIVATE ${TORCH_LIBRARIES} ${TORCH_PYTHON_LIBRARY} c10 cuda)
-install(TARGETS infllm_ops LIBRARY DESTINATION "sgl_kernel")
+install(
+    TARGETS infllm_ops
+    LIBRARY DESTINATION "sgl_kernel"
+    RUNTIME DESTINATION "sgl_kernel"
+)
+endif()
 
 # Build spatial_ops as a separate, optional extension for green contexts
+if(SGL_KERNEL_BUILD_SPATIAL)
 set(SPATIAL_SOURCES
     "csrc/spatial/greenctx_stream.cu"
     "csrc/spatial_extension.cc"
@@ -553,13 +744,22 @@ set(SPATIAL_SOURCES
 Python_add_library(spatial_ops MODULE USE_SABI ${SKBUILD_SABI_VERSION} WITH_SOABI ${SPATIAL_SOURCES})
 target_compile_options(spatial_ops PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:${SGL_KERNEL_CUDA_FLAGS}>)
 target_link_libraries(spatial_ops PRIVATE ${TORCH_LIBRARIES} c10 cuda)
-install(TARGETS spatial_ops LIBRARY DESTINATION sgl_kernel)
+install(
+    TARGETS spatial_ops
+    LIBRARY DESTINATION sgl_kernel
+    RUNTIME DESTINATION sgl_kernel
+)
+endif()
 
 # ============================ Extra Install: FLashMLA ============================= #
+if(SGL_KERNEL_BUILD_FLASHMLA)
 include(${CMAKE_CURRENT_LIST_DIR}/cmake/flashmla.cmake)
+endif()
 
 # ============================ Extra Install: triton kernels ============================= #
+if(SGL_KERNEL_INSTALL_TRITON_KERNELS)
 install(DIRECTORY "${repo-triton_SOURCE_DIR}/python/triton_kernels/triton_kernels/"
         DESTINATION "triton_kernels"
         PATTERN ".git*" EXCLUDE
         PATTERN "__pycache__" EXCLUDE)
+endif()

--- a/python/sglang/kernels/aot/README.md
+++ b/python/sglang/kernels/aot/README.md
@@ -44,6 +44,33 @@ make build MAX_JOBS=2
 make build MAX_JOBS=2 CMAKE_ARGS="-DSGL_KERNEL_COMPILE_THREADS=1"
 ```
 
+### Windows ARM64
+
+Windows ARM64 builds require native ARM64 Python, CUDA-enabled ARM64 PyTorch,
+CUDA Toolkit 13+, and Visual Studio Build Tools with the ARM64 C++ toolchain.
+The Windows wheel intentionally contains the SM100+ `common_ops` module and
+omits optional Linux-oriented modules (FA3, FlashMLA, InfLLM-V2, spatial ops,
+and bundled Triton kernels).
+
+```powershell
+.\build_windows_arm64.ps1 `
+  -Python python `
+  -Wheelhouse C:\path\to\arm64\wheelhouse `
+  -CudaArchitectures 121a
+```
+
+Run the Windows ARM64 smoke test after installing the wheel:
+
+```powershell
+python -m pip install --force-reinstall --no-deps .\dist\sglang_kernel-*-win_arm64.whl
+python -m pytest --confcutdir .\tests\windows .\tests\windows\test_windows_arm64_smoke.py
+```
+
+GitHub-hosted Windows ARM64 runners currently do not include the Windows ARM64
+CUDA Toolkit, and PyTorch does not publish a Windows ARM64 wheel. The build must
+therefore run on a CUDA-enabled Windows ARM64 runner with a compatible PyTorch
+wheel preinstalled.
+
 ## Contribution
 
 ### Steps to add a new kernel:

--- a/python/sglang/kernels/aot/build_windows_arm64.ps1
+++ b/python/sglang/kernels/aot/build_windows_arm64.ps1
@@ -1,0 +1,131 @@
+param(
+    [string]$Python = "python",
+    [string]$Wheelhouse = "",
+    [string]$CudaArchitectures = "121a",
+    [int]$BuildJobs = 2,
+    [int]$NvccThreads = 2,
+    [string]$BuildDir = "",
+    [string]$OutDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$AotRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+if (-not $OutDir) {
+    $OutDir = Join-Path $AotRoot "dist"
+}
+$OutDir = [IO.Path]::GetFullPath($OutDir)
+if (-not $BuildDir) {
+    $BuildDir = Join-Path $env:TEMP "sgl-kernel-winarm64-build"
+}
+$BuildDir = [IO.Path]::GetFullPath($BuildDir)
+
+$PythonCommand = Get-Command $Python -ErrorAction Stop
+$PythonExe = $PythonCommand.Source
+if (-not $PythonExe) {
+    $PythonExe = $PythonCommand.Path
+}
+
+& $PythonExe -c "import platform, sysconfig; assert platform.machine().lower() == 'arm64', platform.machine(); assert sysconfig.get_platform() == 'win-arm64', sysconfig.get_platform()"
+if ($LASTEXITCODE -ne 0) {
+    throw "A native Windows ARM64 Python interpreter is required."
+}
+
+& $PythonExe -m pip --version *> $null
+if ($LASTEXITCODE -ne 0) {
+    & $PythonExe -m ensurepip --upgrade
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to bootstrap pip in the selected Python environment."
+    }
+}
+
+try {
+    & $PythonExe -c "import torch; assert torch.version.cuda is not None; print(f'PyTorch {torch.__version__}, CUDA {torch.version.cuda}')"
+    if ($LASTEXITCODE -ne 0) {
+        throw "PyTorch validation failed."
+    }
+} catch {
+    if (-not $Wheelhouse) {
+        throw "CUDA-enabled Windows ARM64 PyTorch is required. Pass -Wheelhouse with a compatible torch wheel."
+    }
+    $TorchWheel = Get-ChildItem -LiteralPath $Wheelhouse -Filter "torch-*.whl" |
+        Sort-Object Name -Descending |
+        Select-Object -First 1
+    if (-not $TorchWheel) {
+        throw "No torch wheel was found in $Wheelhouse."
+    }
+    & $PythonExe -m pip install --pre $TorchWheel.FullName
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failed to install $($TorchWheel.Name)."
+    }
+}
+
+& $PythonExe -m pip install "build>=1.2" "scikit-build-core>=0.10" "cmake>=3.31,<4" ninja numpy wheel
+if ($LASTEXITCODE -ne 0) {
+    throw "Failed to install build dependencies."
+}
+
+$TorchCmakePrefix = & $PythonExe -c "import torch; print(torch.utils.cmake_prefix_path)"
+if ($LASTEXITCODE -ne 0 -or -not $TorchCmakePrefix) {
+    throw "Could not determine the PyTorch CMake prefix."
+}
+
+$CudaPath = $env:CUDA_PATH
+if (-not $CudaPath) {
+    $Nvcc = Get-Command nvcc -ErrorAction Stop
+    $CudaPath = Split-Path -Parent (Split-Path -Parent $Nvcc.Source)
+}
+if (-not (Test-Path (Join-Path $CudaPath "bin\nvcc.exe"))) {
+    throw "CUDA Toolkit was not found under $CudaPath."
+}
+
+$Vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+if (-not (Test-Path $Vswhere)) {
+    throw "vswhere.exe was not found. Install Visual Studio Build Tools with ARM64 C++ support."
+}
+$VsPath = & $Vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath
+if (-not $VsPath) {
+    throw "Visual Studio ARM64 C++ build tools were not found."
+}
+$Vcvars = Join-Path $VsPath "VC\Auxiliary\Build\vcvarsall.bat"
+
+New-Item -ItemType Directory -Force -Path $OutDir | Out-Null
+$CmakeArgs = @(
+    "-DCMAKE_CUDA_ARCHITECTURES=OFF",
+    "-DSGL_KERNEL_CUDA_ARCHITECTURES=$CudaArchitectures",
+    "-DSGL_KERNEL_COMPILE_THREADS=$NvccThreads",
+    "-DSGL_KERNEL_BUILD_SM90=OFF",
+    "-DSGL_KERNEL_ENABLE_FA3=OFF",
+    "-DSGL_KERNEL_BUILD_INFLLM=OFF",
+    "-DSGL_KERNEL_BUILD_SPATIAL=OFF",
+    "-DSGL_KERNEL_BUILD_FLASHMLA=OFF",
+    "-DSGL_KERNEL_INSTALL_TRITON_KERNELS=OFF",
+    "-DSGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN=OFF",
+    "-DSGL_KERNEL_ENABLE_CUTLASS_MLA=OFF",
+    "-DSGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS=OFF"
+) -join " "
+
+$BuildCommand = @(
+    "set `"PATH=$(Split-Path -Parent $Vswhere);%PATH%`"",
+    "call `"$Vcvars`" arm64",
+    "set `"CUDA_PATH=$CudaPath`"",
+    "set `"CMAKE_PREFIX_PATH=$TorchCmakePrefix`"",
+    "set `"CMAKE_GENERATOR=Ninja`"",
+    "set `"CMAKE_BUILD_PARALLEL_LEVEL=$BuildJobs`"",
+    "set `"TORCH_CUDA_ARCH_LIST=12.1`"",
+    "set `"CMAKE_ARGS=$CmakeArgs`"",
+    "cd /d `"$AotRoot`"",
+    "`"$PythonExe`" -m build --wheel --no-isolation -Cbuild-dir=`"$BuildDir`" --outdir `"$OutDir`""
+) -join " && "
+
+& $env:ComSpec /d /s /c $BuildCommand
+if ($LASTEXITCODE -ne 0) {
+    throw "Windows ARM64 sglang-kernel build failed with exit code $LASTEXITCODE."
+}
+
+$Wheels = @(Get-ChildItem -LiteralPath $OutDir -Filter "*win_arm64.whl")
+if ($Wheels.Count -ne 1) {
+    throw "Expected one Windows ARM64 wheel in $OutDir, found $($Wheels.Count)."
+}
+Write-Output "Built $($Wheels[0].FullName)"

--- a/python/sglang/kernels/aot/csrc/allreduce/custom_all_reduce.cuh
+++ b/python/sglang/kernels/aot/csrc/allreduce/custom_all_reduce.cuh
@@ -288,7 +288,7 @@ __global__ void __launch_bounds__(kMaxThreadsPerBlock, 1) custom_all_reduce_2sho
   const int32_t group_id = tidx >> group_stride_sft;
   const int32_t coalesce_tid = tidx & (coalesce_num - 1);
 
-  typedef int16_t Vec __attribute__((vector_size(16)));
+  using Vec = uint4;
 
   const int32_t stride = gridDim.x * thread_num;
   int32_t idx_base = bidx * thread_num;

--- a/python/sglang/kernels/aot/csrc/attention/merge_attn_states.cu
+++ b/python/sglang/kernels/aot/csrc/attention/merge_attn_states.cu
@@ -1,7 +1,9 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
+#include <math_constants.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <optional>
 
 #include "pytorch_extension_utils.h"
@@ -28,7 +30,7 @@ inline __device__ void from_float(__nv_bfloat16& d, float s) {
 }
 
 // Implements section 2.2 of https://www.arxiv.org/pdf/2501.01005
-template <typename scalar_t, const uint NUM_THREADS>
+template <typename scalar_t, const uint32_t NUM_THREADS>
 __global__ void merge_attn_states_kernel(
     scalar_t* output,
     float* output_lse,
@@ -36,27 +38,27 @@ __global__ void merge_attn_states_kernel(
     const float* prefix_lse,
     const scalar_t* suffix_output,
     const float* suffix_lse,
-    const uint num_tokens,
-    const uint num_heads,
-    const uint head_size) {
+    const uint32_t num_tokens,
+    const uint32_t num_heads,
+    const uint32_t head_size) {
   using pack_128b_t = uint4;
-  const uint pack_size = 16 / sizeof(scalar_t);
-  const uint threads_per_head = head_size / pack_size;
+  const uint32_t pack_size = 16 / sizeof(scalar_t);
+  const uint32_t threads_per_head = head_size / pack_size;
 
-  const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
-  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
+  const uint32_t global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
+  const uint32_t token_head_threads = num_tokens * num_heads * threads_per_head;
 
   if (global_idx >= token_head_threads) return;
 
   // global_idx -> token_idx + head_idx + pack_idx
-  const uint token_head_idx = global_idx / threads_per_head;
-  const uint pack_idx = global_idx % threads_per_head;
+  const uint32_t token_head_idx = global_idx / threads_per_head;
+  const uint32_t pack_idx = global_idx % threads_per_head;
 
-  const uint token_idx = token_head_idx / num_heads;
-  const uint head_idx = token_head_idx % num_heads;
+  const uint32_t token_idx = token_head_idx / num_heads;
+  const uint32_t head_idx = token_head_idx % num_heads;
 
-  const uint pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
-  const uint head_offset = token_idx * num_heads * head_size + head_idx * head_size;
+  const uint32_t pack_offset = pack_idx * pack_size;  // (0~15)*8, etc.
+  const uint32_t head_offset = token_idx * num_heads * head_size + head_idx * head_size;
   const scalar_t* prefix_head_ptr = prefix_output + head_offset;
   const scalar_t* suffix_head_ptr = suffix_output + head_offset;
   scalar_t* output_head_ptr = output + head_offset;
@@ -65,8 +67,8 @@ __global__ void merge_attn_states_kernel(
   // float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
   float p_lse = prefix_lse[token_idx * num_heads + head_idx];
   float s_lse = suffix_lse[token_idx * num_heads + head_idx];
-  p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
-  s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+  p_lse = isinf(p_lse) ? -CUDART_INF_F : p_lse;
+  s_lse = isinf(s_lse) ? -CUDART_INF_F : s_lse;
 
   const float max_lse = fmaxf(p_lse, s_lse);
   p_lse = p_lse - max_lse;
@@ -84,7 +86,7 @@ __global__ void merge_attn_states_kernel(
     pack_128b_t o_out_pack;
 
 #pragma unroll
-    for (uint i = 0; i < pack_size; ++i) {
+    for (uint32_t i = 0; i < pack_size; ++i) {
       // Always use float for FMA to keep high precision.
       // half(uint16_t), bfloat16, float -> float.
       const float p_out_f = to_float(reinterpret_cast<const scalar_t*>(&p_out_pack)[i]);
@@ -156,16 +158,16 @@ void merge_attn_states_launcher(
     at::Tensor& output,               // [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
     at::Tensor& output_lse            // [NUM_TOKENS, NUM_HEADS]
 ) {
-  constexpr uint NUM_THREADS = 128;
-  const uint num_tokens = output.size(0);
-  const uint num_heads = output.size(1);
-  const uint head_size = output.size(2);
-  const uint pack_size = 16 / sizeof(scalar_t);
+  constexpr uint32_t NUM_THREADS = 128;
+  const uint32_t num_tokens = output.size(0);
+  const uint32_t num_heads = output.size(1);
+  const uint32_t head_size = output.size(2);
+  const uint32_t pack_size = 16 / sizeof(scalar_t);
   TORCH_CHECK(head_size % pack_size == 0, "headsize must be multiple of pack_size:", pack_size);
   // Process one pack elements per thread. for float, the
   // pack_size is 4 for half/bf16, the pack_size is 8.
-  const uint threads_per_head = head_size / pack_size;
-  const uint total_threads = num_tokens * num_heads * threads_per_head;
+  const uint32_t threads_per_head = head_size / pack_size;
+  const uint32_t total_threads = num_tokens * num_heads * threads_per_head;
 
   dim3 block(NUM_THREADS);
   dim3 grid((total_threads + NUM_THREADS - 1) / NUM_THREADS);

--- a/python/sglang/kernels/aot/csrc/common_extension.cc
+++ b/python/sglang/kernels/aot/csrc/common_extension.cc
@@ -43,11 +43,13 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
    */
   m.def("merge_state_v2(Tensor v_a, Tensor s_a, Tensor v_b, Tensor s_b, Tensor! v_merged, Tensor! s_merged) -> ()");
   m.impl("merge_state_v2", torch::kCUDA, &merge_state_v2);
+#ifdef SGL_KERNEL_ENABLE_CUTLASS_MLA
   m.def(
       "cutlass_mla_decode(Tensor! out, Tensor q_nope, Tensor q_pe, Tensor kv_c_and_k_pe_cache, Tensor seq_lens, Tensor "
       "page_table, Tensor! workspace, float sm_scale, int num_kv_splits) -> ()");
   m.impl("cutlass_mla_decode", torch::kCUDA, &cutlass_mla_decode);
   m.def("cutlass_mla_get_workspace_size", &cutlass_mla_get_workspace_size);
+#endif
 
   /*
    * From csrc/infllm_v2
@@ -110,6 +112,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From csrc/gemm
    */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def("awq_dequantize(Tensor qweight, Tensor scales, Tensor qzeros) -> Tensor");
   m.impl("awq_dequantize", torch::kCUDA, &awq_dequantize);
 
@@ -122,6 +125,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "fp8_scaled_mm(Tensor mat_a, Tensor mat_b, Tensor scales_a, Tensor scales_b, ScalarType out_dtype, Tensor? "
       "bias) -> Tensor");
   m.impl("fp8_scaled_mm", torch::kCUDA, &fp8_scaled_mm);
+#endif
 
   m.def(
       "sgl_per_token_group_quant_8bit(Tensor input, Tensor! output_q, Tensor! output_s, int group_size,"
@@ -141,6 +145,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From csrc/gemm/gptq
    */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def(
       "gptq_gemm(Tensor a, Tensor b_q_weight, Tensor b_gptq_qzeros, Tensor b_gptq_scales, Tensor b_g_idx, bool "
       "use_shuffle, int bit) -> Tensor");
@@ -148,6 +153,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
 
   m.def("gptq_shuffle(Tensor! q_weight, Tensor q_perm, int bit) -> ()");
   m.impl("gptq_shuffle", torch::kCUDA, &gptq_shuffle);
+#endif
 
   /*
    * From csrc/moe
@@ -178,12 +184,14 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   // now routes through the unified Triton router
   // (python/sglang/kernels/ops/moe/moe_fused_gate.py).
 
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def(
       "fp8_blockwise_scaled_grouped_mm(Tensor output, Tensor a_ptrs, Tensor b_ptrs, Tensor out_ptrs, Tensor "
       "a_scales_ptrs, Tensor b_scales_ptrs, Tensor a, Tensor b, Tensor scales_a, Tensor scales_b, Tensor "
       "stride_a, Tensor stride_b, Tensor stride_c, Tensor layout_sfa, Tensor layout_sfb, Tensor problem_sizes, Tensor "
       "expert_offsets, Tensor workspace) -> ()");
   m.impl("fp8_blockwise_scaled_grouped_mm", torch::kCUDA, &fp8_blockwise_scaled_grouped_mm);
+#endif
 
   m.def(
       "prepare_moe_input(Tensor topk_ids, Tensor expert_offsets, Tensor? blockscale_offsets, Tensor problem_sizes1,"
@@ -223,6 +231,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From csrc/moe/cutlass_moe/w4a8
    */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def(
       "get_cutlass_w4a8_moe_mm_data(Tensor topk_ids, Tensor! expert_offsets, "
       "                        Tensor! problem_sizes1, Tensor! problem_sizes2, "
@@ -238,6 +247,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "               Tensor b_strides, Tensor d_strides, Tensor s_strides,"
       "               int chunk_size, int topk) -> ()");
   m.impl("cutlass_w4a8_moe_mm", torch::kCUDA, &cutlass_w4a8_moe_mm);
+#endif
 
   /*
    * From csrc/speculative
@@ -352,6 +362,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From Sparse Flash Attention
    */
+#ifdef SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN
   m.def(
       "fwd_sparse(Tensor! q, Tensor k, Tensor v, "
       "Tensor block_count, Tensor block_offset, Tensor column_count, Tensor column_index, "
@@ -392,6 +403,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "   int context_size, int block_size_M, int block_size_N, "
       "   bool causal) -> ()");
   m.impl("convert_vertical_slash_indexes_mergehead", torch::kCUDA, &convert_vertical_slash_indexes_mergehead);
+#endif
 
   /*
    * From csrc/grammar
@@ -434,6 +446,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
   /*
    * From csrc/mamba
    */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def(
       "causal_conv1d_update(Tensor! x,"
       "Tensor! conv_state,"
@@ -455,10 +468,12 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "bool silu_activation,"
       "int pad_slot_id) -> ()");
   m.impl("causal_conv1d_fwd", torch::kCUDA, &causal_conv1d_fwd);
+#endif
 
   /*
    * From csrc/expert_sepcialization
    */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
   m.def(
       "es_fp8_blockwise_scaled_grouped_mm(Tensor output, Tensor a, Tensor b, Tensor scales_a, Tensor scales_b, Tensor "
       "stride_a, Tensor stride_b, Tensor stride_d, Tensor problem_sizes, Tensor expert_offsets, Tensor workspace) -> "
@@ -472,6 +487,7 @@ TORCH_LIBRARY_FRAGMENT(sgl_kernel, m) {
       "es_sm100_mxfp8_blockscaled_grouped_quant(Tensor input, Tensor problem_sizes, Tensor expert_offsets, Tensor "
       "blockscale_offsets, Tensor quant_output, Tensor scale_factor) -> () ");
   m.impl("es_sm100_mxfp8_blockscaled_grouped_quant", &es_sm100_mxfp8_blockscaled_grouped_quant);
+#endif
 }
 
 REGISTER_EXTENSION(common_ops)

--- a/python/sglang/kernels/aot/csrc/elementwise/activation.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/activation.cu
@@ -28,6 +28,12 @@
 #include "hip/hip_act_and_mul.cuh"
 #endif
 
+#if defined(USE_ROCM)
+#define SGL_ACTIVATION_NAMESPACE sgl_hip::activation
+#else
+#define SGL_ACTIVATION_NAMESPACE flashinfer::activation
+#endif
+
 // Adapted from flashinfer activation
 // https://github.com/flashinfer-ai/flashinfer/blob/4e8eb1879f9c3ba6d75511e5893183bf8f289a62/csrc/activation.cu#L44
 
@@ -93,13 +99,8 @@ void silu_and_mul(at::Tensor& out, at::Tensor& input) {
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     dim3 block(std::min(d / vec_size, 1024U));
-#if USE_ROCM
-    sgl_hip::activation::act_and_mul_kernel<c_type, silu>
+    SGL_ACTIVATION_NAMESPACE::act_and_mul_kernel<c_type, silu>
         <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#else
-    flashinfer::activation::act_and_mul_kernel<c_type, silu>
-        <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#endif
     return true;
   });
 }
@@ -115,13 +116,8 @@ void gelu_tanh_and_mul(at::Tensor& out, at::Tensor& input) {
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     dim3 block(std::min(d / vec_size, 1024U));
-#if USE_ROCM
-    sgl_hip::activation::act_and_mul_kernel<c_type, gelu_tanh>
+    SGL_ACTIVATION_NAMESPACE::act_and_mul_kernel<c_type, gelu_tanh>
         <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#else
-    flashinfer::activation::act_and_mul_kernel<c_type, gelu_tanh>
-        <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#endif
     return true;
   });
 }
@@ -137,13 +133,8 @@ void gelu_and_mul(at::Tensor& out, at::Tensor& input) {
   DISPATCH_PYTORCH_DTYPE_TO_CTYPE_FLOAT_FP16(input.scalar_type(), c_type, [&] {
     uint32_t vec_size = 16 / sizeof(c_type);
     dim3 block(std::min(d / vec_size, 1024U));
-#if USE_ROCM
-    sgl_hip::activation::act_and_mul_kernel<c_type, gelu>
+    SGL_ACTIVATION_NAMESPACE::act_and_mul_kernel<c_type, gelu>
         <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#else
-    flashinfer::activation::act_and_mul_kernel<c_type, gelu>
-        <<<grid, block, 0, stream>>>(static_cast<c_type*>(out.data_ptr()), static_cast<c_type*>(input.data_ptr()), d);
-#endif
 
     return true;
   });
@@ -168,3 +159,5 @@ void gelu_quick(at::Tensor& out, const at::Tensor& input) {
   });
 }
 #endif
+
+#undef SGL_ACTIVATION_NAMESPACE

--- a/python/sglang/kernels/aot/csrc/gemm/math.hpp
+++ b/python/sglang/kernels/aot/csrc/gemm/math.hpp
@@ -5,7 +5,13 @@
 
 inline constexpr uint32_t next_pow_2(uint32_t const num) {
   if (num <= 1) return num;
-  return 1 << (CHAR_BIT * sizeof(num) - __builtin_clz(num - 1));
+  uint32_t value = num - 1;
+  value |= value >> 1;
+  value |= value >> 2;
+  value |= value >> 4;
+  value |= value >> 8;
+  value |= value >> 16;
+  return value + 1;
 }
 
 template <typename A, typename B>

--- a/python/sglang/kernels/aot/csrc/gemm/per_token_quant_fp8.cu
+++ b/python/sglang/kernels/aot/csrc/gemm/per_token_quant_fp8.cu
@@ -250,7 +250,7 @@ void sgl_per_token_quant_fp8(torch::Tensor input, torch::Tensor output_q, torch:
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
   const int sm_count = at::cuda::getCurrentDeviceProperties()->multiProcessorCount;
-  const int TOKENS_PER_CTA = 8;
+  constexpr int TOKENS_PER_CTA = 8;
   const bool use_warp_kernel = (num_tokens >= sm_count * 2 * TOKENS_PER_CTA);
   const bool use_vec16 = (hidden_dim % 16 == 0);
   const bool use_vec8 = (hidden_dim % 8 == 0);

--- a/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
+++ b/python/sglang/kernels/aot/csrc/kvcacheio/transfer.cu
@@ -8,7 +8,14 @@
 #include <vector>
 
 #if !defined(USE_ROCM) && !defined(USE_MUSA)
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
 #include <dlfcn.h>
+#endif
 #define WARP_SIZE 32
 #include "pytorch_extension_utils.h"
 #else
@@ -806,7 +813,20 @@ inline void transfer_kv_page_first_direct_impl(
   }
 
   // Symbol gate: runtime may not expose cudaMemcpyBatchAsync in some environments.
+#if defined(_WIN32)
+  static FARPROC cuda_memcpy_batch_async_sym = []() -> FARPROC {
+    for (const char* dll_name : {"cudart64_13.dll", "cudart64_12.dll"}) {
+      if (HMODULE module = GetModuleHandleA(dll_name)) {
+        if (FARPROC symbol = GetProcAddress(module, "cudaMemcpyBatchAsync")) {
+          return symbol;
+        }
+      }
+    }
+    return nullptr;
+  }();
+#else
   static void* cuda_memcpy_batch_async_sym = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
+#endif
   if (cuda_memcpy_batch_async_sym == nullptr) {
     fallback_to_page_copy();
     return;

--- a/python/sglang/kernels/aot/csrc/moe/fused_qknorm_rope_kernel.cu
+++ b/python/sglang/kernels/aot/csrc/moe/fused_qknorm_rope_kernel.cu
@@ -27,6 +27,7 @@
 #include <torch/cuda.h>
 
 #include <cmath>
+#include <cstdint>
 
 #define CHECK_TYPE(x, st) \
   TORCH_CHECK(x.scalar_type() == st, #x " dtype is ", x.scalar_type(), ", while ", st, " is expected")
@@ -45,17 +46,17 @@ struct packed_as;
 
 // Specialization for packed_as used in this kernel.
 template <>
-struct packed_as<uint, 1> {
-  using type = uint;
+struct packed_as<uint32_t, 1> {
+  using type = uint32_t;
 };
 
 template <>
-struct packed_as<uint, 2> {
+struct packed_as<uint32_t, 2> {
   using type = uint2;
 };
 
 template <>
-struct packed_as<uint, 4> {
+struct packed_as<uint32_t, 4> {
   using type = uint4;
 };
 
@@ -150,8 +151,8 @@ __global__ void fusedQKNormRopeKernel(
   float elements[numElemsPerThread];
   constexpr int elemSizeBytes = numElemsPerThread * sizeof(__nv_bfloat16);
   static_assert(elemSizeBytes % 4 == 0, "numSizeBytes must be a multiple of 4");
-  constexpr int vecSize = elemSizeBytes / 4;  // Use packed_as<uint, vecSize> to perform loading/saving.
-  using vec_T = typename tensorrt_llm::common::packed_as<uint, vecSize>::type;
+  constexpr int vecSize = elemSizeBytes / 4;  // Use packed_as<uint32_t, vecSize> to perform loading/saving.
+  using vec_T = typename tensorrt_llm::common::packed_as<uint32_t, vecSize>::type;
 
   int offsetWarp;  // Offset for the warp
   if (isQ) {
@@ -170,7 +171,7 @@ __global__ void fusedQKNormRopeKernel(
   {
     vec_T vec = *reinterpret_cast<vec_T const*>(&qkv[offsetThread]);
     for (int i = 0; i < vecSize; i++) {
-      float2 vals = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint*>(&vec) + i));
+      float2 vals = __bfloat1622float2(*reinterpret_cast<__nv_bfloat162*>(reinterpret_cast<uint32_t*>(&vec) + i));
       sumOfSquares += vals.x * vals.x;
       sumOfSquares += vals.y * vals.y;
       elements[2 * i] = vals.x;
@@ -245,7 +246,7 @@ __global__ void fusedQKNormRopeKernel(
     vec_T vec;
     for (int i = 0; i < vecSize; i++) {
       __nv_bfloat162 vals = __float22bfloat162_rn(make_float2(elements[2 * i], elements[2 * i + 1]));
-      reinterpret_cast<__nv_bfloat162&>(*(reinterpret_cast<uint*>(&vec) + i)) = vals;
+      reinterpret_cast<__nv_bfloat162&>(*(reinterpret_cast<uint32_t*>(&vec) + i)) = vals;
     }
     vec_T* outputPtr = reinterpret_cast<vec_T*>(&qkv[offsetThread]);
     *outputPtr = vec;

--- a/python/sglang/kernels/aot/csrc/moe/moe_sum_reduce.cu
+++ b/python/sglang/kernels/aot/csrc/moe/moe_sum_reduce.cu
@@ -27,20 +27,20 @@ __device__ __forceinline__ T from_acc(opmath_t<T> x) {
 
 template <>
 __device__ __forceinline__ opmath_t<at::Half> to_acc<at::Half>(at::Half x) {
-  return __half2float(__nv_half(x));
+  return __half2float(__ushort_as_half(x.x));
 }
 template <>
 __device__ __forceinline__ at::Half from_acc<at::Half>(opmath_t<at::Half> x) {
-  return __float2half_rn(x);
+  return at::Half(__half_as_ushort(__float2half_rn(x)), at::Half::from_bits());
 }
 
 template <>
 __device__ __forceinline__ opmath_t<at::BFloat16> to_acc<at::BFloat16>(at::BFloat16 x) {
-  return __bfloat162float(__nv_bfloat16(x));
+  return __bfloat162float(__ushort_as_bfloat16(x.x));
 }
 template <>
 __device__ __forceinline__ at::BFloat16 from_acc<at::BFloat16>(opmath_t<at::BFloat16> x) {
-  return __float2bfloat16_rn(x);
+  return at::BFloat16(__bfloat16_as_ushort(__float2bfloat16_rn(x)), at::BFloat16::from_bits());
 }
 
 template <typename T>

--- a/python/sglang/kernels/aot/include/sgl_kernel_ops.h
+++ b/python/sglang/kernels/aot/include/sgl_kernel_ops.h
@@ -96,6 +96,7 @@ void register_graph_buffers(
  */
 void merge_state_v2(
     at::Tensor v_a, at::Tensor s_a, at::Tensor v_b, at::Tensor s_b, at::Tensor v_merged, at::Tensor s_merged);
+#ifdef SGL_KERNEL_ENABLE_CUTLASS_MLA
 void cutlass_mla_decode(
     torch::Tensor const& out,
     torch::Tensor const& q_nope,
@@ -111,6 +112,7 @@ int64_t cutlass_mla_get_workspace_size(
     int64_t num_batches,
     int64_t sm_count = 0,
     int64_t num_kv_splits = 1 /* Set to 1 to avoid cuda_graph issue by default. */);
+#endif
 
 /*
  * From csrc/infllm_v2
@@ -220,6 +222,7 @@ void dsv4_fused_q_indexer_rope_hadamard_quant(
 /*
  * From csrc/gemm
  */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 torch::Tensor awq_dequantize(torch::Tensor qweight, torch::Tensor scales, torch::Tensor qzeros);
 torch::Tensor int8_scaled_mm(
     const torch::Tensor& mat_a,
@@ -235,6 +238,7 @@ torch::Tensor fp8_scaled_mm(
     const torch::Tensor& scales_b,
     const torch::Dtype& out_dtype,
     const c10::optional<torch::Tensor>& bias);
+#endif
 void sgl_per_token_group_quant_8bit(
     at::Tensor input,
     at::Tensor output_q,
@@ -257,6 +261,7 @@ void sgl_per_token_group_quant_8bit_v2(
     const std::optional<torch::Tensor>& masked_m);
 void sgl_per_token_quant_fp8(at::Tensor input, at::Tensor output_q, at::Tensor output_s);
 
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 torch::Tensor gptq_gemm(
     torch::Tensor a,
     torch::Tensor b_q_weight,
@@ -267,6 +272,7 @@ torch::Tensor gptq_gemm(
     int64_t bit);
 
 void gptq_shuffle(torch::Tensor q_weight, torch::Tensor q_perm, int64_t bit);
+#endif
 
 /*
  * From csrc/moe
@@ -301,6 +307,7 @@ void moe_sum_reduce(at::Tensor& input, at::Tensor& output, double routed_scaling
 
 void moe_sum(torch::Tensor& input, torch::Tensor& output);
 
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 void fp8_blockwise_scaled_grouped_mm(
     torch::Tensor& output,
     torch::Tensor& a_ptrs,
@@ -320,6 +327,7 @@ void fp8_blockwise_scaled_grouped_mm(
     const torch::Tensor& problem_sizes,
     const torch::Tensor& expert_offsets,
     const torch::Tensor& workspace);
+#endif
 
 void prepare_moe_input(
     const torch::Tensor& topk_ids,
@@ -391,6 +399,7 @@ void fused_qk_norm_rope(
 /*
  * From csrc/moe/cutlass_moe/w4a8
  */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 void get_cutlass_w4a8_moe_mm_data(
     const torch::Tensor& topk_ids,
     torch::Tensor& expert_offsets,
@@ -416,6 +425,7 @@ void cutlass_w4a8_moe_mm(
     torch::Tensor const& s_strides,
     int64_t chunk_size,
     int64_t topk);
+#endif
 /*
  * From csrc/speculative
  */
@@ -640,6 +650,7 @@ namespace flash {
 /*
  * From fa2 sparse
  */
+#ifdef SGL_KERNEL_ENABLE_SPARSE_FLASH_ATTN
 std::vector<at::Tensor> mha_fwd_sparse(
     at::Tensor& q,        // batch_size x seqlen_q x num_heads x head_size
     const at::Tensor& k,  // batch_size x seqlen_k x num_heads_k x head_size
@@ -680,6 +691,7 @@ std::vector<at::Tensor> mha_varlen_fwd_sparse(
     const double softcap,
     const bool return_softmax,
     c10::optional<at::Generator> gen_);
+#endif
 }  // namespace flash
 
 void convert_vertical_slash_indexes(
@@ -751,6 +763,7 @@ std::vector<int64_t> create_greenctx_stream_by_value(int64_t smA, int64_t smB, i
 /*
  * From csrc/mamba
  */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 void causal_conv1d_update(
     const at::Tensor& x,
     const at::Tensor& conv_state,
@@ -771,10 +784,12 @@ void causal_conv1d_fwd(
     const std::optional<at::Tensor>& has_initial_state,
     bool silu_activation,
     int64_t pad_slot_id);
+#endif
 
 /*
  * From csrc/expert_specialization
  */
+#ifdef SGL_KERNEL_ENABLE_EXTENDED_CUDA_OPS
 void es_fp8_blockwise_scaled_grouped_mm(
     torch::Tensor& output,
     const torch::Tensor& a,
@@ -805,6 +820,7 @@ void es_sm100_mxfp8_blockscaled_grouped_quant(
     const torch::Tensor& blockscale_offsets,
     torch::Tensor& quant_output,
     torch::Tensor& scale_factor);
+#endif
 
 /*
  * From flashmla

--- a/python/sglang/kernels/aot/include/utils.h
+++ b/python/sglang/kernels/aot/include/utils.h
@@ -372,17 +372,17 @@ __device__ __forceinline__ dstDtype castFromFloat(float val) {
 #ifndef USE_ROCM
 #include <c10/util/Float8_e4m3fn.h>
 using FP8_TYPE = c10::Float8_e4m3fn;
-C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
+#define FP8_E4M3_MAX 448.0f
 #else  // USE_ROCM
 #if HIP_FP8_TYPE_FNUZ
 #include <c10/util/Float8_e4m3fnuz.h>
 using FP8_TYPE = c10::Float8_e4m3fnuz;
-constexpr auto FP8_E4M3_MAX = 224.0f;
+#define FP8_E4M3_MAX 224.0f
 #else
 #if HIP_FP8_TYPE_E4M3
 #include <c10/util/Float8_e4m3fn.h>
 using FP8_TYPE = c10::Float8_e4m3fn;
-C10_HOST_DEVICE constexpr auto FP8_E4M3_MAX = std::numeric_limits<FP8_TYPE>::max();
+#define FP8_E4M3_MAX 448.0f
 #else
 #error "fp8 is not supported in this processor (arch < gfx942)."
 #endif  // HIP_FP8_TYPE_E4M3
@@ -456,7 +456,13 @@ inline torch::Tensor pad_tensor(const torch::Tensor& tensor, int64_t alignment =
 // Get the next power of 2 of a number
 inline uint32_t next_pow2(uint32_t x) noexcept {
   if (x <= 1) return 1;
-  return 1u << (32 - __builtin_clz(x - 1));
+  --x;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return x + 1;
 }
 
 /*

--- a/python/sglang/kernels/aot/python/sgl_kernel/__init__.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/__init__.py
@@ -15,12 +15,12 @@ else:
         _preload_cuda_library,
     )
 
-    # Initialize the ops library based on current GPU
-    common_ops = _load_architecture_specific_ops()
-
     # Preload the CUDA library to avoid the issue of libcudart.so.12 not found
     if torch.version.cuda is not None:
         _preload_cuda_library()
+
+    # Initialize the ops library based on current GPU
+    common_ops = _load_architecture_specific_ops()
 
     from sgl_kernel.allreduce import *
     from sgl_kernel.attention import (

--- a/python/sglang/kernels/aot/python/sgl_kernel/infllm_v2/_loader.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/infllm_v2/_loader.py
@@ -9,6 +9,7 @@ candidate locations and loads the extension by file path.
 """
 
 import glob
+import importlib.machinery
 import importlib.util
 import site
 import sys
@@ -57,13 +58,14 @@ def _candidate_dirs() -> List[Path]:
     return unique
 
 
-def _find_so() -> Optional[Path]:
+def _find_extension() -> Optional[Path]:
     for d in _candidate_dirs():
         if not d.is_dir():
             continue
-        matches = sorted(glob.glob(str(d / "infllm_ops*.so")))
-        if matches:
-            return Path(matches[0])
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES:
+            matches = sorted(glob.glob(str(d / f"infllm_ops*{suffix}")))
+            if matches:
+                return Path(matches[0])
     return None
 
 
@@ -82,16 +84,18 @@ def load_infllm_ops():
     except Exception:
         pass
 
-    so_path = _find_so()
-    if so_path is None:
+    extension_path = _find_extension()
+    if extension_path is None:
         raise ImportError(
-            "[sgl_kernel] Could not locate the 'infllm_ops' extension (infllm_ops*.so). "
+            "[sgl_kernel] Could not locate the 'infllm_ops' native extension. "
             "Ensure sgl-kernel was built with the InfLLM-V2 FlashAttention backend."
         )
 
-    spec = importlib.util.spec_from_file_location("infllm_ops", str(so_path))
+    spec = importlib.util.spec_from_file_location("infllm_ops", str(extension_path))
     if spec is None or spec.loader is None:
-        raise ImportError(f"[sgl_kernel] Could not create module spec for {so_path}")
+        raise ImportError(
+            f"[sgl_kernel] Could not create module spec for {extension_path}"
+        )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     _infllm_ops = module

--- a/python/sglang/kernels/aot/python/sgl_kernel/load_utils.py
+++ b/python/sglang/kernels/aot/python/sgl_kernel/load_utils.py
@@ -10,6 +10,7 @@ from typing import List
 import torch
 
 logger = logging.getLogger(__name__)
+_dll_directory_handles = []
 
 
 def _get_compute_capability():
@@ -214,8 +215,23 @@ def _find_cuda_home():
 
 
 def _preload_cuda_library():
-    """Preload the CUDA runtime library to help avoid 'libcudart.so not found' issues."""
+    """Preload the CUDA runtime library before importing the native extension."""
     cuda_home = Path(_find_cuda_home())
+
+    if os.name == "nt":
+        cuda_bin = cuda_home / "bin"
+        if cuda_bin.is_dir() and hasattr(os, "add_dll_directory"):
+            # Keep the handle alive for as long as the process can import CUDA DLLs.
+            _dll_directory_handles.append(os.add_dll_directory(str(cuda_bin)))
+        for candidate in sorted(cuda_bin.glob("cudart64_*.dll"), reverse=True):
+            try:
+                ctypes.WinDLL(str(candidate))
+                logger.debug(f"Preloaded CUDA runtime under {candidate}")
+                return
+            except OSError as e:
+                logger.debug(f"Failed to load {candidate}: {e}")
+        logger.debug("[sgl_kernel] Could not preload a Windows CUDA runtime DLL")
+        return
 
     candidate_dirs = [
         cuda_home / "lib",

--- a/python/sglang/kernels/aot/tests/windows/test_windows_arm64_smoke.py
+++ b/python/sglang/kernels/aot/tests/windows/test_windows_arm64_smoke.py
@@ -1,0 +1,74 @@
+"""Smoke coverage for the reduced Windows ARM64 CUDA wheel."""
+
+import platform
+import sys
+
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32" or platform.machine().lower() != "arm64",
+    reason="Windows ARM64 kernel smoke tests",
+)
+
+
+def test_minimax_core_cuda_ops():
+    import sgl_kernel
+
+    assert torch.cuda.is_available()
+
+    torch.manual_seed(0)
+    activation_input = torch.randn(4, 256, device="cuda", dtype=torch.float16)
+    activation_output = sgl_kernel.silu_and_mul(activation_input)
+    activation_reference = (
+        torch.nn.functional.silu(activation_input[:, :128]) * activation_input[:, 128:]
+    )
+    torch.testing.assert_close(
+        activation_output, activation_reference, rtol=1e-3, atol=1e-3
+    )
+
+    norm_input = torch.randn(4, 128, device="cuda", dtype=torch.float16)
+    norm_weight = torch.randn(128, device="cuda", dtype=torch.float16)
+    norm_output = sgl_kernel.rmsnorm(
+        norm_input, norm_weight, eps=1e-6, enable_pdl=False
+    )
+    norm_reference = (
+        norm_input
+        * torch.rsqrt(norm_input.float().pow(2).mean(-1, keepdim=True) + 1e-6).to(
+            norm_input.dtype
+        )
+        * norm_weight
+    )
+    torch.testing.assert_close(norm_output, norm_reference, rtol=2e-3, atol=2e-3)
+
+    gating_output = torch.randn(8, 32, device="cuda", dtype=torch.float32)
+    topk_weights = torch.empty(8, 4, device="cuda", dtype=torch.float32)
+    topk_indices = torch.empty(8, 4, device="cuda", dtype=torch.int32)
+    sgl_kernel.topk_sigmoid(topk_weights, topk_indices, gating_output)
+    weights_reference, indices_reference = torch.topk(
+        torch.sigmoid(gating_output), 4, dim=-1
+    )
+    torch.testing.assert_close(topk_weights, weights_reference, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(topk_indices, indices_reference.int(), rtol=0, atol=0)
+
+    quant_input = torch.randn(32, 512, device="cuda", dtype=torch.float16)
+    quant_output = torch.empty_like(quant_input, dtype=torch.float8_e4m3fn)
+    quant_scales = torch.empty(32, device="cuda", dtype=torch.float32)
+    sgl_kernel.sgl_per_token_quant_fp8(quant_input, quant_output, quant_scales)
+    assert torch.isfinite(quant_scales).all()
+    assert (quant_scales > 0).all()
+    fp8_info = torch.finfo(torch.float8_e4m3fn)
+    quant_reference = (
+        quant_input.float() * quant_scales.reciprocal().unsqueeze(1)
+    ).clamp(min=fp8_info.min, max=fp8_info.max)
+    torch.testing.assert_close(
+        quant_output.float(),
+        quant_reference.to(torch.float8_e4m3fn).float(),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+
+    moe_input = torch.randn(8, 4, 128, device="cuda", dtype=torch.bfloat16)
+    moe_output = torch.empty(8, 128, device="cuda", dtype=torch.bfloat16)
+    sgl_kernel.moe_sum_reduce(moe_input, moe_output, 1.0)
+    torch.testing.assert_close(moe_output, moe_input.sum(dim=1), rtol=2e-2, atol=2e-2)

--- a/scripts/ci/utils/verify_windows_arm64_kernel_wheel.py
+++ b/scripts/ci/utils/verify_windows_arm64_kernel_wheel.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Verify the reduced native Windows ARM64 sglang-kernel wheel."""
+
+import argparse
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+
+def verify_wheel(wheel_dir: Path) -> Path:
+    wheels = list(wheel_dir.glob("sglang_kernel-*-win_arm64.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected one kernel wheel, found {len(wheels)}")
+
+    wheel_path = wheels[0]
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = wheel.namelist()
+        metadata_names = [
+            name for name in names if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_names) != 1:
+            raise RuntimeError(f"expected one METADATA file, found {metadata_names}")
+        metadata = Parser().parsestr(wheel.read(metadata_names[0]).decode("utf-8"))
+
+    native_modules = [
+        name
+        for name in names
+        if name.startswith("sgl_kernel/sm100/common_ops") and name.endswith(".pyd")
+    ]
+    if len(native_modules) != 1:
+        raise RuntimeError(
+            f"expected one SM100+ common_ops module, found {native_modules}"
+        )
+    if any(name.startswith("sgl_kernel/sm90/common_ops") for name in names):
+        raise RuntimeError("Windows ARM64 wheel unexpectedly contains the SM90 module")
+    if metadata["Name"] != "sglang-kernel":
+        raise RuntimeError(f"unexpected distribution name: {metadata['Name']}")
+
+    print(f"verified {wheel_path} ({metadata['Version']})")
+    return wheel_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel_dir", type=Path)
+    args = parser.parse_args()
+    verify_wheel(args.wheel_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This is the kernel half of #34339, split into a bottom replacement PR that targets `main` directly.

- add a native Windows ARM64 `sglang-kernel` build path and document the required ARM64 Python, CUDA, and Visual Studio toolchain
- gate Linux-oriented and unsupported optional modules while retaining the SM100+ common CUDA operators
- add MSVC/NVCC portability fixes, Windows CUDA DLL discovery/preloading, and native extension suffix handling
- add Windows ARM64 CUDA smoke coverage and wheel-content verification

## Validation

- verified the 19-file diff exactly matches the corresponding immutable source snapshot from #34339
- validated changed Python syntax and the PowerShell build script parser
- exercised the Windows ARM64 wheel verifier against a synthetic wheel
- native build and CUDA smoke execution require CUDA-enabled Windows ARM64 PyTorch and CUDA Toolkit, which are not installed on this checkout

Unrelated line-ending-only changes from the original PR were intentionally excluded.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31559413630](https://github.com/sgl-project/sglang/actions/runs/31559413630)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559413525](https://github.com/sgl-project/sglang/actions/runs/31559413525)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->