### PR TITLE
[AMD] Fix Quark W4A4 MXFP4 MoE clamped-SwiGLU on the AITER path

### DIFF
--- a/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
+++ b/python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -614,7 +615,23 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             moe_runner_backend = MoeRunnerBackend.AITER
 
         if moe_runner_backend.is_aiter():
-            self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
+            # The AITER MXFP4 per-1x32 kernel keys its q_dtype_a / kernel
+            # selection on activation == Swiglu. Clamped-SwiGLU checkpoints
+            # (e.g. MiniMax-M3) declare activation="silu" together with a
+            # gemm1_clamp_limit, so translate it to "swiglu" here, mirroring
+            # Mxfp4MoEMethod (gpt-oss). Without this the runner quantizes
+            # activations on the plain-SiLU branch and produces garbage.
+            # Plain-SwiGLU Quark MXFP4 models (no clamp) keep activation="silu"
+            # so their existing path is untouched.
+            aiter_config = moe_runner_config
+            swiglu_limit = (
+                moe_runner_config.gemm1_clamp_limit
+                or moe_runner_config.swiglu_limit
+                or 0.0
+            )
+            if swiglu_limit > 0:
+                aiter_config = replace(moe_runner_config, activation="swiglu")
+            self.runner = MoeRunner(moe_runner_backend, aiter_config)
         else:
             # TODO(cwan): refactor other backends
             pass
@@ -647,5 +664,14 @@ class QuarkW4A4MXFp4MoE(QuarkMoEScheme):
             w13_scale=layer.w13_weight_scale,
             w2_scale=layer.w2_weight_scale,
             expert_mask=layer.dispatcher.expert_mask_gpu,
+            # Forward the GPT-OSS-style clamped-SwiGLU limit so the AITER MoE
+            # runner enters the clamped-SwiGLU path (gate_mode + swiglu_limit)
+            # instead of plain SiLU. Mirrors Mxfp4MoEMethod; checkpoints without
+            # a clamp resolve to 0.0 and keep the previous behavior.
+            swiglu_limit=(
+                self.moe_runner_config.gemm1_clamp_limit
+                or self.moe_runner_config.swiglu_limit
+                or 0.0
+            ),
         )
         return self.runner.run(dispatch_output, quant_info)

