### PR TITLE
[AMD][CI] Pre-build AITER JIT kernels after a forced AITER rebuild

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -359,6 +359,15 @@ if [[ "${NEED_REBUILD}" == "true" ]]; then
         AITER_USE_SYSTEM_TRITON=1 GPU_ARCHS=${GPU_ARCH_LIST} python3 setup.py develop
     "
 
+    # `setup.py develop` does not compile any kernel module, so the rebuild above
+    # leaves the JIT cache empty. Pay that cost here instead of inside a test,
+    # where a cold module blocks the scheduler loop past its 300s watchdog.
+    echo "[CI-AITER-CHECK] === AITER KERNEL WARMUP START ==="
+    docker exec -e GPU_ARCHS="${GPU_ARCH_LIST}" ci_sglang \
+        python3 /sglang-checkout/scripts/ci/amd/amd_ci_warmup_aiter.py \
+        || echo "[CI-AITER-CHECK] AITER warmup did not complete; continuing"
+    echo "[CI-AITER-CHECK] === AITER KERNEL WARMUP COMPLETE ==="
+
     echo "[CI-AITER-CHECK] === AITER REBUILD COMPLETE ==="
 fi
 
@@ -367,14 +376,3 @@ echo "[CI-AITER-CHECK] === AITER VERSION CHECK END ==="
 # Must be the final pip operation: force httpx>=0.25.0 so the anthropic SDK can
 # construct its httpx transport (see ensure_httpx definition above).
 ensure_httpx
-
-
-# # Clear pre-built AITER kernels from Docker image to avoid segfaults
-# # The Docker image may contain pre-compiled kernels incompatible with the current environment
-# echo "Clearing pre-built AITER kernels from Docker image..."
-# docker exec ci_sglang find /sgl-workspace/aiter/aiter/jit -name "*.so" -delete 2>/dev/null || true
-# docker exec ci_sglang ls -la /sgl-workspace/aiter/aiter/jit/ 2>/dev/null || echo "jit dir empty or not found"
-
-# # Pre-build AITER kernels to avoid timeout during tests
-# echo "Warming up AITER JIT kernels..."
-# docker exec -e SGLANG_USE_AITER=1 ci_sglang python3 /sglang-checkout/scripts/ci/amd/amd_ci_warmup_aiter.py || echo "AITER warmup completed (some kernels may not be available)"

--- a/scripts/ci/amd/amd_ci_warmup_aiter.py
+++ b/scripts/ci/amd/amd_ci_warmup_aiter.py
@@ -1,151 +1,145 @@
 #!/usr/bin/env python3
+"""Pre-build the AITER JIT modules that the AMD nightly suites need.
+
+AITER compiles its kernel modules lazily, on first use. That is fine when the CI
+image ships a matching prebuilt AITER, but the AITER Scout workflow forces a
+source rebuild in every job (AITER_COMMIT_OVERRIDE), which empties the JIT cache.
+The first request that reaches a cold module then blocks the scheduler loop for
+as long as the compile takes -- measured at 363s for
+module_gemm_a8w8_blockscale_bpreshuffle_cktile on gfx950, above the 300s
+scheduler watchdog, which SIGQUITs the server mid-test.
+
+Running this after an AITER rebuild moves that cost into the install step, where
+no watchdog is running. Modules are built by name through the same code path as
+AITER's compile_ops decorator, so no kernel arguments or tensor layouts are
+needed here.
+
+MODULES is the union of the modules observed in the AMD 8-GPU nightly jobs that
+repeatedly time out under Scout (DeepSeek-V4 Flash/Pro, DeepSeek-R1 hicache and
+MXFP4, Qwen3-235B MXFP4, GLM-5.1, MiniMax-M2.7). Unknown names are skipped, so
+the list can lag behind AITER without breaking the job.
 """
-Warmup script to pre-build AITER JIT kernels.
 
