### PR TITLE
[Diffusion][MiniMax H3] Extend exact QKNorm+RoPE rounding to SM103

### DIFF
--- a/python/sglang/kernels/jit/csrc/diffusion/qknorm_rope.cuh
+++ b/python/sglang/kernels/jit/csrc/diffusion/qknorm_rope.cuh
@@ -55,7 +55,7 @@ SGL_DEVICE CacheDType load_cache_value(const CacheDType* ptr, int64_t idx) {
 
 template <typename T>
 SGL_DEVICE T rotary_mul_rn(T lhs, T rhs) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1030 || __CUDA_ARCH__ >= 1200)
   uint16_t lhs_bits;
   uint16_t rhs_bits;
   if constexpr (std::is_same_v<T, bf16_t>) {
@@ -83,9 +83,10 @@ SGL_DEVICE T rotary_mul_rn(T lhs, T rhs) {
 
 template <typename T>
 SGL_DEVICE T rotary_add(T x, T cos, T y, T sin) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
-  // nvcc may contract the packed local expression on SM120 even though the
-  // reference RoPE kernel rounds both products to the activation dtype first.
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1030 || __CUDA_ARCH__ >= 1200)
+  // nvcc may contract the packed local expression on Blackwell SM103/SM120
+  // even though the reference RoPE kernel rounds both products to the
+  // activation dtype first.
   const T lhs = rotary_mul_rn(x, cos);
   const T rhs = rotary_mul_rn(y, sin);
   uint16_t lhs_bits;
@@ -115,7 +116,7 @@ SGL_DEVICE T rotary_add(T x, T cos, T y, T sin) {
 
 template <typename T>
 SGL_DEVICE T rotary_sub(T x, T cos, T y, T sin) {
-#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1200
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 1030 || __CUDA_ARCH__ >= 1200)
   const T lhs = rotary_mul_rn(x, cos);
   const T rhs = rotary_mul_rn(y, sin);
   uint16_t lhs_bits;


### PR DESCRIPTION
## Motivation

The exact QKNorm+RoPE path added for SM120 also needs the explicit BF16
rounding helpers on B300 (SM103). Without them, nvcc contracts/promotes the
packed rotary expression and the fused result differs from the split BF16
QKNorm + RoPE reference by one ULP.

## Modifications

- Enable the existing exact multiply/add/sub helpers for `__CUDA_ARCH__ == 1030`.
- Keep the existing SM120+ behavior unchanged.
- Do not change the kernel launch or non-Blackwell code path.

## Accuracy Tests

- B300:
  `test_qknorm_rope_preserves_split_bf16_rounding`: **1 passed** with
  `torch.equal` for both Q and K.
- The same test fails on SM103 without this guard extension.

## Speed Tests

Production shape `(7936, 56, 128)`, rope dim 96, BF16, B300:

| Variant | Latency (us) |
|---|---:|
| SM120-only exact helpers | 166.55 |
| SM103 + SM120 exact helpers | 166.10 |

The 0.3% difference is measurement noise; this is a correctness-only change.

## Checklist

- [x] Run `clang-format --dry-run --Werror` and `git diff --check`.
- [x] Validate exact split-reference rounding on B300.
- [x] Confirm no material performance regression.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31559011774](https://github.com/sgl-project/sglang/actions/runs/31559011774)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559011525](https://github.com/sgl-project/sglang/actions/runs/31559011525)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->