### PR TITLE
Remove many scheduler synchronization to enable overlap scheduler on agent workload

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -101,6 +101,15 @@ class StagedPrefillTransferIndices:
     mamba_indices: Optional[torch.Tensor] = None
 
 
+@dataclass
+class StagedCachedPrefixTransferIndices:
+    """Pinned prefix page IDs staged before the DP admission collective."""
+
+    end_idx: int
+    page_indices: torch.Tensor
+    ready_event: object
+
+
 def _copy_page_indices_to_pinned_cpu(
     kv_indices: torch.Tensor, page_size: int
 ) -> torch.Tensor:
@@ -622,6 +631,73 @@ class SchedulerDisaggregationPrefillMixin:
 
         return staged
 
+    def stage_cached_prefix_transfer_indices(
+        self: Scheduler, batch: Optional[ScheduleBatch]
+    ) -> None:
+        """Stage early-send page IDs before DP admission can block the CPU.
+
+        ``maybe_send_cached_prefix_chunk`` runs immediately before the suffix
+        forward.  Converting the device mapping there with pageable ``.cpu()``
+        can drain an unrelated prior forward from the scheduler stream.  Queue
+        the fixed-shape D2H here, before the DP-attention collective, and make
+        the eventual sender wait only for this narrow copy event.
+        """
+        if (
+            batch is None
+            or _is_npu
+            or not envs.SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get()
+        ):
+            return
+
+        page_size = self.token_to_kv_pool_allocator.page_size
+        pending = []
+        for req in batch.reqs:
+            if req.pending_bootstrap or is_aborted(req):
+                continue
+            if self.enable_staging and req.early_send_prefix_end is None:
+                req.early_send_prefix_end = max(
+                    0, len(req.prefix_indices) - req.host_hit_length
+                )
+            cached_end = (
+                req.early_send_prefix_end
+                if self.enable_staging
+                else len(req.prefix_indices) - req.host_hit_length
+            )
+            if (
+                cached_end <= req.start_send_idx
+                or cached_end % page_size != 0
+            ):
+                continue
+
+            full_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, :cached_end
+            ]
+            transfer_indices = (
+                self.token_to_kv_pool_allocator.translate_kv_indices_for_transfer(
+                    full_indices
+                )
+            )
+            pending.append(
+                (
+                    req,
+                    cached_end,
+                    _copy_page_indices_to_pinned_cpu(transfer_indices, page_size),
+                )
+            )
+
+        if not pending:
+            return
+        ready_event = self.device_module.Event()
+        ready_event.record()
+        for req, cached_end, page_indices in pending:
+            req._staged_cached_prefix_transfer_indices = (
+                StagedCachedPrefixTransferIndices(
+                    end_idx=cached_end,
+                    page_indices=page_indices,
+                    ready_event=ready_event,
+                )
+            )
+
     def resolve_waiting_queue_bootstrap(self: Scheduler) -> None:
         """Resolve bootstrap status for waiting prefill requests before admission.
 
@@ -682,6 +758,7 @@ class SchedulerDisaggregationPrefillMixin:
         prefill_plan = self.get_new_batch_prefill(running_batch)
         batch = prefill_plan.batch_to_run
         running_batch = prefill_plan.running_batch
+        self.stage_cached_prefix_transfer_indices(batch)
         batch = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(batch)
 
         if batch:
@@ -1111,6 +1188,7 @@ class SchedulerDisaggregationPrefillMixin:
         for the process lifetime.
         """
         self.disagg_prefill_pending_chunk_rids.discard(req.rid)
+        req._staged_cached_prefix_transfer_indices = None
 
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:
         self.clear_pending_chunk_send(req)
@@ -1302,6 +1380,10 @@ class SchedulerDisaggregationPrefillMixin:
         staged: Optional[StagedPrefillTransferIndices] = getattr(
             req, "_staged_prefill_transfer_indices", None
         )
+        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = getattr(
+            req, "_staged_cached_prefix_transfer_indices", None
+        )
+        staged_prefix_ready = False
         if last_chunk:
             self.disagg_metadata_buffers.set_buf(req)
 
@@ -1438,6 +1520,19 @@ class SchedulerDisaggregationPrefillMixin:
         for seg_start, seg_end in segments:
             is_final_segment = seg_end == end_idx
             if (
+                staged_prefix is not None
+                and staged_prefix.end_idx >= seg_end
+                and seg_start % page_size == 0
+            ):
+                if not staged_prefix_ready:
+                    staged_prefix.ready_event.synchronize()
+                    staged_prefix_ready = True
+                page_start = seg_start // page_size
+                page_count = kv_to_page_num(seg_end - seg_start, page_size)
+                page_indices = staged_prefix.page_indices[
+                    page_start : page_start + page_count
+                ].numpy()
+            elif (
                 staged is not None
                 and staged.end_idx >= seg_end
                 and seg_start % page_size == 0
@@ -1470,6 +1565,8 @@ class SchedulerDisaggregationPrefillMixin:
                 num_kv_tokens=seg_end - seg_start,
             )
         req.start_send_idx = end_idx
+        if staged_prefix is not None and end_idx >= staged_prefix.end_idx:
+            req._staged_cached_prefix_transfer_indices = None
         # A last chunk needs no entry: every `last_chunk=True` call site has
         # already put the request on `disagg_prefill_inflight_queue`.
         if last_chunk:
@@ -1490,6 +1587,7 @@ class SchedulerDisaggregationPrefillMixin:
         req.tmp_end_idx = -1
         req.disagg_decode_prefix_len = 0
         req.early_send_prefix_end = None
+        req._staged_cached_prefix_transfer_indices = None
         req.hidden_states_tensor = None
         req.output_dsa_topk_indices = None
         req.pending_bootstrap = True

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1319,8 +1319,8 @@ class SchedulerDisaggregationPrefillMixin:
             # not a complete physical DCP page. The regular final send covers
             # the full range; only skip this optional early-send optimization.
             return
