### PR TITLE
[Scheduler] Add --long-prefill-token-threshold to bound one request's share of the prefill batch

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1405,6 +1405,18 @@ class PrefillAdder:
                     storage_hit_len=req.storage_hit_length,
                 )
             else:
+                # Only one request may be left mid-prefill per pass: the scheduler
+                # tracks a single `chunked_req` (see the `assert self.chunked_req is
+                # None` before it adopts `new_chunked_req`), so a second would be
+                # partially prefilled and then dropped, losing its progress. Without
+                # a long-prefill cap this is implicit -- the first such request
+                # exhausts `rem_chunk_tokens` and `budget_state()` ends the pass --
+                # but the cap deliberately leaves budget behind, so refuse here
+                # instead. The request keeps its place in the waiting queue and is
+                # admitted on a later pass.
+                if self.new_chunked_req is not None or has_chunked_req:
+                    return AddReqResult.OTHER
+
                 # Make sure at least one page is available
                 trunc_len = chunk_tokens_limit // self.page_size * self.page_size
 

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -506,9 +506,11 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        long_prefill_token_threshold: int = 0,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
+        self.long_prefill_token_threshold = long_prefill_token_threshold
         self.tree_cache = tree_cache
         self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
         self.running_batch = running_batch
@@ -702,6 +704,34 @@ class PrefillAdder:
             )
 
         return available_and_evictable - self.cur_rem_token_offset
