### PR TITLE
Support SGLang on Windows ARM64

### DIFF
--- a/.github/workflows/pr-test-windows-arm64.yml
+++ b/.github/workflows/pr-test-windows-arm64.yml
@@ -1,0 +1,88 @@
+name: PR Test (Windows ARM64 build)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "python/**"
+      - "rust/Cargo.lock"
+      - "rust/Cargo.toml"
+      - "rust/sglang-mm/**"
+      - "scripts/ci/utils/verify_windows_arm64_wheel.py"
+      - ".github/workflows/release-pypi.yml"
+      - ".github/workflows/pr-test-windows-arm64.yml"
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+    paths:
+      - "python/**"
+      - "rust/Cargo.lock"
+      - "rust/Cargo.toml"
+      - "rust/sglang-mm/**"
+      - "scripts/ci/utils/verify_windows_arm64_wheel.py"
+      - ".github/workflows/release-pypi.yml"
+      - ".github/workflows/pr-test-windows-arm64.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: windows-arm64-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-wheel:
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-ci')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-ci')
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        # CPython 3.10 does not publish a native Windows ARM64 distribution.
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: arm64
+
+      - name: Verify native toolchain
+        shell: pwsh
+        run: |
+          python -c "import platform, sysconfig; assert platform.machine().lower() == 'arm64'; assert sysconfig.get_platform() == 'win-arm64'"
+          rustc -vV
+          cargo --version
+          clang --version
+
+      - name: Install Python build frontend
+        run: python -m pip install build
+
+      - name: Build Windows ARM64 wheel
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath`) do set "VS_PATH=%%i"
+          if not defined VS_PATH (
+            echo Visual Studio ARM64 build tools were not found.
+            exit /b 1
+          )
+          set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer;%PATH%"
+          call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          copy /Y README.md python\README.md
+          copy /Y LICENSE python\LICENSE
+          python -m build --wheel --outdir dist python
+
+      - name: Verify wheel contents
+        run: python scripts/ci/utils/verify_windows_arm64_wheel.py dist
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: sglang-wheel-python${{ matrix.python-version }}-windows-arm64
+          path: dist/*.whl

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -87,8 +87,79 @@ jobs:
           name: wheel-py${{ matrix.python-version }}-${{ matrix.arch }}
           path: python/dist/*.whl
 
+  build-windows-arm64:
+    if: github.repository == 'sgl-project/sglang'
+    strategy:
+      fail-fast: false
+      matrix:
+        # CPython 3.10 does not publish a native Windows ARM64 distribution.
+        python-version: ["3.11", "3.12", "3.13"]
+    runs-on: windows-11-arm
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: "recursive"
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: arm64
+
+      - name: Verify native toolchain
+        shell: pwsh
+        run: |
+          python -c "import platform, sysconfig; assert platform.machine().lower() == 'arm64'; assert sysconfig.get_platform() == 'win-arm64'"
+          rustc -vV
+          cargo --version
+          clang --version
+
+      - name: Set release version
+        if: inputs.version != ''
+        shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          $version = $env:RELEASE_VERSION -replace '^v', ''
+          "SETUPTOOLS_SCM_PRETEND_VERSION=$version" >> $env:GITHUB_ENV
+          Write-Output "Pinning wheel version to $version"
+
+      - name: Install Python build frontend
+        run: python -m pip install build
+
+      - name: Build Windows ARM64 wheel
+        shell: cmd
+        run: |
+          for /f "usebackq tokens=*" %%i in (`"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.ARM64 -property installationPath`) do set "VS_PATH=%%i"
+          if not defined VS_PATH (
+            echo Visual Studio ARM64 build tools were not found.
+            exit /b 1
+          )
+          set "PATH=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer;%PATH%"
+          call "%VS_PATH%\VC\Auxiliary\Build\vcvarsall.bat" arm64
+          copy /Y README.md python\README.md
+          copy /Y LICENSE python\LICENSE
+          python -m build --wheel --outdir dist python
+
+      - name: Verify wheel
+        shell: pwsh
+        run: |
+          python scripts/ci/utils/verify_windows_arm64_wheel.py dist
+          python -m pip install twine
+          $wheel = Get-ChildItem dist\*.whl | Select-Object -First 1
+          python -m twine check $wheel.FullName
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-py${{ matrix.python-version }}-windows-arm64
+          path: dist/*.whl
+
   publish:
-    needs: build
+    needs: [build, build-windows-arm64]
     if: github.repository == 'sgl-project/sglang'
     runs-on: ubuntu-latest
     environment: "prod"

--- a/python/setup.py
+++ b/python/setup.py
@@ -11,23 +11,28 @@ crate whose Cargo.toml declares
 is built as a PyO3 extension module at that import path. Adding a new extension
 crate therefore needs no pyproject changes — declare the metadata in the crate.
 
-Two filters can narrow the discovered set:
+Three filters can narrow the discovered set:
 
 - [tool.sglang] rust-extensions in the active pyproject.toml: a list of
   case-insensitive substrings of the target module. Platform pyprojects use
   this to build a subset (e.g. pyproject_other.toml builds only "multimodal";
   grpc needs proto/tonic and is intentionally CUDA-only).
+- Native Windows ARM64 builds default to "multimodal", the cross-platform
+  extension. The server extension uses POSIX shared memory. An explicit
+  SGLANG_BUILD_RUST_EXTS value overrides this platform default.
 - SGLANG_BUILD_RUST_EXTS env var, applied at build time on top of the above:
-  unset or "all" builds everything, "none" builds nothing, and a
-  comma-separated list matches substrings, e.g. "grpc" matches
-  "sglang.srt.grpc._core". It is read directly from os.environ instead of
-  sglang.srt.environ, which is not importable until the package is built.
+  "all" builds everything, "none" builds nothing, and a comma-separated list
+  matches substrings, e.g. "grpc" matches "sglang.srt.grpc._core". It is read
+  directly from os.environ instead of sglang.srt.environ, which is not
+  importable until the package is built.
 """
 
 import json
 import os
+import platform
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 from setuptools import setup
@@ -149,6 +154,23 @@ def _pyproject_rust_extensions(declared):
     )
 
 
+def _platform_rust_extensions(declared):
+    """Apply native platform defaults unless the environment overrides them."""
+    raw = os.environ.get(_BUILD_RUST_EXTS_ENV)
+    if raw is not None and raw.strip():
+        return declared
+    if sys.platform == "win32" and platform.machine().lower() in {
+        "aarch64",
+        "arm64",
+    }:
+        return _match_by_substring(
+            declared=declared,
+            tokens=["multimodal"],
+            source="Windows ARM64 default Rust extension set",
+        )
+    return declared
+
+
 def _selected_rust_extensions(declared):
     """Apply the SGLANG_BUILD_RUST_EXTS build-time filter."""
     declared = list(declared)
@@ -179,7 +201,9 @@ def _declared_rust_extensions():
     # (e.g. from an sdist) still work.
     if (os.environ.get(_BUILD_RUST_EXTS_ENV) or "").strip().lower() == "none":
         return []
-    return _pyproject_rust_extensions(_discovered_rust_extensions())
+    return _platform_rust_extensions(
+        _pyproject_rust_extensions(_discovered_rust_extensions())
+    )
 
 
 if build_rust is not None:

--- a/scripts/ci/utils/verify_windows_arm64_wheel.py
+++ b/scripts/ci/utils/verify_windows_arm64_wheel.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Verify the native Windows ARM64 SGLang wheel produced by this interpreter."""
+
+import argparse
+import sys
+import zipfile
+from email.parser import Parser
+from pathlib import Path
+
+
+def verify_wheel(wheel_dir: Path) -> Path:
+    wheels = list(wheel_dir.glob("*.whl"))
+    if len(wheels) != 1:
+        raise RuntimeError(f"expected one wheel in {wheel_dir}, found {len(wheels)}")
+
+    wheel_path = wheels[0]
+    python_tag = f"cp{sys.version_info.major}{sys.version_info.minor}"
+    expected_suffix = f"-{python_tag}-{python_tag}-win_arm64.whl"
+    if not wheel_path.name.endswith(expected_suffix):
+        raise RuntimeError(f"unexpected Windows ARM64 wheel tag: {wheel_path.name}")
+
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = wheel.namelist()
+        metadata_names = [
+            name for name in names if name.endswith(".dist-info/METADATA")
+        ]
+        if len(metadata_names) != 1:
+            raise RuntimeError(f"expected one METADATA file, found {metadata_names}")
+        metadata = Parser().parsestr(wheel.read(metadata_names[0]).decode("utf-8"))
+
+    multimodal = [
+        name
+        for name in names
+        if name.startswith("sglang/srt/multimodal/_core") and name.endswith(".pyd")
+    ]
+    unsupported = [
+        name
+        for name in names
+        if name.startswith(
+            (
+                "sglang/srt/grpc/_core",
+                "sglang/srt/server/_core",
+            )
+        )
+        and name.endswith(".pyd")
+    ]
+    if len(multimodal) != 1:
+        raise RuntimeError(f"expected one multimodal extension, found {multimodal}")
+    if unsupported:
+        raise RuntimeError(
+            f"found unsupported Windows extension modules: {unsupported}"
+        )
+
+    version = metadata["Version"]
+    if not version or version.startswith("0.0.0"):
+        raise RuntimeError(f"setuptools-scm produced an invalid version: {version}")
+
+    print(f"verified {wheel_path} ({version})")
+    return wheel_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("wheel_dir", type=Path)
+    args = parser.parse_args()
+    verify_wheel(args.wheel_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is the SGLang packaging and CI half of #34339. The sibling kernel changes are tracked independently in #34501.

## Changes

- Select only the cross-platform multimodal Rust extension by default for native Windows ARM64 builds while preserving explicit `SGLANG_BUILD_RUST_EXTS` overrides.
- Build Python 3.11-3.13 Windows ARM64 wheels in PR CI and the PyPI release workflow.
- Verify native wheel tags, setuptools-scm versions, required multimodal extension contents, and exclusion of unsupported gRPC/server extensions.

This PR intentionally excludes unrelated line-ending-only changes from the original PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31559416498](https://github.com/sgl-project/sglang/actions/runs/31559416498)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559416438](https://github.com/sgl-project/sglang/actions/runs/31559416438)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->