### PR TITLE
[Diffusion][LTX-2] Allocate AdaLN outputs from one contiguous slab

### DIFF
--- a/python/sglang/kernels/ops/diffusion/triton/ltx2_ada_values.py
+++ b/python/sglang/kernels/ops/diffusion/triton/ltx2_ada_values.py
@@ -165,10 +165,12 @@ def ltx2_ada_values9(
 
     batch, seq, _ = timestep.shape
     rows = int(batch * seq)
-    outs = tuple(
-        torch.empty((batch, seq, hidden), device=timestep.device, dtype=timestep.dtype)
-        for _ in range(9)
+    # Each returned output is a disjoint, contiguous view, so one allocation
+    # avoids nine allocator round trips per transformer block.
+    output_storage = torch.empty(
+        (9, batch, seq, hidden), device=timestep.device, dtype=timestep.dtype
     )
+    outs = tuple(output_storage.unbind(dim=0))
     _ltx2_ada_values9_kernel[(rows,)](
         timestep,
         scale_shift_table,

--- a/test/registered/kernels/ops/diffusion/test_ltx2_ada_values.py
+++ b/test/registered/kernels/ops/diffusion/test_ltx2_ada_values.py
@@ -54,6 +54,28 @@ def test_ltx2_ada_values9(
 
     assert len(actual) == 9
     for actual_value, expected_value in zip(actual, expected):
+        assert actual_value.is_contiguous()
+        torch.testing.assert_close(actual_value, expected_value, atol=0, rtol=0)
+
+
+@torch.no_grad()
+def test_ltx2_ada_values9_torch_compile_fullgraph() -> None:
+    hidden = 4096
+    scale_shift_table = torch.randn(
+        9, hidden, device=DEVICE, dtype=torch.bfloat16
+    ).contiguous()
+    timestep = torch.randn(
+        1, 1, 9 * hidden, device=DEVICE, dtype=torch.bfloat16
+    ).contiguous()
+
+    actual = torch.compile(ltx2_ada_values9, fullgraph=True)(
+        scale_shift_table, timestep
+    )
+    expected = _reference(scale_shift_table, timestep)
+
+    assert len(actual) == 9
+    for actual_value, expected_value in zip(actual, expected):
+        assert actual_value.is_contiguous()
         torch.testing.assert_close(actual_value, expected_value, atol=0, rtol=0)
 
 


### PR DESCRIPTION
## Motivation

`ltx2_ada_values9` allocated nine independent CUDA tensors on every
transformer-block invocation. The Triton kernel writes disjoint outputs with
identical shape and dtype, so these allocator round trips are unnecessary.

## Modifications

- Allocate one `[9, B, S, D]` output slab.
- Return the nine disjoint `unbind(0)` views expected by existing callers.
- Add contiguous-output checks and a `torch.compile(fullgraph=True)`
  regression.

## Accuracy Tests

- B300 `test_ltx2_ada_values.py`: **6 passed**.
- All nine outputs remain contiguous and bit-exact against the eager
  scale/shift reference.
- The returned tuple compiles successfully with `fullgraph=True`.

## Speed Tests

Production shape `B=1, S=1, D=4096`, BF16, B300; 9 rounds x 2,000 calls:

| Variant | Median wrapper latency (us) | `aten::empty` |
|---|---:|---:|
| Nine allocations | 24.40 | 9 |
| One slab + unbind | 14.98 | 1 |

This is a **1.63x** wrapper speedup and reduces `aten::empty` from 9 to 1.

## Checklist

- [x] Run `ruff check`, `ruff format --check`, and `git diff --check`.
- [x] Validate values, contiguity, and fullgraph compilation on B300.
- [x] Confirm the returned nine-view API remains unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31559021251](https://github.com/sgl-project/sglang/actions/runs/31559021251)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31559021225](https://github.com/sgl-project/sglang/actions/runs/31559021225)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->