### PR TITLE
[XPU] Enable symmetric-memory one-shot all-reduce

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/xpu_symm_mem.py
+++ b/python/sglang/srt/distributed/device_communicators/xpu_symm_mem.py
@@ -1,0 +1,214 @@
+"""Symmetric-memory all-reduce for Intel XPU."""
+
+import logging
+import socket
+from typing import Optional, Union
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from sglang.srt.environ import envs
+from sglang.srt.utils import is_xpu
+
+logger = logging.getLogger(__name__)
+
+try:
+    import torch.distributed._symmetric_memory as torch_symm_mem
+
+    _import_error: Optional[BaseException] = None
+except ImportError as e:  # pragma: no cover
+    torch_symm_mem = None
+    _import_error = e
+
+
+class XpuSymmMemCommunicator:
+    """One-shot all-reduce over torch symmetric memory on Intel XPU.
+
+    Mirrors the ``TorchSymmMemCommunicator`` call contract so GroupCoordinator's
+    dispatch needs no device special case. It is a separate class because that
+    one is built on ``symm_mem::{multimem,two_shot}_all_reduce_``, which
+    torch-xpu-ops does not register, and disables itself when
+    ``multicast_ptr == 0`` -- always the case on Xe. Only the allocator half of
+    the backend exists for XPU, hence the Triton reduce kernel.
+    """
+
+    # Peer mapping is intra-node only.
+    _MAX_WORLD_SIZE = 8
+
+    def __init__(self, group: ProcessGroup, device: Union[int, str, torch.device]):
+        self.disabled = True
+        self.buffer = None
+        self.handle = None
+        self.max_bytes = 0
+        self._staging = {}
+        # Assigned before the guards below: a disabled communicator still gets
+        # introspected (e.g. group.group_name by model-side custom-AR probes).
+        if isinstance(device, int):
+            device = torch.device(f"xpu:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        self.device = device
+        self.group = group
+        self.world_size = dist.get_world_size(group)
+
+        if not is_xpu():
+            return
+        if torch_symm_mem is None:
+            logger.warning(
+                "XpuSymmMemCommunicator: torch symmetric memory is unavailable "
+                "(%s); falling back to the default all-reduce.",
+                _import_error,
+            )
+            return
+
+        # Lazy: the reduce kernel pulls in Triton.
+        from sglang.srt.hardware_backend.xpu.kernels.comm.one_shot_all_reduce import (
+            SUPPORTED_DTYPES,
+            pack_peer_ptrs,
+        )
+
+        backend = torch_symm_mem.get_backend(device)
+        if backend != "XPU":
+            logger.warning(
+                "XpuSymmMemCommunicator: symmetric-memory backend for %s is %s, "
+                "expected 'XPU'; falling back to the default all-reduce.",
+                device,
+                backend,
+            )
+            return
+        if self.world_size > self._MAX_WORLD_SIZE:
+            logger.warning(
+                "XpuSymmMemCommunicator: world size %d exceeds the supported "
+                "maximum %d, communicator is not available.",
+                self.world_size,
+                self._MAX_WORLD_SIZE,
+            )
+            return
+        if not self._is_single_node(group):
+            logger.warning(
+                "XpuSymmMemCommunicator: group spans multiple hosts, "
+                "communicator is not available (peer mapping is intra-node)."
+            )
+            return
+
+        max_bytes = envs.SGLANG_XPU_SYMM_MEM_MAX_BYTES.get()
+        # The buffer is reinterpreted as every supported dtype, so keep it
+        # aligned to the widest element (fp32).
+        self.max_bytes = max_bytes - max_bytes % 4
+        if self.max_bytes <= 0:
+            logger.warning(
+                "XpuSymmMemCommunicator: SGLANG_XPU_SYMM_MEM_MAX_BYTES=%d leaves "
+                "no usable buffer, communicator is not available.",
+                max_bytes,
+            )
+            return
+
+        try:
+            self.buffer = torch_symm_mem.empty(
+                self.max_bytes, dtype=torch.uint8, device=device
+            )
+            self.handle = torch_symm_mem.rendezvous(self.buffer, group.group_name)
+        except Exception as e:
+            # Importing a peer's allocation goes through pidfd_getfd, which needs
+            # ptrace permission; restrictive seccomp / yama fails here.
+            logger.warning(
+                "XpuSymmMemCommunicator: symmetric-memory rendezvous failed (%s); "
+                "falling back to the default all-reduce.",
+                e,
+            )
+            self.buffer = None
+            self.handle = None
+            return
+
+        self.peer_ptrs = pack_peer_ptrs(self.handle.buffer_ptrs, device)
+        self._staging = {dtype: self.buffer.view(dtype) for dtype in SUPPORTED_DTYPES}
+        if not self._compile_kernel(group):
+            self.buffer = None
+            self.handle = None
+            self._staging = {}
+            return
+
+        self.disabled = False
+        logger.info(
+            "XpuSymmMemCommunicator: enabled on %s (world_size=%d, max_bytes=%d).",
+            device,
+            self.world_size,
+            self.max_bytes,
+        )
+
+    def _is_single_node(self, group: ProcessGroup) -> bool:
+        hostnames = [None] * self.world_size
+        dist.all_gather_object(hostnames, socket.gethostname(), group=group)
+        return len(set(hostnames)) == 1
+
+    def _compile_kernel(self, group: ProcessGroup) -> bool:
+        """Build the Triton specialization up front.
+
+        A first launch from inside a graph capture would otherwise JIT
+        mid-capture, and a build failure becomes a fallback here instead of an
+        error on a forward pass. Reads only buffers rendezvous already mapped,
+        so no barrier is involved. The verdict is reduced across the group
+        because ranks that disagree would diverge on every later all-reduce.
+        """
+        from sglang.srt.hardware_backend.xpu.kernels.comm.one_shot_all_reduce import (
+            one_shot_all_reduce,
+        )
+
+        compiled = torch.ones(1, dtype=torch.int32)
+        try:
+            probe = torch.empty(64, dtype=torch.bfloat16, device=self.device)
+            one_shot_all_reduce(self.peer_ptrs, probe, self.world_size)
+            torch.xpu.synchronize()
+        except Exception as e:
+            logger.warning(
+                "XpuSymmMemCommunicator: one-shot kernel failed to build (%s); "
+                "falling back to the default all-reduce.",
+                e,
+            )
+            compiled.zero_()
+        dist.all_reduce(compiled, op=dist.ReduceOp.MIN, group=group)
+        return bool(compiled.item())
+
+    def should_torch_symm_mem_allreduce(self, inp: torch.Tensor) -> bool:
+        """Whether the one-shot path can take this tensor."""
+        if self.disabled:
+            return False
+        if inp.device != self.device:
+            return False
+        if inp.dtype not in self._staging:
+            return False
+        if not inp.is_contiguous():
+            return False
+        inp_bytes = inp.numel() * inp.element_size()
+        if inp_bytes % 4 != 0:
+            return False
+        return inp_bytes <= self.max_bytes
+
+    def all_reduce(
+        self, inp: torch.Tensor, *, out: Optional[torch.Tensor] = None
+    ) -> Optional[torch.Tensor]:
+        """Sum-all-reduce ``inp`` by reading every rank's buffer once.
+
+        Returns ``None`` for an ineligible input, which sends the caller to the
+        default collective. ``out=inp`` reduces in place: peers read the staging
+        copy, not ``out``.
+        """
+        from sglang.srt.hardware_backend.xpu.kernels.comm.one_shot_all_reduce import (
+            one_shot_all_reduce,
+        )
+
+        if not self.should_torch_symm_mem_allreduce(inp):
+            return None
+        if out is None:
+            out = torch.empty_like(inp)
+
+        numel = inp.numel()
+        self._staging[inp.dtype][:numel].copy_(inp.view(-1))
+        # The first barrier publishes every rank's input before anyone reads its
+        # peers; the second stops the next call's staging write from racing a
+        # peer that is still reading this one.
+        self.handle.barrier()
+        one_shot_all_reduce(self.peer_ptrs, out.view(-1), self.world_size)
+        self.handle.barrier()
+        return out

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -418,6 +418,9 @@ class GroupCoordinator:
         from sglang.srt.distributed.device_communicators.torch_symm_mem import (
             TorchSymmMemCommunicator,
         )
+        from sglang.srt.distributed.device_communicators.xpu_symm_mem import (
+            XpuSymmMemCommunicator,
+        )
         from sglang.srt.layers.dp_attention import is_allocation_symmetric
 
         self.is_symmetric_memory_enabled = is_symmetric_memory_enabled
@@ -479,9 +482,16 @@ class GroupCoordinator:
         elif self.world_size > 1 and is_hip():
             logger.info("[AR] All-reduce call path: NCCL (custom AR disabled)")
 
-        self.torch_symm_mem_comm: Optional[TorchSymmMemCommunicator] = None
+        self.torch_symm_mem_comm: Optional[
+            Union[TorchSymmMemCommunicator, XpuSymmMemCommunicator]
+        ] = None
         if self.use_torch_symm_mem_all_reduce and self.world_size > 1:
-            self.torch_symm_mem_comm = TorchSymmMemCommunicator(
+            # XPU has no multimem / one-shot / two-shot symm_mem ops, so it
+            # needs its own communicator with the same call contract.
+            symm_mem_cls = (
+                XpuSymmMemCommunicator if _is_xpu else TorchSymmMemCommunicator
+            )
+            self.torch_symm_mem_comm = symm_mem_cls(
                 group=self.cpu_group,
                 device=self.device,
             )
@@ -662,7 +672,8 @@ class GroupCoordinator:
             # an opaque call and does not decompose it into _c10d_functional primitives
             # (which invoke sycl_event.wait() and break XPU graph capture).
             # Keeps the operation in-place; the all-reduce is performed by
-            # _all_reduce_in_place, which for XPU falls through to
+            # _all_reduce_in_place, which for XPU takes the symmetric-memory
+            # one-shot path for eligible payloads and otherwise falls through to
             # torch.distributed.all_reduce on self.device_group (the same group
             # used by xpu_communicator).
             inplace_all_reduce(input_, group_name=self.unique_name)

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1335,6 +1335,10 @@ class Envs:
     # Symmetric Memory
     SGLANG_SYMM_MEM_PREALLOC_GB_SIZE = EnvInt(-1)
     SGLANG_DEBUG_SYMM_MEM = EnvBool(False)
+    # Payload ceiling (and buffer size) for the Intel XPU symmetric-memory
+    # one-shot all-reduce; larger payloads fall back to the default collective.
+    # Tunable because the crossover depends on peer bandwidth (Xe Link vs PCIe).
+    SGLANG_XPU_SYMM_MEM_MAX_BYTES = EnvInt(512 * 1024)
 
     # Aiter
     SGLANG_USE_AITER_FP8_PER_TOKEN = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/xpu/kernels/comm/one_shot_all_reduce.py
+++ b/python/sglang/srt/hardware_backend/xpu/kernels/comm/one_shot_all_reduce.py
@@ -1,0 +1,78 @@
+"""Triton one-shot all-reduce over Intel XPU symmetric memory.
+
+Every rank reads all peers' symmetric buffers (IPC-mapped by torch-xpu-ops'
+``XPUSymmetricMemory``) and reduces locally. torch-xpu-ops registers no
+``symm_mem::*`` reduce kernel to call instead, and Xe reports no multicast
+support, so the ``multimem`` variant is not an option either.
+
+Accumulation is fp32 in ascending rank order, so the result is bitwise identical
+on every rank and stable across runs.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import numpy as np
+import torch
+import triton
+import triton.language as tl
+
+_BLOCK_SIZE = 2048
+_NUM_WARPS = 8
+
+_TRITON_DTYPE = {
+    torch.bfloat16: tl.bfloat16,
+    torch.float16: tl.float16,
+    torch.float32: tl.float32,
+}
+
+SUPPORTED_DTYPES = tuple(_TRITON_DTYPE)
+
+
+def pack_peer_ptrs(buffer_ptrs: Sequence[int], device: torch.device) -> torch.Tensor:
+    """Pack peer buffer addresses into an int64 device tensor for Triton.
+
+    Intel USM device pointers have the high bit set, so they are reinterpreted
+    from uint64: ``torch.tensor(buffer_ptrs, dtype=torch.int64)`` overflows.
+    """
+    packed = np.array(list(buffer_ptrs), dtype=np.uint64).view(np.int64)
+    return torch.from_numpy(packed).to(device)
+
+
+@triton.jit
+def _one_shot_all_reduce_kernel(
+    peer_ptrs,
+    out_ptr,
+    numel,
+    WORLD_SIZE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    DTYPE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for peer in tl.static_range(WORLD_SIZE):
+        peer_base = tl.load(peer_ptrs + peer).to(tl.pointer_type(DTYPE))
+        acc += tl.load(peer_base + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr + offsets, acc.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+def one_shot_all_reduce(
+    peer_ptrs: torch.Tensor, out: torch.Tensor, world_size: int
+) -> None:
+    """Sum ``world_size`` peer symmetric buffers into flat contiguous ``out``.
+
+    The caller owns synchronization: every rank must have staged its input
+    before this runs, and no rank may re-stage until all peers have read it.
+    """
+    numel = out.numel()
+    _one_shot_all_reduce_kernel[(triton.cdiv(numel, _BLOCK_SIZE),)](
+        peer_ptrs,
+        out,
+        numel,
+        WORLD_SIZE=world_size,
+        BLOCK_SIZE=_BLOCK_SIZE,
+        DTYPE=_TRITON_DTYPE[out.dtype],
+        num_warps=_NUM_WARPS,
+    )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1974,7 +1974,7 @@ class ServerArgs:
     ] = False
     enable_torch_symm_mem: A[
         bool,
-        "Enable using torch symm mem for all-reduce kernel and fall back to NCCL. Only supports CUDA device SM90 and above. SM90 supports world size 4, 6, 8. SM100 supports world size 6, 8.",
+        "Enable using torch symm mem for all-reduce kernel and fall back to NCCL. On CUDA, only supports device SM90 and above. SM90 supports world size 4, 6, 8. SM100 supports world size 6, 8. On Intel XPU, runs a one-shot all-reduce over IPC-mapped peer buffers for payloads up to SGLANG_XPU_SYMM_MEM_MAX_BYTES (world size up to 8, single node) and falls back to oneCCL otherwise.",
         NS("exec.comm"),
     ] = False
     enable_scattered_sconv: A[

--- a/test/registered/xpu/test_xpu_symm_mem_all_reduce.py
+++ b/test/registered/xpu/test_xpu_symm_mem_all_reduce.py
@@ -1,0 +1,149 @@
+"""Correctness test for the Intel XPU symmetric-memory one-shot all-reduce.
+
+The sweep lives in one test function on purpose: every rank must issue the same
+sequence of collectives, and a shuffled test order (pytest-randomly seeds per
+process) would pair ranks on different payloads.
+
+Usage::
+
+    # Runs itself under torchrun on 2 XPUs:
+    python test/registered/xpu/test_xpu_symm_mem_all_reduce.py
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+import torch.distributed as dist
+
+from sglang.srt.distributed.device_communicators.xpu_symm_mem import (
+    XpuSymmMemCommunicator,
+)
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_xpu_ci
+
+register_xpu_ci(est_time=180, suite="nightly-xpu-2-gpu", nightly=True)
+
+_WORLD_SIZE = 2
+_MAX_BYTES = 512 * 1024
+_DTYPES = [torch.bfloat16, torch.float16, torch.float32]
+# 128 exercises a masked block tail; 65536 sits on the 512 KiB fp32 ceiling.
+_NUMELS = [128, 3584, 65536]
+
+_comm_cache = {}
+
+
+def _get_comm() -> XpuSymmMemCommunicator:
+    """One communicator per worker; rendezvous is collective, so cache it."""
+    if "comm" not in _comm_cache:
+        local_rank = int(os.environ["LOCAL_RANK"])
+        torch.xpu.set_device(local_rank)
+        dist.init_process_group(backend="gloo")
+        _comm_cache["comm"] = XpuSymmMemCommunicator(
+            group=dist.group.WORLD, device=torch.device(f"xpu:{local_rank}")
+        )
+    return _comm_cache["comm"]
+
+
+def _shards(numel: int, dtype: torch.dtype, world_size: int) -> list[torch.Tensor]:
+    """Per-rank inputs, seeded so every rank can build the reference locally."""
+    return [
+        torch.randn(
+            numel,
+            generator=torch.Generator().manual_seed(1234 + rank),
+            dtype=torch.float32,
+        ).to(dtype)
+        for rank in range(world_size)
+    ]
+
+
+def _reference(shards: list[torch.Tensor], dtype: torch.dtype) -> torch.Tensor:
+    """Accumulate in fp32 in ascending rank order, exactly as the kernel does."""
+    acc = shards[0].float()
+    for shard in shards[1:]:
+        acc = acc + shard.float()
+    return acc.to(dtype)
+
+
+@torch.inference_mode()
+def test_one_shot_all_reduce_matches_ordered_fp32_sum() -> None:
+    comm = _get_comm()
+    if comm.disabled:
+        pytest.skip("XPU symmetric memory unavailable")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+
+    for dtype in _DTYPES:
+        for numel in _NUMELS:
+            if numel * torch.finfo(dtype).bits // 8 > comm.max_bytes:
+                continue
+            shards = _shards(numel, dtype, world_size)
+            expected = _reference(shards, dtype)
+            inp = shards[rank].to(comm.device)
+
+            out = comm.all_reduce(inp)
+            assert out is not None, f"{dtype}/{numel} rejected by the fast path"
+            torch.testing.assert_close(out.cpu(), expected, atol=0, rtol=0)
+
+            # In-place form, as GroupCoordinator._all_reduce_in_place calls it.
+            inplace = inp.clone()
+            assert comm.all_reduce(inplace, out=inplace) is not None
+            torch.testing.assert_close(inplace.cpu(), expected, atol=0, rtol=0)
+
+
+@torch.inference_mode()
+def test_ineligible_payloads_fall_back() -> None:
+    """Rejected inputs must return None so the caller falls back."""
+    comm = _get_comm()
+    if comm.disabled:
+        pytest.skip("XPU symmetric memory unavailable")
+
+    max_bf16 = comm.max_bytes // 2
+    too_large = torch.zeros(max_bf16 + 1, dtype=torch.bfloat16, device=comm.device)
+    assert not comm.should_torch_symm_mem_allreduce(too_large)
+    assert comm.all_reduce(too_large) is None
+
+    exactly_max = torch.zeros(max_bf16, dtype=torch.bfloat16, device=comm.device)
+    assert comm.should_torch_symm_mem_allreduce(exactly_max)
+
+    unsupported_dtype = torch.zeros(128, dtype=torch.float64, device=comm.device)
+    assert not comm.should_torch_symm_mem_allreduce(unsupported_dtype)
+
+    non_contiguous = torch.zeros(128, 8, dtype=torch.bfloat16, device=comm.device)[
+        :, ::2
+    ]
+    assert not comm.should_torch_symm_mem_allreduce(non_contiguous)
+
+    on_cpu = torch.zeros(128, dtype=torch.bfloat16)
+    assert not comm.should_torch_symm_mem_allreduce(on_cpu)
+
+
+def _main() -> int:
+    if torch.xpu.device_count() < _WORLD_SIZE:
+        print(f"needs {_WORLD_SIZE} XPUs, found {torch.xpu.device_count()}; skipping")
+        return 0
+    with envs.SGLANG_XPU_SYMM_MEM_MAX_BYTES.override(_MAX_BYTES):
+        return subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "torch.distributed.run",
+                f"--nproc-per-node={_WORLD_SIZE}",
+                __file__,
+                *sys.argv[1:],
+            ],
+            env={**os.environ, "_XPU_SYMM_MEM_TEST_WORKER": "1"},
+        ).returncode
+
+
+if __name__ == "__main__":
+    if os.environ.get("_XPU_SYMM_MEM_TEST_WORKER"):
+        args = ["-x" if a == "-f" else a for a in sys.argv[1:]]
+        # no:randomly — a per-process shuffle would put ranks on different
+        # collectives; the tests below assume a fixed order across ranks.
+        sys.exit(pytest.main([__file__, "-p", "no:randomly", *args]))
+    sys.exit(_main())


