### PR TITLE
fix(benchmark): request token IDs when counting OpenAI prompts

### DIFF
--- a/python/sglang/benchmark/datasets/openai_dataset.py
+++ b/python/sglang/benchmark/datasets/openai_dataset.py
@@ -3,8 +3,8 @@ from argparse import Namespace
 from dataclasses import dataclass
 from typing import List, Optional
 
-import numpy as np
-from transformers import PreTrainedTokenizerBase
+import numpy as npƒ
+from transformers import PreTrainedTokenizerBaseƒ
 
 from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
 
@@ -85,7 +85,7 @@ def sample_openai_requests(
         # This includes the messages but not the tools
         prompt_len = len(
             tokenizer.apply_chat_template(
-                messages, tokenize=True, add_generation_prompt=True
+                messages, tokenize=True, add_generation_prompt=True, return_dict=False
             )
         )
 

--- a/python/sglang/benchmark/datasets/openai_dataset.py
+++ b/python/sglang/benchmark/datasets/openai_dataset.py
@@ -3,7 +3,7 @@ from argparse import Namespace
 from dataclasses import dataclass
 from typing import List, Optional
 
-import numpy as npƒ
+import numpy as np
 from transformers import PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets.common import BaseDataset, DatasetRow

--- a/python/sglang/benchmark/datasets/openai_dataset.py
+++ b/python/sglang/benchmark/datasets/openai_dataset.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 import numpy as npƒ
-from transformers import PreTrainedTokenizerBaseƒ
+from transformers import PreTrainedTokenizerBase
 
 from sglang.benchmark.datasets.common import BaseDataset, DatasetRow
 


### PR DESCRIPTION
Fix incorrect prompt token counting in the OpenAI benchmark dataset loader by explicitly setting return_dict=False when calling apply_chat_template().

The OpenAI dataset loader currently calculates prompt length with:
```python
prompt_len = len(
    tokenizer.apply_chat_template(
        messages,
        tokenize=True,
        add_generation_prompt=True,
    )
)
``` 
In Transformers v5, apply_chat_template() may return a BatchEncoding by default. Calling len() on a BatchEncoding returns the number of fields, such as input_ids and attention_mask, instead of the number of input tokens.

This was reproduced with:
+ Model/tokenizer: Gemma 4 26B A4B
+ Tokenizer class: GemmaTokenizer
+ Transformers version: 5.12.1

Transformers v5 changed `apply_chat_template()` to consistently return a
`BatchEncoding` by default, as documented in the
[Transformers v5 migration guide](https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md#4-apply_chat_template-returns-batchencoding).

The OpenAI dataset loader still assumes that the return value is a plain list
of token IDs and calls `len()` on it. For a `BatchEncoding`, `len()` returns
the number of fields instead of the token sequence length.

For one example prompt:
```
Prompt characters: 724
Return type: BatchEncoding
BatchEncoding keys: ['input_ids', 'attention_mask']
len(BatchEncoding): 2
len(BatchEncoding['input_ids']): 481
``` 
As a result, a 481-token prompt was reported as 2 tokens. In a benchmark with 5,000 requests, the total input token count was incorrectly reported as 10,000.
## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31560836427](https://github.com/sgl-project/sglang/actions/runs/31560836427)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31560836318](https://github.com/sgl-project/sglang/actions/runs/31560836318)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->