### PR TITLE
feat(serving): add --enable-sort-tool-schema-keys to share prefix cache across tool key orders

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1095,6 +1095,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-sort-tool-schema-keys`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Recursively sort the JSON schema keys of tool parameters so clients that send equivalent tool definitions in a different key order share the same prefix cache. Tool parameters are then rendered in sorted rather than client order.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
+    </tr>
+        <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--reasoning-parser`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Specify the parser for reasoning models. Supported parsers: [deepseek-r1, deepseek-v3, glm45, gpt-oss, kimi, qwen3, qwen3-thinking, step3].</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -73,6 +73,7 @@ from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.conversation import generate_chat_conv
 from sglang.srt.parser.jinja_template_utils import process_content_for_template_format
 from sglang.srt.parser.reasoning_parser import ReasoningParser
+from sglang.srt.utils import sort_json
 
 if TYPE_CHECKING:
     from sglang.srt.managers.tokenizer_manager import TokenizerManager
@@ -358,6 +359,22 @@ class OpenAIServingChat(OpenAIServingBase):
 
     def _request_id_prefix(self) -> str:
         return "chatcmpl-"
+
+    def _canonicalize_tool_parameters(self, tools: List[Tool]) -> None:
+        """Sort JSON-schema keys in tool parameters so equivalent tools share a prefix.
+
+        Pydantic emits declared fields in class-declaration order, so the
+        free-form ``Function.parameters`` payload is the only part of a tool
+        definition that carries a client's key order into the rendered prompt.
+        Normalizing the tool objects themselves covers every encoding path and
+        keeps the grammar constraint consistent with the prompt.
+        """
+        if not self.tokenizer_manager.server_args.enable_sort_tool_schema_keys:
+            return
+        for tool in tools:
+            parameters = tool.function.parameters
+            if isinstance(parameters, (dict, list)):
+                tool.function.parameters = sort_json(parameters)
 
     def _effective_tools(self, request: ChatCompletionRequest) -> List[Tool]:
         tools = list(request.tools or [])
@@ -1057,6 +1074,7 @@ class OpenAIServingChat(OpenAIServingBase):
         tool_call_stop = None
         required_parsed_natively = False
         effective_tools = self._effective_tools(request)
+        self._canonicalize_tool_parameters(effective_tools)
         if effective_tools and request.tool_choice != "none":
             request.skip_special_tokens = False
             if not isinstance(request.tool_choice, str):

--- a/python/sglang/srt/parser/inkling_renderer.py
+++ b/python/sglang/srt/parser/inkling_renderer.py
@@ -20,6 +20,7 @@ from sglang.srt.parser.inkling_tokenizer import (
     MESSAGE_MODEL,
     ROLE_MESSAGE_TOKENS,
 )
+from sglang.srt.utils import sort_json
 
 
 class InklingTextTokenizer(Protocol):
@@ -279,19 +280,11 @@ def _as_mapping(value: Any) -> Mapping[str, Any]:
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(
-        _sort_json(value),
+        sort_json(value),
         ensure_ascii=False,
         allow_nan=False,
         separators=(",", ":"),
     )
-
-
-def _sort_json(value: Any) -> Any:
-    if isinstance(value, Mapping):
-        return {str(key): _sort_json(value[key]) for key in sorted(value)}
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
-        return [_sort_json(item) for item in value]
-    return value
 
 
 def _tool_declare_json(tools: Sequence[Mapping[str, Any]]) -> str:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1348,6 +1348,13 @@ class ServerArgs:
         "Return number of cached tokens in usage.prompt_tokens_details for each openai request.",
         NS("serving"),
     ] = False
