### PR TITLE
[VLA] Bound Pi0.5 CUDA graphs with prompt buckets

### DIFF
--- a/docs/cookbook/vla/OpenPI/Pi0.5.mdx
+++ b/docs/cookbook/vla/OpenPI/Pi0.5.mdx
@@ -81,7 +81,7 @@ These registered LeRobot checkpoints dispatch to the native `multimodal_gen` Pi0
 | `parameters.action_dim` | integer, optional | Internal padded action dimension. Defaults to the checkpoint config. |
 | `runtime.return_timing` | boolean, optional | Return stage timing fields. Defaults to `true`. |
 | `runtime.prefix_cache` | boolean or `"auto"`, optional | Enable exact full-prefix lookup for this request when the server has `enable_global_prefix_cache=true`. Defaults to `"auto"`. |
-| `runtime.cuda_graph` | boolean or `"auto"`, optional | Enable the available prefix and action-denoise CUDA graph paths for this request. Defaults to `"auto"`. |
+| `runtime.cuda_graph` | boolean or `"auto"`, optional | Enable the available prefix and action-denoise CUDA graph paths for this request. Setting it to `false` also disables configured prompt bucketing, so the request stays on its exact-length eager path. Defaults to `"auto"`. |
 | `runtime.output_format` | `"list"` or `"numpy"`, optional | Use `"list"` for JSON compatibility. Use `"numpy"` with msgpack or Python clients to avoid Python-list materialization. Defaults to `"list"`. |
 | `runtime.response_format` | `"envelope"` or `"raw"`, optional | HTTP-only response shape. `"envelope"` returns the generic action envelope. `"raw"` returns the policy payload directly. Defaults to `"envelope"`. |
 
@@ -261,12 +261,30 @@ asyncio.run(main())
 - Request-local `PrefixContext` is always reused across all denoise steps in one request. The prefix K/V is not cloned per step.
 - The optional global prefix cache is a bounded exact-match LRU. It is disabled by default because changing robot frames rarely hit it and enabling it prevents unrelated misses from entering grouped prefix execution. Set `enable_global_prefix_cache=true` for repeated observations, retries, or multiple policy calls over the same camera/state sample; `runtime.prefix_cache` can then disable lookup per request.
 - Partial-prefix reuse is not supported because Pi0.5 combines image and tokenized task/state inputs under full attention. Changing any input can change every deeper-layer prefix K/V tensor. The exact key hashes resized and normalized pixels before SigLIP, plus effective token IDs, token masks, camera masks, model revision, dtype, and parallel layout. Tensor content hashing reuses SRT's CPU/CUDA implementation; hashing the pre-SigLIP input lets an exact hit skip both the vision encoder and prefix transformer.
-- CUDA graph capture targets single-request prefix encoding and one action-denoise step. Prefix capture uses one bounded input-shape bucket by default; grouped prefixes, prefix TP, CPU offload, and global prefix-cache misses stay eager. The denoise graph is replayed across the flow-matching loop and uses batch size, prefix length, action horizon, action dim, dtype, and parallel layout in its shape signature. With action SP enabled, the denoise bucket uses the local action shard length and rank-specific position offset.
+- CUDA graph capture targets single-request prefix encoding and one action-denoise step. Exact prompt lengths are used by default. Prefix TP, CPU offload, and global prefix-cache misses stay eager; grouped prefix encoding is also eager, but configured prompt bucketing still stabilizes the resulting action-graph signature. The denoise graph is replayed across the flow-matching loop and uses batch size, prefix length, action horizon, action dim, dtype, attention layout, and parallel layout in its shape signature. With action SP enabled, the denoise graph uses the local action shard length and rank-specific position offset.
 - Cache-DiT is not used in the default Pi0.5 path. The current robot policy target is numerically lossless inference, while Cache-DiT-style reuse is an image/video DiT approximation that needs separate policy-quality validation before it can be recommended for action control.
 - Do not use CFG parallelism to split the 10 Euler steps. Use it only for independent branches such as multiple candidate actions or future conditional/unconditional branches.
 - Prefix TP uses native SGLang parallel linear layers for the PaliGemma language prefix model when model parallel TP is initialized and the VLA split broadcast group is not active. The action expert does not share that TP layout. The v1 split prefix/action path instead uses the SP group: prefix root computes/broadcasts `PrefixContext`, while action ranks run the SP action path.
 - The split path uses the SP group as the action group: prefix root computes/broadcasts `PrefixContext`, all action ranks broadcast the initial action noise once, shard the action horizon, and run the action expert through Ulysses attention when the prefix is full-attention, ring degree is one, heads are divisible by SP size, and the horizon is evenly shardable. Otherwise it falls back to action-root execution.
 - `lerobot/pi05_libero_base` returns 7 action dimensions even though the internal padded action tensor uses 32 dimensions.
+
+### 5.1 Variable-Length Prompt CUDA Graphs
+
+By default, `prompt_token_buckets` is empty. The prefix graph keeps the first captured signature at its default capacity of one; a different prompt shape runs eagerly instead of evicting and recapturing on every request. Action graphs use a bounded LRU with `action_cuda_graph_max_entries=16` by default. Eviction calls `CUDAGraph.reset()` and releases the cache-owned static tensors, although the CUDA allocator can retain its previous reserved-memory high-water mark.
+
+For serving traffic with many nearby prompt lengths, opt in to a small set of token buckets:
+
+```json File
+{
+  "prompt_token_buckets": [32, 64, 128, 200],
+  "prefix_cuda_graph_max_entries": 4,
+  "action_cuda_graph_max_entries": 4
+}
+```
+
+The tokenizer output is trimmed or padded to the smallest configured bucket that fits its effective masked length. Tokens beyond the largest configured bucket keep their exact length and run eagerly instead of creating extra graph signatures. Padding remains excluded by the attention mask, and every logical length in one bucket follows the same masked-attention control flow. With buckets enabled, the prefix and action graph caches both use LRU replacement; normally set their capacities to at least the number of hot buckets to avoid capture churn. The active graph policy and bucket list are also exposed by `/v1/actions/metadata`.
+
+Prompt bucketing is not guaranteed to be bit-exact. Masked padding changes the physical attention shape and can change floating-point reduction order. In a fixed-noise H200 check over effective token lengths `20`, `31`, `33`, `60`, `65`, `100`, `129`, and `180`, `[32, 64, 128, 200]` buckets produced action max absolute differences of `0.00461` to `0.01387` versus exact-length eager execution. Treat buckets as a throughput/latency optimization and validate closed-loop policy quality for the deployed checkpoint. Leave the list empty when exact numerical behavior is required.
 
 ## 6. VRAM Tuning
 
@@ -297,7 +315,8 @@ Use this single-GPU config first for 16GB-class robot workstations. It keeps par
   "prefix_cache_max_entries": 0,
   "enable_prefix_cuda_graph": true,
   "prefix_cuda_graph_max_entries": 1,
