### PR TITLE
feat(rust-server): support `save_remote_model` and `save_sharded_model`

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2122,6 +2122,23 @@ class RpcReqOutput(BaseReq, kw_only=True):
     message: str
 
 
+class SaveRemoteModelReqInput(BaseReq, kw_only=True):
+    url: str
+    # Required when a draft model is loaded; the scheduler asserts on it.
+    draft_url: Optional[str] = None
+
+
+class SaveShardedModelReqInput(BaseReq, kw_only=True):
+    path: str
+    pattern: Optional[str] = None
+    max_size: Optional[int] = None
+
+
+class SaveModelReqOutput(BaseReq, kw_only=True):
+    success: bool
+    message: str = ""
+
+
 class LoadLoRAAdapterReqInput(BaseReq, kw_only=True):
     # The name of the lora module to newly loaded.
     lora_name: str

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -25,7 +25,18 @@ from collections import deque
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from sglang.srt.runtime_context import (
     get_device,
@@ -154,6 +165,9 @@ from sglang.srt.managers.io_struct import (
     ResumeMemoryOccupationReqInput,
     RpcReqInput,
     RpcReqOutput,
+    SaveModelReqOutput,
+    SaveRemoteModelReqInput,
+    SaveShardedModelReqInput,
     ScaleElasticEPReqInput,
     ScaleElasticEPReqOutput,
     SendWeightsToRemoteInstanceReqInput,
@@ -1587,6 +1601,8 @@ class Scheduler(
                 (GetInternalStateReq, self.get_internal_state),
                 (SetInternalStateReq, self.set_internal_state),
                 (RpcReqInput, self.handle_rpc_request),
+                (SaveRemoteModelReqInput, self.handle_save_remote_model),
+                (SaveShardedModelReqInput, self.handle_save_sharded_model),
                 (ExpertDistributionReq, self.expert_distribution_handle),
                 (LoadLoRAAdapterReqInput, self.load_lora_adapter),
                 (
@@ -4399,6 +4415,39 @@ class Scheduler(
 
     def save_sharded_model(self, **kwargs):
         self.weight_updater.save_sharded_model(kwargs)
+
+    def handle_save_remote_model(self, recv_req: SaveRemoteModelReqInput):
+        return self._save_model_on_all_ranks(
+            lambda: self.weight_updater.save_remote_model(
+                {"url": recv_req.url, "draft_url": recv_req.draft_url}
+            )
+        )
+
+    def handle_save_sharded_model(self, recv_req: SaveShardedModelReqInput):
+        return self._save_model_on_all_ranks(
+            lambda: self.weight_updater.save_sharded_model(
+                {
+                    "path": recv_req.path,
+                    "pattern": recv_req.pattern,
+                    "max_size": recv_req.max_size,
+                }
+            )
+        )
+
+    def _save_model_on_all_ranks(self, save: Callable[[], None]) -> SaveModelReqOutput:
+        # Every rank writes its own shard, so rank 0 must not answer "saved"
+        # until the peers are done. The caller reads the files right after.
+        success = True
+        message = ""
+        try:
+            save()
+        except Exception as e:
+            success = False
+            message = str(e)
+            logger.error(f"Failed to save model: {e}")
+
+        barrier(group=self.tp_group.cpu_group)
+        return SaveModelReqOutput(success=success, message=message)
 
     def handle_rpc_request(self, recv_req: RpcReqInput):
         # Handle RPC requests

--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -1,22 +1,27 @@
 //! Common control-plane endpoints — `/server_info`, `/get_model_info`
-//! (+ `/model_info` alias), plus the control-request submission path
+//! (+ `/model_info` alias), `/save_remote_model`, `/save_sharded_model`, plus the
+//! control-request submission path
 //! (`await_control_result`, on the shared `submit`). Data-plane endpoints (incl. `/health*`,
 //! which round-trips a generate probe) live in the sibling `native_api` and
 //! `openai` modules; the shared `AppState` lives in the parent
 //! `api_server` module.
 
 use axum::{
-    Router,
+    Json, Router,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
-    routing::get,
+    routing::{get, post},
 };
+use serde::Deserialize;
 
 use super::AppState;
 use super::guard::AbortGuard;
 use super::submit::submit;
-use crate::message::{ControlRequest, EgressItem, GetInternalStateReq, RequestKind};
+use crate::message::{
+    ControlRequest, EgressItem, GetInternalStateReq, RequestKind, SaveRemoteModelReqInput,
+    SaveShardedModelReqInput,
+};
 use crate::runtime::ServerArgs;
 
 /// The routes this module owns, mounted by `api_server::serve`.
@@ -29,6 +34,11 @@ pub(super) fn routes() -> Router<AppState> {
         // alias).
         .route("/get_model_info", get(model_info))
         .route("/model_info", get(model_info))
+        // Weight export: these write to a caller-supplied path or upload to a
+        // caller-supplied URL, and the TODO(auth) in `api_server::serve` applies:
+        // no route in this server is behind an api key yet.
+        .route("/save_remote_model", post(save_remote_model))
+        .route("/save_sharded_model", post(save_sharded_model))
 }
 
 /// Submit a control request through the ingress FSM (no tokenization) and await the
@@ -119,6 +129,82 @@ async fn server_info(State(state): State<AppState>) -> Response {
                 .into_response()
         }
     }
+}
+
+#[derive(Deserialize)]
+struct SaveRemoteModelBody {
+    url: String,
+    #[serde(default)]
+    draft_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct SaveShardedModelBody {
+    path: String,
+    #[serde(default)]
+    pattern: Option<String>,
+    #[serde(default)]
+    max_size: Option<i64>,
+}
+
+/// `POST /save_remote_model`: export the weights to a remote connector URL.
+async fn save_remote_model(
+    State(state): State<AppState>,
+    Json(body): Json<SaveRemoteModelBody>,
+) -> Response {
+    await_save(
+        &state,
+        ControlRequest::SaveRemoteModelReqInput(SaveRemoteModelReqInput::new(
+            crate::ids::Rid::new().to_string(),
+            body.url,
+            body.draft_url,
+        )),
+    )
+    .await
+}
+
+/// `POST /save_sharded_model`: export the weights as one shard per TP rank.
+async fn save_sharded_model(
+    State(state): State<AppState>,
+    Json(body): Json<SaveShardedModelBody>,
+) -> Response {
+    await_save(
+        &state,
+        ControlRequest::SaveShardedModelReqInput(SaveShardedModelReqInput::new(
+            crate::ids::Rid::new().to_string(),
+            body.path,
+            body.pattern,
+            body.max_size,
+        )),
+    )
+    .await
+}
+
+/// A failed export comes back as an ordinary result with `success: false`, not an
+/// egress error: the scheduler must catch it to reach its all-rank barrier.
+async fn await_save(state: &AppState, control: ControlRequest) -> Response {
+    let bytes = match await_control_result(state, control).await {
+        Ok(b) => b,
+        Err(resp) => return resp,
+    };
+    match rmp_serde::from_slice::<SaveModelReqOutput>(&bytes) {
+        Ok(out) if out.success => {
+            (StatusCode::OK, Json(serde_json::json!({"success": true}))).into_response()
+        }
+        Ok(out) => (StatusCode::INTERNAL_SERVER_ERROR, out.message).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "save_model: undecodable scheduler response");
+            (StatusCode::INTERNAL_SERVER_ERROR, "bad save_model response").into_response()
+        }
+    }
+}
+
+/// Named map, not a positional array: `push_control_output` sends the output
+/// through `msgspec.structs.asdict`, so field order does not matter here.
+#[derive(Deserialize)]
+struct SaveModelReqOutput {
+    success: bool,
+    message: String,
 }
 
 /// Runtime-metric keys `get_internal_state` adds atop the server-args dump. We copy

--- a/rust/sglang-server/src/message.rs
+++ b/rust/sglang-server/src/message.rs
@@ -22,7 +22,10 @@ pub use egress::{
     frame_egress_result,
 };
 pub use finish_reason::Matched;
-pub(crate) use io_struct::{AbortReq, ControlRequest, GetInternalStateReq};
+pub(crate) use io_struct::{
+    AbortReq, ControlRequest, GetInternalStateReq, SaveRemoteModelReqInput,
+    SaveShardedModelReqInput,
+};
 pub use request::{GenerateBody, GenerateRequest, MmRequest, MmWorkItem, RequestKind};
 // Constructed directly only by tests: `api_server::prefetch` fills its
 // `prefetched` field, everything else gets it packed inside a `GenerateRequest`.

--- a/rust/sglang-server/src/message/io_struct.rs
+++ b/rust/sglang-server/src/message/io_struct.rs
@@ -69,6 +69,22 @@ control_messages! {
 
     /// `/server_info`'s control request: a bare `BaseReq` with no extra fields.
     GetInternalStateReq {}
+
+    /// The scheduler's `SaveRemoteModelReqInput`: export the weights to a
+    /// remote connector URL, one key namespace per TP rank.
+    SaveRemoteModelReqInput {
+        url: String,
+        /// The scheduler asserts on this when a draft model is loaded.
+        draft_url: Option<String>,
+    }
+
+    /// The scheduler's `SaveShardedModelReqInput`: export the weights as one
+    /// safetensors shard per TP rank under `path`.
+    SaveShardedModelReqInput {
+        path: String,
+        pattern: Option<String>,
+        max_size: Option<i64>,
+    }
 }
 
 /// Borrow a request as its wire struct, resolving `Option` scalars to the wire
@@ -122,6 +138,27 @@ impl GetInternalStateReq {
     }
 }
 
+impl SaveRemoteModelReqInput {
+    pub fn new(rid: String, url: String, draft_url: Option<String>) -> Self {
+        Self {
+            rid,
+            url,
+            draft_url,
+        }
+    }
+}
+
+impl SaveShardedModelReqInput {
+    pub fn new(rid: String, path: String, pattern: Option<String>, max_size: Option<i64>) -> Self {
+        Self {
+            rid,
+            path,
+            pattern,
+            max_size,
+        }
+    }
+}
+
 impl AbortReq {
     pub fn new(rid: String, abort_all: bool) -> Self {
         Self {
@@ -153,6 +190,41 @@ mod tests {
         assert_eq!(arr[3].as_bool(), Some(false));
         assert!(arr[4].is_nil());
         assert!(arr[5].is_nil());
+    }
+
+    /// The save requests carry the export destination on a POSITIONAL wire, so a
+    /// field inserted in the wrong slot writes the weights somewhere else (or
+    /// fails to decode) rather than erroring here. Pin every index.
+    #[test]
+    fn save_req_msgpack_shape() {
+        let b = SaveRemoteModelReqInput::new("r1".into(), "s3://bucket/m".into(), None)
+            .encode()
+            .unwrap();
+        let val = rmpv::decode::read_value(&mut &b[..]).unwrap();
+        let arr = val.as_array().expect("array");
+        assert_eq!(arr.len(), 5, "[tag, rid, http_ipc, url, draft_url]");
+        assert_eq!(arr[0].as_str(), Some("SaveRemoteModelReqInput"));
+        assert_eq!(arr[1].as_str(), Some("r1"));
+        assert!(arr[2].is_nil());
+        assert_eq!(arr[3].as_str(), Some("s3://bucket/m"));
+        assert!(arr[4].is_nil(), "draft_url defaults to nil");
+
+        let b = SaveShardedModelReqInput::new("r2".into(), "/out".into(), None, Some(4096))
+            .encode()
+            .unwrap();
+        let val = rmpv::decode::read_value(&mut &b[..]).unwrap();
+        let arr = val.as_array().expect("array");
+        assert_eq!(
+            arr.len(),
+            6,
+            "[tag, rid, http_ipc, path, pattern, max_size]"
+        );
+        assert_eq!(arr[0].as_str(), Some("SaveShardedModelReqInput"));
+        assert_eq!(arr[1].as_str(), Some("r2"));
+        assert!(arr[2].is_nil());
+        assert_eq!(arr[3].as_str(), Some("/out"));
+        assert!(arr[4].is_nil(), "pattern defaults to nil");
+        assert_eq!(arr[5].as_u64(), Some(4096), "max_size at idx 5");
     }
 
     /// The header must be positionally aligned: `input_embeds` (idx 5) /

--- a/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
+++ b/test/registered/unit/managers/test_msgpack_ipc_roundtrip.py
@@ -26,6 +26,9 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterFromTensorsReqInput,
     ParallelismInfo,
     RpcReqInput,
+    SaveModelReqOutput,
+    SaveRemoteModelReqInput,
+    SaveShardedModelReqInput,
     SetInternalStateReq,
     SetInternalStateReqOutput,
     UpdateWeightFromDiskReqInput,
@@ -123,6 +126,17 @@ REGISTRY_TYPE_INSTANCES = {
         parameters={"flag": True, "n": 1, "ratio": 2.0, "name": "x", "opt": None},
     ),
     "RpcReqInput/none": RpcReqInput(method="collective_rpc", parameters=None),
+    "SaveRemoteModelReqInput": SaveRemoteModelReqInput(
+        url="s3://bucket/model", draft_url="s3://bucket/draft"
+    ),
+    "SaveShardedModelReqInput": SaveShardedModelReqInput(
+        path="/tmp/out",
+        pattern="model-rank-{rank}-part-{part}.safetensors",
+        max_size=4096,
+    ),
+    "SaveModelReqOutput": SaveModelReqOutput(
+        success=False, message="no such directory"
+    ),
     "LoadLoRAAdapterFromTensorsReqInput": LoadLoRAAdapterFromTensorsReqInput(
         lora_name="adapter",
         config_dict={"r": 8, "lora_alpha": 16, "target_modules": ["q_proj", "v_proj"]},


### PR DESCRIPTION
## Motivation

Model export does not work under `SGLANG_RUST_SERVER`. Both operations are only reachable through `Engine.collective_rpc`. We want to implement it in the Rust server.

We want to migrate `Engine.collective_rpc` to Rust server. `Engine.save_remote_model` and `Engine.save_sharded_model` are the only 2 methods use it.

## Modifications

Add the two operations as typed control requests, reusing the existing control plane: the Rust ingress already routes `RequestKind::Control` generically, and control requests are already broadcast to every TP rank.

- `io_struct.py` / `message/io_struct.rs`: `SaveRemoteModelReqInput`, `SaveShardedModelReqInput`, `SaveModelReqOutput`.
- `api_server/common.rs`: `POST /save_remote_model`, `POST /save_sharded_model`. Success returns `200 {"success": true}`, a failed export returns `500` with the message.
- `scheduler.py`: two handlers sharing `_save_model_on_all_ranks`, which runs the export and then barriers on `tp_group.cpu_group` so rank 0 does not answer before its peers finish writing.

## Accuracy Tests

The exported shards were reloaded with `--load-format sharded_state` and generated coherent output at TP 1, 2, and 4.

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31571162976](https://github.com/sgl-project/sglang/actions/runs/31571162976)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31571162796](https://github.com/sgl-project/sglang/actions/runs/31571162796)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->