### PR TITLE
refactor: keep MiniMax-H3's checkpoint QKV row order instead of rewriting it

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/qknorm.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/qknorm.cuh
@@ -19,9 +19,13 @@ namespace sglang {
 
 struct QKNormParams {
   void* __restrict__ q;
-  void* __restrict__ k;  // k is offset by (-num_qo_heads * head_dim) elements
+  void* __restrict__ k;  // k is offset by (-num_qo_heads * head_stride) elements
   int64_t q_stride;
   int64_t k_stride;
+  // Elements between consecutive heads. Equal to head_dim when q and k are their
+  // own tensors, larger when they are views into an interleaved [.., h, 3, d]
+  // projection output. Shared by q and k, which the matcher enforces.
+  int64_t head_stride;
   uint32_t num_qo_heads;
   uint32_t num_kv_heads;
   float eps;
@@ -40,7 +44,8 @@ __global__ void fused_qknorm_warp(const QKNormParams __grid_constant__ params) {
   using Storage = norm::StorageType<Float, kHeadDim>;
 
   static_assert(sizeof(Float) == 2, "Only support FP16/BF16");
-  const auto& [q, k, q_stride, k_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] = params;
+  const auto& [q, k, q_stride, k_stride, head_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] =
+      params;
 
   const auto num_blks = gridDim.x;
   const auto num_workers = num_blks * kWarpsPerBlock;
@@ -55,8 +60,8 @@ __global__ void fused_qknorm_warp(const QKNormParams __grid_constant__ params) {
     const int64_t token_id = idx / num_q_and_k_heads;
     const int64_t head_id = idx % num_q_and_k_heads;
     const auto load_q = head_id < num_qo_heads;
-    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
-                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
+    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * head_stride))
+                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * head_stride));
     const auto weight = load_q ? q_weight : k_weight;
     const auto input_vec = gmem.load(input);
     const auto weight_vec = gmem.load(weight);
@@ -77,7 +82,8 @@ __global__ void fused_qknorm_cta(const QKNormParams __grid_constant__ params) {
   constexpr auto kNumWarps = kNumThreads / kWarpThreads;
 
   static_assert(sizeof(Float) == 2, "Only support FP16/BF16");
-  const auto& [q, k, q_stride, k_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] = params;
+  const auto& [q, k, q_stride, k_stride, head_stride, num_qo_heads, num_kv_heads, eps, q_weight, k_weight, num_tokens] =
+      params;
 
   const auto num_q_and_k_heads = num_qo_heads + num_kv_heads;
   const auto num_works = num_q_and_k_heads * num_tokens;
@@ -90,8 +96,8 @@ __global__ void fused_qknorm_cta(const QKNormParams __grid_constant__ params) {
     const int64_t token_id = idx / num_q_and_k_heads;
     const int64_t head_id = idx % num_q_and_k_heads;
     const auto load_q = head_id < num_qo_heads;
-    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * kHeadDim))
-                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * kHeadDim));
+    const auto input = load_q ? pointer::offset(q, 2 * (token_id * q_stride + head_id * head_stride))
+                              : pointer::offset(k, 2 * (token_id * k_stride + head_id * head_stride));
     const auto weight = load_q ? q_weight : k_weight;
     const auto input_vec = gmem.load(input);
     const auto weight_vec = gmem.load(weight);
