### PR TITLE
fix(muse-glimmer): recover tool calls the detector currently drops

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -513,6 +513,12 @@ class Envs:
 
     # Tool Calling
     SGLANG_FORWARD_UNKNOWN_TOOLS = EnvBool(False)
+    # Muse Glimmer: treat an ATEM payload that arrives with no
+    # "to=<tool><|message|>" channel header as a tool call instead of content.
+    # Off by default: the detector is deliberately stricter than the vendor
+    # parser, so an <atem:invoke> inside reasoning or a final answer stays text.
+    # Turn on for checkpoints that emit header-less calls in practice.
+    SGLANG_ENABLE_MUSE_IMPLICIT_TOOL_CALLS = EnvBool(False)
 
     # Native web search (Exa). EXA_API_KEY is the vendor BYOK credential
     # (kept as-is, not renamed to SGLANG_*); the SGLANG_EXA_* knobs tune the

--- a/python/sglang/srt/function_call/muse_glimmer_detector.py
+++ b/python/sglang/srt/function_call/muse_glimmer_detector.py
@@ -40,6 +40,15 @@ _PARAM_RE = re.compile(
 # Recipients whose bodies are prose, never tool calls.
 _NON_TOOL_RECIPIENTS = frozenset({"self", "user"})
 
+# Stand-in recipient for a tool payload that arrived without a channel header.
+_IMPLICIT_TOOL = "\x00implicit-tool"
+
+
+def _atem_start(text: str) -> int:
+    """Index where an ATEM payload begins in ``text``, or -1."""
+    hits = [i for i in (text.find(FUNCTION_CALLS_OPEN), text.find("<atem:invoke")) if i != -1]
+    return min(hits) if hits else -1
+
 
 def _is_tool_channel(recipient: Optional[str]) -> bool:
     """True when this channel routes to a tool."""
@@ -219,15 +228,45 @@ class MuseGlimmerDetector(BaseFormatDetector):
         final: bool,
     ) -> int:
         if not _is_tool_channel(self._recipient):
-            normal_parts.append(chunk)
-            return len(chunk)
+            # Opt-in, and only for an unframed body. A body that explicitly
+            # routes to self or user is reasoning or a final answer, and ATEM
+            # markup inside it is quoted text -- never a call -- so those
+            # channels keep upstream's strict behaviour even when enabled.
+            start = (
+                _atem_start(chunk)
+                if (
+                    self._recipient is None
+                    and envs.SGLANG_ENABLE_MUSE_IMPLICIT_TOOL_CALLS.get()
+                )
+                else -1
+            )
+            if start == -1:
+                normal_parts.append(chunk)
+                return len(chunk)
+            # The model appends a call to a prose body with no <|eom|> and no
+            # to=<tool><|message|> header. The content ends at the ATEM marker and
+            # the rest of the body is a tool channel.
+            if start:
+                normal_parts.append(chunk[:start])
+            self._recipient = _IMPLICIT_TOOL
+            return start + self._consume_body(
+                chunk[start:], registered, calls, normal_parts, final
+            )
 
         pos = 0
         while pos < len(chunk):
             if self._open_invoke is None:
                 m = _INVOKE_OPEN_RE.search(chunk, pos)
                 if m is None:
-                    return pos if not final else len(chunk)
+                    if not final:
+                        return pos
+                    # A tool body with no ATEM invoke: the model emitted the
+                    # JSON-array form (what a grammar constraint asks for).
+                    # Parse it instead of discarding the whole generation.
+                    self._emit_json_calls(
+                        chunk[pos:], registered, calls, normal_parts
+                    )
+                    return len(chunk)
                 self._open_invoke = m.group("name")
                 pos = m.end()
                 continue
@@ -247,6 +286,56 @@ class MuseGlimmerDetector(BaseFormatDetector):
             pos = close_at + len(INVOKE_CLOSE)
 
         return len(chunk)
+
+    def _emit_json_calls(
+        self,
+        chunk: str,
+        registered: Set[str],
+        calls: List[ToolCallItem],
+        normal_parts: List[str],
+    ) -> None:
+        """Parse a ``[{"name": ..., "parameters": {...}}]`` body on a tool channel.
+
+        Falls back to emitting the text so an unrecognized body surfaces to the
+        client instead of vanishing.
+        """
+        residue = chunk
+        for marker in (FUNCTION_CALLS_OPEN, FUNCTION_CALLS_CLOSE, INVOKE_CLOSE):
+            residue = residue.replace(marker, "")
+        if not residue.strip():
+            # Nothing but framing left over from an already-emitted call.
+            return
+
+        # Parse the marker-stripped residue, not the raw chunk: a body that
+        # closes with </atem:function_calls> leaves trailing markup that makes
+        # json.loads fail, which would surface the whole block as content.
+        start = min(
+            (i for i in (residue.find("["), residue.find("{")) if i != -1), default=-1
+        )
+        payload = None
+        if start != -1:
+            try:
+                payload = json.loads(residue[start:].strip())
+            except (json.JSONDecodeError, ValueError):
+                payload = None
+        if payload is None:
+            normal_parts.append(chunk)
+            return
+        if isinstance(payload, dict):
+            payload = [payload]
+        emitted = False
+        for entry in payload if isinstance(payload, list) else []:
+            if not isinstance(entry, dict) or "name" not in entry:
+                continue
+            args = entry.get("parameters", entry.get("arguments")) or {}
+            if isinstance(args, str):
+                args = _decode_value(args)
+            item = self._emit_call(entry["name"], args, registered)
+            if item is not None:
+                calls.append(item)
+                emitted = True
+        if not emitted:
+            normal_parts.append(chunk)
 
     def supports_structural_tag(self) -> bool:
         return False

