### PR TITLE
Fix DFlash sliding attention causality defaults

### DIFF
--- a/python/sglang/srt/configs/muse_glimmer.py
+++ b/python/sglang/srt/configs/muse_glimmer.py
@@ -28,6 +28,7 @@ _ARCH = "muse-glimmer"
 class MuseGlimmerAssistantConfig(PretrainedConfig):
 
     model_type = "muse_glimmer_assistant"
+    is_causal = False
     # The DFlash draft has no head; draft_worker_common borrows the target's.
     vocab_size = None
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 def _get_dflash_attention_type(config, *, default: AttentionType) -> AttentionType:
     """Honor explicit causality while preserving legacy layer defaults."""
-    text_config = getattr(config, "text_config", None) or config
+    text_config = config.get_text_config()
     is_causal = getattr(text_config, "is_causal", None)
     if is_causal is None:
         return default

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -43,14 +43,13 @@ if _is_npu:
 logger = logging.getLogger(__name__)
 
 
-def _get_dflash_attention_type(config) -> AttentionType:
-    """Bidirectional over the draft block unless the checkpoint says causal."""
+def _get_dflash_attention_type(config, *, default: AttentionType) -> AttentionType:
+    """Honor explicit causality while preserving legacy layer defaults."""
     text_config = getattr(config, "text_config", None) or config
-    return (
-        AttentionType.DECODER
-        if getattr(text_config, "is_causal", False)
-        else AttentionType.ENCODER_ONLY
-    )
+    is_causal = getattr(text_config, "is_causal", None)
+    if is_causal is None:
+        return default
+    return AttentionType.DECODER if is_causal else AttentionType.ENCODER_ONLY
 
 
 def _get_dflash_layer_attention_params(
@@ -67,12 +66,15 @@ def _get_dflash_layer_attention_params(
 
     layer_type = layer_types[layer_id]
     if layer_type == "full_attention":
-        return -1, _get_dflash_attention_type(config)
+        return -1, _get_dflash_attention_type(
+            config, default=AttentionType.ENCODER_ONLY
+        )
     if layer_type == "sliding_attention":
-        # Windowing is orthogonal to causality (mask is p1 - p0 >= window).
         sliding_window_size = get_dflash_attention_sliding_window_size(config)
         assert sliding_window_size is not None
-        return sliding_window_size, _get_dflash_attention_type(config)
+        return sliding_window_size, _get_dflash_attention_type(
+            config, default=AttentionType.DECODER
+        )
     raise ValueError(
         "Unsupported DFLASH draft layer type. "
         f"layer_types[{layer_id}]={layer_type!r}."


### PR DESCRIPTION
## Motivation

PR #34262 changed DFlash sliding-attention layers from the legacy causal behavior to bidirectional attention when a checkpoint does not declare `is_causal`. The `z-lab/gemma-4-31B-it-DFlash` config has four sliding-attention layers and no `is_causal` field, so its average speculative accept length regressed from approximately 5.62 to 5.27 and failed `test_gemma4_dflash_31b_extra.py`'s 5.4 threshold.

This change restores compatibility for existing DFlash checkpoints while retaining Muse Glimmer's intended bidirectional draft attention.

## Modifications

- Preserve the historical layer-specific defaults when a DFlash checkpoint does not declare `is_causal`:
  - sliding-attention layers use causal (`AttentionType.DECODER`) attention;
  - full-attention layers use bidirectional (`AttentionType.ENCODER_ONLY`) attention.
- Continue honoring explicit `is_causal=True` and `is_causal=False` checkpoint declarations for every DFlash attention layer.
- Declare `MuseGlimmerAssistantConfig.is_causal = False` so Muse Glimmer explicitly retains bidirectional full and sliding draft attention.
- Use `config.get_text_config()` for canonical text-config resolution.

## Accuracy Tests

The regression boundary was confirmed from scheduled CI runs:

| Scheduled run | Commit | Gemma-4 DFlash result |
| --- | --- | --- |
| #134351 | `ceeaec2078` | PASS, accept length `5.61731` |
| #134738 | `546965fc72` | PASS, accept length `5.62095` |
| #134970 | `857910bd35` | FAIL, accept length `5.30446`; retry `5.27089` |

Local configuration-path validation loaded the cached checkpoints through SGLang's actual config parser and evaluated every draft layer:

- Gemma-4 DFlash: four sliding layers resolved to `DECODER`; the full layer resolved to `ENCODER_ONLY`.
- Muse Glimmer: all sliding layers resolved to `ENCODER_ONLY`.
- Explicit `is_causal=False` and `is_causal=True` both override the legacy defaults consistently.

The Gemma-4 DFlash acceptance test passed locally on 2x NVIDIA H100 80GB GPUs with TP=2 and the Extra CI runtime environment:

```bash
CUDA_VISIBLE_DEVICES=0,1 \
NCCL_NVLS_ENABLE=0 \
SGLANG_ENABLE_ASYNC_ASSERT=true \
SGLANG_CUDA_COREDUMP=1 \
SGLANG_IS_IN_CI=true \
python -u test/registered/spec/test_gemma4_dflash_31b_extra.py -f
```

```text
Total latency: 19.885 s
Score: 0.790
Output throughput: 1246.108 token/s
[METRIC] gsm8k_score=0.79 labels={"model": "google/gemma-4-31B-it", "eval": "gsm8k"}
[METRIC] gsm8k_latency=19.885110595991137 labels={"model": "google/gemma-4-31B-it", "eval": "gsm8k"}
====================
Speculative decoding: no per-request spec_accept_length in responses (non-speculative server, or --api completion which lacks return_meta_info).
====================
Writing report to /tmp/gsm8k_google_gemma-4-31B-it.html
{'score:std': np.float64(0.4073082370883261), 'score': np.float64(0.79), 'latency': 19.885110595991137, 'output_throughput': 1246.1082316029701}
Writing results to /tmp/gsm8k_google_gemma-4-31B-it.json
[2026-08-12 04:44:17] INFO:     127.0.0.1:58074 - "GET /server_info HTTP/1.1" 200 OK
[Gemma4 31B DFlash] score=0.7900 threshold=0.7500 avg_spec_accept_length=5.633289124668435
WARNING:root:GITHUB_STEP_SUMMARY environment variable not set
.
----------------------------------------------------------------------
Ran 1 test in 71.033s

OK
```

This restores the accept length from the regressed `5.27-5.30` range to the historical `5.61-5.62` range. CI should also run the Muse-specific acceptance test to confirm its explicit bidirectional behavior end to end:

- `test/registered/spec/dflash/test_muse_glimmer_dflash_assistant_gsm8k.py`

Additional checks:

- `git diff --check`
- `python -m compileall -q` on both modified files
- scoped pre-commit hooks on both modified files

## Speed Tests and Profiling

No standalone speed benchmark or profile was run. The local Gemma-4 DFlash acceptance test completed its 200-example GSM8K evaluation in 19.885 seconds at 1246.108 output tokens/s. This change restores the acceptance behavior guarded by the existing test and does not add work to the inference path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31564810857](https://github.com/sgl-project/sglang/actions/runs/31564810857)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31564810558](https://github.com/sgl-project/sglang/actions/runs/31564810558)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->