@@ -123,17 +129,18 @@ struct QKNormKernelWarp {
     auto D = SymbolicSize{"head_dim"};
     auto Sq = SymbolicSize{"q_stride"};
     auto Sk = SymbolicSize{"k_stride"};
+    auto Sd = SymbolicSize{"head_stride"};
     auto device = SymbolicDevice{};
     D.set_value(kHeadDim);
     device.set_options<kDLCUDA>();
 
     TensorMatcher({N, Q, D})  // q input
-        .with_strides({Sq, D, 1})
+        .with_strides({Sq, Sd, 1})
         .with_dtype<DType>()
         .with_device(device)
         .verify(q);
     TensorMatcher({N, K, D})  // k input
-        .with_strides({Sk, D, 1})
+        .with_strides({Sk, Sd, 1})
         .with_dtype<DType>()
         .with_device(device)
         .verify(k);
@@ -146,13 +153,15 @@ struct QKNormKernelWarp {
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     const auto num_qo_heads = static_cast<uint32_t>(Q.unwrap());
     const auto num_kv_heads = static_cast<uint32_t>(K.unwrap());
+    const auto head_stride = static_cast<int64_t>(Sd.unwrap());
 
     // NOTE: we offset the k here to reduce computation cost in the kernel
     const auto params = QKNormParams{
         .q = q.data_ptr(),
-        .k = pointer::offset(k.data_ptr(), -2 * static_cast<int64_t>(num_qo_heads) * kHeadDim),
+        .k = pointer::offset(k.data_ptr(), -2 * static_cast<int64_t>(num_qo_heads) * head_stride),
         .q_stride = static_cast<int64_t>(Sq.unwrap()),
         .k_stride = static_cast<int64_t>(Sk.unwrap()),
+        .head_stride = head_stride,
         .num_qo_heads = num_qo_heads,
         .num_kv_heads = num_kv_heads,
         .eps = eps,
@@ -197,17 +206,18 @@ struct QKNormKernelCTA {
     auto D = SymbolicSize{"head_dim"};
     auto Sq = SymbolicSize{"q_stride"};
     auto Sk = SymbolicSize{"k_stride"};
+    auto Sd = SymbolicSize{"head_stride"};
     auto device = SymbolicDevice{};
     D.set_value(kHeadDim);
     device.set_options<kDLCUDA>();
 
     TensorMatcher({N, Q, D})  // q input
-        .with_strides({Sq, D, 1})
+        .with_strides({Sq, Sd, 1})
         .with_dtype<DType>()
         .with_device(device)
         .verify(q);
     TensorMatcher({N, K, D})  // k input
-        .with_strides({Sk, D, 1})
+        .with_strides({Sk, Sd, 1})
         .with_dtype<DType>()
         .with_device(device)
         .verify(k);
@@ -220,13 +230,15 @@ struct QKNormKernelCTA {
     const auto num_tokens = static_cast<uint32_t>(N.unwrap());
     const auto num_qo_heads = static_cast<uint32_t>(Q.unwrap());
     const auto num_kv_heads = static_cast<uint32_t>(K.unwrap());
+    const auto head_stride = static_cast<int64_t>(Sd.unwrap());
 
     // NOTE: we offset the k here to reduce computation cost in the kernel
     const auto params = QKNormParams{
         .q = q.data_ptr(),
-        .k = pointer::offset(k.data_ptr(), -2 * static_cast<int64_t>(num_qo_heads) * kHeadDim),
+        .k = pointer::offset(k.data_ptr(), -2 * static_cast<int64_t>(num_qo_heads) * head_stride),
         .q_stride = static_cast<int64_t>(Sq.unwrap()),
         .k_stride = static_cast<int64_t>(Sk.unwrap()),
+        .head_stride = head_stride,
         .num_qo_heads = num_qo_heads,
         .num_kv_heads = num_kv_heads,
         .eps = eps,

--- a/python/sglang/multimodal_gen/runtime/loader/rank_local_checkpoint.py
+++ b/python/sglang/multimodal_gen/runtime/loader/rank_local_checkpoint.py
@@ -15,6 +15,8 @@ from torch.distributed.fsdp import FSDPModule
 from sglang.multimodal_gen.runtime.distributed import get_tp_rank, get_tp_world_size
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
+    MergedColumnParallelLinear,
+    QKVParallelLinear,
     ReplicatedLinear,
     RowParallelLinear,
 )
@@ -248,6 +250,13 @@ def _resolve_tp_shard_dim(
     owner = weight_loader.__self__
     if isinstance(owner, ReplicatedLinear):
         return True, None
+    if isinstance(owner, (MergedColumnParallelLinear, QKVParallelLinear)):
+        # These subclass ColumnParallelLinear but hold several logical matrices
+        # in one tensor -- [gate; up], or [q; k; v]. Each is sharded separately,
+        # so this rank's rows are one slice per segment, not one contiguous
+        # slice of the whole tensor. Reading a rank-local slice would take part
+        # of the first segment and none of the rest, with the right shape.
+        return False, None
     if isinstance(owner, ColumnParallelLinear):
         output_dim = actual_param.__dict__.get("output_dim")
         return output_dim is not None, output_dim

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -281,7 +281,9 @@ def _apply_qk_norm(
         and q.dtype == _BF16_DTYPE
         and q.dtype == k.dtype == q_norm.weight.dtype == k_norm.weight.dtype
         and q.stride(-1) == k.stride(-1) == 1
-        and q.stride(-2) == k.stride(-2) == head_dim
+        # The kernel takes the head stride as a symbol, but shares it between q
+        # and k, so they only have to agree -- interleaved views have 3*head_dim.
+        and q.stride(-2) == k.stride(-2)
         and q_norm.eps == k_norm.eps
         and not torch.compiler.is_compiling()
     ):

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -531,20 +531,37 @@ class MiniMaxH3Attention(nn.Module):
         self.prefix = prefix
         self._attention_impl = None
         self._attention_backend_enum: AttentionBackendEnum | None = None
-        # The checkpoint stores one fused qkv tensor. Each logical Q/K/V
-        # matrix must be sharded independently; a plain ColumnParallelLinear
-        # would instead slice across the concatenated tensor and is incorrect
-        # for TP > 1.
-        self.qkv_proj = MergedColumnParallelLinear(
-            arch.hidden_size,
-            [self.inner_dim] * 3,
-            bias=False,
-            gather_output=False,
-            params_dtype=_BF16_DTYPE,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
-        self._install_qkv_weight_loader(arch)
+        # The checkpoint stores one fused qkv tensor whose rows are ordered per
+        # head as [q, k, v]. That order is what makes a plain contiguous column
+        # shard correct: rows [r*3*inner/tp, ...) are exactly heads
+        # [r*H/tp, ...), each with its own q, k and v -- which is what the
+        # upstream layout was designed for. So the stock sharding and loader
+        # already do the right thing and the rows never need reordering.
+        # Quantisation keeps the old path: there the row order belongs to the
+        # quant method's layout, and splitting the tensor into three logical
+        # matrices decides the shape of its scales.
+        self.native_qkv_order = quant_config is None
+        if self.native_qkv_order:
+            self.qkv_proj = ColumnParallelLinear(
+                arch.hidden_size,
+                3 * self.inner_dim,
+                bias=False,
+                gather_output=False,
+                params_dtype=_BF16_DTYPE,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+        else:
+            self.qkv_proj = MergedColumnParallelLinear(
+                arch.hidden_size,
+                [self.inner_dim] * 3,
+                bias=False,
+                gather_output=False,
+                params_dtype=_BF16_DTYPE,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
+            self._install_qkv_weight_loader(arch)
         self.q_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         self.k_norm = _norm(arch.attention_head_dim, eps=arch.qk_norm_eps)
         # cache width covers cos/sin for temporal, height, and width frequencies
@@ -644,10 +661,15 @@ class MiniMaxH3Attention(nn.Module):
         """
         total = x.shape[0]
         qkv, _ = self.qkv_proj(x)
-        q, k, v = qkv.split(self.local_inner_dim, dim=-1)
-        q = q.view(total, self.num_heads, self.head_dim)
-        k = k.view(total, self.num_heads, self.head_dim)
-        v = v.view(total, self.num_heads, self.head_dim)
+        if self.native_qkv_order:
+            # Rows are per-head [q, k, v], so the head axis comes first and the
+            # three views share the last axis with a 3*head_dim head stride.
+            q, k, v = qkv.view(total, self.num_heads, 3, self.head_dim).unbind(dim=2)
+        else:
+            q, k, v = qkv.split(self.local_inner_dim, dim=-1)
+            q = q.view(total, self.num_heads, self.head_dim)
+            k = k.view(total, self.num_heads, self.head_dim)
+            v = v.view(total, self.num_heads, self.head_dim)
         if rope_cache is None:
             q, k = _apply_qk_norm(
                 q,

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_dit_contract.py
@@ -99,6 +99,71 @@ def test_native_weight_names_and_grouped_qkv_reorder():
             )
 
 
+def test_native_qkv_order_yields_the_same_q_k_v():
+    """Keeping the checkpoint's row order must not move a single value.
+
+    The rows arrive per head as [q, k, v]. The reordering path rewrites them to
+    [q_all, k_all, v_all] and splits the projection output by thirds; the native
+    path leaves them alone and splits on the head's inner axis. It is the same
+    GEMM either way -- only which output row lands where changes -- so the two
+    have to agree bit for bit, not merely close.
+    """
+    heads, head_dim, hidden, rows = 8, 4, 6, 17
+    torch.manual_seed(0)
+    raw = torch.randn(heads * 3 * head_dim, hidden)
+    reordered = _reorder_grouped_qkv_to_qkv(
+        raw, num_query_groups=heads, heads_per_group=1, head_dim=head_dim
+    )
+    x = torch.randn(rows, hidden)
+
+    native = (x @ raw.T).view(rows, heads, 3, head_dim).unbind(dim=2)
+    legacy = tuple(
+        t.view(rows, heads, head_dim)
+        for t in (x @ reordered.T).split(heads * head_dim, dim=-1)
+    )
+    for name, a, b in zip("qkv", native, legacy):
+        assert torch.equal(a, b), name
+
+    # The native views are strided, which is what every consumer downstream has
+    # to accept; only the last axis is guaranteed contiguous.
+    assert native[0].stride() == (heads * 3 * head_dim, 3 * head_dim, 1)
+
+
+def test_native_qkv_order_makes_a_column_shard_a_head_range():
+    """A contiguous column shard must be exactly a range of whole heads.
+
+    This is what lets the stock ColumnParallelLinear loader replace the custom
+    one. Were it to stop holding, tensor parallelism would split heads across
+    ranks with the right shapes and the wrong contents -- silently.
+    """
+    heads, head_dim, hidden = 8, 4, 6
+    torch.manual_seed(0)
+    raw = torch.randn(heads * 3 * head_dim, hidden)
+    for tp_size in (1, 2, 4, 8):
+        shard = raw.shape[0] // tp_size
+        local_heads = heads // tp_size
+        for tp_rank in range(tp_size):
+            assert torch.equal(
+                raw.narrow(0, tp_rank * shard, shard),
+                raw.view(heads, 3, head_dim, hidden)
+                .narrow(0, tp_rank * local_heads, local_heads)
+                .reshape(shard, hidden),
+            ), (tp_size, tp_rank)
+
+    # The reordered layout is why MergedColumnParallelLinear exists: there the
+    # same contiguous shard is a slice of q only.
+    reordered = _reorder_grouped_qkv_to_qkv(
+        raw, num_query_groups=heads, heads_per_group=1, head_dim=head_dim
+    )
+    shard = reordered.shape[0] // 2
+    assert not torch.equal(
+        reordered.narrow(0, 0, shard),
+        raw.view(heads, 3, head_dim, hidden)
+        .narrow(0, 0, heads // 2)
+        .reshape(shard, hidden),
+    )
+
+
 def test_tp_and_ulysses_admission_uses_tp_local_shapes():
     arch = MiniMaxH3DiTArchConfig()
     model = MiniMaxH3DiTModel.__new__(MiniMaxH3DiTModel)
@@ -164,8 +229,21 @@ def test_meta_model_enforces_mixed_precision_weight_contract():
         )
 
     assert model._fsdp_mixed_dtype_params
+    # Unquantised, the checkpoint's rows are kept as they are, and rank-local
+    # FSDP can shard them directly -- a contiguous row range is a head range --
+    # so no pre-shard transform is installed. Quantisation still reorders, and
+    # still needs one.
     qkv_weight = model.blocks[0].attn.qkv_proj.weight
-    assert callable(qkv_weight.rank_local_weight_transform)
+    assert not hasattr(qkv_weight, "rank_local_weight_transform")
+    with torch.device("meta"):
+        quantised = MiniMaxH3DiTModel(
+            config=MiniMaxH3DiTConfig(),
+            hf_config={},
+            quant_config=Fp8Config(ignored_layers=[]),
+        )
+    assert callable(
+        quantised.blocks[0].attn.qkv_proj.weight.rank_local_weight_transform
+    )
     for name, tensor in model.state_dict().items():
         if name in expected_fp32:
             assert tensor.dtype == torch.float32, name

--- a/test/registered/kernels/ops/diffusion/test_ulysses_qkv.py
+++ b/test/registered/kernels/ops/diffusion/test_ulysses_qkv.py
@@ -40,6 +40,28 @@ def test_pack_qkv_destination_major_is_bit_exact(dtype):
     assert torch.equal(actual, expected)
 
 
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_pack_qkv_destination_major_accepts_strided_views(dtype):
+    """q/k/v reach this kernel as views of one projection output, not as tensors.
+
+    Keeping the checkpoint's per-head [q, k, v] row order makes the projection
+    emit [rows, heads, 3, head_size], so q/k/v are its unbind views: contiguous
+    on the last axis only, with a 3*head_size head stride. The kernel reads
+    through strides, so packing those views has to match packing dense copies.
+    """
+    torch.manual_seed(0)
+    rows, world_size, global_heads, head_size = 17, 4, 12, 64
+    qkv = torch.randn(rows, global_heads, 3, head_size, device="cuda", dtype=dtype)
+    q, k, v = qkv.unbind(dim=2)
+    assert q.stride(-1) == 1 and not q.is_contiguous()
+
+    strided = pack_qkv_destination_major(q, k, v, world_size)
+    dense = pack_qkv_destination_major(
+        q.contiguous(), k.contiguous(), v.contiguous(), world_size
+    )
+    assert torch.equal(strided, dense)
+
+
 def test_pack_qkv_destination_major_validates_inputs():
     q = torch.empty(2, 4, 8, device="cuda", dtype=torch.bfloat16)
     with pytest.raises(ValueError, match="same 3D shape"):

--- a/test/registered/kernels/ops/layernorm/test_qknorm.py
+++ b/test/registered/kernels/ops/layernorm/test_qknorm.py
@@ -98,5 +98,35 @@ def test_qknorm(batch_size: int, n_k: int, n_q: int, head_dim: int) -> None:
     triton.testing.assert_close(q_k_aot[1], q_k_jit[1], atol=1e-2, rtol=1e-2)
 
 
+@pytest.mark.parametrize("head_dim", [64, 128, 256])
+def test_qknorm_accepts_strided_views(head_dim: int) -> None:
+    """q and k may be views of one interleaved projection output.
+
+    A QKV projection whose weight keeps the checkpoint's per-head [q, k, v] row
+    order emits [rows, heads, 3, head_dim], and q/k are its views: contiguous on
+    the last axis only, with a 3*head_dim head stride. The kernel takes the head
+    stride as a symbol, so normalising those views has to match normalising
+    dense copies, bit for bit -- it is the same arithmetic on the same values.
+    """
+    rows, heads = 17, 8
+    torch.manual_seed(0)
+    qkv = torch.randn(rows, heads, 3, head_dim, device=DEVICE, dtype=DTYPE)
+    q, k = qkv[:, :, 0], qkv[:, :, 1]
+    assert q.stride(-2) == 3 * head_dim and q.stride(-1) == 1
+    v_before = qkv[:, :, 2].clone()
+
+    q_dense, k_dense = q.contiguous(), k.contiguous()
+    q_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+    k_weight = torch.randn(head_dim, device=DEVICE, dtype=DTYPE)
+
+    sglang_jit_qknorm(q, k, q_weight, k_weight)
+    sglang_jit_qknorm(q_dense, k_dense, q_weight, k_weight)
+
+    assert torch.equal(q, q_dense)
+    assert torch.equal(k, k_dense)
+    # The rows between q and k belong to v; an over-wide write would land there.
+    assert torch.equal(qkv[:, :, 2], v_before)
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
## What

H3's checkpoint stores `qkv_proj.weight` with rows ordered per head as `[q, k, v]`
(Megatron's layout). The loader rewrote it into `[q_all, k_all, v_all]`, which forced
`MergedColumnParallelLinear`, a custom `_copy_grouped_qkv_tp_shard` path, and an FSDP
`rank_local_weight_transform` hook.

Keeping the original order makes the stock `ColumnParallelLinear` correct on its own: a
contiguous column shard *is* a head range. Verified against the real checkpoint for every
tp dividing 56.

## Commits

```
877f11b3b7  fix: exclude fused column-parallel weights from rank-local TP sharding
8bcc6e10bd  refactor: keep the checkpoint's QKV row order instead of rewriting it
4eba747034  perf: let the qk-norm kernel take the head stride as a symbol
```

The order matters. `MergedColumnParallelLinear` and `QKVParallelLinear` subclass
`ColumnParallelLinear`, so `_resolve_tp_shard_dim` read their fused `[gate; up]` weight as
a plain column shard — right shape, wrong rows, no error. H3 was immune only because its
custom loader closure disqualified the whole model from that path; removing the closure
exposes it, and `mlp.fc1` is mis-sharded in all 52 blocks at TP > 1. **This is not
H3-specific** — any model with a fused column-parallel weight and no disqualifying custom
loader hits it.

## Gains

- Drops a `permute` + `cat` of every qkv tensor at load: 231 MB × 52 blocks.
- Removes the reorder, the custom TP shard path and the FSDP transform hook from the
  unquantised path.
- The token refiner's qk-norm now reaches the CUDA kernel instead of the PyTorch fallback.
- Unblocks removing the Ulysses pack kernel (follow-up).

## Results

**Accuracy** — 4×H100, TP 2 × Ulysses 2, t2va 768p / 4 s / 6 steps, same prompt and seed:

| | md5 | size |
|---|---|---|
| main | `e966925e…` | 338,485 B |
| this branch | `e966925e…` | 338,485 B |

Byte-identical.

main:

https://github.com/user-attachments/assets/c550a708-a301-43d0-8c54-825213c07156

this branch:

https://github.com/user-attachments/assets/35cce55e-fc46-4327-a0d5-56666e779d8f

**Performance** — 4×H100, Ulysses 4, TP 1, `t2va_5s` (1344×768, 49 steps), arms run in
both orders on idle GPUs:

| arm | DenoisingStage | loop |
|---|---|---|
| main | 72.17 s | 1.47 s/it |
| this branch | 72.05 s | 1.47 s/it |

No regression. This PR does not remove the Ulysses pack kernel, so a flat result is the
expected one.

**Tests** — 1866 passed. Four added: q/k/v bit-identical across both paths, a column
shard equals a head range, and the pack and qk-norm kernels accept strided views.

Quantisation keeps the old path (`quant_config is None` gates the new one).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31570409446](https://github.com/sgl-project/sglang/actions/runs/31570409446)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31570409271](https://github.com/sgl-project/sglang/actions/runs/31570409271)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->