### PR TITLE
[AMD] [Bugfix] Stop registering oversized inputs in the AMD deterministic all-reduce

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -293,18 +293,47 @@ class CustomAllreduce:
                 )
         elif self.use_amd_deterministic_impl:
             inp_size = inp.numel() * inp.element_size()
-            if inp_size < self.max_size:
+            if inp_size <= self.max_size:
                 reg_buffer = self.buffer.view(inp.dtype)[: inp.numel()]
                 ops.deterministic_all_reduce_unreg(self._ptr, inp, reg_buffer, out)
             else:
-                self.register_buffer(inp)
-                ops.deterministic_all_reduce_reg(self._ptr, inp, out)
+                self._deterministic_all_reduce_oversized(inp, out)
         else:  # normal AMD ROCm path
             if registered:
                 ops.all_reduce_reg(self._ptr, inp, out)
             else:
                 ops.all_reduce_unreg(self._ptr, inp, self.buffer, out)
         return out
+
+    def _deterministic_all_reduce_oversized(
+        self, inp: torch.Tensor, out: torch.Tensor
+    ) -> None:
+        """Reduce an input larger than `self.buffer` one piece at a time.
+
+        Registering the input instead would be cheaper per call, but each
+        registration permanently consumes a `rank_data` slot, so a server that
+        keeps seeing oversized inputs (a large `chunked_prefill_size` is enough
+        to produce one per forward pass) eventually dies with "Rank data buffer
+        is overflowed". Splitting cannot change the result of any element: an
+        all-reduce is elementwise, and the 1-stage kernel accumulates ranks in
+        a fixed order regardless of how many elements it is given.
+        """
+        # `should_custom_ar` only guarantees weak contiguity, so alias the flat
+        # memory span the kernel reads rather than going through `view`.
+        flat_inp = inp.as_strided((inp.numel(),), (1,))
+        flat_out = out.as_strided((out.numel(),), (1,))
+        reg_buffer = self.buffer.view(inp.dtype)
+        # `max_size` is a multiple of 16 bytes, so every piece keeps the 16-byte
+        # size and alignment the kernel requires.
+        chunk = self.max_size // inp.element_size()
+        for beg in range(0, flat_inp.numel(), chunk):
+            piece = flat_inp[beg : beg + chunk]
+            ops.deterministic_all_reduce_unreg(
+                self._ptr,
+                piece,
+                reg_buffer[: piece.numel()],
+                flat_out[beg : beg + chunk],
+            )
 
     def custom_all_reduce(self, input: torch.Tensor) -> Optional[torch.Tensor]:
         """The main allreduce API that provides support for cuda graph."""

--- a/test/registered/kernels/ops/communication/test_amd_deterministic_custom_allreduce.py
+++ b/test/registered/kernels/ops/communication/test_amd_deterministic_custom_allreduce.py
@@ -11,6 +11,9 @@ This test compares:
 1. Deterministic kernel (same batch size)
 2. Deterministic kernel (different batch size)
 