### PR DESCRIPTION
## Motivation

Tensor-parallel all-reduce on Intel XPU currently goes through `XpuCommunicator`, which is a
plain `dist.all_reduce` over oneCCL. None of the latency-optimized all-reduce paths are
available: custom AR (v1/v2), quick-AR and mscclpp are CUDA/ROCm-only, and PyNCCL is
explicitly excluded for XPU. At decode-time TP shapes (e.g. batch 8 x hidden 3584 bf16 =
~57 KB) the collective's fixed cost dominates, so there is no small-message fast path at all.

Torch symmetric memory looks like the natural fit, but only half of it exists on XPU:
torch-xpu-ops ships `XPUSymmetricMemory` (allocator, IPC rendezvous over
`syclexp::ipc_memory`, signal pads, barrier) and registers **no** `symm_mem::*` reduce
kernels — `one_shot_all_reduce`, `two_shot_all_reduce_` and `multimem_all_reduce_` have no XPU
implementation. Xe also reports `has_multicast_support() == false`. `TorchSymmMemCommunicator`
is therefore unusable as-is: it is built on `multimem`/`two_shot_all_reduce_` and disables
itself whenever `multicast_ptr == 0`.

This PR supplies the missing reduce step so XPU can use the symmetric memory that the driver
stack already provides.

