### PR TITLE
[Bugfix] Preserve MXFP4 Triton weights in sharded state

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -948,6 +948,18 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 layer.w2_weight, layer.w2_weight_scale, num_warps
             )
 
+            # Keep the postprocessed storage registered on the layer so model
+            # state exports contain the tensors consumed by Triton kernels.
+            for name, tensor in (
+                ("w13_weight", w13_weight),
+                ("w13_weight_scale", w13_scale),
+                ("w2_weight", w2_weight),
+                ("w2_weight_scale", w2_scale),
+            ):
+                param = getattr(layer, name)
+                param.data = tensor.storage.data
+                tensor.storage.data = param
+
             self.w13_precision_config = PrecisionConfig(
                 b_mx_scale=w13_scale, flex_ctx=FlexCtx(rhs_data=w13_flex)
             )
@@ -957,8 +969,6 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
 
             self.w13_weight_triton_tensor = w13_weight
             self.w2_weight_triton_tensor = w2_weight
-            del layer.w13_weight
-            del layer.w2_weight
         elif _is_cpu and _is_cpu_amx_available:
             _amx_process_weight_after_loading(layer, ["w13_weight", "w2_weight"])
             if use_intel_amx_backend(layer):

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -1677,7 +1677,9 @@ class ShardedStateLoader(BaseModelLoader):
                 part_idx += 1
                 total_size = 0
                 state_dict_part = {}
-            state_dict_part[key] = tensor
+            state_dict_part[key] = (
+                tensor.detach().to(device="cpu", copy=False).contiguous()
+            )
             total_size += param_size
         if len(state_dict_part) > 0:
             filename = pattern.format(rank=rank, part=part_idx)