-        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = getattr(
-            req, "_staged_cached_prefix_transfer_indices", None
+        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = (
+            req._staged_cached_prefix_transfer_indices
         )
         if (
             staged_prefix is not None
@@ -1385,11 +1385,11 @@ class SchedulerDisaggregationPrefillMixin:
             return
 
         state_indices: Optional[List] = None
-        staged: Optional[StagedPrefillTransferIndices] = getattr(
-            req, "_staged_prefill_transfer_indices", None
+        staged: Optional[StagedPrefillTransferIndices] = (
+            req._staged_prefill_transfer_indices
         )
-        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = getattr(
-            req, "_staged_cached_prefix_transfer_indices", None
+        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = (
+            req._staged_cached_prefix_transfer_indices
         )
         staged_prefix_ready = False
         if last_chunk:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -563,11 +563,7 @@ class SchedulerDisaggregationPrefillMixin:
         staged: Dict[str, StagedPrefillTransferIndices] = {}
 
         for req in batch.reqs:
-            if (
-                req.pending_bootstrap
-                or is_aborted(req)
-                or req.extend_range is None
-            ):
+            if req.pending_bootstrap or is_aborted(req) or req.extend_range is None:
                 continue
 
             transfer_input_len = len(req.origin_input_ids)
@@ -593,12 +589,10 @@ class SchedulerDisaggregationPrefillMixin:
             is_last_chunk = end_idx >= transfer_input_len
             if is_last_chunk:
                 if StateType.MAMBA in state_types:
-                    mamba_indices = (
-                        self.req_to_token_pool.translate_mamba_indices(
-                            self.req_to_token_pool.req_index_to_mamba_index_mapping[
-                                req.req_pool_idx
-                            ]
-                        )
+                    mamba_indices = self.req_to_token_pool.translate_mamba_indices(
+                        self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                            req.req_pool_idx
+                        ]
                     )
                     entry.mamba_indices = _copy_to_pinned_cpu(mamba_indices)
 
@@ -663,10 +657,7 @@ class SchedulerDisaggregationPrefillMixin:
                 if self.enable_staging
                 else len(req.prefix_indices) - req.host_hit_length
             )
-            if (
-                cached_end <= req.start_send_idx
-                or cached_end % page_size != 0
-            ):
+            if cached_end <= req.start_send_idx or cached_end % page_size != 0:
                 continue
 
             full_indices = self.req_to_token_pool.req_to_token[
@@ -1324,6 +1315,20 @@ class SchedulerDisaggregationPrefillMixin:
             # DCP radix hits can end on a logical cache-page boundary that is
             # not a complete physical DCP page. The regular final send covers
             # the full range; only skip this optional early-send optimization.
+            return
+        staged_prefix: Optional[StagedCachedPrefixTransferIndices] = getattr(
+            req, "_staged_cached_prefix_transfer_indices", None
+        )
+        if (
+            staged_prefix is not None
+            and staged_prefix.end_idx >= cached_end
+            and not staged_prefix.ready_event.query()
+        ):
+            # Early-send is optional. Under overlap scheduling the pinned D2H
+            # can still be behind the previous forward. Waiting here blocks
+            # the scheduler and turns one slow DP rank into an all-gather idle
+            # gap on every rank. Retry on the request's next chunk; if there
+            # is no next chunk, the regular final send covers the full range.
             return
         # Early-send issues the KV read before this step's forward is enqueued,
         # but under overlap scheduling the PRIOR step's prefill forward may still

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -597,7 +597,10 @@ class SchedulerDisaggregationPrefillMixin:
                     entry.mamba_indices = _copy_to_pinned_cpu(mamba_indices)
 
                 if StateType.SWA in state_types:
-                    window_start = max(0, end_idx - self.sliding_window_size)
+                    window_start = max(
+                        req.disagg_decode_prefix_len,
+                        end_idx - self.sliding_window_size,
+                    )
                     window_start = (window_start // page_size) * page_size
                     swa_indices = (
                         self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -23,8 +23,9 @@ import hashlib
 import logging
 from array import array
 from collections import deque
+from dataclasses import dataclass
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -86,6 +87,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _is_npu = is_npu()
+
+
+@dataclass
+class StagedPrefillTransferIndices:
+    """Pinned CPU mirrors covered by GenerationBatchResult.copy_done."""
+
+    end_idx: int
+    full_page_indices: torch.Tensor
+    dsa_page_indices: Optional[torch.Tensor] = None
+    swa_seq_len: Optional[int] = None
+    swa_page_indices: Optional[torch.Tensor] = None
+    mamba_indices: Optional[torch.Tensor] = None
+
+
+def _copy_page_indices_to_pinned_cpu(
+    kv_indices: torch.Tensor, page_size: int
+) -> torch.Tensor:
+    """Queue a fixed-shape page-id D2H without synchronizing the caller."""
+    page_indices = kv_indices[::page_size].to(torch.int64) // page_size
+    cpu_indices = torch.empty(
+        page_indices.shape, dtype=page_indices.dtype, device="cpu", pin_memory=True
+    )
+    cpu_indices.copy_(page_indices, non_blocking=True)
+    page_indices.record_stream(torch.cuda.current_stream(page_indices.device))
+    return cpu_indices
+
+
+def _copy_to_pinned_cpu(tensor: torch.Tensor) -> torch.Tensor:
+    cpu_tensor = torch.empty(
+        tensor.shape, dtype=tensor.dtype, device="cpu", pin_memory=True
+    )
+    cpu_tensor.copy_(tensor, non_blocking=True)
+    tensor.record_stream(torch.cuda.current_stream(tensor.device))
+    return cpu_tensor
 
 
 def should_force_retry(req: Req) -> bool:
@@ -498,6 +533,95 @@ class SchedulerDisaggregationPrefillMixin:
             if room is not None and room in kv_mgr.transfer_infos:
                 prefetch(room)
 
+    def stage_prefill_transfer_indices(
+        self: Scheduler, batch: ScheduleBatch
+    ) -> Dict[str, StagedPrefillTransferIndices]:
+        """Queue page-index D2H copies on the existing result-copy stream.
+
+        The scheduler consumes these tensors only after ``copy_done``.  This
+        keeps send_kv_chunk() from executing a series of pageable ``.cpu()`` /
+        ``.numpy()`` calls after the forward, each of which otherwise drains the
+        schedule stream.  The pending-send set also closes the unified-memory
+        move gate while the staged physical addresses are waiting to be sent.
+        """
+        if _is_npu:
+            return {}
+
+        page_size = self.token_to_kv_pool_allocator.page_size
+        state_types = set(
+            self.disagg_prefill_bootstrap_queue.kv_manager.kv_args.state_types
+        )
+        staged: Dict[str, StagedPrefillTransferIndices] = {}
+
+        for req in batch.reqs:
+            if (
+                req.pending_bootstrap
+                or is_aborted(req)
+                or req.extend_range is None
+            ):
+                continue
+
+            transfer_input_len = len(req.origin_input_ids)
+            end_idx = min(req.extend_range.end, transfer_input_len)
+            if end_idx <= 0 or end_idx < req.start_send_idx:
+                continue
+
+            full_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, :end_idx
+            ]
+            transfer_indices = (
+                self.token_to_kv_pool_allocator.translate_kv_indices_for_transfer(
+                    full_indices
+                )
+            )
+            entry = StagedPrefillTransferIndices(
+                end_idx=end_idx,
+                full_page_indices=_copy_page_indices_to_pinned_cpu(
+                    transfer_indices, page_size
+                ),
+            )
+
+            is_last_chunk = end_idx >= transfer_input_len
+            if is_last_chunk:
+                if StateType.MAMBA in state_types:
+                    mamba_indices = (
+                        self.req_to_token_pool.translate_mamba_indices(
+                            self.req_to_token_pool.req_index_to_mamba_index_mapping[
+                                req.req_pool_idx
+                            ]
+                        )
+                    )
+                    entry.mamba_indices = _copy_to_pinned_cpu(mamba_indices)
+
+                if StateType.SWA in state_types:
+                    window_start = max(0, end_idx - self.sliding_window_size)
+                    window_start = (window_start // page_size) * page_size
+                    swa_indices = (
+                        self.token_to_kv_pool_allocator.translate_loc_from_full_to_swa(
+                            full_indices[window_start:end_idx]
+                        )
+                    )
+                    entry.swa_seq_len = end_idx
+                    entry.swa_page_indices = _copy_page_indices_to_pinned_cpu(
+                        swa_indices, page_size
+                    )
+
+                if (
+                    StateType.DSA in state_types
+                    or StateType.MINIMAX_INDEX_K in state_types
+                ):
+                    # Preserve the existing state-pool addressing semantics:
+                    # unlike the main KV transfer, this path intentionally uses
+                    # the req_to_token values before unified-pool translation.
+                    entry.dsa_page_indices = _copy_page_indices_to_pinned_cpu(
+                        full_indices, page_size
+                    )
+
+            staged[str(req.rid)] = entry
+            self.disagg_prefill_pending_chunk_rids.add(req.rid)
+
+        return staged
+
     def resolve_waiting_queue_bootstrap(self: Scheduler) -> None:
         """Resolve bootstrap status for waiting prefill requests before admission.
 
@@ -684,6 +808,11 @@ class SchedulerDisaggregationPrefillMixin:
             self.batch_result_processor.snapshot_auxiliary_output_starts(batch, result)
         )
         auxiliary_output = result.auxiliary_host_output
+        staged_transfer_indices = result.disagg_transfer_indices or {}
+        for req in batch.reqs:
+            req._staged_prefill_transfer_indices = staged_transfer_indices.get(
+                str(req.rid)
+            )
         if result.routed_experts_output is not None:
             result.routed_experts_output.finalize()
             result.routed_experts_output = None
@@ -1170,6 +1299,9 @@ class SchedulerDisaggregationPrefillMixin:
             return
 
         state_indices: Optional[List] = None
+        staged: Optional[StagedPrefillTransferIndices] = getattr(
+            req, "_staged_prefill_transfer_indices", None
+        )
         if last_chunk:
             self.disagg_metadata_buffers.set_buf(req)
 
@@ -1181,6 +1313,8 @@ class SchedulerDisaggregationPrefillMixin:
             c128_seq_len = transfer_input_len
 
             def _mamba_payload():
+                if staged is not None and staged.mamba_indices is not None:
+                    return [staged.mamba_indices.numpy()]
                 return [
                     self.req_to_token_pool.translate_mamba_indices(
                         self.req_to_token_pool.req_index_to_mamba_index_mapping[
@@ -1192,6 +1326,12 @@ class SchedulerDisaggregationPrefillMixin:
                 ]
 
             def _swa_payload():
+                if (
+                    staged is not None
+                    and staged.swa_seq_len == seq_len
+                    and staged.swa_page_indices is not None
+                ):
+                    return staged.swa_page_indices.numpy()
                 window_size = self.sliding_window_size
                 window_start = max(req.disagg_decode_prefix_len, seq_len - window_size)
                 window_start = (window_start // page_size) * page_size
@@ -1206,6 +1346,14 @@ class SchedulerDisaggregationPrefillMixin:
                 return kv_to_page_indices(window_kv_indices_swa, page_size)
 
             def _full_kv_pages_payload():
+                if (
+                    staged is not None
+                    and staged.end_idx >= seq_len
+                    and staged.dsa_page_indices is not None
+                ):
+                    return staged.dsa_page_indices[
+                        : kv_to_page_num(seq_len, page_size)
+                    ].numpy()
                 kv_indices_full = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, :seq_len
                 ]
@@ -1289,17 +1437,28 @@ class SchedulerDisaggregationPrefillMixin:
 
         for seg_start, seg_end in segments:
             is_final_segment = seg_end == end_idx
-            kv_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, seg_start:seg_end
-            ]
-            # Unified memory: req_to_token holds VIRTUAL ids; the transfer needs
-            # physical ones. Per segment, since each is its own gather.
-            kv_indices = (
-                self.token_to_kv_pool_allocator.translate_kv_indices_for_transfer(
-                    kv_indices
+            if (
+                staged is not None
+                and staged.end_idx >= seg_end
+                and seg_start % page_size == 0
+            ):
+                page_start = seg_start // page_size
+                page_count = kv_to_page_num(seg_end - seg_start, page_size)
+                page_indices = staged.full_page_indices[
+                    page_start : page_start + page_count
+                ].numpy()
+            else:
+                kv_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, seg_start:seg_end
+                ]
+                # Unified memory: req_to_token holds VIRTUAL ids; the transfer needs
+                # physical ones. Per segment, since each is its own gather.
+                kv_indices = (
+                    self.token_to_kv_pool_allocator.translate_kv_indices_for_transfer(
+                        kv_indices
+                    )
                 )
-            )
-            page_indices = kv_to_page_indices(kv_indices, page_size)
+                page_indices = kv_to_page_indices(kv_indices, page_size)
             segment_is_last = last_chunk and is_final_segment
             if not req.disagg_kv_sender.should_send_kv_chunk(
                 len(page_indices), segment_is_last
@@ -1315,6 +1474,7 @@ class SchedulerDisaggregationPrefillMixin:
         # already put the request on `disagg_prefill_inflight_queue`.
         if last_chunk:
             self.disagg_prefill_pending_chunk_rids.discard(req.rid)
+            req._staged_prefill_transfer_indices = None
         else:
             self.disagg_prefill_pending_chunk_rids.add(req.rid)
 

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1056,6 +1056,21 @@ class Envs:
     # DeepGEMM Mega MoE
     # ===================================================================
     SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK = EnvInt(8192)
+    # 0 derives the launch size from DeepGEMM's current device SM count.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS = EnvInt(0)
+    # Blackwell MegaMoE uses a whole-grid software barrier. Keep a small even
+    # safety margin so every cluster can become resident beside other streams.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS = EnvInt(2)
+    # When set, the mega-MoE x slot is packed E2M1 (FP4) instead of FP8 E4M3.
+    # Halves symm-buffer footprint and unlocks the MXF4 mainloop downstream.
+    # Setting this also exports DG_USE_FP4_ACTS=1 so DeepGEMM's symm-buffer
+    # sizing + fp8_fp4_mega_moe pick up the FP4 layout.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS = EnvBool(False)
+    # Switches the L1+L2 mainloops from kind::mxf8f6f4 (K=32 with-padding) to
+    # kind::mxf4 (K=64 dense) inside fp8_fp4_mega_moe. No effect unless
+    # SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_FP4_ACTS is also set; DeepGEMM asserts
+    # this combination on the host side.
+    SGLANG_OPT_DEEPGEMM_MEGA_MOE_USE_MXF4_KIND = EnvBool(False)
 
     # ===================================================================
     # Top-k kernels

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -135,6 +135,16 @@ class AttentionBackend(ABC):
             return SharedReadEnds.IN_REPLAY
         return SharedReadEnds.UNKNOWN
 
+    def prepare_prefill_shared_read_snapshot(
+        self, forward_batch: ForwardBatch, *, num_qo_tokens: int
+    ) -> None:
+        """Snapshot late prefill reads before a PRE_REPLAY event is published.
+
+        Runners call this only after the actual eager/replay query geometry is
+        known. Backends that retain scheduler-shared reads into the model
+        forward keep the default no-op and must not declare PRE_REPLAY.
+        """
+
     # Chunked-prefix FullCG capture has a second model topology and stable
     # prefix buffers. Backends must opt in explicitly so the runner does not
     # assume that generic ForwardBatch metadata is sufficient for every

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -405,10 +405,11 @@ class DSV4Metadata:
     c4_compress_metadata: Optional[FusedCompressMetadata] = None
     c128_compress_metadata: Optional[FusedCompressMetadata] = None
 
-    # Lazily populated on the first call to ``_forward_prefill_sparse`` and
-    # reused across every layer in the chunk. Reset to ``None`` when graph
-    # metadata is refreshed so replay rebuilds it from the live batch.
+    # Built at the runner's prefill WAR boundary for the fast path; otherwise
+    # populated lazily by ``_forward_prefill_sparse``. Reused across every
+    # layer in the chunk and reset when graph metadata is refreshed.
     sparse_prefill_cache: Optional[SparsePrefillChunkCache] = None
+    prefill_shared_reads_snapshotted: bool = False
 
     @property
     def core_metadata(self) -> DSV4AttnMetadata:
@@ -422,6 +423,7 @@ class DSV4Metadata:
             self.c128_compress_metadata, src=other.c128_compress_metadata
         )
         self.sparse_prefill_cache = None
+        self.prefill_shared_reads_snapshotted = False
 
     def refresh_for_breakable_cuda_graph_replay_(self, static_metadata: DSV4Metadata):
         self.core_attn_metadata.refresh_for_breakable_cuda_graph_replay_(
@@ -441,6 +443,7 @@ class DSV4Metadata:
                 src=static_metadata.c128_compress_metadata,
             )
         self.sparse_prefill_cache = None
+        self.prefill_shared_reads_snapshotted = False
 
 
 @dataclass
@@ -516,6 +519,13 @@ class DeepseekV4AttnBackend(
             if self.model_runner.spec_algorithm.is_dspark():
                 return SharedReadEnds.IN_REPLAY
             return SharedReadEnds.POST_REPLAY
+        metadata = self.forward_metadata
+        if (
+            fm == ForwardMode.EXTEND
+            and isinstance(metadata, DSV4Metadata)
+            and metadata.prefill_shared_reads_snapshotted
+        ):
+            return SharedReadEnds.PRE_REPLAY
         return super().shared_read_ends(fm)
 
     def __init__(
@@ -1351,6 +1361,66 @@ class DeepseekV4AttnBackend(
         self.forward_metadata = self._build_forward_metadata(forward_batch)
         self.init_forward_metadata_in_graph(forward_batch)
 
+    def prepare_prefill_shared_read_snapshot(
+        self, forward_batch: ForwardBatch, *, num_qo_tokens: int
+    ) -> None:
+        # DFLASH/DSPARK have no later prefill draft-extend reader. Sparse
+        # prefill otherwise reads req_to_token/full_to_swa lazily in its first
+        # layer, so snapshot those mappings after the runner has resolved the
+        # actual query geometry. CP-v2 uses a rank-local query layout that this
+        # global snapshot does not represent.
+        metadata = self.forward_metadata
+        if isinstance(metadata, DSV4Metadata):
+            metadata.prefill_shared_reads_snapshotted = False
+        snapshot_shared_prefill_reads = (
+            envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.get()
+            and forward_batch.forward_mode == ForwardMode.EXTEND
+            and self.model_runner.spec_algorithm.is_dflash_family()
+            and not is_cp_v2_active(forward_batch)
+        )
+        if not snapshot_shared_prefill_reads:
+            return
+
+        assert isinstance(metadata, DSV4Metadata)
+        use_sparse_prefill = not _is_sm120 and (
+            num_qo_tokens > _LARGE_INDEXER_QUERY_THRESHOLD
+            or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+        )
+        if use_sparse_prefill:
+            metadata.sparse_prefill_cache = self._build_sparse_prefill_chunk_cache(
+                forward_batch, num_qo_tokens=num_qo_tokens
+            )
+        metadata.prefill_shared_reads_snapshotted = True
+
+    def _build_sparse_prefill_chunk_cache(
+        self, forward_batch: ForwardBatch, *, num_qo_tokens: int
+    ) -> SparsePrefillChunkCache:
+        seq_lens_cpu = forward_batch.seq_lens_cpu
+        assert seq_lens_cpu is not None
+        extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
+        assert extend_seq_lens_cpu is not None
+        seq_lens_cpu_list = seq_lens_cpu.tolist()
+        total_swa = sum(
+            min(int(seq_len), int(extend_len) + SWA_WINDOW - 1)
+            for seq_len, extend_len in zip(
+                seq_lens_cpu_list, extend_seq_lens_cpu, strict=True
+            )
+        )
+        # ``swa_window_size`` on the pool is its storage page size, not the
+        # model's SWA window, so pass both explicitly.
+        return SparsePrefillChunkCache.build(
+            seq_lens=forward_batch.seq_lens.to(torch.int32),
+            extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
+            req_pool_indices=forward_batch.req_pool_indices.to(torch.int32),
+            req_to_token=self.req_to_token,
+            full_to_swa=self.token_to_kv_pool.full_to_swa_index_mapping,
+            swa_window_size=SWA_WINDOW,
+            swa_page_size=self.token_to_kv_pool.swa_window_size,
+            num_qo_tokens=num_qo_tokens,
+            max_seq_len=max(seq_lens_cpu_list),
+            total_swa=total_swa,
+        )
+
     def _build_forward_metadata(
         self,
         forward_batch: ForwardBatch,
@@ -1790,29 +1860,8 @@ class DeepseekV4AttnBackend(
 
         cache = self.forward_metadata.sparse_prefill_cache
         if cache is None:
-            seq_lens_cpu = forward_batch.seq_lens_cpu
-            assert seq_lens_cpu is not None
-            extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
-            assert extend_seq_lens_cpu is not None
-            total_swa = sum(
-                min(int(seq_len), int(extend_len) + SWA_WINDOW - 1)
-                for seq_len, extend_len in zip(
-                    seq_lens_cpu.tolist(), extend_seq_lens_cpu, strict=True
-                )
-            )
-            # ``swa_window_size`` on the pool is its storage page size, not
-            # the model's SWA window — pass both explicitly.
-            cache = SparsePrefillChunkCache.build(
-                seq_lens=forward_batch.seq_lens.to(torch.int32),
-                extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
-                req_pool_indices=forward_batch.req_pool_indices.to(torch.int32),
-                req_to_token=self.req_to_token,
-                full_to_swa=token_to_kv_pool.full_to_swa_index_mapping,
-                swa_window_size=SWA_WINDOW,
-                swa_page_size=token_to_kv_pool.swa_window_size,
-                num_qo_tokens=q_flat.shape[0],
-                max_seq_len=int(seq_lens_cpu.max().item()),
-                total_swa=total_swa,
+            cache = self._build_sparse_prefill_chunk_cache(
+                forward_batch, num_qo_tokens=q_flat.shape[0]
             )
             self.forward_metadata.sparse_prefill_cache = cache
 
@@ -1986,27 +2035,8 @@ class DeepseekV4AttnBackend(
 
         cache = self.forward_metadata.sparse_prefill_cache
         if cache is None:
-            seq_lens_cpu = forward_batch.seq_lens_cpu
-            assert seq_lens_cpu is not None
-            extend_seq_lens_cpu = forward_batch.extend_seq_lens_cpu
-            assert extend_seq_lens_cpu is not None
-            total_swa = sum(
-                min(int(seq_len), int(extend_len) + SWA_WINDOW - 1)
-                for seq_len, extend_len in zip(
-                    seq_lens_cpu.tolist(), extend_seq_lens_cpu, strict=True
-                )
-            )
-            cache = SparsePrefillChunkCache.build(
-                seq_lens=forward_batch.seq_lens.to(torch.int32),
-                extend_seq_lens=forward_batch.extend_seq_lens.to(torch.int32),
-                req_pool_indices=forward_batch.req_pool_indices.to(torch.int32),
-                req_to_token=self.req_to_token,
-                full_to_swa=token_to_kv_pool.full_to_swa_index_mapping,
-                swa_window_size=SWA_WINDOW,
-                swa_page_size=token_to_kv_pool.swa_window_size,
-                num_qo_tokens=q_flat.shape[0],
-                max_seq_len=int(seq_lens_cpu.max().item()),
-                total_swa=total_swa,
+            cache = self._build_sparse_prefill_chunk_cache(
+                forward_batch, num_qo_tokens=q_flat.shape[0]
             )
             self.forward_metadata.sparse_prefill_cache = cache
 

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -16,7 +16,7 @@
 from __future__ import annotations
 
 import os
-from contextlib import nullcontext
+from contextlib import contextmanager, nullcontext
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -44,6 +44,42 @@ if TYPE_CHECKING:
 _MEGA_MOE_SYMM_BUFFER: dict = {}
 
 
+def _resolve_mega_moe_deep_gemm_num_sms(current_num_sms: int) -> int:
+    explicit_num_sms = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.get()
+    if explicit_num_sms > 0:
+        target_num_sms = min(explicit_num_sms, current_num_sms)
+    else:
+        reserved_num_sms = max(envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.get(), 0)
+        target_num_sms = current_num_sms - reserved_num_sms
+
+    target_num_sms = max(1, min(target_num_sms, current_num_sms))
+    if current_num_sms >= 2:
+        target_num_sms = max(2, target_num_sms)
+        target_num_sms -= target_num_sms % 2
+    return target_num_sms
+
+
+@contextmanager
+def _configure_mega_moe_deep_gemm_num_sms(deep_gemm):
+    current_num_sms = deep_gemm.get_num_sms()
+    # The SM90 MegaMoE implementation does not use the Blackwell whole-grid
+    # clustered launch that needs a residency margin.
+    if _device_sm < 100:
+        yield current_num_sms
+        return
+
+    target_num_sms = _resolve_mega_moe_deep_gemm_num_sms(current_num_sms)
+    if target_num_sms == current_num_sms:
+        yield current_num_sms
+        return
+
+    deep_gemm.set_num_sms(target_num_sms)
+    try:
+        yield target_num_sms
+    finally:
+        deep_gemm.set_num_sms(current_num_sms)
+
+
 def _get_mega_moe_symm_buffer(
     group,
     num_experts: int,
@@ -51,6 +87,7 @@ def _get_mega_moe_symm_buffer(
     num_topk: int,
     hidden: int,
     intermediate_hidden: int,
+    num_sms: int,
 ) -> SymmBuffer:
     import deep_gemm
 
@@ -61,6 +98,7 @@ def _get_mega_moe_symm_buffer(
         num_topk,
         hidden,
         intermediate_hidden,
+        num_sms,
     )
     buf = _MEGA_MOE_SYMM_BUFFER.get(key)
     if buf is None:
@@ -144,6 +182,27 @@ def _run_mega_routed(
 ) -> torch.Tensor:
     import deep_gemm
 
+    with _configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms:
+        return _run_mega_routed_impl(
+            moe,
+            hidden_states,
+            forward_batch,
+            input_ids_global,
+            num_tokens,
+            deep_gemm_num_sms=num_sms,
+        )
+
+
+def _run_mega_routed_impl(
+    moe: DeepseekV2MoE,
+    hidden_states: torch.Tensor,
+    forward_batch: Optional[ForwardBatch],
+    input_ids_global: Optional[torch.Tensor],
+    num_tokens: int,
+    deep_gemm_num_sms: int,
+) -> torch.Tensor:
+    import deep_gemm
+
     from sglang.srt.distributed.parallel_state import get_moe_ep_group
 
     hidden_size = moe.config.hidden_size
@@ -191,6 +250,7 @@ def _run_mega_routed(
         num_topk=top_k,
         hidden=hidden_size,
         intermediate_hidden=intermediate_size,
+        num_sms=deep_gemm_num_sms,
     )
 
     if num_tokens > 0:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -805,6 +805,8 @@ class HiCacheController:
         device_indices: torch.Tensor,
         priority: Optional[int] = None,
         node_id: int = -1,
+        *,
+        defer_start: bool = False,
     ) -> Optional[torch.Tensor]:
         """
         Back up KV caches from device memory to host memory.
@@ -815,7 +817,8 @@ class HiCacheController:
         self.write_queue.append(
             CacheOperation(host_indices, device_indices, node_id, priority)
         )
-        self.start_writing()
+        if not defer_start:
+            self.start_writing()
         return host_indices
 
     def start_writing(self) -> None:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -182,14 +182,12 @@ class CacheOperation:
             -1,
             priority,
             pool_transfers=CacheOperation._merge_pool_transfers(ops),
-            device_values_ready_event=next(
-                (
-                    op.device_values_ready_event
-                    for op in reversed(ops)
-                    if op.device_values_ready_event is not None
-                ),
-                None,
-            ),
+            device_values_ready_event=tuple(
+                op.device_values_ready_event
+                for op in ops
+                if op.device_values_ready_event is not None
+            )
+            or None,
         )
         merged_op.node_ids = node_ids
         return merged_op
@@ -426,7 +424,13 @@ class HiCacheController:
                 # CUDA current streams are thread-local.  Wait on the event
                 # recorded by the scheduler before Tensor.cpu() observes the
                 # allocator output from its current forward stream.
-                dependency.synchronize()
+                dependencies = (
+                    dependency
+                    if isinstance(dependency, (list, tuple))
+                    else (dependency,)
+                )
+                for event in dependencies:
+                    event.synchronize()
                 fn(*args)
             except BaseException as exc:
                 self._direct_dispatch_error = exc

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -122,12 +122,14 @@ class CacheOperation:
         node_id: int,
         priority: Optional[int] = None,
         pool_transfers: Optional[List[PoolTransfer]] = None,
+        device_values_ready_event=None,
     ):
         self.host_indices = host_indices
         self.device_indices = device_indices
         self.node_ids = [node_id]
         self.data = None
         self.pool_transfers = pool_transfers
+        self.device_values_ready_event = device_values_ready_event
 
         self.id = CacheOperation.counter
         CacheOperation.counter += 1
@@ -180,6 +182,14 @@ class CacheOperation:
             -1,
             priority,
             pool_transfers=CacheOperation._merge_pool_transfers(ops),
+            device_values_ready_event=next(
+                (
+                    op.device_values_ready_event
+                    for op in reversed(ops)
+                    if op.device_values_ready_event is not None
+                ),
+                None,
+            ),
         )
         merged_op.node_ids = node_ids
         return merged_op
@@ -424,10 +434,11 @@ class HiCacheController:
             finally:
                 self._direct_dispatch_queue.task_done()
 
-    def _enqueue_direct_dispatch(self, fn, *args) -> None:
+    def _enqueue_direct_dispatch(self, fn, *args, dependency=None) -> None:
         self.check_direct_dispatch_error()
-        dependency = device_module.Event()
-        dependency.record()
+        if dependency is None:
+            dependency = device_module.Event()
+            dependency.record()
         self._direct_dispatch_queue.put((dependency, fn, args))
 
     def check_direct_dispatch_error(self) -> None:

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -47,6 +47,21 @@ logger = logging.getLogger(__name__)
 device_module = get_device_module()
 
 
+def _resolve_background_thread_device(device: torch.device | str):
+    """Return a device value accepted by ``set_device`` in a new thread.
+
+    Device pools may expose the generic ``torch.device("cuda")`` because each
+    scheduler process already selected its local GPU.  CUDA's current-device
+    selection is thread-local, however, and ``set_device(torch.device("cuda"))``
+    rejects a device without an index.  Resolve that index on the scheduler
+    thread before starting the helper thread.
+    """
+    device = torch.device(device)
+    if device.type != "cpu" and device.index is None:
+        return device_module.current_device()
+    return device
+
+
 class LayerLoadingEvent:
     def __init__(self, num_layers: int):
         self._num_layers = num_layers
@@ -346,6 +361,26 @@ class HiCacheController:
 
         self.l2_transfer_engine = L2TransferEngine(io_backend)
 
+        # Direct I/O needs CPU index arrays.  Converting CUDA allocator output
+        # with Tensor.cpu() can block for the entire outstanding forward on the
+        # scheduler's current stream.  Dispatch direct transfers from a helper
+        # thread so that unavoidable D2H index readiness never stalls the
+        # scheduler launch loop.
+        self._direct_dispatch_queue: Queue = Queue()
+        self._direct_dispatch_error: Optional[BaseException] = None
+        self._direct_dispatch_thread = None
+        self._direct_dispatch_device = None
+        if self.io_backend == "direct":
+            self._direct_dispatch_device = _resolve_background_thread_device(
+                self.device
+            )
+            self._direct_dispatch_thread = threading.Thread(
+                target=self._direct_dispatch_thread_func,
+                name="hicache-direct-dispatch",
+                daemon=True,
+            )
+            self._direct_dispatch_thread.start()
+
         # If a storage backend is provided at startup, treat it as an implicit attach,
         # so init/runtime share the same lifecycle semantics and code paths.
         if storage_backend is not None:
@@ -368,6 +403,44 @@ class HiCacheController:
                 torch.distributed.get_world_size(group=self.attn_cp_group),
             )
         return 0, 1
+
+    def _direct_dispatch_thread_func(self) -> None:
+        if torch.device(self.device).type != "cpu":
+            device_module.set_device(self._direct_dispatch_device)
+        while True:
+            task = self._direct_dispatch_queue.get()
+            try:
+                if task is None:
+                    return
+                dependency, fn, args = task
+                # CUDA current streams are thread-local.  Wait on the event
+                # recorded by the scheduler before Tensor.cpu() observes the
+                # allocator output from its current forward stream.
+                dependency.synchronize()
+                fn(*args)
+            except BaseException as exc:
+                self._direct_dispatch_error = exc
+                logger.exception("HiCache direct transfer dispatch failed")
+            finally:
+                self._direct_dispatch_queue.task_done()
+
+    def _enqueue_direct_dispatch(self, fn, *args) -> None:
+        self.check_direct_dispatch_error()
+        dependency = device_module.Event()
+        dependency.record()
+        self._direct_dispatch_queue.put((dependency, fn, args))
+
+    def check_direct_dispatch_error(self) -> None:
+        if self._direct_dispatch_error is not None:
+            error = self._direct_dispatch_error
+            self._direct_dispatch_error = None
+            raise RuntimeError("HiCache direct transfer dispatch failed") from error
+
+    def wait_direct_dispatch(self) -> None:
+        if self._direct_dispatch_thread is None:
+            return
+        self._direct_dispatch_queue.join()
+        self.check_direct_dispatch_error()
 
     def _create_prefetch_sync_groups(self) -> None:
         from sglang.srt.distributed.parallel_state import create_custom_parallel_group
@@ -696,6 +769,9 @@ class HiCacheController:
         )
 
     def reset(self):
+        # Do not clear queues or acknowledgements while a helper-owned direct
+        # transfer still references their tensors.
+        self.wait_direct_dispatch()
         self.storage_stop_event.set()
 
         self.write_queue.clear()
@@ -747,8 +823,14 @@ class HiCacheController:
             return
 
         op = CacheOperation.merge_ops(self.write_queue)
-        host_indices, device_indices, pool_transfers = self._move_write_operation(op)
         self.write_queue.clear()
+        if self.io_backend == "direct":
+            self._enqueue_direct_dispatch(self._start_writing_op, op)
+        else:
+            self._start_writing_op(op)
+
+    def _start_writing_op(self, op: CacheOperation) -> None:
+        host_indices, device_indices, pool_transfers = self._move_write_operation(op)
 
         completion = self.l2_transfer_engine.submit_device_to_host(
             self._l2_transfers(host_indices, device_indices, pool_transfers)
@@ -874,10 +956,18 @@ class HiCacheController:
 
         producer_id = self.layer_done_counter.update_producer()
         op = CacheOperation.merge_ops(self.load_queue)
-        host_indices, device_indices, pool_transfers = self._move_op_indices(op)
         self.load_queue.clear()
         producer_event = self.layer_done_counter.events[producer_id]
         producer_event.start_event.record()
+        if self.io_backend == "direct":
+            self._enqueue_direct_dispatch(self._start_loading_op, op, producer_id)
+        else:
+            self._start_loading_op(op, producer_id)
+        return producer_id
+
+    def _start_loading_op(self, op: CacheOperation, producer_id: int) -> None:
+        host_indices, device_indices, pool_transfers = self._move_op_indices(op)
+        producer_event = self.layer_done_counter.events[producer_id]
 
         completion = self.l2_transfer_engine.submit_host_to_device(
             self._l2_load_transfers(host_indices, device_indices, pool_transfers),
@@ -897,7 +987,6 @@ class HiCacheController:
                 num_bytes=self._transfer_num_bytes(op),
             )
         )
-        return producer_id
 
     def evict_device(self, device_indices: torch.Tensor) -> int:
         self.mem_pool_device_allocator.free(device_indices)

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -67,6 +67,28 @@ class LayerLoadingEvent:
         self._num_layers = num_layers
         self.load_events = [device_module.Event() for _ in range(num_layers)]
         self.start_event = device_module.Event()  # start event on controller stream
+        # A CUDA wait issued before an event has ever been recorded does not
+        # wait for a future record. Direct-I/O dispatch therefore publishes a
+        # small CPU-side handoff after the helper has enqueued every per-layer
+        # copy and completion event. The consumer waits only for submission,
+        # not for the copies themselves; GPU execution remains layer-overlapped.
+        self._submission_ready = threading.Event()
+        self._submission_error: Optional[BaseException] = None
+
+    def reset_submission(self):
+        self._submission_error = None
+        self._submission_ready.clear()
+
+    def mark_submitted(self, error: Optional[BaseException] = None):
+        self._submission_error = error
+        self._submission_ready.set()
+
+    def wait_until_submitted(self):
+        self._submission_ready.wait()
+        if self._submission_error is not None:
+            raise RuntimeError(
+                "HiCache load submission failed"
+            ) from self._submission_error
 
     def complete(self, layer_index: int):
         assert 0 <= layer_index < self._num_layers
@@ -91,14 +113,18 @@ class LayerDoneCounter:
 
     def update_producer(self):
         self.producer_index = (self.producer_index + 1) % self.num_counters
-        assert self.events[
-            self.producer_index
-        ].finish_event.query(), (
-            "Producer finish event should be ready before being reused."
-        )
+        producer_event = self.events[self.producer_index]
+        assert (
+            producer_event.finish_event.query()
+        ), "Producer finish event should be ready before being reused."
+        producer_event.reset_submission()
         return self.producer_index
 
     def set_consumer(self, index: int):
+        if index >= 0:
+            # Ensure the CUDA events below have a concrete record in the H2D
+            # stream before model code calls wait_event on them.
+            self.events[index].wait_until_submitted()
         self.consumer_index = index
 
     def wait_until(self, threshold: int):
@@ -978,10 +1004,25 @@ class HiCacheController:
         producer_event = self.layer_done_counter.events[producer_id]
         producer_event.start_event.record()
         if self.io_backend == "direct":
-            self._enqueue_direct_dispatch(self._start_loading_op, op, producer_id)
+            self._enqueue_direct_dispatch(
+                self._start_loading_op_and_signal_submission, op, producer_id
+            )
         else:
             self._start_loading_op(op, producer_id)
+            producer_event.mark_submitted()
         return producer_id
+
+    def _start_loading_op_and_signal_submission(
+        self, op: CacheOperation, producer_id: int
+    ) -> None:
+        producer_event = self.layer_done_counter.events[producer_id]
+        try:
+            self._start_loading_op(op, producer_id)
+        except BaseException as exc:
+            producer_event.mark_submitted(error=exc)
+            raise
+        else:
+            producer_event.mark_submitted()
 
     def _start_loading_op(self, op: CacheOperation, producer_id: int) -> None:
         host_indices, device_indices, pool_transfers = self._move_op_indices(op)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1178,7 +1178,6 @@ class Req(ReqDllmMixin):
         # kv_send(req.input_ids[req.start_send_idx:req.extend_range.end])
         # start_send_idx = req.extend_range.end
         self.start_send_idx: int = 0
-        self.disagg_decode_prefix_len: int = 0
 
         # For overlap schedule, we delay the kv transfer until `process_batch_result_disagg_prefill` rather than `process_prefill_chunk` in non-overlap
         # This is because kv is not ready in `process_prefill_chunk`.
@@ -1190,6 +1189,8 @@ class Req(ReqDllmMixin):
         # At-rest device-resident prefix end, snapshotted on the request's
         # first prefill batch; the cached-prefix early-send never goes past it.
         self.early_send_prefix_end: Optional[int] = None
+        self._staged_prefill_transfer_indices = None
+        self._staged_cached_prefix_transfer_indices = None
         self.metadata_buffer_index: int = -1
         # Used in overlap sequence to signal that an optimistic request should
         # abort chunking. Set in create_sender, consumed in process_batch_result.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1520,7 +1520,6 @@ class Scheduler(
         self.copy_stream_ctx: CudaStreamContext = self.device_module.stream(
             self.copy_stream
         )
-
         if not self.enable_overlap:
             return
 
@@ -3809,6 +3808,13 @@ class Scheduler(
                             if _is_hip:
                                 # Cross-stream sync costs more than the tiny D2H it
                                 # overlaps.
+                                if (
+                                    self.disaggregation_mode
+                                    == DisaggregationMode.PREFILL
+                                ):
+                                    batch_result.disagg_transfer_indices = (
+                                        self.stage_prefill_transfer_indices(batch)
+                                    )
                                 batch_result.copy_to_cpu(
                                     return_logprob=batch.return_logprob,
                                     return_hidden_states=batch.return_hidden_states,
@@ -3819,6 +3825,13 @@ class Scheduler(
                                 # gated by copy_done, so nothing on forward_stream waits.
                                 self.copy_stream.wait_stream(self.forward_stream)
                                 with self.copy_stream_ctx:
+                                    if (
+                                        self.disaggregation_mode
+                                        == DisaggregationMode.PREFILL
+                                    ):
+                                        batch_result.disagg_transfer_indices = (
+                                            self.stage_prefill_transfer_indices(batch)
+                                        )
                                     batch_result.copy_to_cpu(
                                         return_logprob=batch.return_logprob,
                                         return_hidden_states=batch.return_hidden_states,
@@ -3859,6 +3872,10 @@ class Scheduler(
                 self.update_cache_from_scheduler(batch, batch_result)
                 # Sync D2H so the result processor can read CPU tensors.
                 batch_result.copy_done = self.device_module.Event()
+                if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                    batch_result.disagg_transfer_indices = (
+                        self.stage_prefill_transfer_indices(batch)
+                    )
                 batch_result.copy_to_cpu(
                     return_logprob=batch.return_logprob,
                     return_hidden_states=batch.return_hidden_states,
@@ -4016,6 +4033,10 @@ class Scheduler(
         # with subsequent forward computation.
         self.copy_stream.wait_stream(self.forward_stream)
         with self.copy_stream_ctx:
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                batch_result.disagg_transfer_indices = (
+                    self.stage_prefill_transfer_indices(cur_batch)
+                )
             batch_result.copy_to_cpu(
                 return_logprob=cur_batch.return_logprob,
                 return_hidden_states=cur_batch.return_hidden_states,

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -72,6 +72,11 @@ class GenerationBatchResult:
     future_indices: Optional[torch.Tensor] = None
     speculative_num_draft_tokens: Optional[int] = None
 
+    # Pinned CPU page/state indices prepared on the result copy stream for
+    # disaggregated prefill.  They are consumed after copy_done fires, avoiding
+    # synchronous tiny D2H reads in send_kv_chunk().
+    disagg_transfer_indices: Optional[dict] = None
+
     # Grammar FSM advance memoization (spec-v2 overlap). advance_grammar_fsm sets
     # these once — eagerly via the scheduler's grammar barrier inside verify(), or
     # lazily in _resolve_spec_v2_tokens — and the latter consumes

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -301,8 +301,13 @@ def alloc_for_extend(
         ]
 
     # Create tensors for allocation
-    prefix_lens_cpu = torch.tensor(batch.prefix_lens, dtype=torch.int64)
-    extend_lens_cpu = torch.tensor(batch.extend_lens, dtype=torch.int64)
+    pin_memory = is_pin_memory_available(batch.device)
+    prefix_lens_cpu = torch.tensor(
+        batch.prefix_lens, dtype=torch.int64, pin_memory=pin_memory
+    )
+    extend_lens_cpu = torch.tensor(
+        batch.extend_lens, dtype=torch.int64, pin_memory=pin_memory
+    )
     prefix_lens_device = prefix_lens_cpu.to(batch.device, non_blocking=True)
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
@@ -310,7 +315,9 @@ def alloc_for_extend(
     req_pool_indices = alloc_req_slots(
         batch.req_to_token_pool, batch.reqs, batch.tree_cache
     )
-    req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+    req_pool_indices_cpu = torch.tensor(
+        req_pool_indices, dtype=torch.int64, pin_memory=pin_memory
+    )
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
 
     # Allocate KV cache (throws exception on failure)

--- a/python/sglang/srt/mem_cache/allocator/base.py
+++ b/python/sglang/srt/mem_cache/allocator/base.py
@@ -46,6 +46,7 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         self.release_pages = None
         self.is_not_in_free_group = True
         self.free_group = []
+        self.free_segments_group = []
 
     @property
     def size_full(self):
@@ -63,11 +64,19 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
     def free_group_begin(self):
         self.is_not_in_free_group = False
         self.free_group = []
+        self.free_segments_group = []
 
     def free_group_end(self):
         self.is_not_in_free_group = True
         if self.free_group:
-            self.free(torch.cat(self.free_group))
+            free_group = self.free_group
+            self.free_group = []
+            self.free(torch.cat(free_group))
+        if self.free_segments_group:
+            segment_groups = self.free_segments_group
+            self.free_segments_group = []
+            for segments, swa_evicted_seqlen in segment_groups:
+                self.free_segments(segments, swa_evicted_seqlen=swa_evicted_seqlen)
 
     @staticmethod
     def _copy_for_free_group(free_index: torch.Tensor) -> torch.Tensor:
@@ -130,16 +139,49 @@ class BaseTokenToKVPoolAllocator(abc.ABC):
         data-dependent dedup. Default: plain free()."""
         self.free(free_index)
 
-    def free_segments(self, segments):
+    def free_swa_segment(self, free_index: torch.Tensor, *, start_pos: int):
+        """Free an SWA-only contiguous segment of one request's KV row.
+
+        SWA allocators may use ``start_pos`` to avoid data-dependent page
+        discovery. Other implementations retain the legacy free_swa path.
+        """
+        self.free_swa(free_index)
+
+    def free_segments(self, segments, *, swa_evicted_seqlen: int | None = None):
         """Free disjoint ascending ``(free_index, start_pos)`` segments of one
         request's kv row; a boundary page shared by consecutive segments is
-        emitted once (the later segment's head is trimmed)."""
+        emitted once (the later segment's head is trimmed).
+
+        ``swa_evicted_seqlen`` is ignored by non-SWA allocators. Composite SWA
+        allocators use it to select the still-live SWA suffix without inspecting
+        device mappings. ``None`` retains their legacy mapping-discovery path.
+        Each call remains a separate request when deferred by a free group.
+        """
+        segments = [
+            (free_index, start_pos)
+            for free_index, start_pos in segments
+            if free_index.numel() > 0
+        ]
+        if not segments:
+            return
+        if not self.is_not_in_free_group:
+            self.free_segments_group.append(
+                (
+                    [
+                        (self._copy_for_free_group(free_index), start_pos)
+                        for free_index, start_pos in segments
+                    ],
+                    swa_evicted_seqlen,
+                )
+            )
+            return
+        self._free_segments_impl(segments, swa_evicted_seqlen=swa_evicted_seqlen)
+
+    def _free_segments_impl(self, segments, *, swa_evicted_seqlen: int | None) -> None:
         ps = self.page_size
         prev_end = None
         for free_index, start_pos in segments:
             n = free_index.numel()
-            if n == 0:
-                continue
             seg_end = start_pos + n
             if prev_end is not None and start_pos // ps == (prev_end - 1) // ps:
                 boundary = (start_pos // ps + 1) * ps

--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -371,6 +371,9 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def free_swa(self, free_indices: torch.Tensor):
         self.logical_attn_allocator.free_swa(free_indices)
 
+    def free_swa_segment(self, free_indices: torch.Tensor, *, start_pos: int):
+        self.logical_attn_allocator.free_swa_segment(free_indices, start_pos=start_pos)
+
     def available_size(self) -> int:
         return min(
             self.logical_attn_allocator.available_size(),
@@ -577,6 +580,7 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.full_to_hisparse_device_index_mapping[:-1].fill_(0)
         self.is_not_in_free_group = True
         self.free_group = []
+        self.free_segments_group = []
 
     def free(self, free_index: torch.Tensor):
         if free_index.numel() == 0:
@@ -586,3 +590,8 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.logical_attn_allocator.free(free_index)
         else:
             self.free_group.append(self._copy_for_free_group(free_index))
+
+    def _free_segments_impl(self, segments, *, swa_evicted_seqlen: int | None) -> None:
+        self.logical_attn_allocator.free_segments(
+            segments, swa_evicted_seqlen=swa_evicted_seqlen
+        )

--- a/python/sglang/srt/mem_cache/allocator/paged.py
+++ b/python/sglang/srt/mem_cache/allocator/paged.py
@@ -42,6 +42,16 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.memory_pool import KVCache
 
 
+def page_representatives_from_segment(
+    free_index: torch.Tensor, *, start_pos: int, page_size: int
+) -> tuple[torch.Tensor, ...]:
+    """Return one token representative for every page touched by a segment."""
+    offset = start_pos % page_size
+    if offset == 0:
+        return (free_index[::page_size],)
+    return (free_index[:1], free_index[page_size - offset :: page_size])
+
+
 def alloc_extend_naive(
     prefix_lens,
     seq_lens,
@@ -279,11 +289,9 @@ class PagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             return
 
         ps = self.page_size
-        offset = start_pos % ps
-        if offset == 0:
-            pieces = (free_index[::ps],)
-        else:
-            pieces = (free_index[:1], free_index[ps - offset :: ps])
+        pieces = page_representatives_from_segment(
+            free_index, start_pos=start_pos, page_size=ps
+        )
 
         if self.debug_mode:
             # reference unique on CPU: the NPU subclass deliberately avoids device unique

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -1,7 +1,10 @@
 import torch
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
-from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import (
+    PagedTokenToKVPoolAllocator,
+    page_representatives_from_segment,
+)
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_swa_memory_pool import BaseSWAKVPool
 from sglang.srt.utils import is_npu
@@ -96,6 +99,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.is_not_in_free_group = True
         self.free_group = []
         self.swa_free_group = []
+        self.free_segments_group = []
+        self.swa_free_segments_group = []
 
         self._kvcache = kvcache
         self.clear()
@@ -161,7 +166,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
         assert alloc_swa_indices is not None
 
-        self.set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
+        self._set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
         return alloc_full_indices
 
     def new_pages_available(self, num_full_pages: int, num_swa_pages: int) -> bool:
@@ -212,7 +217,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert alloc_full_indices is not None
         assert alloc_swa_indices is not None
 
-        self.set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
+        self._set_full_to_swa_mapping(alloc_full_indices, alloc_swa_indices)
 
         return alloc_full_indices
 
@@ -276,7 +281,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         )
         assert alloc_swa_indices is not None
 
-        self.set_full_to_swa_mapping(
+        self._set_full_to_swa_mapping(
             alloc_full_indices[-swa_tail_len:], alloc_swa_indices
         )
         if swa_tail_len < extend_num_tokens:
@@ -321,7 +326,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         # NOTE: the API is not idempotent.
         if self.is_not_in_free_group:
             self.full_attn_allocator.free(free_index)
-            self.free_swa(free_index)
+            self._free_swa_legacy(free_index)
         else:
             self.free_group.append(self._copy_for_free_group(free_index))
         assert (
@@ -332,10 +337,34 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def set_full_to_swa_mapping(
         self, full_indices: torch.Tensor, swa_indices: torch.Tensor
     ) -> None:
-        """Write full_to_swa_index_mapping[full_indices[i]] = swa_indices[i].
+        """Map page-dense Full/SWA token indices with matching offsets.
 
-        Used by HiCache load-back path to rebuild the mapping after FULL and SWA device alloc.
+        HiCache load-back and tombstone recovery rebuild mappings through this
+        public API. The paged segment-free fast path requires every input page
+        to be complete and contiguous on both sides.
         """
+        if full_indices.numel() == 0:
+            return
+        assert full_indices.numel() == swa_indices.numel()
+        assert full_indices.numel() % self.page_size == 0
+        assert full_indices.device == swa_indices.device
+
+        offsets = torch.arange(self.page_size, device=full_indices.device)
+        full_pages = full_indices.to(torch.int64).reshape(-1, self.page_size)
+        swa_pages = swa_indices.to(torch.int64).reshape(-1, self.page_size)
+        is_page_dense = torch.all(
+            full_pages == full_pages[:, :1] + offsets
+        ) & torch.all(swa_pages == swa_pages[:, :1] + offsets)
+        torch._assert_async(
+            is_page_dense,
+            "Full/SWA mapping must contain complete pages with matching offsets",
+        )
+
+        self._set_full_to_swa_mapping(full_indices, swa_indices)
+
+    def _set_full_to_swa_mapping(
+        self, full_indices: torch.Tensor, swa_indices: torch.Tensor
+    ) -> None:
         if full_indices.numel() == 0:
             return
         assert full_indices.numel() == swa_indices.numel()
@@ -350,7 +379,87 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         # host-resident scalar and blocks until the stream drains.
         self.full_to_swa_index_mapping.index_fill_(0, full_indices.to(torch.int64), 0)
 
+    def _free_segments_impl(self, segments, *, swa_evicted_seqlen: int | None) -> None:
+        if swa_evicted_seqlen is None or self.page_size == 1:
+            super()._free_segments_impl(segments, swa_evicted_seqlen=swa_evicted_seqlen)
+            return
+
+        self.full_attn_allocator.free_segments(segments)
+
+        mapped_full_segments = []
+        for free_index, start_pos in segments:
+            end_pos = start_pos + free_index.numel()
+            live_start = max(start_pos, swa_evicted_seqlen)
+            if live_start >= end_pos:
+                continue
+            live_full = free_index[live_start - start_pos :]
+            mapped_full_segments.append((live_full, live_start))
+
+        self._free_mapped_swa_segments(mapped_full_segments)
+
+    def _free_mapped_swa_segments(self, full_segments) -> None:
+        swa_segments = []
+        for full_indices, start_pos in full_segments:
+            swa_indices = torch.index_select(
+                self.full_to_swa_index_mapping,
+                0,
+                full_indices.to(torch.int64),
+            )
+            if self.swa_attn_allocator.debug_mode:
+                assert torch.all(
+                    swa_indices > 0
+                ).item(), "SWA release encountered an unmapped token"
+            swa_segments.append((swa_indices, start_pos))
+
+        self.swa_attn_allocator.free_segments(swa_segments)
+        for full_indices, start_pos in full_segments:
+            if (
+                start_pos % self.page_size == 0
+                and full_indices.numel() % self.page_size == 0
+            ):
+                mapping_indices = full_indices
+            else:
+                representatives = page_representatives_from_segment(
+                    full_indices, start_pos=start_pos, page_size=self.page_size
+                )
+                full_page_ids = torch.cat(
+                    [
+                        representative.to(torch.int64) // self.page_size
+                        for representative in representatives
+                    ]
+                )
+                page_offsets = torch.arange(
+                    self.page_size,
+                    dtype=torch.int64,
+                    device=full_indices.device,
+                )
+                mapping_indices = (
+                    full_page_ids[:, None] * self.page_size + page_offsets[None, :]
+                ).reshape(-1)
+            self.clear_full_to_swa_mapping(mapping_indices)
+
     def free_swa(self, free_index: torch.Tensor):
+        self._free_swa_legacy(free_index)
+
+    def free_swa_segment(self, free_index: torch.Tensor, *, start_pos: int):
+        """Free a dense page-aligned SWA window segment without torch.unique."""
+        if free_index.numel() == 0:
+            return
+        if self.page_size == 1:
+            self.free_swa(free_index)
+            return
+        if not self.is_not_in_free_group:
+            self.swa_free_segments_group.append(
+                (self._copy_for_free_group(free_index), start_pos)
+            )
+            return
+
+        assert start_pos % self.page_size == 0
+        assert free_index.numel() % self.page_size == 0
+
+        self._free_mapped_swa_segments([(free_index, start_pos)])
+
+    def _free_swa_legacy(self, free_index: torch.Tensor):
         if free_index.numel() == 0:
             return
 
@@ -371,13 +480,32 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def free_group_begin(self):
         super().free_group_begin()
         self.swa_free_group = []
+        self.swa_free_segments_group = []
 
     def free_group_end(self):
-        super().free_group_end()
+        self.is_not_in_free_group = True
+        if self.free_group:
+            self.free(torch.cat(self.free_group))
+
+        segment_groups = self.free_segments_group
+        self.free_segments_group = []
+        for segments, swa_evicted_seqlen in segment_groups:
+            if swa_evicted_seqlen is None:
+                self.free_segments(segments)
+
+        if self.swa_free_segments_group:
+            swa_segment_group = self.swa_free_segments_group
+            self.swa_free_segments_group = []
+            for free_index, start_pos in swa_segment_group:
+                self.free_swa_segment(free_index, start_pos=start_pos)
         if self.swa_free_group:
             swa_free_group = self.swa_free_group
             self.swa_free_group = []
             self.free_swa(torch.cat(swa_free_group))
+
+        for segments, swa_evicted_seqlen in segment_groups:
+            if swa_evicted_seqlen is not None:
+                self.free_segments(segments, swa_evicted_seqlen=swa_evicted_seqlen)
 
     def _expand_to_full_pages(self, indices: torch.Tensor) -> torch.Tensor:
         pages = torch.unique(indices // self.page_size)
@@ -408,6 +536,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.is_not_in_free_group = True
         self.free_group = []
         self.swa_free_group = []
+        self.free_segments_group = []
+        self.swa_free_segments_group = []
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
@@ -459,6 +589,7 @@ class PureSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         self.release_pages = None
         self.is_not_in_free_group = True
         self.free_group = []
+        self.free_segments_group = []
 
         self._kvcache = kvcache
         self.swa_attn_allocator.clear()
@@ -517,16 +648,13 @@ class PureSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             self.free_group.append(self._copy_for_free_group(free_index))
 
     def free_group_begin(self):
-        self.is_not_in_free_group = False
-        self.free_group = []
+        BaseTokenToKVPoolAllocator.free_group_begin(self)
 
     def free_group_end(self):
-        self.is_not_in_free_group = True
-        if self.free_group:
-            self.free(torch.cat(self.free_group))
-        self.free_group = []
+        BaseTokenToKVPoolAllocator.free_group_end(self)
 
     def clear(self):
         self.swa_attn_allocator.clear()
         self.is_not_in_free_group = True
         self.free_group = []
+        self.free_segments_group = []

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -84,7 +84,10 @@ class ChunkCache(BasePrefixCache):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.cache_protected_len : kv_len_to_handle
         ]
-        self.token_to_kv_pool_allocator.free(kv_indices)
+        self.token_to_kv_pool_allocator.free_segments(
+            [(kv_indices, req.cache_protected_len)],
+            swa_evicted_seqlen=req.kv.swa_evicted_seqlen,
+        )
 
     def cache_unfinished_req(self, req: Req, chunked=False):
         kv_indices = self.req_to_token_pool.req_to_token[

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -100,7 +100,9 @@ def free_swa_out_of_window_slots(
         free_slots = req_to_token_pool.req_to_token[
             req.req_pool_idx, req.kv.swa_evicted_seqlen : new_swa_evicted_seqlen
         ]
-        token_to_kv_pool_allocator.free_swa(free_slots)
+        token_to_kv_pool_allocator.free_swa_segment(
+            free_slots, start_pos=req.kv.swa_evicted_seqlen
+        )
         req.kv.swa_evicted_seqlen = new_swa_evicted_seqlen
 
 
@@ -264,7 +266,10 @@ def _release_overallocated_kv_indices(
         ]
         # start_p is aligned to the allocator's physical page size above, so it
         # never shares a page with cache_finished_req's tail free in this group.
-        allocator.free_segment(indices_to_free, start_pos=start_p)
+        allocator.free_segments(
+            [(indices_to_free, start_p)],
+            swa_evicted_seqlen=req.kv.swa_evicted_seqlen,
+        )
 
 
 def available_and_evictable_str(tree_cache: BasePrefixCache) -> str:

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1026,8 +1026,10 @@ class HiRadixCache(RadixCache):
         return count_values[0], count_values[1], tuple(count_values[2:])
 
     def writing_check(self, write_back=False, finish_count: Optional[int] = None):
+        self.cache_controller.check_direct_dispatch_error()
         if write_back:
             # blocking till all write back complete
+            self.cache_controller.wait_direct_dispatch()
             while len(self.ongoing_write_through) > 0:
                 for ack in self.cache_controller.ack_write_queue:
                     ack.finish_event.synchronize()

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -352,13 +352,13 @@ class HybridCacheController(BaseHiCacheController):
         ops = self.write_queue
         self.write_queue = []
         if self.io_backend == "direct":
-            dependency = next(
-                (
+            dependency = (
+                tuple(
                     op.device_values_ready_event
-                    for op in reversed(ops)
+                    for op in ops
                     if op.device_values_ready_event is not None
-                ),
-                None,
+                )
+                or None
             )
             self._enqueue_direct_dispatch(
                 self._merge_and_start_writing_ops,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -317,6 +317,7 @@ class HybridCacheController(BaseHiCacheController):
         extra_pools: Optional[list[PoolTransfer]] = None,
         *,
         defer_start: bool = False,
+        device_values_ready_event=None,
     ) -> Optional[torch.Tensor]:
         host_indices = self.mem_pool_host.alloc(len(device_indices))
         if host_indices is None:
@@ -338,11 +339,38 @@ class HybridCacheController(BaseHiCacheController):
                 node_id,
                 priority,
                 pool_transfers=pool_transfers or None,
+                device_values_ready_event=device_values_ready_event,
             )
         )
         if not defer_start:
             self.start_writing()
         return host_indices
+
+    def start_writing(self) -> None:
+        if not self.write_queue:
+            return
+        ops = self.write_queue
+        self.write_queue = []
+        if self.io_backend == "direct":
+            dependency = next(
+                (
+                    op.device_values_ready_event
+                    for op in reversed(ops)
+                    if op.device_values_ready_event is not None
+                ),
+                None,
+            )
+            self._enqueue_direct_dispatch(
+                self._merge_and_start_writing_ops,
+                ops,
+                dependency=dependency,
+            )
+        else:
+            self._start_writing_op(CacheOperation.merge_ops(ops))
+
+    def _merge_and_start_writing_ops(self, ops: list[CacheOperation]) -> None:
+        """Merge direct-I/O indices on the helper's CUDA stream."""
+        self._start_writing_op(CacheOperation.merge_ops(ops))
 
     def _move_op_indices(
         self, op: CacheOperation
@@ -625,8 +653,15 @@ class HybridCacheController(BaseHiCacheController):
         if operation.pool_transfers:
             resolved_pool_transfers = []
             for transfer in operation.pool_transfers:
+                transfer_device_indices = transfer.device_indices
+                if (
+                    self.io_backend == "direct"
+                    and transfer_device_indices is not None
+                    and transfer_device_indices.dtype != torch.int64
+                ):
+                    transfer_device_indices = transfer_device_indices.to(torch.int64)
                 transfer_host_indices, transfer_device_indices = self.move_indices(
-                    transfer.host_indices, transfer.device_indices
+                    transfer.host_indices, transfer_device_indices
                 )
                 # Keep the original PoolTransfer unchanged because tree-owned
                 # transfers may still reference radix-tree host state. The

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -315,6 +315,8 @@ class HybridCacheController(BaseHiCacheController):
         priority: Optional[int] = None,
         node_id: int = -1,
         extra_pools: Optional[list[PoolTransfer]] = None,
+        *,
+        defer_start: bool = False,
     ) -> Optional[torch.Tensor]:
         host_indices = self.mem_pool_host.alloc(len(device_indices))
         if host_indices is None:
@@ -338,7 +340,8 @@ class HybridCacheController(BaseHiCacheController):
                 pool_transfers=pool_transfers or None,
             )
         )
-        self.start_writing()
+        if not defer_start:
+            self.start_writing()
         return host_indices
 
     def _move_op_indices(

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -36,6 +36,7 @@ from sglang.srt.mem_cache.allocator import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import (
     alloc_decode_kernel,
     alloc_extend_kernel,
+    page_representatives_from_segment,
 )
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.unified_memory_pool import (
@@ -290,6 +291,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             self.free_virtual_ids = None
         self.is_not_in_free_group = True
         self.free_group: List[torch.Tensor] = []
+        self.free_page_reps_group: List[torch.Tensor] = []
         self._inverse_history.clear()
         self._free_phys_pages = torch.empty(0, dtype=torch.int64, device=self.device)
         self._pending_reuse.clear()
@@ -1009,6 +1011,53 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                 self.free_virtual_ids = torch.cat([self.free_virtual_ids, free_v_pages])
             self._compact_pending(freed_p_pages)
 
+    def free_segment(self, free_index: torch.Tensor, *, start_pos: int) -> None:
+        """Free a dense request-row segment without data-dependent dedup.
+
+        A request's token slots are consecutive within every page, so fixed
+        stride slices provide one representative per touched virtual page.
+        This avoids ``torch.unique`` and its dynamic-output-length D2H readback
+        on the scheduler's critical enqueue path.
+        """
+        if free_index is None or free_index.numel() == 0:
+            return
+
+        pieces = page_representatives_from_segment(
+            free_index, start_pos=start_pos, page_size=self.page_size
+        )
+        if not self.is_not_in_free_group:
+            self.free_page_reps_group.extend(
+                self._copy_for_free_group(piece) for piece in pieces
+            )
+            return
+        self._free_page_ids(*(piece // self.page_size for piece in pieces))
+
+    def _free_page_ids(self, *page_ids: torch.Tensor) -> None:
+        """Release already-deduplicated virtual page ids."""
+        free_v_pages = page_ids[0] if len(page_ids) == 1 else torch.cat(page_ids)
+        if free_v_pages.numel() == 0:
+            return
+        free_v_pages = free_v_pages.detach().to(torch.int64)
+
+        if self.lazy_compaction:
+            self._free_lazy_pages(free_v_pages)
+            return
+
+        if self.forward_stream is not None:
+            with record_function("MultiEndedAlloc.free.wait_stream"):
+                torch.cuda.current_stream().wait_stream(self.forward_stream)
+        with record_function("MultiEndedAlloc.free.v2p_lookup"):
+            freed_p_pages = self.virtual_to_physical[free_v_pages]
+        with record_function("MultiEndedAlloc.free.sync_check"):
+            if bool((freed_p_pages < 0).any().item()):
+                self._raise_stale_slot_assertion(
+                    free_v=free_v_pages, freed_p=freed_p_pages
+                )
+        self.virtual_to_physical[free_v_pages] = -1
+        if self.is_id_owner:
+            self.free_virtual_ids = torch.cat([self.free_virtual_ids, free_v_pages])
+        self._compact_pending(freed_p_pages)
+
     def _free_lazy(self, free_index: torch.Tensor) -> None:
         """Lazy free path: disjoint-element scatters + ONE `torch.cat` onto
         `_free_phys_pages`. No sort, no boundary absorb, no watermark mutation,
@@ -1019,7 +1068,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         Callers must not double-free: a tombstone (-1) here would be cat'd onto
         the free list.
         """
-        self._stats_n_free_lazy += 1
         with record_function("MultiEndedAlloc._free_lazy"):
             with record_function("MultiEndedAlloc._free_lazy.v2p_lookup"):
                 free_v_pages_raw = free_index.detach().to(torch.int64)
@@ -1027,7 +1075,13 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
                     free_v_pages = free_v_pages_raw
                 else:
                     free_v_pages = torch.unique(free_v_pages_raw // self.page_size)
-                freed_p_pages = self.virtual_to_physical[free_v_pages]
+            self._free_lazy_pages(free_v_pages)
+
+    def _free_lazy_pages(self, free_v_pages: torch.Tensor) -> None:
+        """Lazy-release virtual page ids that are already deduplicated."""
+        self._stats_n_free_lazy += 1
+        with record_function("MultiEndedAlloc._free_lazy_pages"):
+            freed_p_pages = self.virtual_to_physical[free_v_pages]
             # Disjoint-element scatters — no barrier (a freed v has no live reader;
             # per-element scatter writes are atomic).
             self.virtual_to_physical[free_v_pages] = -1
@@ -1719,6 +1773,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
     def free_group_begin(self) -> None:
         self.is_not_in_free_group = False
         self.free_group = []
+        self.free_page_reps_group = []
 
     def free_group_end(self) -> None:
         self.is_not_in_free_group = True
@@ -1726,6 +1781,10 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             merged = torch.cat(self.free_group)
             self.free_group = []
             self.free(merged)
+        if self.free_page_reps_group:
+            page_ids = torch.cat(self.free_page_reps_group) // self.page_size
+            self.free_page_reps_group = []
+            self._free_page_ids(page_ids)
 
 
 class UnifiedMambaTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
@@ -2144,6 +2203,7 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
 
         self.is_not_in_free_group = True
         self.free_group: List[torch.Tensor] = []
+        self.free_segments_group = []
         # Empty (not None) for the leak checker.
         self.free_pages = torch.empty(0, dtype=torch.int64, device=device)
         self.release_pages = torch.empty(0, dtype=torch.int64, device=device)
@@ -2489,6 +2549,32 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         self.swa_attn_allocator.free(live)
         self.swa_attn_allocator.clear_inverse_history()
 
+    def free_swa_segment(self, free_index: torch.Tensor, *, start_pos: int) -> None:
+        """Use the composite allocator's existing tombstone-aware SWA release."""
+        self.free_swa(free_index)
+
+    def _free_segments_impl(self, segments, *, swa_evicted_seqlen: int | None) -> None:
+        if swa_evicted_seqlen is None:
+            BaseTokenToKVPoolAllocator._free_segments_impl(
+                self, segments, swa_evicted_seqlen=None
+            )
+            return
+
+        self.full_attn_allocator.free_segments(segments)
+
+        live_swa_segments = []
+        for free_index, start_pos in segments:
+            end_pos = start_pos + free_index.numel()
+            live_start = max(start_pos, swa_evicted_seqlen)
+            if live_start < end_pos:
+                live_swa_segments.append(
+                    (free_index[live_start - start_pos :], live_start)
+                )
+        self.swa_attn_allocator.free_segments(live_swa_segments)
+
+        self.full_attn_allocator.clear_inverse_history()
+        self.swa_attn_allocator.clear_inverse_history()
+
     def set_full_to_swa_mapping(
         self, full_indices: torch.Tensor, swa_indices: torch.Tensor
     ) -> None:
@@ -2505,21 +2591,17 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
     # -- free-group --
 
     def free_group_begin(self) -> None:
-        self.is_not_in_free_group = False
-        self.free_group = []
+        BaseTokenToKVPoolAllocator.free_group_begin(self)
 
     def free_group_end(self) -> None:
-        self.is_not_in_free_group = True
-        if self.free_group:
-            merged = torch.cat(self.free_group)
-            self.free_group = []
-            self.free(merged)
+        BaseTokenToKVPoolAllocator.free_group_end(self)
 
     def clear(self) -> None:
         self.full_attn_allocator.clear()
         self.swa_attn_allocator.clear()
         self.is_not_in_free_group = True
         self.free_group = []
+        self.free_segments_group = []
 
     # -- Lazy compaction hooks --
 

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -712,7 +712,10 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             out.add_(offsets)
             out.clamp_(min=0)  # tombstoned page: -1*ps + offset in [-ps, -1]
             return out
-        phys_pages = self.virtual_to_physical[virt_pages]
+        # Keep the hot transfer-metadata path asynchronous. CUDA advanced
+        # indexing may perform a host-side bounds check; index_select does not
+        # force that scalar readback.
+        phys_pages = torch.index_select(self.virtual_to_physical, 0, virt_pages)
         result = phys_pages * self.page_size + offsets
         return torch.clamp_min(result, 0)
 
@@ -2388,7 +2391,9 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         ps = self.swa_attn_allocator.page_size
         virt_pages = kv_indices // ps
         offsets = kv_indices % ps
-        swa_phys_pages = self.swa_attn_allocator.virtual_to_physical[virt_pages]
+        swa_phys_pages = torch.index_select(
+            self.swa_attn_allocator.virtual_to_physical, 0, virt_pages
+        )
         result = (swa_phys_pages * ps + offsets).to(torch.int32)
         result = torch.clamp_min(result, 0)
         if out is not None:

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -422,6 +422,8 @@ class FullComponent(TreeComponent):
                 self.tree_core.component_evictable_size_[ct] += n_len
                 self.tree_core._update_evictable_leaf_sets(n)
 
+            self.tree_core._record_device_values_ready()
+
             self.tree_core._update_evictable_leaf_sets(node)
 
     def free_host_values(self, host_values: list[torch.Tensor]) -> None:

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -435,9 +435,11 @@ class FullComponent(TreeComponent):
             alloc = self.cache.token_to_kv_pool_allocator
             for indices in action.indices:
                 if self.cache.is_swa_enabled:
-                    alloc.full_attn_allocator.free(indices)
+                    # Component values are page-aligned segments, so their page
+                    # representatives are known without dynamic deduplication.
+                    alloc.full_attn_allocator.free_segment(indices, start_pos=0)
                 else:
-                    alloc.free(indices)
+                    alloc.free_segment(indices, start_pos=0)
             return
         raise AssertionError(
             f"FullComponent: unhandled ComponentAction {type(action).__name__}"

--- a/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/full_component.py
@@ -421,8 +421,7 @@ class FullComponent(TreeComponent):
                 # Full uses leaf sets, not LRU
                 self.tree_core.component_evictable_size_[ct] += n_len
                 self.tree_core._update_evictable_leaf_sets(n)
-
-            self.tree_core._record_device_values_ready()
+                self.tree_core._record_device_values_ready(n)
 
             self.tree_core._update_evictable_leaf_sets(node)
 

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -225,7 +225,7 @@ class MambaComponent(TreeComponent):
         assert params.mamba_value is not None
         if is_new_leaf:
             node.component_data[self.component_type].value = params.mamba_value
-            self.tree_core._record_device_values_ready()
+            self.tree_core._record_device_values_ready(node)
             self.tree_core.lru_lists[self.component_type].insert_mru(node)
             self.tree_core.component_evictable_size_[self.component_type] += len(
                 params.mamba_value
@@ -234,7 +234,7 @@ class MambaComponent(TreeComponent):
             return
         if node.component_data[self.component_type].value is None:
             node.component_data[self.component_type].value = params.mamba_value
-            self.tree_core._record_device_values_ready()
+            self.tree_core._record_device_values_ready(node)
             # move from host LRU to device LRU
             host_lru = self.tree_core.host_lru_lists[self.component_type]
             if host_lru.in_list(node):
@@ -795,7 +795,7 @@ class MambaComponent(TreeComponent):
             if transfer.device_indices is not None:
                 cd = node.component_data[ct]
                 cd.value = transfer.device_indices.clone()
-                self.tree_core._record_device_values_ready()
+                self.tree_core._record_device_values_ready(node)
                 count = len(cd.value)
                 # Move from host LRU to device LRU
                 host_lru = self.tree_core.host_lru_lists[ct]

--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -225,6 +225,7 @@ class MambaComponent(TreeComponent):
         assert params.mamba_value is not None
         if is_new_leaf:
             node.component_data[self.component_type].value = params.mamba_value
+            self.tree_core._record_device_values_ready()
             self.tree_core.lru_lists[self.component_type].insert_mru(node)
             self.tree_core.component_evictable_size_[self.component_type] += len(
                 params.mamba_value
@@ -233,6 +234,7 @@ class MambaComponent(TreeComponent):
             return
         if node.component_data[self.component_type].value is None:
             node.component_data[self.component_type].value = params.mamba_value
+            self.tree_core._record_device_values_ready()
             # move from host LRU to device LRU
             host_lru = self.tree_core.host_lru_lists[self.component_type]
             if host_lru.in_list(node):
@@ -793,6 +795,7 @@ class MambaComponent(TreeComponent):
             if transfer.device_indices is not None:
                 cd = node.component_data[ct]
                 cd.value = transfer.device_indices.clone()
+                self.tree_core._record_device_values_ready()
                 count = len(cd.value)
                 # Move from host LRU to device LRU
                 host_lru = self.tree_core.host_lru_lists[ct]

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -22,7 +22,6 @@ from sglang.srt.mem_cache.hicache_storage import (
 from sglang.srt.mem_cache.unified_cache.cache_action import (
     FreeComponentDeviceSlot,
     FreeComponentHostSlot,
-    FreeDeviceKV,
     RebuildFullToSWAMapping,
     RecoverSWAWithLockedFull,
     SWARebuild,
@@ -295,7 +294,9 @@ class SWAComponent(TreeComponent):
                 )
                 return 0
             full_cd.value = value_slice.clone()
-            cache_actions.append(FreeDeviceKV([old_full]))
+            cache_actions.append(
+                FreeComponentDeviceSlot([old_full], component_type=BASE_COMPONENT_TYPE)
+            )
             cache_actions.append(SWARebuild(node.id, value_slice))
             return 0
         elif swa_evicted_seqlen < total_prefix_len + prefix_len:
@@ -313,7 +314,9 @@ class SWAComponent(TreeComponent):
                 )
                 return start_idx
             node.component_data[BASE_COMPONENT_TYPE].value = new_full.clone()
-            cache_actions.append(FreeDeviceKV([old_full]))
+            cache_actions.append(
+                FreeComponentDeviceSlot([old_full], component_type=BASE_COMPONENT_TYPE)
+            )
             cache_actions.append(SWARebuild(node.id, new_full))
             return start_idx
         else:
@@ -1127,7 +1130,7 @@ class SWAComponent(TreeComponent):
         alloc = self.cache.token_to_kv_pool_allocator
         if isinstance(action, FreeComponentDeviceSlot):
             for indices in action.indices:
-                alloc.free_swa(indices)
+                alloc.free_swa_segment(indices, start_pos=0)
             return
         if isinstance(action, FreeComponentHostSlot):
             for host_indices in action.host_indices:
@@ -1149,7 +1152,7 @@ class SWAComponent(TreeComponent):
             swa_value = self._translate_full_to_swa(action.incoming_full)
             alloc.set_full_to_swa_mapping(action.kept_full, swa_value)
             alloc.clear_full_to_swa_mapping(action.incoming_full)
-            alloc.full_attn_allocator.free(action.incoming_full)
+            alloc.full_attn_allocator.free_segment(action.incoming_full, start_pos=0)
             self.tree_core.set_component_device_value(
                 action.node_id, self.component_type, swa_value
             )

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -294,6 +294,10 @@ class SWAComponent(TreeComponent):
                 )
                 return 0
             full_cd.value = value_slice.clone()
+            self.tree_core._record_device_values_ready()
+            # This node's SWA component is a tombstone, so old_full owns no SWA
+            # slots.  Freeing it through the combined allocator needlessly
+            # performs dynamic mapping discovery on CUDA.
             cache_actions.append(
                 FreeComponentDeviceSlot([old_full], component_type=BASE_COMPONENT_TYPE)
             )
@@ -314,6 +318,7 @@ class SWAComponent(TreeComponent):
                 )
                 return start_idx
             node.component_data[BASE_COMPONENT_TYPE].value = new_full.clone()
+            self.tree_core._record_device_values_ready()
             cache_actions.append(
                 FreeComponentDeviceSlot([old_full], component_type=BASE_COMPONENT_TYPE)
             )
@@ -831,7 +836,10 @@ class SWAComponent(TreeComponent):
             return [
                 PoolTransfer(
                     name=PoolName.SWA,
-                    device_indices=cd.value.to(torch.int64),
+                    # Direct I/O normalizes this on its helper stream after the
+                    # tree-value readiness event.  Converting here would append
+                    # CUDA work to the scheduler stream after that event.
+                    device_indices=cd.value,
                 )
             ]
 

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -294,7 +294,7 @@ class SWAComponent(TreeComponent):
                 )
                 return 0
             full_cd.value = value_slice.clone()
-            self.tree_core._record_device_values_ready()
+            self.tree_core._record_device_values_ready(node)
             # This node's SWA component is a tombstone, so old_full owns no SWA
             # slots.  Freeing it through the combined allocator needlessly
             # performs dynamic mapping discovery on CUDA.
@@ -318,7 +318,7 @@ class SWAComponent(TreeComponent):
                 )
                 return start_idx
             node.component_data[BASE_COMPONENT_TYPE].value = new_full.clone()
-            self.tree_core._record_device_values_ready()
+            self.tree_core._record_device_values_ready(node)
             cache_actions.append(
                 FreeComponentDeviceSlot([old_full], component_type=BASE_COMPONENT_TYPE)
             )

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -2001,19 +2001,16 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         node = self.node_by_id(node_id)
         cache_actions: list[CacheAction | ComponentAction] = []
         if self.is_write_back:
-            # Write-back may reclaim a duplicate host copy while H->D DMA is
-            # still reading it, so pin every source node until the ack.
-            for xfers in ([kv_xfer], *comp_xfers.values()):
-                for xfer in xfers:
-                    for nid in xfer.nodes_to_load or ():
-                        pinned = self.node_by_id(nid)
-                        # One live load-back per node; only the same anchor may
-                        # re-pin (a node can sit in Full and aux transfer lists).
-                        assert pinned.load_back_pending_id in (None, node_id), (
-                            f"node {nid} pinned by load-back "
-                            f"{pinned.load_back_pending_id}, new anchor {node_id}"
-                        )
-                        pinned.load_back_pending_id = node_id
+            # Pin Full KV host slots against duplicate reclaim until the ack.
+            # Auxiliary pools have independent host locks and may legitimately
+            # load the same radix node under a different anchor.
+            for nid in kv_xfer.nodes_to_load or ():
+                pinned = self.node_by_id(nid)
+                assert pinned.load_back_pending_id in (None, node_id), (
+                    f"node {nid} pinned by load-back "
+                    f"{pinned.load_back_pending_id}, new anchor {node_id}"
+                )
+                pinned.load_back_pending_id = node_id
         kv_xfer.device_indices = device_indices
         self.components_by_type[BASE_COMPONENT_TYPE].commit_hicache_transfer(
             node,

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -47,6 +47,7 @@ from sglang.srt.mem_cache.unified_cache.cache_action import (
     BackupKV,
     CacheAction,
     ComponentAction,
+    FreeComponentDeviceSlot,
     FreeDeviceKV,
     ReplaceWriteThroughOnNodeSplit,
 )
@@ -939,7 +940,10 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
     @staticmethod
     def _is_deferrable_action(action: CacheAction | ComponentAction) -> bool:
         """Fire-and-forget actions safe to batch until the next barrier."""
-        return isinstance(action, (FreeDeviceKV, ReplaceWriteThroughOnNodeSplit))
+        return isinstance(
+            action,
+            (FreeDeviceKV, FreeComponentDeviceSlot, ReplaceWriteThroughOnNodeSplit),
+        )
 
     def _insert_walk_step(self, state: _InsertWalkState) -> None:
         """Process one walked node, appending its barrier actions to the state."""
@@ -990,9 +994,24 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
             dup_start = max(0, state.params.prev_prefix_len - state.total_prefix_length)
             if dup_start < consumed_from:
+                full_value = value_slice[dup_start:consumed_from]
                 step_actions.append(
-                    FreeDeviceKV([value_slice[dup_start:consumed_from]])
+                    FreeComponentDeviceSlot(
+                        [full_value], component_type=BASE_COMPONENT_TYPE
+                    )
                 )
+                if ComponentType.SWA in self.components_by_type:
+                    swa_start = max(
+                        dup_start,
+                        state.params.swa_evicted_seqlen - state.total_prefix_length,
+                    )
+                    if swa_start < consumed_from:
+                        step_actions.append(
+                            FreeComponentDeviceSlot(
+                                [value_slice[swa_start:consumed_from]],
+                                component_type=ComponentType.SWA,
+                            )
+                        )
 
         if self._inc_hit_count_and_check(node, state.params.chunked):
             step_actions.append(self._build_backup_kv_action(node))

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -79,12 +79,14 @@ from sglang.srt.mem_cache.utils import (
     get_eviction_strategy,
     split_node_hash_value,
 )
+from sglang.srt.utils import get_device_module
 
 if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 
 logger = logging.getLogger(__name__)
+device_module = get_device_module()
 
 # 42 bits: digest * 1000003 (< 2^20) stays under 2^62, so the update never
 # overflows int64 with plain (non-wrapping) arithmetic in the Rust port, and
@@ -440,6 +442,12 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         # The single in-flight resumable insert, if suspended at a barrier.
         self._ongoing_insert_walk_state: Optional[_InsertWalkState] = None
+
+        # Direct HiCache write-back runs index conversion on a helper thread.
+        # Keep one rolling event at the last tree-owned CUDA-index mutation so
+        # that helper waits only for the values it will read, not for unrelated
+        # forwards appended later to the scheduler's current stream.
+        self._device_values_ready_event = None
 
         self.root_node = self._new_node()
         self.root_node.priority = -sys.maxsize
@@ -1115,6 +1123,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         for component in self.components:
             component.redistribute_on_node_split(new_parent=new_node, child=child)
+        self._record_device_values_ready()
         new_node.parent.children[key.child_key(self.page_size)] = new_node
 
         # A split of a backuped node tells the cache to fix its publish list.
@@ -1154,6 +1163,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.parent = parent
         new_node.key = key
         new_node.component_data[BASE_COMPONENT_TYPE].value = value.clone()
+        self._record_device_values_ready()
         parent.children[key.child_key(self.page_size)] = new_node
         self.component_evictable_size_[BASE_COMPONENT_TYPE] += len(value)
         if self.enable_storage:
@@ -1174,6 +1184,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         assert cd.value is None
         n = len(fresh_value)
         cd.value = fresh_value.clone()
+        self._record_device_values_ready()
         self.component_evictable_size_[ct] += n
         self._update_evictable_leaf_sets(node)
         # A backuped node restored from fresh KV is a duplicate right away.
@@ -2072,11 +2083,29 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         assert component_type != BASE_COMPONENT_TYPE
         node = self.node_by_id(node_id)
         node.component_data[component_type].value = value
+        self._record_device_values_ready()
         host_lru = self.host_lru_lists[component_type]
         if host_lru.in_list(node):
             host_lru.remove_node(node)
         self.lru_lists[component_type].insert_mru(node)
         self.component_evictable_size_[component_type] += len(value)
+
+    def _record_device_values_ready(self) -> None:
+        """Publish readiness of the latest tree-owned CUDA index mutation.
+
+        Replacing the previous event is safe because all tree mutations are
+        ordered on the scheduler's current stream.  A later event therefore
+        covers every device index currently reachable from the tree.
+        """
+        if torch.device(self.device).type == "cpu":
+            return
+        event = device_module.Event()
+        event.record()
+        self._device_values_ready_event = event
+
+    def device_values_ready_event(self):
+        """Return the narrow dependency for direct D->H index conversion."""
+        return self._device_values_ready_event
 
     def get_component_device_value(
         self, node_id: NodeId, component_type: ComponentType

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -137,6 +137,10 @@ class UnifiedTreeNode:
         # Anchor NodeId of an in-flight H->D load-back reading this node's
         # host slots; such host copies must not be reclaimed until the ack.
         self.load_back_pending_id: Optional[int] = None
+        # Readiness of CUDA index tensors owned by this node. Direct HiCache
+        # eviction must not wait on unrelated, newer mutations elsewhere in
+        # the radix tree.
+        self.device_values_ready_event = None
 
     def component(self, component_type: ComponentType) -> ComponentData:
         return self.component_data[component_type]
@@ -442,12 +446,6 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         # The single in-flight resumable insert, if suspended at a barrier.
         self._ongoing_insert_walk_state: Optional[_InsertWalkState] = None
-
-        # Direct HiCache write-back runs index conversion on a helper thread.
-        # Keep one rolling event at the last tree-owned CUDA-index mutation so
-        # that helper waits only for the values it will read, not for unrelated
-        # forwards appended later to the scheduler's current stream.
-        self._device_values_ready_event = None
 
         self.root_node = self._new_node()
         self.root_node.priority = -sys.maxsize
@@ -1123,7 +1121,8 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
 
         for component in self.components:
             component.redistribute_on_node_split(new_parent=new_node, child=child)
-        self._record_device_values_ready()
+        self._record_device_values_ready(new_node)
+        self._record_device_values_ready(child)
         new_node.parent.children[key.child_key(self.page_size)] = new_node
 
         # A split of a backuped node tells the cache to fix its publish list.
@@ -1163,7 +1162,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         new_node.parent = parent
         new_node.key = key
         new_node.component_data[BASE_COMPONENT_TYPE].value = value.clone()
-        self._record_device_values_ready()
+        self._record_device_values_ready(new_node)
         parent.children[key.child_key(self.page_size)] = new_node
         self.component_evictable_size_[BASE_COMPONENT_TYPE] += len(value)
         if self.enable_storage:
@@ -1184,7 +1183,7 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         assert cd.value is None
         n = len(fresh_value)
         cd.value = fresh_value.clone()
-        self._record_device_values_ready()
+        self._record_device_values_ready(node)
         self.component_evictable_size_[ct] += n
         self._update_evictable_leaf_sets(node)
         # A backuped node restored from fresh KV is a duplicate right away.
@@ -2083,29 +2082,24 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         assert component_type != BASE_COMPONENT_TYPE
         node = self.node_by_id(node_id)
         node.component_data[component_type].value = value
-        self._record_device_values_ready()
+        self._record_device_values_ready(node)
         host_lru = self.host_lru_lists[component_type]
         if host_lru.in_list(node):
             host_lru.remove_node(node)
         self.lru_lists[component_type].insert_mru(node)
         self.component_evictable_size_[component_type] += len(value)
 
-    def _record_device_values_ready(self) -> None:
-        """Publish readiness of the latest tree-owned CUDA index mutation.
-
-        Replacing the previous event is safe because all tree mutations are
-        ordered on the scheduler's current stream.  A later event therefore
-        covers every device index currently reachable from the tree.
-        """
+    def _record_device_values_ready(self, node: UnifiedTreeNode) -> None:
+        """Publish readiness of CUDA index mutations owned by ``node``."""
         if torch.device(self.device).type == "cpu":
             return
         event = device_module.Event()
         event.record()
-        self._device_values_ready_event = event
+        node.device_values_ready_event = event
 
-    def device_values_ready_event(self):
+    def device_values_ready_event(self, node_id: NodeId):
         """Return the narrow dependency for direct D->H index conversion."""
-        return self._device_values_ready_event
+        return self.node_by_id(node_id).device_values_ready_event
 
     def get_component_device_value(
         self, node_id: NodeId, component_type: ComponentType

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2386,6 +2386,7 @@ class UnifiedRadixCache(BasePrefixCache):
             storage_queue_sizes = ()
             extra_pool_names = ()
         else:
+            cc.check_direct_dispatch_error()
             write_acks = self._count_ready_acks(cc.ack_write_queue)
             load_acks = self._count_ready_acks(cc.ack_load_queue)
             extra_release_queues = getattr(cc, "extra_host_mem_release_queues", {})
@@ -2437,9 +2438,11 @@ class UnifiedRadixCache(BasePrefixCache):
         cc = self.cache_controller
         if cc is None:
             return
+        cc.check_direct_dispatch_error()
 
         if write_back:
             # Blocking: wait for all pending write-backs
+            cc.wait_direct_dispatch()
             while self.ongoing_write_through:
                 for ack in cc.ack_write_queue:
                     ack.finish_event.synchronize()
@@ -2492,6 +2495,7 @@ class UnifiedRadixCache(BasePrefixCache):
         cc = self.cache_controller
         if cc is None:
             return
+        cc.check_direct_dispatch_error()
         if finish_count is None:
             # Every rank must enter the all_reduce below; ongoing_load_back can
             # diverge across ranks.

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1383,6 +1383,7 @@ class UnifiedRadixCache(BasePrefixCache):
             node_id=node_id,
             extra_pools=aux_xfers or None,
             defer_start=defer_start,
+            device_values_ready_event=self.tree_core.device_values_ready_event(),
         )
 
     def _track_write_through_node(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -750,7 +750,10 @@ class UnifiedRadixCache(BasePrefixCache):
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx, :kv_len_to_handle
             ]
-            self.token_to_kv_pool_allocator.free_segment(kv_indices, start_pos=0)
+            self.token_to_kv_pool_allocator.free_segments(
+                [(kv_indices, 0)],
+                swa_evicted_seqlen=req.kv.swa_evicted_seqlen,
+            )
             for comp in self._components_tuple:
                 comp.cleanup_after_caching_req(req, is_finished=True)
             return
@@ -807,11 +810,14 @@ class UnifiedRadixCache(BasePrefixCache):
             segments = [(kv_indices[page_aligned_len:], page_aligned_len)]
             if tail_free_start is not None:
                 segments.append((kv_indices_full[tail_free_start:], tail_free_start))
-            self.token_to_kv_pool_allocator.free_segments(segments)
+            self.token_to_kv_pool_allocator.free_segments(
+                segments,
+                swa_evicted_seqlen=req.kv.swa_evicted_seqlen,
+            )
         else:
-            self.token_to_kv_pool_allocator.free_segment(
-                kv_indices[req.cache_protected_len :],
-                start_pos=req.cache_protected_len,
+            self.token_to_kv_pool_allocator.free_segments(
+                [(kv_indices[req.cache_protected_len :], req.cache_protected_len)],
+                swa_evicted_seqlen=req.kv.swa_evicted_seqlen,
             )
 
         self._dec_req_lock(req, skip_swa=req.swa_prefix_lock_released)

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -117,6 +117,11 @@ COMPONENT_REGISTRY: dict[ComponentType, type[TreeComponent]] = {
 
 logger = logging.getLogger(__name__)
 
+# Write-back eviction can visit hundreds of small radix leaves in one scheduler
+# pass. Submit several leaves together so the L2 backend can merge their index
+# ranges into one transfer operation, while keeping each batch bounded.
+_WRITE_BACK_EVICTION_BATCH_SIZE = 32
+
 
 class _OngoingWriteThrough(NamedTuple):
     """Tracks an in-flight D→H write-through operation."""
@@ -617,6 +622,33 @@ class UnifiedRadixCache(BasePrefixCache):
         self._accumulate_tracker(tracker, result.tracker)
         return result.is_dropped
 
+    def _flush_write_back_eviction_batch(
+        self,
+        node_ids: list[NodeId],
+        tracker: dict[ComponentType, int],
+    ) -> None:
+        """Submit queued leaf backups together, then safely demote them."""
+        # The common eviction driver also serves caches without HiCache.  Such
+        # passes cannot have deferred write-back work and need no flush.
+        if self.cache_controller is None:
+            assert not node_ids and not self.ongoing_write_through
+            return
+        if (
+            not node_ids
+            and not self.cache_controller.write_queue
+            and not self.ongoing_write_through
+        ):
+            return
+
+        # CacheController.write(..., defer_start=True) leaves the operations in
+        # write_queue. start_writing merges those operations so each host pool
+        # receives one larger transfer instead of one transfer per radix leaf.
+        self.cache_controller.start_writing()
+        self.writing_check(write_back=True)
+        for node_id in node_ids:
+            self._demote(node_id, tracker)
+        node_ids.clear()
+
     def _evict_components(
         self,
         request_by_type: dict[ComponentType, int],
@@ -631,21 +663,59 @@ class UnifiedRadixCache(BasePrefixCache):
             if tracker[ct] >= request_cnt:
                 continue
             self.tree_core.evict_device_start(ct, request_cnt)
+            pending_node_ids: list[NodeId] = []
+            pending_tokens = 0
             try:
-                while (
-                    node_id := self._evict_device_next_node(ct, tracker)
-                ) is not None:
+                while tracker[ct] + pending_tokens < request_cnt:
+                    node_id = self._evict_device_next_node(ct, tracker)
+                    if node_id is None:
+                        if pending_node_ids:
+                            # A Full eviction cursor discovers a parent only
+                            # after its last device-resident child is demoted.
+                            # Deferred demotion can therefore exhaust the
+                            # current frontier even though flushing this batch
+                            # immediately exposes more candidates.  Rebuild the
+                            # cursor after the flush so deep radix chains keep
+                            # the same eviction semantics as the unbatched
+                            # path, while independent leaves still share one
+                            # transfer.
+                            self._flush_write_back_eviction_batch(
+                                pending_node_ids, tracker
+                            )
+                            pending_tokens = 0
+                            if tracker[ct] < request_cnt:
+                                self.tree_core.evict_device_end(ct)
+                                self.tree_core.evict_device_start(ct, request_cnt)
+                                continue
+                        break
                     backup_kv = self._evict_device_leaf(node_id, tracker)
                     if backup_kv is not None:
-                        # Deferred demote: run the D->H backup, demote only on success.
-                        written = self._execute_and_commit_kv_backup(
-                            backup_kv, write_back=True
+                        # Keep the leaf resident until its D->H batch completes.
+                        value = (
+                            self.tree_core.node_by_id(node_id).component_data[ct].value
                         )
-                        freed_before_drop = dict(tracker)
+                        assert value is not None
+                        written = self._execute_and_commit_kv_backup(
+                            backup_kv,
+                            write_back=True,
+                            defer_start=True,
+                        )
                         if written > 0:
-                            self.writing_check(write_back=True)
-                            self._demote(node_id, tracker)
-                        elif self._drop_subtree_no_host(node_id, tracker):
+                            pending_node_ids.append(node_id)
+                            pending_tokens += len(value)
+                            if len(pending_node_ids) >= _WRITE_BACK_EVICTION_BATCH_SIZE:
+                                self._flush_write_back_eviction_batch(
+                                    pending_node_ids, tracker
+                                )
+                                pending_tokens = 0
+                            continue
+
+                        # A failed host allocation must not strand backups that
+                        # were already committed earlier in this batch.
+                        self._flush_write_back_eviction_batch(pending_node_ids, tracker)
+                        pending_tokens = 0
+                        freed_before_drop = dict(tracker)
+                        if self._drop_subtree_no_host(node_id, tracker):
                             self._record_dropped_tokens(tracker, freed_before_drop)
                             logger.warning(
                                 "write_back: KV subtree dropped without backup "
@@ -661,7 +731,10 @@ class UnifiedRadixCache(BasePrefixCache):
                                 node_id,
                             )
             finally:
-                self.tree_core.evict_device_end(ct)
+                try:
+                    self._flush_write_back_eviction_batch(pending_node_ids, tracker)
+                finally:
+                    self.tree_core.evict_device_end(ct)
 
     def _record_dropped_tokens(
         self,
@@ -1238,7 +1311,11 @@ class UnifiedRadixCache(BasePrefixCache):
     # ---- HiCache: Backup / LoadBack ----
 
     def _execute_and_commit_kv_backup(
-        self, action: BackupKV, write_back: bool = False
+        self,
+        action: BackupKV,
+        write_back: bool = False,
+        *,
+        defer_start: bool = False,
     ) -> int:
         """Run a backup action top-down, stopping at the first failed backup."""
         if self.buffer_pipeline is not None:
@@ -1260,7 +1337,11 @@ class UnifiedRadixCache(BasePrefixCache):
                 continue
             sidecar_xfers = self._build_backup_sidecar(device_value, comp_xfers)
             host_indices = self._execute_kv_backup(
-                node_id, device_value, comp_xfers, sidecar_xfers
+                node_id,
+                device_value,
+                comp_xfers,
+                sidecar_xfers,
+                defer_start=defer_start,
             )
             if host_indices is None:
                 return 0
@@ -1279,7 +1360,15 @@ class UnifiedRadixCache(BasePrefixCache):
             CacheTransferPhase.BACKUP_HOST, kv_xfer, comp_xfers
         )
 
-    def _execute_kv_backup(self, node_id, device_value, comp_xfers, sidecar_xfers):
+    def _execute_kv_backup(
+        self,
+        node_id,
+        device_value,
+        comp_xfers,
+        sidecar_xfers,
+        *,
+        defer_start: bool = False,
+    ):
         """Execute Backup action."""
         kv_tokens = len(device_value)
         host_avail = self.cache_controller.mem_pool_host.available_size()
@@ -1290,7 +1379,10 @@ class UnifiedRadixCache(BasePrefixCache):
         aux_xfers = [x for xfers in comp_xfers.values() for x in xfers]
         aux_xfers.extend(sidecar_xfers)
         return self.cache_controller.write(
-            device_value, node_id=node_id, extra_pools=aux_xfers or None
+            device_value,
+            node_id=node_id,
+            extra_pools=aux_xfers or None,
+            defer_start=defer_start,
         )
 
     def _track_write_through_node(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1383,7 +1383,7 @@ class UnifiedRadixCache(BasePrefixCache):
             node_id=node_id,
             extra_pools=aux_xfers or None,
             defer_start=defer_start,
-            device_values_ready_event=self.tree_core.device_values_ready_event(),
+            device_values_ready_event=self.tree_core.device_values_ready_event(node_id),
         )
 
     def _track_write_through_node(

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -692,12 +692,15 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         self.original_global_num_tokens_cpu = batch.global_num_tokens
         self.global_num_tokens_cpu = global_num_tokens
+        pin_memory = is_pin_memory_available(device)
         self.global_num_tokens_gpu = torch.tensor(
-            global_num_tokens, dtype=torch.int64
+            global_num_tokens, dtype=torch.int64, pin_memory=pin_memory
         ).to(device, non_blocking=True)
         self.global_num_tokens_for_logprob_cpu = global_num_tokens_for_logprob
         self.global_num_tokens_for_logprob_gpu = torch.tensor(
-            global_num_tokens_for_logprob, dtype=torch.int64
+            global_num_tokens_for_logprob,
+            dtype=torch.int64,
+            pin_memory=pin_memory,
         ).to(device, non_blocking=True)
         self.can_run_dp_cuda_graph = batch.can_run_dp_cuda_graph
 
@@ -835,9 +838,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
 
         num_tokens = len(batch.input_ids) if batch.input_ids is not None else 0
         if enable_num_token_non_padded():
-            ret.num_token_non_padded = torch.tensor(num_tokens, dtype=torch.int32).to(
-                device, non_blocking=True
-            )
+            ret.num_token_non_padded = torch.tensor(
+                num_tokens,
+                dtype=torch.int32,
+                pin_memory=is_pin_memory_available(device),
+            ).to(device, non_blocking=True)
         ret.num_token_non_padded_cpu = num_tokens
 
         ret.init_mlp_sync_metadata(batch, device)
@@ -875,11 +880,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             if isinstance(extend_seq_lens, list):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
                 assert isinstance(extend_prefix_lens, list)
+                pin_memory = is_pin_memory_available(device)
                 ret.extend_seq_lens = torch.tensor(
-                    extend_seq_lens, dtype=torch.int32
+                    extend_seq_lens, dtype=torch.int32, pin_memory=pin_memory
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens = torch.tensor(
-                    extend_prefix_lens, dtype=torch.int32
+                    extend_prefix_lens, dtype=torch.int32, pin_memory=pin_memory
                 ).to(device, non_blocking=True)
                 ret.extend_prefix_lens_cpu = extend_prefix_lens
                 ret.extend_seq_lens_cpu = extend_seq_lens

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -49,6 +49,9 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     enable_tc_piecewise_cuda_graph,
     set_tc_piecewise_forward_context,
 )
+from sglang.srt.model_executor.runner_utils import (
+    maybe_publish_prefill_shared_read_done,
+)
 from sglang.srt.runtime_context import (
     get_parallel,
     get_spec,
@@ -305,6 +308,15 @@ class EagerRunner(BaseRunner):
                 # e.g. Moss-VL's prefill cross-attention custom mask.
                 model_runner.model.prepare_forward_batch(forward_batch)
             model_runner.attn_backend.init_forward_metadata(forward_batch)
+            model_runner.attn_backend.prepare_prefill_shared_read_snapshot(
+                forward_batch,
+                num_qo_tokens=len(forward_batch.input_ids),
+            )
+            maybe_publish_prefill_shared_read_done(
+                model_runner,
+                forward_batch,
+                torch.get_device_module(model_runner.device),
+            )
 
         if not cp_v2_active:
             forward_batch.attn_cp_metadata = None

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1022,6 +1022,9 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             return
         if not self.use_captured_attn_metadata:
             attn_backend.init_forward_metadata(forward_batch)
+            attn_backend.prepare_prefill_shared_read_snapshot(
+                forward_batch, num_qo_tokens=num_tokens
+            )
             return
         assert self.attn_metadata_buffers is not None
         metadata = self.attn_metadata_buffers[num_tokens]

--- a/python/sglang/srt/model_executor/runner_utils/shared_read_event.py
+++ b/python/sglang/srt/model_executor/runner_utils/shared_read_event.py
@@ -1,4 +1,4 @@
-"""Shared-read-done event utilities for CUDA graph runners."""
+"""Shared-read-done event utilities for graph and eager runners."""
 
 import logging
 from typing import Optional
@@ -31,9 +31,13 @@ def maybe_publish_prefill_shared_read_done(
         return
     if forward_batch.forward_mode != ForwardMode.EXTEND:
         return
-    # TODO(Jialin): Relax this gate for speculative decoding after its prefill
-    # WAR boundaries are validated.
-    if not model_runner.spec_algorithm.is_none():
+    # TODO(Jialin): Relax for EAGLE/MTP after validating the later
+    # draft-extend reader's WAR boundary.
+    if (
+        not model_runner.spec_algorithm.is_none()
+        and not model_runner.spec_algorithm.is_dflash_family()
+    ):
+        # Other speculative algorithms may have a later draft-extend reader.
         return
     # The record lands right after replay prep, so PRE_REPLAY only.
     declared = model_runner.attn_backend.shared_read_ends(forward_batch.forward_mode)

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -28,6 +28,7 @@ from sglang.srt.speculative.spec_info import (
     spec_scale_global_num_tokens,
 )
 from sglang.srt.speculative.spec_utils import draft_tp_context
+from sglang.srt.utils.common import is_pin_memory_available
 from sglang.srt.utils.invariants import Bucket, Invariant, NotNaN, expect
 
 logger = logging.getLogger(__name__)
@@ -55,7 +56,11 @@ def _make_num_token_non_padded(
 ) -> Optional[torch.Tensor]:
     if not enable_num_token_non_padded():
         return None
-    return torch.tensor(num_tokens, dtype=torch.int32).to(device, non_blocking=True)
+    return torch.tensor(
+        num_tokens,
+        dtype=torch.int32,
+        pin_memory=is_pin_memory_available(device),
+    ).to(device, non_blocking=True)
 
 
 class DraftBlockResult(msgspec.Struct, frozen=True):
@@ -409,16 +414,16 @@ class DraftBlockProposer:
         device = self.draft_model_runner.device
         forward_batch.original_global_num_tokens_cpu = batch.global_num_tokens
         num_tokens = forward_batch.input_ids.numel()
-        if enable_num_token_non_padded():
-            forward_batch.num_token_non_padded = torch.tensor(
-                num_tokens, dtype=torch.int32, device=device
-            )
+        num_token_non_padded = _make_num_token_non_padded(num_tokens, device)
+        if num_token_non_padded is not None:
+            forward_batch.num_token_non_padded = num_token_non_padded
         forward_batch.num_token_non_padded_cpu = num_tokens
         forward_batch.global_num_tokens_cpu = gnt
         forward_batch.global_num_tokens_for_logprob_cpu = gnt_logprob
-        forward_batch.global_num_tokens_gpu = torch.tensor(gnt, dtype=torch.int64).to(
-            device, non_blocking=True
-        )
+        pin_memory = is_pin_memory_available(device)
+        forward_batch.global_num_tokens_gpu = torch.tensor(
+            gnt, dtype=torch.int64, pin_memory=pin_memory
+        ).to(device, non_blocking=True)
         forward_batch.global_num_tokens_for_logprob_gpu = torch.tensor(
-            gnt_logprob, dtype=torch.int64
+            gnt_logprob, dtype=torch.int64, pin_memory=pin_memory
         ).to(device, non_blocking=True)

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -73,7 +73,12 @@ from sglang.srt.speculative.spec_utils import (
     draft_tp_context,
     prepare_mamba_track_for_verify,
 )
-from sglang.srt.utils import get_available_gpu_memory, is_cuda, is_npu
+from sglang.srt.utils import (
+    get_available_gpu_memory,
+    is_cuda,
+    is_npu,
+    is_pin_memory_available,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -477,10 +482,13 @@ class DSparkWorkerV2(BaseSpecWorker):
         # Must inject before prefill returns: the scheduler may update radix
         # afterward, invalidating out_cache_loc.
         device = next_token_ids.device
-        ctx_lens = torch.tensor(batch.extend_lens, dtype=torch.int32, device=device)
+        pin_memory = is_pin_memory_available(device)
+        ctx_lens = torch.tensor(
+            batch.extend_lens, dtype=torch.int32, pin_memory=pin_memory
+        ).to(device, non_blocking=True)
         draft_seq_lens = torch.tensor(
-            batch.prefix_lens, dtype=torch.int32, device=device
-        )
+            batch.prefix_lens, dtype=torch.int32, pin_memory=pin_memory
+        ).to(device, non_blocking=True)
         positions, _ = compute_position(
             self.model_runner.prefill_attention_backend_str,
             draft_seq_lens,

--- a/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
+++ b/test/registered/attention/unittests/dsv4/test_deepseek_v4.py
@@ -391,6 +391,125 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
             DeepseekV4AttnBackend.use_captured_forward_metadata_for_breakable_cuda_graph
         )
 
+    def test_prefill_snapshot_declares_pre_replay_boundary(self):
+        from sglang.srt.layers.attention.base_attn_backend import SharedReadEnds
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DeepseekV4AttnBackend,
+            DSV4Metadata,
+        )
+
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.forward_metadata = DSV4Metadata(
+            self._make_core_metadata(0), indexer_metadata=None
+        )
+        self.assertIs(
+            backend.shared_read_ends(ForwardMode.EXTEND),
+            SharedReadEnds.UNKNOWN,
+        )
+
+        backend.forward_metadata.prefill_shared_reads_snapshotted = True
+        self.assertIs(
+            backend.shared_read_ends(ForwardMode.EXTEND),
+            SharedReadEnds.PRE_REPLAY,
+        )
+
+    def test_dense_prefill_snapshot_declares_pre_replay(self):
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DeepseekV4AttnBackend,
+            DSV4Metadata,
+        )
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.model_runner = SimpleNamespace(
+            spec_algorithm=SpeculativeAlgorithm.DFLASH
+        )
+        backend.forward_metadata = DSV4Metadata(
+            self._make_core_metadata(0), indexer_metadata=None
+        )
+        backend._build_sparse_prefill_chunk_cache = mock.Mock()
+        batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+
+        with (
+            envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(True),
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.override(False),
+            mock.patch(
+                "sglang.srt.layers.attention.deepseek_v4_backend._is_sm120", True
+            ),
+        ):
+            backend.prepare_prefill_shared_read_snapshot(batch, num_qo_tokens=12288)
+
+        backend._build_sparse_prefill_chunk_cache.assert_not_called()
+        self.assertTrue(backend.forward_metadata.prefill_shared_reads_snapshotted)
+
+    def test_sparse_prefill_snapshot_uses_runner_token_count(self):
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DeepseekV4AttnBackend,
+            DSV4Metadata,
+        )
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.model_runner = SimpleNamespace(
+            spec_algorithm=SpeculativeAlgorithm.DSPARK
+        )
+        backend.forward_metadata = DSV4Metadata(
+            self._make_core_metadata(0), indexer_metadata=None
+        )
+        cache = object()
+        backend._build_sparse_prefill_chunk_cache = mock.Mock(return_value=cache)
+        batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+
+        with (
+            envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(True),
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.override(True),
+            mock.patch(
+                "sglang.srt.layers.attention.deepseek_v4_backend._is_sm120", False
+            ),
+        ):
+            backend.prepare_prefill_shared_read_snapshot(batch, num_qo_tokens=12288)
+
+        backend._build_sparse_prefill_chunk_cache.assert_called_once_with(
+            batch, num_qo_tokens=12288
+        )
+        self.assertIs(backend.forward_metadata.sparse_prefill_cache, cache)
+        self.assertTrue(backend.forward_metadata.prefill_shared_reads_snapshotted)
+
+    def test_sparse_prefill_snapshot_marks_success_only_after_build(self):
+        from sglang.srt.environ import envs
+        from sglang.srt.layers.attention.deepseek_v4_backend import (
+            DeepseekV4AttnBackend,
+            DSV4Metadata,
+        )
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        backend = object.__new__(DeepseekV4AttnBackend)
+        backend.model_runner = SimpleNamespace(
+            spec_algorithm=SpeculativeAlgorithm.DFLASH
+        )
+        backend.forward_metadata = DSV4Metadata(
+            self._make_core_metadata(0), indexer_metadata=None
+        )
+        backend.forward_metadata.prefill_shared_reads_snapshotted = True
+        backend._build_sparse_prefill_chunk_cache = mock.Mock(
+            side_effect=RuntimeError("snapshot failed")
+        )
+        batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+
+        with (
+            envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(True),
+            envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.override(True),
+            mock.patch(
+                "sglang.srt.layers.attention.deepseek_v4_backend._is_sm120", False
+            ),
+            self.assertRaisesRegex(RuntimeError, "snapshot failed"),
+        ):
+            backend.prepare_prefill_shared_read_snapshot(batch, num_qo_tokens=12288)
+
+        self.assertFalse(backend.forward_metadata.prefill_shared_reads_snapshotted)
+
     def test_refresh_replay_metadata_preserves_captured_tensor_storage(self):
         capture_metadata = self._make_core_metadata(0)
         replay_metadata = self._make_core_metadata(1000)
@@ -459,6 +578,7 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
             self._make_core_metadata(0), indexer_metadata=None
         )
         capture_metadata.sparse_prefill_cache = object()
+        capture_metadata.prefill_shared_reads_snapshotted = True
         replay_metadata = DSV4Metadata(
             self._make_core_metadata(1000), indexer_metadata=None
         )
@@ -487,6 +607,7 @@ class TestDSV4BreakableCudaGraphMetadataContract(CustomTestCase):
         self.assertTrue(calls[0][2])
         self.assertIs(backend.forward_metadata, capture_metadata)
         self.assertIsNone(capture_metadata.sparse_prefill_cache)
+        self.assertFalse(capture_metadata.prefill_shared_reads_snapshotted)
         self.assertTrue(
             torch.equal(
                 capture_metadata.core_attn_metadata.seq_lens_casual,

--- a/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
+++ b/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.disaggregation.prefill import (
+    SchedulerDisaggregationPrefillMixin,
+)
+
+
+class _Event:
+    def __init__(self):
+        self.recorded = False
+
+    def record(self):
+        self.recorded = True
+
+
+class _Allocator:
+    page_size = 4
+
+    @staticmethod
+    def translate_kv_indices_for_transfer(indices):
+        return indices + 100
+
+
+def test_stage_cached_prefix_transfer_indices_before_send():
+    req = SimpleNamespace(
+        pending_bootstrap=False,
+        to_finish=False,
+        early_send_prefix_end=None,
+        prefix_indices=torch.arange(12),
+        host_hit_length=4,
+        start_send_idx=0,
+        req_pool_idx=1,
+    )
+    scheduler = SimpleNamespace(
+        enable_staging=True,
+        token_to_kv_pool_allocator=_Allocator(),
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=torch.arange(32).view(2, 16)
+        ),
+        device_module=SimpleNamespace(Event=_Event),
+    )
+    staged_page_ids = torch.tensor([29, 30])
+
+    with (
+        patch(
+            "sglang.srt.disaggregation.prefill."
+            "_copy_page_indices_to_pinned_cpu",
+            return_value=staged_page_ids,
+        ) as copy_page_ids,
+        patch(
+            "sglang.srt.disaggregation.prefill.envs."
+            "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get",
+            return_value=True,
+        ),
+        patch("sglang.srt.disaggregation.prefill.is_aborted", return_value=False),
+    ):
+        SchedulerDisaggregationPrefillMixin.stage_cached_prefix_transfer_indices(
+            scheduler, SimpleNamespace(reqs=[req])
+        )
+
+    assert req.early_send_prefix_end == 8
+    staged = req._staged_cached_prefix_transfer_indices
+    assert staged.end_idx == 8
+    assert staged.page_indices is staged_page_ids
+    assert staged.ready_event.recorded
+    copy_page_ids.assert_called_once()
+    torch.testing.assert_close(
+        copy_page_ids.call_args.args[0],
+        torch.arange(16, 24) + 100,
+    )
+    assert copy_page_ids.call_args.args[1] == 4
+
+
+def test_stage_cached_prefix_skips_partial_page():
+    req = SimpleNamespace(
+        pending_bootstrap=False,
+        to_finish=False,
+        early_send_prefix_end=None,
+        prefix_indices=torch.arange(10),
+        host_hit_length=4,
+        start_send_idx=0,
+        req_pool_idx=0,
+    )
+    scheduler = SimpleNamespace(
+        enable_staging=True,
+        token_to_kv_pool_allocator=_Allocator(),
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=torch.arange(16).view(1, 16)
+        ),
+        device_module=SimpleNamespace(Event=_Event),
+    )
+
+    with (
+        patch(
+            "sglang.srt.disaggregation.prefill."
+            "_copy_page_indices_to_pinned_cpu"
+        ) as copy_page_ids,
+        patch(
+            "sglang.srt.disaggregation.prefill.envs."
+            "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get",
+            return_value=True,
+        ),
+        patch("sglang.srt.disaggregation.prefill.is_aborted", return_value=False),
+    ):
+        SchedulerDisaggregationPrefillMixin.stage_cached_prefix_transfer_indices(
+            scheduler, SimpleNamespace(reqs=[req])
+        )
+
+    copy_page_ids.assert_not_called()
+    assert not hasattr(req, "_staged_cached_prefix_transfer_indices")

--- a/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
+++ b/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
@@ -1,19 +1,28 @@
+import sys
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
+import pytest
 import torch
 
 from sglang.srt.disaggregation.prefill import (
     SchedulerDisaggregationPrefillMixin,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class _Event:
     def __init__(self):
         self.recorded = False
+        self.ready = True
 
     def record(self):
         self.recorded = True
+
+    def query(self):
+        return self.ready
 
 
 class _Allocator:
@@ -37,17 +46,14 @@ def test_stage_cached_prefix_transfer_indices_before_send():
     scheduler = SimpleNamespace(
         enable_staging=True,
         token_to_kv_pool_allocator=_Allocator(),
-        req_to_token_pool=SimpleNamespace(
-            req_to_token=torch.arange(32).view(2, 16)
-        ),
+        req_to_token_pool=SimpleNamespace(req_to_token=torch.arange(32).view(2, 16)),
         device_module=SimpleNamespace(Event=_Event),
     )
     staged_page_ids = torch.tensor([29, 30])
 
     with (
         patch(
-            "sglang.srt.disaggregation.prefill."
-            "_copy_page_indices_to_pinned_cpu",
+            "sglang.srt.disaggregation.prefill." "_copy_page_indices_to_pinned_cpu",
             return_value=staged_page_ids,
         ) as copy_page_ids,
         patch(
@@ -87,16 +93,13 @@ def test_stage_cached_prefix_skips_partial_page():
     scheduler = SimpleNamespace(
         enable_staging=True,
         token_to_kv_pool_allocator=_Allocator(),
-        req_to_token_pool=SimpleNamespace(
-            req_to_token=torch.arange(16).view(1, 16)
-        ),
+        req_to_token_pool=SimpleNamespace(req_to_token=torch.arange(16).view(1, 16)),
         device_module=SimpleNamespace(Event=_Event),
     )
 
     with (
         patch(
-            "sglang.srt.disaggregation.prefill."
-            "_copy_page_indices_to_pinned_cpu"
+            "sglang.srt.disaggregation.prefill." "_copy_page_indices_to_pinned_cpu"
         ) as copy_page_ids,
         patch(
             "sglang.srt.disaggregation.prefill.envs."
@@ -111,3 +114,79 @@ def test_stage_cached_prefix_skips_partial_page():
 
     copy_page_ids.assert_not_called()
     assert not hasattr(req, "_staged_cached_prefix_transfer_indices")
+
+
+def test_cached_prefix_early_send_does_not_wait_for_staging_copy():
+    ready_event = _Event()
+    ready_event.ready = False
+    req = SimpleNamespace(
+        pending_bootstrap=False,
+        early_send_prefix_end=8,
+        prefix_indices=torch.arange(12),
+        host_hit_length=4,
+        start_send_idx=0,
+        _staged_cached_prefix_transfer_indices=SimpleNamespace(
+            end_idx=8,
+            ready_event=ready_event,
+        ),
+    )
+    scheduler = SimpleNamespace(
+        enable_staging=True,
+        enable_overlap=True,
+        token_to_kv_pool_allocator=_Allocator(),
+        send_kv_chunk=Mock(),
+    )
+
+    with (
+        patch(
+            "sglang.srt.disaggregation.prefill.envs."
+            "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get",
+            return_value=True,
+        ),
+        patch("torch.cuda.Event") as cuda_event,
+    ):
+        SchedulerDisaggregationPrefillMixin.maybe_send_cached_prefix_chunk(
+            scheduler, req
+        )
+
+    scheduler.send_kv_chunk.assert_not_called()
+    cuda_event.assert_not_called()
+
+
+def test_cached_prefix_early_send_uses_ready_staging_copy():
+    ready_event = _Event()
+    req = SimpleNamespace(
+        pending_bootstrap=False,
+        early_send_prefix_end=8,
+        prefix_indices=torch.arange(12),
+        host_hit_length=4,
+        start_send_idx=0,
+        _staged_cached_prefix_transfer_indices=SimpleNamespace(
+            end_idx=8,
+            ready_event=ready_event,
+        ),
+        disagg_kv_sender=SimpleNamespace(),
+    )
+    scheduler = SimpleNamespace(
+        enable_staging=True,
+        enable_overlap=False,
+        token_to_kv_pool_allocator=_Allocator(),
+        send_kv_chunk=Mock(),
+    )
+
+    with (
+        patch(
+            "sglang.srt.disaggregation.prefill.envs."
+            "SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get",
+            return_value=True,
+        ),
+    ):
+        SchedulerDisaggregationPrefillMixin.maybe_send_cached_prefix_chunk(
+            scheduler, req
+        )
+
+    scheduler.send_kv_chunk.assert_called_once_with(req, last_chunk=False, end_idx=8)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
+++ b/test/registered/unit/disaggregation/test_prefill_cached_prefix_staging.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 import pytest
 import torch
 
+from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.prefill import (
     SchedulerDisaggregationPrefillMixin,
 )
@@ -31,6 +32,51 @@ class _Allocator:
     @staticmethod
     def translate_kv_indices_for_transfer(indices):
         return indices + 100
+
+    @staticmethod
+    def translate_loc_from_full_to_swa(indices):
+        return indices + 200
+
+
+def test_stage_final_swa_transfer_respects_decode_prefix():
+    req = SimpleNamespace(
+        pending_bootstrap=False,
+        extend_range=SimpleNamespace(end=20),
+        origin_input_ids=list(range(20)),
+        start_send_idx=0,
+        req_pool_idx=0,
+        rid="request-1",
+        disagg_decode_prefix_len=12,
+    )
+    scheduler = SimpleNamespace(
+        token_to_kv_pool_allocator=_Allocator(),
+        req_to_token_pool=SimpleNamespace(req_to_token=torch.arange(32).view(1, 32)),
+        disagg_prefill_bootstrap_queue=SimpleNamespace(
+            kv_manager=SimpleNamespace(
+                kv_args=SimpleNamespace(state_types=[StateType.SWA])
+            )
+        ),
+        sliding_window_size=16,
+        disagg_prefill_pending_chunk_rids=set(),
+    )
+    staged_full = torch.tensor([1])
+    staged_swa = torch.tensor([2])
+
+    with (
+        patch(
+            "sglang.srt.disaggregation.prefill._copy_page_indices_to_pinned_cpu",
+            side_effect=[staged_full, staged_swa],
+        ) as copy_page_ids,
+        patch("sglang.srt.disaggregation.prefill.is_aborted", return_value=False),
+    ):
+        staged = SchedulerDisaggregationPrefillMixin.stage_prefill_transfer_indices(
+            scheduler, SimpleNamespace(reqs=[req])
+        )
+
+    assert staged[req.rid].swa_page_indices is staged_swa
+    torch.testing.assert_close(
+        copy_page_ids.call_args_list[1].args[0], torch.arange(12, 20) + 200
+    )
 
 
 def test_stage_cached_prefix_transfer_indices_before_send():

--- a/test/registered/unit/layers/moe/test_mega_moe_deepgemm_num_sms.py
+++ b/test/registered/unit/layers/moe/test_mega_moe_deepgemm_num_sms.py
@@ -1,0 +1,84 @@
+"""Unit tests for Blackwell DeepGEMM MegaMoE SM-count selection."""
+
+import unittest
+from unittest import mock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+from sglang.srt.environ import envs  # noqa: E402
+from sglang.srt.layers.moe import mega_moe  # noqa: E402
+
+
+class FakeDeepGemm:
+    def __init__(self, num_sms: int):
+        self._num_sms = num_sms
+        self.set_num_sms_calls = []
+
+    def get_num_sms(self) -> int:
+        return self._num_sms
+
+    def set_num_sms(self, num_sms: int) -> None:
+        self.set_num_sms_calls.append(num_sms)
+        self._num_sms = num_sms
+
+
+class TestMegaMoEDeepGemmNumSms(unittest.TestCase):
+    def test_blackwell_reserves_two_sms_and_restores(self):
+        deep_gemm = FakeDeepGemm(num_sms=152)
+
+        with (
+            mock.patch.object(mega_moe, "_device_sm", 103),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(2),
+            mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms,
+        ):
+            self.assertEqual(num_sms, 150)
+            self.assertEqual(deep_gemm.get_num_sms(), 150)
+
+        self.assertEqual(deep_gemm.get_num_sms(), 152)
+        self.assertEqual(deep_gemm.set_num_sms_calls, [150, 152])
+
+    def test_odd_target_is_rounded_down_for_clusters(self):
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(0),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(1),
+        ):
+            self.assertEqual(mega_moe._resolve_mega_moe_deep_gemm_num_sms(152), 150)
+
+    def test_explicit_count_is_clamped_and_rounded(self):
+        with envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(151):
+            self.assertEqual(mega_moe._resolve_mega_moe_deep_gemm_num_sms(152), 150)
+        with envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(200):
+            self.assertEqual(mega_moe._resolve_mega_moe_deep_gemm_num_sms(152), 152)
+
+    def test_restores_count_when_forward_raises(self):
+        deep_gemm = FakeDeepGemm(num_sms=152)
+
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            with (
+                mock.patch.object(mega_moe, "_device_sm", 103),
+                envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_SMS.override(150),
+                mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm),
+            ):
+                raise RuntimeError("boom")
+
+        self.assertEqual(deep_gemm.get_num_sms(), 152)
+        self.assertEqual(deep_gemm.set_num_sms_calls, [150, 152])
+
+    def test_sm90_keeps_full_device_count(self):
+        deep_gemm = FakeDeepGemm(num_sms=132)
+
+        with (
+            mock.patch.object(mega_moe, "_device_sm", 90),
+            envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_RESERVED_SMS.override(2),
+            mega_moe._configure_mega_moe_deep_gemm_num_sms(deep_gemm) as num_sms,
+        ):
+            self.assertEqual(num_sms, 132)
+
+        self.assertEqual(deep_gemm.set_num_sms_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -7,7 +7,12 @@ from unittest import mock
 
 import torch
 
-from sglang.srt.managers.cache_controller import CacheOperation, HiCacheController
+from sglang.srt.managers import cache_controller as manager_cache_controller
+from sglang.srt.managers.cache_controller import (
+    CacheOperation,
+    HiCacheController,
+    LayerDoneCounter,
+)
 from sglang.srt.mem_cache import l2_transfer as transfer_module
 from sglang.srt.mem_cache.hicache_storage import (
     PoolHitPolicy,
@@ -18,11 +23,6 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
 from sglang.srt.mem_cache.l2_transfer import L2Transfer, L2TransferEngine
-from sglang.srt.mem_cache.unified_cache import unified_tree_core
-from sglang.srt.mem_cache.unified_cache.unified_tree_core import (
-    UnifiedTreeCore,
-    UnifiedTreeNode,
-)
 from sglang.srt.mem_cache.memory_pool_host import (
     DeepSeekV4PagedHostPool,
     DeepSeekV4StateHostPool,
@@ -34,6 +34,11 @@ from sglang.srt.mem_cache.pool_host.dsa import DSAIndexerPoolHost
 from sglang.srt.mem_cache.pool_host.mamba import MambaPoolHost
 from sglang.srt.mem_cache.pool_host.mha import MHATokenToKVPoolHost
 from sglang.srt.mem_cache.pool_host.mla import MLATokenToKVPoolHost
+from sglang.srt.mem_cache.unified_cache import unified_tree_core
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import (
+    UnifiedTreeCore,
+    UnifiedTreeNode,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -272,6 +277,61 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         )
         controller._num_tokens_by_pool.assert_called_once_with(merged_op)
         self.assertEqual(controller.ack_load_queue[0].node_ids, [7, 7])
+
+    def test_consumer_waits_until_load_events_are_submitted(self):
+        counter = LayerDoneCounter.__new__(LayerDoneCounter)
+        counter.consumer_index = -1
+        event = mock.Mock()
+        counter.events = [event]
+
+        counter.set_consumer(0)
+
+        event.wait_until_submitted.assert_called_once_with()
+        self.assertEqual(counter.consumer_index, 0)
+
+    def test_direct_load_signals_only_after_cuda_submission(self):
+        op = CacheOperation(_indices(0, 4), _indices(4, 8), 7)
+        producer_event = mock.Mock()
+        order = []
+        producer_event.mark_submitted.side_effect = lambda **_: order.append("signal")
+
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.load_queue = [op]
+        controller.io_backend = "direct"
+        controller.layer_done_counter = mock.Mock()
+        controller.layer_done_counter.update_producer.return_value = 0
+        controller.layer_done_counter.events = [producer_event]
+        controller._enqueue_direct_dispatch = mock.Mock()
+        controller._start_loading_op = mock.Mock(
+            side_effect=lambda *_: order.append("submit")
+        )
+
+        self.assertEqual(controller.start_loading(), 0)
+        producer_event.mark_submitted.assert_not_called()
+        dispatch = controller._enqueue_direct_dispatch.call_args
+        self.assertIs(
+            dispatch.args[0].__func__,
+            controller._start_loading_op_and_signal_submission.__func__,
+        )
+
+        dispatch.args[0](*dispatch.args[1:])
+
+        self.assertEqual(order, ["submit", "signal"])
+
+    def test_direct_load_submission_error_unblocks_consumer(self):
+        producer_event = mock.Mock()
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.layer_done_counter = mock.Mock()
+        controller.layer_done_counter.events = [producer_event]
+        failure = RuntimeError("submit failed")
+        controller._start_loading_op = mock.Mock(side_effect=failure)
+
+        with self.assertRaisesRegex(RuntimeError, "submit failed"):
+            controller._start_loading_op_and_signal_submission(
+                CacheOperation(_indices(0, 1), _indices(1, 2), 3), 0
+            )
+
+        producer_event.mark_submitted.assert_called_once_with(error=failure)
 
     def test_l2_transfer_maps_global_layers(self):
         host_pool = mock.Mock()
@@ -1085,7 +1145,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         self.assertEqual(captured["host_indices"].device.type, "cpu")
 
     def test_direct_cache_controller_defers_index_copy_to_dispatch_thread(self):
-        op = ManagerCacheOperation(
+        op = CacheOperation(
             host_indices=_indices(0, 4),
             device_indices=_indices(4, 8),
             node_id=1,
@@ -1159,9 +1219,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         merged = CacheOperation.merge_ops(ops)
 
-        self.assertEqual(
-            merged.device_values_ready_event, (first_event, latest_event)
-        )
+        self.assertEqual(merged.device_values_ready_event, (first_event, latest_event))
 
     def test_direct_hybrid_normalizes_aux_indices_on_helper_path(self):
         controller = HybridCacheController.__new__(HybridCacheController)
@@ -1200,9 +1258,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         fake_device_module = mock.Mock()
         fake_device_module.Event.side_effect = [first_event, second_event]
 
-        with mock.patch.object(
-            unified_tree_core, "device_module", fake_device_module
-        ):
+        with mock.patch.object(unified_tree_core, "device_module", fake_device_module):
             tree._record_device_values_ready(first_node)
             tree._record_device_values_ready(second_node)
 
@@ -1219,9 +1275,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller.start_writing = mock.Mock()
         device_indices = _indices(0, 4)
 
-        host_indices = controller.write(
-            device_indices, node_id=7, defer_start=True
-        )
+        host_indices = controller.write(device_indices, node_id=7, defer_start=True)
 
         self.assertTrue(torch.equal(host_indices, _indices(8, 12)))
         self.assertEqual(len(controller.write_queue), 1)
@@ -1237,9 +1291,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller.start_writing = mock.Mock()
         device_indices = _indices(0, 4)
 
-        host_indices = controller.write(
-            device_indices, node_id=9, defer_start=True
-        )
+        host_indices = controller.write(device_indices, node_id=9, defer_start=True)
 
         self.assertTrue(torch.equal(host_indices, _indices(8, 12)))
         self.assertEqual(len(controller.write_queue), 1)

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -1130,6 +1130,41 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         )
         controller.move_hybrid_indices.assert_not_called()
 
+    def test_cache_controller_can_defer_write_submission_for_batching(self):
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.mem_pool_host = mock.Mock()
+        controller.mem_pool_host.alloc.return_value = _indices(8, 12)
+        controller.write_queue = []
+        controller.start_writing = mock.Mock()
+        device_indices = _indices(0, 4)
+
+        host_indices = controller.write(
+            device_indices, node_id=7, defer_start=True
+        )
+
+        self.assertTrue(torch.equal(host_indices, _indices(8, 12)))
+        self.assertEqual(len(controller.write_queue), 1)
+        self.assertEqual(controller.write_queue[0].node_ids, [7])
+        controller.start_writing.assert_not_called()
+
+    def test_hybrid_controller_can_defer_write_submission_for_batching(self):
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.mem_pool_host = mock.Mock()
+        controller.mem_pool_host.alloc.return_value = _indices(8, 12)
+        controller._resolve_pool_transfers_allocation = mock.Mock(return_value=[])
+        controller.write_queue = []
+        controller.start_writing = mock.Mock()
+        device_indices = _indices(0, 4)
+
+        host_indices = controller.write(
+            device_indices, node_id=9, defer_start=True
+        )
+
+        self.assertTrue(torch.equal(host_indices, _indices(8, 12)))
+        self.assertEqual(len(controller.write_queue), 1)
+        self.assertEqual(controller.write_queue[0].node_ids, [9])
+        controller.start_writing.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -18,6 +18,8 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
     HybridCacheController,
 )
 from sglang.srt.mem_cache.l2_transfer import L2Transfer, L2TransferEngine
+from sglang.srt.mem_cache.unified_cache import unified_tree_core
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
 from sglang.srt.mem_cache.memory_pool_host import (
     DeepSeekV4PagedHostPool,
     DeepSeekV4StateHostPool,
@@ -1102,6 +1104,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller.move_indices.assert_not_called()
 
     def test_direct_hybrid_controller_defers_all_pool_index_copies(self):
+        ready_event = object()
         op = CacheOperation(
             host_indices=_indices(0, 4),
             device_indices=_indices(4, 8),
@@ -1113,6 +1116,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
                     device_indices=_indices(4, 8),
                 )
             ],
+            device_values_ready_event=ready_event,
         )
         controller = HybridCacheController.__new__(HybridCacheController)
         controller.write_queue = [op]
@@ -1126,9 +1130,71 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         self.assertEqual(controller.write_queue, [])
         controller._enqueue_direct_dispatch.assert_called_once_with(
-            controller._start_writing_op, op
+            controller._merge_and_start_writing_ops,
+            [op],
+            dependency=ready_event,
         )
         controller.move_hybrid_indices.assert_not_called()
+
+    def test_hybrid_merge_keeps_latest_device_value_dependency(self):
+        first_event = object()
+        latest_event = object()
+        ops = [
+            CacheOperation(
+                _indices(0, 2),
+                _indices(2, 4),
+                node_id=1,
+                device_values_ready_event=first_event,
+            ),
+            CacheOperation(
+                _indices(4, 6),
+                _indices(6, 8),
+                node_id=2,
+                device_values_ready_event=latest_event,
+            ),
+        ]
+
+        merged = CacheOperation.merge_ops(ops)
+
+        self.assertIs(merged.device_values_ready_event, latest_event)
+
+    def test_direct_hybrid_normalizes_aux_indices_on_helper_path(self):
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.io_backend = "direct"
+        operation = CacheOperation(
+            _indices(0, 2),
+            _indices(2, 4),
+            node_id=1,
+            pool_transfers=[
+                PoolTransfer(
+                    name=PoolName.SWA,
+                    host_indices=_indices(0, 2),
+                    device_indices=torch.arange(2, dtype=torch.int32),
+                )
+            ],
+        )
+        controller.move_indices = mock.Mock(
+            side_effect=lambda host, device: (host, device)
+        )
+
+        _, _, transfers = controller.move_hybrid_indices(operation)
+
+        self.assertEqual(transfers[0].device_indices.dtype, torch.int64)
+
+    def test_tree_readiness_event_records_only_a_narrow_current_stream_point(self):
+        tree = UnifiedTreeCore.__new__(UnifiedTreeCore)
+        tree.device = torch.device("cuda")
+        event = mock.Mock()
+        fake_device_module = mock.Mock()
+        fake_device_module.Event.return_value = event
+
+        with mock.patch.object(
+            unified_tree_core, "device_module", fake_device_module
+        ):
+            tree._record_device_values_ready()
+
+        event.record.assert_called_once_with()
+        self.assertIs(tree.device_values_ready_event(), event)
 
     def test_cache_controller_can_defer_write_submission_for_batching(self):
         controller = HiCacheController.__new__(HiCacheController)

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -213,6 +213,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         op = CacheOperation(_indices(0, 4), _indices(4, 8), 7)
         op.pool_transfers = [transfer]
         controller = mock.Mock(spec=HybridCacheController)
+        controller.io_backend = "kernel"
         controller.load_queue = [op, op]
         controller.layer_done_counter = mock.MagicMock()
         controller.layer_done_counter.update_producer.return_value = 0
@@ -229,6 +230,9 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         )
         controller._l2_load_transfers.side_effect = lambda *args: (
             HybridCacheController._l2_load_transfers(controller, *args)
+        )
+        controller._start_loading_op.side_effect = lambda *args: (
+            HybridCacheController._start_loading_op(controller, *args)
         )
         controller._num_tokens_by_pool.return_value = {}
         controller._transfer_num_bytes.return_value = 0
@@ -379,6 +383,25 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         )
         self.assertIs(pool_transfers[0].host_indices, mock.sentinel.host_indices)
         self.assertIs(pool_transfers[0].device_indices, mock.sentinel.device_indices)
+
+    def test_background_thread_device_resolves_missing_cuda_index(self):
+        with mock.patch.object(
+            manager_cache_controller.device_module,
+            "current_device",
+            return_value=3,
+        ) as current_device:
+            resolved = manager_cache_controller._resolve_background_thread_device(
+                "cuda"
+            )
+
+        self.assertEqual(resolved, 3)
+        current_device.assert_called_once_with()
+
+    def test_background_thread_device_keeps_explicit_index(self):
+        resolved = manager_cache_controller._resolve_background_thread_device(
+            torch.device("cuda:2")
+        )
+        self.assertEqual(resolved, torch.device("cuda:2"))
 
     def _patched_transfers(self, src_registry=None, module=MEMORY_POOL_HOST_MODULE):
         staged_side_effect = None
@@ -1055,6 +1078,57 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         controller.move_indices.assert_called_once()
         self.assertEqual(captured["host_indices"].device.type, "cpu")
+
+    def test_direct_cache_controller_defers_index_copy_to_dispatch_thread(self):
+        op = ManagerCacheOperation(
+            host_indices=_indices(0, 4),
+            device_indices=_indices(4, 8),
+            node_id=1,
+        )
+        controller = HiCacheController.__new__(HiCacheController)
+        controller.write_queue = [op]
+        controller.io_backend = "direct"
+        controller._enqueue_direct_dispatch = mock.Mock()
+        controller.move_indices = mock.Mock(
+            side_effect=AssertionError("scheduler must not copy direct indices")
+        )
+
+        controller.start_writing()
+
+        self.assertEqual(controller.write_queue, [])
+        controller._enqueue_direct_dispatch.assert_called_once_with(
+            controller._start_writing_op, op
+        )
+        controller.move_indices.assert_not_called()
+
+    def test_direct_hybrid_controller_defers_all_pool_index_copies(self):
+        op = CacheOperation(
+            host_indices=_indices(0, 4),
+            device_indices=_indices(4, 8),
+            node_id=1,
+            pool_transfers=[
+                PoolTransfer(
+                    name=PoolName.DEEPSEEK_V4_C4,
+                    host_indices=_indices(0, 4),
+                    device_indices=_indices(4, 8),
+                )
+            ],
+        )
+        controller = HybridCacheController.__new__(HybridCacheController)
+        controller.write_queue = [op]
+        controller.io_backend = "direct"
+        controller._enqueue_direct_dispatch = mock.Mock()
+        controller.move_hybrid_indices = mock.Mock(
+            side_effect=AssertionError("scheduler must not copy direct indices")
+        )
+
+        controller.start_writing()
+
+        self.assertEqual(controller.write_queue, [])
+        controller._enqueue_direct_dispatch.assert_called_once_with(
+            controller._start_writing_op, op
+        )
+        controller.move_hybrid_indices.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -19,7 +19,10 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import (
 )
 from sglang.srt.mem_cache.l2_transfer import L2Transfer, L2TransferEngine
 from sglang.srt.mem_cache.unified_cache import unified_tree_core
-from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import (
+    UnifiedTreeCore,
+    UnifiedTreeNode,
+)
 from sglang.srt.mem_cache.memory_pool_host import (
     DeepSeekV4PagedHostPool,
     DeepSeekV4StateHostPool,
@@ -1132,11 +1135,11 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller._enqueue_direct_dispatch.assert_called_once_with(
             controller._merge_and_start_writing_ops,
             [op],
-            dependency=ready_event,
+            dependency=(ready_event,),
         )
         controller.move_hybrid_indices.assert_not_called()
 
-    def test_hybrid_merge_keeps_latest_device_value_dependency(self):
+    def test_hybrid_merge_keeps_each_node_device_value_dependency(self):
         first_event = object()
         latest_event = object()
         ops = [
@@ -1156,7 +1159,9 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         merged = CacheOperation.merge_ops(ops)
 
-        self.assertIs(merged.device_values_ready_event, latest_event)
+        self.assertEqual(
+            merged.device_values_ready_event, (first_event, latest_event)
+        )
 
     def test_direct_hybrid_normalizes_aux_indices_on_helper_path(self):
         controller = HybridCacheController.__new__(HybridCacheController)
@@ -1181,20 +1186,30 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
 
         self.assertEqual(transfers[0].device_indices.dtype, torch.int64)
 
-    def test_tree_readiness_event_records_only_a_narrow_current_stream_point(self):
+    def test_tree_readiness_events_are_owned_by_each_node(self):
         tree = UnifiedTreeCore.__new__(UnifiedTreeCore)
         tree.device = torch.device("cuda")
-        event = mock.Mock()
+        first_node = UnifiedTreeNode(())
+        second_node = UnifiedTreeNode(())
+        tree._node_arena = {
+            first_node.id: first_node,
+            second_node.id: second_node,
+        }
+        first_event = mock.Mock()
+        second_event = mock.Mock()
         fake_device_module = mock.Mock()
-        fake_device_module.Event.return_value = event
+        fake_device_module.Event.side_effect = [first_event, second_event]
 
         with mock.patch.object(
             unified_tree_core, "device_module", fake_device_module
         ):
-            tree._record_device_values_ready()
+            tree._record_device_values_ready(first_node)
+            tree._record_device_values_ready(second_node)
 
-        event.record.assert_called_once_with()
-        self.assertIs(tree.device_values_ready_event(), event)
+        first_event.record.assert_called_once_with()
+        second_event.record.assert_called_once_with()
+        self.assertIs(tree.device_values_ready_event(first_node.id), first_event)
+        self.assertIs(tree.device_values_ready_event(second_node.id), second_event)
 
     def test_cache_controller_can_defer_write_submission_for_batching(self):
         controller = HiCacheController.__new__(HiCacheController)

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -3,6 +3,8 @@
 import os
 import unittest
 from array import array
+from types import SimpleNamespace
+from unittest import mock
 
 import torch
 
@@ -117,6 +119,34 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         self.assertEqual(list(stored_cpu[0].token_ids), [1, 2, 3, 4])
         self.assertIsNone(stored_cpu[0].parent_block_hash)
         self.assertEqual(len(stored_cpu[0].block_hashes), 2)
+
+    def test_write_back_waits_for_direct_dispatch_to_publish_ack(self):
+        cache = object.__new__(HiRadixCache)
+        cache.ongoing_write_through = {7: object()}
+        cache.cache_controller = mock.Mock()
+        cache.cache_controller.ack_write_queue = []
+        ack = SimpleNamespace(
+            finish_event=mock.Mock(),
+            node_ids=[7],
+        )
+
+        def publish_ack():
+            cache.cache_controller.ack_write_queue.append(ack)
+
+        cache.cache_controller.wait_direct_dispatch.side_effect = publish_ack
+        cache._finish_write_through_ack = mock.Mock(
+            side_effect=lambda ack_id, release_lock: cache.ongoing_write_through.pop(
+                ack_id
+            )
+        )
+        cache._log_write_ack_metrics = mock.Mock()
+
+        cache.writing_check(write_back=True)
+
+        cache.cache_controller.check_direct_dispatch_error.assert_called_once_with()
+        cache.cache_controller.wait_direct_dispatch.assert_called_once_with()
+        ack.finish_event.synchronize.assert_called_once_with()
+        cache._finish_write_through_ack.assert_called_once_with(7, release_lock=False)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_multi_ended_allocator.py
+++ b/test/registered/unit/mem_cache/test_multi_ended_allocator.py
@@ -26,6 +26,7 @@ register_cpu_ci(est_time=8, suite="base-a-test-cpu")
 
 import random
 import unittest
+from unittest.mock import Mock, patch
 
 import torch
 
@@ -565,6 +566,25 @@ class TestUnifiedSWATokenToKVPoolAllocator(unittest.TestCase):
     slot-conservation, the `schedulable_*` split, and watermark
     rollback."""
 
+    def test_segment_release_uses_shared_ids_and_cpu_frontier(self):
+        allocator = object.__new__(UnifiedSWATokenToKVPoolAllocator)
+        allocator.page_size = 4
+        allocator.is_not_in_free_group = True
+        allocator.full_attn_allocator = Mock()
+        allocator.swa_attn_allocator = Mock()
+        first = torch.arange(8, 16, dtype=torch.int64)
+        second = torch.arange(16, 24, dtype=torch.int64)
+        segments = [(first, 0), (second, 8)]
+
+        with patch("torch.unique", side_effect=AssertionError("unexpected unique")):
+            allocator.free_segments(segments, swa_evicted_seqlen=12)
+
+        allocator.full_attn_allocator.free_segments.assert_called_once_with(segments)
+        swa_segments = allocator.swa_attn_allocator.free_segments.call_args.args[0]
+        self.assertEqual(len(swa_segments), 1)
+        torch.testing.assert_close(swa_segments[0][0], second[4:])
+        self.assertEqual(swa_segments[0][1], 12)
+
     def _build(
         self,
         n_full_slots=32,
@@ -934,7 +954,14 @@ class TestPagedMultiEndedAllocator(unittest.TestCase):
 
     PAGE_SIZE = 8
 
-    def _build(self, n_full_pages=16, n_swa_pages=8, full_layer_num=2, swa_layer_num=2):
+    def _build(
+        self,
+        n_full_pages=16,
+        n_swa_pages=8,
+        full_layer_num=2,
+        swa_layer_num=2,
+        lazy_compaction=False,
+    ):
         full_spec = MHASubPoolSpec(
             name="full",
             layer_num=full_layer_num,
@@ -973,6 +1000,7 @@ class TestPagedMultiEndedAllocator(unittest.TestCase):
             device=_DEV,
             is_id_owner=True,
             page_size=self.PAGE_SIZE,
+            lazy_compaction=lazy_compaction,
         )
         swa_alloc = MultiEndedAllocator(
             kvcache=swa_kv,
@@ -981,10 +1009,45 @@ class TestPagedMultiEndedAllocator(unittest.TestCase):
             device=_DEV,
             is_id_owner=True,
             page_size=self.PAGE_SIZE,
+            lazy_compaction=lazy_compaction,
         )
         full_alloc.bind_peer(swa_alloc)
         swa_alloc.bind_peer(full_alloc)
         return pool, full_alloc, swa_alloc, full_kv, swa_kv
+
+    def test_free_segment_avoids_unique_in_lazy_path(self):
+        _, full_alloc, _, _, _ = self._build(lazy_compaction=True)
+        row = full_alloc.alloc(3 * self.PAGE_SIZE)
+        segment = row[1 : 2 * self.PAGE_SIZE + 2]
+        expected_pages = torch.unique(segment // self.PAGE_SIZE)
+
+        with patch("torch.unique", side_effect=AssertionError("unexpected unique")):
+            full_alloc.free_segment(segment, start_pos=1)
+
+        self.assertTrue(torch.all(full_alloc.virtual_to_physical[expected_pages] == -1))
+        self.assertEqual(full_alloc.live_page_count, 0)
+
+    def test_grouped_free_segment_owns_representatives_without_unique(self):
+        _, full_alloc, _, _, _ = self._build(lazy_compaction=True)
+        row = full_alloc.alloc(2 * self.PAGE_SIZE)
+        expected_pages = torch.unique(row // self.PAGE_SIZE)
+
+        full_alloc.free_group_begin()
+        full_alloc.free_segment(row, start_pos=0)
+        row.zero_()
+        with patch("torch.unique", side_effect=AssertionError("unexpected unique")):
+            full_alloc.free_group_end()
+
+        self.assertTrue(torch.all(full_alloc.virtual_to_physical[expected_pages] == -1))
+
+    def test_composite_swa_segment_uses_tombstone_aware_fallback(self):
+        composite = object.__new__(UnifiedSWATokenToKVPoolAllocator)
+        composite.free_swa = Mock()
+        indices = torch.arange(self.PAGE_SIZE, 2 * self.PAGE_SIZE)
+
+        composite.free_swa_segment(indices, start_pos=self.PAGE_SIZE)
+
+        composite.free_swa.assert_called_once_with(indices)
 
     def _stamp_tokens(
         self, alloc: MultiEndedAllocator, kv: _FakeKVCache, v_tokens: torch.Tensor

--- a/test/registered/unit/mem_cache/test_paged_free_segment.py
+++ b/test/registered/unit/mem_cache/test_paged_free_segment.py
@@ -13,6 +13,7 @@ import torch
 
 from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.common import _release_overallocated_kv_indices
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -131,7 +132,10 @@ class TestFreeSegment(unittest.TestCase):
             token_to_kv_pool_allocator=alloc,
             req_to_token_pool=SimpleNamespace(req_to_token=row.unsqueeze(0)),
         )
-        req = SimpleNamespace(req_pool_idx=0)
+        req = SimpleNamespace(
+            req_pool_idx=0,
+            kv=SimpleNamespace(swa_evicted_seqlen=0),
+        )
 
         before = len(alloc.free_pages)
         alloc.free_group_begin()
@@ -226,6 +230,96 @@ class TestBaseFallbackFreeSegments(unittest.TestCase):
         alloc.free_segments([(row[0:6], 0), (row[6:11], 6)])
         per_call_pages = [set((t // PAGE_SIZE).tolist()) for t in alloc.freed]
         self.assertEqual(per_call_pages, [{0, 1}, {2}])
+
+
+class TestSWADenseSegmentRelease(unittest.TestCase):
+    def _make_swa_allocator(self):
+        alloc = object.__new__(SWATokenToKVPoolAllocator)
+        alloc.page_size = PAGE_SIZE
+        alloc.device = "cpu"
+        alloc.full_attn_allocator = _make_allocator(need_sort=True)
+        alloc.swa_attn_allocator = _make_allocator(need_sort=True)
+        alloc.full_to_swa_index_mapping = torch.zeros(
+            NUM_PAGES * PAGE_SIZE + PAGE_SIZE + 1, dtype=torch.int64
+        )
+        alloc.is_not_in_free_group = True
+        alloc.free_group = []
+        alloc.swa_free_group = []
+        alloc.free_segments_group = []
+        alloc.swa_free_segments_group = []
+        return alloc
+
+    def test_releases_swa_window_segment_without_unique(self):
+        alloc = self._make_swa_allocator()
+        full_row = alloc.full_attn_allocator.alloc(3 * PAGE_SIZE)
+        swa_row = alloc.swa_attn_allocator.alloc(3 * PAGE_SIZE)
+        alloc.full_to_swa_index_mapping[full_row] = swa_row
+
+        with patch("torch.unique", side_effect=AssertionError("unexpected unique")):
+            alloc.free_swa_segment(full_row[: 2 * PAGE_SIZE], start_pos=0)
+
+        self.assertEqual(len(alloc.full_attn_allocator.release_pages), 0)
+        self.assertEqual(len(alloc.swa_attn_allocator.release_pages), 2)
+        self.assertTrue(
+            torch.all(alloc.full_to_swa_index_mapping[full_row[: 2 * PAGE_SIZE]] == 0)
+        )
+        self.assertTrue(
+            torch.all(alloc.full_to_swa_index_mapping[full_row[2 * PAGE_SIZE :]] > 0)
+        )
+
+    def test_known_frontier_is_fast_and_unknown_frontier_uses_legacy(self):
+        alloc = self._make_swa_allocator()
+        full_row = alloc.full_attn_allocator.alloc(3 * PAGE_SIZE)
+        swa_row = alloc.swa_attn_allocator.alloc(2 * PAGE_SIZE)
+        alloc.full_to_swa_index_mapping[full_row[PAGE_SIZE:]] = swa_row
+
+        with patch("torch.unique", side_effect=AssertionError("unexpected unique")):
+            alloc.free_segments([(full_row, 0)], swa_evicted_seqlen=PAGE_SIZE)
+
+        self.assertEqual(len(alloc.full_attn_allocator.release_pages), 3)
+        self.assertEqual(len(alloc.swa_attn_allocator.release_pages), 2)
+        self.assertTrue(torch.all(alloc.full_to_swa_index_mapping[full_row] == 0))
+
+        fallback = self._make_swa_allocator()
+        indices = torch.arange(1, PAGE_SIZE + 1, dtype=torch.int64)
+        with patch.object(fallback, "free") as legacy_free:
+            fallback.free_segments([(indices, 0)])
+        legacy_free.assert_called_once_with(indices)
+
+    def test_grouped_requests_with_same_positions_remain_distinct(self):
+        alloc = self._make_swa_allocator()
+        first_full = alloc.full_attn_allocator.alloc(PAGE_SIZE)
+        first_swa = alloc.swa_attn_allocator.alloc(PAGE_SIZE)
+        second_full = alloc.full_attn_allocator.alloc(PAGE_SIZE)
+        second_swa = alloc.swa_attn_allocator.alloc(PAGE_SIZE)
+        alloc.full_to_swa_index_mapping[first_full] = first_swa
+        alloc.full_to_swa_index_mapping[second_full] = second_swa
+        expected_full_pages = torch.unique(
+            torch.cat((first_full, second_full)) // PAGE_SIZE
+        )
+        expected_swa_pages = torch.unique(
+            torch.cat((first_swa, second_swa)) // PAGE_SIZE
+        )
+
+        alloc.free_group_begin()
+        alloc.free_segments([(first_full, 0)], swa_evicted_seqlen=0)
+        alloc.free_segments([(second_full, 0)], swa_evicted_seqlen=0)
+        first_full.zero_()
+        second_full.zero_()
+        alloc.free_group_end()
+
+        self.assertTrue(
+            torch.equal(
+                torch.sort(alloc.full_attn_allocator.release_pages)[0],
+                expected_full_pages,
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                torch.sort(alloc.swa_attn_allocator.release_pages)[0],
+                expected_swa_pages,
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_pure_swa_chunk_cache.py
+++ b/test/registered/unit/mem_cache/test_pure_swa_chunk_cache.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 
 import torch
 
-from sglang.srt.mem_cache.chunk_cache import PureSWAChunkCache
+from sglang.srt.mem_cache.chunk_cache import ChunkCache, PureSWAChunkCache
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -57,6 +57,40 @@ class TestPureSWAChunkCache(CustomTestCase):
 
         freed = cache.token_to_kv_pool_allocator.freed[0]
         self.assertTrue(torch.equal(freed, torch.tensor([2, 6, 7])))
+
+
+class _RecordingAllocator:
+    def __init__(self):
+        self.calls = []
+
+    def free_segments(self, segments, *, swa_evicted_seqlen=None):
+        owned_segments = [
+            (indices.detach().cpu().clone(), start_pos)
+            for indices, start_pos in segments
+        ]
+        self.calls.append((owned_segments, swa_evicted_seqlen))
+
+
+class TestChunkCache(CustomTestCase):
+    def test_finished_req_passes_swa_eviction_frontier(self):
+        cache = ChunkCache.__new__(ChunkCache)
+        cache.req_to_token_pool = SimpleNamespace(
+            req_to_token=torch.arange(12, dtype=torch.int64).unsqueeze(0)
+        )
+        cache.token_to_kv_pool_allocator = _RecordingAllocator()
+        req = SimpleNamespace(
+            req_pool_idx=0,
+            cache_protected_len=2,
+            kv=SimpleNamespace(swa_evicted_seqlen=8),
+        )
+
+        cache.cache_finished_req(req, kv_len_to_handle=11)
+
+        [(segments, swa_evicted_seqlen)] = cache.token_to_kv_pool_allocator.calls
+        [(indices, start_pos)] = segments
+        self.assertTrue(torch.equal(indices, torch.arange(2, 11)))
+        self.assertEqual(start_pos, 2)
+        self.assertEqual(swa_evicted_seqlen, 8)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
+++ b/test/registered/unit/mem_cache/test_swa_alloc_extend_page_estimation.py
@@ -47,6 +47,7 @@ def _make_self(*, page_size: int, full_available: int, swa_available: int):
         translate_loc_from_full_to_swa=lambda last_loc: last_loc,
         new_pages_available=new_pages_available,
         set_full_to_swa_mapping=set_full_to_swa_mapping,
+        _set_full_to_swa_mapping=set_full_to_swa_mapping,
         full_to_swa_index_mapping=full_to_swa_index_mapping,
     )
 

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -6185,24 +6185,26 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
         UnifiedRadixCache._apply_cache_action(cache, action)
         component.apply_component_action.assert_called_once_with(action)
 
-    def test_apply_component_action_device_kv_full_swa_uses_full_attn(self):
+    def test_apply_component_action_device_kv_full_swa_uses_segment_release(self):
         cache = mock.MagicMock()
         cache.is_swa_enabled = True
         indices = torch.tensor([4, 5])
         _component_with_cache(ComponentType.FULL, cache).apply_component_action(
             FreeComponentDeviceSlot([indices], component_type=ComponentType.FULL)
         )
-        cache.token_to_kv_pool_allocator.full_attn_allocator.free.assert_called_once_with(
-            indices
+        cache.token_to_kv_pool_allocator.full_attn_allocator.free_segment.assert_called_once_with(
+            indices, start_pos=0
         )
 
-    def test_apply_component_action_device_kv_swa_uses_free_swa(self):
+    def test_apply_component_action_device_kv_swa_uses_segment_release(self):
         cache = mock.MagicMock()
         indices = torch.tensor([4, 5])
         _component_with_cache(ComponentType.SWA, cache).apply_component_action(
             FreeComponentDeviceSlot([indices], component_type=ComponentType.SWA)
         )
-        cache.token_to_kv_pool_allocator.free_swa.assert_called_once_with(indices)
+        cache.token_to_kv_pool_allocator.free_swa_segment.assert_called_once_with(
+            indices, start_pos=0
+        )
 
     def test_apply_component_action_device_kv_mamba_uses_mamba_allocator(self):
         cache = mock.MagicMock()
@@ -6298,9 +6300,11 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
     def test_apply_component_action_swa_recover_on_full_locked(self):
         cache = mock.MagicMock()
         alloc = cache.token_to_kv_pool_allocator
-        kept_full = torch.tensor([1, 2], dtype=torch.int64)
-        incoming_full = torch.tensor([3, 4], dtype=torch.int64)
-        swa_value = alloc.translate_loc_from_full_to_swa.return_value
+        alloc.page_size = 2
+        kept_full = torch.tensor([2, 3], dtype=torch.int64)
+        incoming_full = torch.tensor([4, 5], dtype=torch.int64)
+        swa_value = torch.tensor([6, 7], dtype=torch.int64)
+        alloc.translate_loc_from_full_to_swa.return_value = swa_value
         _component_with_cache(ComponentType.SWA, cache).apply_component_action(
             RecoverSWAWithLockedFull(
                 node_id=5,
@@ -6313,7 +6317,9 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
         alloc.set_full_to_swa_mapping.assert_called_once_with(kept_full, swa_value)
         # the incoming full's stale mapping is cleared, then its slot freed (full-only)
         alloc.clear_full_to_swa_mapping.assert_called_once_with(incoming_full)
-        alloc.full_attn_allocator.free.assert_called_once_with(incoming_full)
+        alloc.full_attn_allocator.free_segment.assert_called_once_with(
+            incoming_full, start_pos=0
+        )
         alloc.free.assert_not_called()
         cache.tree_core.set_component_device_value.assert_called_once_with(
             5, ComponentType.SWA, swa_value
@@ -6515,7 +6521,9 @@ class TestResumableInsertWalk(_InsertWalkSuite):
         )
         step = cache.tree_core.begin_insert(params)
         self.assertIsNotNone(step.result)
-        self.assertTrue(any(isinstance(a, FreeDeviceKV) for a in step.actions))
+        self.assertTrue(
+            any(isinstance(a, FreeComponentDeviceSlot) for a in step.actions)
+        )
         cache._apply_cache_actions(step.actions)
         cache.tree_core.end_insert()
         cache.sanity_check()

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -258,7 +258,7 @@ class TestUnifiedTreeNodeGetPrefixHashValues(CustomTestCase):
 
 class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
     def _build_core(self, *, is_write_back: bool):
-        component_types = (ComponentType.FULL,)
+        component_types = (ComponentType.FULL, ComponentType.SWA)
         root = UnifiedTreeNode(component_types)
         shared = UnifiedTreeNode(component_types)
         anchor_a = UnifiedTreeNode(component_types)
@@ -272,7 +272,9 @@ class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
         core.is_write_back = is_write_back
         core.root_node = root
         core.node_by_id.side_effect = nodes.__getitem__
-        core.components_by_type = {ComponentType.FULL: mock.Mock()}
+        core.components_by_type = {
+            component_type: mock.Mock() for component_type in component_types
+        }
         core.full_host_duplicates = {}
         core._is_settled_full_host_duplicate.side_effect = (
             lambda node: UnifiedTreeCore._is_settled_full_host_duplicate(core, node)
@@ -282,18 +284,29 @@ class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
         )
         return core, shared, anchor_a, anchor_b
 
-    def _commit_load_back(self, core, anchor, source):
-        transfer = PoolTransfer(
+    def _commit_load_back(self, core, anchor, *, full_nodes=(), swa_nodes=()):
+        kv_xfer = PoolTransfer(
             name=PoolName.KV,
-            host_indices=torch.tensor([1], dtype=torch.int64),
-            nodes_to_load=[source.id],
+            host_indices=torch.tensor([1] * len(full_nodes), dtype=torch.int64),
+            nodes_to_load=[node.id for node in full_nodes],
         )
+        comp_xfers = {}
+        if swa_nodes:
+            comp_xfers[ComponentType.SWA] = [
+                PoolTransfer(
+                    name=PoolName.SWA,
+                    host_indices=torch.tensor(
+                        [2] * len(swa_nodes), dtype=torch.int64
+                    ),
+                    nodes_to_load=[node.id for node in swa_nodes],
+                )
+            ]
         return UnifiedTreeCore.commit_load_back(
             core,
             anchor.id,
-            torch.tensor([2], dtype=torch.int64),
-            transfer,
-            {},
+            torch.tensor([3] * len(full_nodes), dtype=torch.int64),
+            kv_xfer,
+            comp_xfers,
         )
 
     def test_write_through_different_anchors_track_duplicate_without_pending(self):
@@ -302,8 +315,8 @@ class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
         full.value = torch.tensor([1], dtype=torch.int64)
         full.host_value = torch.tensor([2], dtype=torch.int64)
 
-        self._commit_load_back(core, anchor_a, shared)
-        self._commit_load_back(core, anchor_b, shared)
+        self._commit_load_back(core, anchor_a, full_nodes=(shared,))
+        self._commit_load_back(core, anchor_b, full_nodes=(shared,))
         UnifiedTreeCore.finish_load_back(core, anchor_a.id)
 
         self.assertIsNone(shared.load_back_pending_id)
@@ -318,18 +331,43 @@ class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
         full.value = torch.tensor([1], dtype=torch.int64)
         full.host_value = torch.tensor([2], dtype=torch.int64)
 
-        self._commit_load_back(core, anchor_a, shared)
+        self._commit_load_back(core, anchor_a, full_nodes=(shared,))
 
         self.assertEqual(shared.load_back_pending_id, anchor_a.id)
         self.assertFalse(UnifiedTreeCore._can_reclaim_full_host_duplicate(core, shared))
         with self.assertRaisesRegex(AssertionError, "new anchor"):
-            self._commit_load_back(core, anchor_b, shared)
+            self._commit_load_back(core, anchor_b, full_nodes=(shared,))
 
         UnifiedTreeCore.finish_load_back(core, anchor_a.id)
 
         self.assertIsNone(shared.load_back_pending_id)
         self.assertTrue(UnifiedTreeCore._can_reclaim_full_host_duplicate(core, shared))
         core._update_duplicate_tracking.assert_called_once_with(shared)
+
+    def test_auxiliary_overlap_does_not_replace_full_pending_anchor(self):
+        core, shared, descendant, _ = self._build_core(is_write_back=True)
+        full = shared.component_data[ComponentType.FULL]
+        full.value = torch.tensor([1], dtype=torch.int64)
+        full.host_value = torch.tensor([2], dtype=torch.int64)
+
+        self._commit_load_back(core, descendant, full_nodes=(shared,))
+        self.assertEqual(shared.load_back_pending_id, descendant.id)
+
+        # A later request may load an auxiliary pool for the shared ancestor
+        # while the descendant's Full KV DMA is still in flight.
+        self._commit_load_back(core, shared, swa_nodes=(shared,))
+        UnifiedTreeCore.finish_load_back(core, shared.id)
+        self.assertEqual(shared.load_back_pending_id, descendant.id)
+
+        UnifiedTreeCore.finish_load_back(core, descendant.id)
+        self.assertIsNone(shared.load_back_pending_id)
+
+    def test_full_overlap_with_different_anchor_is_still_rejected(self):
+        core, shared, descendant, _ = self._build_core(is_write_back=True)
+        self._commit_load_back(core, descendant, full_nodes=(shared,))
+
+        with self.assertRaisesRegex(AssertionError, "new anchor"):
+            self._commit_load_back(core, shared, full_nodes=(shared,))
 
 
 def _write_backup(cache, node, write_back: bool = False) -> int:

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -295,9 +295,7 @@ class TestUnifiedTreeCoreLoadBackPending(CustomTestCase):
             comp_xfers[ComponentType.SWA] = [
                 PoolTransfer(
                     name=PoolName.SWA,
-                    host_indices=torch.tensor(
-                        [2] * len(swa_nodes), dtype=torch.int64
-                    ),
+                    host_indices=torch.tensor([2] * len(swa_nodes), dtype=torch.int64),
                     nodes_to_load=[node.id for node in swa_nodes],
                 )
             ]
@@ -6240,6 +6238,41 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
         cache.token_to_kv_pool_allocator.full_attn_allocator.free_segment.assert_called_once_with(
             indices, start_pos=0
         )
+
+    def test_flush_write_back_batch_waits_before_demoting(self):
+        cache = object.__new__(UnifiedRadixCache)
+        cache.cache_controller = mock.Mock()
+        cache.cache_controller.write_queue = [mock.sentinel.pending_write]
+        cache.ongoing_write_through = {}
+        cache.writing_check = mock.Mock()
+        cache._demote = mock.Mock()
+        tracker = {ComponentType.FULL: 0}
+        node_ids = [11, 12]
+        calls = mock.Mock()
+        calls.attach_mock(cache.cache_controller.start_writing, "start")
+        calls.attach_mock(cache.writing_check, "wait")
+        calls.attach_mock(cache._demote, "demote")
+
+        cache._flush_write_back_eviction_batch(node_ids, tracker)
+
+        self.assertEqual(
+            calls.mock_calls,
+            [
+                mock.call.start(),
+                mock.call.wait(write_back=True),
+                mock.call.demote(11, tracker),
+                mock.call.demote(12, tracker),
+            ],
+        )
+        self.assertEqual(node_ids, [])
+
+    def test_flush_write_back_batch_is_noop_without_hicache(self):
+        cache = object.__new__(UnifiedRadixCache)
+        cache.cache_controller = None
+        cache.ongoing_write_through = {}
+        tracker = {ComponentType.FULL: 0}
+
+        cache._flush_write_back_eviction_batch([], tracker)
 
     def test_apply_component_action_device_kv_swa_uses_segment_release(self):
         cache = mock.MagicMock()

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -661,6 +661,11 @@ class TestUnifiedRadixCacheKVEvents(CustomTestCase):
         self.assertTrue(loaded)
         producer_id = cache.ready_to_load_host_cache()
         self.assertNotEqual(producer_id, -1)
+        # Direct HiCache deliberately prepares transfer indices on a helper
+        # thread.  These helpers assert the final post-DMA cache state, so wait
+        # for that preparation before inspecting the acknowledgement queue;
+        # production scheduling remains asynchronous and polls it next step.
+        cache.cache_controller.wait_direct_dispatch()
         for ack in list(cache.cache_controller.ack_load_queue):
             ack.finish_event.synchronize()
         cache.loading_check()
@@ -3726,6 +3731,7 @@ class UnifiedRadixCacheSuite:
         self.assertTrue(loaded)
         producer_id = cache.ready_to_load_host_cache()
         self.assertNotEqual(producer_id, -1)
+        cache.cache_controller.wait_direct_dispatch()
         for ack in list(cache.cache_controller.ack_load_queue):
             ack.finish_event.synchronize()
         cache.loading_check()
@@ -4209,6 +4215,7 @@ class UnifiedRadixCacheSuite:
     def _finish_pending_loads(self, cache):
         producer_id = cache.ready_to_load_host_cache()
         self.assertNotEqual(producer_id, -1)
+        cache.cache_controller.wait_direct_dispatch()
         for ack in list(cache.cache_controller.ack_load_queue):
             ack.finish_event.synchronize()
         cache.loading_check()

--- a/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_cuda_graph_padding.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest import mock
 
 from sglang.srt.model_executor.cuda_graph_config import Backend
 from sglang.srt.model_executor.forward_batch_info import (
@@ -51,6 +52,25 @@ class TestPrefillCudaGraphPadding(CustomTestCase):
         runner = self._make_runner()
 
         self.assertTrue(runner.can_run_graph(self._make_forward_batch(8)))
+
+    def test_replay_snapshot_uses_padded_token_count(self):
+        runner = self._make_runner()
+        runner.use_captured_attn_metadata = False
+        attn_backend = mock.Mock()
+        runner.model_runner = SimpleNamespace(attn_backend=attn_backend)
+        forward_batch = self._make_forward_batch(8)
+        static_forward_batch = self._make_forward_batch(16)
+
+        runner._prepare_forward_metadata_for_replay(
+            forward_batch,
+            static_forward_batch,
+            num_tokens=16,
+        )
+
+        attn_backend.init_forward_metadata.assert_called_once_with(forward_batch)
+        attn_backend.prepare_prefill_shared_read_snapshot.assert_called_once_with(
+            forward_batch, num_qo_tokens=16
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/runner/test_prefill_shared_read_done.py
+++ b/test/registered/unit/model_executor/runner/test_prefill_shared_read_done.py
@@ -12,7 +12,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.runner_utils import (
     maybe_publish_prefill_shared_read_done,
 )
-from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_info import SpecInputType, SpeculativeAlgorithm
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -41,8 +41,13 @@ def _model_runner(*, spec_algorithm=SpeculativeAlgorithm.NONE, compliant=True):
 _DEVICE_MODULE = SimpleNamespace(Event=_Event)
 
 
-def _batch(mode=ForwardMode.EXTEND):
-    return SimpleNamespace(forward_mode=mode)
+def _batch(mode=ForwardMode.EXTEND, spec_input_type=None):
+    spec_info = (
+        None
+        if spec_input_type is None
+        else SimpleNamespace(spec_input_type=spec_input_type)
+    )
+    return SimpleNamespace(forward_mode=mode, spec_info=spec_info)
 
 
 def test_publishes_recorded_event_when_enabled():
@@ -58,6 +63,29 @@ def test_disabled_when_flag_is_false():
     with envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(False):
         maybe_publish_prefill_shared_read_done(runner, _batch(), _DEVICE_MODULE)
     assert runner.shared_read_done_event is None
+
+
+def test_eagle_draft_extend_does_not_publish():
+    runner = _model_runner(spec_algorithm=SpeculativeAlgorithm.EAGLE)
+    batch = _batch(spec_input_type=SpecInputType.EAGLE_DRAFT_EXTEND)
+    with envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(True):
+        maybe_publish_prefill_shared_read_done(runner, batch, _DEVICE_MODULE)
+    assert runner.shared_read_done_event is None
+
+
+@pytest.mark.parametrize(
+    "algorithm", (SpeculativeAlgorithm.DFLASH, SpeculativeAlgorithm.DSPARK)
+)
+@pytest.mark.parametrize("enabled", (False, True))
+def test_dflash_family_target_prefill_respects_prefill_flag(algorithm, enabled):
+    runner = _model_runner(spec_algorithm=algorithm)
+    with envs.SGLANG_ENABLE_PREFILL_WAR_READ_DONE.override(enabled):
+        maybe_publish_prefill_shared_read_done(runner, _batch(), _DEVICE_MODULE)
+    if enabled:
+        published = runner.shared_read_done_event
+        assert isinstance(published, _Event) and published.recorded
+    else:
+        assert runner.shared_read_done_event is None
 
 
 def test_gates_exclude_non_prefill_unsupported_algorithm_and_noncompliant_backend():


### PR DESCRIPTION
## Motivation

DSV4 disaggregated sparse prefill still exposes scheduler-side CUDA synchronization and long host stalls across allocator cleanup, transfer-index preparation, HiCache write-back/load-back, and speculative-MoE execution. Under full GB300 load, Blackwell MegaMoE can additionally deadlock at its whole-grid software barrier when every SM is occupied.

## Changes

### HiCache

- Dispatch unavoidable direct-I/O index readiness waits from a device-bound helper thread.
- Batch unified write-back eviction transfers.
- Keep Full-KV load-back ownership separate from auxiliary-pool locks.
- Track readiness per evicted node and wait only for the nodes included in a transfer.

### Sparse-prefill and allocator cleanup

- Preserve dense segment metadata and free paged SWA/HiSparse/unified mappings without data-dependent `torch.unique` discovery.
- Remove scalar synchronization from unified SWA CPU-copy bookkeeping.
- Build sparse-prefill metadata before replay and publish the shared-read boundary for EAGLE/DFLASH/DSpark paths.
- Pin scheduler metadata before asynchronous H2D copies.

### Disaggregated transfer scheduling

- Stage prefill and cached-prefix transfer indices asynchronously instead of converting them on the scheduler hot path.
- Avoid blocking cached-prefix early sends.
- Move request-scoped prefill DP-rank registration to a reusable background executor.

### Blackwell MegaMoE

- Reserve two SMs by default for Blackwell MegaMoE so side-stream/NCCL work can drain while its clustered grid barrier is active.
- Keep Hopper behavior unchanged and provide explicit total-SM/reserved-SM environment overrides.

## Breakdown

This PR remains the integration and end-to-end performance reference while its independent changes are split into focused PRs:

- #35944 — pin scheduler-produced host metadata before non-blocking H2D copies.
- #35953 — release paged SWA segments without device synchronization; unified-cache support remains planned.
- #35947 — publish the DSV4 speculative-prefill shared-read completion boundary.
- Disaggregated prefill transfer-index staging — planned.
- Prefill DP-rank registration outside the scheduler hot path — planned.
- HiCache direct-I/O dispatch and write-back batching/readiness — planned.
- Blackwell MegaMoE SM reservation — retained as an independent follow-up pending focused validation.

## Validation

- Real DSpark GSM8K validation completed all 1,319 samples without a MegaMoE grid-barrier timeout: flexible exact match **0.9659 ± 0.0050**, strict exact match **0.9666 ± 0.0049**.

### Throughput A/B

The comparison used the same GB300 AgentX workload and serving configuration: 2xDEP8 prefill plus DEP12 decode (28 GPUs), concurrency 1152, a 300-second trace idle-gap cap, and a 2.1 HiCache ratio. Both columns use completed profiling records from the full 3,600-second send window and AIPerf's end-to-end measurement duration (approximately 3,630 seconds). Total throughput is input plus output tokens per second divided by all 28 allocated GPUs.

| Metric | Main baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| Total throughput (tok/s/GPU) | 75,767 | **106,548** | **+40.6%** |
| Aggregate output throughput (tok/s) | 16,254 | **23,038** | **+41.7%** |
| Completed requests | 59,213 | **84,216** | **+42.2%** |
| Mean TTFT | 40.72 s | **26.71 s** | **-34.4%** |
| Median TTFT | 35.91 s | **20.55 s** | **-42.8%** |
| Mean end-to-end latency | 53.58 s | **42.40 s** | **-20.9%** |

The PR-side metrics were aggregated from the complete raw AIPerf profile. Applying the same aggregation to the baseline raw profile reproduces its final AIPerf JSON metrics.

## TODO

- Pipeline the DP-attention metadata gather/readback to avoid blocking the scheduler, and investigate DP-rank arrival skew.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32831255047](https://github.com/sgl-project/sglang/actions/runs/32831255047)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32831254753](https://github.com/sgl-project/sglang/actions/runs/32831254753)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32831255006](https://github.com/sgl-project/sglang/actions/runs/32831255006)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->