--- a/test/registered/unit/function_call/test_muse_glimmer_detector.py
+++ b/test/registered/unit/function_call/test_muse_glimmer_detector.py
@@ -10,6 +10,7 @@ must never become a real tool call.
 import json
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
 from sglang.srt.function_call.muse_glimmer_detector import MuseGlimmerDetector
 from sglang.srt.parser.reasoning_parser import ReasoningParser
@@ -235,6 +236,22 @@ class TestMuseGlimmerDetector(CustomTestCase):
         normal, calls = self.parse(text)
         self.assertEqual(calls, [])
         self.assertEqual(normal, text)
+
+    def test_unframed_atem_becomes_a_call_when_opted_in(self):
+        """The opt-in reverses the strictness above for checkpoints that need it."""
+        text = atem(DOUBLED, city="Paris")
+        with envs.SGLANG_ENABLE_MUSE_IMPLICIT_TOOL_CALLS.override(True):
+            normal, calls = self.parse(text)
+        self.assertEqual(calls, [("get_weather", {"city": "Paris"})])
+        self.assertEqual(normal, "")
+
+    def test_prose_then_unframed_atem_keeps_both_when_opted_in(self):
+        """Content before the marker survives alongside the call."""
+        prose = "I'll check the weather for Paris.\n"
+        with envs.SGLANG_ENABLE_MUSE_IMPLICIT_TOOL_CALLS.override(True):
+            normal, calls = self.parse(prose + atem(DOUBLED, city="Paris"))
+        self.assertEqual(calls, [("get_weather", {"city": "Paris"})])
+        self.assertEqual(normal, prose)
 
     # ---- integration with the reasoning parser ----------------------------
 


### PR DESCRIPTION
Two ways a Muse Glimmer tool call is silently lost today. Both reproduce on
`main` (`687967c70d`) serving `meta-models/Muse-Glimmer-30B` (BF16).

## 1. A header-less call is handed back as raw markup

The model answers in prose and appends the call with no `<|eom|>` and no
`to=<tool><|message|>` header. The detector copies the whole body into
content, so the client gets this as chat text and no tool call, with
`finish_reason: "stop"`:

```
"I'll check the current weather for San Francisco.
<atem:function_calls>
<atem:invoke name="get_weather">..."
```

Content now ends at the ATEM marker and the remainder is parsed as a tool
body, so the sentence and the call both survive.

**This is opt-in** via `SGLANG_ENABLE_MUSE_IMPLICIT_TOOL_CALLS`, default off,
and it applies only to an **unframed** body. A body that explicitly routes to
`self` or `user` is reasoning or a final answer, where ATEM markup is quoted
text and must stay content — unchanged with the flag either way.

A flag rather than a straight behaviour change because the distinction cannot
be recovered from the stream: the reasoning parser strips the channel header
before the tool detector sees the text, so a quoted block in a final answer
and a genuine header-less call arrive identical. `test_unframed_atem_is_content_not_a_call`
pins the current behaviour deliberately, and this respects it by default.

## 2. A non-ATEM tool body is deleted outright

When a tool channel carries something other than `<atem:invoke>` markup — the
JSON array a grammar constraint asks for — the body was consumed without
emitting anything: no tool call *and* no content. The generation is destroyed
rather than leaked.

It is now parsed as `[{"name": ..., "parameters": {...}}]` (bare object and
`arguments` alias accepted), falling back to emitting the text as content if
it is not JSON either.

The marker-stripped residue is what gets parsed, not the raw chunk. Parsing
the raw chunk only works on a truncated body; a normally-closed block fails
`json.loads` on the trailing tag and leaks:

| body | before | after |
|---|---|---|
| no closing tag | parsed | parsed |
| `+ </atem:function_calls>` | **leaked as content** | parsed |
| `+ </atem:function_calls><\|eom\|>` | **leaked as content** | parsed |

## Testing

`test/registered/unit/function_call/` — **465 passed, 0 failed**, flag off and on.
Adds two regression cases for the opt-in path that fail before this change.

Live on one A100 80GB, BF16 and the Q4_K_M GGUF, streaming and non-streaming:
leak rate on the kquant checkpoint went from 5/10 to 0/10 with 10/10 calls
parsed; 0/6 leaked on BF16.

Credit for the original diagnosis and both fixes to @sid-rp.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31601195336](https://github.com/sgl-project/sglang/actions/runs/31601195336)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31601194069](https://github.com/sgl-project/sglang/actions/runs/31601194069)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->