### PR TITLE
[Diffusion][Z-Image] Tune native QK RMSNorm launch for SM103

### DIFF
--- a/python/sglang/kernels/ops/diffusion/triton/zimage_native_norm.py
+++ b/python/sglang/kernels/ops/diffusion/triton/zimage_native_norm.py
@@ -7,6 +7,8 @@ import torch
 import triton  # type: ignore
 import triton.language as tl  # type: ignore
 
+from sglang.kernels.jit.utils import get_jit_cuda_arch
+
 
 @triton.jit
 def _qk_rmsnorm_native_kernel(
@@ -149,7 +151,13 @@ def zimage_qk_rmsnorm_native(
         return None
     nheads = x.shape[2]
     n_rows = x.shape[0] * x.shape[1] * nheads
-    rows_per_prog = 8
+    arch = get_jit_cuda_arch()
+    is_sm103 = arch.major == 10 and arch.minor == 3
+    # The production Z-Image shape is launch-bound on B300. Grouping more rows
+    # while using one warp group reduces latency without changing the launch
+    # tuned for other architectures.
+    rows_per_prog = 16 if is_sm103 else 8
+    num_warps = 4 if is_sm103 else 8
     y = torch.empty(x.shape, dtype=x.dtype, device=x.device)
     grid = (triton.cdiv(n_rows, rows_per_prog),)
     with torch.get_device_module().device(x.device):
@@ -163,7 +171,7 @@ def zimage_qk_rmsnorm_native(
             head_dim,
             eps,
             rows_per_prog=rows_per_prog,
-            num_warps=8,
+            num_warps=num_warps,
         )
     return y
 


### PR DESCRIPTION
## Motivation

The bit-exact native Z-Image Q/K RMSNorm kernel used a single launch
configuration on every GPU. At the production Z-Image shape, B300 is
launch-bound with `rows_per_prog=8, num_warps=8`.

## Modifications

- Use `rows_per_prog=16, num_warps=4` on SM103.
- Preserve `rows_per_prog=8, num_warps=8` on every other architecture.
- Keep the kernel math and bit-exact rounding order unchanged.

## Accuracy Tests

- B300 `test_zimage_qknorm_fusion.py`: **2 passed**.
- The strided fused-QKV path remains `torch.equal` to the eager
  `ZImageRMSNorm` reference.

## Speed Tests and Profiling

Production shape `(1, 4096, 24, 128)`, BF16, B300:

| Launch | Latency (us) | Speedup |
|---|---:|---:|
| 8 rows, 8 warps | 24.58 | 1.00x |
| 16 rows, 4 warps | 14.33 | **1.72x** |

An exhaustive B300 row/warp sweep selected the proposed launch. Nsight Compute
replay duration also dropped from 37.15 us to 15.65 us.

## Checklist

- [x] Run `ruff check`, `ruff format --check`, and `git diff --check`.
- [x] Validate bit-exact strided Q/K normalization on B300.
- [x] Preserve launches on non-SM103 GPUs.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31559018268](https://github.com/sgl-project/sglang/actions/runs/31559018268)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559018039](https://github.com/sgl-project/sglang/actions/runs/31559018039)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->