### PR TITLE
[diffusion] model: Fix FLUX.1-dev graph breaks

### DIFF
--- a/python/sglang/kernels/ops/diffusion/modulate_scale_shift.py
+++ b/python/sglang/kernels/ops/diffusion/modulate_scale_shift.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 import torch
 
 from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
@@ -72,7 +73,8 @@ def can_use_modulate_scale_shift_cuda(
     x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor
 ) -> bool:
     if (
-        x.dtype not in _SUPPORTED_DTYPES
+        not current_platform.is_cuda()
+        or x.dtype not in _SUPPORTED_DTYPES
         or scale.dtype != x.dtype
         or shift.dtype != x.dtype
         or not (x.is_cuda and scale.is_cuda and shift.is_cuda)

--- a/python/sglang/multimodal_gen/runtime/models/dits/base.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/base.py
@@ -83,6 +83,17 @@ class BaseDiT(nn.Module, ABC):
         """Run model-specific post-load weight fixups after all parameters are materialized."""
         return None
 
+    def apply_torch_compile(self, *, compile_kwargs: dict[str, Any]) -> None:
+        """Apply ``torch.compile`` to this DiT for inference.
+
+        Default: compile the whole ``forward`` in place. DiTs whose ``forward``
+        contains per-step Python control flow that must stay outside the graph
+        (e.g. Spectrum step-skipping, which reads the forward context) override
+        this to compile only a pure sub-region and keep ``forward`` eager, so
+        the dynamic control flow neither splits nor invalidates the graph.
+        """
+        self.compile(**compile_kwargs)
+
     @property
     def supported_attention_backends(self) -> set[AttentionBackendEnum]:
         return self._supported_attention_backends

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -93,6 +93,7 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.torch_compile import CallableModule
 
 logger = init_logger(__name__)  # pylint: disable=invalid-name
 
@@ -1272,6 +1273,10 @@ class FluxTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             "single_transformer_blocks",
         ]
 
+        # Set by apply_torch_compile: the block stack compiled as a single
+        # graph. None => run the block stack eagerly (torch.compile disabled).
+        self._compiled_run_blocks: Optional[CallableModule] = None
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -1381,36 +1386,85 @@ class FluxTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         run_transformer_blocks = (
             self.begin_spectrum_step() if spectrum_enabled else True
         )
+        # The block stack is the sole torch.compile region (see _run_blocks /
+        # apply_torch_compile). The forward-context read and the Spectrum step
+        # decision above stay eager so their per-step Python control flow never
+        # splits or invalidates that graph.
+        run_blocks = (
+            self._run_blocks
+            if self._compiled_run_blocks is None
+            else self._compiled_run_blocks
+        )
         if run_transformer_blocks:
-            for block in self.transformer_blocks:
-                encoder_hidden_states, hidden_states = block(
-                    hidden_states=hidden_states,
-                    encoder_hidden_states=encoder_hidden_states,
-                    temb=temb,
-                    freqs_cis=freqs_cis,
-                    joint_attention_kwargs=joint_attention_kwargs,
-                    num_replicated_prefix=num_replicated_prefix,
-                )
-            for block in self.single_transformer_blocks:
-                encoder_hidden_states, hidden_states = block(
-                    hidden_states=hidden_states,
-                    encoder_hidden_states=encoder_hidden_states,
-                    temb=temb,
-                    freqs_cis=singles_freqs_cis,
-                    joint_attention_kwargs=joint_attention_kwargs,
-                    num_replicated_prefix=num_replicated_prefix,
-                )
+            hidden_states = run_blocks(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                freqs_cis=freqs_cis,
+                singles_freqs_cis=singles_freqs_cis,
+                joint_attention_kwargs=joint_attention_kwargs,
+                num_replicated_prefix=num_replicated_prefix,
+            )
             if spectrum_enabled:
                 self.spectrum_record_features(hidden_states)
-        else:
-            if spectrum_enabled:
-                hidden_states = self.spectrum_predict_features(hidden_states)
+        elif spectrum_enabled:
+            hidden_states = self.spectrum_predict_features(hidden_states)
 
         hidden_states = self.norm_out(hidden_states, temb)
 
         output, _ = self.proj_out(hidden_states)
 
         return output