-This script triggers compilation of commonly used AITER kernels by importing
-the relevant modules and calling functions with sample data. This avoids
-timeouts during actual tests when kernels need to be compiled on first use.
-
-Run this after clearing pre-built AITER kernels from the Docker image.
-"""
-
+import inspect
 import os
 import sys
 import time
 
-# Ensure AITER is enabled
-os.environ["SGLANG_USE_AITER"] = "1"
+os.environ.setdefault("SGLANG_USE_AITER", "1")
+
+MODULES = [
+    "module_aiter_core",
+    # Blockscale FP8 GEMM: the DeepSeek-V4 hang, and by far the costliest pair.
+    "module_gemm_a8w8_blockscale_bpreshuffle_cktile",
+    "module_gemm_a8w8_blockscale_bpreshuffle",
+    "module_gemm_a8w8_blockscale_bpreshuffle_asm",
+    "module_gemm_a8w8_blockscale_cktile",
+    "module_gemm_a16w16_asm",
+    "module_gemm_common",
+    # Attention / MLA.
+    "module_mhc",
+    "module_mla_asm",
+    "module_mla_metadata",
+    "module_mla_reduce",
+    "module_pa_sparse_prefill_opus",
+    "module_ps_metadata",
+    # MoE.
+    "module_moe_asm",
+    "module_moe_fmoe_asm",
+    "module_moe_opus",
+    "module_moe_sorting_opus",
+    "module_moe_topk",
+    "module_moe_topksoftmax_asm",
+    # Norm / rope / quant / elementwise.
+    "module_activation",
+    "module_cache",
+    "module_custom",
+    "module_custom_all_reduce",
+    "module_deepgemm_opus",
+    "module_fused_qk_norm_rope_cache_quant_shuffle",
+    "module_norm",
+    "module_quant",
+    "module_rmsnorm_quant",
+    "module_rope_2c_cached_positions_fwd",
+    "module_sample",
+]
 
 
-def warmup_aiter_kernels():
-    """Trigger AITER JIT kernel compilation."""
-    import torch
+def is_built(core, md_name):
+    """True if the module's .so is already on disk and valid for this arch.
 