--- a/test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4_moe.py
+++ b/test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4_moe.py
@@ -1,0 +1,126 @@
+"""Unit tests for the Quark W4A4 MXFP4 MoE clamped-SwiGLU plumbing.
+
+CPU-only, no model loading and no aiter/ROCm dependency: they exercise the
+pure-Python control flow in ``QuarkW4A4MXFp4MoE.create_moe_runner`` and
+``apply_weights`` that decides whether the AITER MoE runner is driven on the
+clamped-SwiGLU path (``activation="swiglu"`` + ``swiglu_limit``) or the plain
+SiLU path. See the regression these guard against: clamped-SwiGLU MXFP4
+checkpoints (e.g. MiniMax-M3) declare ``activation="silu"`` + a
+``gemm1_clamp_limit``, and without this plumbing the experts silently run plain
+SiLU and emit garbage.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import sglang.srt.layers.moe.utils as moe_utils
+import sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4_moe as quark_moe
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.quantization.quark.schemes.quark_w4a4_mxfp4_moe import (
+    QuarkW4A4MXFp4MoE,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_scheme() -> QuarkW4A4MXFp4MoE:
+    # is_checkpoint_mxfp4_serialized=True skips the gfx95 hardware check.
+    return QuarkW4A4MXFp4MoE(
+        weight_config={"qscheme": "per_group"},
+        input_config={"qscheme": "per_group", "is_dynamic": True},
+    )
+
+
+def _force_aiter_runner(monkeypatch):
+    """Make ``create_moe_runner`` take the AITER branch and capture its config."""
+    captured = {}
+
+    def fake_moe_runner(backend, config):
+        captured["backend"] = backend
+        captured["config"] = config
+        return object()
+
+    monkeypatch.setattr(quark_moe, "MoeRunner", fake_moe_runner)
+    monkeypatch.setattr(
+        moe_utils, "get_moe_runner_backend", lambda: MoeRunnerBackend.AITER
+    )
+    return captured
+
+
+def _fake_layer():
+    # dtype uint8 so we never hit the float4_e2m1fn_x2 view branch (also guarded
+    # by delattr in the apply_weights tests below).
+    return SimpleNamespace(
+        w13_weight=torch.zeros(1, dtype=torch.uint8),
+        w2_weight=torch.zeros(1, dtype=torch.uint8),
+        w13_weight_scale=torch.zeros(1, dtype=torch.uint8),
+        w2_weight_scale=torch.zeros(1, dtype=torch.uint8),
+        dispatcher=SimpleNamespace(expert_mask_gpu=torch.zeros(1)),
+    )
+
+
+def _capturing_runner(store):
+    class _Runner:
+        def run(self, dispatch_output, quant_info):
+            store["quant_info"] = quant_info
+            return "ran"
+
+    return _Runner()
+
+
+def test_create_moe_runner_translates_activation_to_swiglu_when_clamped(monkeypatch):
+    captured = _force_aiter_runner(monkeypatch)
+    scheme = _make_scheme()
+
+    cfg = MoeRunnerConfig(activation="silu", gemm1_clamp_limit=7.0)
+    scheme.create_moe_runner(layer=None, moe_runner_config=cfg)
+
+    assert captured["config"].activation == "swiglu"
+    # The original config is left untouched (dataclasses.replace returns a copy).
+    assert cfg.activation == "silu"
+
+
+def test_create_moe_runner_keeps_silu_without_clamp(monkeypatch):
+    captured = _force_aiter_runner(monkeypatch)
+    scheme = _make_scheme()
+
+    cfg = MoeRunnerConfig(activation="silu")  # no clamp
+    scheme.create_moe_runner(layer=None, moe_runner_config=cfg)
+
+    assert captured["config"].activation == "silu"
+    assert captured["config"] is cfg
+
+
+def test_apply_weights_forwards_swiglu_limit_when_clamped(monkeypatch):
+    monkeypatch.delattr(torch, "float4_e2m1fn_x2", raising=False)
+    scheme = _make_scheme()
+    scheme.moe_runner_config = MoeRunnerConfig(
+        activation="swiglu", gemm1_clamp_limit=7.0
+    )
+    store = {}
+    scheme.runner = _capturing_runner(store)
+
+    result = scheme.apply_weights(_fake_layer(), dispatch_output=object())
+
+    assert result == "ran"
+    assert store["quant_info"].swiglu_limit == 7.0
+
+
+def test_apply_weights_defaults_swiglu_limit_zero_without_clamp(monkeypatch):
+    monkeypatch.delattr(torch, "float4_e2m1fn_x2", raising=False)
+    scheme = _make_scheme()
+    scheme.moe_runner_config = MoeRunnerConfig(activation="silu")  # no clamp
+    store = {}
+    scheme.runner = _capturing_runner(store)
+
+    scheme.apply_weights(_fake_layer(), dispatch_output=object())
+
+    assert store["quant_info"].swiglu_limit == 0.0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation
This PR fixes output quality for `amd/MiniMax-M3-MXFP4`.

The Quark W4A4 MXFP4 scheme omits `swiglu_limit` when building `AiterMoeQuantInfo`, so MiniMax-M3's clamped-SiLU MoE (`gemm1_alpha`=1.702, `gemm1_clamp_limit`=7.0) never gets clamped in the AITER runner (`layers/moe/moe_runner/aiter.py`), producing garbage output. 

## Modifications

`python/sglang/srt/layers/quantization/quark/schemes/quark_w4a4_mxfp4_moe.py` (mirrors `Mxfp4MoEMethod`):

- `create_moe_runner`: for the AITER backend, translate `activation` to `"swiglu"` via `dataclasses.replace` when a clamp limit is set
  (`gemm1_clamp_limit`/`swiglu_limit > 0`).
- `apply_weights`: forward `swiglu_limit = gemm1_clamp_limit or swiglu_limit or 0.0` onto `AiterMoeQuantInfo`.

Both are **gated on a positive clamp limit**, so plain-SwiGLU Quark MXFP4 models (limit unset → 0.0) keep `activation="silu"` and `swiglu_limit=0.0` and are unchanged.

Runtime note: to match MiniMax-M3's `interleaved=False` gate/up layout, launch
with `SGLANG_USE_AITER_MOE_GU_ITLV=0` (SEPARATED gate_mode). This env is
already handled upstream in the AITER runner; this PR only makes the runner
reach that path.

## Accuracy Tests

amd/MiniMax-M3-MXFP4, TP4, MI350x/MI355x.

- Before this fix: MXFP4 output is incoherent (token-salad); 
- After this fix: coherent output; AIME25 ≈ 0.81–0.83 (n=10) vs 0.88 for the
  BF16 baseline. 
 GSM8k test: 
{
  "gsm8k": {
    "name": "gsm8k",
    "alias": "gsm8k",
    "sample_len": 1319,
    "exact_match,strict-match": 0.9507202426080363,
    "exact_match_stderr,strict-match": 0.00596215065581247,
    "exact_match,flexible-extract": 0.9613343442001516,
    "exact_match_stderr,flexible-extract": 0.005310583162098061
  }
}
evalscope:10 times AIME25
{
  "aime25/MiniMax-M3-MXFP4@aime25": 0.8367,
  "aime25/mean_acc": 0.8367,
  "aime25/default": 0.8367
}

## Benchmarking and Profiling
The changed branch is taken only for clamped-SwiGLU checkpoints, and plain-SwiGLU Quark MXFP4 models run the
identical code path as before (`activation="silu"`, `swiglu_limit=0.0`), so
there is no hot-path change. Serving throughput of `amd/MiniMax-M3-MXFP4` with
the fix applied (`SGLANG_USE_AITER`, `SGLANG_USE_AITER_MOE_GU_ITLV=0`), TP4 on
MI350x:
Config: `generated-shared-prefix`, concurrency 4 (unbounded request rate),
1024 in / 1024 out, 32 requests, 208 s.
| Metric | Value |
| --- | --- |
| Requests completed | 32 |
| Request throughput | 0.15 req/s |
| Output throughput | **307 tok/s** |
| Total throughput | 12,886 tok/s |
| Input throughput | 12,579 tok/s |
| Effective concurrency | 4.0 |
Latency (median / p99):
| Metric | Median | p99 |
| --- | --- | --- |
| E2E latency | 25.5 s | 29.0 s |
| TTFT | 1.77 s | 5.86 s |
| TPOT (per output token) | 11.9 ms | 12.2 ms |
| ITL (inter-token) | 11.6 ms | 23.3 ms |

## Unit tests

`test/registered/unit/layers/quantization/test_quark_w4a4_mxfp4_moe.py`
(CPU-only): asserts the activation translation happens iff a clamp limit is
set, and that `swiglu_limit` is forwarded (clamped) / stays 0.0 (unclamped).

## Checklist

- [x] Format code with pre-commit (black 26.1.0, isort 7.0.0).
- [x] Add unit tests.
- [X] Provide accuracy/speed benchmark results (fill in exact numbers above).
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31575062322](https://github.com/sgl-project/sglang/actions/runs/31575062322)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31575062051](https://github.com/sgl-project/sglang/actions/runs/31575062051)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->