+
+    def _run_blocks(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        freqs_cis: Optional[torch.Tensor],
+        singles_freqs_cis: Optional[torch.Tensor],
+        joint_attention_kwargs: Optional[Dict[str, Any]],
+        num_replicated_prefix: int,
+    ) -> torch.Tensor:
+        """The dual + single transformer block stack: the torch.compile region.
+
+        Kept free of forward-context reads and Spectrum control flow so it
+        traces to a single graph. Returns the post-block ``hidden_states`` (the
+        Spectrum-cached quantity); the block-threaded ``encoder_hidden_states``
+        is not needed downstream.
+        """
+        for block in self.transformer_blocks:
+            encoder_hidden_states, hidden_states = block(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                freqs_cis=freqs_cis,
+                joint_attention_kwargs=joint_attention_kwargs,
+                num_replicated_prefix=num_replicated_prefix,
+            )
+        for block in self.single_transformer_blocks:
+            encoder_hidden_states, hidden_states = block(
+                hidden_states=hidden_states,
+                encoder_hidden_states=encoder_hidden_states,
+                temb=temb,
+                freqs_cis=singles_freqs_cis,
+                joint_attention_kwargs=joint_attention_kwargs,
+                num_replicated_prefix=num_replicated_prefix,
+            )
+        return hidden_states
+
+    def apply_torch_compile(self, *, compile_kwargs: dict[str, Any]) -> None:
+        """Compile only the block stack, leaving ``forward`` eager.
+
+        FLUX's ``forward`` reads the forward context and runs the Spectrum step
+        schedule (stateful Python + host syncs). Compiling the whole forward
+        would break the graph mid-way and thrash recompiles as the run/skip
+        decision flips each step, so the compile region is narrowed to the pure
+        block stack (:meth:`_run_blocks`).
+        """
+        runner = CallableModule(self._run_blocks)
+        runner.compile(**compile_kwargs)
+        self._compiled_run_blocks = runner
 
 
 EntryClass = FluxTransformer2DModel

--- a/python/sglang/multimodal_gen/runtime/utils/torch_compile.py
+++ b/python/sglang/multimodal_gen/runtime/utils/torch_compile.py
@@ -3,12 +3,15 @@
 import os
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import torch.nn as nn
 
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.srt.utils.common import get_compiler_backend
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.models.dits.base import BaseDiT
 
 
 def maybe_enable_inductor_compute_comm_overlap() -> None:
@@ -76,14 +79,14 @@ class CompiledModuleRegistry:
 
     def compile_once(
         self,
-        module: nn.Module,
+        module: "BaseDiT",
         *,
         compile_kwargs: dict[str, object],
     ) -> bool:
         module_id = id(module)
         if module_id in self.module_ids:
             return False
-        module.compile(**compile_kwargs)
+        module.apply_torch_compile(compile_kwargs=compile_kwargs)
         self.module_ids.add(module_id)
         return True
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

A couple of recent PRs have introduced some more graph breaks that regress the performance of FLUX.1-dev.

Graph break 1 - `can_use_modulate_scale_shift_cuda`:
This is a ROCm-specific graph break. PR #34004 added support for fused adaLN modulation for FLUX.1. The guard function for this should return False for non-NV devices, but it only checked for `q.is_cuda`, which is true for ROCm. 

Graph break 2 - `forward_batch = get_forward_context().forward_batch`
This is a trickier one. PR #31491 added support for Spectrum acceleration / cache. As part of it, FLUX.1-dev now calls `get_forward_context().forward_batch`. This is a read from a global object from outside the graph. This drops the surrounding code to eager, including the if clause after it. This makes it so that each block is in their own graph, a bit like regional compile. Otherwise this might not be a problem, but as FLUX.1-dev is such a small model, recent GPUs are so fast at it that the overhead from graph look-ups is non-trivial.

## Modifications

