### PR TITLE
[diffusion] UX: suppress noisy worker startup warnings

### DIFF
--- a/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
+++ b/python/sglang/multimodal_gen/runtime/managers/gpu_worker.py
@@ -15,6 +15,13 @@ import numpy as np
 import torch
 from setproctitle import setproctitle
 
+from sglang.multimodal_gen.runtime.utils.logging_utils import (  # isort: skip
+    globally_suppress_loggers,
+)
+
+# spawned workers import model dependencies before entering run_scheduler_process
+globally_suppress_loggers()
+
 from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.distributed import (
     get_sp_group,
@@ -65,7 +72,6 @@ from sglang.multimodal_gen.runtime.server_args import PortArgs, ServerArgs
 from sglang.multimodal_gen.runtime.utils.common import set_cuda_arch, set_musa_arch
 from sglang.multimodal_gen.runtime.utils.logging_utils import (
     configure_logger,
-    globally_suppress_loggers,
     init_logger,
 )
 from sglang.multimodal_gen.runtime.utils.perf_logger import (

--- a/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/logging_utils.py
@@ -517,6 +517,17 @@ class _UvicornAccessLogFilter(logging.Filter):
         return True
 
 
+class _PytreeEnumRegistrationFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return not (
+            "is an Enum subclass and is now natively supported by torch.compile"
+            in message
+            and "Calling register_constant() on Enum subclasses is deprecated"
+            in message
+        )
+
+
 def configure_logger(server_args, prefix: str = ""):
     log_format = f"[%(asctime)s{prefix}] %(message)s"
     datefmt = "%m-%d %H:%M:%S"
@@ -569,6 +580,13 @@ def globally_suppress_loggers():
 
     for name in target_names:
         logging.getLogger(name).setLevel(logging.ERROR)
+
+    pytree_logger = logging.getLogger("torch.utils._pytree")
+    if not any(
+        isinstance(filter_, _PytreeEnumRegistrationFilter)
+        for filter_ in pytree_logger.filters
+    ):
+        pytree_logger.addFilter(_PytreeEnumRegistrationFilter())
 
 
 # source: https://github.com/vllm-project/vllm/blob/a11f4a81e027efd9ef783b943489c222950ac989/vllm/utils/system_utils.py#L60

--- a/python/sglang/multimodal_gen/test/unit/test_logging_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_logging_utils.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import logging
+import unittest
+
+from sglang.multimodal_gen.runtime.utils.logging_utils import (
+    globally_suppress_loggers,
+)
+
+
+class TestSuppressNoisyDependencyLogs(unittest.TestCase):
+    def test_filters_only_pytree_enum_registration_deprecation(self):
+        logger = logging.getLogger("torch.utils._pytree")
+        with self.assertLogs(logger, level=logging.WARNING) as captured:
+            globally_suppress_loggers()
+            logger.warning(
+                "<enum 'KernelPreference'> is an Enum subclass and is now "
+                "natively supported by torch.compile as an opaque value type. "
+                "Calling register_constant() on Enum subclasses is deprecated "
+                "and will be an error in a future release."
+            )
+            logger.warning("unrelated pytree warning")
+
+        self.assertEqual(
+            captured.output,
+            ["WARNING:torch.utils._pytree:unrelated pytree warning"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- configure dependency logger suppression before spawned diffusion workers import model modules
- suppress the PyTorch pytree Enum `register_constant()` deprecation emitted by torchao
- preserve unrelated `torch.utils._pytree` warnings and add regression coverage

This removes duplicate per-rank startup noise without changing model loading or torchao behavior.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31560810742](https://github.com/sgl-project/sglang/actions/runs/31560810742)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31560810734](https://github.com/sgl-project/sglang/actions/runs/31560810734)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->