### PR TITLE
[Fix] Correct inverted assertion message for enable_mixed_chunk with speculative decoding

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9028,7 +9028,7 @@ class ServerArgs:
         if self.speculative_algorithm is not None:
             assert (
                 not self.enable_mixed_chunk
-            ), "enable_mixed_chunk is required for speculative decoding"
+            ), "enable_mixed_chunk is not supported with speculative decoding"
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).


### PR DESCRIPTION
## Motivation

When speculative decoding is enabled, the assertion rejects enable_mixed_chunk. The current message incorrectly states that it is required, which is the opposite of the enforced condition and can mislead users.

## Modifications

Correct the assertion message to state that enable_mixed_chunk is not supported with speculative decoding.

## Accuracy Tests

Not applicable. This is an error-message-only change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime behavior or performance.

## Checklist

- [x] Formatting checked with git diff --check.
- [x] Unit tests are not required for this error-message-only change.
- [x] Documentation changes are not required.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] The change follows the existing code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31581899469](https://github.com/sgl-project/sglang/actions/runs/31581899469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31581899176](https://github.com/sgl-project/sglang/actions/runs/31581899176)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->