### PR TITLE
Fix flaky negative penalty test

### DIFF
--- a/test/registered/sampling/test_penalty.py
+++ b/test/registered/sampling/test_penalty.py
@@ -216,26 +216,6 @@ class TestPenalty(CustomTestCase):
         }
         self._test_penalty_effect(prompt, baseline_params, penalty_params)
 
-    def test_penalty_edge_cases_negative_penalty_values(self):
-        """Test that negative penalties decrease vocabulary diversity."""
-        prompt = "Write the word 'test' exactly 15 times in a row, separated by spaces."
-        baseline_params = {
-            "frequency_penalty": 0.0,
-            "presence_penalty": 0.0,
-            "repetition_penalty": 1.0,
-        }
-        negative_penalty_params = {
-            "frequency_penalty": -0.5,
-            "presence_penalty": -0.25,
-            "repetition_penalty": 1.0,
-        }
-        self._test_penalty_effect(
-            prompt,
-            baseline_params,
-            negative_penalty_params,
-            expected_reduction=False,
-        )
-
     def test_penalty_edge_cases_extreme_penalty_values(self):
         """Test that extreme penalties strongly increase vocabulary diversity."""
         prompt = (

--- a/test/registered/unit/sampling/test_penaltylib.py
+++ b/test/registered/unit/sampling/test_penaltylib.py
@@ -184,6 +184,18 @@ class TestBatchedFrequencyPenalizer(CustomTestCase):
         pen.apply(logits)
         self.assertAlmostEqual(logits[0, 3].item(), -2.0, places=5)
 
+    def test_negative_penalty_increases_repeated_token_logit(self):
+        """Test that a negative frequency penalty rewards repeated tokens."""
+        _, pen = self._setup([-0.5])
+        pen.cumulate_output_tokens(torch.tensor([4]))
+        pen.cumulate_output_tokens(torch.tensor([4]))
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+
+        self.assertAlmostEqual(logits[0, 4].item(), 1.0, places=5)
+        self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
+
     def test_filter_keeps_subset(self):
         """Test that filter retains only the selected batch indices."""
         orch, pen = self._setup([1.0, 2.0])
@@ -249,6 +261,18 @@ class TestBatchedPresencePenalizer(CustomTestCase):
         pen.apply(logits)
         # scatter_ overwrites (not adds), so penalty should be 1.0, not 2.0
         self.assertAlmostEqual(logits[0, 7].item(), -1.0, places=5)
+
+    def test_negative_penalty_increases_present_token_logit(self):
+        """Test that a negative presence penalty rewards a present token once."""
+        _, pen = self._setup([-0.75])
+        pen.cumulate_output_tokens(torch.tensor([7]))
+        pen.cumulate_output_tokens(torch.tensor([7]))
+
+        logits = torch.zeros(1, VOCAB_SIZE)
+        pen.apply(logits)
+
+        self.assertAlmostEqual(logits[0, 7].item(), 0.75, places=5)
+        self.assertAlmostEqual(logits[0, 0].item(), 0.0, places=5)
 
     def test_filter_keeps_subset(self):
         """Test that filter retains the first request's presence penalty."""


### PR DESCRIPTION
[by Codex]

## Summary

- remove the stochastic negative-penalty integration assertion based on whole-completion vocabulary diversity
- add deterministic unit coverage showing that negative frequency penalties increase a repeated token's logit
- add deterministic unit coverage showing that negative presence penalties increase a present token's logit once

## Why this is needed

`test_penalty_edge_cases_negative_penalty_values` intermittently fails on the RTX 5090 CI runner. One example is the unrelated failure seen in #27689: https://github.com/sgl-project/sglang/actions/runs/31560198226/job/94007819037?pr=27689

The test assumes that rewarding previously seen tokens must reduce vocabulary diversity over an entire generated completion. That does not follow from the penalty semantics. Frequency and presence penalties adjust individual next-token logits, but once sampling selects a different token, the two autoregressive generations can follow completely different trajectories. Their final unique-word ratios therefore do not have a guaranteed ordering, even when the penalty implementation is correct.

The failed job demonstrated this instability twice:

- first attempt: baseline diversity `0.140`, negative-penalty diversity `0.237`
- retry: baseline diversity `0.058`, negative-penalty diversity `0.205`

The implementation already applies the expected sign: subtracting a negative accumulated penalty raises the logit of a repeated/present token. The new unit tests verify that behavior directly without model sampling.

## Test history

- #11931 originally added the negative-penalty integration test. It counted occurrences of the prompted word with the near-greedy default temperature of `0.05`.
- #18285 added fixed seeds while addressing flakiness in the same penalty-effect helper.
- #18380 attempted to make the penalty tests more effective, but it also changed this case to whole-completion vocabulary diversity, raised temperature to `0.8`, and increased generation length to 150 tokens. Those changes made the negative case depend on long sampled trajectories and produced the current intermittent failure mode.

This PR keeps the end-to-end positive-penalty integration coverage and moves the negative sign/accumulation guarantees to deterministic unit tests.

## Validation

- `python3 test/registered/unit/sampling/test_penaltylib.py`: 42 tests passed
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`: passed

CI has intentionally not been triggered yet.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31579339705](https://github.com/sgl-project/sglang/actions/runs/31579339705)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31579339506](https://github.com/sgl-project/sglang/actions/runs/31579339506)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->