-  "enable_action_cuda_graph": true
+  "enable_action_cuda_graph": true,
+  "action_cuda_graph_max_entries": 16
 }
 ```
 
@@ -462,6 +481,7 @@ The following checks were run on H100 GPUs with the native SGLang Pi0.5 path:
 | Official OpenPI parity | Against OpenPI PyTorch revision `15a9616`, with the same LeRobot checkpoint revision, observation, and noise: first-step velocity max/mean absolute difference `0.02677` / `0.00344`; production 10-step normalized action `0.00813` / `0.00092`. |
 | Action denoise CUDA graph | Eager 10-step denoise `125.4 ms`; steady graph replay `50.8 ms`; max output difference `0`. |
 | Prefix CUDA graph | On H200 with action graph already enabled, ALOHA batch=1 p50 improved from `48.04 ms` to `42.98 ms` (`1.118x`). Two observations at 5 and 10 steps were bit-exact with graph disabled. One prefix shape bucket added about `48.5 MiB`; batch=4 showed no benefit and stays eager. |
+| Variable-length prompt buckets | On H200 with `lerobot/pi05_base`, effective token lengths `20`, `31`, `33`, `60`, `65`, `100`, `129`, and `180` produced exactly four prefix/action graph signatures with `[32, 64, 128, 200]` buckets. After capture, end-to-end p50 was `54.27 ms` (`13.20 ms` prefix, `39.54 ms` denoise). A capacity-two sequence over four buckets captured four graphs and evicted two without capture failures. Fixed-noise differences versus exact-length eager are reported in section 5.1. |
 | Exact full-prefix cache | First prefix pass about `203 ms`; exact cache hit prefix stage about `0.2 ms`. |
 | `lerobot/pi05_libero_base` direct end-to-end | Image keys `image`, `image2`, `empty_camera_0`; state dim `8`; output action dim `7`; output tensor shape `[1, 50, 32]`. |
 | Python grouped execution | ALOHA batch=4 grouped path measured `91.9 ms / 4` on current mixed precision: prefix `18.4 ms`, action denoise `61.2 ms`, preprocess about `2.4 ms` per request. Sequential Python loop batch=4 measured `211.9 ms / 4`. |
@@ -471,7 +491,7 @@ The following checks were run on H100 GPUs with the native SGLang Pi0.5 path:
 | OpenPI/SGLang precision | Official OpenPI JAX inference restores the public GCS checkpoint as bf16 with selected fp32 stability compute and returns float32 actions. The converted OpenPI PyTorch `pi05_aloha` checkpoint keeps `119,720,608` fp32 stability params; SGLang reports the same fp32 set and `3,233,713,264` bf16 runtime params after skipping unused LM heads. |
 | Native attention dtype | Checkpoint source tensors may be fp32, but SGLang finalizes PiGemma and SigLIP compute dtype before native attention backend selection; backend logs showed `Using fa attention backend` for the PiGemma path in the prior run. |
 | 16GB-free Python pressure | With an H100 artificially constrained to `16381 MiB` free before model load, single-GPU bf16 no-offload Python grouped path completed without OOM. Re-run latency after precision or loader changes before using pressure numbers for deployment sizing. |
-| Low-VRAM switches | Disabling prefix cache prevents cache growth across changing robot frames. Prefix graph residency is bounded by `prefix_cuda_graph_max_entries` (default `1`); set `enable_prefix_cuda_graph=false` or the limit to `0` to save about `48.5 MiB` for the validated ALOHA bucket. Action graph can stay enabled when the action expert remains resident; disable both graph paths for offload fallback modes. |
+| Low-VRAM switches | Disabling prefix cache prevents cache growth across changing robot frames. Prefix and action graph residency are bounded by `prefix_cuda_graph_max_entries` (default `1`) and `action_cuda_graph_max_entries` (default `16`). Set either limit to `0` to disable that graph path; disabling the prefix graph saves about `48.5 MiB` for the validated ALOHA shape. Disable both graph paths for offload fallback modes. |
 | Offload fallback | CPU/offload modes are retained as numerically lossless compatibility fallbacks, but earlier fp32-runtime offload latency numbers are stale after the bf16 dtype correction and should be revalidated before deployment decisions. |
 | Run:ai direct loader | Single-GPU serve streamed `13.5 GiB` safetensors to `cuda:0` in about `1.5 s` and returned `[50, 32]` actions. Distributed direct streaming is now rank-local and should be revalidated on the target split topology; offload ranks with CPU targets still use the safe loader. |
 | OpenPI comparison status | Official OpenPI GCS `pi05_base` is a JAX checkpoint; converted PyTorch eager was validated without `torch.compile`. On 80GB H100, ALOHA OpenPI PyTorch eager was about `125-130 ms` single and about `164 ms / 4` in the direct-model batch path. Current SGLang Python grouped measured `52.4 ms` single and `91.9 ms / 4`; JAX OpenPI was `53.0 ms` single and `59.5 ms / 2` in a short check. |

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/pi05.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/pi05.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
@@ -47,8 +48,13 @@ class Pi05PipelineConfig(PipelineConfig):
 
     enable_global_prefix_cache: bool = False
     enable_prefix_cuda_graph: bool = True
+    # Bucket prompt tokens so common serving lengths reuse the same prefix and
+    # action CUDA graphs. Opt in explicitly because padding can change floating
+    # point reduction order even though padded tokens remain attention-masked.
+    prompt_token_buckets: tuple[int, ...] = ()
     prefix_cuda_graph_max_entries: int = 1
     enable_action_cuda_graph: bool = True
+    action_cuda_graph_max_entries: int = 16
     prefix_cache_max_entries: int = 1
     prefix_cache_layout_version: str = "pi05-prefix-v1"
     offload_prefix_image_encoder: bool = False
@@ -85,6 +91,48 @@ class Pi05PipelineConfig(PipelineConfig):
             ),
         }
     )
+
+    def __post_init__(self) -> None:
+        self._normalize_and_validate_cuda_graph_config()
+
+    def _normalize_and_validate_cuda_graph_config(self) -> None:
+        try:
+            buckets = tuple(int(bucket) for bucket in self.prompt_token_buckets)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("prompt_token_buckets must contain integers") from exc
+        if any(bucket <= 0 for bucket in buckets):
+            raise ValueError("prompt_token_buckets must contain positive lengths")
+        if tuple(sorted(set(buckets))) != buckets:
+            raise ValueError(
+                "prompt_token_buckets must be strictly increasing and unique"
+            )
+        if buckets and buckets[-1] > self.max_token_len:
+            raise ValueError(
+                "prompt_token_buckets cannot exceed max_token_len "
+                f"({self.max_token_len}), got {buckets[-1]}"
+            )
+        if self.prefix_cuda_graph_max_entries < 0:
+            raise ValueError("prefix_cuda_graph_max_entries must be non-negative")
+        if self.action_cuda_graph_max_entries < 0:
+            raise ValueError("action_cuda_graph_max_entries must be non-negative")
+        self.prompt_token_buckets = buckets
+
+    def check_pipeline_config(self) -> None:
+        super().check_pipeline_config()
+        # JSON/CLI overrides are applied after dataclass construction.
+        self._normalize_and_validate_cuda_graph_config()
+
+    def update_pipeline_config(self, source_pipeline_dict: dict[str, Any]) -> None:
+        # PipelineConfig treats tuples of ModelConfig specially. ``all`` is
+        # vacuously true for our default empty bucket tuple, so handle this
+        # variable-length scalar tuple outside the generic updater.
+        source_pipeline_dict = dict(source_pipeline_dict)
+        missing = object()
+        buckets = source_pipeline_dict.pop("prompt_token_buckets", missing)
+        super().update_pipeline_config(source_pipeline_dict)
+        if buckets is not missing:
+            self.prompt_token_buckets = buckets
+            self._normalize_and_validate_cuda_graph_config()
 
     def supports_dynamic_batching(self):
         return True

--- a/python/sglang/multimodal_gen/runtime/entrypoints/action/protocol.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/action/protocol.py
@@ -199,6 +199,40 @@ def action_metadata(server_args: ServerArgs) -> dict[str, Any]:
         "policy_family",
         type(pipeline_config).__name__.removesuffix("PipelineConfig").lower(),
     )
+    prefix_graph_max_entries = getattr(
+        pipeline_config, "prefix_cuda_graph_max_entries", 0
+    )
+    action_graph_max_entries = getattr(
+        pipeline_config, "action_cuda_graph_max_entries", 0
+    )
+    prefix_graph_offload = any(
+        (
+            getattr(pipeline_config, "offload_prefix_image_encoder", False),
+            getattr(pipeline_config, "offload_prefix_image_encoder_after_embed", False),
+            getattr(pipeline_config, "offload_prefix_token_embedding", False),
+            getattr(pipeline_config, "offload_prefix_language_layers", False),
+            getattr(
+                pipeline_config, "offload_prefix_language_layers_after_prefix", False
+            ),
+            getattr(
+                pipeline_config,
+                "offload_prefix_language_layer_count_after_prefix",
+                0,
+            )
+            > 0,
+            getattr(pipeline_config, "empty_cache_after_prefix", False),
+        )
+    )
+    prefix_graph_enabled = bool(
+        getattr(pipeline_config, "enable_prefix_cuda_graph", False)
+        and prefix_graph_max_entries > 0
+        and not prefix_graph_offload
+    )
+    action_graph_enabled = bool(
+        getattr(pipeline_config, "enable_action_cuda_graph", False)
+        and action_graph_max_entries > 0
+        and not getattr(pipeline_config, "offload_action_expert_after_denoise", False)
+    )
     return {
         "object": "action.metadata",
         "model": server_args.served_model_name,
@@ -219,6 +253,15 @@ def action_metadata(server_args: ServerArgs) -> dict[str, Any]:
         "runtime": {
             "materialize_dtype": pipeline_config.materialize_dtype,
             "enable_autocast": pipeline_config.enable_autocast,
+            "cuda_graph": {
+                "prefix_enabled": prefix_graph_enabled,
+                "prefix_max_entries": prefix_graph_max_entries,
+                "action_enabled": action_graph_enabled,
+                "action_max_entries": action_graph_max_entries,
+                "prompt_token_buckets": list(
+                    getattr(pipeline_config, "prompt_token_buckets", ())
+                ),
+            },
             "parallelism": {
                 "num_gpus": server_args.num_gpus,
                 "tp_size": server_args.tp_size,
@@ -236,11 +279,13 @@ def action_metadata(server_args: ServerArgs) -> dict[str, Any]:
             "prefix_cache": (
                 "auto" if pipeline_config.enable_global_prefix_cache else False
             ),
-            "cuda_graph": "auto" if pipeline_config.enable_action_cuda_graph else False,
+            "cuda_graph": (
+                "auto" if prefix_graph_enabled or action_graph_enabled else False
+            ),
         },
         "capabilities": {
             "exact_prefix_cache": True,
-            "cuda_graph": pipeline_config.enable_action_cuda_graph,
+            "cuda_graph": prefix_graph_enabled or action_graph_enabled,
             "realtime_websocket": True,
             "openpi_websocket": True,
             "batch_inputs": False,

--- a/python/sglang/multimodal_gen/runtime/models/vlas/pi05_core.py
+++ b/python/sglang/multimodal_gen/runtime/models/vlas/pi05_core.py
@@ -1452,12 +1452,17 @@ class Pi05CoreModel(nn.Module):
         )
         self._offload_prefix_image_encoder_after_embed()
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
-        prefix_full_attention = bool(prefix_full_attention_hint)
-        if prefix_full_attention:
+        prefix_full_attention = (
+            bool(prefix_full_attention_hint)
+            if prefix_full_attention_hint is not None
+            else None
+        )
+        if prefix_full_attention is True:
             attention_mask = None
         else:
             prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
-            prefix_full_attention = bool(prefix_att_2d_masks.all().item())
+            if prefix_full_attention is None:
+                prefix_full_attention = bool(prefix_att_2d_masks.all().item())
             attention_mask = self.prepare_attention_masks_4d(
                 prefix_att_2d_masks,
                 full_attention=prefix_full_attention,
@@ -1506,7 +1511,12 @@ class Pi05CoreModel(nn.Module):
                 [prefix_pad_2d_masks, suffix_att_2d_masks],
                 dim=2,
             )
-            attention_mask = self.prepare_attention_masks_4d(full_att_2d_masks)
+            # This branch already proves the mask is not full attention. Passing
+            # the static hint avoids a tensor ``.item()`` during CUDA capture.
+            attention_mask = self.prepare_attention_masks_4d(
+                full_att_2d_masks,
+                full_attention=False,
+            )
         prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
         position_ids = (
             prefix_offsets

--- a/python/sglang/multimodal_gen/runtime/models/vlas/pi05_policy.py
+++ b/python/sglang/multimodal_gen/runtime/models/vlas/pi05_policy.py
@@ -52,6 +52,11 @@ from sglang.multimodal_gen.runtime.vla.parallel import (
     broadcast_tensor_from_rank,
     get_vla_split_group,
 )
+from sglang.multimodal_gen.runtime.vla.prompt_bucketing import (
+    bucket_prompt_tokens,
+    effective_token_length,
+    select_prompt_token_bucket,
+)
 from sglang.multimodal_gen.runtime.vla.prefix_cache import (
     PrefixContext,
     VLADensePrefixCache,
@@ -166,9 +171,14 @@ class Pi05PolicyModel(nn.Module):
         self.prefix_graph_runner = VLAPrefixGraphRunner(
             enabled=self._prefix_cuda_graph_enabled(),
             max_entries=config.prefix_cuda_graph_max_entries,
+            evict_on_miss=bool(config.prompt_token_buckets),
         )
         self.graph_runner = VLADenoiseGraphRunner(
-            enabled=config.enable_action_cuda_graph
+            enabled=(
+                config.enable_action_cuda_graph
+                and not self._offload_action_expert_between_requests()
+            ),
+            max_entries=config.action_cuda_graph_max_entries,
         )
 
     def _should_use_prefix_tensor_parallel(self) -> bool:
@@ -197,9 +207,28 @@ class Pi05PolicyModel(nn.Module):
                 self.config.offload_prefix_token_embedding,
                 self.config.offload_prefix_language_layers,
                 self.config.offload_prefix_language_layers_after_prefix,
+                self.config.offload_prefix_language_layer_count_after_prefix > 0,
                 self.config.empty_cache_after_prefix,
             )
         )
+
+    def _prompt_token_bucketing_enabled(self) -> bool:
+        graph_path_available = self.prefix_graph_runner.enabled or (
+            self.graph_runner.enabled
+            and not self._offload_action_expert_between_requests()
+        )
+        if (
+            not self.config.prompt_token_buckets
+            or not graph_path_available
+            or self.device.type != "cuda"
+            or self.runtime_role not in ("all", "prefix")
+            or self._prefix_tensor_parallel_enabled()
+        ):
+            return False
+        # The current action-SP path requires a full-attention prefix. Bucket
+        # padding is masked, so preserve that distributed fast path until its
+        # attention implementation supports prefix padding masks.
+        return get_vla_split_group() is None
 
     @staticmethod
     def _to_empty_preserve_buffers(module: nn.Module, *, device: torch.device) -> None:
@@ -783,6 +812,8 @@ class Pi05PolicyModel(nn.Module):
     def build_prefix_cache_key(
         self,
         observation: VLAObservationBatch,
+        *,
+        bucket_prompt: bool = False,
     ) -> str:
         camera_order = tuple(observation.metadata.get("camera_order", ()))
         image_hashes = {
@@ -791,7 +822,7 @@ class Pi05PolicyModel(nn.Module):
         masks = {
             name: bool(mask.item()) for name, mask in observation.image_masks.items()
         }
-        token_len = int(observation.token_masks.sum(dim=1).max().item())
+        token_len = effective_token_length(observation.token_masks)
         tokens = (
             observation.tokens[:, :token_len] if token_len > 0 else observation.tokens
         )
@@ -801,6 +832,19 @@ class Pi05PolicyModel(nn.Module):
             else observation.token_masks
         )
         model_revision = os.path.basename(os.path.normpath(self.model_path))
+        prompt_bucket = None
+        bucketing_enabled = bucket_prompt and self._prompt_token_bucketing_enabled()
+        if bucketing_enabled:
+            prompt_bucket = select_prompt_token_bucket(
+                token_len,
+                self.config.prompt_token_buckets,
+            )
+        if prompt_bucket is not None:
+            prompt_layout = f"bucket-{prompt_bucket}"
+        elif bucketing_enabled:
+            prompt_layout = "bucket-miss-exact"
+        else:
+            prompt_layout = "exact"
         return VLAPrefixCacheManager.make_key(
             model_revision=model_revision,
             tokenizer_id=f"{self.config.paligemma_variant}:{self.config.max_token_len}",
@@ -809,7 +853,9 @@ class Pi05PolicyModel(nn.Module):
             token_digest=tensor_fingerprint(tokens),
             token_mask_digest=tensor_fingerprint(token_masks),
             masks=masks,
-            positions_version=self.config.prefix_cache_layout_version,
+            positions_version=(
+                f"{self.config.prefix_cache_layout_version}:{prompt_layout}"
+            ),
             dtype=str(self.dtype).replace("torch.", ""),
             parallel_layout_version=self.config.parallel_layout_version,
             cache_namespace="pi05",
@@ -856,6 +902,7 @@ class Pi05PolicyModel(nn.Module):
         observation: VLAObservationBatch,
         *,
         use_cuda_graph: bool = True,
+        bucket_prompt: bool | None = None,
     ) -> PrefixContext:
         camera_order = tuple(observation.metadata.get("camera_order", ()))
         images = [
@@ -865,19 +912,44 @@ class Pi05PolicyModel(nn.Module):
         image_masks = [
             observation.image_masks[name].to(self.device) for name in camera_order
         ]
-        token_len = int(observation.token_masks.sum(dim=1).max().item())
-        tokens_trimmed = token_len > 0
-        if tokens_trimmed and token_len < observation.tokens.shape[1]:
-            tokens_cpu = observation.tokens[:, :token_len]
-            token_masks_cpu = observation.token_masks[:, :token_len]
+        if bucket_prompt is None:
+            bucket_prompt = use_cuda_graph
+        use_prompt_bucket = bucket_prompt and self._prompt_token_bucketing_enabled()
+        if use_prompt_bucket:
+            tokens_cpu, token_masks_cpu, token_len, prompt_bucket = (
+                bucket_prompt_tokens(
+                    observation.tokens,
+                    observation.token_masks,
+                    self.config.prompt_token_buckets,
+                )
+            )
         else:
-            tokens_cpu = observation.tokens
-            token_masks_cpu = observation.token_masks
+            token_len = effective_token_length(observation.token_masks)
+            prompt_bucket = None
+            if 0 < token_len < observation.tokens.shape[1]:
+                tokens_cpu = observation.tokens[:, :token_len]
+                token_masks_cpu = observation.token_masks[:, :token_len]
+            else:
+                tokens_cpu = observation.tokens
+                token_masks_cpu = observation.token_masks
+        prompt_bucket_miss = use_prompt_bucket and prompt_bucket is None
+        preserve_token_shape = token_len > 0 or prompt_bucket is not None
         tokens = tokens_cpu.to(self.device)
         token_masks = token_masks_cpu.to(self.device)
-        prefix_full_attention_hint = all(
-            bool(observation.image_masks[name].all().item()) for name in camera_order
-        ) and bool(token_masks_cpu.all().item())
+        # Always use the masked control flow for a bucket, including a prompt
+        # that exactly fills it. This lets every logical length in that bucket
+        # share both prefix and action graph signatures safely.
+        prefix_full_attention_hint = (
+            False
+            if prompt_bucket is not None
+            else (
+                all(
+                    bool(observation.image_masks[name].all().item())
+                    for name in camera_order
+                )
+                and bool(token_masks_cpu.all().item())
+            )
+        )
 
         image_count = len(images)
         graph_inputs = tuple([*images, *image_masks, tokens, token_masks])
@@ -894,7 +966,7 @@ class Pi05PolicyModel(nn.Module):
                     current_tokens,
                     current_token_masks,
                     prefix_full_attention_hint=prefix_full_attention_hint,
-                    tokens_trimmed=tokens_trimmed,
+                    tokens_trimmed=preserve_token_shape,
                 )
             )
             past_key_values = self._materialize_prefix_kv_for_action(past_key_values)
@@ -902,13 +974,18 @@ class Pi05PolicyModel(nn.Module):
                 past_key_values=past_key_values,
                 prefix_pad_masks=prefix_pad_masks,
                 prefix_len=prefix_pad_masks.shape[1],
-                layout={"full_attention": full_attention},
+                layout={
+                    "full_attention": full_attention,
+                    "prompt_token_bucket": prompt_bucket,
+                    "cuda_graph_eligible": not prompt_bucket_miss,
+                },
             )
 
         if (
             not use_cuda_graph
             or not self.prefix_graph_runner.enabled
             or observation.batch_size != 1
+            or prompt_bucket_miss
         ):
             return encode(graph_inputs)
 
@@ -921,7 +998,8 @@ class Pi05PolicyModel(nn.Module):
             static_layout=(
                 image_count,
                 prefix_full_attention_hint,
-                tokens_trimmed,
+                preserve_token_shape,
+                prompt_bucket,
             ),
             parallel_layout=self.config.parallel_layout_version,
         )
@@ -956,9 +1034,9 @@ class Pi05PolicyModel(nn.Module):
         action_position_offset: int = 0,
         action_sp_enabled: bool = False,
     ) -> torch.Tensor:
-        if not bool(prefix_context.layout.get("full_attention", False)):
-            use_cuda_graph = False
-        if not use_cuda_graph:
+        if not use_cuda_graph or not prefix_context.layout.get(
+            "cuda_graph_eligible", True
+        ):
             return self.action_expert(
                 prefix_context,
                 x_t,
@@ -978,6 +1056,7 @@ class Pi05PolicyModel(nn.Module):
             action_dim=x_t.shape[2],
             dtype=str(x_t.dtype).replace("torch.", ""),
             parallel_layout=parallel_layout,
+            full_attention=bool(prefix_context.layout.get("full_attention", False)),
         )
 
         def step_fn(

--- a/python/sglang/multimodal_gen/runtime/models/vlas/pi05_policy.py
+++ b/python/sglang/multimodal_gen/runtime/models/vlas/pi05_policy.py
@@ -52,15 +52,15 @@ from sglang.multimodal_gen.runtime.vla.parallel import (
     broadcast_tensor_from_rank,
     get_vla_split_group,
 )
-from sglang.multimodal_gen.runtime.vla.prompt_bucketing import (
-    bucket_prompt_tokens,
-    effective_token_length,
-    select_prompt_token_bucket,
-)
 from sglang.multimodal_gen.runtime.vla.prefix_cache import (
     PrefixContext,
     VLADensePrefixCache,
     VLAPrefixCacheManager,
+)
+from sglang.multimodal_gen.runtime.vla.prompt_bucketing import (
+    bucket_prompt_tokens,
+    effective_token_length,
+    select_prompt_token_bucket,
 )
 from sglang.multimodal_gen.utils import set_mixed_precision_policy
 

--- a/python/sglang/multimodal_gen/runtime/pipelines/pi05.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/pi05.py
@@ -59,7 +59,8 @@ class Pi05Pipeline(ComposedPipelineBase):
             or bool(server_args.text_encoder_cpu_offload)
         )
         logger.info(
-            "Pi05 memory config: prefix_cache=%s/%s, cuda_graph=%s/%s/%s, "
+            "Pi05 memory config: prefix_cache=%s/%s, "
+            "cuda_graph=prefix:%s/%s action:%s/%s buckets:%s, "
             "offload_image=%s, offload_image_after_embed=%s, "
             "offload_tokens=%s, offload_language_layers=%s, "
             "offload_language_after_prefix=%s/%s, "
@@ -69,6 +70,8 @@ class Pi05Pipeline(ComposedPipelineBase):
             pipeline_config.enable_prefix_cuda_graph,
             pipeline_config.prefix_cuda_graph_max_entries,
             pipeline_config.enable_action_cuda_graph,
+            pipeline_config.action_cuda_graph_max_entries,
+            pipeline_config.prompt_token_buckets,
             pipeline_config.offload_prefix_image_encoder,
             pipeline_config.offload_prefix_image_encoder_after_embed,
             pipeline_config.offload_prefix_token_embedding,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/vla.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/vla.py
@@ -185,9 +185,11 @@ class VLAPrefixEncodingStage(PipelineStage):
                 vla_state(batch)["observation_batch"] for batch in group_batches
             ]
             grouped_observation = collate_vla_observation_batches(observations)
+            cuda_graph_enabled = _cuda_graph_enabled(group_batches[0])
             prefix_context = self.policy_model.encode_prefix(
                 grouped_observation,
-                use_cuda_graph=_cuda_graph_enabled(group_batches[0]),
+                use_cuda_graph=cuda_graph_enabled,
+                bucket_prompt=cuda_graph_enabled,
             )
             prefix_ms = (time.perf_counter() - prefix_start) * 1000
 
@@ -203,6 +205,9 @@ class VLAPrefixEncodingStage(PipelineStage):
                     "hit": False,
                     "scope": "request",
                     "prefix_len": prefix_context.prefix_len,
+                    "prompt_token_bucket": prefix_context.layout.get(
+                        "prompt_token_bucket"
+                    ),
                     "grouped": True,
                     "batch_size": len(group_batches),
                 }
@@ -260,7 +265,10 @@ class VLAPrefixEncodingStage(PipelineStage):
         """try querying the cache for PrefixContext with prefix cache key built from observations and other keys"""
         cache_enabled = _effective_prefix_cache_enabled(batch, server_args)
         if cache_enabled:
-            cache_key = self.policy_model.build_prefix_cache_key(observation)
+            cache_key = self.policy_model.build_prefix_cache_key(
+                observation,
+                bucket_prompt=_cuda_graph_enabled(batch),
+            )
             cached_context = self.prefix_cache.get(cache_key)
         else:
             cache_key = None
@@ -299,6 +307,7 @@ class VLAPrefixEncodingStage(PipelineStage):
                 "scope": "global",
                 "mode": "exact",
                 "prefix_len": cached_context.prefix_len,
+                "prompt_token_bucket": cached_context.layout.get("prompt_token_bucket"),
             }
             if split is not None:
                 self._send_prefix_result(batch, split, cached_context)
@@ -307,9 +316,11 @@ class VLAPrefixEncodingStage(PipelineStage):
         prefix_start = time.perf_counter()
 
         # 3. run encoding
+        cuda_graph_enabled = _cuda_graph_enabled(batch)
         prefix_context = self.policy_model.encode_prefix(
             observation,
-            use_cuda_graph=_cuda_graph_enabled(batch) and not cache_enabled,
+            use_cuda_graph=cuda_graph_enabled and not cache_enabled,
+            bucket_prompt=cuda_graph_enabled,
         )
         if cache_key is not None:
             prefix_context.cache_key_digest = cache_key
@@ -321,6 +332,7 @@ class VLAPrefixEncodingStage(PipelineStage):
             "scope": "global" if cache_enabled else "request",
             "mode": "exact" if cache_enabled else "disabled",
             "prefix_len": prefix_context.prefix_len,
+            "prompt_token_bucket": prefix_context.layout.get("prompt_token_bucket"),
         }
 
         # 4. update prefix kv cache
@@ -421,7 +433,6 @@ class VLAActionDenoisingStage(PipelineStage):
             )
         elif should_run_action:
             # broadcast PrefixContext from action root rank to action ranks
-            options = vla_options(batch)
             noise = observation.noise if observation is not None else None
             actions = self.policy_model.sample_actions(
                 observation,

--- a/python/sglang/multimodal_gen/runtime/vla/cuda_graph.py
+++ b/python/sglang/multimodal_gen/runtime/vla/cuda_graph.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Any, Callable
 
@@ -46,6 +47,7 @@ class VLADenoiseGraphSignature:
     action_dim: int
     dtype: str
     parallel_layout: str
+    full_attention: bool
 
 
 @dataclass
@@ -57,6 +59,106 @@ class _CapturedDenoiseGraph:
     static_output: torch.Tensor
     current_context_id: int | None = None
     current_context_digest: str | None = None
+
+
+@dataclass(frozen=True)
+class VLAGraphCacheInfo:
+    size: int
+    max_entries: int
+    hits: int
+    misses: int
+    captures: int
+    evictions: int
+    failures: int
+    evict_on_miss: bool
+
+
+class _BoundedCaptureCache:
+    """Small LRU that owns CUDA graph executables and their static buffers."""
+
+    def __init__(self, name: str, max_entries: int, *, evict_on_miss: bool = True):
+        self.name = name
+        self.max_entries = max(0, int(max_entries))
+        self.evict_on_miss = evict_on_miss
+        self.entries: OrderedDict[Any, Any] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+        self.captures = 0
+        self.evictions = 0
+        self.failures = 0
+
+    @staticmethod
+    def _release(entry: Any) -> None:
+        reset = getattr(entry.graph, "reset", None)
+        if callable(reset):
+            reset()
+
+    def get(self, signature: Any) -> Any | None:
+        entry = self.entries.get(signature)
+        if entry is None:
+            self.misses += 1
+            return None
+        self.hits += 1
+        self.entries.move_to_end(signature)
+        return entry
+
+    def put(self, signature: Any, entry: Any) -> bool:
+        if self.max_entries == 0:
+            self._release(entry)
+            return False
+        if signature not in self.entries and not self.can_admit(signature):
+            self._release(entry)
+            return False
+        previous = self.entries.pop(signature, None)
+        if previous is not None:
+            self._release(previous)
+        self.entries[signature] = entry
+        self.captures += 1
+
+        while len(self.entries) > self.max_entries:
+            evicted_signature, evicted = self.entries.popitem(last=False)
+            self._release(evicted)
+            self.evictions += 1
+            logger.info(
+                "Evicted VLA %s CUDA graph for signature %s (entries=%d/%d)",
+                self.name,
+                evicted_signature,
+                len(self.entries),
+                self.max_entries,
+            )
+        return True
+
+    def can_admit(self, signature: Any) -> bool:
+        return (
+            signature in self.entries
+            or len(self.entries) < self.max_entries
+            or self.evict_on_miss
+        )
+
+    def discard(self, signature: Any) -> None:
+        entry = self.entries.pop(signature, None)
+        if entry is not None:
+            self._release(entry)
+
+    def mark_failure(self) -> None:
+        self.failures += 1
+
+    def clear(self) -> None:
+        for entry in self.entries.values():
+            self._release(entry)
+        self.entries.clear()
+
+    def info(self) -> VLAGraphCacheInfo:
+        return VLAGraphCacheInfo(
+            size=len(self.entries),
+            max_entries=self.max_entries,
+            hits=self.hits,
+            misses=self.misses,
+            captures=self.captures,
+            evictions=self.evictions,
+            failures=self.failures,
+            evict_on_miss=self.evict_on_miss,
+        )
 
 
 def _clone_past_key_values(past_key_values: Any) -> Any:
@@ -95,13 +197,30 @@ def _copy_prefix_context_(dst: PrefixContext, src: PrefixContext) -> None:
 class VLAPrefixGraphRunner:
     """Full CUDA graph runner for VLA prefix encoding shape buckets."""
 
-    def __init__(self, enabled: bool = True, max_entries: int = 1):
-        self.max_entries = max(0, max_entries)
+    def __init__(
+        self,
+        enabled: bool = True,
+        max_entries: int = 1,
+        *,
+        evict_on_miss: bool = False,
+    ):
+        self._cache = _BoundedCaptureCache(
+            "prefix", max_entries, evict_on_miss=evict_on_miss
+        )
+        self.max_entries = self._cache.max_entries
         self.enabled = enabled and self.max_entries > 0
-        self._captured: dict[VLAPrefixGraphSignature, _CapturedPrefixGraph] = {}
+        # Keep this alias for lightweight runtime diagnostics and compatibility.
+        self._captured = self._cache.entries
         self._disabled_signatures: set[VLAPrefixGraphSignature] = set()
         self._capture_stream: torch.cuda.Stream | None = None
         self._graph_pool: Any = None
+
+    def cache_info(self) -> VLAGraphCacheInfo:
+        return self._cache.info()
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._disabled_signatures.clear()
 
     def _capture(
         self,
@@ -140,11 +259,11 @@ class VLAPrefixGraphRunner:
             static_inputs=static_inputs,
             static_output=static_output,
         )
-        self._captured[signature] = captured
         logger.info(
-            "Captured VLA prefix CUDA graph: batch=%d inputs=%s",
+            "Captured VLA prefix CUDA graph: batch=%d inputs=%s (capacity=%d)",
             signature.batch_size,
             signature.input_shapes,
+            self.max_entries,
         )
         return captured
 
@@ -162,12 +281,13 @@ class VLAPrefixGraphRunner:
         ):
             return step_fn(inputs)
 
-        captured = self._captured.get(signature)
-        if captured is None and len(self._captured) >= self.max_entries:
+        captured = self._cache.get(signature)
+        if captured is None and not self._cache.can_admit(signature):
             return step_fn(inputs)
         try:
             if captured is None:
                 captured = self._capture(signature, step_fn, inputs)
+                self._cache.put(signature, captured)
             else:
                 for static_input, current_input in zip(
                     captured.static_inputs, inputs, strict=True
@@ -180,7 +300,8 @@ class VLAPrefixGraphRunner:
             return captured.static_output
         except Exception:
             self._disabled_signatures.add(signature)
-            self._captured.pop(signature, None)
+            self._cache.discard(signature)
+            self._cache.mark_failure()
             logger.warning(
                 "VLA prefix CUDA graph disabled for signature %s",
                 signature,
@@ -196,12 +317,21 @@ class VLADenoiseGraphRunner:
     diffusion BCG and does not capture prefix encoding or token decode.
     """
 
-    def __init__(self, enabled: bool = True):
-        self.enabled = enabled
-        self._captured: dict[VLADenoiseGraphSignature, _CapturedDenoiseGraph] = {}
+    def __init__(self, enabled: bool = True, max_entries: int = 16):
+        self._cache = _BoundedCaptureCache("action-denoise", max_entries)
+        self.max_entries = self._cache.max_entries
+        self.enabled = enabled and self.max_entries > 0
+        self._captured = self._cache.entries
         self._disabled_signatures: set[VLADenoiseGraphSignature] = set()
         self._capture_stream: torch.cuda.Stream | None = None
         self._graph_pool: Any = None
+
+    def cache_info(self) -> VLAGraphCacheInfo:
+        return self._cache.info()
+
+    def clear(self) -> None:
+        self._cache.clear()
+        self._disabled_signatures.clear()
 
     def _sync_context_if_needed(
         self,
@@ -279,15 +409,16 @@ class VLADenoiseGraphRunner:
             current_context_id=id(prefix_context.past_key_values),
             current_context_digest=prefix_context.cache_key_digest,
         )
-        self._captured[signature] = captured
         logger.info(
             "Captured VLA denoise CUDA graph: batch=%d prefix=%d action=%dx%d "
-            "dtype=%s",
+            "dtype=%s full_attention=%s (capacity=%d)",
             signature.batch_size,
             signature.prefix_len,
             signature.action_horizon,
             signature.action_dim,
             signature.dtype,
+            signature.full_attention,
+            self.max_entries,
         )
         return captured
 
@@ -305,12 +436,13 @@ class VLADenoiseGraphRunner:
         if x_t.device.type != "cuda":
             return step_fn(prefix_context, x_t, timestep)
 
-        captured = self._captured.get(signature)
+        captured = self._cache.get(signature)
         try:
             if captured is None:
                 captured = self._capture(
                     signature, step_fn, prefix_context, x_t, timestep
                 )
+                self._cache.put(signature, captured)
                 captured.graph.replay()
             else:
                 self._sync_context_if_needed(captured, prefix_context)
@@ -320,7 +452,8 @@ class VLADenoiseGraphRunner:
             return captured.static_output
         except Exception:
             self._disabled_signatures.add(signature)
-            self._captured.pop(signature, None)
+            self._cache.discard(signature)
+            self._cache.mark_failure()
             logger.warning(
                 "VLA denoise CUDA graph disabled for signature %s",
                 signature,

--- a/python/sglang/multimodal_gen/runtime/vla/prompt_bucketing.py
+++ b/python/sglang/multimodal_gen/runtime/vla/prompt_bucketing.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+import torch.nn.functional as F
+
+
+def effective_token_length(token_masks: torch.Tensor) -> int:
+    """Return the last potentially visible token position across a batch.
+
+    Pi0.5 tokenizers right-pad today, but externally supplied masks may contain
+    holes. Counting ``True`` values would drop a valid token after a hole when
+    trimming, so use the final visible position instead.
+    """
+
+    if token_masks.ndim != 2:
+        raise ValueError(
+            f"Pi0.5 token masks must be [batch, seq], got {token_masks.shape}"
+        )
+    if token_masks.shape[1] == 0:
+        return 0
+
+    positions = torch.arange(
+        1,
+        token_masks.shape[1] + 1,
+        device=token_masks.device,
+        dtype=torch.long,
+    )
+    lengths = torch.where(token_masks.to(torch.bool), positions, 0).amax(dim=1)
+    return int(lengths.max().item())
+
+
+def select_prompt_token_bucket(
+    token_length: int,
+    buckets: Sequence[int],
+) -> int | None:
+    """Select the smallest configured bucket that contains ``token_length``."""
+
+    if token_length < 0:
+        raise ValueError("token_length must be non-negative")
+    return next((int(bucket) for bucket in buckets if token_length <= bucket), None)
+
+
+def bucket_prompt_tokens(
+    tokens: torch.Tensor,
+    token_masks: torch.Tensor,
+    buckets: Sequence[int],
+    *,
+    pad_token_id: int = 0,
+) -> tuple[torch.Tensor, torch.Tensor, int, int | None]:
+    """Trim/pad Pi0.5 tokens to a stable CUDA graph bucket.
+
+    The returned mask always preserves the logical prompt. Padded token values
+    are therefore never visible to prefix or action attention; they only make
+    the physical K/V shape stable enough for graph replay.
+    """
+
+    if tokens.ndim != 2:
+        raise ValueError(f"Pi0.5 tokens must be [batch, seq], got {tokens.shape}")
+    if token_masks.shape != tokens.shape:
+        raise ValueError(
+            "Pi0.5 tokens and token masks must have identical shapes, got "
+            f"{tokens.shape} and {token_masks.shape}"
+        )
+
+    logical_length = effective_token_length(token_masks)
+    bucket = select_prompt_token_bucket(logical_length, buckets)
+    target_length = bucket if bucket is not None else logical_length
+
+    # Preserve the historical empty-prompt fallback when bucketing is disabled
+    # or no bucket can contain the input.
+    if target_length == 0 and bucket is None:
+        target_length = tokens.shape[1]
+
+    if tokens.shape[1] >= target_length:
+        return (
+            tokens[:, :target_length],
+            token_masks[:, :target_length],
+            logical_length,
+            bucket,
+        )
+
+    padding = target_length - tokens.shape[1]
+    return (
+        F.pad(tokens, (0, padding), value=pad_token_id),
+        F.pad(token_masks, (0, padding), value=False),
+        logical_length,
+        bucket,
+    )

--- a/python/sglang/multimodal_gen/test/unit/test_pi05_action_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_pi05_action_api.py
@@ -160,7 +160,10 @@ def test_action_metadata_reports_policy_shape_and_capabilities():
         action_horizon=10,
         action_dim=32,
         output_action_dim=7,
+        prompt_token_buckets=(32, 64, 128, 200),
+        prefix_cuda_graph_max_entries=4,
         enable_action_cuda_graph=True,
+        action_cuda_graph_max_entries=6,
     )
 
     metadata = action_metadata(_server_args(config))
@@ -176,6 +179,13 @@ def test_action_metadata_reports_policy_shape_and_capabilities():
     assert metadata["output"]["padded_action_dim"] == 32
     assert metadata["runtime"]["materialize_dtype"] == "bf16"
     assert metadata["runtime"]["enable_autocast"] is True
+    assert metadata["runtime"]["cuda_graph"] == {
+        "prefix_enabled": True,
+        "prefix_max_entries": 4,
+        "action_enabled": True,
+        "action_max_entries": 6,
+        "prompt_token_buckets": [32, 64, 128, 200],
+    }
     assert metadata["runtime"]["parallelism"]["num_gpus"] == 1
     assert metadata["runtime"]["parallelism"]["kv_gather_degree"] == 1
     assert metadata["runtime"]["parallelism"]["prefix_strategy"] == "tp"
@@ -183,6 +193,32 @@ def test_action_metadata_reports_policy_shape_and_capabilities():
     assert metadata["defaults"]["prefix_cache"] is False
     assert metadata["capabilities"]["realtime_websocket"]
     assert metadata["capabilities"]["openpi_websocket"]
+
+
+def test_action_metadata_treats_zero_graph_capacity_as_disabled():
+    config = Pi05PipelineConfig(
+        prefix_cuda_graph_max_entries=0,
+        action_cuda_graph_max_entries=0,
+    )
+
+    metadata = action_metadata(_server_args(config))
+
+    assert metadata["runtime"]["cuda_graph"]["prefix_enabled"] is False
+    assert metadata["runtime"]["cuda_graph"]["action_enabled"] is False
+    assert metadata["defaults"]["cuda_graph"] is False
+    assert metadata["capabilities"]["cuda_graph"] is False
+
+
+def test_action_metadata_reports_action_graph_disabled_by_offload():
+    config = Pi05PipelineConfig(
+        enable_prefix_cuda_graph=False,
+        offload_action_expert_after_denoise=True,
+    )
+
+    metadata = action_metadata(_server_args(config))
+
+    assert metadata["runtime"]["cuda_graph"]["action_enabled"] is False
+    assert metadata["defaults"]["cuda_graph"] is False
 
 
 def test_action_generation_response_uses_actual_output_parameters():

--- a/python/sglang/multimodal_gen/test/unit/test_pi05_cuda_graph_bucketing.py
+++ b/python/sglang/multimodal_gen/test/unit/test_pi05_cuda_graph_bucketing.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+import sglang.multimodal_gen.runtime.models.vlas.pi05_policy as pi05_policy_module
+from sglang.multimodal_gen.configs.pipeline_configs.pi05 import Pi05PipelineConfig
+from sglang.multimodal_gen.runtime.models.vlas.pi05_policy import Pi05PolicyModel
+from sglang.multimodal_gen.runtime.vla.cuda_graph import (
+    VLADenoiseGraphRunner,
+    VLADenoiseGraphSignature,
+    VLAPrefixGraphRunner,
+    _BoundedCaptureCache,
+)
+from sglang.multimodal_gen.runtime.vla.prompt_bucketing import (
+    bucket_prompt_tokens,
+    effective_token_length,
+    select_prompt_token_bucket,
+)
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeGraph:
+    def __init__(self):
+        self.reset_calls = 0
+
+    def reset(self):
+        self.reset_calls += 1
+
+
+def _fake_capture():
+    return SimpleNamespace(graph=_FakeGraph())
+
+
+class TestPi05PromptBucketing(CustomTestCase):
+    def test_selects_smallest_bucket(self):
+        buckets = (32, 64, 128, 200)
+        self.assertEqual(select_prompt_token_bucket(1, buckets), 32)
+        self.assertEqual(select_prompt_token_bucket(32, buckets), 32)
+        self.assertEqual(select_prompt_token_bucket(33, buckets), 64)
+        self.assertEqual(select_prompt_token_bucket(200, buckets), 200)
+        self.assertIsNone(select_prompt_token_bucket(201, buckets))
+
+    def test_effective_length_preserves_valid_tokens_after_mask_holes(self):
+        masks = torch.tensor(
+            [
+                [True, False, False, True, False],
+                [True, True, False, False, False],
+            ]
+        )
+        self.assertEqual(effective_token_length(masks), 4)
+
+    def test_bucket_preserves_logical_mask_and_existing_padding_values(self):
+        tokens = torch.arange(10).unsqueeze(0)
+        masks = torch.tensor([[True] * 5 + [False] * 5])
+
+        padded_tokens, padded_masks, logical_length, bucket = bucket_prompt_tokens(
+            tokens,
+            masks,
+            (8, 16),
+        )
+
+        self.assertEqual(logical_length, 5)
+        self.assertEqual(bucket, 8)
+        torch.testing.assert_close(padded_tokens, tokens[:, :8])
+        torch.testing.assert_close(
+            padded_masks,
+            torch.tensor([[True] * 5 + [False] * 3]),
+        )
+
+    def test_bucket_can_extend_externally_supplied_short_tokens(self):
+        tokens = torch.tensor([[11, 12, 13]])
+        masks = torch.tensor([[True, True, True]])
+
+        padded_tokens, padded_masks, logical_length, bucket = bucket_prompt_tokens(
+            tokens,
+            masks,
+            (8,),
+            pad_token_id=99,
+        )
+
+        self.assertEqual((logical_length, bucket), (3, 8))
+        self.assertEqual(padded_tokens.tolist(), [[11, 12, 13, 99, 99, 99, 99, 99]])
+        self.assertEqual(
+            padded_masks.tolist(),
+            [[True, True, True, False, False, False, False, False]],
+        )
+
+    def test_length_above_largest_bucket_uses_exact_shape(self):
+        tokens = torch.arange(70).unsqueeze(0)
+        masks = torch.tensor([[True] * 65 + [False] * 5])
+
+        exact_tokens, exact_masks, logical_length, bucket = bucket_prompt_tokens(
+            tokens,
+            masks,
+            (32, 64),
+        )
+
+        self.assertEqual(logical_length, 65)
+        self.assertIsNone(bucket)
+        self.assertEqual(exact_tokens.shape, (1, 65))
+        self.assertTrue(exact_masks.all())
+
+    def test_prefix_cache_separates_exact_and_bucketed_layouts(self):
+        model = Pi05PolicyModel.__new__(Pi05PolicyModel)
+        model.config = Pi05PipelineConfig(prompt_token_buckets=(32, 64))
+        model.device = torch.device("cuda")
+        model.dtype = torch.bfloat16
+        model.model_path = "lerobot/pi05_base"
+        model.runtime_role = "all"
+        model.prefix_graph_runner = SimpleNamespace(enabled=True)
+        model.graph_runner = SimpleNamespace(enabled=True)
+        model._prefix_tensor_parallel_enabled = lambda: False
+        observation = SimpleNamespace(
+            metadata={"camera_order": ("front",)},
+            images={"front": torch.zeros(1, 3, 2, 2)},
+            image_masks={"front": torch.tensor(True)},
+            tokens=torch.arange(40).unsqueeze(0),
+            token_masks=torch.tensor([[True] * 20 + [False] * 20]),
+        )
+        with patch.object(pi05_policy_module, "get_vla_split_group", return_value=None):
+            exact = model.build_prefix_cache_key(observation, bucket_prompt=False)
+            bucketed = model.build_prefix_cache_key(observation, bucket_prompt=True)
+
+        self.assertNotEqual(exact, bucketed)
+
+        observation.tokens = torch.arange(70).unsqueeze(0)
+        observation.token_masks = torch.ones(1, 70, dtype=torch.bool)
+        with patch.object(pi05_policy_module, "get_vla_split_group", return_value=None):
+            exact = model.build_prefix_cache_key(observation, bucket_prompt=False)
+            bucket_miss = model.build_prefix_cache_key(observation, bucket_prompt=True)
+        self.assertNotEqual(exact, bucket_miss)
+
+    def test_prefix_cache_key_keeps_visible_tokens_after_mask_holes(self):
+        model = Pi05PolicyModel.__new__(Pi05PolicyModel)
+        model.config = Pi05PipelineConfig()
+        model.dtype = torch.bfloat16
+        model.model_path = "lerobot/pi05_base"
+        common = dict(
+            metadata={"camera_order": ("front",)},
+            images={"front": torch.zeros(1, 3, 2, 2)},
+            image_masks={"front": torch.tensor(True)},
+            token_masks=torch.tensor([[True, False, False, True, False]]),
+        )
+        first = SimpleNamespace(tokens=torch.tensor([[1, 2, 3, 4, 0]]), **common)
+        second = SimpleNamespace(tokens=torch.tensor([[1, 2, 3, 9, 0]]), **common)
+
+        self.assertNotEqual(
+            model.build_prefix_cache_key(first),
+            model.build_prefix_cache_key(second),
+        )
+
+    def test_bucket_miss_disables_action_graph_capture(self):
+        model = Pi05PolicyModel.__new__(Pi05PolicyModel)
+        torch.nn.Module.__init__(model)
+        model.action_expert = lambda context, x_t, timestep, **kwargs: x_t + 1
+        model.graph_runner = SimpleNamespace(
+            capture_or_run=lambda *args, **kwargs: self.fail(
+                "bucket misses must stay eager"
+            )
+        )
+        context = SimpleNamespace(
+            layout={"cuda_graph_eligible": False},
+            prefix_len=900,
+        )
+        x_t = torch.zeros(1, 50, 32)
+
+        output = model.denoise_step(
+            context,
+            x_t,
+            torch.ones(1),
+            use_cuda_graph=True,
+        )
+
+        torch.testing.assert_close(output, torch.ones_like(x_t))
+
+
+class TestPi05CudaGraphLRU(CustomTestCase):
+    def test_lru_hit_updates_eviction_order_and_releases_graph(self):
+        cache = _BoundedCaptureCache("test", max_entries=2)
+        first = _fake_capture()
+        second = _fake_capture()
+        third = _fake_capture()
+        cache.put("first", first)
+        cache.put("second", second)
+
+        self.assertIs(cache.get("first"), first)
+        cache.put("third", third)
+
+        self.assertEqual(tuple(cache.entries), ("first", "third"))
+        self.assertEqual(second.graph.reset_calls, 1)
+        info = cache.info()
+        self.assertEqual(info.size, 2)
+        self.assertEqual(info.hits, 1)
+        self.assertEqual(info.captures, 3)
+        self.assertEqual(info.evictions, 1)
+
+        self.assertIsNone(cache.get("missing"))
+        self.assertEqual(cache.info().misses, 1)
+
+        cache.clear()
+        self.assertEqual(first.graph.reset_calls, 1)
+        self.assertEqual(third.graph.reset_calls, 1)
+
+    def test_non_evicting_cache_rejects_new_signature_at_capacity(self):
+        cache = _BoundedCaptureCache("test", max_entries=1, evict_on_miss=False)
+        first = _fake_capture()
+        rejected = _fake_capture()
+        cache.put("first", first)
+
+        self.assertFalse(cache.can_admit("second"))
+        self.assertTrue(cache.can_admit("first"))
+        self.assertFalse(cache.put("second", rejected))
+        self.assertEqual(tuple(cache.entries), ("first",))
+        self.assertEqual(first.graph.reset_calls, 0)
+        self.assertEqual(rejected.graph.reset_calls, 1)
+
+    def test_zero_capacity_releases_capture_and_disables_runners(self):
+        cache = _BoundedCaptureCache("test", max_entries=0)
+        capture = _fake_capture()
+        cache.put("unused", capture)
+
+        self.assertEqual(capture.graph.reset_calls, 1)
+        self.assertEqual(cache.info().size, 0)
+        self.assertFalse(VLAPrefixGraphRunner(enabled=True, max_entries=0).enabled)
+        self.assertFalse(VLADenoiseGraphRunner(enabled=True, max_entries=0).enabled)
+
+    def test_attention_layout_is_part_of_action_graph_signature(self):
+        common = dict(
+            batch_size=1,
+            prefix_len=800,
+            action_horizon=50,
+            action_dim=32,
+            dtype="float32",
+            parallel_layout="pi05-v1",
+        )
+        full = VLADenoiseGraphSignature(**common, full_attention=True)
+        masked = VLADenoiseGraphSignature(**common, full_attention=False)
+        self.assertNotEqual(full, masked)
+
+
+class TestPi05CudaGraphConfig(CustomTestCase):
+    def test_defaults_preserve_exact_prompt_shapes_and_bound_action_graphs(self):
+        config = Pi05PipelineConfig()
+        self.assertEqual(config.prompt_token_buckets, ())
+        self.assertEqual(config.prefix_cuda_graph_max_entries, 1)
+        self.assertGreater(config.action_cuda_graph_max_entries, 0)
+
+    def test_prefix_graph_is_disabled_by_partial_language_offload(self):
+        model = Pi05PolicyModel.__new__(Pi05PolicyModel)
+        model.config = Pi05PipelineConfig(
+            offload_prefix_language_layer_count_after_prefix=1
+        )
+        model.device = torch.device("cuda")
+        model.runtime_role = "all"
+        model._prefix_tensor_parallel_enabled = lambda: False
+
+        self.assertFalse(model._prefix_cuda_graph_enabled())
+
+    def test_json_style_bucket_list_is_normalized(self):
+        config = Pi05PipelineConfig()
+        config.update_pipeline_config(
+            {
+                "prompt_token_buckets": [16, 48, 96],
+                "action_cuda_graph_max_entries": 3,
+            }
+        )
+        self.assertEqual(config.prompt_token_buckets, (16, 48, 96))
+        self.assertEqual(config.action_cuda_graph_max_entries, 3)
+
+    def test_invalid_graph_configs_are_rejected(self):
+        cases = (
+            ({"prompt_token_buckets": (32, 32)}, "strictly increasing"),
+            ({"prompt_token_buckets": (64, 32)}, "strictly increasing"),
+            ({"prompt_token_buckets": (0, 32)}, "positive"),
+            ({"prompt_token_buckets": (32, 256)}, "max_token_len"),
+            ({"prefix_cuda_graph_max_entries": -1}, "prefix_cuda_graph"),
+            ({"action_cuda_graph_max_entries": -1}, "action_cuda_graph"),
+        )
+        for overrides, match in cases:
+            with self.subTest(overrides=overrides):
+                config = Pi05PipelineConfig()
+                for name, value in overrides.items():
+                    setattr(config, name, value)
+                with self.assertRaisesRegex(ValueError, match):
+                    config.check_pipeline_config()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add opt-in Pi0.5 prompt token buckets so nearby prompt lengths reuse the same prefix and action CUDA graph signatures
- replace unbounded action graph storage with a capacity-bounded LRU, and give prefix graphs bounded/LRU behavior without causing default recapture churn
- make masked Prefix/Action CUDA graph capture safe, including attention masks with holes
- expose the configured graph capacities and buckets in startup logs and `/v1/actions/metadata`
- document numerical behavior and add focused config, bucketing, cache lifecycle, API, and signature tests

## Motivation

Pi0.5 prompt lengths vary with the task text. The physical prefix length is also part of the action-denoise graph signature, so serving a stream of different prompt lengths could capture many action graphs and retain all of their executables/static buffers. Prefix graphs had a capacity, but the default single entry could either reject useful nearby lengths or, with naive eviction, cause capture churn.

This PR adds an explicit serving policy: users can bucket prompt tokens to a small set such as `[32, 64, 128, 200]`, while both graph caches have explicit capacities and lifecycle accounting.

## Execution flow

```mermaid
flowchart TD
    A["Action request enters VLAPrefixEncodingStage.forward"] --> B{"runtime.cuda_graph enabled"}
    B -->|"false"| C["Keep exact prompt length and run eager"]
    B -->|"true"| D["Pi05PolicyModel.encode_prefix selects smallest configured token bucket"]:::changed
    D -->|"bucket found"| E["Pad tokens and preserve the logical attention mask"]:::changed
    D -->|"above largest bucket"| C
    E --> F{"Bounded prefix graph cache lookup"}:::changed
    F -->|"hit"| G["Replay captured prefix graph"]
    F -->|"miss"| H["Capture or LRU-evict with CUDAGraph.reset"]:::changed
    C --> I["Build PrefixContext with graph eligibility and attention layout"]:::changed
    G --> I
    H --> I
    I --> J["VLADenoiseGraphSignature includes prefix length and full-attention mode"]:::changed
    J --> K["Replay/capture bounded action-denoise LRU"]:::changed
    K --> L["Return action chunk"]

    M["Legend: dashed border = added or modified by this PR"]:::changed
    classDef changed stroke-dasharray:5 5,stroke-width:2px;
