### PR TITLE
[diffusion] Sparse attention backends: run the dense path on the dense backend

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/sol_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/sol_attn.py
@@ -6,7 +6,6 @@ import re
 
 import torch
 
-from sglang.kernels.ops.attention.flash_attention import flash_attn_varlen_func
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
     AttentionBackend,
     AttentionImpl,
@@ -98,15 +97,59 @@ class SolAttnImpl(AttentionImpl):
         prefix: str = "",
         **extra_impl_args,
     ) -> None:
-        del num_heads, num_kv_heads, extra_impl_args
+        del extra_impl_args
         if head_size != _SOL_ATTN_HEAD_DIM:
             raise ValueError(
                 f"Sol-Attn requires head_size={_SOL_ATTN_HEAD_DIM}, got {head_size}"
             )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_size = head_size
         self.causal = causal
         self.softmax_scale = softmax_scale
         self.prefix = prefix
         self.layer_idx = self._parse_layer_idx(prefix)
+        self._dense_impl: AttentionImpl | None = None
+
+    def _get_dense_impl(self) -> AttentionImpl:
+        """Dense attention, used wherever the schedule excludes sparsity.
+
+        Resolved through the selector rather than bound to one kernel entry
+        point. Calling the raw varlen op directly took its ``ver=3`` default
+        instead of the version the platform resolved, which on sm_100 fell
+        through FA3's arch guard into an FA2 import that no longer exists there.
+        Asking the selector for the platform's preferred dense backend also
+        keeps the skipped steps on the same kernel a dense reference render
+        uses, so they do not diverge before any sparsity applies.
+
+        Built on first use, so constructing an impl does not require a platform
+        that can resolve a dense backend.
+        """
+        if self._dense_impl is not None:
+            return self._dense_impl
+
+        from sglang.multimodal_gen.runtime.layers.attention.selector import (
+            get_attn_backend,
+        )
+
+        backend = get_attn_backend(
+            self.head_size,
+            torch.bfloat16,
+            supported_attention_backends={
+                AttentionBackendEnum.FA,
+                AttentionBackendEnum.TORCH_SDPA,
+            },
+            selected_attention_backend=AttentionBackendEnum.DYNAMIC_CUDNN_SDPA,
+        )
+        self._dense_impl = backend.get_impl_cls()(
+            num_heads=self.num_heads,
+            head_size=self.head_size,
+            causal=self.causal,
+            softmax_scale=self.softmax_scale,
+            num_kv_heads=self.num_kv_heads,
+            prefix=f"{self.prefix}.dense",
+        )
+        return self._dense_impl
 
     @staticmethod
     def _parse_layer_idx(prefix: str) -> int | None:
@@ -140,16 +183,12 @@ class SolAttnImpl(AttentionImpl):
         cu_seqlens: torch.Tensor,
         max_seqlen: int,
     ) -> torch.Tensor:
-        output = flash_attn_varlen_func(
+        output = self._get_dense_impl().forward_varlen(
             query,
             key,
             value,
-            cu_seqlens_q=cu_seqlens,
-            cu_seqlens_k=cu_seqlens,
-            max_seqlen_q=max_seqlen,
-            max_seqlen_k=max_seqlen,
-            softmax_scale=self.softmax_scale,
-            causal=self.causal,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
         )
         return output[0] if isinstance(output, tuple) else output
 

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse_attn.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/subblock_sparse_attn.py
@@ -246,7 +246,15 @@ class SubBlockSparseAttentionImpl(AttentionImpl):
             )
 
     def _build_dense_impl(self, *, causal: bool) -> AttentionImpl:
-        """Flash attention, used wherever the schedule excludes sparsity."""
+        """Dense attention, used wherever the schedule excludes sparsity.
+
+        Asks for the same backend an unmodified run would have picked rather
+        than pinning FA: on sm_100 that is cuDNN SDPA, which the platform
+        prefers over the FA4 CuTe kernels for dense diffusion attention. Pinning
+        FA left the skipped steps on the slower kernel *and* computed them with a
+        different kernel than a dense reference render, so the two trajectories
+        separated before any sparsity applied.
+        """
         from sglang.multimodal_gen.runtime.layers.attention.selector import (
             get_attn_backend,
         )
@@ -258,7 +266,7 @@ class SubBlockSparseAttentionImpl(AttentionImpl):
                 AttentionBackendEnum.FA,
                 AttentionBackendEnum.TORCH_SDPA,
             },