+
+    def _apply_long_prefill_cap(self, rem_tokens: int) -> int:
+        """Cap one request's share of this prefill batch's token budget.
+
+        Without a cap, a request whose remaining prefill exceeds the batch budget
+        takes all of it (`chunked_prefill_size`), so `rem_chunk_tokens` reaches 0
+        and `budget_state()` refuses every other waiting request. That repeats on
+        every pass until the long prefill finishes, so a single long prompt holds
+        the prefill batch for its whole prefill and every other request in the
+        queue waits behind it.
+
+        With the cap set, a long request takes at most `long_prefill_token_threshold`
+        tokens per pass and the remainder of the budget stays available to admit
+        other requests into the same forward. The long request still makes progress
+        every pass -- it is slowed, not starved -- and short requests stop paying its
+        prefill latency.
+
+        The cap is floored at one page so a long request always makes progress, and
+        rounded down to a page multiple to keep the paged allocator's alignment
+        invariants (the chunked branch of `add_one_req` re-aligns as well).
+        `rem_tokens <= 0` is passed through untouched: those are the exhausted-budget
+        paths, whose own handling must not be masked here.
+        """
+        if self.long_prefill_token_threshold <= 0 or rem_tokens <= 0:
+            return rem_tokens
+        capped = min(rem_tokens, self.long_prefill_token_threshold)
+        capped = capped // self.page_size * self.page_size
+        return max(capped, min(self.page_size, rem_tokens))
 
     def _swa_budget_for_req(
         self, extend_input_len: int, max_new_tokens: int, swa_host_hit_length: int = 0
@@ -991,12 +1021,16 @@ class PrefillAdder:
                 _rem_tokens = min(
                     _rem_tokens, int(self.rem_swa_tokens) - self.page_size
                 )
+            # Long-prefill cap: leave budget for other requests in this batch so a
+            # multi-chunk request cannot hold the prefill batch to itself for the
+            # whole of its prefill. See `_long_prefill_cap`.
+            _rem_tokens = self._apply_long_prefill_cap(_rem_tokens)
             # The chunked_req must be added to the list; otherwise, it will cause a memory leak.
             # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
             if _rem_tokens <= 0:
                 if self.is_hybrid_swa:
                     return req
-                _rem_tokens = self.rem_chunk_tokens
+                _rem_tokens = self._apply_long_prefill_cap(self.rem_chunk_tokens)
 
         # A mid-chunk rank prefills this pass regardless of the delayer
         # verdict, so report prefillable=True and ignore the result.
@@ -1245,6 +1279,14 @@ class PrefillAdder:
                 if self.rem_chunk_tokens is None or swa_cap <= 0:
                     return AddReqResult.NO_TOKEN
                 chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
+
+        # Long-prefill cap, applied before the chunked/non-chunked split below so a
+        # request that already fits under the cap still prefills in a single pass:
+        # only requests longer than the threshold are chunked by it. Composes with the
+        # SWA cap above (whichever is tighter wins). Skipped when chunked prefill is
+        # off -- there is no chunking to spread the request over.
+        if chunk_tokens_limit is not None:
+            chunk_tokens_limit = self._apply_long_prefill_cap(chunk_tokens_limit)
 
         if (
             self.rem_chunk_tokens is None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -485,6 +485,12 @@ class AddReqResult(Enum):
     CONTINUE = auto()  # Continue to add requests
     NO_TOKEN = auto()  # No token left
     OTHER = auto()  # Other reasons to stop adding requests
+    # Skip this request for this pass but keep considering the rest of the
+    # queue: it cannot be admitted right now (a chunked prefill slot is taken)
+    # but later, smaller requests still can be. Only returned when
+    # long_prefill_token_threshold is enabled; at the default the admission
+    # loop keeps its historical stop-at-first-refusal behavior.
+    SKIP = auto()
 
 
 class PrefillAdder:
@@ -704,6 +710,17 @@ class PrefillAdder:
             )
 
         return available_and_evictable - self.cur_rem_token_offset
+
+    def _chunked_slot_busy_result(self) -> AddReqResult:
+        """Result for a request that needs the chunked-prefill slot while it is
+        taken. With the fairness cap enabled, skip only this request so smaller
+        requests behind it can still join this batch; at the default, preserve
+        the historical stop-the-whole-pass behavior."""
+        return (
+            AddReqResult.SKIP
+            if self.long_prefill_token_threshold > 0
+            else AddReqResult.OTHER
+        )
 
     def _apply_long_prefill_cap(self, rem_tokens: int) -> int:
         """Cap one request's share of this prefill batch's token budget.
@@ -1082,7 +1099,7 @@ class PrefillAdder:
             else:
                 self.tree_cache.dec_lock_ref(last_node)
 
-    def add_one_req_ignore_eos(self, req: Req):
+    def add_one_req_ignore_eos(self, req: Req, has_chunked_req: bool):
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
@@ -1173,7 +1190,10 @@ class PrefillAdder:
             self._add_dllm_req(req, 0)
         elif (
             self.rem_chunk_tokens is None  # chunked prefill is disabled
-            or cand_extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
+            # it is the last chunk (the fairness cap picks which requests get
+            # chunked here too, same as the add_one_req split)
+            or cand_extend_input_len
+            <= self._apply_long_prefill_cap(self.rem_chunk_tokens)
         ):
             if (
                 tile_stop := self._check_prefill_tile_budget(cand_extend_input_len)
@@ -1196,8 +1216,17 @@ class PrefillAdder:
             if self.rem_chunk_tokens <= 0:
                 return AddReqResult.OTHER
 
-            # Chunked prefill
-            trunc_len = self.rem_chunk_tokens
+            # Same single-chunked-slot invariant as add_one_req's chunked
+            # branch: with the fairness cap leaving budget behind, an in-flight
+            # chunk no longer implies rem_chunk_tokens == 0, so without this
+            # guard an ignore_eos request would overwrite new_chunked_req and
+            # trip the scheduler's `assert self.chunked_req is None`.
+            if self.new_chunked_req is not None or has_chunked_req:
+                return self._chunked_slot_busy_result()
+
+            # Chunked prefill (capped so an ignore_eos request cannot hold the
+            # prefill batch to itself either)
+            trunc_len = self._apply_long_prefill_cap(self.rem_chunk_tokens)
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
@@ -1231,7 +1260,7 @@ class PrefillAdder:
             return AddReqResult.OTHER
 
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
-            return self.add_one_req_ignore_eos(req)
+            return self.add_one_req_ignore_eos(req, has_chunked_req)
 
         # Reserve page_size for page-alignment overhead: the paged allocator may
         # consume one extra page per request (see alloc_extend), which
@@ -1279,14 +1308,6 @@ class PrefillAdder:
                 if self.rem_chunk_tokens is None or swa_cap <= 0:
                     return AddReqResult.NO_TOKEN
                 chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
-
-        # Long-prefill cap, applied before the chunked/non-chunked split below so a
-        # request that already fits under the cap still prefills in a single pass:
-        # only requests longer than the threshold are chunked by it. Composes with the
-        # SWA cap above (whichever is tighter wins). Skipped when chunked prefill is
-        # off -- there is no chunking to spread the request over.
-        if chunk_tokens_limit is not None:
-            chunk_tokens_limit = self._apply_long_prefill_cap(chunk_tokens_limit)
 
         if (
             self.rem_chunk_tokens is None
@@ -1354,6 +1375,17 @@ class PrefillAdder:
                 len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
             )
 
+            # Long-prefill cap, applied before the chunked/non-chunked split
+            # below so a request that already fits under the cap still prefills
+            # in a single pass: only requests longer than the threshold are
+            # chunked by it. Composes with the SWA cap (whichever is tighter
+            # wins) -- applied here, after the post-lock SWA re-check above,
+            # because that re-check recomputes chunk_tokens_limit. Skipped when
+            # chunked prefill is off -- there is no chunking to spread the
+            # request over.
+            if chunk_tokens_limit is not None:
+                chunk_tokens_limit = self._apply_long_prefill_cap(chunk_tokens_limit)
+
             if (
                 self.rem_chunk_tokens is None
                 and len(self.can_run_list) != 0
@@ -1413,9 +1445,11 @@ class PrefillAdder:
                 # exhausts `rem_chunk_tokens` and `budget_state()` ends the pass --
                 # but the cap deliberately leaves budget behind, so refuse here
                 # instead. The request keeps its place in the waiting queue and is
-                # admitted on a later pass.
+                # admitted on a later pass. SKIP (cap on) lets the admission loop
+                # continue to smaller requests queued behind this one; OTHER (cap
+                # off) preserves the historical stop-the-pass behavior.
                 if self.new_chunked_req is not None or has_chunked_req:
-                    return AddReqResult.OTHER
+                    return self._chunked_slot_busy_result()
 
                 # Make sure at least one page is available
                 trunc_len = chunk_tokens_limit // self.page_size * self.page_size

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1164,6 +1164,28 @@ class Scheduler(
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and get_schedule().enable_mixed_chunk
         )
+        # Per-request share of the prefill batch budget. Only meaningful with chunked
+        # prefill: without chunking there is no way to spread a long request across
+        # passes, so the cap would only be able to refuse it.
+        requested_long_prefill = get_schedule().long_prefill_token_threshold
+        self.long_prefill_token_threshold = (
+            requested_long_prefill if self.chunked_prefill_size is not None else 0
+        )
+        if requested_long_prefill > 0:
+            if self.chunked_prefill_size is None:
+                logger.warning(
+                    "long_prefill_token_threshold=%d is ignored because chunked prefill "
+                    "is disabled; a request cannot be spread over passes without it.",
+                    requested_long_prefill,
+                )
+            elif requested_long_prefill >= self.chunked_prefill_size:
+                logger.warning(
+                    "long_prefill_token_threshold=%d >= chunked_prefill_size=%d, so a "
+                    "long request can still take the whole prefill batch budget. Set it "
+                    "below chunked_prefill_size to leave room for other requests.",
+                    requested_long_prefill,
+                    self.chunked_prefill_size,
+                )
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -3257,6 +3279,7 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            long_prefill_token_threshold=self.long_prefill_token_threshold,
         )
 
         if self.chunked_req is not None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3369,6 +3369,13 @@ class Scheduler(
                             req.mamba_pool_idx.unsqueeze(-1)
                         )
                         req.mamba_pool_idx = None
+                if res == AddReqResult.SKIP:
+                    # The chunked-prefill slot is taken (long_prefill_token_threshold
+                    # keeps the rest of the budget free): this request waits for a
+                    # later pass, but smaller requests behind it can still be
+                    # admitted into this batch. It keeps its place in the waiting
+                    # queue, so the skip is bounded by the in-flight prefill.
+                    continue
                 break
 
         if mamba_allocator is not None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -816,6 +816,25 @@ class ServerArgs:
         ),
         NS("schedule"),
     ] = 16384
+    long_prefill_token_threshold: A[
+        int,
+        Arg(
+            help=(
+                "Cap on how many prefill tokens a single request may take from one "
+                "prefill batch. A request whose remaining prefill exceeds this is "
+                "chunked at the threshold, leaving the rest of the batch budget free "
+                "to admit other requests into the same forward, so one long prompt "
+                "cannot hold the prefill batch to itself for the whole of its prefill. "
+                "0 (default) disables the cap and preserves current behavior. Only "
+                "applies with chunked prefill enabled; set it below "
+                "--chunked-prefill-size for it to have an effect. Rounded down to a "
+                "multiple of the page size, with a floor of one page."
+                + f"\n\n{human_readable_int.__doc__}"
+            ),
+            type_parser=human_readable_int,
+        ),
+        NS("schedule"),
+    ] = 0
     prefill_max_requests: A[
         Optional[int],
         "The maximum number of requests in a prefill batch. If not specified, there is no limit.",
@@ -8937,6 +8956,13 @@ class ServerArgs:
             assert (
                 self.chunked_prefill_size % self.page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
+
+        # Check the long-prefill cap. Whether it actually applies also depends on
+        # chunked prefill being enabled, which is resolved later (GPU-dependent
+        # defaults); the scheduler warns there, where the final values are known.
+        assert (
+            self.long_prefill_token_threshold >= 0
+        ), "long_prefill_token_threshold must be non-negative (0 disables the cap)"
 
         # Check pdmux
         if self.enable_pdmux:

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -1034,6 +1034,62 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder._apply_long_prefill_cap(0), 0)
         self.assertEqual(adder._apply_long_prefill_cap(-128), -128)
 
+    def test_long_prefill_cap_admits_only_one_chunked_req_per_pass(self):
+        # The scheduler tracks a single chunked_req (`assert self.chunked_req is
+        # None` before adopting new_chunked_req), so at most one request may be
+        # left mid-prefill per pass -- a second would be partially prefilled and
+        # then dropped, losing its progress. Without the cap this is implicit (the
+        # first long request exhausts the budget and ends the pass); the cap leaves
+        # budget behind, so the limit has to be enforced explicitly.
+        adder = self._long_prefill_adder(threshold=2048)
+
+        first = self._long_prefill_req("long-0", extend_input_len=500_000)
+        self.assertEqual(
+            adder.add_one_req(first, has_chunked_req=False, truncation_align_size=None),
+            AddReqResult.CONTINUE,
+        )
+        self.assertIs(adder.new_chunked_req, first)
+
+        second = self._long_prefill_req("long-1", extend_input_len=500_000)
+        result = adder.add_one_req(
+            second, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertNotIn(second, adder.can_run_list)
+        self.assertIs(adder.new_chunked_req, first)  # not overwritten
+
+    def test_long_prefill_cap_refuses_long_req_behind_inflight_chunk(self):
+        # Same invariant from the other direction: a chunked_req is already in
+        # flight (has_chunked_req=True), so a newly arriving long request must not
+        # start a second chunked prefill even though the cap left budget free.
+        adder = self._long_prefill_adder(threshold=2048)
+        adder.add_chunked_req(self._long_prefill_req("inflight", 500_000))
+
+        newcomer = self._long_prefill_req("newlong", extend_input_len=500_000)
+        result = adder.add_one_req(
+            newcomer, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertNotIn(newcomer, adder.can_run_list)
+        self.assertIsNone(adder.new_chunked_req)
+
+    def test_short_req_still_admitted_behind_inflight_chunk(self):
+        # The guard above must not block the feature: a request that fits under the
+        # cap is not chunked, so it can still join the batch alongside an in-flight
+        # long prefill. This is the fairness behaviour the flag exists for.
+        adder = self._long_prefill_adder(threshold=2048)
+        adder.add_chunked_req(self._long_prefill_req("inflight", 500_000))
+
+        short = self._long_prefill_req("short", extend_input_len=1024)
+        result = adder.add_one_req(
+            short, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIn(short, adder.can_run_list)
+
     def test_long_prefill_cap_composes_with_swa_cap(self):
         # Both caps bound the same value; the tighter one must win so neither
         # the SWA pool reservation nor the fairness cap can be exceeded.

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -912,15 +912,19 @@ class TestPrefillAdder(CustomTestCase):
         )
         return adder
 
-    def _long_prefill_req(self, rid, extend_input_len, prefix_len=0):
+    def _long_prefill_req(self, rid, extend_input_len, prefix_len=0, ignore_eos=False):
         req = self.create_mock_req(rid, priority=0, max_new_tokens=128)
         req.prefix_indices = list(range(prefix_len))
         req.full_untruncated_fill_ids = list(range(prefix_len + extend_input_len))
         # add_one_req reads these; create_mock_req only covers the add_chunked_req
         # and preemption paths the other tests exercise.
-        req.sampling_params.ignore_eos = False
+        req.sampling_params.ignore_eos = ignore_eos
         req.last_node = MagicMock()
         req.swa_host_hit_length = 0
+        # add_one_req_ignore_eos accounting reads these.
+        req.origin_input_ids = list(range(prefix_len + extend_input_len))
+        req.output_ids = []
+        req.mamba_pool_idx = None
         req.set_extend_range = MagicMock(
             side_effect=lambda start, end: setattr(
                 req, "extend_range", Range(start, end)
@@ -1040,7 +1044,9 @@ class TestPrefillAdder(CustomTestCase):
         # left mid-prefill per pass -- a second would be partially prefilled and
         # then dropped, losing its progress. Without the cap this is implicit (the
         # first long request exhausts the budget and ends the pass); the cap leaves
-        # budget behind, so the limit has to be enforced explicitly.
+        # budget behind, so the limit has to be enforced explicitly. SKIP (not
+        # OTHER) so the admission loop continues to smaller requests queued
+        # behind this one.
         adder = self._long_prefill_adder(threshold=2048)
 
         first = self._long_prefill_req("long-0", extend_input_len=500_000)
@@ -1055,7 +1061,7 @@ class TestPrefillAdder(CustomTestCase):
             second, has_chunked_req=False, truncation_align_size=None
         )
 
-        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertEqual(result, AddReqResult.SKIP)
         self.assertNotIn(second, adder.can_run_list)
         self.assertIs(adder.new_chunked_req, first)  # not overwritten
 
@@ -1071,8 +1077,22 @@ class TestPrefillAdder(CustomTestCase):
             newcomer, has_chunked_req=True, truncation_align_size=None
         )
 
-        self.assertEqual(result, AddReqResult.OTHER)
+        self.assertEqual(result, AddReqResult.SKIP)
         self.assertNotIn(newcomer, adder.can_run_list)
+        self.assertIsNone(adder.new_chunked_req)
+
+    def test_chunked_slot_guard_returns_other_at_default(self):
+        # With the cap disabled the guard must preserve the historical
+        # stop-the-whole-pass result (OTHER) -- the admission loop's behavior at
+        # default settings is unchanged.
+        adder = self._long_prefill_adder(threshold=0)
+
+        newcomer = self._long_prefill_req("newlong", extend_input_len=500_000)
+        result = adder.add_one_req(
+            newcomer, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.OTHER)
         self.assertIsNone(adder.new_chunked_req)
 
     def test_short_req_still_admitted_behind_inflight_chunk(self):
@@ -1097,6 +1117,94 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder._apply_long_prefill_cap(1024), 1024)  # SWA tighter
         adder_tight = self._long_prefill_adder(threshold=512)
         self.assertEqual(adder_tight._apply_long_prefill_cap(1024), 512)  # cap tighter
+
+    def test_long_prefill_cap_survives_swa_post_lock_recheck(self):
+        # add_one_req re-checks the SWA budget after acquiring the tree lock and
+        # recomputes chunk_tokens_limit there. The cap must be applied after that
+        # recomputation, or a hybrid-SWA request under SWA pressure silently
+        # loses it and takes min(rem_chunk, swa_cap) instead of the threshold.
+        # Numbers: rem_swa=200, reserved=min(40,128)+8=48 -> swa_cap=152;
+        # rem_chunk=512; threshold=64. Without the fix the chunk is 152.
+        # size_swa=512 makes the request _swa_req_never_fits (budget 520 >= 512),
+        # which is what takes the swa_cap escape hatch instead of NO_TOKEN.
+        PAGE, WINDOW, REM_SWA, REM_CHUNK, THRESHOLD = 8, 128, 200, 512, 64
+        self.mock_token_allocator.swa_available_size.return_value = REM_SWA
+        self.mock_token_allocator.full_available_size.return_value = 10_000_000
+        self.mock_token_allocator.available_size.return_value = 10_000_000
+        self.mock_token_allocator.size_swa = 512  # _swa_req_never_fits -> True
+        self.mock_tree_cache.sliding_window_size = WINDOW
+        self.mock_tree_cache.is_tree_cache.return_value = False
+        adder = self.create_adder(
+            self.create_running_batch(),
+            page_size=PAGE,
+            rem_chunk_tokens=REM_CHUNK,
+            long_prefill_token_threshold=THRESHOLD,
+        )
+        adder.is_hybrid_swa = True
+
+        req = self._long_prefill_req("long", extend_input_len=100_000)
+        req.sampling_params.max_new_tokens = 40
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIs(adder.new_chunked_req, req)
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, THRESHOLD)  # not min(REM_CHUNK, swa_cap)=152
+
+    def test_long_prefill_cap_ignore_eos_chunked_at_threshold(self):
+        # The ignore_eos path (tree cache disabled) has its own chunked branch;
+        # the cap must apply there too or an ignore_eos request could still take
+        # the whole batch budget.
+        self.mock_tree_cache.disable = True
+        adder = self._long_prefill_adder(threshold=2048)
+
+        req = self._long_prefill_req("long", extend_input_len=500_000, ignore_eos=True)
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIs(adder.new_chunked_req, req)
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, 2048)
+
+    def test_long_prefill_cap_ignore_eos_under_threshold_prefills_whole(self):
+        # Same split as the normal path: an ignore_eos request that fits under
+        # the cap is not chunked by it.
+        self.mock_tree_cache.disable = True
+        adder = self._long_prefill_adder(threshold=2048)
+
+        req = self._long_prefill_req("short", extend_input_len=1024, ignore_eos=True)
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIsNone(adder.new_chunked_req)
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, 1024)
+
+    def test_long_prefill_cap_ignore_eos_behind_inflight_chunk_is_refused(self):
+        # Crash regression: with the cap on, an in-flight chunk leaves
+        # rem_chunk_tokens > 0, so the ignore_eos chunked branch became
+        # reachable while a chunk is in flight. Without the guard it set
+        # new_chunked_req, tripping the scheduler's
+        # `assert self.chunked_req is None`. With the cap off the same request
+        # is refused at rem_chunk_tokens <= 0, so this state is cap-introduced.
+        self.mock_tree_cache.disable = True
+        adder = self._long_prefill_adder(threshold=2048)
+        adder.add_chunked_req(self._long_prefill_req("inflight", 500_000))
+
+        late = self._long_prefill_req("late", extend_input_len=500_000, ignore_eos=True)
+        result = adder.add_one_req(
+            late, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.SKIP)
+        self.assertNotIn(late, adder.can_run_list)
+        self.assertIsNone(adder.new_chunked_req)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -890,6 +890,158 @@ class TestPrefillAdder(CustomTestCase):
             )._swa_req_never_fits(**req)
         )
 
+    # ---- long_prefill_token_threshold -------------------------------------
+
+    def _long_prefill_adder(
+        self,
+        *,
+        threshold,
+        rem_chunk=8192,
+        page_size=64,
+        rem_input=16384,
+        available=10_000_000,
+    ):
+        self.mock_token_allocator.available_size.return_value = available
+        self.mock_token_allocator.full_available_size.return_value = available
+        adder = self.create_adder(
+            self.create_running_batch(),
+            page_size=page_size,
+            rem_chunk_tokens=rem_chunk,
+            rem_input_tokens=rem_input,
+            long_prefill_token_threshold=threshold,
+        )
+        return adder
+
+    def _long_prefill_req(self, rid, extend_input_len, prefix_len=0):
+        req = self.create_mock_req(rid, priority=0, max_new_tokens=128)
+        req.prefix_indices = list(range(prefix_len))
+        req.full_untruncated_fill_ids = list(range(prefix_len + extend_input_len))
+        # add_one_req reads these; create_mock_req only covers the add_chunked_req
+        # and preemption paths the other tests exercise.
+        req.sampling_params.ignore_eos = False
+        req.last_node = MagicMock()
+        req.swa_host_hit_length = 0
+        req.set_extend_range = MagicMock(
+            side_effect=lambda start, end: setattr(
+                req, "extend_range", Range(start, end)
+            )
+        )
+        return req
+
+    def test_long_prefill_cap_leaves_budget_for_other_requests(self):
+        # The behaviour this flag exists for. Without the cap a long chunked req
+        # consumes the whole batch budget (rem_chunk_tokens -> 0), so every other
+        # waiting request is refused and waits out the long prefill. With it, the
+        # long req takes its capped share and a short req still joins the batch.
+        THRESHOLD, REM_CHUNK = 2048, 8192
+        adder = self._long_prefill_adder(threshold=THRESHOLD, rem_chunk=REM_CHUNK)
+
+        long_req = self._long_prefill_req("long", extend_input_len=500_000)
+        self.assertIs(adder.add_chunked_req(long_req), long_req)  # still truncated
+        start, end = long_req.set_extend_range.call_args.args
+        self.assertEqual(end - start, THRESHOLD)
+        self.assertEqual(adder.rem_chunk_tokens, REM_CHUNK - THRESHOLD)
+
+        short_req = self._long_prefill_req("short", extend_input_len=1024)
+        result = adder.add_one_req(
+            short_req, has_chunked_req=True, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIn(short_req, adder.can_run_list)
+
+    def test_without_cap_long_req_takes_whole_budget(self):
+        # Baseline for the test above: threshold=0 keeps today's behaviour, so the
+        # regression this flag guards against is visible in the same terms.
+        REM_CHUNK = 8192
+        adder = self._long_prefill_adder(threshold=0, rem_chunk=REM_CHUNK)
+
+        long_req = self._long_prefill_req("long", extend_input_len=500_000)
+        adder.add_chunked_req(long_req)
+        start, end = long_req.set_extend_range.call_args.args
+
+        self.assertEqual(end - start, REM_CHUNK)
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+        self.assertEqual(adder.budget_state(), AddReqResult.OTHER)
+
+    def test_long_prefill_cap_does_not_chunk_requests_under_threshold(self):
+        # A request already shorter than the cap must still prefill in one pass:
+        # the cap picks which requests get chunked, it does not add chunking.
+        adder = self._long_prefill_adder(threshold=2048)
+        req = self._long_prefill_req("short", extend_input_len=512)
+
+        result = adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertEqual(result, AddReqResult.CONTINUE)
+        self.assertIsNone(adder.new_chunked_req)  # not chunked
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, 512)
+
+    def test_long_prefill_cap_chunks_new_long_request(self):
+        # The cap applies on a long request's first pass too, not only to an
+        # already-chunked one, so it cannot take the whole budget on arrival.
+        THRESHOLD = 2048
+        adder = self._long_prefill_adder(threshold=THRESHOLD)
+        req = self._long_prefill_req("long", extend_input_len=500_000)
+
+        adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
+
+        self.assertIs(adder.new_chunked_req, req)
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, THRESHOLD)
+
+    def test_long_prefill_cap_is_page_aligned(self):
+        # trunc_len feeds a paged allocator, so a threshold that is not a page
+        # multiple must round down rather than break alignment.
+        PAGE, THRESHOLD = 64, 2000  # 2000 = 31.25 pages
+        adder = self._long_prefill_adder(threshold=THRESHOLD, page_size=PAGE)
+        req = self._long_prefill_req("long", extend_input_len=500_000)
+
+        adder.add_chunked_req(req)
+
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, THRESHOLD // PAGE * PAGE)  # 1984
+        self.assertEqual((end - start) % PAGE, 0)
+
+    def test_long_prefill_cap_floors_at_one_page(self):
+        # A threshold below one page must not round down to zero: the long
+        # request has to keep making progress, or it never finishes.
+        PAGE = 64
+        adder = self._long_prefill_adder(threshold=8, page_size=PAGE)
+        req = self._long_prefill_req("long", extend_input_len=500_000)
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIs(result, req)
+        start, end = req.set_extend_range.call_args.args
+        self.assertEqual(end - start, PAGE)
+
+    def test_long_prefill_cap_disabled_by_default(self):
+        # Default (0) must be a no-op: same chunk size as before the flag existed.
+        REM_CHUNK = 8192
+        adder = self._long_prefill_adder(threshold=0, rem_chunk=REM_CHUNK)
+
+        self.assertEqual(adder._apply_long_prefill_cap(REM_CHUNK), REM_CHUNK)
+
+    def test_long_prefill_cap_passes_through_exhausted_budget(self):
+        # <= 0 marks the exhausted-budget paths, which callers handle themselves
+        # (add_chunked_req's memory-leak fallback, add_one_req's trunc_len <= 0
+        # refusal). The cap must not rewrite those into a positive allocation.
+        adder = self._long_prefill_adder(threshold=2048)
+
+        self.assertEqual(adder._apply_long_prefill_cap(0), 0)
+        self.assertEqual(adder._apply_long_prefill_cap(-128), -128)
+
+    def test_long_prefill_cap_composes_with_swa_cap(self):
+        # Both caps bound the same value; the tighter one must win so neither
+        # the SWA pool reservation nor the fairness cap can be exceeded.
+        adder = self._long_prefill_adder(threshold=4096)
+        self.assertEqual(adder._apply_long_prefill_cap(1024), 1024)  # SWA tighter
+        adder_tight = self._long_prefill_adder(threshold=512)
+        self.assertEqual(adder_tight._apply_long_prefill_cap(1024), 512)  # cap tighter
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

A request whose remaining prefill exceeds the prefill batch budget takes **all** of it. `add_chunked_req` allocates `min(rem_chunk_tokens, rem_total_tokens)` and `_update_prefill_budget` subtracts that from `rem_chunk_tokens`, leaving 0. Every subsequent `add_one_req` in that pass then hits `trunc_len = 0 → AddReqResult.OTHER`, and the admission loop breaks. `budget_state()` returns `OTHER` for the same reason.

That repeats on **every** pass until the long prefill completes. With `--chunked-prefill-size 8192`, a 590K-token prefill is ~72 passes during which the prefill batch contains exactly one request, and every other request in the waiting queue waits out that entire prefill — regardless of how small it is or how long it has been waiting.

This is a multi-tenancy fairness problem: one tenant's long prompt determines every other tenant's TTFT on that instance.

### Production measurement

Kimi-K3 on 8×B300 (TP8, DSPARK, `--chunked-prefill-size 8192`). One account sent 642K–912K-token prompts from two concurrent agent loops, ~90 s apart, each taking 100–160 s — so a long prefill was continuously in flight for 50 minutes. Per-request tracing over that window:

| | p50 TTFT | p99 TTFT | requests > 60 s |
|---|---|---|---|
| hour before | 1 326 ms | 46.3 s | 0.56 % |
| **affected hour** | **783 ms** | **158.1 s** | **10.35 %** |
| hour after | 668 ms | 26.2 s | 0.00 % |

p50 barely moves — this is purely a tail effect, and short requests pay it. One example: a request needing 78 265 tokens of prefill was handed to the engine at t=198 s and produced its first token at t=328.6 s. Its own prefill was ~1 s. Two long prompts were ahead of it, one with 63 s of prefill remaining and one needing 67 s. 63 + 67 = 130.

Requests also reached first token in **clusters**, precisely at the moments a long prefill finished and released the budget — the signature of admission blocking rather than compute saturation.

### Why the existing controls don't cover it

- `--max-prefill-tokens` — the effective per-pass budget is `min(max_prefill_tokens, chunked_prefill_size)` (see #29531), so raising it changes nothing while chunking caps the batch.
- `--chunked-prefill-size` — enlarging it enlarges the chunk by the same amount, which is still fully consumed.
- `--enable-mixed-chunk` — asserted off for any `speculative_algorithm`.
- `--schedule-policy` / `--enable-priority-scheduling` — reorder the waiting queue, which changes *who* waits, not *whether* someone does. #10063 was closed as covered by priority scheduling; a commenter later showed high-priority short requests still block, and a maintainer confirmed ("yes, this is an issue").

No existing option caps how many tokens a *single request* may take from a batch. `--prefill-max-requests` caps the request *count*, not tokens.

## Modifications

Add `--long-prefill-token-threshold` (default `0`, disabled).

`PrefillAdder._apply_long_prefill_cap()` bounds one request's allocation, applied at both sites where a request can consume the budget:

- `add_chunked_req` — continuation chunks of an in-flight long prefill
- `add_one_req` — a new long request's first chunk, applied before the chunked/non-chunked split so requests already under the threshold still prefill in a single pass

Behavior:

- Rounded down to a page multiple; floored at one page so a long request always advances.
- `rem_tokens <= 0` passes through untouched — those are the exhausted-budget paths whose own handling (the memory-leak fallback in `add_chunked_req`, the `trunc_len <= 0` refusal in `add_one_req`) must not be masked.
- Composes with the SWA cap; whichever is tighter wins.
- Forced to 0 when chunked prefill is disabled, with a warning: without chunking there is no way to spread a request across passes, so a cap could only refuse it.
- Warns when the threshold is `>= chunked_prefill_size`, where it cannot have an effect.

Effect of `--long-prefill-token-threshold 2048` with `--chunked-prefill-size 8192`, one 500K-token request mid-prefill and three short requests waiting:

```
threshold=0  (current behaviour)
  long request chunk : 8192 tokens
  rem_chunk after    : 0
  batch size         : 1 request
  short reqs admitted: NONE — they wait out the long prefill

threshold=2048
  long request chunk : 2048 tokens
  rem_chunk after    : 2560
  batch size         : 4 requests
  short reqs admitted: short-0(1024), short-1(2048), short-2(512)
```

The long request is slowed (4 passes per 8192 tokens instead of 1) but never starved, and short requests stop paying its prefill latency.

## Prior art

vLLM's V1 scheduler exposes the same control as `long_prefill_token_threshold`, clamping `num_new_tokens` in both its running and waiting loops. Its scheduler hits the identical failure at the default (`0`, disabled): a long prefill consumes the whole `token_budget` and new requests wait.

## Related

- #29531 — documents the `min(max_prefill_tokens, chunked_prefill_size)` budget coupling this cap works around; proposes a startup warning only
- #32549 — same conditions (DSPARK, `chunked-prefill-size 8192`, prefill-first), decode starvation rather than admission starvation
- #10063 — requested exactly this, citing vLLM's flags; closed as covered by priority scheduling, which the thread then showed it is not
- #34058, #32775 — bound consecutive prefills to protect decode; complementary, different victim
- #32911 — HRRN queue ordering; complementary, changes ordering rather than per-request share

## Accuracy Tests

No change to model outputs. Default `0` is a no-op: `_apply_long_prefill_cap` returns its input unchanged, so chunk sizes and admission decisions are byte-identical to before.

## Speed Tests and Profiling

The trade is deliberate and bounded: a long request's prefill is spread over more passes (each smaller), while requests behind it stop waiting for that prefill to finish. On the production workload above, the affected hour had 10.35 % of requests over 60 s TTFT; the mechanism that produced those is what this cap removes.

I do not have a clean multi-tenant benchmark to publish alongside this — happy to run one if maintainers have a preferred harness, and to add an end-to-end test under `test/registered/scheduler/` if that's wanted for this behavior.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests).
- [x] Update documentation as needed, including docstrings or example tutorials.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31585358223](https://github.com/sgl-project/sglang/actions/runs/31585358223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31585357829](https://github.com/sgl-project/sglang/actions/runs/31585357829)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->