--- a/test/registered/unit/model_loader/test_mxfp4_sharded_state.py
+++ b/test/registered/unit/model_loader/test_mxfp4_sharded_state.py
@@ -1,0 +1,148 @@
+"""Regression test for MXFP4 Triton-kernel sharded state exports."""
+
+import sys
+import tempfile
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from safetensors.torch import safe_open
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+maybe_stub_sgl_kernel()
+
+import sglang.srt.layers.quantization.mxfp4 as mxfp4_module  # noqa: E402
+import sglang.srt.model_loader.loader as loader_module  # noqa: E402
+from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod  # noqa: E402
+from sglang.srt.model_loader.loader import ShardedStateLoader  # noqa: E402
+
+_RUNTIME_STATE_NAMES = (
+    "w13_weight",
+    "w13_weight_scale",
+    "w2_weight",
+    "w2_weight_scale",
+)
+
+
+def _new_method():
+    method = Mxfp4MoEMethod.__new__(Mxfp4MoEMethod)
+    method.use_marlin = False
+    method.use_deep_gemm = False
+    method._fi_kernel = None
+    method.use_flashinfer = False
+    method.use_triton_kernels = True
+    return method
+
+
+class _TinyMxfp4Layer(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        for name, shape, value in (
+            ("w13_weight", (1, 4, 3), 17),
+            ("w13_weight_scale", (1, 4, 2), 113),
+            ("w2_weight", (1, 3, 2), 18),
+            ("w2_weight_scale", (1, 3, 2), 114),
+        ):
+            parameter = torch.nn.Parameter(
+                torch.full(shape, value, dtype=torch.uint8), requires_grad=False
+            )
+            parameter.test_marker = name
+            self.register_parameter(name, parameter)
+        self.w13_weight_bias = torch.nn.Parameter(
+            torch.full((1, 4), 3, dtype=torch.bfloat16), requires_grad=False
+        )
+        self.w2_weight_bias = torch.nn.Parameter(
+            torch.full((1, 3), 4, dtype=torch.bfloat16), requires_grad=False
+        )
+
+
+class _WrappedTensor:
+    def __init__(self, data):
+        self.storage = SimpleNamespace(data=data)
+
+    @property
+    def data(self):
+        return self.storage.data
+
+
+def _fake_swizzle(weight, scale, _num_warps):
+    def wrap(tensor):
+        data = tensor.detach().clone().transpose(-2, -1)
+        return _WrappedTensor(data)
+
+    return wrap(weight), object(), wrap(scale)
+
+
+class TestMxfp4ShardedState(CustomTestCase):
+    def test_runtime_weight_and_scale_round_trip(self):
+        triton_kernels = ModuleType("triton_kernels")
+        triton_kernels.__path__ = []
+        triton_matmul = ModuleType("triton_kernels.matmul")
+        triton_matmul.FlexCtx = SimpleNamespace
+        triton_matmul.PrecisionConfig = SimpleNamespace
+
+        layer = _TinyMxfp4Layer()
+        method = _new_method()
+        original_parameters = {
+            name: getattr(layer, name) for name in _RUNTIME_STATE_NAMES
+        }
+
+        with patch.dict(
+            sys.modules,
+            {
+                "triton_kernels": triton_kernels,
+                "triton_kernels.matmul": triton_matmul,
+            },
+        ), patch.object(
+            mxfp4_module, "_swizzle_mxfp4", side_effect=_fake_swizzle
+        ), patch.object(
+            mxfp4_module, "_use_aiter", False
+        ), patch.object(
+            torch.cuda, "empty_cache"
+        ):
+            method.process_weights_after_loading(layer)
+
+        runtime_tensors = {
+            "w13_weight": method.w13_weight_triton_tensor,
+            "w13_weight_scale": method.w13_precision_config.b_mx_scale,
+            "w2_weight": method.w2_weight_triton_tensor,
+            "w2_weight_scale": method.w2_precision_config.b_mx_scale,
+        }
+        state = layer.state_dict()
+        for value, name in enumerate(_RUNTIME_STATE_NAMES, start=1):
+            parameter = getattr(layer, name)
+            runtime_tensor = runtime_tensors[name]
+            self.assertIs(parameter, original_parameters[name])
+            self.assertEqual(parameter.test_marker, name)
+            self.assertIn(name, state)
+            self.assertFalse(parameter.is_contiguous())
+            self.assertIs(runtime_tensor.storage.data, parameter)
+            self.assertEqual(
+                runtime_tensor.storage.data.data_ptr(), parameter.data_ptr()
+            )
+
+            # This is the copy performed by ShardedStateLoader.load_model.
+            incoming = torch.full_like(state[name], value)
+            state[name].copy_(incoming)
+            self.assertTrue(torch.equal(runtime_tensor.storage.data, incoming))
+
+        with tempfile.TemporaryDirectory() as output_dir, patch.object(
+            loader_module, "get_parallel", return_value=SimpleNamespace(tp_rank=0)
+        ):
+            ShardedStateLoader.save_model(layer, output_dir)
+            checkpoint = f"{output_dir}/model-rank-0-part-0.safetensors"
+            with safe_open(checkpoint, framework="pt") as handle:
+                self.assertEqual(set(handle.keys()), set(state))
+                for name, expected in state.items():
+                    self.assertTrue(
+                        torch.equal(handle.get_tensor(name), expected), name
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep Triton-swizzled MXFP4 expert weights and scales registered on the layer
- serialize non-contiguous postprocessed tensors through contiguous CPU snapshots
- add a CPU regression test for runtime-state aliasing and sharded export

## Root cause

The Triton MXFP4 post-load path moved the swizzled `w13` and `w2` weight wrappers onto the quantization method and deleted the registered layer parameters. `ShardedStateLoader.save_model` only exports `model.state_dict()`, so those runtime weights were omitted.

On reload, SGLang postprocesses freshly initialized placeholders before it builds the expected state dict. The missing weights therefore disappeared from both the checkpoint and the expected-key set, and loading silently succeeded with placeholder runtime weights. The swizzled scales held by `PrecisionConfig` had the same stale-storage problem even though the original scale parameters remained registered.

This change rebinds all four Triton runtime tensors (two weights and two scales) to their existing registered `Parameter` objects. The module state and the kernel wrappers then share the same backing storage, so sharded load copies update the tensors actually consumed by the kernels. Parameter identity and loader attributes are preserved.

The Hopper swizzle can produce non-contiguous runtime tensors. Safetensors rejects those tensors, so the exporter materializes contiguous CPU snapshots at the save boundary without changing the runtime layout.

Fixes #34448

## Validation

- `python3 scripts/ci/check_registered_tests.py`
- Black 26.1.0 (`--check`) on the three changed files
- isort 7.0.0 (`--check-only`) on the new test
- Ruff 0.15.1 (`F401`, `F821`, `UP037`) on the three changed files
- `git diff --check`
- `python3 -m py_compile test/registered/unit/model_loader/test_mxfp4_sharded_state.py`
- focused macOS CPU regression run with import-only stubs for unavailable GPU dependencies: `1 test`, `OK`
- the same regression test against `upstream/main@2d76d537e5` fails as expected because `w13_weight` is absent after postprocessing

The focused CPU test is registered in `base-a-test-cpu`. This local run exercised the real MXFP4 postprocessing method and real sharded-state saver, while stubbing only imports unavailable on macOS. A GH200 `gpt-oss-20b` end-to-end logits comparison was not available locally; project CI and a hardware smoke test should provide the final production validation.
