### PR TITLE
[Fix] Stream prose between and after DSML tool calls

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -93,6 +93,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self.prefix_parameter_end_call = ["</", "｜DSML｜", "parameter"]
         self.prefix_invoke_end_call = ["</", "｜DSML｜", "inv", "oke"]
         self.current_tool_id = -1
+        # False while nothing but whitespace has been emitted since the last DSML
+        # tag: that whitespace is the layout separating the tag from the prose
+        # after it, not content. True to start with, because the preamble is
+        # content from the first character.
+        self._gap_started = True
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a deepseek v32 format tool call."""
@@ -194,18 +199,23 @@ class DeepSeekV32Detector(BaseFormatDetector):
         :return: ParseResult indicating success or failure, consumed text, leftover text, and parsed calls.
         """
         idx = text.find(self.bot_token)
-        normal_text = text[:idx].removesuffix("\n\n") if idx != -1 else text
-        if self.bot_token not in text:
-            return StreamingParseResult(normal_text=normal_text, calls=[])
+        if idx == -1:
+            # No section opener, but the turn may have been cut off inside one.
+            return StreamingParseResult(normal_text=self._cut_at_markup(text), calls=[])
+
+        normal_text = text[:idx].removesuffix("\n\n")
 
         calls = []
         try:
-            sections = re.findall(self.function_calls_regex, text, re.DOTALL)
+            sections = list(re.finditer(self.function_calls_regex, text, re.DOTALL))
             if not sections:
                 return StreamingParseResult(normal_text=normal_text, calls=[])
 
+            normal_text += self._section_gaps(text, sections)
+
             # Find all invoke blocks
-            for function_calls_content in sections:
+            for section in sections:
+                function_calls_content = section.group(1)
                 for invoke_match in re.finditer(
                     self.invoke_regex, function_calls_content, re.DOTALL
                 ):
@@ -225,6 +235,59 @@ class DeepSeekV32Detector(BaseFormatDetector):
             logger.error(f"Error in detect_and_parse: {e}")
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
+
+    @staticmethod
+    def _cut_at_markup(text: str) -> str:
+        """Everything up to the first DSML tag, opening or closing, and its indent.
+
+        A turn can stop anywhere -- a length cap, an abort -- including in the
+        middle of a tag the model was still writing. What follows the `<｜` (or
+        `</｜`) was markup by then, not content, and must not reach the client;
+        what precedes it is prose no completed call ever consumed. The whitespace
+        in front of the tag goes with it, exactly as `_strip_section_markers`
+        drops the indent of a tag that did finish arriving.
+        """
+        markup = re.search(r"\s*</?｜", text)
+        return text if markup is None else text[: markup.start()]
+
+    def _gap_text(self, text: str) -> str:
+        """Drop the layout whitespace at the head of a gap, once per gap.
+
+        The blank line between a section closer and the prose after it indents
+        the markup; it is not the model's paragraph break. Tracked on the
+        instance rather than trimmed in place because a gap arrives over several
+        deltas: only the whitespace before the gap's first real character is
+        layout, and a newline in the middle of the prose has to survive.
+
+        Call this on text that is being emitted, never on text `_split_flushable`
+        may still hold back: a fragment that grows into a tag would otherwise
+        count as the gap's first real character and strand the layout behind it.
+        """
+        if not self._gap_started:
+            text = text.lstrip()
+            self._gap_started = bool(text)
+        return text
+
+    def _section_gaps(self, text: str, sections: list["re.Match[str]"]) -> str:
+        """The normal text between and after the tool call sections of `text`.
+
+        The one-shot counterpart of what the streaming path emits from
+        `_gap_text` and `_lead_text`, and trimmed to match: leading layout goes
+        everywhere, trailing layout only where another section follows it and
+        can claim the whitespace as its indent. The last gap ends the turn, so
+        its trailing newlines are the model's own.
+        """
+        gaps = []
+        for i, section in enumerate(sections):
+            is_last = i + 1 == len(sections)
+            end = len(text) if is_last else sections[i + 1].start()
+            gap = self._cut_at_markup(text[section.end() : end]).lstrip()
+            if gap in ("<", "</"):
+                # Nothing in this gap but the first characters of the next tag,
+                # which the turn stopped inside of. Layout, not the model's `<`.
+                gap = ""
+            gaps.append(gap if is_last else gap.rstrip())
+        return "".join(gaps)
 
     def _markers(self) -> tuple[str, ...]:
         """Every DSML tag this detector can meet, longest-lived first.
@@ -251,6 +314,18 @@ class DeepSeekV32Detector(BaseFormatDetector):
         for token in (self.eot_token, self.invoke_end_token, self.bot_token):
             text = re.sub(rf"\s*{re.escape(token)}", "", text)
         return text
+
+    def _strip_leading_closers(self, text: str) -> str:
+        """Drop the closers of a call that already streamed, and their indent.
+
+        Only the leading run: a tag further in is one the turn was cut off
+        inside, and `_cut_at_markup` has to see it where it stands rather than
+        have it spliced out from under the prose in front of it.
+        """
+        closers = "|".join(
+            re.escape(t) for t in (self.invoke_end_token, self.eot_token)
+        )
+        return re.sub(rf"^(?:\s*(?:{closers}))+", "", text)
 
     def _split_flushable(self, text: str) -> tuple[str, str]:
         """Split `text` into (safe to emit now, hold back for the next chunk).
@@ -284,15 +359,32 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         `_split_flushable` withholds anything that could still turn out to be a
         DSML tag. Once the stream is over nothing more is coming, so a held
-        fragment was ordinary text all along and is owed to the client.
+        fragment was ordinary text all along and is owed to the client -- unless
+        the tag did arrive and the turn ended inside it, which is what
+        `_cut_at_markup` separates.
         """
         held, self._buffer = self._buffer, ""
-        return StreamingParseResult(normal_text=self._strip_section_markers(held))
+        bot_pos = held.find(self.bot_token)
+        if bot_pos != -1 and self.current_tool_id == -1:
+            # The turn stopped inside the opening section, before any invoke was
+            # matched, so what is held is the preamble and nothing else. Trim it
+            # exactly as `detect_and_parse` trims it.
+            return StreamingParseResult(normal_text=held[:bot_pos].removesuffix("\n\n"))
+
+        # Closers first: the buffer can still carry those of a call that did
+        # finish, and the prose after them is owed to the client.
+        held = self._cut_at_markup(self._strip_leading_closers(held))
+        if not self._gap_started:
+            # Nothing but layout has been emitted since the last tag, so a lone
+            # `<` sitting in it is the next tag cut short rather than the model's
+            # own `5 < 6` -- which is why that reading is confined to here.
+            held = held.partition("<")[0]
+        return StreamingParseResult(normal_text=self._gap_text(held))
 
     def _lead_text(
-        self, current_text: str, *, call_start: int, is_first_call: bool
-    ) -> str:
-        """The normal text sitting in front of the call that starts at `call_start`.
+        self, current_text: str, *, invoke_start: int, is_first_call: bool
+    ) -> tuple[str, int]:
+        """The normal text in front of the call, and where that call begins.
 
         The two trims differ on purpose. The first call keeps `detect_and_parse`'s
         exact `removesuffix("\\n\\n")` so the streaming and one-shot paths agree on
@@ -302,11 +394,12 @@ class DeepSeekV32Detector(BaseFormatDetector):
         whitespace lands in this lead or in the preceding flush depending only on
         where the deltas happened to split.
         """