```

`runtime.cuda_graph=false` preserves exact-length eager behavior. With graph execution enabled, the policy uses the smallest fitting bucket, forces one masked-attention control flow per bucket, and routes Prefix/Action graph lookups through bounded caches. Requests beyond the largest configured bucket stay exact-length and eager, so they cannot create an open-ended tail of signatures.

## Defaults and compatibility

- `prompt_token_buckets=()` by default, so existing exact prompt shapes and numerics are preserved.
- `prefix_cuda_graph_max_entries=1` by default. Without buckets, capacity misses stay eager instead of evicting and recapturing the first graph.
- `action_cuda_graph_max_entries=16` bounds the formerly unbounded action graph dictionary.
- With prompt buckets configured, both Prefix and Action caches use LRU replacement and reset evicted CUDA graphs.
- Prompt bucketing is disabled for prefix TP, split prefix/action execution, graph-incompatible offload modes, and per-request `runtime.cuda_graph=false`.
- Exact and bucketed global prefix-cache contexts use distinct cache keys, including the bucket-miss eager layout.

## H200 validation

Hardware/model: one NVIDIA H200, `lerobot/pi05_base`, bf16 model path, fixed action noise.

- effective token lengths `20, 31, 33, 60, 65, 100, 129, 180` collapsed to exactly four Prefix/Action signatures with `[32, 64, 128, 200]`
- Prefix cache: 4 captures, 28 hits, 0 evictions, 0 failures
- Action cache: 4 captures, 316 hits, 0 evictions, 0 failures
- steady end-to-end p50: `54.27 ms` (`13.20 ms` prefix, `39.54 ms` denoise)
- capacity-two LRU sequence across four buckets: 4 new captures and 2 evictions for each cache, with 0 failures
- exact-length masked graph path, including a hole in the token mask: first capture and replay were bit-exact to eager (`max_abs_diff=0`)

Prompt padding is intentionally opt-in: changing the physical attention shape changed floating-point reduction order. Against exact-length eager execution, the fixed-noise action max absolute difference ranged from `0.00461` to `0.01387` across the eight lengths. The cookbook calls out that closed-loop policy quality must be validated before enabling buckets.

## Tests

- `ruff check` and `ruff format --check` on all touched Python files
- `python -m compileall` on all touched Python files
- H200 targeted unit tests: `38 passed`, `6 subtests passed`
- H200 multimodal-gen unit directory: `1491 passed`, `105 skipped`; 5 unrelated failures were reproduced unchanged on the baseline worktree (LingBot realtime state, realtime latent config, realtime WebUI asset version, Sana streaming CAM parity, and LTX2 H200 auto-offload expectation)
- real-model H200 bucket/signature/LRU validation and exact masked-graph parity as reported above

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31611589273](https://github.com/sgl-project/sglang/actions/runs/31611589273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31611588520](https://github.com/sgl-project/sglang/actions/runs/31611588520)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->