### PR TITLE
[AMD] Add MiniMax-M3 decode IndexCache (reuse sparse block selection …

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1290,6 +1290,24 @@ class Envs:
     SGLANG_MINIMAX_M3_FUSED_SWIGLU_MXFP8 = EnvBool(False)
     SGLANG_MINIMAX_M3_FUSED_MOE_COMBINE = EnvBool(False)
 
+    # MiniMax-M3 IndexCache: reuse the sparse block selection (topk_idx) across
+    # sparse layers during DECODE, recomputing the lightning indexer only on 1 of
+    # every STRIDE sparse layers and reusing the last selection on the other
+    # STRIDE-1. Removes most of the per-step indexer score + top-k cost.
+    # 0/1 = OFF (compute every layer, stock behavior). Any value > 1 is an
+    # approximation (adjacent layers may pick slightly different blocks), so gate
+    # on accuracy (e.g. GSM8K) and sweep STRIDE.
+    SGLANG_MINIMAX_INDEXCACHE_STRIDE = EnvInt(0)
+    # IndexCache reuse mode (only used when STRIDE > 1):
+    #   "full" - on reuse layers skip the indexer entirely and reuse BOTH the
+    #            index-head output (idx_o) and the block selection (topk_idx).
+    #            Max speedup, stronger approximation.
+    #   "topk" - on reuse layers still run the indexer to recompute idx_o, but
+    #            substitute the cached block selection into the main sparse attn.
+    #            Isolates the accuracy impact of selection reuse (no perf win
+    #            without a dedicated index-value kernel; use for the A/B study).
+    SGLANG_MINIMAX_INDEXCACHE_MODE = EnvStr("full")
+
     # MiniMax-M3 on ROCm force-disables custom all-reduce in its model override
     # (arg_groups/overrides.py) when aiter all-reduce fusion is off. Set this to
     # opt back in and keep custom/quick all-reduce enabled -- e.g. to run the

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -124,6 +124,36 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 self.block_size_k,
             )
         self._msa_dec_meta = None
+
+        # ---- IndexCache ----
+        # Reuse the decode block selection (topk_idx) across sparse layers:
+        # recompute the lightning indexer only on 1 of every `stride` sparse
+        # layers (the "cadence" layers) and reuse the last selection on the rest.
+        self.indexcache_stride = envs.SGLANG_MINIMAX_INDEXCACHE_STRIDE.get() or 0
+        self.indexcache_mode = (
+            envs.SGLANG_MINIMAX_INDEXCACHE_MODE.get() or "full"
+        ).lower()
+        # Execution-order position of each sparse layer (0,1,2,... over the sorted
+        # sparse layer ids); a layer is a cadence layer iff pos % stride == 0.
+        self._sparse_layer_pos = {
+            lid: i for i, lid in enumerate(sorted(self.sparse_layer_ids))
+        }
+        # Per-forward cache of the last computed index state
+        # (idx_o, main_topk_idx, real_seq_lens); reset every forward in
+        # init_forward_metadata_out_graph. Reused within a single forward only,
+        # so it is CUDA-graph safe (cadence layers run before reuse layers).
+        self._indexcache_state = None
+        if self.indexcache_stride and self.indexcache_stride > 1:
+            logger.warning(
+                "[MiniMaxSparse] IndexCache ENABLED: stride=%d mode=%r "
+                "(decode indexer reused on %d of every %d sparse layers; "
+                "accuracy-gate this change, e.g. GSM8K).",
+                self.indexcache_stride,
+                self.indexcache_mode,
+                self.indexcache_stride - 1,
+                self.indexcache_stride,
+            )
+
         if self.use_msa:
             from sglang.srt.runtime_context import get_parallel
 
@@ -198,6 +228,9 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # cuda-graph replay views are a SimpleNamespace without extend_seq_lens_cpu,
         # and TARGET_VERIFY sets it to None despite is_extend() — getattr covers both.
         self._msa_dec_meta = None
+        # New forward -> drop the IndexCache selection so the first (cadence)
+        # sparse layer of this forward recomputes it.
+        self._indexcache_state = None
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is not None:
             self._max_seqlen_q = int(max(extend_lens))
@@ -516,7 +549,31 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             q = _quant_q_fp8(q, layer.q_scale_float)
             idx_q = _quant_q_fp8(idx_q, layer.idx_q_scale_float)
 