+    enable_sort_tool_schema_keys: A[
+        bool,
+        "Recursively sort the JSON schema keys of tool parameters so clients that send "
+        "equivalent tool definitions in a different key order share the same prefix cache. "
+        "Tool parameters are then rendered in sorted rather than client order.",
+        NS("serving"),
+    ] = False
     reasoning_parser: A[Optional[str], NS("serving")] = None
     default_chat_template_kwargs: A[
         Optional[Dict[str, Any]],

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -48,6 +48,7 @@ import uuid
 import warnings
 from array import array
 from collections import OrderedDict, defaultdict
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from decimal import Decimal
@@ -4291,6 +4292,21 @@ def json_list_type(value):
         raise argparse.ArgumentTypeError(
             f"Invalid JSON list: {value}. Please provide a valid JSON list."
         )
+
+
+def sort_json(value: Any) -> Any:
+    """Recursively sort dict keys for deterministic serialization.
+
+    Keys are coerced to str() before sorting. This is safe for JSON-parsed
+    input where all keys are already strings. Callers passing non-string
+    keys (e.g. int) must ensure no collisions exist after str() coercion,
+    as {1: "x", "1": "y"} would silently collapse to {"1": "y"}.
+    """
+    if isinstance(value, Mapping):
+        return {str(k): sort_json(value[k]) for k in sorted(value, key=str)}
+    if isinstance(value, (list, tuple)):
+        return [sort_json(item) for item in value]
+    return value
 
 
 def get_extend_input_len_swa_limit(

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -66,6 +66,7 @@ class _MockTokenizerManager:
             model_path="deepseek-ai/DeepSeek-V4-Flash",
             revision=None,
             enable_cache_report=False,
+            enable_sort_tool_schema_keys=False,
             tool_call_parser="hermes",
             reasoning_parser=None,
             stream_response_default_include_usage=False,
@@ -965,6 +966,119 @@ class ServingChatTestCase(unittest.TestCase):
             "not-json <| kimi_image_placeholder |>",
         )
         self.assertNotIn("image_prompts", kwargs)
+
+    @staticmethod
+    def _unsorted_tool():
+        return {
+            "type": "function",
+            "function": {
+                "name": "weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "zebra": {"type": "string"},
+                        "apple": {"type": "integer"},
+                    },
+                },
+            },
+        }
+
+    def test_canonicalize_tool_parameters_gates_on_server_flag(self):
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Weather?"}],
+            tools=[self._unsorted_tool()],
+        )
+        tools = self.chat._effective_tools(request)
+
+        self.chat._canonicalize_tool_parameters(tools)
+        self.assertEqual(
+            list(request.tools[0].function.parameters["properties"]),
+            ["zebra", "apple"],
+        )
+
+        self.tm.server_args.enable_sort_tool_schema_keys = True
+        self.chat._canonicalize_tool_parameters(tools)
+        parameters = request.tools[0].function.parameters
+        self.assertEqual(list(parameters), ["properties", "type"])
+        self.assertEqual(list(parameters["properties"]), ["apple", "zebra"])
+
+    def test_sort_tool_schema_keys_canonicalizes_parameters_only(self):
+        self.template_manager.chat_template_name = None
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.server_args.enable_sort_tool_schema_keys = True
+        self.tm.tokenizer.apply_chat_template.return_value = [7, 8, 9]
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "developer",
+                    "content": "Be helpful",
+                    "tools": [self._unsorted_tool()],
+                },
+                {"role": "user", "content": "Weather?"},
+            ],
+            tools=[self._unsorted_tool()],
+        )
+
+        self.chat._process_messages(request, is_multimodal=False)
+
+        call = self.tm.tokenizer.apply_chat_template.call_args
+        for tool in (call.args[0][0]["tools"][0], call.kwargs["tools"][0]):
+            # pydantic already emits declared fields in a stable order; only the
+            # free-form parameters schema is re-ordered.
+            self.assertEqual(list(tool.keys()), ["type", "function"])
+            self.assertEqual(
+                list(tool["function"].keys()),
+                ["description", "name", "parameters"],
+            )
+            self.assertEqual(
+                list(tool["function"]["parameters"]["properties"].keys()),
+                ["apple", "zebra"],
+            )
+
+    def test_sort_tool_schema_keys_covers_message_only_tools(self):
+        self.template_manager.chat_template_name = None
+        self.chat.chat_encoding_spec = None
+        self.tm.server_args.enable_sort_tool_schema_keys = True
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[
+                {
+                    "role": "developer",
+                    "content": "Be helpful",
+                    "tools": [self._unsorted_tool()],
+                },
+                {"role": "user", "content": "Weather?"},
+            ],
+        )
+
+        self.chat._process_messages(request, is_multimodal=False)
+
+        messages = self.tm.tokenizer.apply_chat_template.call_args.args[0]
+        self.assertEqual(
+            list(messages[0]["tools"][0]["function"]["parameters"]["properties"]),
+            ["apple", "zebra"],
+        )
+
+    def test_sort_tool_schema_keys_disabled_preserves_key_order(self):
+        self.template_manager.chat_template_name = None
+        self.chat.chat_encoding_spec = "kimi_k3"
+        self.tm.tokenizer.apply_chat_template.return_value = [7, 8, 9]
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "Weather?"}],
+            tools=[self._unsorted_tool()],
+        )
+
+        self.chat._process_messages(request, is_multimodal=False)
+
+        call = self.tm.tokenizer.apply_chat_template.call_args
+        self.assertEqual(
+            list(call.kwargs["tools"][0]["function"]["parameters"]["properties"]),
+            ["zebra", "apple"],
+        )
 
     def test_message_tools_participate_in_validation_across_encodings(self):
         tool = {

--- a/test/registered/unit/utils/test_sort_json.py
+++ b/test/registered/unit/utils/test_sort_json.py
@@ -1,0 +1,51 @@
+"""
+Unit-tests for sglang.srt.utils.common.sort_json (no pytest).
+Run with:
+    python -m unittest test_sort_json -v
+from this directory.
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import unittest
+
+from sglang.srt.utils.common import sort_json
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class SortJsonTestCase(unittest.TestCase):
+    def test_sorts_nested_dict_keys(self):
+        result = sort_json({"b": {"d": 1, "c": 2}, "a": 3})
+        self.assertEqual(list(result.keys()), ["a", "b"])
+        self.assertEqual(list(result["b"].keys()), ["c", "d"])
+
+    def test_preserves_list_order(self):
+        value = {"required": ["zebra", "apple"], "items": [3, 1, 2]}
+        result = sort_json(value)
+        self.assertEqual(result["required"], ["zebra", "apple"])
+        self.assertEqual(result["items"], [3, 1, 2])
+
+    def test_sorts_dicts_inside_lists(self):
+        result = sort_json([{"b": 1, "a": 2}])
+        self.assertEqual(list(result[0].keys()), ["a", "b"])
+
+    def test_mixed_type_keys_do_not_crash(self):
+        self.assertEqual(sort_json({1: "x", "a": "y"}), {"1": "x", "a": "y"})
+
+    def test_passthrough_scalars(self):
+        self.assertEqual(sort_json("s"), "s")
+        self.assertEqual(sort_json(3.14), 3.14)
+        self.assertIsNone(sort_json(None))
+
+    def test_does_not_mutate_input(self):
+        value = {"b": 1, "a": 2}
+        sort_json(value)
+        self.assertEqual(list(value.keys()), ["b", "a"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When different clients send semantically equivalent tool definitions with different JSON key orders (e.g., serializers that emit schema keys in different orders), the rendered prompts differ and the requests cannot share the same prefix cache, hurting prefix-cache hit rate for tool-heavy workloads.

Pydantic already emits the declared fields of a tool definition (`type`, `function`, `name`, `description`, ...) in a stable order, so the free-form `function.parameters` JSON-schema payload is the only part that carries the client's key order into the rendered prompt. Normalizing it lets equivalent tool definitions map to byte-identical prompts.

### Why clients send different key orders: a real production trace

This is not a hypothetical concern. In our production request trace, the same `search` tool arrived with the `properties` and `required` keys swapped between two client requests:

Request A:

```json
"parameters": {
  "type": "object",
  "properties": {
    "query": {"type": "string", "description": "..."},
    "time_range": {"type": "string", "description": "...", "enum": ["..."]},
    "search_source": {"type": "string", "description": "...", "enum": ["..."]}
  },
  "required": ["query", "time_range", "search_source"]
}
```

Request B (same tool, different key order):

```json
"parameters": {
  "type": "object",
  "required": ["query", "time_range", "search_source"],
  "properties": {
    "query": {"type": "string", "description": "..."},
    "time_range": {"type": "string", "description": "...", "enum": ["..."]},
    "search_source": {"type": "string", "description": "...", "enum": ["..."]}
  }
}
```

Key order variation like this is common in practice because tool schemas are frequently built as plain dicts/maps on the client side, and the emitted order depends on the construction path:

- Different client services or code paths define the same tool (e.g., one hand-writes the dict literal, another builds it via a JSON-Schema/OpenAPI generator that emits `required` at a different position).
- Different languages/serializers order keys differently (e.g., Go's `encoding/json` sorts map keys alphabetically, while Python/JS preserve insertion order).
- Different SDK or library versions serialize the same schema object in different field orders.

Since the tool block is rendered verbatim into the prompt, requests A and B produce different token sequences at the tools section and cannot share the prefix cache, even though the tools are semantically identical. With `--enable-sort-tool-schema-keys` enabled, both render byte-identically and hit the same prefix.

**Measured impact:** with our real user trace, enabling this flag increased the total prefix cache hit rate by 15 percentage points.

## Modifications

- Add a new opt-in server flag `--enable-sort-tool-schema-keys` (default `False`). When enabled, the JSON-schema keys of tool parameters are recursively sorted so equivalent tool definitions share the same prefix cache.
- Add `_canonicalize_tool_parameters` in `OpenAIServingChat`, applied in `_process_messages` before template rendering and constraint building. Because it normalizes the shared `Tool` objects in place, it covers every encoding path (chat template rendering, grammar/JSON-schema constraints, message-level tools, and the Responses API which routes through `ChatCompletionRequest`), keeping the grammar constraint consistent with the prompt.
- Extract the existing `_sort_json` helper from `inkling_renderer.py` into a shared `sort_json` utility in `sglang.srt.utils.common` and reuse it in both places.
- Document the new flag in `server_arguments.mdx`.

Note: this flag is off by default and only changes the key order in which tool parameters are rendered; it does not change model behavior or request semantics.

## Accuracy Tests

Tool calling accuracy was evaluated with the [Berkeley Function Calling Leaderboard (BFCL)](https://github.com/ShishirPatil/gorilla/blob/main/berkeley-function-call-leaderboard/README.md), comparing the flag disabled (baseline) vs. enabled. Enabling `--enable-sort-tool-schema-keys` shows no degradation in tool calling accuracy.

Baseline (flag disabled):
<img width="3454" height="834" alt="image" src="https://github.com/user-attachments/assets/1e70c5d1-09ea-48c0-8a7f-7ae20a29f6d7" />

With `--enable-sort-tool-schema-keys` enabled:

<img width="3446" height="932" alt="image" src="https://github.com/user-attachments/assets/d79b85a4-cdb3-4d39-8774-f0b3e38d92fa" />


## Speed Tests and Profiling

The flag is off by default and adds zero overhead when disabled. When enabled, it performs a lightweight recursive key sort on tool parameters per request (negligible compared to tokenization/inference), in exchange for a higher prefix-cache hit rate when clients send equivalent tools with differing key orders. With our real user trace, the total prefix cache hit rate increased by 15 percentage points.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31581585839](https://github.com/sgl-project/sglang/actions/runs/31581585839)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31581585609](https://github.com/sgl-project/sglang/actions/runs/31581585609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->