### PR TITLE
[ROCm][Bugfix] Kimi-K3: opt-in gfx942 MXFP4-to-int4 MoE conversion

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -688,6 +688,8 @@ class Envs:
     SGLANG_QUANT_ALLOW_DOWNCASTING = EnvBool(False)
     SGLANG_FP8_IGNORED_LAYERS = EnvStr("")
     SGLANG_FP4_IGNORED_LAYERS = EnvStr("")
+    # Requantize Kimi-K3's MXFP4 experts to int4 on gfx942 (lossy, opt-in).
+    SGLANG_K3_SITU_GFX942_INT4 = EnvBool(False)
 
     # Quantization (Humming)
     SGLANG_HUMMING_ONLINE_QUANT_CONFIG = EnvJSON(None)

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import replace
 from typing import TYPE_CHECKING, List, Optional
@@ -146,6 +147,8 @@ if TYPE_CHECKING:
         CombineInput,
         StandardDispatchOutput,
     )
+
+logger = logging.getLogger(__name__)
 
 _is_cpu = is_cpu()
 _is_hip = is_hip()
@@ -543,6 +546,85 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.register_parameter("w2_weight_bias", w2_weight_bias)
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
+    def _k3_situ_gfx942_int4_enabled(self, layer) -> bool:
+        if not envs.SGLANG_K3_SITU_GFX942_INT4.get():
+            return False
+        if getattr(layer.moe_runner_config, "activation", None) != "situ":
+            return False
+        try:
+            from aiter.jit.utils.chip_info import get_gfx
+
+            return get_gfx() == "gfx942"
+        except Exception:
+            return False
+
+    @staticmethod
+    def _check_aiter_packed_int4_activation() -> None:
+        import inspect
+
+        from aiter.ops.flydsl.kernels.moe_gemm_2stage import compile_moe_gemm1
+
+        if "act" not in inspect.signature(compile_moe_gemm1).parameters:
+            raise RuntimeError(
+                "SGLANG_K3_SITU_GFX942_INT4 needs an aiter carrying "
+                "ROCm/aiter#4471; this one computes SiLU instead of SiTUv2."
+            )
+
+    def _convert_k3_situ_weights_to_int4(self, layer) -> None:
+        """Requantize MXFP4 experts to int4 with a groupwise-32 bf16 scale."""
+        from aiter import dtypes as _adt
+        from aiter.ops.quant import per_1x32_i4_quant
+        from aiter.ops.shuffle import (
+            pack_int8_to_packed_int4,
+            shuffle_scale_for_int4,
+            shuffle_weight,
+        )
+        from aiter.utility import fp4_utils
+
+        self._check_aiter_packed_int4_activation()
+        logger.warning(
+            "Requantizing Kimi-K3's MXFP4 experts to int4 for gfx942. e2m1 is "
+            "non-uniform and int4 is not, so this re-grids every weight."
+        )
+
+        fp4_dtype = torch.float4_e2m1fn_x2
+        e8m0_dtype = torch.float8_e8m0fnu
+
+        def _convert(w_param, s_param):
+            w_f32 = fp4_utils.mxfp4_to_f32(w_param.data.view(fp4_dtype))
+            s_f32 = fp4_utils.e8m0_to_f32(s_param.data.view(e8m0_dtype))
+            E, N, K = w_f32.shape
+            w_deq = (
+                (w_f32.view(E, N, K // 32, 32) * s_f32.view(E, N, K // 32, 1))
+                .view(E, N, K)
+                .to(torch.bfloat16)
+            )
+            del w_f32, s_f32
+            w_qt, w_scale = per_1x32_i4_quant(w_deq)
+            del w_deq
+            w_qt = w_qt.view(_adt.i4x2).view(E, N, K)
+            w_packed = pack_int8_to_packed_int4(
+                shuffle_weight(w_qt.view(_adt.i8), (16, 16))
+            )
+            w_packed = w_packed.view(E, N, K // 2).view(_adt.i4x2)
+            w_scale_shuf = (
+                shuffle_scale_for_int4(w_scale, group_size=32).view(-1).contiguous()
+            )
+            del w_qt, w_scale
+            torch.cuda.empty_cache()
+            return w_packed, w_scale_shuf
+
+        w13, w13_scale = _convert(layer.w13_weight, layer.w13_weight_scale)
+        w2, w2_scale = _convert(layer.w2_weight, layer.w2_weight_scale)
+
+        layer.w13_weight.data = w13
+        layer.w2_weight.data = w2
+        layer.w13_weight_scale.data = w13_scale
+        layer.w2_weight_scale.data = w2_scale
+        layer.w13_weight.is_shuffled = True
+        layer.w2_weight.is_shuffled = True
+        self._k3_situ_int4 = True
+
     def process_weights_after_loading(self, layer):
         if self.use_marlin:
             from sglang.srt.layers.quantization.marlin_utils import (
@@ -846,6 +928,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 )
             if getattr(layer, "w2_weight_bias", None) is not None:
                 layer.w2_weight_bias.data = layer.w2_weight_bias.data.to(torch.float32)
+
+            if self._k3_situ_gfx942_int4_enabled(layer):
+                self._convert_k3_situ_weights_to_int4(layer)
+                return
 
             e, n, k = layer.w13_weight.shape
             gate_up_interleaved = getattr(
@@ -1690,7 +1776,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 AiterQuantType,
             )
 
-            if hasattr(torch, "float4_e2m1fn_x2"):
+            if getattr(self, "_k3_situ_int4", False):
+                w13_weight = layer.w13_weight
+                w2_weight = layer.w2_weight
+            elif hasattr(torch, "float4_e2m1fn_x2"):
                 w13_weight = layer.w13_weight.view(torch.float4_e2m1fn_x2)
                 w2_weight = layer.w2_weight.view(torch.float4_e2m1fn_x2)
             else:


### PR DESCRIPTION
> Draft: depends on [ROCm/aiter#4471](https://github.com/ROCm/aiter/pull/4471), which is still open. This path refuses to load without it.

## Motivation

Kimi-K3 does not run on gfx942 (MI300X / MI325X). There is no tuned gfx942 config for K3's MXFP4 MoE shapes (`kimik3_fp4_tuned_fmoe.csv` is gfx950-only), so aiter improvises a heuristic FlyDSL kernel that emits a 128-bit buffer->LDS DMA. Wide direct-to-LDS is a gfx950 capability, and on gfx942 SelectionDAG cannot legalize the operand:

```
[aiter] [fused_moe] no tuned FlyDSL config for (...), using heuristic FlyDSL fallback
    (kn1='flydsl_moe1_abf16_wfp4_bf16_t32x128x256_w2', ...)
ExpandIntegerOperand ... llvm.amdgcn.raw.ptr.buffer.load.lds ... (s128)
LLVM ERROR: Do not know how to expand this operator's operand!
```

This is `report_fatal_error` inside the compiler, so Python cannot catch or retry it.

The same weights packed as int4 land on a smaller tile that never issues that DMA. From `get_2stage_cfgs` on the EP8 shape:

```
int4 -> flydsl_moe1_abf16_wint4_bf16_t16x128x128   # compiles
fp4  -> flydsl_moe1_abf16_wfp4_bf16_t32x128x256_w2 # LLVM abort
```

Neither dtype has gfx942 tuning, and there is no K3 int4 config either. int4 works because of the tile size, not because it is a supported path. Same workaround as [vllm-project/vllm#51274](https://github.com/vllm-project/vllm/pull/51274).

## Modifications

Opt-in through `SGLANG_K3_SITU_GFX942_INT4`, default off, so nothing changes unless it is set.

**`python/sglang/srt/environ.py`**

Register `SGLANG_K3_SITU_GFX942_INT4` as `EnvBool(False)` alongside the other quantization flags.

**`python/sglang/srt/layers/quantization/mxfp4.py`**

- `Mxfp4MoEMethod._k3_situ_gfx942_int4_enabled` gates the path on the flag, `situ` activation and `gfx942`. The aiter import sits in a `try/except`, so non-ROCm builds return False.
- `Mxfp4MoEMethod._convert_k3_situ_weights_to_int4` converts each expert tensor: dequantize MXFP4 (`fp4x2` x `e8m0`) to bf16, requantize with `per_1x32_i4_quant`, preshuffle through `shuffle_weight(..., (16, 16))` + `pack_int8_to_packed_int4`, and `shuffle_scale_for_int4(..., group_size=32)` for the scales. Intermediates are freed as it goes, since the bf16 staging tensor is 4x the packed weight.
- `Mxfp4MoEMethod._check_aiter_packed_int4_activation` refuses to load when aiter predates ROCm/aiter#4471. Before that fix the packed-int4 stage1 epilogue hardcodes `y = silu(vg) * vu` and drops the requested activation, so K3 serves fluent text computed with SiLU instead of SiTUv2. Nothing raises on its own, hence the hard error.
- `process_weights_after_loading` runs the conversion before the existing MXFP4 shuffle path and returns early.
- `apply` skips the unconditional `.view(torch.float4_e2m1fn_x2)` once the conversion ran. That view is what routed K3 into the broken kernel family.

The conversion is lossy and logs a warning: e2m1 is non-uniform, int4 is not, so every weight is re-gridded. Gated on gfx942 and SiTUv2, so no other architecture or model reaches the new code.

## Accuracy Tests

Pending. The development runs used 100-example MMLU and GSM8K subsets, which is too small to say anything useful here, and they predate the current aiter. 

## Speed Tests and Profiling

Pending, for the same reason.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). 
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31591286401](https://github.com/sgl-project/sglang/actions/runs/31591286401)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31591286308](https://github.com/sgl-project/sglang/actions/runs/31591286308)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->