### PR TITLE
[Diffusion] Tune QK head LayerNorm for SM103

### DIFF
--- a/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
+++ b/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
@@ -341,9 +341,13 @@ def _is_bf16_cuda(t: torch.Tensor) -> bool:
     return t.is_cuda and t.dtype is torch.bfloat16
 
 
-def _is_sm120_or_newer() -> bool:
+def _qk_head_launch_config() -> tuple[int, int]:
     arch = get_jit_cuda_arch()
-    return arch.major * 10 + arch.minor >= 120
+    if arch.major == 10 and arch.minor == 3:
+        return 16, 1
+    if arch.major * 10 + arch.minor >= 120:
+        return 8, 4
+    return 64, 2
 
 
 def _mod_row_stride(t: torch.Tensor, batch: int, hidden: int) -> int | None:
@@ -460,12 +464,10 @@ def fused_qk_head_layernorm(
     launch, bit-exact vs the eager aten kernel."""
     head_dim = q.shape[-1]
     n_rows = q.numel() // head_dim
-    # SM120 has a smaller register file per SM than H200.  Grouping 64 exact
-    # Welford rows in one program depresses occupancy on RTX 5090; an exhaustive
-    # production-shape sweep selects 8 rows / 4 warps there (about 10% faster).
-    # Preserve the independently tuned SM90 launch byte-for-byte.
-    is_sm120 = _is_sm120_or_newer()
-    rows = 8 if is_sm120 else 64
+    # Architecture sweeps at the production GLM shape select 16 rows / 1 warp
+    # on B300 (SM103) and 8 rows / 4 warps on RTX 5090 (SM120). Preserve the
+    # independently tuned H100/H200 launch on all other architectures.
+    rows, num_warps = _qk_head_launch_config()
     q_out = torch.empty_like(q)
     k_out = torch.empty_like(k)
     with torch.cuda.device(q.device):
@@ -481,6 +483,6 @@ def fused_qk_head_layernorm(
             ROWS=rows,
             # H200-tuned: 62us at (1, 4360, 32, 128) vs the 301us of the two
             # aten launches (one 128-thread block per head_dim-element row).
-            num_warps=4 if is_sm120 else 2,
+            num_warps=num_warps,
         )
     return q_out, k_out


### PR DESCRIPTION
## Motivation

PR #34349 tuned the exact Q/K head LayerNorm launch for SM120 while preserving
the H100/H200 launch. B300 (SM103) also suffers from register pressure with the
SM90 `ROWS=64, num_warps=2` configuration, but its best launch is different
from SM120.

## Modifications

- Use `ROWS=16, num_warps=1` on SM103.
- Preserve `ROWS=8, num_warps=4` on SM120+.
- Preserve `ROWS=64, num_warps=2` on all other architectures.

## Accuracy Tests

- B300: `test_glm_image_ln_modulate.py`: **6 passed**.
- The production-shape Q/K output remains bit-exact against eager LayerNorm.

## Speed Tests and Profiling

Production shape `(1, 4360, 32, 128)`, BF16 Q and K, B300:

| Launch | Latency (us) | Speedup |
|---|---:|---:|
| `ROWS=64, num_warps=2` | 44.97 | 1.00x |
| `ROWS=16, num_warps=1` | 30.78 | **1.46x** |

An exhaustive B300 row/warp sweep selected the proposed launch. Nsight Compute
also showed registers/thread dropping from 168 to 80 and achieved occupancy
increasing from 17.5% to 33.4%.

## Checklist

- [x] Run `ruff check`, `ruff format --check`, and `git diff --check`.
- [x] Validate bit-exactness on B300.
- [x] Preserve the existing SM120 and SM90 launch configurations.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31559008891](https://github.com/sgl-project/sglang/actions/runs/31559008891)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559008681](https://github.com/sgl-project/sglang/actions/runs/31559008681)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->