### PR TITLE
[Cherry-pick to release/v0.5.17] Backport 2-CTA TGV exit barrier (#32954)

### DIFF
--- a/python/sglang/kernels/ops/gemm/cutedsl_bf16_gemm.py
+++ b/python/sglang/kernels/ops/gemm/cutedsl_bf16_gemm.py
@@ -490,6 +490,21 @@ class TgvGemmCuteExtKernel:
                 d_layout,
             )
 
+        if cutlass.const_expr(self.use_2cta):
+            # Cluster-wide exit barrier (sgl-project/sglang#32907): cluster
+            # sync previously existed only at kernel entry, so one CTA could
+            # retire while its peer still had in-flight peer-redirected
+            # mbarrier arrives / multicast tcgen05.commit / TMEM dealloc
+            # targeting it -> CUDBG_EXCEPTION_CLUSTER_BLOCK_NOT_PRESENT
+            # (Xid 13 "CTA Not Present"). All 8 warps (256 threads) of both
+            # cluster CTAs arrive here after their dispatch branch returns,
+            # so no CTA can exit until the peer's tail work has landed.
+            # relaxed arrive (matches the entry barrier at L378): this fence is
+            # only about CTA lifetime, not inter-CTA smem visibility -- every
+            # cross-CTA datum above already flows through mbarrier phases.
+            cute.arch.cluster_arrive_relaxed()
+            cute.arch.cluster_wait()
+
     # ====================================================================
     # DMA_A WARP — TMA-loads A tiles into sA[..., stage], one per K-iter.
     # 1-CTA: SM90_TMA_LOAD into local sA, arrives on local bar_full.


### PR DESCRIPTION
## Motivation

Addresses #34522.

Issue #34522 reports a reproducible `CUDA error: unspecified launch failure` on Kimi-K3 + DSPARK at concurrency 1 on SM103 with SGLang v0.5.17. That release predates the merged 2-CTA TGV kernel-exit race fix in #32954:

- `v0.5.17`: `29481685462732237d80d86076d6563e1f658102` (2026-08-07)
- source fix: `166c6f71811087d427feed48c685356965810707` (2026-08-11)

The release branch still lacks the trailing cluster barrier. This matches the affected low-batch path: on SM10x, Kimi-K3 BF16 GEMMs with `m <= 8` select the CuTeDSL TGV kernel, and the failure is reported asynchronously at the scheduler's next stream synchronization.

## Modifications

Exact backport of the kernel change from #32954 to `release/v0.5.17`:

```python
if cutlass.const_expr(self.use_2cta):
    cute.arch.cluster_arrive_relaxed()
    cute.arch.cluster_wait()
```

The barrier keeps both CTAs alive until peer-directed mbarrier/TMEM tail work has landed. It is compiled out for 1-CTA tactics. No backend policy, hardware support, or model selection is changed.

**Source PR:** #32954  
**Source commit:** `166c6f71811087d427feed48c685356965810707`

## Validation

- `git diff --check`
- `python -m compileall -q python/sglang/kernels/ops/gemm/cutedsl_bf16_gemm.py`
- Stable patch ID matches the accepted source commit exactly: `fa477d62b96943889ce289b1846f82292e94a5c1`
- Source PR #32954 includes B300/SM103 Kimi-K3 + DSPARK production soak, numeric checks, and PDL CUDA-graph stress results.

This backport was not rerun on SM103 hardware locally. The reporter should retest the single-concurrency reproduction with this branch and check `dmesg` for Xid 13 / `CTA Not Present` if the failure persists.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829029376](https://github.com/sgl-project/sglang/actions/runs/34829029376)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829029179](https://github.com/sgl-project/sglang/actions/runs/34829029179)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->