## Modifications

- **`device_communicators/xpu_symm_mem.py`** — new `XpuSymmMemCommunicator`. Allocates a
  symmetric staging buffer, rendezvous over the group, then per all-reduce: stage → barrier →
  read every peer's buffer and reduce → barrier. It implements the same call contract
  `GroupCoordinator` already uses (`disabled` / `should_torch_symm_mem_allreduce` /
  `all_reduce`), so the existing fast-path dispatch selects it with no new device branch in
  `all_reduce`.
- **`hardware_backend/xpu/kernels/comm/one_shot_all_reduce.py`** — the Triton kernel.
  Accumulates in fp32 over ranks in ascending order, so the result is bitwise identical on
  every rank and stable across runs. Peer addresses are passed as an int64 device tensor
  reinterpreted from uint64 (Intel USM pointers have the high bit set and overflow int64).
- **`parallel_state.py`** — construct the XPU communicator for `torch_symm_mem_comm` when the
  device is XPU, `TorchSymmMemCommunicator` otherwise. CUDA behaviour and ordering are
  unchanged.
- **`environ.py`** — `SGLANG_XPU_SYMM_MEM_MAX_BYTES` (default 512 KiB).
- **`server_args.py`** — `--enable-torch-symm-mem` help text now covers XPU.

Behaviour and guards:

- Opt-in via `--enable-torch-symm-mem`; without it nothing changes.
- One-shot moves `(world_size - 1) x payload` across the interconnect to save a round trip, so
  it is a small-message optimization. Payloads above `SGLANG_XPU_SYMM_MEM_MAX_BYTES`, other
  dtypes (supported: bf16 / fp16 / fp32), non-contiguous inputs and non-4-byte-aligned sizes
  fall back to the default collective. The threshold is an env var because the crossover is
  platform-specific (Xe Link vs PCIe).
- Disables itself and falls back, with a warning, when: the symmetric-memory backend for the
  device is not `"XPU"`, world size > 8, the group spans multiple hosts (peer mapping is
  intra-node), or rendezvous fails — importing a peer allocation uses `pidfd_getfd`, which
  needs ptrace permission and fails under restrictive container seccomp/yama.
- The Triton specialization is built at init rather than on first use: a first launch from
  inside a graph capture would otherwise JIT mid-capture, and a build failure degrades to a
  fallback instead of erroring on a forward pass. The verdict is reduced across the group so
  ranks cannot disagree.
- `--enable-deterministic-inference` still disables `enable_torch_symm_mem`, unchanged from
  CUDA. The kernel itself is order-deterministic, but selecting between two algorithms by
  payload size is not batch-invariant, which is the existing rationale and applies equally
  here.