-    if not torch.cuda.is_available():
-        print("CUDA/ROCm not available, skipping AITER warmup")
-        return
+    Checked on disk rather than via core.get_module(): the ASM modules are loaded
+    through ctypes, so importing them as Python extensions raises even when they
+    are built.
+    """
+    jit_dir = getattr(core, "this_dir", None)
+    if jit_dir is None:
+        try:
+            core.get_module(md_name)
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+    if not os.path.exists(os.path.join(jit_dir, f"{md_name}.so")):
+        return False
+    needs_arch_rebuild = getattr(core, "_needs_arch_rebuild", None)
+    return not (needs_arch_rebuild is not None and needs_arch_rebuild(md_name))
 
-    print("=" * 60)
-    print("AITER JIT Kernel Warmup")
-    print("=" * 60)
 
-    device = torch.device("cuda:0")
-    start_time = time.time()
+def build(core, md_name):
+    """Build one module by name. Returns 'cached', 'built' or an error string."""
+    if is_built(core, md_name):
+        return "cached"
 
-    # Warmup module_rmsnorm_quant (small module, ~2MB)
-    # Triggered by rmsnorm2d_fwd when hidden_size <= 8192
     try:
-        print(
-            "\n[1/5] Warming up module_rmsnorm_quant (rmsnorm2d_fwd, hidden<=8192)..."
-        )
-        from aiter import rmsnorm2d_fwd
+        args = core.get_args_of_build(md_name)
+    except Exception as e:  # noqa: BLE001
+        return f"unknown module: {e}"
 
-        hidden_size = 4096
-        batch_size = 512  # Use larger batch to match CUDA graph capture
-        x = torch.randn(batch_size, hidden_size, dtype=torch.bfloat16, device=device)
-        weight = torch.ones(hidden_size, dtype=torch.bfloat16, device=device)
-        eps = 1e-6
+    # get_args_of_build returns a superset of build_module's parameters, and the
+    # set has changed across AITER versions, so pass only what it accepts.
+    accepted = inspect.signature(core.build_module).parameters
+    kwargs = {k: v for k, v in args.items() if k in accepted and k != "md_name"}
 
-        # hidden_size=4096 <= 8192 -> takes rmsnorm() path -> compiles module_rmsnorm_quant
-        _ = rmsnorm2d_fwd(x, weight, eps)
-        torch.cuda.synchronize()
-        print("   module_rmsnorm_quant compiled successfully")
-    except Exception as e:
-        print(f"   module_rmsnorm_quant warmup failed: {e}")
-
-    # Warmup module_rmsnorm (large CK module, ~159MB)
-    # Triggered by rmsnorm2d_fwd_with_add (always uses CK path)
-    # NOTE: rmsnorm2d_fwd_with_add signature is:
-    #   rmsnorm2d_fwd_with_add(out, input, residual_in, residual_out, weight, epsilon)
+    hip_clang_path = args.get("hip_clang_path")
+    prev_hip_clang_path = None
+    if hip_clang_path is not None and os.path.exists(hip_clang_path):
+        prev_hip_clang_path = os.environ.get("HIP_CLANG_PATH")
+        os.environ["HIP_CLANG_PATH"] = hip_clang_path
     try:
-        print("\n[2/5] Warming up module_rmsnorm (rmsnorm2d_fwd_with_add, CK path)...")
-        from aiter import rmsnorm2d_fwd_with_add
+        core.build_module(md_name, **kwargs)
+        return "built"
+    except Exception as e:  # noqa: BLE001
+        return f"build failed: {e}"
+    finally:
+        if hip_clang_path is not None and os.path.exists(hip_clang_path):
+            if prev_hip_clang_path is None:
+                os.environ.pop("HIP_CLANG_PATH", None)
+            else:
+                os.environ["HIP_CLANG_PATH"] = prev_hip_clang_path
 
-        hidden_size = 4096
-        batch_size = 512
-        x = torch.randn(batch_size, hidden_size, dtype=torch.bfloat16, device=device)
-        residual_in = torch.randn(
-            batch_size, hidden_size, dtype=torch.bfloat16, device=device
-        )
-        output = torch.empty_like(x)
-        residual_out = torch.empty_like(x)
-        weight = torch.ones(hidden_size, dtype=torch.bfloat16, device=device)
-        eps = 1e-6
 
-        # This triggers JIT compilation of module_rmsnorm (CK kernels)
-        rmsnorm2d_fwd_with_add(output, x, residual_in, residual_out, weight, eps)
-        torch.cuda.synchronize()
-        print("   module_rmsnorm compiled successfully")
-    except Exception as e:
-        print(f"   module_rmsnorm warmup failed: {e}")
-
-    # Warmup module_rmsnorm via rmsnorm2d_fwd with large hidden_size (CK path)
-    # When hidden_size > 8192, rmsnorm2d_fwd takes the rmsnorm2d_fwd_ck path
-    # which also uses module_rmsnorm (already compiled in step 2, but this
-    # ensures the CK rmsnorm2d_fwd path is exercised as well)
+def main():
     try:
-        print("\n[3/5] Warming up rmsnorm2d_fwd CK path (hidden>8192)...")
-        from aiter import rmsnorm2d_fwd
+        from aiter.jit import core
+    except ImportError as e:
+        print(f"AITER not importable ({e}); skipping warmup")
+        return 0
 
-        hidden_size = 16384  # > 8192 to trigger rmsnorm2d_fwd_ck (module_rmsnorm)
-        batch_size = 32
-        x = torch.randn(batch_size, hidden_size, dtype=torch.bfloat16, device=device)
-        weight = torch.ones(hidden_size, dtype=torch.bfloat16, device=device)
-        eps = 1e-6
+    print(f"Warming up {len(MODULES)} AITER JIT modules")
+    counts = {}
+    start = time.perf_counter()
+    for md_name in MODULES:
+        t0 = time.perf_counter()
+        status = build(core, md_name)
+        counts[status.split(":")[0]] = counts.get(status.split(":")[0], 0) + 1
+        print(f"  {md_name}: {status} ({time.perf_counter() - t0:.1f}s)", flush=True)
 
-        _ = rmsnorm2d_fwd(x, weight, eps)
-        torch.cuda.synchronize()
-        print("   rmsnorm2d_fwd CK path compiled successfully")
-    except Exception as e:
-        print(f"   rmsnorm2d_fwd CK path warmup skipped: {e}")
-
-    # Warmup rotary embedding kernel if available
-    try:
-        print("\n[4/5] Warming up rotary embedding kernel...")
-        from aiter import rotary_embedding
-
-        head_size = 128
-        seq_len = 32
-        num_heads = 32
-        positions = torch.arange(seq_len, device=device)
-        query = torch.randn(
-            seq_len, num_heads, head_size, dtype=torch.bfloat16, device=device
-        )
-        key = torch.randn(
-            seq_len, num_heads, head_size, dtype=torch.bfloat16, device=device
-        )
-        cos = torch.ones(seq_len, head_size // 2, dtype=torch.bfloat16, device=device)
-        sin = torch.zeros(seq_len, head_size // 2, dtype=torch.bfloat16, device=device)
-
-        _ = rotary_embedding(positions, query, key, head_size, cos, sin, True)
-        torch.cuda.synchronize()
-        print("   Rotary embedding kernel compiled successfully")
-    except Exception as e:
-        print(f"   Rotary embedding warmup skipped (may not be available): {e}")
-
-    # Warmup activation kernels if available
-    try:
-        print("\n[5/5] Warming up activation kernels...")
-        from aiter import silu_and_mul
-
-        hidden_size = 4096
-        batch_size = 512
-        x = torch.randn(
-            batch_size, hidden_size * 2, dtype=torch.bfloat16, device=device
-        )
-        out = torch.empty(batch_size, hidden_size, dtype=torch.bfloat16, device=device)
-
-        silu_and_mul(out, x)
-        torch.cuda.synchronize()
-        print("   Activation kernel compiled successfully")
-    except Exception as e:
-        print(f"   Activation warmup skipped (may not be available): {e}")
-
-    elapsed = time.time() - start_time
-    print("\n" + "=" * 60)
-    print(f"AITER warmup completed in {elapsed:.1f}s")
-    print("=" * 60 + "\n")
+    summary = ", ".join(f"{k}={v}" for k, v in sorted(counts.items()))
+    print(f"AITER warmup finished in {time.perf_counter() - start:.1f}s ({summary})")
+    # Never fail the job: a cold module only costs time later, and AITER module
+    # names move around between releases.
+    return 0
 
 
 if __name__ == "__main__":
-    warmup_aiter_kernels()
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

The AITER Scout workflow sets `AITER_COMMIT_OVERRIDE`, which makes
`amd_ci_install_dependency.sh` delete and rebuild AITER from source in **every**
job. `setup.py develop` compiles no kernel module (it finishes in ~19s in CI), so
every job starts with an empty JIT cache and compiles kernels lazily, on first
use, inside the scheduler process.

Measured on an 8x MI355X box with the Scout's exact config (SGLang `694ef532`,
AITER `aa30480f`, `rocm/sgl-dev:v0.5.17-rocm720-mi35x`), one cold job pays 633s
of JIT compilation across 16 modules, and it is very lopsided:

| module | cold compile |
|---|---|
| `module_gemm_a8w8_blockscale_bpreshuffle_cktile` | **363.2s** |
| `module_gemm_a8w8_blockscale_bpreshuffle` | 85.0s |
| `module_mhc` | 40.5s |
| `module_moe_topk` | 30.8s |
| 12 others | < 20s each |

The scheduler watchdog is 300s, so that first module alone can outlast it. In
[run 31481126981](https://github.com/sgl-project/sglang/actions/runs/31481126981)
both DSV4 8-GPU jobs died exactly that way -- hard watchdog timeout followed by
`SIGQUIT`, with every rank's py-spy stack stopped in the same frame,
`quantization/fp8.py:1029` (`w8a8_block_fp8_linear`), which is the AITER
blockscale GEMM:

- `nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720` (`test_deepseek_v4_flash_fp8_tbo.py`, both `unified_kv_triton` and `triton`)
- `nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720` (`test_deepseek_v4_pro_fp4_mtp.py`, `unified_kv_triton`)

Both jobs have failed in **all 5** most recent Scout runs, while the regular
nightlies on `main` pass them -- the regular nightlies keep the image's prebuilt
AITER and never hit a cold cache. On a local repro with the identical config
(`ServerArgs` matches CI on 459/459 fields bar the random seed) all of these
tests pass, including the full suite for both backends, which is consistent with
a timing-dependent compile stall rather than a defect in the tests.

## Modifications

- `amd_ci_warmup_aiter.py`: build the needed modules **by name**, through the
  same `get_args_of_build` + `build_module` path as AITER's `compile_ops`
  decorator. This needs no kernel arguments or tensor layouts, so it does not
  drift with op signatures. Existence is checked on disk because the ASM modules
  load via ctypes and cannot be imported as Python extensions. Unknown module
  names and build failures are reported and skipped, never fatal.
- The module list is the union actually observed in the 8-GPU nightly jobs that
  repeatedly time out under Scout: DeepSeek-V4 Flash and Pro, DeepSeek-R1
  hicache and MXFP4-tp4, Qwen3-235B MXFP4, GLM-5.1 and MiniMax-M2.7 (30 modules,
  extracted from their job logs).
- `amd_ci_install_dependency.sh`: invoke it inside the `NEED_REBUILD` block,
  right after the AITER build. Regular nightly and PR CI keep the image's AITER,
  never set `NEED_REBUILD`, and so are completely unaffected.
- Dropped the commented-out warmup/kernel-clearing block at the bottom of the
  install script, which this supersedes.

## Accuracy Tests

No functional change to SGLang; this only moves kernel compilation earlier in
the same job.

## Speed Tests and Profiling

Verified in a container built from the Scout's own config:

- Warm cache: 30/30 reported `cached`, total 0.1s -- idempotent, and a no-op for
  any job whose image already ships the kernels.
- Cold: builds correctly by name. 11 modules were built from scratch across the
  runs, including the critical one after deleting its `.so` and build directory
  (`module_gemm_a8w8_blockscale_bpreshuffle_cktile: built (162.6s)` -- faster
  than the 363s seen mid-test, since it is not competing with 8 busy ranks).
- Side benefit visible locally: with a warm cache the `fp8_tbo` GSM8K eval runs
  in 32s at 4050 tok/s versus 418s at 314 tok/s cold, a 13x difference that all
  Scout jobs currently pay.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-to-ci) -- CI-only change, exercised by the AMD nightly jobs themselves.
- [ ] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#writing-documentation).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/reference/accuracy/accuracy.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting in merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829033242](https://github.com/sgl-project/sglang/actions/runs/34829033242)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829032629](https://github.com/sgl-project/sglang/actions/runs/34829032629)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829033279](https://github.com/sgl-project/sglang/actions/runs/34829033279)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