<!-- Detail the changes made in this pull request. -->
- GB1: Added a simle platform check so the path is only taken on real CUDA systems.
- GB2: This is a bit hacky, so I'm open for any suggestions here. Instead of compiling the entire transformer, we now compile the  block loop into a single graph. This is not as fast as a fullgraph would be, but is a lot better than compiling each block alone. Now there's a single graph per inference step vs 40 or so.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

**Before:**
<img width="1024" height="1024" alt="A_small_cat_20260812-125731_e0b82352" src="https://github.com/user-attachments/assets/325b4077-115f-4ac8-99e5-9167ef5ded8d" />


**After:**
<img width="1024" height="1024" alt="A_small_cat_20260812-130039_953a61ba" src="https://github.com/user-attachments/assets/8534bf33-36ae-41be-b649-0b6571ba8cd0" />


## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

**Baseline vs GB1**
```
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 1440.94 ms | 823.96 ms | **-616.97 ms (-42.8%)** | ✅ |
| **Throughput** | 0.69 req/s | 1.21 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.03 | 0.03 | -0.00 | -8.4% | ⚪️ |
| TextEncodingStage | 16.16 | 16.05 | -0.12 | -0.7% | ⚪️ |
| LatentPreparationStage | 0.13 | 0.10 | -0.03 | -20.1% | ⚪️ |
| TimestepPreparationStage | 0.32 | 0.30 | -0.02 | -4.8% | ⚪️ |
| DenoisingStage | 1294.64 | 800.90 | -493.74 | -38.1% | 🟢 |
| DecodingStage | 4.98 | 4.69 | -0.29 | -5.8% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.03 | 0.03 | -0.01 | -20.3% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.00 | -0.00 | -44.6% | ⚪️ |
```
**Baseline vs GB2**
```
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 1440.94 ms | 720.93 ms | **-720.00 ms (-50.0%)** | ✅ |
| **Throughput** | 0.69 req/s | 1.39 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.03 | 0.07 | +0.04 | +104.5% | ⚪️ |
| TextEncodingStage | 16.16 | 17.24 | +1.08 | +6.7% | ⚪️ |
| LatentPreparationStage | 0.13 | 0.10 | -0.02 | -18.6% | ⚪️ |
| TimestepPreparationStage | 0.32 | 0.30 | -0.02 | -5.1% | ⚪️ |
| DenoisingStage | 1294.64 | 695.49 | -599.15 | -46.3% | 🟢 |
| DecodingStage | 4.98 | 5.14 | +0.16 | +3.2% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.03 | 0.03 | -0.00 | -5.4% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.01 | 0.01 | -0.00 | -24.9% | ⚪️ |
```

**GB1 vs GB2**
```
#### 1. High-level Summary
| Metric | Baseline | New | Diff | Status |
| :--- | :--- | :--- | :--- | :--- |
| **E2E Latency** | 823.96 ms | 720.93 ms | **-103.03 ms (-12.5%)** | ✅ |
| **Throughput** | 1.21 req/s | 1.39 req/s | - | - |


#### 2. Stage Breakdown
| Stage Name | Baseline (ms) | New (ms) | Diff (ms) | Diff (%) | Status |
| :--- | :--- | :--- | :--- | :--- | :--- |
| InputValidationStage | 0.03 | 0.07 | +0.04 | +123.3% | ⚪️ |
| TextEncodingStage | 16.05 | 17.24 | +1.19 | +7.4% | ⚪️ |
| LatentPreparationStage | 0.10 | 0.10 | +0.00 | +1.9% | ⚪️ |
| TimestepPreparationStage | 0.30 | 0.30 | -0.00 | -0.3% | ⚪️ |
| DenoisingStage | 800.90 | 695.49 | -105.41 | -13.2% | ⚪️ |
| DecodingStage | 4.69 | 5.14 | +0.45 | +9.5% | ⚪️ |
| Scheduler.return_result.spill_arrays | 0.03 | 0.03 | +0.00 | +18.7% | ⚪️ |
| SchedulerClient.materialize_file_refs | 0.00 | 0.01 | +0.00 | +35.5% | ⚪️ |
```


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31601738391](https://github.com/sgl-project/sglang/actions/runs/31601738391)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31601738184](https://github.com/sgl-project/sglang/actions/runs/31601738184)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->