### PR TITLE
[Tokenizer] Add --tokenizer-backend=gigatoken: ~50x faster prompt encode, byte-identical

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -116,9 +116,9 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--tokenizer-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Tokenizer backend. 'huggingface' uses the default HuggingFace tokenizers library; 'fastokens' uses the <a href="https://github.com/crusoecloud/fastokens">fastokens</a> library for faster tokenization. Requires the <code>fastokens</code> package to be installed.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Tokenizer backend. 'huggingface' uses the default HuggingFace tokenizers library; 'fastokens' and 'gigatoken' use the <a href="https://github.com/crusoecloud/fastokens">fastokens</a> and <a href="https://github.com/marcelroed/gigatoken">gigatoken</a> libraries for faster tokenization, and require the corresponding package to be installed (<code>pip install 'sglang[fastokens]'</code> / <code>pip install 'sglang[gigatoken]'</code>).</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`huggingface`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>huggingface</code>, <code>fastokens</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>huggingface</code>, <code>fastokens</code>, <code>gigatoken</code></td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--tokenizer-worker-num`</td>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -151,6 +151,10 @@ fastokens = [
   "fastokens>=0.1.1,<0.2.0",
 ]
 
+gigatoken = [
+  "gigatoken>=0.10.0,<0.11.0",
+]
+
 test = [
   "accelerate",
   "addict",
@@ -179,6 +183,7 @@ test = [
   "pytest-cov",
   "sentence_transformers",
   "sglang[fastokens]",
+  "sglang[gigatoken]",
   "tabulate",
 ]
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -507,9 +507,10 @@ class ServerArgs:
         str,
         Arg(
             help="Tokenizer backend. 'huggingface' uses the default HuggingFace "
-            "tokenizers library, and 'fastokens' uses the fastokens library "
-            "for faster tokenization. Requires the fastokens package to be installed.",
-            choices=["huggingface", "fastokens"],
+            "tokenizers library; 'fastokens' and 'gigatoken' use those libraries "
+            "for faster tokenization, and require the corresponding package to be "
+            "installed (pip install 'sglang[fastokens]' / 'sglang[gigatoken]').",
+            choices=["huggingface", "fastokens", "gigatoken"],
         ),
         NS("serving"),
     ] = "huggingface"

--- a/python/sglang/srt/tokenizer/gigatoken_tokenizer.py
+++ b/python/sglang/srt/tokenizer/gigatoken_tokenizer.py
@@ -1,0 +1,396 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Route a HuggingFace tokenizer's encode/decode hot paths through gigatoken.
+
+gigatoken (https://github.com/marcelroed/gigatoken) is a SIMD byte-pair encoder
+that encodes a single document 50-200x faster than `tokenizers` does, which
+matters here because SGLang tokenizes one prompt per request on the
+TokenizerManager event loop and detokenizes every streamed token.
+
+Rather than replace the tokenizer object with gigatoken's own HF-compatible
+shim, this keeps the loaded tokenizer and overrides only the four methods on
+the serving hot path, so the chat template, added-token bookkeeping, xgrammar's
+TokenizerInfo, multimodal processors and `save_pretrained` all keep working
+against the real implementation. Every call shape gigatoken has not been
+verified byte-identical on -- sequence pairs, padding, truncation, tensor
+returns, token_type_ids, `clean_up_tokenization_spaces` -- falls through to the
+original method, so a request can be slower than it could be but is never
+tokenized differently.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Encode kwargs the fast path understands. Anything else means a call shape
+# gigatoken parity was not established for, so the call goes to transformers.
+_KNOWN_ENCODE_KWARGS = frozenset(
+    {
+        "add_special_tokens",
+        "return_attention_mask",
+        "return_token_type_ids",
+        "verbose",
+    }
+)
+
+# Encode kwargs that must be absent or falsy to stay on the fast path: each one
+# asks for row assembly (padding, truncation, tensors, segment ids) that
+# gigatoken is not driving here.
+_ENCODE_KWARGS_MUST_BE_FALSY = (
+    "text_pair",
+    "padding",
+    "truncation",
+    "max_length",
+    "return_tensors",
+    "return_token_type_ids",
+    "is_split_into_words",
+)
+
+# Decode kwargs the fast path understands.
+_KNOWN_DECODE_KWARGS = frozenset(
+    {
+        "skip_special_tokens",
+        # PreTrainedTokenizerFast._decode ignores this outright (it is a slow
+        # tokenizer concept), so gigatoken dropping it matches HF exactly.
+        "spaces_between_special_tokens",
+        "clean_up_tokenization_spaces",
+    }
+)
+
+# The BatchEncoding keys the fast path produces. A tokenizer whose
+# model_input_names asks for more (BERT-style `token_type_ids`) would silently
+# lose a key, so those keep using transformers for `__call__`.
+_FAST_PATH_MODEL_INPUTS = frozenset({"input_ids", "attention_mask"})
+
+# Probes used to discover what the post-processor prepends/appends. Two
+# unrelated strings that tokenize to different ids, so agreement between them
+# is evidence the affixes are constant rather than content-dependent.
+_AFFIX_PROBES = ("gigatoken affix probe", "下一个 42 probe")
+
+# Probe for the decode check below: ASCII, a CJK run and a 4-byte emoji, so
+# that cutting it at token boundaries produces incomplete UTF-8 sequences.
+_DECODE_PROBE = "ok 日本語 🚀 end"
+
+# Cache of generated subclasses, keyed by the class being accelerated: swapping
+# __class__ per instance keeps the patch off every other tokenizer of the same
+# type living in this process (e.g. a multimodal processor's own copy).
+_accelerated_classes: dict[type, type] = {}
+
+
+class GigatokenUnavailable(RuntimeError):
+    """gigatoken cannot back this tokenizer; the caller should not use it."""
+
+
+def _load_gigatoken(tokenizer):
+    try:
+        import gigatoken
+    except ImportError as e:
+        raise GigatokenUnavailable(
+            "The gigatoken package is required when --tokenizer-backend=gigatoken. "
+            "Install it with: pip install 'sglang[gigatoken]'"
+        ) from e
+    try:
+        return gigatoken.Tokenizer(tokenizer)
+    except Exception as e:
+        raise GigatokenUnavailable(
+            f"gigatoken cannot load this tokenizer ({type(tokenizer).__name__}): {e}"
+        ) from e
+
+
+def _find_subsequence(haystack: list[int], needle: list[int]) -> Optional[int]:
+    """Index where `needle` occurs contiguously in `haystack`, else None."""
+    first = needle[0]
+    for i in range(len(haystack) - len(needle) + 1):
+        if haystack[i] == first and haystack[i : i + len(needle)] == needle:
+            return i
+    return None
+
+
+def _discover_special_affixes(tokenizer) -> Optional[tuple[list[int], list[int]]]:
+    """The ids the post-processor puts before/after a single sequence.
+
+    Read off the tokenizer itself rather than parsed out of tokenizer.json, by
+    encoding a probe both ways and diffing. Returns None when the difference is
+    not a constant prefix/suffix (the probes disagree, or the specials are
+    interleaved), which disables only the add_special_tokens=True fast path.
+    """
+    affixes = set()
+    for probe in _AFFIX_PROBES:
+        bare = tokenizer.encode(probe, add_special_tokens=False)
+        with_specials = tokenizer.encode(probe, add_special_tokens=True)
+        if not bare or len(with_specials) < len(bare):
+            return None
+        start = _find_subsequence(with_specials, bare)
+        if start is None:
+            return None
+        affixes.add(
+            (
+                tuple(with_specials[:start]),
+                tuple(with_specials[start + len(bare) :]),
+            )
+        )
+    if len(affixes) != 1:
+        return None
+    prefix, suffix = affixes.pop()
+    return list(prefix), list(suffix)
+
+
+def _decode_matches_on_partial_characters(tokenizer, backend) -> bool:
+    """Whether gigatoken detokenizes every sub-range of a probe like HF does.
+
+    DetokenizerManager decodes overlapping [surr:read] token windows, so a
+    window can end mid-character and the two implementations have to agree on
+    the resulting U+FFFD run. They do for byte-level BPE, but byte-fallback
+    (SentencePiece) tokenizers emit one U+FFFD per undecodable byte in HF and
+    one for the whole truncated sequence in gigatoken -- a difference that
+    would show up in streamed chunk boundaries. Probing beats testing for
+    byte_fallback because it checks the behavior we actually depend on, and
+    stops gating decode if gigatoken's replacement policy ever changes.
+    """
+    ids = tokenizer.encode(_DECODE_PROBE, add_special_tokens=False)
+    for read in range(1, len(ids) + 1):
+        for surr in range(read):
+            window = ids[surr:read]
+            expected = tokenizer.decode(window, skip_special_tokens=False)
+            got = backend.decode(window).decode("utf-8", errors="replace")
+            if expected != got:
+                return False
+    return True
+
+
+def _is_plain_text_input(text) -> bool:
+    """A lone string or a list of strings -- no pairs, no pre-tokenized input."""
+    if isinstance(text, str):
+        return True
+    if isinstance(text, (list, tuple)):
+        return all(isinstance(item, str) for item in text)
+    return False
+
+
+def _is_plain_encode_call(kwargs: dict[str, Any]) -> bool:
+    """Whether this is the bare "just tokenize it" shape gigatoken covers."""
+    if not _KNOWN_ENCODE_KWARGS.issuperset(kwargs):
+        return False
+    return not any(kwargs.get(name) for name in _ENCODE_KWARGS_MUST_BE_FALSY)
+
+
+class _GigatokenMethods:
+    """encode/decode overrides mixed under the tokenizer's original class.
+
+    Injected via `__class__` reassignment (see `accelerate_with_gigatoken`), so
+    `super()` reaches the real transformers implementation and every fallback
+    behaves exactly as an unaccelerated server would. Only `text` is accepted
+    positionally: a call that passes anything else by position is handed
+    straight to transformers rather than risking a different argument binding.
+    """
+
+    # Set on the instance by accelerate_with_gigatoken.
+    _gigatoken: Any
+    _gigatoken_prefix_ids: Optional[list[int]]
+    _gigatoken_suffix_ids: Optional[list[int]]
+    _gigatoken_special_ids: frozenset
+    _gigatoken_plain_model_inputs: bool
+    _gigatoken_decode_ok: bool
+
+    def __call__(self, text=None, *args: Any, **kwargs: Any):
+        affixes = self._gigatoken_affixes(kwargs)
+        if (
+            args
+            or affixes is None
+            or not self._gigatoken_plain_model_inputs
+            or not _is_plain_text_input(text)
+            or not _is_plain_encode_call(kwargs)
+        ):
+            return super().__call__(text, *args, **kwargs)
+
+        from transformers.tokenization_utils_base import BatchEncoding
+
+        prefix, suffix = affixes
+        with_mask = kwargs.get("return_attention_mask") is not False
+        if isinstance(text, str):
+            ids = prefix + self._gigatoken.encode(text).tolist() + suffix
+            data: dict[str, Any] = {"input_ids": ids}
+            if with_mask:
+                data["attention_mask"] = [1] * len(ids)
+        else:
+            rows = [
+                prefix + row + suffix
+                for row in self._gigatoken.encode_batch_list(list(text), parallel=False)
+            ]
+            data = {"input_ids": rows}
+            if with_mask:
+                data["attention_mask"] = [[1] * len(row) for row in rows]
+        return BatchEncoding(data)
+
+    def encode(self, text=None, *args: Any, **kwargs: Any) -> list[int]:
+        affixes = self._gigatoken_affixes(kwargs)
+        if (
+            args
+            or affixes is None
+            or not isinstance(text, str)
+            or not _is_plain_encode_call(kwargs)
+        ):
+            return super().encode(text, *args, **kwargs)
+        prefix, suffix = affixes
+        return prefix + self._gigatoken.encode(text).tolist() + suffix
+
+    def decode(self, token_ids=None, *args: Any, **kwargs: Any) -> str:
+        if args or not self._gigatoken_can_decode(kwargs):
+            return super().decode(token_ids, *args, **kwargs)
+        return self._gigatoken_decode(
+            token_ids, kwargs.get("skip_special_tokens", False)
+        )
+
+    def __deepcopy__(self, memo):
+        """Copy the tokenizer while sharing the gigatoken backend.
+
+        The backend is a Rust object that cannot be pickled, and the default
+        deepcopy reaches it through this instance's `__dict__`. That matters
+        because `MultimodalProcessorExecutor` deepcopies the whole processor to
+        get one clone per worker: without this, the copy raises and sglang
+        silently falls back to synchronous multimodal processing.
+
+        Sharing rather than rebuilding is safe — gigatoken's encode holds the
+        GIL, so concurrent callers of one backend serialize — and it keeps the
+        clones from each allocating another pretoken cache.
+        """
+        cls = type(self)
+        clone = cls.__new__(cls)
+        memo[id(self)] = clone
+        for name, value in self.__dict__.items():
+            object.__setattr__(
+                clone,
+                name,
+                value if name == "_gigatoken" else copy.deepcopy(value, memo),
+            )
+        return clone
+
+    def batch_decode(self, sequences=None, *args: Any, **kwargs: Any) -> list[str]:
+        if args or not self._gigatoken_can_decode(kwargs):
+            return super().batch_decode(sequences, *args, **kwargs)
+        skip = kwargs.get("skip_special_tokens", False)
+        return [self._gigatoken_decode(ids, skip) for ids in sequences]
+
+    # -- helpers ------------------------------------------------------------
+
+    def _gigatoken_affixes(
+        self, kwargs: dict[str, Any]
+    ) -> Optional[tuple[list[int], list[int]]]:
+        """(prefix, suffix) to wrap the ids in, or None to fall back."""
+        if not kwargs.get("add_special_tokens", True):
+            return [], []
+        if self._gigatoken_prefix_ids is None:
+            return None
+        return self._gigatoken_prefix_ids, self._gigatoken_suffix_ids
+
+    def _gigatoken_can_decode(self, kwargs: dict[str, Any]) -> bool:
+        if not self._gigatoken_decode_ok:
+            return False
+        if not _KNOWN_DECODE_KWARGS.issuperset(kwargs):
+            return False
+        # transformers v5 skips cleanup for BPE models, but honor the request by
+        # falling back rather than reasoning about which model kind this is.
+        cleanup = kwargs.get("clean_up_tokenization_spaces")
+        if cleanup is None:
+            cleanup = self.clean_up_tokenization_spaces
+        return not cleanup
+
+    def _gigatoken_decode(self, token_ids, skip_special_tokens: bool) -> str:
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+        if skip_special_tokens and self._gigatoken_special_ids:
+            special = self._gigatoken_special_ids
+            token_ids = [i for i in token_ids if i not in special]
+        # Without filtering the sequence goes through untouched: numpy arrays
+        # and array('q') buffers are borrowed by the Rust decoder, so no
+        # per-token Python int is built.
+        return self._gigatoken.decode(token_ids).decode("utf-8", errors="replace")
+
+
+def _accelerated_class(base: type) -> type:
+    cls = _accelerated_classes.get(base)
+    if cls is None:
+        cls = type(f"Gigatoken{base.__name__}", (_GigatokenMethods, base), {})
+        _accelerated_classes[base] = cls
+    return cls
+
+
+def accelerate_with_gigatoken(tokenizer):
+    """Back `tokenizer`'s encode/decode hot paths with gigatoken, in place.
+
+    Returns the same object with its class swapped for a generated subclass, so
+    `isinstance` checks, attribute assignment (e.g. `tokenizer.chat_template =
+    ...`) and every method not overridden behave exactly as before. Raises
+    GigatokenUnavailable if gigatoken is missing or cannot load this tokenizer.
+    """
+    if isinstance(tokenizer, _GigatokenMethods):
+        return tokenizer
+
+    base_name = type(tokenizer).__name__
+    backend = _load_gigatoken(tokenizer)
+    affixes = _discover_special_affixes(tokenizer)
+    if affixes is None:
+        logger.info(
+            "gigatoken: %s adds special tokens in a shape that is not a constant "
+            "prefix/suffix; add_special_tokens=True will use the HuggingFace path.",
+            base_name,
+        )
+        prefix_ids = suffix_ids = None
+    else:
+        prefix_ids, suffix_ids = affixes
+
+    plain_model_inputs = _FAST_PATH_MODEL_INPUTS.issuperset(tokenizer.model_input_names)
+    if not plain_model_inputs:
+        logger.info(
+            "gigatoken: %s requires model inputs %s beyond input_ids/attention_mask; "
+            "encoding will use the HuggingFace path, decoding still uses gigatoken.",
+            base_name,
+            sorted(set(tokenizer.model_input_names) - _FAST_PATH_MODEL_INPUTS),
+        )
+
+    decode_ok = _decode_matches_on_partial_characters(tokenizer, backend.backend)
+    if not decode_ok:
+        logger.info(
+            "gigatoken: %s detokenizes truncated multi-byte characters differently "
+            "from HuggingFace (byte-fallback vocabularies do); decoding will use the "
+            "HuggingFace path, encoding still uses gigatoken.",
+            base_name,
+        )
+
+    tokenizer._gigatoken = backend
+    tokenizer._gigatoken_prefix_ids = prefix_ids
+    tokenizer._gigatoken_suffix_ids = suffix_ids
+    tokenizer._gigatoken_plain_model_inputs = plain_model_inputs
+    tokenizer._gigatoken_decode_ok = decode_ok
+    tokenizer._gigatoken_special_ids = frozenset(
+        token_id
+        for token_id, token in tokenizer.added_tokens_decoder.items()
+        if token.special
+    )
+    tokenizer.__class__ = _accelerated_class(type(tokenizer))
+
+    logger.info(
+        "gigatoken backend enabled for %s (encode=%s, decode=%s, "
+        "special affixes: prefix=%s suffix=%s)",
+        base_name,
+        "gigatoken" if plain_model_inputs else "huggingface",
+        "gigatoken" if decode_ok else "huggingface",
+        prefix_ids,
+        suffix_ids,
+    )
+    return tokenizer

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -25,6 +25,7 @@ from transformers import (
 )
 
 from sglang.srt.multimodal.customized_mm_processor_utils import _CUSTOMIZED_MM_PROCESSOR
+from sglang.srt.tokenizer.gigatoken_tokenizer import accelerate_with_gigatoken
 from sglang.srt.utils import logger
 
 from .common import (
@@ -381,4 +382,8 @@ def get_processor(
     _fix_special_tokens_pattern(tokenizer)
     _fix_added_tokens_encoding(tokenizer)
     attach_additional_stop_token_ids(tokenizer)
+    if tokenizer_backend == "gigatoken":
+        # In place, so `processor.tokenizer` (which the multimodal processors
+        # call directly) is the accelerated object too.
+        accelerate_with_gigatoken(tokenizer)
     return processor

--- a/python/sglang/srt/utils/hf_transformers/tokenizer.py
+++ b/python/sglang/srt/utils/hf_transformers/tokenizer.py
@@ -26,6 +26,7 @@ from transformers import (
 )
 
 from sglang.srt.connector import create_remote_connector
+from sglang.srt.tokenizer.gigatoken_tokenizer import accelerate_with_gigatoken
 from sglang.srt.utils import is_remote_url, logger
 from sglang.srt.utils.patch_tokenizer import patch_tokenizer
 
@@ -417,7 +418,9 @@ def _fix_special_tokens_pattern(tokenizer):
         tokenizer.special_tokens_pattern = "none"
 
 
-def _apply_post_load_fixes(tokenizer, tokenizer_name, revision):
+def _apply_post_load_fixes(
+    tokenizer, tokenizer_name, revision, tokenizer_backend="huggingface"
+):
     """Apply all post-load patches and return the final tokenizer."""
     _fix_v5_tokenizer_components(tokenizer, tokenizer_name, revision)
     _fix_v5_add_bos_eos_token(tokenizer, tokenizer_name, revision)
@@ -431,7 +434,12 @@ def _apply_post_load_fixes(tokenizer, tokenizer_name, revision):
     patch_mistral_common_tokenizer(tokenizer)
     _fix_special_tokens_pattern(tokenizer)
     attach_additional_stop_token_ids(tokenizer)
-    return patch_tokenizer(tokenizer)
+    tokenizer = patch_tokenizer(tokenizer)
+    # Last, so gigatoken's overrides sit above every fixup applied here and the
+    # affix discovery reads the tokenizer in its final configuration.
+    if tokenizer_backend == "gigatoken":
+        tokenizer = accelerate_with_gigatoken(tokenizer)
+    return tokenizer
 
 
 # ---------------------------------------------------------------------------
@@ -499,7 +507,10 @@ def get_tokenizer(
         tokenizer = build_gguf_tokenizer(tokenizer_name)
         _fix_special_tokens_pattern(tokenizer)
         attach_additional_stop_token_ids(tokenizer)
-        return patch_tokenizer(tokenizer)
+        tokenizer = patch_tokenizer(tokenizer)
+        if tokenizer_backend == "gigatoken":
+            tokenizer = accelerate_with_gigatoken(tokenizer)
+        return tokenizer
 
     tokenizer_name = _resolve_tokenizer_name(tokenizer_name, kwargs)
 
@@ -543,7 +554,12 @@ def get_tokenizer(
                     tokenizer_name, *args, **common_kwargs
                 )
 
-        return _apply_post_load_fixes(tokenizer, tokenizer_name, tokenizer_revision)
+        return _apply_post_load_fixes(
+            tokenizer,
+            tokenizer_name,
+            tokenizer_revision,
+            tokenizer_backend=tokenizer_backend,
+        )
     except Exception as e:
         if tokenizer_backend == "fastokens":
             raise RuntimeError(
@@ -551,6 +567,13 @@ def get_tokenizer(
                 f"This model's tokenizer may not be supported by fastokens — "
                 f"see https://github.com/crusoecloud/fastokens. "
                 f"Re-run without --tokenizer-backend=fastokens to use the default backend."
+            ) from e
+        if tokenizer_backend == "gigatoken":
+            raise RuntimeError(
+                f"gigatoken failed to load tokenizer for {tokenizer_name!r}. "
+                f"This model's tokenizer may not be supported by gigatoken — "
+                f"see https://github.com/marcelroed/gigatoken. "
+                f"Re-run without --tokenizer-backend=gigatoken to use the default backend."
             ) from e
         raise
 

--- a/test/registered/unit/utils/test_hf_transformers_gigatoken.py
+++ b/test/registered/unit/utils/test_hf_transformers_gigatoken.py
@@ -1,0 +1,291 @@
+"""Verification that --tokenizer-backend=gigatoken keeps tokenization
+byte-identical to the HuggingFace baseline and preserves the rest of the
+tokenizer object.
+
+gigatoken replaces only encode/decode; anything it has not been verified
+byte-identical on must fall back to transformers. Both directions are silent
+when broken -- a wrong fast path mistokenizes prompts, and a wrong fallback
+drops padding or token_type_ids -- so each is pinned here against a baseline
+tokenizer loaded through the default backend.
+"""
+
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+    CustomTestCase,
+)
+
+TOKENIZER_MODEL = DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN
+
+register_cpu_ci(est_time=60, suite="base-a-test-cpu")
+
+
+try:
+    import gigatoken  # noqa: F401
+
+    HAS_GIGATOKEN = True
+except ImportError:
+    HAS_GIGATOKEN = False
+
+# Text shapes the serving path actually feeds the tokenizer: plain prose, chat
+# markup carrying special tokens, code, CJK, emoji (multi-byte boundaries the
+# incremental detokenizer trips on), and whitespace runs.
+TEXTS = [
+    "Hello, world!",
+    "",
+    " ",
+    "\n\n\t ",
+    "The quick brown fox jumps over the lazy dog. " * 40,
+    "<|im_start|>system\nYou are helpful.<|im_end|>\n"
+    "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n",
+    "def f(x: int) -> int:\n    return x**2  # comment\n",
+    "日本語のテキスト、中文文本，한국어 텍스트",
+    "emoji 🚀🔥👨‍👩‍👧‍👦 and 🇺🇸 flags",
+    "https://example.com/p?q=1&r=2#frag",
+]
+
+
+@unittest.skipUnless(HAS_GIGATOKEN, "gigatoken package not installed")
+class TestGigatokenBackend(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        from sglang.srt.utils.hf_transformers.tokenizer import get_tokenizer
+
+        cls.baseline = get_tokenizer(TOKENIZER_MODEL)
+        cls.accel = get_tokenizer(TOKENIZER_MODEL, tokenizer_backend="gigatoken")
+
+    def test_backend_is_applied(self):
+        from sglang.srt.tokenizer.gigatoken_tokenizer import _GigatokenMethods
+
+        self.assertIsInstance(self.accel, _GigatokenMethods)
+        # The class swap must keep the original type in the MRO, since SGLang
+        # and transformers both branch on isinstance(tokenizer, ...).
+        self.assertIsInstance(self.accel, type(self.baseline))
+
+    def test_encode_matches_huggingface(self):
+        """Ids must be identical, including the post-processor's affixes."""
+        for text in TEXTS:
+            for add_special in (True, False):
+                with self.subTest(text=text[:30], add_special_tokens=add_special):
+                    self.assertEqual(
+                        self.accel.encode(text, add_special_tokens=add_special),
+                        self.baseline.encode(text, add_special_tokens=add_special),
+                    )
+                    self.assertEqual(
+                        self.accel(text, add_special_tokens=add_special)["input_ids"],
+                        self.baseline(text, add_special_tokens=add_special)[
+                            "input_ids"
+                        ],
+                    )
+
+    def test_batch_encode_matches_huggingface(self):
+        """The dynamic-batch tokenizer path passes a list of prompts."""
+        expected = self.baseline(TEXTS)
+        got = self.accel(TEXTS)
+        self.assertEqual(got["input_ids"], expected["input_ids"])
+        self.assertEqual(got["attention_mask"], expected["attention_mask"])
+
+    def test_incremental_decode_matches_huggingface(self):
+        """DetokenizerManager decodes overlapping [surr:read] windows, so every
+        window -- including ones cutting a multi-byte character in half -- must
+        decode exactly as HF does, or streamed text drifts."""
+        ids = self.baseline.encode(
+            "Streaming 日本語 🚀 output tokens", add_special_tokens=False
+        )
+        for read in range(1, len(ids) + 1):
+            for surr in range(read):
+                window = ids[surr:read]
+                with self.subTest(window=(surr, read)):
+                    self.assertEqual(
+                        self.accel.decode(window, skip_special_tokens=False),
+                        self.baseline.decode(window, skip_special_tokens=False),
+                    )
+
+    def test_byte_fallback_decode_is_gated_off(self):
+        """A byte-fallback (SentencePiece) vocabulary emits one U+FFFD per
+        undecodable byte in HF but one per truncated sequence in gigatoken, so
+        the startup probe must take those tokenizers off the decode fast path.
+
+        Without the probe, streaming a Llama-2-family model produces a
+        different number of replacement characters mid-multibyte-character than
+        the HuggingFace reference. Guards against the probe degrading to
+        always-true.
+        """
+        from sglang.srt.utils.hf_transformers.tokenizer import get_tokenizer
+
+        # Llama 2's vocabulary: SentencePiece BPE with byte_fallback.
+        sp = get_tokenizer(
+            "hf-internal-testing/llama-tokenizer", tokenizer_backend="gigatoken"
+        )
+        self.assertFalse(sp._gigatoken_decode_ok)
+        # Encoding is unaffected -- that is the point of gating decode only.
+        reference = get_tokenizer("hf-internal-testing/llama-tokenizer")
+        ids = reference.encode("Streaming 日本語 🚀 output", add_special_tokens=False)
+        self.assertEqual(
+            sp.encode("Streaming 日本語 🚀 output", add_special_tokens=False), ids
+        )
+        for read in range(1, len(ids) + 1):
+            for surr in range(read):
+                window = ids[surr:read]
+                with self.subTest(window=(surr, read)):
+                    self.assertEqual(sp.decode(window), reference.decode(window))
+
+    def test_single_int_decode_honors_skip_special_tokens(self):
+        """decode() accepts a bare int, and skip_special_tokens must still drop
+        it when it is special.
+
+        An earlier revision wrapped the int and skipped the filter in the same
+        if/elif, so decode(eos_id, skip_special_tokens=True) returned
+        "<|im_end|>" instead of "".
+        """
+        eos = self.baseline.eos_token_id
+        for skip in (True, False):
+            with self.subTest(skip_special_tokens=skip):
+                self.assertEqual(
+                    self.accel.decode(eos, skip_special_tokens=skip),
+                    self.baseline.decode(eos, skip_special_tokens=skip),
+                )
+
+    def test_batch_decode_matches_huggingface(self):
+        ids = [self.baseline.encode(text) for text in TEXTS if text.strip()]
+        for skip in (True, False):
+            with self.subTest(skip_special_tokens=skip):
+                self.assertEqual(
+                    self.accel.batch_decode(ids, skip_special_tokens=skip),
+                    self.baseline.batch_decode(ids, skip_special_tokens=skip),
+                )
+
+    def test_unsupported_call_shapes_fall_back(self):
+        """Call shapes gigatoken does not drive must reach transformers.
+
+        Each of these produces output the fast path cannot build (padded rows,
+        tensors, truncation, segment ids, pair encoding). If the guard ever
+        degrades to always-true, the fast path answers instead and the result
+        silently loses padding/tensors rather than raising.
+        """
+        self.accel.pad_token = self.accel.eos_token
+        self.baseline.pad_token = self.baseline.eos_token
+        pair = ["short", "a much longer second sequence here"]
+        cases = [
+            ("padding", dict(padding=True)),
+            ("padding_max_length", dict(padding="max_length", max_length=32)),
+            ("truncation", dict(truncation=True, max_length=8)),
+            ("token_type_ids", dict(return_token_type_ids=True)),
+        ]
+        for name, kwargs in cases:
+            with self.subTest(case=name):
+                self.assertEqual(
+                    dict(self.accel(pair, **kwargs)),
+                    dict(self.baseline(pair, **kwargs)),
+                )
+
+        # A sequence pair is rejected by gigatoken outright; falling back means
+        # transformers' own error/behavior surfaces, not gigatoken's.
+        self.assertEqual(
+            self.accel("query", text_pair="document")["input_ids"],
+            self.baseline("query", text_pair="document")["input_ids"],
+        )
+
+    def test_positional_args_fall_back(self):
+        """`encode(text, pair)` binds the 2nd positional to text_pair in
+        transformers; the override only accepts `text` positionally, so such a
+        call must be handed over rather than re-bound to a different meaning.
+        """
+        self.assertEqual(
+            self.accel.encode("query", "document"),
+            self.baseline.encode("query", "document"),
+        )
+
+    def test_cold_path_surface_survives(self):
+        """Everything off the encode/decode path must behave as before.
+
+        The whole reason this integration patches methods instead of swapping
+        the tokenizer for gigatoken's HFCompat shim is that HFCompat has no
+        chat template, no added-token bookkeeping and no save_pretrained; a
+        future refactor toward wholesale replacement would break these.
+        """
+        messages = [{"role": "user", "content": "hi"}]
+        self.assertEqual(
+            self.accel.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            ),
+            self.baseline.apply_chat_template(
+                messages, tokenize=False, add_generation_prompt=True
+            ),
+        )
+        # TemplateManager assigns chat_template onto the tokenizer, and
+        # apply_chat_template must then use the assigned value.
+        self.accel.chat_template = "{{ 'patched:' }}{{ messages[0]['content'] }}"
+        self.assertEqual(
+            self.accel.apply_chat_template(messages, tokenize=False), "patched:hi"
+        )
+
+        self.assertEqual(self.accel.get_vocab(), self.baseline.get_vocab())
+        self.assertEqual(
+            self.accel.added_tokens_decoder.keys(),
+            self.baseline.added_tokens_decoder.keys(),
+        )
+        self.assertEqual(self.accel.eos_token_id, self.baseline.eos_token_id)
+        self.assertEqual(
+            self.accel.additional_stop_token_ids,
+            self.baseline.additional_stop_token_ids,
+        )
+        self.assertEqual(
+            self.accel.convert_tokens_to_ids("hello"),
+            self.baseline.convert_tokens_to_ids("hello"),
+        )
+
+    def test_xgrammar_tokenizer_info_still_builds(self):
+        """Constrained decoding builds xgrammar's TokenizerInfo straight from
+        the tokenizer object, reading the backend vocab and decoder. gigatoken's
+        own HFCompat shim cannot satisfy that; patching methods on the real
+        tokenizer must, so this pins the difference.
+        """
+        from xgrammar import TokenizerInfo
+
+        info = TokenizerInfo.from_huggingface(
+            self.accel, vocab_size=self.accel.vocab_size
+        )
+        expected = TokenizerInfo.from_huggingface(
+            self.baseline, vocab_size=self.baseline.vocab_size
+        )
+        self.assertEqual(info.vocab_size, expected.vocab_size)
+        self.assertEqual(info.decoded_vocab, expected.decoded_vocab)
+
+    def test_deepcopy_keeps_working(self):
+        """The accelerated tokenizer must survive `copy.deepcopy`.
+
+        `MultimodalProcessorExecutor.__init__` deepcopies the whole processor to
+        get one clone per worker. The gigatoken backend is a Rust object that
+        cannot be pickled, so before `__deepcopy__` was added this raised
+        `TypeError: cannot pickle 'builtins.BPETokenizer' object`, sglang caught
+        it, and every multimodal server silently dropped to synchronous
+        processing — observed on a live server, not hypothetical.
+        """
+        import copy
+
+        clone = copy.deepcopy(self.accel)
+        text = "Hello, world! 日本語 🚀"
+        self.assertEqual(clone.encode(text), self.baseline.encode(text))
+        self.assertEqual(
+            clone.decode(clone.encode(text)),
+            self.baseline.decode(self.baseline.encode(text)),
+        )
+        # The clone shares the backend rather than building a second cache.
+        self.assertIs(clone._gigatoken, self.accel._gigatoken)
+
+    def test_idempotent(self):
+        """get_tokenizer applies acceleration once; re-applying must not stack
+        another subclass (which would recurse through super() forever)."""
+        from sglang.srt.tokenizer.gigatoken_tokenizer import (
+            accelerate_with_gigatoken,
+        )
+
+        before = type(self.accel)
+        self.assertIs(type(accelerate_with_gigatoken(self.accel)), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang tokenizes one prompt per request on the `TokenizerManager` event loop, where HuggingFace `tokenizers` runs at ~4-5 MB/s per thread. [gigatoken](https://github.com/marcelroed/gigatoken) is a SIMD byte-pair encoder that is 135-194x faster at the raw-API level; through the `transformers` tokenizer surface SGLang actually calls, this lands as a **38-56x** reduction in encode time — a 28k-token prompt costs 21.5 ms of event-loop time today and 0.42 ms with this change (Qwen2.5-1.5B tokenizer, M4 Max). Decode gets 11x on whole sequences and ~3x on the short overlapping windows `DetokenizerManager` streams.

This adds it as an opt-in third choice for the existing `--tokenizer-backend` flag, alongside `huggingface` (default, unchanged) and `fastokens`. Nothing changes unless you pass `--tokenizer-backend=gigatoken`.

## Modifications

- **`python/sglang/srt/tokenizer/gigatoken_tokenizer.py`** (new) — `accelerate_with_gigatoken(tokenizer)` keeps the loaded HF tokenizer and overrides only the four serving hot-path methods (`__call__`, `encode`, `decode`, `batch_decode`) by swapping `__class__` for a generated subclass.

  Rather than replacing the tokenizer object with gigatoken's own HF-compatible shim (`gigatoken.Tokenizer(tok).as_hf()`). Measured against that shim, swapping the whole object loses `chat_template`, `apply_chat_template`, `model_max_length`, `backend_tokenizer`, `save_pretrained`, `init_kwargs` and `clean_up_tokenization_spaces`; `xgrammar.TokenizerInfo.from_huggingface` raises `ValueError: Unsupported tokenizer type`; `apply_chat_template` raises `AttributeError`; and `added_tokens_decoder` yields `str` rather than `AddedToken`, so `.special` lookups break. Patching methods leaves all of that on the real implementation.

  Every call shape gigatoken has not been verified byte-identical on — sequence pairs, padding, truncation, tensor returns, `token_type_ids`, `clean_up_tokenization_spaces`, or anything passed positionally — falls through to transformers. A request can therefore be slower than it could be, but is never tokenized differently. This is deliberately more conservative than gigatoken's shim, which does implement padding/truncation/`return_tensors`; those paths can be opened up later behind parity tests.

  Two properties are established by probing the tokenizer at load rather than by parsing `tokenizer.json`, so they self-correct if gigatoken's behavior changes:
  - The special-token affixes the post-processor adds, read off by encoding a probe with and without specials and diffing (Llama 3's BOS, ModernBERT's CLS/SEP, Nemotron's `[1]` are all discovered this way). This also keeps us off gigatoken's private `_prefix_ids`, and degrades to the HuggingFace path instead of raising for post-processors it cannot reproduce.
  - Whether truncated multi-byte characters detokenize identically. Byte-fallback (SentencePiece) vocabularies emit one U+FFFD per undecodable byte in HF but one per truncated sequence in gigatoken — **14 of 66** overlapping `[surr:read]` windows differ on Llama 2 (`'ok 日本語 ��'` vs `'ok 日本語 �'`) while full-sequence decode matches. Those tokenizers keep HuggingFace for decode and still get gigatoken for encode. This divergence is not documented upstream.

  The subclass also defines `__deepcopy__`. `MultimodalProcessorExecutor.__init__` deepcopies the whole processor to get one clone per worker, and the gigatoken backend is a Rust object that cannot be pickled; without this the copy raised `TypeError: cannot pickle 'builtins.BPETokenizer' object`, which sglang catches — so every multimodal server run with this backend silently lost concurrent multimodal processing, marked only by one log line. This is inherent to the library rather than to this integration: gigatoken defines no `__getstate__`/`__reduce__`/`__deepcopy__` anywhere, and `deepcopy` of its own `as_hf()` shim fails the same way. The copy shares the backend rather than duplicating it: gigatoken's encode holds the GIL so concurrent callers of one backend serialize, and sharing keeps N clones from each allocating another pretoken cache.

- **`python/sglang/srt/utils/hf_transformers/tokenizer.py`** — apply the acceleration last in `_apply_post_load_fixes` (and on the GGUF path), so the overrides sit above every fixup and the affix probing reads the tokenizer in its final configuration. Adds a targeted error message when gigatoken cannot load a tokenizer, mirroring the existing `fastokens` one.
- **`python/sglang/srt/utils/hf_transformers/processor.py`** — accelerate the processor's tokenizer in place, so `processor.tokenizer` (which the multimodal processors call directly) is the accelerated object.
- **`python/sglang/srt/server_args.py`** — `gigatoken` added to the `--tokenizer-backend` choices.
- **`python/pyproject.toml`** — a `[gigatoken]` extra, also pulled into `[test]` so CI can run the new tests.
- **`docs/docs/advanced_features/server_arguments.mdx`** — the `--tokenizer-backend` row updated to list the new choice. The Ascend NPU support matrix (`docs/docs/hardware-platforms/ascend-npus/reference/support_features.mdx`) is deliberately left alone: gigatoken has not been exercised on NPU, so I did not want to imply support there.

## Known limitations

- **Two tokenizers cannot use the flag and fail at startup** with an actionable error (same hard-fail behavior as `--tokenizer-backend=fastokens`):
  - `deepseek-ai/DeepSeek-V3` — SGLang's loader resolves it to class `LlamaTokenizer`, which serializes `byte_fallback=True` over a byte-level vocab carrying no `<0xHH>` tokens, and gigatoken rejects that combination. Note this is specific to SGLang's loader: `AutoTokenizer.from_pretrained` yields `TokenizersBackend` with `byte_fallback=False`, which loads fine. (The two are genuinely different tokenizers — SGLang's prepends BOS `0` that `AutoTokenizer`'s does not, which is `_fix_v5_add_bos_eos_token` working as intended.)
  - `BAAI/bge-reranker-v2-m3` — `XLMRobertaTokenizer` is a Unigram model, which gigatoken does not support.

  Happy to switch either to warn-and-fall-back-to-HuggingFace instead of a hard failure if reviewers prefer that; the current behavior follows the `fastokens` precedent.
- Byte-fallback (SentencePiece) tokenizers use gigatoken for encode and HuggingFace for decode, per the probe above.
- ~25% of the remaining fast-path time at 28k tokens is `prefix + ids.tolist() + suffix` copying the list twice when both affixes are empty (the common case for byte-level BPE). Left as a follow-up rather than folded in here.

## Accuracy Tests

Verified through SGLang's own `get_tokenizer()` — i.e. after all of SGLang's post-load fixups, which is what a server actually runs — across every tokenizer available locally: **21 of 23 load, and all 21 match the `huggingface` backend exactly** on encode (with and without special tokens), `__call__`, full-sequence decode, and every overlapping partial-decode window. The 2 that do not load are the ones listed under Known limitations. Covered: Qwen 2.5/3/3.5, Llama 3/3.2, TinyLlama, Mistral v0.3, Phi-4-mini, OLMo 2, GLM 4.5-Air, Nemotron Nano, Kimi K2, GPT-OSS, ModernBERT, and the Llama 2 (byte-fallback) tokenizer.

A wider earlier sweep over 15 tokenizer families on ~1518 ShareGPT turns plus adversarial synthetics — encode with and without specials, batch encode, decode, and every incremental decode window — was run against directly-loaded HuggingFace tokenizers. That sweep listed DeepSeek V3 as passing; it does *not* hold through SGLang's loader, per Known limitations, and the DeepSeek claim should be read as withdrawn. A live server produced identical greedy outputs and identical streaming chunks against the default backend.

`test/registered/unit/utils/test_hf_transformers_gigatoken.py` passes (13 tests, 78 subtests), as do the neighbouring `test_hf_transformers.py` and `test_patch_tokenizer.py` (83 tests total), confirming the default path is untouched.

## Speed Tests and Profiling

Encode, Qwen2.5-1.5B tokenizer, M4 Max. "SGLang+gigatoken" is the patched `tokenizer.encode()` a server actually calls; "raw API" is `gigatoken.Tokenizer.encode()` returning numpy, shown to make clear where the remaining overhead lives (`.tolist()` into Python lists, which SGLang needs).

| tokens | transformers | SGLang+gigatoken | delivered | raw gigatoken API | raw-API speedup |
|---|---|---|---|---|---|
| 101 | 84 us | 2.2 us | **38x** | 0.6 us | 135x |
| 901 | 663 us | 11.9 us | **56x** | 3.4 us | 194x |
| 7,001 | 5,274 us | 106 us | **50x** | 29 us | 181x |
| 28,001 | 21,544 us | 423 us | **51x** | 116 us | 185x |

Decode, same tokenizer:

| shape | transformers | SGLang+gigatoken | speedup |
|---|---|---|---|
| single decode, 901 ids | 88 us | 8.2 us | 11x |
| `batch_decode`, 64 short streaming windows | 103 us | 34 us | 3x |

This is CPU-side event-loop cost, so the end-to-end effect is on TTFT and on `TokenizerManager` throughput under many concurrent long prompts, not on GPU kernels.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