-        idx_o, o = minimax_sparse_decode(
+        # ---- IndexCache: recompute (cadence) vs reuse ----
+        # A sparse layer recomputes the lightning indexer iff it is a cadence
+        # layer (pos % stride == 0) or IndexCache is off; otherwise it reuses the
+        # last cached selection. All sparse layers of a forward run in order
+        # (cadence before reuse), so within-forward reuse is CUDA-graph safe.
+        stride = self.indexcache_stride
+        indexcache_on = bool(stride and stride > 1)
+        pos = self._sparse_layer_pos.get(layer.layer_id, 0)
+        is_reuse = (
+            indexcache_on
+            and (pos % stride != 0)
+            and (self._indexcache_state is not None)
+        )
+        # "full" mode reuses the cached idx_o; if this layer needs a real idx_o
+        # (index value enabled) but the cadence layer had none, recompute instead
+        # so index_o_proj never receives a stale/None idx_o.
+        if (
+            is_reuse
+            and self.indexcache_mode != "topk"
+            and not disable_value
+            and self._indexcache_state[0] is None
+        ):
+            is_reuse = False
+
+        common_args = (
             q,
             None,
             k_cache,
@@ -534,6 +591,8 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             self.topk_blocks,
             self.init_blocks,
             self.local_blocks,
+        )
+        common_kwargs = dict(
             score_type=self.score_type,
             disable_index_value=disable_value,
             dense_main_attn_fn=attn_fn,
@@ -548,6 +607,34 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
             idx_k_scale=layer.idx_k_scale_float,
             idx_v_scale=layer.idx_v_scale_float,
         )
+
+        if not is_reuse:
+            # Cadence layer (or IndexCache off): run the indexer, cache its state.
+            idx_o, o, main_topk_idx, real_seq_lens = minimax_sparse_decode(
+                *common_args, return_index_state=True, **common_kwargs
+            )
+            if indexcache_on:
+                self._indexcache_state = (idx_o, main_topk_idx, real_seq_lens)
+        else:
+            cached_idx_o, cached_topk_idx, cached_real_seq_lens = self._indexcache_state
+            if self.indexcache_mode == "topk":
+                # Recompute idx_o; reuse only the block selection.
+                idx_o, o = minimax_sparse_decode(
+                    *common_args,
+                    reuse_main_topk_idx=cached_topk_idx,
+                    reuse_real_seq_lens=cached_real_seq_lens,
+                    **common_kwargs,
+                )
+            else:
+                # "full": skip the indexer entirely, reuse idx_o + selection.
+                idx_o, o = minimax_sparse_decode(
+                    *common_args,
+                    skip_indexer=True,
+                    reuse_idx_o=(None if disable_value else cached_idx_o),
+                    reuse_main_topk_idx=cached_topk_idx,
+                    reuse_real_seq_lens=cached_real_seq_lens,
+                    **common_kwargs,
+                )
         return (
             None if idx_o is None else idx_o.reshape(q.shape[0], -1).contiguous(),
             o.reshape(q.shape[0], -1).contiguous(),

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -12,6 +12,11 @@ from sglang.srt.configs.model_config import (
     get_minimax_sparse_score_type,
 )
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.minimax_sparse_ops.indexcache import (
+    indexcache_enabled,
+    indexcache_layer_positions,
+    indexcache_should_reuse,
+)
 from sglang.srt.layers.attention.minimax_sparse_ops.minimax_sparse import (
     minimax_sparse_decode,
     minimax_sparse_prefill,
@@ -135,15 +140,13 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         ).lower()
         # Execution-order position of each sparse layer (0,1,2,... over the sorted
         # sparse layer ids); a layer is a cadence layer iff pos % stride == 0.
-        self._sparse_layer_pos = {
-            lid: i for i, lid in enumerate(sorted(self.sparse_layer_ids))
-        }
+        self._sparse_layer_pos = indexcache_layer_positions(self.sparse_layer_ids)
         # Per-forward cache of the last computed index state
         # (idx_o, main_topk_idx, real_seq_lens); reset every forward in
         # init_forward_metadata_out_graph. Reused within a single forward only,
         # so it is CUDA-graph safe (cadence layers run before reuse layers).
         self._indexcache_state = None
-        if self.indexcache_stride and self.indexcache_stride > 1:
+        if indexcache_enabled(self.indexcache_stride):
             logger.warning(
                 "[MiniMaxSparse] IndexCache ENABLED: stride=%d mode=%r "
                 "(decode indexer reused on %d of every %d sparse layers; "
@@ -555,12 +558,10 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
         # last cached selection. All sparse layers of a forward run in order
         # (cadence before reuse), so within-forward reuse is CUDA-graph safe.
         stride = self.indexcache_stride
-        indexcache_on = bool(stride and stride > 1)
+        indexcache_on = indexcache_enabled(stride)
         pos = self._sparse_layer_pos.get(layer.layer_id, 0)
-        is_reuse = (
-            indexcache_on
-            and (pos % stride != 0)
-            and (self._indexcache_state is not None)
+        is_reuse = indexcache_should_reuse(
+            pos, stride, self._indexcache_state is not None
         )
         # "full" mode reuses the cached idx_o; if this layer needs a real idx_o
         # (index value enabled) but the cadence layer had none, recompute instead

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/indexcache.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/indexcache.py
@@ -1,0 +1,48 @@
+"""Pure decision logic for MiniMax-M3 decode IndexCache.
+
+IndexCache reuses the sparse block selection (``topk_idx``) across sparse layers
+during decode: the lightning indexer is recomputed only on 1 of every ``stride``
+sparse layers (the "cadence" layers) and the last selection is reused on the
+other ``stride - 1``.
+
+The helpers here are deliberately dependency-free (no torch / triton) so the
+cadence policy can be unit-tested on CPU without importing the attention
+backend. ``MiniMaxSparseAttnBackend`` imports and drives them at runtime.
+"""
+
+from typing import Dict, Iterable
+
+
+def indexcache_enabled(stride: int) -> bool:
+    """Whether IndexCache reuse is active for ``stride``.
+
+    ``stride`` of 0 or 1 means OFF (recompute the indexer on every sparse layer,
+    the stock behavior); any value ``> 1`` enables reuse with that cadence.
+    """
+    return bool(stride and stride > 1)
+
+
+def indexcache_layer_positions(sparse_layer_ids: Iterable[int]) -> Dict[int, int]:
+    """Map each sparse layer id to its execution-order position.
+
+    Positions are 0-based over the sorted sparse layer ids, so a layer is a
+    cadence (recompute) layer iff ``position % stride == 0``.
+    """
+    return {lid: i for i, lid in enumerate(sorted(sparse_layer_ids))}
+
+
+def indexcache_should_reuse(pos: int, stride: int, has_cached_state: bool) -> bool:
+    """Whether the sparse layer at execution position ``pos`` should REUSE the
+    cached block selection instead of recomputing the lightning indexer.
+
+    Reuse happens only when IndexCache is enabled, the layer is not a cadence
+    layer (``pos % stride != 0``), and a selection has already been cached this
+    forward. The first sparse layer of a forward is always position 0 (a cadence
+    layer) and has no cached state, so it recomputes -- which is what makes
+    within-forward reuse CUDA-graph safe (cadence layers run before reuse ones).
+    """
+    if not indexcache_enabled(stride):
+        return False
+    if not has_cached_state:
+        return False
+    return pos % stride != 0

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -232,85 +232,99 @@ def minimax_sparse_decode(
     idx_q_scale: Optional[float] = None,
     idx_k_scale: Optional[float] = None,
     idx_v_scale: Optional[float] = None,
-) -> Tuple[torch.Tensor, torch.Tensor]:
+    # ---- IndexCache ----
+    skip_indexer: bool = False,  # "full" reuse: do NOT launch the indexer at all
+    reuse_idx_o: Optional[torch.Tensor] = None,  # "full" reuse: index-head output
+    reuse_main_topk_idx: Optional[torch.Tensor] = None,  # reuse block selection
+    reuse_real_seq_lens: Optional[torch.Tensor] = None,  # reuse effective KV lens
+    return_index_state: bool = False,  # also return cache state for reuse layers
+) -> Tuple[torch.Tensor, ...]:
     # Step 1: Flash decode with topk index (using index head). When the dense main
     # attention is used, the indexer emits the page table directly (fused
     # transform) instead of block ids, plus the per-query effective KV length.
-    idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
-        q=idx_q,
-        sink=idx_sink,
-        k_cache=idx_k_cache,
-        v_cache=idx_v_cache,
-        req_to_token=req_to_token,
-        seq_lens=seq_lens,
-        max_seqlen=max_seqlen,
-        slot_ids=slot_ids,
-        block_size=block_size_k,
-        topk=topk,
-        init_blocks=init_blocks,
-        local_blocks=local_blocks,
-        sm_scale=idx_sm_scale,
-        score_type=score_type,
-        disable_index_value=disable_index_value,
-        use_dense_main_attn=dense_main_attn_fn is not None,
-        page_size=page_size,
-        q_scale=idx_q_scale,
-        k_scale=idx_k_scale,
-        v_scale=idx_v_scale,
-    )
+    #
+    # IndexCache: ``main_topk_idx`` is the block selection
+    # actually consumed by the main sparse attention below (post GQA-reduce, or
+    # the dense page table). A cadence layer computes it here and hands it back
+    # (return_index_state=True); a reuse layer either skips the indexer entirely
+    # (skip_indexer, "full" mode) or recomputes idx_o but substitutes the cached
+    # selection ("topk" mode).
     num_idx_heads = idx_q.shape[1]
     num_kv_heads = k_cache.shape[1]
     idx_group_size = num_idx_heads // num_kv_heads
-    if dense_main_attn_fn is not None:
-        # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
-        assert idx_group_size == 1
-        o = dense_main_attn_fn(q, topk_idx, real_seq_lens)
-    else:
-        # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
-        if idx_group_size > 1:
-            topk_idx = topk_index_reduce(
-                topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
-            )
-        # Step 3: Sparse attention using topk index (main head). The MSA path
-        # only replaces this step; keep the Triton path when sink is present.
-        if use_msa and sink is None:
-            from .msa import MSAUnavailableError, msa_sparse_decode_main
+    real_seq_lens = reuse_real_seq_lens
 
-            try:
-                o = msa_sparse_decode_main(
-                    q=q,
-                    k_cache=k_cache,
-                    v_cache=v_cache,
-                    topk_idx=topk_idx,
-                    req_to_token=req_to_token,
-                    slot_ids=slot_ids,
-                    seq_lens=seq_lens,
-                    block_size_k=block_size_k,
-                    sm_scale=sm_scale,
-                    kv_indices=msa_kv_indices,
-                    plan=msa_plan,
-                    q_scale=q_scale,
-                    k_scale=k_scale,
-                    v_scale=v_scale,
-                )
-            except MSAUnavailableError as err:
-                _warn_msa_fallback(err)
-                o = flash_decode_with_gqa_share_sparse(
-                    q=q,
-                    sink=sink,
-                    k_cache=k_cache,
-                    v_cache=v_cache,
-                    req_to_token=req_to_token,
-                    seq_lens=seq_lens,
-                    slot_ids=slot_ids,
-                    block_size=block_size_k,
-                    topk_idx=topk_idx,
-                    sm_scale=sm_scale,
-                    q_scale=q_scale,
-                    k_scale=k_scale,
-                    v_scale=v_scale,
-                )
+    if skip_indexer:
+        # "full"-mode reuse layer: no indexer launch at all.
+        idx_o = reuse_idx_o
+        main_topk_idx = reuse_main_topk_idx
+    else:
+        idx_o, topk_idx, real_seq_lens = flash_decode_with_topk_idx(
+            q=idx_q,
+            sink=idx_sink,
+            k_cache=idx_k_cache,
+            v_cache=idx_v_cache,
+            req_to_token=req_to_token,
+            seq_lens=seq_lens,
+            max_seqlen=max_seqlen,
+            slot_ids=slot_ids,
+            block_size=block_size_k,
+            topk=topk,
+            init_blocks=init_blocks,
+            local_blocks=local_blocks,
+            sm_scale=idx_sm_scale,
+            score_type=score_type,
+            disable_index_value=disable_index_value,
+            use_dense_main_attn=dense_main_attn_fn is not None,
+            page_size=page_size,
+            q_scale=idx_q_scale,
+            k_scale=idx_k_scale,
+            v_scale=idx_v_scale,
+        )
+        if dense_main_attn_fn is not None:
+            # topk_idx is the page table; real_seq_lens is the per-query cache_seqlens
+            assert idx_group_size == 1
+            main_topk_idx = topk_idx
         else:
+            # Step 2: Reduce topk idx if num_idx_heads > num_kv_heads
+            if idx_group_size > 1:
+                topk_idx = topk_index_reduce(
+                    topk_idx.view(num_kv_heads, idx_group_size, -1, topk), dim=1
+                )
+            main_topk_idx = topk_idx
+        # "topk"-mode reuse: keep the freshly computed idx_o but override the
+        # block selection (and dense effective KV lengths) with the cached ones.
+        if reuse_main_topk_idx is not None:
+            main_topk_idx = reuse_main_topk_idx
+            if reuse_real_seq_lens is not None:
+                real_seq_lens = reuse_real_seq_lens
+
+    # Step 3: Sparse attention using the (possibly cached) topk selection. The
+    # MSA path only replaces this step; keep the Triton path when sink is present.
+    if dense_main_attn_fn is not None:
+        o = dense_main_attn_fn(q, main_topk_idx, real_seq_lens)
+    elif use_msa and sink is None:
+        from .msa import MSAUnavailableError, msa_sparse_decode_main
+
+        try:
+            o = msa_sparse_decode_main(
+                q=q,
+                k_cache=k_cache,
+                v_cache=v_cache,
+                topk_idx=main_topk_idx,
+                req_to_token=req_to_token,
+                slot_ids=slot_ids,
+                seq_lens=seq_lens,
+                block_size_k=block_size_k,
+                sm_scale=sm_scale,
+                kv_indices=msa_kv_indices,
+                plan=msa_plan,
+                q_scale=q_scale,
+                k_scale=k_scale,
+                v_scale=v_scale,
+            )
+        except MSAUnavailableError as err:
+            _warn_msa_fallback(err)
             o = flash_decode_with_gqa_share_sparse(
                 q=q,
                 sink=sink,
@@ -320,10 +334,29 @@ def minimax_sparse_decode(
                 seq_lens=seq_lens,
                 slot_ids=slot_ids,
                 block_size=block_size_k,
-                topk_idx=topk_idx,
+                topk_idx=main_topk_idx,
                 sm_scale=sm_scale,
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
             )
+    else:
+        o = flash_decode_with_gqa_share_sparse(
+            q=q,
+            sink=sink,
+            k_cache=k_cache,
+            v_cache=v_cache,
+            req_to_token=req_to_token,
+            seq_lens=seq_lens,
+            slot_ids=slot_ids,
+            block_size=block_size_k,
+            topk_idx=main_topk_idx,
+            sm_scale=sm_scale,
+            q_scale=q_scale,
+            k_scale=k_scale,
+            v_scale=v_scale,
+        )
+
+    if return_index_state:
+        return idx_o, o, main_topk_idx, real_seq_lens
     return idx_o, o

--- a/test/registered/unit/layers/attention/test_minimax_indexcache_cadence.py
+++ b/test/registered/unit/layers/attention/test_minimax_indexcache_cadence.py
@@ -1,0 +1,84 @@
+"""CPU unit tests for the MiniMax-M3 decode IndexCache cadence policy.
+
+These cover the pure decision logic that drives which sparse layers recompute
+the lightning indexer versus reuse the cached block selection. The helpers are
+dependency-free (no torch / GPU), so this runs on the CPU CI runner.
+"""
+
+import unittest
+
+from sglang.srt.layers.attention.minimax_sparse_ops.indexcache import (
+    indexcache_enabled,
+    indexcache_layer_positions,
+    indexcache_should_reuse,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestIndexCacheEnabled(unittest.TestCase):
+    def test_off_for_zero_and_one(self):
+        # 0/1 = stock behavior (indexer every layer).
+        self.assertFalse(indexcache_enabled(0))
+        self.assertFalse(indexcache_enabled(1))
+
+    def test_on_for_stride_gt_one(self):
+        self.assertTrue(indexcache_enabled(2))
+        self.assertTrue(indexcache_enabled(4))
+
+
+class TestIndexCacheLayerPositions(unittest.TestCase):
+    def test_positions_are_sorted_and_zero_based(self):
+        # Unsorted ids must map to 0-based execution-order positions.
+        self.assertEqual(
+            indexcache_layer_positions([7, 3, 5, 1]),
+            {1: 0, 3: 1, 5: 2, 7: 3},
+        )
+
+    def test_empty(self):
+        self.assertEqual(indexcache_layer_positions([]), {})
+
+
+class TestIndexCacheShouldReuse(unittest.TestCase):
+    def test_disabled_never_reuses(self):
+        for stride in (0, 1):
+            for pos in range(4):
+                self.assertFalse(
+                    indexcache_should_reuse(pos, stride, has_cached_state=True)
+                )
+
+    def test_first_layer_without_state_recomputes(self):
+        # Position 0 is a cadence layer and has no cached state yet -> recompute.
+        self.assertFalse(indexcache_should_reuse(0, 4, has_cached_state=False))
+
+    def test_cadence_pattern_stride_4(self):
+        # With a warm cache: recompute at 0/4/8 (pos % stride == 0), reuse elsewhere.
+        expected_reuse = {
+            0: False,
+            1: True,
+            2: True,
+            3: True,
+            4: False,
+            5: True,
+            8: False,
+        }
+        for pos, want in expected_reuse.items():
+            self.assertEqual(
+                indexcache_should_reuse(pos, 4, has_cached_state=True),
+                want,
+                msg=f"pos={pos}",
+            )
+
+    def test_stride_2_alternates(self):
+        self.assertFalse(indexcache_should_reuse(0, 2, has_cached_state=True))
+        self.assertTrue(indexcache_should_reuse(1, 2, has_cached_state=True))
+        self.assertFalse(indexcache_should_reuse(2, 2, has_cached_state=True))
+
+    def test_reuse_requires_cached_state(self):
+        # A non-cadence layer still recomputes if nothing has been cached.
+        self.assertFalse(indexcache_should_reuse(1, 4, has_cached_state=False))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation
During decode, MiniMax-M3 recomputes its **lightning indexer** (block-score + top-k
block selection) on **every** sparse layer. On MI350x/TP4 that indexer + sparse-attn
bucket is ~**3.5 ms of a ~16 ms decode step (~22%)** — one of the biggest single
decode levers on this model. Because the selected blocks (`topk_idx`) are highly
correlated between adjacent sparse layers, most of that recompute is redundant.
This PR adds an opt-in **IndexCache** that recomputes the indexer on only 1 of every
`STRIDE` sparse layers and reuses the selection on the rest. It is **default-OFF**
and a byte-for-byte no-op unless enabled, so it's zero-risk for existing deployments.
## Summary
IndexCache reuses the decode block selection across sparse layers: the indexer runs
on 1 of every `STRIDE` layers (the *cadence* layers) and the other `STRIDE-1` reuse
the last selection. All sparse layers run in order (cadence before reuse) and the
cache is reset each forward, so reuse is **within-forward only → CUDA-graph safe**.
Two env knobs (default OFF):
- **`SGLANG_MINIMAX_INDEXCACHE_STRIDE`** (int, `0`): `0/1` = OFF (indexer every layer,
  stock). `>1` enables reuse at that cadence.
- **`SGLANG_MINIMAX_INDEXCACHE_MODE`** (str, `"full"`): `full` skips the indexer on
  reuse layers, reusing `idx_o` + `topk_idx` (max speedup); `topk` recomputes `idx_o`
  but substitutes the cached selection (accuracy A/B; no perf win alone).
`minimax_sparse_decode` gains `skip_indexer` / `reuse_idx_o` / `reuse_main_topk_idx` /
`reuse_real_seq_lens` / `return_index_state`; the dense, MSA and Triton GQA paths all
consume the possibly-cached selection. At `STRIDE 0/1` every layer takes the cadence
branch and behavior is unchanged.

## Modifications
Adds an optional **decode IndexCache** for MiniMax-M3 sparse attention: reuse the
sparse block selection (`topk_idx`) across sparse layers during decode, recomputing
the lightning indexer only on 1 of every `STRIDE` sparse layers and reusing the last
selection on the rest. Default OFF (behavior unchanged); within-forward reuse is
CUDA-graph safe (cache reset each forward, cadence layers run before reuse layers).
- **`environ.py`**: two new knobs (default OFF) — `SGLANG_MINIMAX_INDEXCACHE_STRIDE`
  (`0/1` = off, `>1` = reuse cadence) and `SGLANG_MINIMAX_INDEXCACHE_MODE`
  (`"full"` = skip indexer + reuse `idx_o`/`topk_idx`; `"topk"` = recompute `idx_o`,
  reuse only the selection, for accuracy A/B).
- **`minimax_sparse.py`**: `minimax_sparse_decode` gains `skip_indexer` /
  `reuse_idx_o` / `reuse_main_topk_idx` / `reuse_real_seq_lens` / `return_index_state`
  so all main-attn paths consume a possibly-cached selection.
- **`minimax_sparse_backend.py`**: reads the knobs, tracks a per-forward index-state
  cache, and drives the cadence-vs-reuse decision (incl. `full`/`topk` modes).
- **`minimax_sparse_ops/indexcache.py`** (new): dependency-free cadence helpers so the
  policy is CPU-unit-testable; backend calls them.
- **`test/.../test_minimax_indexcache_cadence.py`** (new): CPU unit tests for the
  cadence policy.
Reuse is an approximation, so gate on accuracy (e.g. GSM8K strict-match) at the
shipped STRIDE/MODE.

GSM8k test
## Accuracy Tests
{
  "gsm8k": {
    "name": "gsm8k",
    "alias": "gsm8k",
    "sample_len": 100,
    "exact_match,strict-match": 0.56,
    "exact_match_stderr,strict-match": 0.019694638556693213,
    "exact_match,flexible-extract": 0.98,
    "exact_match_stderr,flexible-extract": 0.014070529413628954
  }
}

AIME25 Test
{
  "n": 30,
  "correct": 25,
  "exact_match": 0.8333333333333334,
  "exact_match_stderr": 0.06804138174397716,
  "truncated_at_max_tokens": 5,
  "never_exited_thinking": 0,
  "looping_ge10_repeats": 0,
  "mean_completion_tokens": 23272,
  "max_completion_tokens": 65536,
  "errored": 0,
  "model": "amd/MiniMax-M3-MXFP4",
  "thinking_mode": "enabled",
  "temperature": 1.0,
  "max_tokens": 65536
}


## Speed Tests and Profiling
**Setup:** MiniMax-M3-MXFP4, MI350x, TP4, sglang v0.5.16 (ROCm 7.2, aiter v0.1.19.post2).
Dataset `generated-shared-prefix`, ISL ≈ 80k (72k shared system prompt + 8k question),
OSL 2000, `num-prompts = 8 × concurrency`, `request-rate=inf`. Concurrency sweep 4→128.
**Baseline** = IndexCache OFF (`SGLANG_MINIMAX_INDEXCACHE_STRIDE=1`, stock per-layer indexer).
**IndexCache** = this PR (reuse decode block-selection across sparse layers).
IndexCache improves throughput and latency at every concurrency, with gains scaling under load
(the indexer + sparse-attn bucket is ~22% of the decode-step GPU kernel time, so removing most
of its recompute pays off most when decode is the bottleneck).
| Concurrency | Total throughput (tok/s) | Median E2E (ms) | Median TTFT (ms) | Median TPOT (ms) |
|---|---|---|---|---|
| 4   | 13,041 → 15,204 (**+16.6%**) | 25,306 → 21,411 (**−15.4%**) | 1,688 → 1,528 (**−9.5%**)  | 11.8 → 9.9  (**−16.6%**) |
| 8   | 20,893 → 25,763 (**+23.3%**) | 31,615 → 25,313 (**−19.9%**) | 3,024 → 1,954 (**−35.4%**) | 14.3 → 11.8 (**−17.1%**) |
| 16  | 35,153 → 43,508 (**+23.8%**) | 37,825 → 29,893 (**−21.0%**) | 6,275 → 1,455 (**−76.8%**) | 15.8 → 14.2 (**−10.0%**) |
| 32  | 51,392 → 63,766 (**+24.1%**) | 52,115 → 41,268 (**−20.8%**) | 9,155 → 1,568 (**−82.9%**) | 21.6 → 19.8 (**−8.4%**)  |
| 64  | 65,013 → 85,454 (**+31.4%**) | 81,736 → 61,198 (**−25.1%**) | 3,423 → 1,662 (**−51.4%**) | 39.1 → 29.6 (**−24.3%**) |
| 128 | 73,890 → 112,137 (**+51.8%**)| 142,892 → 90,724 (**−36.5%**)| 5,506 → 2,238 (**−59.4%**) | 68.2 → 44.1 (**−35.4%**) |
Output (generation) throughput tracks total throughput closely: +16.7% (C=4) → +51.5% (C=128).


## Checklist

- [X] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [X] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [X] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [X] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [X] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31608521289](https://github.com/sgl-project/sglang/actions/runs/31608521289)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31620096913](https://github.com/sgl-project/sglang/actions/runs/31620096913)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->