+It also checks inputs larger than the staging buffer the kernel reduces
+through, which are all-reduced in pieces.
+
 Usage:
     pytest test_amd_deterministic_custom_allreduce.py
 """
@@ -208,12 +211,95 @@ def worker(world_size, rank, port):
     dist.destroy_process_group()
 
 
-def main():
+# The staging buffer the deterministic kernel reduces through holds `max_size`
+# bytes, and a small one makes the behaviour of larger inputs cheap to check.
+OVERSIZED_MAX_SIZE = 256 * 1024
+
+
+def oversized_worker(world_size, rank, port):
+    """All-reduce inputs that do not fit in the staging buffer, repeatedly.
+
+    Such an input used to be registered on every call, and registrations are
+    never released, so a long-running server eventually died with "Rank data
+    buffer is overflowed".
+    """
+    envs.SGLANG_USE_1STAGE_ALLREDUCE.set("1")
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    dist.init_process_group(
+        backend="nccl",
+        init_method=f"tcp://localhost:{port}",
+        rank=rank,
+        world_size=world_size,
+    )
+
+    from torch.distributed import new_group
+
+    from sglang.srt.distributed.device_communicators.custom_all_reduce import (
+        CustomAllreduce,
+    )
+
+    dist.barrier()
+    ar_group = new_group(backend="gloo")
+    dist.barrier()
+
+    custom_ar = CustomAllreduce(
+        group=ar_group, device=device, max_size=OVERSIZED_MAX_SIZE
+    )
+    if custom_ar.disabled or not custom_ar.use_amd_deterministic_impl:
+        if rank == 0:
+            print("✗ Deterministic custom AR not available")
+        dist.destroy_process_group()
+        return
+
+    def check(numel, num_calls):
+        # Small integers, exact in fp32, repeating with a period that does not
+        # divide the piece size, so a misplaced piece changes the result.
+        pattern = (torch.arange(numel, device=device, dtype=torch.float32) % 1021) + 1
+        inp = pattern * (rank + 1)
+        expected = pattern * (world_size * (world_size + 1) // 2)
+        for call in range(num_calls):
+            result = custom_ar.custom_all_reduce(inp)
+            assert result is not None, "custom all-reduce declined the input"
+            if call in (0, num_calls - 1):
+                torch.cuda.synchronize()
+                wrong = result != expected
+                if wrong.any():
+                    idx = int(wrong.to(torch.uint8).argmax())
+                    raise AssertionError(
+                        f"rank {rank}: call {call + 1} on {numel} elements is "
+                        f"wrong in {int(wrong.sum())} places, first at index "
+                        f"{idx}: got {result[idx].item()}, "
+                        f"want {expected[idx].item()}"
+                    )
+
+    # Control: an input that fits, so a failure below is about the size of the
+    # input and not about the kernel or the harness.
+    buffer_elements = OVERSIZED_MAX_SIZE // 4
+    check(buffer_elements // 2, num_calls=1)
+    if rank == 0:
+        print("  ✓ input that fits in the staging buffer: correct")
+
+    # One registration per call used to take a `RankData` slot, and `rank_data`
+    # holds `max_size / sizeof(RankData)` of them; 16 bytes deliberately
+    # under-estimates the 64-byte struct, so this overruns the budget either
+    # way. 2.5 buffers of input also leaves a partial piece at the end.
+    num_calls = OVERSIZED_MAX_SIZE // 16 + 1
+    check(buffer_elements * 5 // 2, num_calls=num_calls)
+    if rank == 0:
+        print(f"  ✓ {num_calls} all-reduces of an oversized input: correct")
+
+    dist.barrier()
+    dist.destroy_process_group()
+
+
+def run_workers(target, title):
     world_size = 8
     available_gpus = torch.cuda.device_count()
 
     print("=" * 70)
-    print("Deterministic Kernel All-Reduce Determinism Test")
+    print(title)
     print("=" * 70)
     print(f"Available GPUs: {available_gpus}")
     print(f"Using world_size: {world_size}")
@@ -233,21 +319,39 @@ def main():
 
     procs = []
     for rank in range(world_size):
-        p = mp.Process(target=worker, args=(world_size, rank, port))
+        p = mp.Process(target=target, args=(world_size, rank, port))
         p.start()
         procs.append(p)
 
     for p in procs:
         p.join()
 
+    failed = {rank: p.exitcode for rank, p in enumerate(procs) if p.exitcode != 0}
+    if failed:
+        raise AssertionError(f"worker processes failed, exit codes by rank: {failed}")
 
-@pytest.mark.skipif(
+
+def main():
+    run_workers(worker, "Deterministic Kernel All-Reduce Determinism Test")
+    run_workers(oversized_worker, "Deterministic Kernel Oversized Input Test")
+
+
+requires_two_gpus = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2,
     reason="Requires at least 2 CUDA GPUs",
 )
+
+
+@requires_two_gpus
 def test_deterministic_custom_allreduce():
     """Test that deterministic custom all-reduce produces consistent results."""
-    main()
+    run_workers(worker, "Deterministic Kernel All-Reduce Determinism Test")
+
+
+@requires_two_gpus
+def test_deterministic_custom_allreduce_oversized_input():
+    """Test inputs larger than the staging buffer, repeated."""
+    run_workers(oversized_worker, "Deterministic Kernel Oversized Input Test")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

On ROCm with `SGLANG_USE_1STAGE_ALLREDUCE=1`, `should_custom_ar()` accepts an input of any size, and `_all_reduce_impl()` routes anything that does not fit the staging buffer to `self.register_buffer(inp)` + `deterministic_all_reduce_reg()`. That registration happens on every call and is never released: `CustomAllreduce::register_buffer()` does `d_rank_data_base_++` and nothing ever hands a slot back, so `rank_data` is a countdown. It holds `max_size / sizeof(RankData)` entries, which is 262144 at the 16 MiB ROCm default.

Anything whose activations exceed `max_size` hits this. At hidden size 6144 in bf16 that is about 1365 tokens, far below a typical `chunked_prefill_size`, so every prefill forward pass burns a slot. Two MiniMax-M3 benchmark sweeps on MI355X died mid-run, both after roughly 55 minutes, with:

```
File "/sgl-workspace/sglang/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py", line 232, in register_buffer
    ops.register_buffer(self._ptr, inp, handles, offsets)
RuntimeError: Rank data buffer is overflowed by 1
```

The scheduler then sends SIGQUIT and the container exits 0, so from the outside the run looks like it finished.

That path also does not reduce. On 2x MI355X the output of an oversized all-reduce is the caller's own input rather than the sum across ranks, which is easy to miss because the leak usually kills the server first. Both problems go away when the input is reduced through the staging buffer instead, so this PR removes the registering path rather than trying to bound it.

## Modifications

- `_all_reduce_impl()` no longer registers oversized inputs. The new `_deterministic_all_reduce_oversized()` reduces them through the pre-registered staging buffer one `max_size` piece at a time. An all-reduce is elementwise and the 1-stage kernel accumulates ranks in a fixed order whatever the length, so neither results nor determinism change; `max_size` is a multiple of 16 bytes, so every piece keeps the size and alignment the kernel requires.
- The in-buffer branch now tests `inp_size <= self.max_size` rather than `<`, so an input of exactly `max_size` uses the single-shot path it fits in.
- `test_amd_deterministic_custom_allreduce.py` gains a case that repeatedly all-reduces an oversized input against an instance with a 256 KiB `max_size`, which reaches the same slot limit in seconds instead of an hour, preceded by a control with an input that fits. Its harness previously ignored worker exit codes, so a failing rank could not fail the test; it now reports them.

## Accuracy Tests

`test/registered/kernels/ops/communication/test_amd_deterministic_custom_allreduce.py` on 2x MI355X, ROCm 7.2, `SGLANG_USE_1STAGE_ALLREDUCE=1`. Inputs are per-rank multiples of a fixed integer pattern, so the expected sum is exact in fp32 and a misplaced piece changes the result.

| case | before | after |
| --- | --- | --- |
| batch-size invariance (existing tests 1 and 2) | deterministic | deterministic |
| input that fits in the staging buffer | correct | correct |
| oversized input, first call | wrong in 131072 of 163840 elements, output equals the caller's own input | correct |
| oversized input, 16385 calls | `RuntimeError: Rank data buffer is overflowed by 1` after 4095 calls, matching the 4096 slots a 256 KiB `rank_data` holds | correct, no growth |

## Speed Tests and Profiling

Inputs at or below `max_size`, which is every decode step and every prefill under the threshold, are unchanged. An oversized input now costs `ceil(bytes / max_size)` kernel launches instead of one, against a path that previously did a `hipMemcpy` of the `RankData` plus an `hipIpcOpenMemHandle` per peer on every single call, so this is not a regression relative to what it replaces.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31577597599](https://github.com/sgl-project/sglang/actions/runs/31577597599)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31577597212](https://github.com/sgl-project/sglang/actions/runs/31577597212)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->