### PR TITLE
fix(diffusion): unshard FSDP root group for custom encoder entry points

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -27,7 +27,10 @@ from sglang.multimodal_gen.runtime.distributed.parallel_state import (
 from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
     ComponentLoader,
 )
-from sglang.multimodal_gen.runtime.loader.fsdp_load import shard_model
+from sglang.multimodal_gen.runtime.loader.fsdp_load import (
+    register_fsdp_entrypoints,
+    shard_model,
+)
 from sglang.multimodal_gen.runtime.loader.utils import (
     set_default_torch_dtype,
     skip_init_modules,
@@ -499,6 +502,7 @@ class TextEncoderLoader(ComponentLoader):
                         or getattr(model, "_fsdp_shard_conditions", None),
                         pin_cpu_memory=server_args.pin_cpu_memory,
                     )
+                    register_fsdp_entrypoints(model)
                 else:
                     model = model.to("cpu")
             else:

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -208,6 +208,19 @@ def _maybe_dequantize_fp8(
 
 
 # TODO(PY): add compile option
+def register_fsdp_entrypoints(model: torch.nn.Module) -> None:
+    """Let FSDP2 unshard around forward passes that bypass ``__call__``.
+
+    FSDP2 only unshards around the wrapped module's own ``forward``. Parameters
+    the shard conditions did not match stay in the catch-all root group, whose
+    hook therefore never fires for a model driven through a custom method, and
+    the first op mixing them with a plain tensor fails. Models declare those
+    entry points in ``_fsdp_forward_methods``.
+    """
+    for name in model._fsdp_forward_methods:
+        register_fsdp_forward_method(model, name)
+
+
 def maybe_load_fsdp_model(
     model_cls: type[nn.Module],
     init_params: dict[str, Any],
@@ -316,8 +329,7 @@ def maybe_load_fsdp_model(
             fsdp_shard_conditions=getattr(model, "_fsdp_shard_conditions", None),
             pin_cpu_memory=pin_cpu_memory,
         )
-        if callable(getattr(model, "refine_prompt_embeds", None)):
-            register_fsdp_forward_method(model, "refine_prompt_embeds")
+        register_fsdp_entrypoints(model)
 
     param_names_mapping_fn = get_param_names_mapping(model.param_names_mapping)
 

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -207,7 +207,6 @@ def _maybe_dequantize_fp8(
     return full_tensor
 
 
-# TODO(PY): add compile option
 def register_fsdp_entrypoints(model: torch.nn.Module) -> None:
     """Let FSDP2 unshard around forward passes that bypass ``__call__``.
 
@@ -215,12 +214,14 @@ def register_fsdp_entrypoints(model: torch.nn.Module) -> None:
     the shard conditions did not match stay in the catch-all root group, whose
     hook therefore never fires for a model driven through a custom method, and
     the first op mixing them with a plain tensor fails. Models declare those
-    entry points in ``_fsdp_forward_methods``.
+    entry points in ``_fsdp_forward_methods``, which every model loaded through
+    FSDP must define; ``BaseDiT`` and ``TextEncoder`` default it to ``()``.
     """
     for name in model._fsdp_forward_methods:
         register_fsdp_forward_method(model, name)
 
 
+# TODO(PY): add compile option
 def maybe_load_fsdp_model(
     model_cls: type[nn.Module],
     init_params: dict[str, Any],
@@ -238,6 +239,9 @@ def maybe_load_fsdp_model(
     weight_load_plan: WeightLoadPlan | None = None,
 ) -> torch.nn.Module:
     """Load a model with optional FSDP (Fully Sharded Data Parallel) support.
+
+    ``model_cls`` must declare ``_fsdp_forward_methods``, the entry points FSDP2
+    has to unshard around (empty when the model is driven through ``__call__``).
 
     Args:
         param_dtype: Data type for model parameters, also used for:

--- a/python/sglang/multimodal_gen/runtime/models/dits/base.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/base.py
@@ -27,6 +27,11 @@ class BaseDiT(nn.Module, ABC):
     # execution semantics support only a subset of the available backends.
     _fsdp_shard_conditions: list = []
     _compile_conditions: list = []
+    # Methods that drive a forward pass without going through __call__. FSDP2
+    # only unshards around the wrapped module's own forward, so anything the
+    # shard conditions left in the root group stays sharded unless the entry
+    # point is registered; loaders read this and register each name.
+    _fsdp_forward_methods: tuple[str, ...] = ()
     param_names_mapping: dict
     reverse_param_names_mapping: dict
     hidden_size: int

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -1026,6 +1026,8 @@ class MiniMaxH3FinalLayer(nn.Module):
 
 class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
     _fsdp_shard_conditions = [is_block]
+    # refine_prompt_embeds drives a forward pass outside __call__.
+    _fsdp_forward_methods = ("refine_prompt_embeds",)
     # parameters mix fp32 (patch projections, timestep embedder, and output
     # heads) with bf16 blocks; FSDP must gather in each parameter's own dtype
     _fsdp_mixed_dtype_params = True

--- a/python/sglang/multimodal_gen/runtime/models/encoders/base.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/base.py
@@ -163,6 +163,11 @@ class TextEncoder(nn.Module, ABC, LayerwiseOffloadableModuleMixin):
         "model.language_model.layers",
     ]
     _fsdp_shard_conditions: list = field(default_factory=lambda: [])
+    # Methods that drive a forward pass without going through __call__. FSDP2
+    # only unshards around the wrapped module's own forward, so anything the
+    # shard conditions left in the root group stays sharded unless the entry
+    # point is registered; loaders read this and register each name.
+    _fsdp_forward_methods: tuple[str, ...] = ()
     _stacked_params_mapping: list[tuple[str, str, str]] = field(default_factory=list)
     _supported_attention_backends: set[AttentionBackendEnum] = (
         TextEncoderConfig()._supported_attention_backends

--- a/python/sglang/multimodal_gen/runtime/models/encoders/minimax_h3_qwen3vl.py
+++ b/python/sglang/multimodal_gen/runtime/models/encoders/minimax_h3_qwen3vl.py
@@ -41,6 +41,10 @@ class MiniMaxH3Qwen3VLEncoder(TextEncoder):
     eight otherwise-idle ranks during encoding.
     """
 
+    # encode_ids drives the forward pass; __call__ is never used, so FSDP2
+    # needs it registered or the root group (the vision tower) stays sharded.
+    _fsdp_forward_methods = ("encode_ids",)
+
     supports_dp_encode = True
 
     @staticmethod

--- a/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
+++ b/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
@@ -16,6 +16,9 @@ from sglang.multimodal_gen.runtime.loader.weight_load_plan import WeightLoadPlan
 
 class _UniformDtypeModel(nn.Module):
     param_names_mapping = {}
+    # Every model the FSDP loader accepts declares its custom forward entry
+    # points, as BaseDiT and TextEncoder do; none here drive one.
+    _fsdp_forward_methods: tuple[str, ...] = ()
 
     def __init__(self) -> None:
         super().__init__()
@@ -32,6 +35,13 @@ class _ReplicatedLinearModel(_UniformDtypeModel):
     def __init__(self) -> None:
         super().__init__()
         self.proj = ReplicatedLinear(4, 4, bias=False)
+
+
+class _CustomEntrypointModel(_UniformDtypeModel):
+    _fsdp_forward_methods = ("refine_prompt_embeds",)
+
+    def refine_prompt_embeds(self) -> None:
+        pass
 
 
 class TestFSDPMixedPrecisionPolicy(unittest.TestCase):
@@ -103,6 +113,45 @@ class TestFSDPMixedPrecisionPolicy(unittest.TestCase):
         self.assertEqual(policy.param_dtype, torch.bfloat16)
         self.assertEqual(state_kwargs["param_dtype"], torch.bfloat16)
         shard_model.assert_not_called()
+
+
+class TestFSDPEntrypointRegistration(unittest.TestCase):
+    def _load_and_capture_registrations(self, model_cls: type[nn.Module]):
+        with (
+            patch.object(fsdp_load.current_platform, "is_mps", return_value=False),
+            patch.object(fsdp_load, "init_device_mesh", return_value=object()),
+            patch.object(fsdp_load, "shard_model"),
+            patch.object(
+                fsdp_load,
+                "safetensors_weights_iterator",
+                return_value=iter(()),
+            ),
+            patch.object(fsdp_load, "load_model_from_full_model_state_dict"),
+            patch.object(fsdp_load, "register_fsdp_forward_method") as register,
+        ):
+            model = fsdp_load.maybe_load_fsdp_model(
+                model_cls=model_cls,
+                init_params={},
+                weight_dir_list=[],
+                device=torch.device("cpu"),
+                hsdp_replicate_dim=1,
+                hsdp_shard_dim=1,
+                param_dtype=torch.bfloat16,
+                reduce_dtype=torch.float32,
+                fsdp_inference=True,
+            )
+
+        return model, register
+
+    def test_declared_entry_points_are_registered(self):
+        model, register = self._load_and_capture_registrations(_CustomEntrypointModel)
+
+        register.assert_called_once_with(model, "refine_prompt_embeds")
+
+    def test_model_without_entry_points_registers_nothing(self):
+        _, register = self._load_and_capture_registrations(_UniformDtypeModel)
+
+        register.assert_not_called()
 
 
 class TestOrdinaryWeightLoading(unittest.TestCase):


### PR DESCRIPTION
## Problem

Encoders loaded with `--text-encoder-cpu-offload` go through FSDP2 `shard_model()`. Parameters that `_fsdp_shard_conditions` does not match land in the catch-all root group, and FSDP2 only unshards around the wrapped module's own `forward`. An encoder whose pipeline entry point is a custom method never triggers that hook, so those parameters stay sharded DTensors for the whole call, and the first op that mixes them with a plain tensor fails.

MiniMax-H3 hits this. Its text-encoding stage calls `MiniMaxH3Qwen3VLEncoder.encode_ids()` rather than `forward()`, and the Qwen3-VL vision tower is entirely root-managed (`is_layer` matches `*.layers.<d>`, the vision tower is `model.visual.blocks.<i>`). Any request with image or video conditioning dies in the patch-embed conv3d:

```
File "transformers/models/qwen3_vl/modeling_qwen3_vl.py", line 96, in forward
    hidden_states = self.proj(hidden_states.to(dtype=target_dtype))...
RuntimeError: aten.convolution.default: got mixed torch.Tensor and DTensor, need to convert all torch.Tensor to DTensor before calling distributed operators!
```

Text-only requests are unaffected because the language layers are matched by the shard conditions and carry their own hooks, so this only shows up once a visual condition is present.

## Solution

Register the custom entry point as an FSDP forward method, mirroring what `fsdp_load.py` already does for the DiT's `refine_prompt_embeds`. The `callable(getattr(model, "encode_ids", None))` guard keeps the change inert for every other encoder — `MiniMaxH3Qwen3VLEncoder` is the only class in the tree that defines `encode_ids`.

## Effect

Verified on 8x RTX PRO 5000 (sm_120), MiniMax-H3, `tp_size=1 / ulysses_degree=8`, 1344x768 124 frames, 50 steps:

| | before | after |
|---|---|---|
| fl2va (2 image keyframes) with `--text-encoder-cpu-offload` | crash | ok |
| whole-card peak memory | 68.50 GiB | 63.09 GiB |
| e2e | n/a | 152.2 s (unchanged vs. the same run without TE offload, 150.7 s) |

ref2va (reference video + reference audio) recovers the same way. Output is bit-identical to a run without text-encoder offload (same mp4 md5). No change when `--text-encoder-cpu-offload` is off: the branch is not entered.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31668940713](https://github.com/sgl-project/sglang/actions/runs/31668940713)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31668940544](https://github.com/sgl-project/sglang/actions/runs/31668940544)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->