-        bot_pos = current_text.rfind(self.bot_token, 0, call_start)
-        if bot_pos != -1:
-            call_start = bot_pos
-        lead = self._strip_section_markers(current_text[:call_start])
-        return lead.removesuffix("\n\n") if is_first_call else lead.rstrip()
+        call_start = current_text.rfind(self.bot_token, 0, invoke_start)
+        if call_start == -1:
+            call_start = invoke_start
+        lead = self._gap_text(self._strip_section_markers(current_text[:call_start]))
+        trimmed = lead.removesuffix("\n\n") if is_first_call else lead.rstrip()
+        return trimmed, call_start
 
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
@@ -338,7 +431,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 if e_token in current_text:
                     current_text = current_text.replace(e_token, "")
             flushable, self._buffer = self._split_flushable(current_text)
-            return StreamingParseResult(normal_text=flushable)
+            return StreamingParseResult(normal_text=self._gap_text(flushable))
 
         all_calls: list[ToolCallItem] = []
         normal_text_parts: list[str] = []
@@ -375,14 +468,19 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 # call: it is only False the first time a call is seen, so an
                 # invoke that spans chunks can't re-emit the same lead.
                 if not self.current_tool_name_sent:
-                    lead = self._lead_text(
+                    lead, call_start = self._lead_text(
                         current_text,
-                        call_start=invoke_match.start(),
+                        invoke_start=invoke_match.start(),
                         is_first_call=is_first_call,
                     )
                     if lead:
                         normal_text_parts.append(lead)
                         lead_is_still_in_current_text = True
+                    # The lead has left the detector, so drop it from the buffer.
+                    # A completed call advances past it below; an incomplete one
+                    # never would, and `finish()` would emit it a second time at
+                    # the end of a turn cut short inside this invoke.
+                    self._buffer = current_text[call_start:]
 
                 # Ensure arrays are large enough for current tool
                 while len(self.prev_tool_call_arr) <= self.current_tool_id:
@@ -446,6 +544,8 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     self._buffer = current_text[invoke_match.end() :]
                     current_text = self._buffer  # Update for next iteration
                     lead_is_still_in_current_text = False
+                    # Whatever whitespace follows the call indents its closers.
+                    self._gap_started = False
 
                     # Move to next tool call
                     self.current_tool_id += 1
@@ -467,7 +567,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 flushable, self._buffer = self._split_flushable(
                     self._strip_section_markers(current_text)
                 )
-                normal_text_parts.append(flushable)
+                normal_text_parts.append(self._gap_text(flushable))
 
             return StreamingParseResult(
                 normal_text="".join(normal_text_parts), calls=all_calls

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -245,26 +245,22 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         The indent belongs to the tag, not to the prose around it, which is why
         `detect_and_parse` never shows it either. Safe to swallow here only
-        because `_split_flushable` refuses to release a trailing newline once a
-        call has been seen, so an indent is still in the buffer when its tag
-        lands however the chunks fell.
+        because `_split_flushable` refuses to release a trailing newline, so an
+        indent is still in the buffer when its tag lands however the chunks fell.
         """
         for token in (self.eot_token, self.invoke_end_token, self.bot_token):
-            text = re.sub(rf"\n*{re.escape(token)}", "", text)
+            text = re.sub(rf"\s*{re.escape(token)}", "", text)
         return text
 
     def _split_flushable(self, text: str) -> tuple[str, str]:
         """Split `text` into (safe to emit now, hold back for the next chunk).
 
-        Held back: a suffix that is a strict prefix of a real marker, and -- once
-        a call has been seen -- a trailing run of newlines, which may yet turn
-        out to be the indent of a tag rather than prose. Emitting an indent is
-        not something a later chunk can take back, and that is what would make
-        the output depend on where the deltas split.
-
-        The newline hold is deliberately conditional. A turn with no tool call
-        at all never reaches the tag-stripping paths, so holding its trailing
-        newlines would strand them: nothing flushes the buffer at end of turn.
+        Held back: a suffix that is a strict prefix of a real marker, and a
+        trailing run of newlines, which may yet turn out to be the indent of a
+        tag rather than prose. Emitting an indent is not something a later chunk
+        can take back, and that is what would make the output depend on where
+        the deltas split. Whatever is held is released by `finish()` once the
+        stream ends and the marker can no longer arrive.
 
         Nothing else is held: prose that merely contains `<` ("5 < 6") streams
         out immediately.
@@ -278,27 +274,39 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 for marker in self._markers()
             ):
                 hold_from = start
-        if self.current_tool_id != -1:
-            # Whatever is held takes its indent with it, otherwise the newlines
-            # in front of a half-arrived tag go out before the tag is known.
-            hold_from = len(text[:hold_from].rstrip("\n"))
+        # Whatever is held takes its indent with it, otherwise the newlines in
+        # front of a half-arrived tag go out before the tag is known.
+        hold_from = len(text[:hold_from].rstrip())
         return text[:hold_from], text[hold_from:]
 
+    def finish(self, tools: list[Tool]) -> StreamingParseResult:
+        """Release text held for a marker that can no longer arrive.
+
+        `_split_flushable` withholds anything that could still turn out to be a
+        DSML tag. Once the stream is over nothing more is coming, so a held
+        fragment was ordinary text all along and is owed to the client.
+        """
+        held, self._buffer = self._buffer, ""
+        return StreamingParseResult(normal_text=self._strip_section_markers(held))
+
     def _lead_text(
-        self, current_text: str, *, call_start: int, trim_trailing_newlines: bool
+        self, current_text: str, *, call_start: int, is_first_call: bool
     ) -> str:
         """The normal text sitting in front of the call that starts at `call_start`.
 
-        `trim_trailing_newlines` is only for the very first call, where the trim
-        keeps this path agreeing with `detect_and_parse`. Later calls must not
-        trim: the same newlines are emitted untouched when the prose arrives in
-        its own chunk, and the result may not depend on the chunk boundaries.
+        The two trims differ on purpose. The first call keeps `detect_and_parse`'s
+        exact `removesuffix("\\n\\n")` so the streaming and one-shot paths agree on
+        the preamble. Every later call drops all trailing whitespace, because
+        whitespace in front of a call is layout -- the separator between parallel
+        invokes is nothing else -- and because the alternative is not stable: that
+        whitespace lands in this lead or in the preceding flush depending only on
+        where the deltas happened to split.
         """
         bot_pos = current_text.rfind(self.bot_token, 0, call_start)
         if bot_pos != -1:
             call_start = bot_pos
         lead = self._strip_section_markers(current_text[:call_start])
-        return lead.removesuffix("\n\n") if trim_trailing_newlines else lead
+        return lead.removesuffix("\n\n") if is_first_call else lead.rstrip()
 
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
@@ -334,6 +342,10 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         all_calls: list[ToolCallItem] = []
         normal_text_parts: list[str] = []
+        # The lead of the call being assembled is still sitting at the head of
+        # current_text; only advancing past a completed call consumes it. The
+        # error path below needs to know, or it re-emits what it dumps verbatim.
+        lead_is_still_in_current_text = False
         try:
             # Loop to handle multiple consecutive invoke blocks
             while True:
@@ -363,13 +375,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 # call: it is only False the first time a call is seen, so an
                 # invoke that spans chunks can't re-emit the same lead.
                 if not self.current_tool_name_sent:
-                    normal_text_parts.append(
-                        self._lead_text(
-                            current_text,
-                            call_start=invoke_match.start(),
-                            trim_trailing_newlines=is_first_call,
-                        )
+                    lead = self._lead_text(
+                        current_text,
+                        call_start=invoke_match.start(),
+                        is_first_call=is_first_call,
                     )
+                    if lead:
+                        normal_text_parts.append(lead)
+                        lead_is_still_in_current_text = True
 
                 # Ensure arrays are large enough for current tool
                 while len(self.prev_tool_call_arr) <= self.current_tool_id:
@@ -432,6 +445,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     # Remove the completed tool call from buffer
                     self._buffer = current_text[invoke_match.end() :]
                     current_text = self._buffer  # Update for next iteration
+                    lead_is_still_in_current_text = False
 
                     # Move to next tool call
                     self.current_tool_id += 1
@@ -461,15 +475,17 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            # Re-emit verbatim rather than swallowing the turn; leads already
-            # collected sit in front of whatever current_text still holds.
+            # Re-emit verbatim rather than swallowing the turn. Leads whose call
+            # completed are gone from current_text and have to be kept; the lead
+            # of the call that failed is still in there and would come out twice.
             # Calls are dropped on purpose: the failure can land between a tool's
             # name and its arguments, and a half-formed call is worse than none.
             self._buffer = ""
-            emitted = "".join(normal_text_parts)
-            if emitted and current_text.startswith(emitted):
-                emitted = ""
-            return StreamingParseResult(normal_text=emitted + current_text)
+            if lead_is_still_in_current_text and normal_text_parts:
+                normal_text_parts.pop()
+            return StreamingParseResult(
+                normal_text="".join(normal_text_parts) + current_text
+            )
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -98,6 +98,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
         # after it, not content. True to start with, because the preamble is
         # content from the first character.
         self._gap_started = True
+        # Whether any normal text has left the detector this turn. A gap has
+        # something to separate itself from only if it has.
+        self._emitted_anything = False
 
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains a deepseek v32 format tool call."""
@@ -203,7 +206,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # No section opener, but the turn may have been cut off inside one.
             return StreamingParseResult(normal_text=self._cut_at_markup(text), calls=[])
 
-        normal_text = text[:idx].removesuffix("\n\n")
+        # The whitespace in front of the opener indents it; the line break the
+        # call stood on comes back from `_join_gap` on the other side.
+        normal_text = text[:idx].rstrip()
 
         calls = []
         try:
@@ -250,43 +255,82 @@ class DeepSeekV32Detector(BaseFormatDetector):
         markup = re.search(r"\s*</?｜", text)
         return text if markup is None else text[: markup.start()]
 
-    def _gap_text(self, text: str) -> str:
-        """Drop the layout whitespace at the head of a gap, once per gap.
+    @staticmethod
+    def _join_gap(layout: str, *, after_text: bool) -> str:
+        """What a gap's leading whitespace collapses to once its call is gone.
 
-        The blank line between a section closer and the prose after it indents
-        the markup; it is not the model's paragraph break. Tracked on the
-        instance rather than trimmed in place because a gap arrives over several
-        deltas: only the whitespace before the gap's first real character is
-        layout, and a newline in the middle of the prose has to survive.
+        The call sat on its own line, so removing it has to leave the line break
+        it was standing on -- and nothing more. Deleting the whitespace outright
+        runs `'Let me look it up.'` into `'It is sunny in SF.'`, and takes the
+        indent off the line that follows, which is content: a list item stops
+        starting its line, a code line loses the four spaces the newline was
+        carrying. Collapsing to two would open a paragraph break the model never
+        wrote.
+
+        Nothing at all when no text has been emitted yet: the turn opened with
+        the call, so there is nothing on the other side to separate from. And a
+        run with no newline in it never had a line to keep -- the call was inline
+        -- so it stands as the model wrote it.
+        """
+        if not after_text:
+            return ""
+        line_start = layout.rfind("\n")
+        return layout if line_start == -1 else "\n" + layout[line_start + 1 :]
+
+    def _gap_text(self, text: str) -> str:
+        """Resolve the layout whitespace at the head of a gap, once per gap.
+
+        Tracked on the instance rather than trimmed in place because a gap
+        arrives over several deltas: only the whitespace before the gap's first
+        real character is layout, and a newline in the middle of the prose has
+        to survive. Whitespace with nothing behind it yet is left for a later
+        delta to resolve, since what it collapses to depends on the text that
+        follows it.
 
         Call this on text that is being emitted, never on text `_split_flushable`
         may still hold back: a fragment that grows into a tag would otherwise
         count as the gap's first real character and strand the layout behind it.
         """
-        if not self._gap_started:
-            text = text.lstrip()
-            self._gap_started = bool(text)
-        return text
+        if self._gap_started:
+            self._emitted_anything = self._emitted_anything or bool(text)
+            return text
+
+        prose = text.lstrip()
+        if not prose:
+            return ""
+
+        layout = text[: len(text) - len(prose)]
+        self._gap_started = True
+        joined = self._join_gap(layout, after_text=self._emitted_anything) + prose
+        self._emitted_anything = True
+        return joined
 
     def _section_gaps(self, text: str, sections: list["re.Match[str]"]) -> str:
         """The normal text between and after the tool call sections of `text`.
 
         The one-shot counterpart of what the streaming path emits from
-        `_gap_text` and `_lead_text`, and trimmed to match: leading layout goes
-        everywhere, trailing layout only where another section follows it and
-        can claim the whitespace as its indent. The last gap ends the turn, so
-        its trailing newlines are the model's own.
+        `_gap_text` and `_lead_text`, trimmed to match: leading layout goes
+        through `_join_gap`, trailing layout goes wherever another section
+        follows it and can claim the whitespace as its indent. The last gap ends
+        the turn, so its trailing newlines are the model's own.
         """
+        emitted = bool(text[: sections[0].start()].strip())
         gaps = []
         for i, section in enumerate(sections):
             is_last = i + 1 == len(sections)
             end = len(text) if is_last else sections[i + 1].start()
-            gap = self._cut_at_markup(text[section.end() : end]).lstrip()
-            if gap in ("<", "</"):
+            gap = self._cut_at_markup(text[section.end() : end])
+            prose = gap.lstrip()
+            if prose in ("<", "</"):
                 # Nothing in this gap but the first characters of the next tag,
                 # which the turn stopped inside of. Layout, not the model's `<`.
-                gap = ""
-            gaps.append(gap if is_last else gap.rstrip())
+                prose = ""
+            if not prose:
+                continue
+            layout = gap[: len(gap) - len(gap.lstrip())]
+            joined = self._join_gap(layout, after_text=emitted) + prose
+            gaps.append(joined if is_last else joined.rstrip())
+            emitted = True
         return "".join(gaps)
 
     def _markers(self) -> tuple[str, ...]:
@@ -369,7 +413,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # The turn stopped inside the opening section, before any invoke was
             # matched, so what is held is the preamble and nothing else. Trim it
             # exactly as `detect_and_parse` trims it.
-            return StreamingParseResult(normal_text=held[:bot_pos].removesuffix("\n\n"))
+            return StreamingParseResult(normal_text=held[:bot_pos].rstrip())
 
         # Closers first: the buffer can still carry those of a call that did
         # finish, and the prose after them is owed to the client.
@@ -381,24 +425,25 @@ class DeepSeekV32Detector(BaseFormatDetector):
             held = held.partition("<")[0]
         return StreamingParseResult(normal_text=self._gap_text(held))
 
-    def _lead_text(
-        self, current_text: str, *, invoke_start: int, is_first_call: bool
-    ) -> tuple[str, int]:
+    def _lead_text(self, current_text: str, *, invoke_start: int) -> tuple[str, int]:
         """The normal text in front of the call, and where that call begins.
 
-        The two trims differ on purpose. The first call keeps `detect_and_parse`'s
-        exact `removesuffix("\\n\\n")` so the streaming and one-shot paths agree on
-        the preamble. Every later call drops all trailing whitespace, because
-        whitespace in front of a call is layout -- the separator between parallel
-        invokes is nothing else -- and because the alternative is not stable: that
-        whitespace lands in this lead or in the preceding flush depending only on
-        where the deltas happened to split.
+        Trailing whitespace always goes: it indents the call, which is all the
+        separator between two parallel invokes ever is, and keeping it would not
+        be stable anyway -- it lands in this lead or in the preceding flush
+        depending only on where the deltas happened to split. What the call was
+        standing on comes back on the other side, from `_join_gap`.
         """
         call_start = current_text.rfind(self.bot_token, 0, invoke_start)
         if call_start == -1:
             call_start = invoke_start
+        had_text = self._emitted_anything
         lead = self._gap_text(self._strip_section_markers(current_text[:call_start]))
-        trimmed = lead.removesuffix("\n\n") if is_first_call else lead.rstrip()
+        trimmed = lead.rstrip()
+        # This is the one caller that trims what `_gap_text` handed back, so it
+        # is the one that has to say what actually reached the client: a lead of
+        # nothing but the call's own indent leaves the turn still empty.
+        self._emitted_anything = had_text or bool(trimmed)
         return trimmed, call_start
 
     def parse_streaming_increment(
@@ -469,9 +514,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 # invoke that spans chunks can't re-emit the same lead.
                 if not self.current_tool_name_sent:
                     lead, call_start = self._lead_text(
-                        current_text,
-                        invoke_start=invoke_match.start(),
-                        is_first_call=is_first_call,
+                        current_text, invoke_start=invoke_match.start()
                     )
                     if lead:
                         normal_text_parts.append(lead)

--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -226,6 +226,80 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # return the normal text if parsing fails
             return StreamingParseResult(normal_text=text)
 
+    def _markers(self) -> tuple[str, ...]:
+        """Every DSML tag this detector can meet, longest-lived first.
+
+        Read off the instance rather than cached at construction: subclasses set
+        their own `bot_token` / `eot_token` after `super().__init__()` (V4 says
+        `tool_calls` where V3.2 says `function_calls`).
+        """
+        return (
+            self.bot_token,
+            self.eot_token,
+            self.invoke_end_token,
+            "<｜DSML｜invoke",
+        )
+
+    def _strip_section_markers(self, text: str) -> str:
+        """Drop whole DSML tags, along with the newlines that indent them.
+
+        The indent belongs to the tag, not to the prose around it, which is why
+        `detect_and_parse` never shows it either. Safe to swallow here only
+        because `_split_flushable` refuses to release a trailing newline once a
+        call has been seen, so an indent is still in the buffer when its tag
+        lands however the chunks fell.
+        """
+        for token in (self.eot_token, self.invoke_end_token, self.bot_token):
+            text = re.sub(rf"\n*{re.escape(token)}", "", text)
+        return text
+
+    def _split_flushable(self, text: str) -> tuple[str, str]:
+        """Split `text` into (safe to emit now, hold back for the next chunk).
+
+        Held back: a suffix that is a strict prefix of a real marker, and -- once
+        a call has been seen -- a trailing run of newlines, which may yet turn
+        out to be the indent of a tag rather than prose. Emitting an indent is
+        not something a later chunk can take back, and that is what would make
+        the output depend on where the deltas split.
+
+        The newline hold is deliberately conditional. A turn with no tool call
+        at all never reaches the tag-stripping paths, so holding its trailing
+        newlines would strand them: nothing flushes the buffer at end of turn.
+
+        Nothing else is held: prose that merely contains `<` ("5 < 6") streams
+        out immediately.
+        """
+        hold_from = len(text)
+        start = text.rfind("<")
+        if start != -1:
+            tail = text[start:]
+            if any(
+                len(tail) < len(marker) and marker.startswith(tail)
+                for marker in self._markers()
+            ):
+                hold_from = start
+        if self.current_tool_id != -1:
+            # Whatever is held takes its indent with it, otherwise the newlines
+            # in front of a half-arrived tag go out before the tag is known.
+            hold_from = len(text[:hold_from].rstrip("\n"))
+        return text[:hold_from], text[hold_from:]
+
+    def _lead_text(
+        self, current_text: str, *, call_start: int, trim_trailing_newlines: bool
+    ) -> str:
+        """The normal text sitting in front of the call that starts at `call_start`.
+
+        `trim_trailing_newlines` is only for the very first call, where the trim
+        keeps this path agreeing with `detect_and_parse`. Later calls must not
+        trim: the same newlines are emitted untouched when the prose arrives in
+        its own chunk, and the result may not depend on the chunk boundaries.
+        """
+        bot_pos = current_text.rfind(self.bot_token, 0, call_start)
+        if bot_pos != -1:
+            call_start = bot_pos
+        lead = self._strip_section_markers(current_text[:call_start])
+        return lead.removesuffix("\n\n") if trim_trailing_newlines else lead
+
     def parse_streaming_increment(
         self, new_text: str, tools: list[Tool]
     ) -> StreamingParseResult:
@@ -252,16 +326,14 @@ class DeepSeekV32Detector(BaseFormatDetector):
             and not potentially_dsml
             and not ends_with_prefix
         ):
-            self._buffer = ""
             for e_token in [self.eot_token, self.invoke_end_token]:
                 if e_token in current_text:
                     current_text = current_text.replace(e_token, "")
-            return StreamingParseResult(normal_text=current_text)
+            flushable, self._buffer = self._split_flushable(current_text)
+            return StreamingParseResult(normal_text=flushable)
 
         all_calls: list[ToolCallItem] = []
-        # Only recovered for the first call: the DSML guard above never releases a
-        # buffer that still holds a marker, so later prose stays buffered.
-        preamble = ""
+        normal_text_parts: list[str] = []
         try:
             # Loop to handle multiple consecutive invoke blocks
             while True:
@@ -278,17 +350,26 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     invoke_match
                 )
 
+                is_first_call = self.current_tool_id == -1
+
                 # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
+                if is_first_call:
                     self.current_tool_id = 0
                     self.prev_tool_call_arr = []
                     self.streamed_args_for_tool = [""]
-                    call_start = invoke_match.start()
-                    bot_pos = current_text.rfind(self.bot_token, 0, call_start)
-                    if bot_pos != -1:
-                        call_start = bot_pos
-                    # Same trailing-newline trim as detect_and_parse, so both agree.
-                    preamble = current_text[:call_start].removesuffix("\n\n")
+
+                # Whatever precedes this call is content the model meant to show.
+                # Guarded on `current_tool_name_sent` so it runs exactly once per
+                # call: it is only False the first time a call is seen, so an
+                # invoke that spans chunks can't re-emit the same lead.
+                if not self.current_tool_name_sent:
+                    normal_text_parts.append(
+                        self._lead_text(
+                            current_text,
+                            call_start=invoke_match.start(),
+                            trim_trailing_newlines=is_first_call,
+                        )
+                    )
 
                 # Ensure arrays are large enough for current tool
                 while len(self.prev_tool_call_arr) <= self.current_tool_id:
@@ -363,19 +444,32 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     # Wait for more chunks until we see </｜DSML｜invoke>
                     break
 
-            # No more invoke blocks found
-            return StreamingParseResult(normal_text=preamble, calls=all_calls)
+            # No more invoke blocks found. Anything still buffered is trailing
+            # prose: the guard at the top can never release it, because the
+            # section closer keeps `potentially_dsml` true for the rest of the
+            # turn. Flush it here instead, holding back only a suffix that could
+            # still grow into a marker.
+            if not self.has_tool_call(current_text):
+                flushable, self._buffer = self._split_flushable(
+                    self._strip_section_markers(current_text)
+                )
+                normal_text_parts.append(flushable)
+
+            return StreamingParseResult(
+                normal_text="".join(normal_text_parts), calls=all_calls
+            )
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            # Re-emit verbatim rather than swallowing the turn; the preamble is
-            # still inside current_text unless a completed call advanced past it.
+            # Re-emit verbatim rather than swallowing the turn; leads already
+            # collected sit in front of whatever current_text still holds.
             # Calls are dropped on purpose: the failure can land between a tool's
             # name and its arguments, and a half-formed call is worse than none.
             self._buffer = ""
-            if not current_text.startswith(preamble):
-                current_text = preamble + current_text
-            return StreamingParseResult(normal_text=current_text)
+            emitted = "".join(normal_text_parts)
+            if emitted and current_text.startswith(emitted):
+                emitted = ""
+            return StreamingParseResult(normal_text=emitted + current_text)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -143,11 +143,68 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
     def test_prose_with_angle_bracket_is_not_held_back(self):
         """Only a suffix that could still grow into a DSML marker may be withheld.
-        Holding every `<` would strand ordinary prose until end of turn, and no
-        end-of-turn flush exists to release it."""
+        Holding every `<` would keep ordinary prose out of the stream until the
+        turn ended, long after the client should have seen it."""
         normal, _ = self._feed([_weather_call("SF"), "\n\n5 < 6 and a < b."])
 
         self.assertIn("5 < 6 and a < b.", normal)
+
+    def test_parallel_calls_do_not_leak_their_separator(self):
+        """Invokes inside one section are separated by layout, not by content.
+        Collecting a lead for every call must not turn that whitespace into an
+        assistant message -- `detect_and_parse` never surfaces it either."""
+        section = _wrapped(
+            _invoke("get_weather", _param("city", "true", "SF"))
+            + "\n"
+            + _invoke("get_weather", _param("city", "true", "NY"))
+        )
+
+        for size in (None, 1, 5, 17):
+            with self.subTest(chunk_size=size):
+                chunks = (
+                    [section]
+                    if size is None
+                    else [section[i : i + size] for i in range(0, len(section), size)]
+                )
+                normal, calls = self._feed(chunks)
+
+                self.assertEqual(normal, "")
+                self.assertEqual([c.name for c in calls if c.name], ["get_weather"] * 2)
+
+    def test_error_on_a_later_call_does_not_duplicate_its_lead(self):
+        """The lead of the call that failed is still at the head of the buffer the
+        error path dumps verbatim, so it must not also be emitted from the parts
+        collected so far. Only leads whose call completed are gone from it."""
+        detector = DeepSeekV4Detector()
+        text = _weather_call("SF") + "\n\nNow the other one.\n\n" + _weather_call("NY")
+        real = DeepSeekV4Detector._parse_parameters_from_xml
+        seen = []
+
+        def fail_on_second(self, *args, **kwargs):
+            seen.append(1)
+            if len(seen) == 2:
+                raise RuntimeError("boom")
+            return real(self, *args, **kwargs)
+
+        with patch.object(
+            DeepSeekV4Detector, "_parse_parameters_from_xml", fail_on_second
+        ):
+            result = detector.parse_streaming_increment(text, self.tools)
+
+        self.assertEqual(result.normal_text.count("Now the other one."), 1)
+
+    def test_finish_releases_text_held_for_a_marker_that_never_came(self):
+        """Trailing newlines are withheld in case they indent a tag still to come.
+        When the stream ends instead, they were ordinary text all along, and the
+        end-of-turn flush is what owes them to the client."""
+        detector = DeepSeekV4Detector()
+        normal = ""
+        for chunk in [_weather_call("SF"), "\n\nBye.\n\n"]:
+            normal += detector.parse_streaming_increment(chunk, self.tools).normal_text
+        normal += detector.finish(self.tools).normal_text
+
+        self.assertTrue(normal.endswith("Bye.\n\n"), repr(normal))
+        self.assertEqual(detector._buffer, "")
 
     def test_parse_error_neither_swallows_nor_duplicates(self):
         """An unexpected parse error must not empty the turn, and the dropped

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -102,6 +102,53 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertEqual(len(result.calls), 2)
 
+    def test_prose_between_two_tool_calls_is_streamed(self):
+        """Prose sitting between two calls used to be dropped outright: the lead
+        was only recovered for the first call, and consuming the second call
+        advanced the buffer straight past the text in front of it."""
+        normal, calls = self._feed(
+            [_weather_call("SF"), "\n\nNow the other city.\n\n", _weather_call("NY")]
+        )
+
+        self.assertIn("Now the other city.", normal)
+        self.assertNotIn(DSML, normal)
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"] * 2)
+
+    def test_prose_after_the_last_tool_call_is_streamed(self):
+        """Trailing prose used to be stranded: the section closer keeps the DSML
+        guard true for the rest of the turn, so the buffer holding the text was
+        never released and nothing flushes it at end of turn."""
+        detector = DeepSeekV4Detector()
+        normal = ""
+        for chunk in [_weather_call("SF"), "\n\nThat's the forecast."]:
+            normal += detector.parse_streaming_increment(chunk, self.tools).normal_text
+
+        self.assertIn("That's the forecast.", normal)
+        self.assertNotIn(DSML, normal)
+        self.assertEqual(detector._buffer, "")
+
+    def test_trailing_prose_is_chunk_invariant(self):
+        """Where the deltas happen to split must not change what the client sees.
+        The lead of a call spanning several chunks is emitted once, and text after
+        a call reads the same whether or not it shares a delta with the closer."""
+        text = _weather_call("SF") + "\n\nAnd that is that."
+        one_shot, _ = self._feed([text])
+
+        for size in (1, 2, 3, 7, 13):
+            with self.subTest(chunk_size=size):
+                split, _ = self._feed(
+                    [text[i : i + size] for i in range(0, len(text), size)]
+                )
+                self.assertEqual(split, one_shot)
+
+    def test_prose_with_angle_bracket_is_not_held_back(self):
+        """Only a suffix that could still grow into a DSML marker may be withheld.
+        Holding every `<` would strand ordinary prose until end of turn, and no
+        end-of-turn flush exists to release it."""
+        normal, _ = self._feed([_weather_call("SF"), "\n\n5 < 6 and a < b."])
+
+        self.assertIn("5 < 6 and a < b.", normal)
+
     def test_parse_error_neither_swallows_nor_duplicates(self):
         """An unexpected parse error must not empty the turn, and the dropped
         buffer must not come back on the next delta."""

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -30,6 +30,35 @@ def _weather_call(city: str = "SF") -> str:
     return _wrapped(_invoke("get_weather", _param("city", "true", city)))
 
 
+# Turn shapes the streaming and one-shot paths must agree on, whatever the chunk
+# size. Anything the one-shot path cannot parse at all -- a bare invoke with no
+# section around it -- is tested on its own instead.
+TURN_SHAPES = {
+    "no tool call at all": "Just talking.\n\n",
+    "preamble": "Hi\n\n" + _weather_call(),
+    "preamble, single newline": "Hi\n" + _weather_call(),
+    "call alone": _weather_call(),
+    "prose after the call": _weather_call() + "\n\nSunny in SF.",
+    "newlines after the call": _weather_call() + "\n\n",
+    "prose between two calls": (
+        _weather_call("SF") + "\n\nNow the other city.\n\n" + _weather_call("NY")
+    ),
+    "sections back to back": _weather_call("SF") + "\n" + _weather_call("NY"),
+    "parallel invokes in one section": _wrapped(
+        _invoke("get_weather", _param("city", "true", "SF"))
+        + "\n"
+        + _invoke("get_weather", _param("city", "true", "NY"))
+    ),
+    "json body": "Lead.\n\n" + _wrapped(_invoke("get_weather", '{"city": "SF"}')),
+    "self-closing invoke": _wrapped(f'<{DSML}invoke name="get_weather"/>')
+    + "\n\nDone.",
+    "angle bracket in the prose": _weather_call() + "\n\n5 < 6 and a < b.",
+    "several paragraphs after the call": (
+        _weather_call() + "\n\nFirst line.\nSecond line.\n\nThird."
+    ),
+}
+
+
 class TestDeepSeekV4Streaming(CustomTestCase):
     def setUp(self):
         self.tools = [
@@ -57,16 +86,77 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             calls.extend(result.calls)
         return normal, calls
 
-    def test_preamble_in_same_delta_as_tool_call(self):
-        """Prose sharing a delta with the tool call must not be dropped, and the
-        streaming and one-shot paths must agree on it."""
-        text = "Let me check.\n" + _weather_call()
-        normal, calls = self._feed([text])
+    def _stream(self, text, chunk_size):
+        """Returns (normal_text, [(name, arguments)]) for `text` fed in deltas of
+        `chunk_size` characters (the whole text at once when it is None), end of
+        turn included.
 
-        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
-        self.assertEqual(
-            normal, DeepSeekV4Detector().detect_and_parse(text, self.tools).normal_text
+        Calls are compared as an ordered list rather than by `tool_index`: the
+        one-shot path numbers them by position in the tools list, the streaming
+        path by call ordinal, so the indices themselves do not line up.
+        """
+        detector = DeepSeekV4Detector()
+        chunks = (
+            [text]
+            if chunk_size is None
+            else [text[i : i + chunk_size] for i in range(0, len(text), chunk_size)]
         )
+        normal, merged = "", {}
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            normal += result.normal_text
+            for call in result.calls:
+                item = merged.setdefault(call.tool_index, {"name": None, "args": ""})
+                if call.name:
+                    item["name"] = call.name
+                item["args"] += call.parameters
+        normal += detector.finish(self.tools).normal_text
+        self.assertEqual(detector._buffer, "", "end of turn left the buffer behind")
+        return normal, [(v["name"], v["args"]) for _, v in sorted(merged.items())]
+
+    def _one_shot(self, text):
+        result = DeepSeekV4Detector().detect_and_parse(text, self.tools)
+        return result.normal_text, [(c.name, c.parameters) for c in result.calls]
+
+    def test_streaming_matches_one_shot_at_every_chunk_size(self):
+        """A turn must read the same however it was cut into deltas, and the same
+        as if it had never been streamed at all.
+
+        Both halves matter. Where the deltas fall is not the model's choice, so
+        anything that depends on it is a bug by construction; and a client that
+        switches `stream=` must not get different content out of the same
+        generation. Down to one character per delta, because that is where a
+        marker or its indent gets split across two chunks -- how the duplicated
+        preamble and the stray newlines this file guards were all found.
+        """
+        for label, text in TURN_SHAPES.items():
+            expected = self._one_shot(text)
+            for size in (None, 1, 2, 3, 5, 13):
+                with self.subTest(shape=label, chunk_size=size):
+                    self.assertEqual(self._stream(text, size), expected)
+
+    def test_turn_cut_off_mid_generation_repeats_nothing_and_leaks_no_markup(self):
+        """A turn that stops inside a tool call is what a length cap looks like.
+
+        The lead used to come out twice -- once from the delta that matched the
+        invoke, once more from the end-of-turn flush, because an invoke that
+        never completes never advances the buffer past it -- and the half-written
+        tag and its partial JSON went to the client as assistant content.
+
+        Only the text is compared with the one-shot path here. The calls cannot
+        be: streaming a cut-off call is exactly what the incremental protocol is
+        for, while `detect_and_parse` has no complete section to report.
+        """
+        full = "Checking.\n" + _weather_call() + "\nSunny."
+
+        for length in range(1, len(full) + 1):
+            text = full[:length]
+            expected, _ = self._one_shot(text)
+            for size in (None, 1, 3, 7):
+                with self.subTest(cut_at=length, chunk_size=size):
+                    normal, _ = self._stream(text, size)
+                    self.assertNotIn(DSML, normal)
+                    self.assertEqual(normal, expected)
 
     def test_preamble_before_bare_invoke_without_wrapper(self):
         """The bare `<｜DSML｜invoke …>` form has no tool_calls wrapper to walk
@@ -76,12 +166,6 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertIn("Checking.", normal)
         self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
-
-    def test_no_dsml_markers_leak_into_normal_text(self):
-        text = "Prose.\n" + _weather_call()
-        normal, _ = self._feed([text[i : i + 4] for i in range(0, len(text), 4)])
-
-        self.assertNotIn(DSML, normal)
 
     def test_malformed_partial_json_falls_back_to_raw_value(self):
         """A partial non-string parameter must not escape as MalformedJSON."""
@@ -102,44 +186,29 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertEqual(len(result.calls), 2)
 
-    def test_prose_between_two_tool_calls_is_streamed(self):
-        """Prose sitting between two calls used to be dropped outright: the lead
-        was only recovered for the first call, and consuming the second call
-        advanced the buffer straight past the text in front of it."""
+    def test_prose_around_tool_calls_reaches_the_client(self):
+        """Prose between two calls used to be dropped outright -- the lead was
+        only recovered for the first call, and consuming the second advanced the
+        buffer straight past the text in front of it -- and prose after the last
+        call was stranded, because the section closer keeps the DSML guard true
+        for the rest of the turn.
+
+        Both are asserted here rather than left to the one-shot comparison: that
+        comparison would still hold if a change dropped this text on both paths.
+        """
         normal, calls = self._feed(
-            [_weather_call("SF"), "\n\nNow the other city.\n\n", _weather_call("NY")]
+            [
+                _weather_call("SF"),
+                "\n\nNow the other city.\n\n",
+                _weather_call("NY"),
+                "\n\nThat's the forecast.",
+            ]
         )
 
         self.assertIn("Now the other city.", normal)
-        self.assertNotIn(DSML, normal)
-        self.assertEqual([c.name for c in calls if c.name], ["get_weather"] * 2)
-
-    def test_prose_after_the_last_tool_call_is_streamed(self):
-        """Trailing prose used to be stranded: the section closer keeps the DSML
-        guard true for the rest of the turn, so the buffer holding the text was
-        never released and nothing flushes it at end of turn."""
-        detector = DeepSeekV4Detector()
-        normal = ""
-        for chunk in [_weather_call("SF"), "\n\nThat's the forecast."]:
-            normal += detector.parse_streaming_increment(chunk, self.tools).normal_text
-
         self.assertIn("That's the forecast.", normal)
         self.assertNotIn(DSML, normal)
-        self.assertEqual(detector._buffer, "")
-
-    def test_trailing_prose_is_chunk_invariant(self):
-        """Where the deltas happen to split must not change what the client sees.
-        The lead of a call spanning several chunks is emitted once, and text after
-        a call reads the same whether or not it shares a delta with the closer."""
-        text = _weather_call("SF") + "\n\nAnd that is that."
-        one_shot, _ = self._feed([text])
-
-        for size in (1, 2, 3, 7, 13):
-            with self.subTest(chunk_size=size):
-                split, _ = self._feed(
-                    [text[i : i + size] for i in range(0, len(text), size)]
-                )
-                self.assertEqual(split, one_shot)
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"] * 2)
 
     def test_prose_with_angle_bracket_is_not_held_back(self):
         """Only a suffix that could still grow into a DSML marker may be withheld.

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -56,6 +56,29 @@ TURN_SHAPES = {
     "several paragraphs after the call": (
         _weather_call() + "\n\nFirst line.\nSecond line.\n\nThird."
     ),
+    "indented line after the call": "Result:\n" + _weather_call() + "\n    x = True\n",
+    "markdown list after the call": (
+        "Here you go:\n\n" + _weather_call() + "\n- SF: sunny\n- LA: hot\n"
+    ),
+}
+
+# What the turn should read as once the calls are taken out of it, for the shapes
+# where getting that wrong is invisible to the one-shot comparison.
+JOINED_TURNS = {
+    "Let me look it up.\n\n"
+    + _weather_call()
+    + "\nIt is sunny in SF.": "Let me look it up.\nIt is sunny in SF.",
+    "我查一下。\n\n"
+    + _weather_call()
+    + "\n旧金山是晴天。": "我查一下。\n旧金山是晴天。",
+    _weather_call()
+    + "\nAnd now the other one:\n"
+    + _weather_call("NY")
+    + "\nDone.": "And now the other one:\nDone.",
+    "Here you go:\n\n"
+    + _weather_call()
+    + "\n- SF: sunny\n- LA: hot\n": "Here you go:\n- SF: sunny\n- LA: hot\n",
+    "Result:\n" + _weather_call() + "\n    x = True\n": "Result:\n    x = True\n",
 }
 
 
@@ -134,6 +157,23 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             for size in (None, 1, 2, 3, 5, 13):
                 with self.subTest(shape=label, chunk_size=size):
                     self.assertEqual(self._stream(text, size), expected)
+
+    def test_removing_a_call_leaves_the_line_it_stood_on(self):
+        """Taking the call out has to leave the line break it was standing on --
+        and only that.
+
+        Dropping the whitespace outright runs the sentence before the call into
+        the one after it, with no word boundary to recover in CJK, and takes the
+        indent off the line that follows: a list item stops starting its line, a
+        code line loses the spaces the newline was carrying. None of that is
+        visible to the one-shot comparison, which agreed with the streaming path
+        on all five of these while both were wrong, so the text is pinned here.
+        """
+        for text, expected in JOINED_TURNS.items():
+            for size in (None, 16, 8, 4, 1):
+                with self.subTest(turn=text[:24], chunk_size=size):
+                    normal, _ = self._stream(text, size)
+                    self.assertEqual(normal, expected)
 
     def test_turn_cut_off_mid_generation_repeats_nothing_and_leaks_no_markup(self):
         """A turn that stops inside a tool call is what a length cap looks like.


### PR DESCRIPTION
## Motivation

The DSML streaming path only recovers the text in front of the **first** tool call. #34458 fixed that lead and left a note in the code saying the rest is still missing:

```python
# Only recovered for the first call: the DSML guard above never releases a
# buffer that still holds a marker, so later prose stays buffered.
```

Content is lost two different ways after that first call:

- **Between two calls — dropped.** Consuming the second invoke sets `self._buffer = current_text[invoke_match.end():]`, advancing straight past the text in front of it.
- **After the last call — stranded.** The section closer keeps `potentially_dsml` true for the rest of the turn, so the guard at the top never releases the buffer, and nothing flushes it at end of turn.

Reproduced against `main` (`DeepSeekV4Detector`, one call, then prose, then a second call):

```
normal_text = ''
buffer left = '\n</｜DSML｜tool_calls>'
```

The prose never reaches the client. Both paths are DSML-specific; the pythonic detector already streams this text, and `test_parse_streaming_multiple_tool_calls` asserts it does.

Two further problems surfaced in review, both fixed here:

- **A turn that ends inside an invoke repeated its lead and leaked markup.** Only a completed call advances the buffer, so an invoke cut short leaves its lead in there after it has already been emitted, and `finish()` released it a second time — along with the half-written tag and its partial JSON, since `_strip_section_markers` only removes tags that finished arriving. That shape is what a length-capped or aborted generation looks like, and it was a regression against `main` on both counts.
- **`detect_and_parse` disagreed with the streaming path.** The one-shot path drops everything between and after the sections — precisely the text this PR recovers for streaming — so the same generation read differently depending on `stream=`.

## Modifications

**Streaming**

- Collect the lead text for every call instead of only the first, guarded on `current_tool_name_sent` so an invoke spanning several deltas cannot re-emit its lead, and drop it from the buffer as soon as it is emitted so nothing can release it again.
- Flush the residual buffer once nothing left in it parses as a call.
- Hold back a suffix that could still grow into a marker, plus a trailing newline run, since newlines indent DSML tags and emitting one before its tag arrives is not something a later delta can take back.
- `finish()` separates the two things it can be holding: a fragment kept back for a marker that never came was ordinary text all along and is owed to the client, whereas a buffer the turn stopped inside of is markup by then and is dropped.

**One-shot**

- `detect_and_parse` walks the sections as match objects and appends the text between and after them.
- A partial opening tag no longer reaches the client as content: `text.find(bot_token)` never saw it, so a turn cut off mid-tag returned the tag verbatim. Pre-existing on `main`.

**Shared**

- Both paths trim a gap the same way. The call sat on its own line, so a gap's leading whitespace collapses to the one line break the call was standing on, plus whatever follows the last newline in it — that belongs to the line the prose resumes on, and dropping it takes the indent off a code line and stops a list item starting its line. It collapses to nothing only when no text has been emitted yet, where the turn opened with the call and there is nothing on the other side to separate from, and it is left alone when it holds no newline at all, where the call was inline. Trailing layout goes wherever another section follows and can claim the whitespace as its indent; the last gap ends the turn, so its trailing newlines are the model's own.
- On the streaming side that trim spans deltas, so it is tracked on the instance rather than applied to each chunk in isolation — a newline in the middle of the prose has to survive.

## Accuracy Test

The two paths now agree, so the tests assert exactly that: streamed `normal_text` and merged calls equal `detect_and_parse`, over 15 turn shapes at chunk sizes down to one character per delta, and over every prefix of a turn for the cut-short case (text only there — streaming a cut-off call is what the incremental protocol is for, while the one-shot path has no complete section to report).

That invariant subsumes the per-chunk substring checks it replaces, and is what surfaced the whitespace differences fixed here. Checked more widely offline than the committed tests run: 16 shapes across both detectors at 26 chunkings, and 6152 truncation prefixes at 7 chunkings — no divergence, no markup in `normal_text`, no chunk-dependent output, and the buffer drained at end of turn every time.

One deliberate departure from `main`: the preamble is trimmed with `rstrip()` rather than `removesuffix("\n\n")`. The separator now comes from the far side of the call, so leaving one behind here too opens a blank line the model never wrote. Both paths change together. With the trims equal on either side of a call, the first call no longer needs a rule of its own.

The joined text is asserted directly as well as through the comparison. It has to be: the streaming and one-shot paths agreed with each other on every shape below while both were dropping the line break, so the invariant alone is blind to it.

| turn | content |
| --- | --- |
| `'Let me look it up.\n\n' + call + '\nIt is sunny in SF.'` | `'Let me look it up.\nIt is sunny in SF.'` |
| `'我查一下。\n\n' + call + '\n旧金山是晴天。'` | `'我查一下。\n旧金山是晴天。'` |
| `call + '\nAnd now the other one:\n' + call + '\nDone.'` | `'And now the other one:\nDone.'` |
| `'Here you go:\n\n' + call + '\n- SF: sunny\n- LA: hot\n'` | `'Here you go:\n- SF: sunny\n- LA: hot\n'` |
| `'Result:\n' + call + '\n    x = True\n'` | `'Result:\n    x = True\n'` |

## Checklist

- Each new case fails on the code it guards against and passes on the fix: 36 and 600 failing subtests against the pre-fix detector, 25 against the one before the line break was kept. The 8 pre-existing cases kept in the file pass either way.
- `test_deepseekv4_detector.py`: 12 tests, 0 failures.
- `test_function_call_parser.py`: 205 tests, 0 failures, identical before and after this change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31892090181](https://github.com/sgl-project/sglang/actions/runs/31892090181)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #31892090039](https://github.com/sgl-project/sglang/actions/runs/31892090039)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->