## Accuracy Tests

New test: `test/registered/xpu/test_xpu_symm_mem_all_reduce.py` (registered
`nightly-xpu-2-gpu`), self-relaunches under torchrun:

```
python test/registered/xpu/test_xpu_symm_mem_all_reduce.py
```

On 2x / 4x / 8x Arc Pro B60, results are **bitwise exact** (`atol=0, rtol=0`) against an fp32
accumulation over peer shards in ascending rank order, for bf16 / fp16 / fp32 at 128 / 3584 /
65536 elements, in both the out-of-place and in-place (`out=inp`) forms. The test also pins
that ineligible payloads are rejected rather than silently staged into a too-small buffer.

End-to-end through the real dispatch, `GroupCoordinator.all_reduce` selects the one-shot path
and returns the correct sum in place (2 ranks -> 3.0, 4 ranks -> 10.0).

The barrier pairing was checked separately under 5 ms of deliberate one-sided host skew:
0/60 iterations mismatched.

## Speed Tests and Profiling

**No speedup is claimed yet — the validation host cannot show one, and I would like this
measured on Xe Link hardware before the threshold default is trusted.**

Measured on the 8x Arc Pro B60 box used for correctness:

| Path | Bandwidth |
|---|---|
| Peer read / write via symmetric memory | 2.5 GB/s |
| Cross-device copy engine | 2.6 GB/s |
| H2D pinned | 3.6 GB/s |
| Local HBM | 197 GB/s |

