### PR TITLE
[AMD] Publish an undated tag for the miles nightly images

### DIFF
--- a/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
@@ -56,3 +56,9 @@ jobs:
 
       - name: Push dated tag
         run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
+
+      - name: Point the undated tag at this build
+        run: |
+          docker buildx imagetools create \
+            -t rocm/sgl-dev:miles-${{ matrix.variant }} \
+               rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}

--- a/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm700-nightly.yml
@@ -57,8 +57,5 @@ jobs:
       - name: Push dated tag
         run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
 
-      - name: Point the undated tag at this build
-        run: |
-          docker buildx imagetools create \
-            -t rocm/sgl-dev:miles-${{ matrix.variant }} \
-               rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
+      - name: Push the undated tag
+        run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}

--- a/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
@@ -55,3 +55,9 @@ jobs:
 
       - name: Push dated tag
         run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
+
+      - name: Point the undated tag at this build
+        run: |
+          docker buildx imagetools create \
+            -t rocm/sgl-dev:miles-${{ matrix.variant }} \
+               rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}

--- a/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
+++ b/.github/workflows/release-docker-amd-miles-rocm720-nightly.yml
@@ -56,8 +56,5 @@ jobs:
       - name: Push dated tag
         run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
 
-      - name: Point the undated tag at this build
-        run: |
-          docker buildx imagetools create \
-            -t rocm/sgl-dev:miles-${{ matrix.variant }} \
-               rocm/sgl-dev:miles-${{ matrix.variant }}-${DATE}
+      - name: Push the undated tag
+        run: docker push rocm/sgl-dev:miles-${{ matrix.variant }}


### PR DESCRIPTION
Co-authored-with: @JessicaJiang-123

## Motivation

The AMD nightly images are published only under a dated tag, so nothing can reference
them stably.

## Modifications

Push the undated `rocm/sgl-dev:miles-<variant>` alongside the dated one in both AMD
nightly workflows.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31562860064](https://github.com/sgl-project/sglang/actions/runs/31562860064)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31562860020](https://github.com/sgl-project/sglang/actions/runs/31562860020)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->