-            selected_attention_backend=AttentionBackendEnum.FA,
+            selected_attention_backend=AttentionBackendEnum.DYNAMIC_CUDNN_SDPA,
         )
         return backend.get_impl_cls()(
             num_heads=self.num_heads,


### PR DESCRIPTION
# [diffusion] Sparse attention backends: run the dense path on the dense backend

## Motivation

`subblock_sparse_attn` and `sol_attn` are both partial-sparsity schemes: they
keep a leading run of denoise steps dense (and, for Sol-Attn, a couple of
layers at every step), and only route the rest through their sparse kernel.
Those dense steps should be computed exactly the way a dense run computes
them. Neither backend was doing that.

**`subblock_sparse_attn`** pinned `AttentionBackendEnum.FA` when resolving its
dense fallback. On sm_100 a run with no sparse backend resolves to
`dynamic_cudnn_sdpa` — the platform prefers cuDNN SDPA over the FA4 CuTe
kernels for dense diffusion attention (see the comment in
`CudaPlatform.get_attn_backend_cls_str`). So a sparse run computed its skipped
steps with a different, and slower, kernel than a dense run computed the same
steps with.

**`sol_attn`** never went through the resolver at all. It imported the raw op

```python
from sglang.kernels.ops.attention.flash_attention import flash_attn_varlen_func
```

and called it with no `ver=`, so it took the signature default `ver=3`. The
version the platform actually resolved lives in a module global `fa_ver`, which
`_prepare_flash_attention_for_blackwell()` sets to `4`; every other caller in
the tree passes `ver=fa_ver` explicitly. On sm_100 `ver=3` fails
`_is_fa3_supported()` (sgl-kernel builds FA3 for sm80/86/89/90a) and falls
through to an FA2 import, which resolves against the PEP 420 implicit namespace
package the FA4 wheel leaves behind at `flash_attn/` — a directory containing
only `cute/` and no `__init__.py`:

```
ImportError: cannot import name 'flash_attn_varlen_func' from 'flash_attn' (unknown location)
```

`(unknown location)` is Python's wording for a package whose `__file__` is
`None`, i.e. a namespace package — the tell that FA4 is installed and FA2 is
not. The first denoise step is a dense step, so **every Sol-Attn request failed
on B200** before this change; nothing ever reached the Sol-Attn kernel.

## Change

Both backends now ask the selector for `DYNAMIC_CUDNN_SDPA`, which is what a
run without a sparse backend resolves to on this platform:

```python
backend = get_attn_backend(
    self.head_size,
    torch.bfloat16,
    supported_attention_backends={AttentionBackendEnum.FA,
                                  AttentionBackendEnum.TORCH_SDPA},
    selected_attention_backend=AttentionBackendEnum.DYNAMIC_CUDNN_SDPA,
)
```

This is reachable exactly as written: `_is_backend_supported` accepts
`DYNAMIC_CUDNN_SDPA` whenever both `FA` and `TORCH_SDPA` are in the supported
set, which is what both call sites already pass, and
`_DynamicCudnnSDPAAttentionBackendResolver` is registered in
`_CUDA_ATTENTION_BACKEND_RESOLVERS`. `DynamicCudnnSDPAImpl` subclasses
`SDPAImpl`, implements `forward` and `forward_varlen`, covers head sizes
32–256, and carries its own `FlashAttentionImpl` to fall back to when cuDNN
raises for a layer.

Sol-Attn's dense impl is built on first use rather than in `__init__`, so
constructing an impl still does not require a platform that can resolve a dense
backend.

## Why consistency here is not cosmetic

Measured on 8× B200 (below): with the dense steps on a different kernel than the
reference render, the two trajectories separate **before any sparsity is
applied**. That mismatch was worth about as much accuracy as the entire gap
between sparsity 0.75 and 0.80 — so any measurement taken with the old code
charged part of a kernel mismatch to the sparse approximation.

## Measurements

MiniMax-H3 `fl2va`, t2va, 1344×768 / 5 s / 50 steps, 8× B200 (sm_100),
Ulysses-8, bf16, `--performance-mode speed`. 15 prompts with fixed seeds,
identical across every arm. Four arms rendered back to back in one session per
round, cold clip dropped from every timing. SubBlock arms include
[flashinfer#4397](https://github.com/flashinfer-ai/flashinfer/pull/4397).

Accuracy is measured per clip against **that round's own dense render** of the
same prompt and seed, then averaged over the 15 clips. These are *difference*
measures, not quality scores: a diffusion trajectory that separates early lands
on a different but equally plausible sample.

### After this change (dense fallback = `dynamic_cudnn_sdpa`)

| arm | DiT denoise ↓ | speedup ↑ | e2e ↓ | PSNR ↑ | SSIM ↑ | LPIPS ↓ | cos ↑ | peak MiB ↓ |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| dense | 18.363 s | 1.000× | 19.964 s | — | — | — | — | 94362 |
| SubBlock 0.75 | 15.105 s | **1.216×** | 16.512 s | **21.01** | **0.7241** | **0.2242** | **0.9556** | 94362 |
| SubBlock 0.80 | 14.407 s | **1.275×** | 15.794 s | 20.54 | 0.7094 | 0.2394 | 0.9517 | 94362 |
| Sol-Attn τ=1.0 | 16.587 s | 1.107× | 18.109 s | 20.51 | 0.7052 | 0.2435 | 0.9511 | 94362 |

### Before this change (dense fallback = FA4)

| arm | DiT denoise ↓ | speedup ↑ | e2e ↓ | PSNR ↑ | SSIM ↑ | LPIPS ↓ | cos ↑ | peak MiB ↓ |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| dense | 18.367 s | 1.000× | 19.974 s | — | — | — | — | 94362 |
| SubBlock 0.75 | 15.051 s | 1.220× | 16.461 s | 20.46 | 0.7001 | 0.2460 | 0.9463 | 94362 |
| SubBlock 0.80 | 14.363 s | 1.279× | 15.750 s | 20.06 | 0.6899 | 0.2566 | 0.9433 | 94362 |
| Sol-Attn τ=1.0 | 16.518 s | 1.112× | 18.046 s | 20.05 | 0.6842 | 0.2612 | 0.9430 | 94362 |

Sol-Attn's "before" column exists only because the run was done with the
`ImportError` patched out in the least invasive way (routing the dense call
through the resolver but still pinning `FA`); on an unpatched tree that arm
cannot produce a single frame on B200.

Peak memory is identical to the megabyte across all four arms in both rounds —
block sparsity saves compute, not activations.

The dense arm was re-rendered after the change as a cross-round control and
landed within 0.02% of before (18.3675 s → 18.3634 s), which is what makes the
two tables comparable.

### Accuracy effect of the change

Paired per clip, after − before, same arm; the sparse path is identical between
the two, only the dense steps' kernel changed. `t` is a one-sample t on the 15
per-clip differences.

| arm | PSNR ↑ | SSIM ↑ | LPIPS ↓ | cos ↑ |
| --- | ---: | ---: | ---: | ---: |
| SubBlock 0.75 | +0.551 (t +2.46) | +0.0240 (t +1.96) | −0.0218 (t −2.27) | +0.0093 |
| SubBlock 0.80 | +0.480 (t +3.14) | +0.0195 (t +2.08) | −0.0172 (t −2.34) | +0.0084 |
| Sol-Attn τ=1.0 | +0.464 (t +3.00) | +0.0210 (t +2.29) | −0.0177 (t −2.68) | +0.0081 |

Every arm improved on every metric by nearly the same amount, which is what
removing a common confound looks like rather than the approximation getting
better. No ranking changes.

The clip-to-clip spread is an order of magnitude larger than any gap between
arms — PSNR ranges 13.2–25.9 dB and SSIM 0.28–0.90 across the 15 prompts —
so arm means against their own standard deviations are uninformative and every
claim here is paired per clip instead.

### Latency effect of the change

| arm | before | after | delta |
| --- | ---: | ---: | ---: |
| dense (control) | 18.3675 ± 0.0408 s | 18.3634 ± 0.0359 s | −0.004 s |
| SubBlock 0.75 | 15.0512 ± 0.0242 s | 15.1055 ± 0.0495 s | +0.054 s |
| SubBlock 0.80 | 14.3633 ± 0.0347 s | 14.4067 ± 0.0415 s | +0.043 s |
| Sol-Attn τ=1.0 | 16.5178 ± 0.1507 s | 16.5868 ± 0.1549 s | +0.069 s |

Despite cuDNN SDPA being the faster kernel, all three sparse arms got 0.3–0.4%
**slower**. Per arm that is about 1σ; three of three with the same sign against
a dense control that moved −0.004 s makes it a small real regression.

The cause is the wrapper, not the kernel: `SDPAImpl.forward_varlen` loops over
the packed documents in Python and copies each segment into a fresh
`torch.empty_like` buffer, where `FlashAttentionImpl` issues one fused varlen
call. H3 packs one real document plus a padding tail, so every dense call pays
an allocation and two copies over a 37.7k-token tensor, at ~50 layers × 10
dense steps.

**So this change buys correctness and accuracy, not latency**, and fusing
`SDPAImpl.forward_varlen` would be a worthwhile follow-up that turns the 0.4%
regression into a gain.

## Reproducing

Server (per arm; the sparse arms add the flags in the table below):

```bash
sglang serve --model-path MiniMaxAI/MiniMax-H3 --model-variant fl2va \
  --num-gpus 8 --ulysses-degree 8 --performance-mode speed \
  --host 127.0.0.1 --port 30061
```

| arm | extra flags |
| --- | --- |
| dense | *(none — platform default)* |
| SubBlock 0.75 | `--attention-backend subblock_sparse_attn --component-attention-backends text_encoder=fa --attention-backend-config '{"sparsity": 0.75, "n_k": 4, "n_q": 4, "skip_first_steps": 10, "skip_first_layers": 0, "min_seq_len": 4096}'` |
| SubBlock 0.80 | the same with `"sparsity": 0.80` |
| Sol-Attn | `--attention-backend sol_attn --component-attention-backends text_encoder=fa --attention-backend-config '{"tau": 1.0, "thresh_type": "diag", "sink_tokens": 0, "sink_start": 0, "dense_steps": 10, "dense_layers": "0,1", "kv_splits": "auto"}'` |

The backend goes on `--attention-backend` with the text encoder overridden back
to `fa`, **not** on `--component-attention-backends transformer=<backend>`. H3
resolves the DiT backend lazily on the first forward, outside the context a
component override applies to, so `transformer=...` parses cleanly and silently
leaves the DiT dense. The `text_encoder=fa` override is not optional: the
Qwen3-VL text encoder admits only `fa` / `torch_sdpa` / `sage_attn_3` and the
server will not start without it.

Request body, per prompt (only `prompt` and `seed` vary):

```json
{
  "model": "MiniMaxAI/MiniMax-H3",
  "prompt": "<prompt>",
  "seconds": 5,
  "task": "t2va",
  "conditions": [],
  "target": {"short_edge": 768, "aspect_ratio": "16:9", "duration_seconds": 5.0},
  "num_outputs_per_prompt": 1,
  "num_inference_steps": 50,
  "flow_shift": 12.0,
  "audio_flow_shift": 3.0,
  "seed": <seed>
}
```

### Prompts and seeds

| seed | prompt |
| ---: | --- |
| 1101 | At night, while their owner sleeps in a bedroom, three cats march in loudly playing tiny brass instruments, then abruptly file out. |
| 2202 | A narrow night market street in the rain, neon signs stacked overhead and reflected in the wet pavement, shoppers moving between lit food stalls. |
| 3303 | Close on a potter's muddy hands centring a lump of wet clay on a spinning wheel, water running off the rim as the wheel turns. |
| 4404 | A black steam locomotive hauls its carriages through a deep snowfield below forested mountains, smoke pouring back over the roofs, a deer standing near the track. |
| 5505 | Two children run along a beach at sunset flying a rainbow kite, gulls scattering ahead of them and the low sun glittering on the wet sand. |
| 6601 | A glassblower turns a glowing gather of molten glass on a blowpipe in a dim workshop, sparks drifting, the shape slowly widening under the jacks. |
| 7702 | Rush hour on a wide city crossing seen from above: umbrellas flood the zebra stripes in both directions as a tram slides through the frame. |
| 8803 | A hummingbird hovers at a red feeder in a sunlit garden, wings a blur, then darts sideways out of frame as a breeze moves the leaves. |
| 9904 | Waves break over black volcanic rocks under a grey sky, spray hanging in the air, a lone gull banking low across the swell. |
| 1015 | A blacksmith hammers an orange-hot bar on an anvil, scale flying off with each strike, then quenches it in a barrel with a burst of steam. |
| 1126 | Time-lapse of cumulus clouds building over a wheat field at dusk, shadows racing across the crop as the light turns amber. |
| 1237 | A barista pours steamed milk into an espresso, the rosetta opening out in the cup, steam curling under a warm overhead lamp. |
| 1348 | Two dancers in a mirrored studio move through a lift, sunlight from high windows crossing the floor, dust visible in the beams. |
| 1459 | A husky team pulls a sled along a snow trail between pines, breath steaming, the camera tracking alongside at running pace. |
| 1560 | Neon reflections ripple on a canal at night as a small boat passes, the wake breaking the light into moving bands. |

### Metric definitions

All four are computed on decoded RGB frames against the dense render of the
same prompt and seed.

* **PSNR** — per frame on uint8 (255 peak), averaged over frames.
* **SSIM** — `skimage.metrics.structural_similarity` per frame across all three
  channels, averaged over frames.
* **LPIPS** — AlexNet variant per frame on [−1, 1] RGB, averaged over frames.
* **cos** — one cosine over the whole clip flattened to a single vector
  (frames × H × W × 3).

## Testing

`pytest python/sglang/multimodal_gen/test/unit/test_sol_attn_backend.py
python/sglang/multimodal_gen/test/unit/test_subblock_sparse_attention.py`
— 24 passed, 14 subtests passed on 8× B200, including the SubBlock numerics
suite that pins the sparse kernel against dense attention at near-zero
sparsity.

Plus the 120 clips above: 4 arms × 15 prompts × 2 rounds, all rendered
end to end.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31601611560](https://github.com/sgl-project/sglang/actions/runs/31601611560)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31601611240](https://github.com/sgl-project/sglang/actions/runs/31601611240)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->