Every interconnect path on this machine is ~2.5 GB/s, roughly 80x below local HBM, so an
algorithm that pulls peer data cannot pay off here regardless of implementation. The
symmetric-memory barrier itself is cheap (~7 us). A oneCCL baseline was not obtainable on this
host: its oneCCL install ships only the CPU plugin, so the XCCL backend fails to initialize
("Could not load any plugin"), which also means no `bench_one_batch --tp 2` numbers.

This is why the path is opt-in and threshold-gated: on a system with real peer bandwidth,
raise `SGLANG_XPU_SYMM_MEM_MAX_BYTES` to the measured crossover; where the interconnect is
slow, leaving the flag off costs nothing.

Also not yet exercised: capture of this path inside `torch.xpu.XPUGraph` (it stays inside the
opaque `inplace_all_reduce` custom op and the kernel is pre-built, but no real graph capture
was run), and the multi-host guard, since validation was single-node.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — covered by the `--enable-torch-symm-mem` help text and the env var comment; happy to add an XPU docs section if maintainers want one.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — accuracy provided above; speed benchmarks pending hardware with usable peer bandwidth and a working oneCCL GPU plugin.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31597646758](https://github.com/sgl-project/sglang/actions/runs/31597646758)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31597646647](https://github.com/sgl-project/sglang/actions/runs/31597646647)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->