### PR TITLE
[AMD] Fix FP8 scale layout for preshuffle GEMMs on ROCm

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -61,7 +61,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.quantization.fp8_utils import (
     _use_aiter_bpreshuffle_gfx95,
-    materialize_bpreshuffle_fp8_scale_tuple,
+    view_aiter_fused_rms_transposed_fp8_scale_tuple,
 )
 from sglang.srt.layers.utils.cp_utils import (
     is_mla_prefill_cp_enabled,
@@ -646,11 +646,22 @@ class LayerCommunicator:
                             dtype_quant=torch.float8_e4m3fn,
                             res1=None,
                             output_unquantized_inp1=_dsa_needs_bf16,
-                            transpose_scale=False,
+                            transpose_scale=_use_aiter_bpreshuffle_gfx95,
                         )
                         if _use_aiter_bpreshuffle_gfx95:
-                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
-                                hidden_states
+                            # transpose_scale=True already wrote the M-major
+                            # bytes the bpreshuffle GEMM wants, so no copy is
+                            # needed -- but aiter hands them back through a
+                            # [M, G] view whose row-major strides describe a
+                            # different layout than the storage. Restride here,
+                            # at the producer, so every downstream consumer
+                            # (all-gather, DSA 3-tuple packing, torch.compile
+                            # stride asserts, the GEMM itself) sees a
+                            # self-consistent tensor.
+                            hidden_states = (
+                                view_aiter_fused_rms_transposed_fp8_scale_tuple(
+                                    hidden_states
+                                )
                             )
                         if _dsa_needs_bf16:
                             hidden_states = (
@@ -696,12 +707,17 @@ class LayerCommunicator:
                                 dtype_quant=torch.float8_e4m3fn,
                                 res1=residual,
                                 output_unquantized_inp1=_dsa_needs_bf16,
-                                transpose_scale=False,
+                                transpose_scale=_use_aiter_bpreshuffle_gfx95,
                             )
                         )
                         if _use_aiter_bpreshuffle_gfx95:
-                            hidden_states = materialize_bpreshuffle_fp8_scale_tuple(
-                                hidden_states
+                            # See the no-residual branch above: restride the
+                            # transpose_scale=True output so its strides match
+                            # the storage layout.
+                            hidden_states = (
+                                view_aiter_fused_rms_transposed_fp8_scale_tuple(
+                                    hidden_states
+                                )
                             )
                         if _dsa_needs_bf16:
                             hidden_states = (

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -122,6 +122,21 @@ def view_aiter_fused_rms_transposed_fp8_scale(scale: torch.Tensor) -> torch.Tens
     return torch.as_strided(scale, scale.shape, (1, scale.shape[0]))
 
 
+def view_aiter_fused_rms_transposed_fp8_scale_tuple(
+    value: Tuple[torch.Tensor, ...],
+) -> Tuple[torch.Tensor, ...]:
+    """Restride the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples.
+
+    Zero-copy counterpart of :func:`materialize_bpreshuffle_fp8_scale_tuple` for
+    producers already invoked with ``transpose_scale=True``.
+    """
+    return (
+        value[0],
+        view_aiter_fused_rms_transposed_fp8_scale(value[1]),
+        *value[2:],
+    )
+
+
 def materialize_bpreshuffle_fp8_scale_tuple(
     value: Tuple[torch.Tensor, ...],
 ) -> Tuple[torch.Tensor, ...]:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1127,7 +1127,17 @@ def aiter_w8a8_block_fp8_linear(
         q_input = input_2d
         x_scale = input_scale
         if _use_aiter_bpreshuffle_gfx95 and not use_triton:
-            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
+            # The CK bpreshuffle GEMM wants the per-token scale in M-major
+            # physical order. Callers on this path hand us the scale either
+            # (a) as raw transpose_scale=True bytes -- physically M-major
+            #     already, exposed as a row-major-looking [M, G] view (strides
+            #     (G, 1)), or (b) pre-materialized to strides (1, M).
+            # as_strided to (1, M) yields the correct logical [M, G] over the
+            # same bytes in both cases -- a no-op on (b), the corrective view
+            # on (a) -- with zero copy. A natural (un-transposed) row-major
+            # scale must never reach this branch; every bpreshuffle producer
+            # emits (a) or (b).
+            x_scale = view_aiter_fused_rms_transposed_fp8_scale(x_scale)
         # On ROCm >= 7.2, scale is in bpreshuffle's transposed layout.
         # Triton needs a row-major view, so adjust strides only. No copy.
         elif use_triton and _use_aiter_bpreshuffle_gfx95:

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -127,23 +127,13 @@ def view_aiter_fused_rms_transposed_fp8_scale_tuple(
 ) -> Tuple[torch.Tensor, ...]:
     """Restride the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples.
 
-    Zero-copy counterpart of :func:`materialize_bpreshuffle_fp8_scale_tuple` for
-    producers already invoked with ``transpose_scale=True``.
+    Tuple-level wrapper around
+    :func:`view_aiter_fused_rms_transposed_fp8_scale` for producers already
+    invoked with ``transpose_scale=True``.
     """
     return (
         value[0],
         view_aiter_fused_rms_transposed_fp8_scale(value[1]),
-        *value[2:],
-    )
-
-
-def materialize_bpreshuffle_fp8_scale_tuple(
-    value: Tuple[torch.Tensor, ...],
-) -> Tuple[torch.Tensor, ...]:
-    """Materialize the scale slot in FP8 ``(q_input, x_scale, ...)`` tuples."""
-    return (
-        value[0],
-        materialize_bpreshuffle_fp8_scale(value[1]),
         *value[2:],
     )
 

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1144,13 +1144,22 @@ def aiter_w8a8_block_fp8_linear(
             x_scale = torch.as_strided(x_scale, x_scale.shape, (1, x_scale.shape[0]))
     else:
         materialize_bpreshuffle_scale = _use_aiter_bpreshuffle_gfx95 and not use_triton
+        # Ask the quant kernel to emit the M-major bytes the bpreshuffle GEMM
+        # wants, instead of writing row-major and transposing afterwards with a
+        # separate fp32 direct_copy kernel.
         q_input, x_scale = aiter_per1x128_quant(
             input_2d,
             quant_dtype=aiter.dtypes.fp8,
-            transpose_scale=False,
+            transpose_scale=materialize_bpreshuffle_scale,
         )
         if materialize_bpreshuffle_scale:
-            x_scale = materialize_bpreshuffle_fp8_scale(x_scale)
+            # The layout here differs from the fused-RMS case, where the
+            # producer has already restrided the scale before we see it. aiter
+            # hands the M-major bytes back through a [M, G] view carrying
+            # row-major (G, 1) strides that do not describe the storage, so
+            # apply the scale view helper to restore (1, M) -- equivalent to
+            # the materialized tensor, minus the copy.
+            x_scale = view_aiter_fused_rms_transposed_fp8_scale(x_scale)
 
     if use_triton:
         gemm_a8w8_blockscale_op = triton_gemm_a8w8_blockscale

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
@@ -18,9 +18,6 @@ from sglang.srt.layers.dcp import (
     all_gather_kv_cache_for_mha_extend,
     filter_dcp_local_kv_indices,
 )
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mha import (
@@ -87,10 +84,8 @@ class DeepseekMHARocmForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         res1=None,
                         output_unquantized_inp1=True,
-                        transpose_scale=False,
+                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
                     )
-                    if _use_aiter_bpreshuffle_gfx95:
-                        q_quanted = materialize_bpreshuffle_fp8_scale_tuple(q_quanted)
                     q = self.q_b_proj(q_quanted)[0].view(
                         -1, self.num_local_heads, self.qk_head_dim
                     )
@@ -131,10 +126,8 @@ class DeepseekMHARocmForwardMixin:
                     dtype_quant=torch.float8_e4m3fn,
                     res1=None,
                     output_unquantized_inp1=False,
-                    transpose_scale=False,
+                    transpose_scale=_use_aiter_bpreshuffle_gfx95,
                 )
-                if _use_aiter_bpreshuffle_gfx95:
-                    q = materialize_bpreshuffle_fp8_scale_tuple(q)
                 q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
             else:
                 q = self.q_a_layernorm(q)
@@ -162,10 +155,8 @@ class DeepseekMHARocmForwardMixin:
                 dtype_quant=torch.float8_e4m3fn,
                 res1=None,
                 output_unquantized_inp1=True,  # return unqaunt kv_a
-                transpose_scale=False,
+                transpose_scale=_use_aiter_bpreshuffle_gfx95,
             )
-            if _use_aiter_bpreshuffle_gfx95:
-                kv_a_quanted = materialize_bpreshuffle_fp8_scale_tuple(kv_a_quanted)
         else:
             kv_a = self.kv_a_layernorm(kv_a)
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -30,9 +30,6 @@ from sglang.srt.layers.dcp import (
     dcp_a2a_lse_reduce,
 )
 from sglang.srt.layers.logits_processor import get_in_autotune_dummy_run
-from sglang.srt.layers.quantization.fp8_utils import (
-    materialize_bpreshuffle_fp8_scale_tuple,
-)
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.lora.deepseek_mla_correction import (
     apply_q_correction as apply_kv_b_lora_q_correction,
@@ -230,12 +227,8 @@ def rocm_absorb_v_bmm(
                 _bmm_buf,
                 group_size=128,
                 dtype_quant=torch.float8_e4m3fn,
-                transpose_scale=False,
+                transpose_scale=_use_aiter_bpreshuffle_gfx95,
             )
-            if _use_aiter_bpreshuffle_gfx95:
-                attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(
-                    attn_bmm_output
-                )
         else:
             attn_bmm_output = _bmm_buf.flatten(1, 2)
     elif attn.o_proj.weight.dtype == torch.uint8:
@@ -247,10 +240,8 @@ def rocm_absorb_v_bmm(
             attn_bmm_output,
             group_size=128,
             dtype_quant=torch.float8_e4m3fn,
-            transpose_scale=False,
+            transpose_scale=_use_aiter_bpreshuffle_gfx95,
         )
-        if _use_aiter_bpreshuffle_gfx95:
-            attn_bmm_output = materialize_bpreshuffle_fp8_scale_tuple(attn_bmm_output)
     else:
         attn_bmm_output = attn_bmm_output.transpose(0, 1).flatten(1, 2)
 
@@ -349,10 +340,8 @@ class DeepseekMLARocmForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         res1=None,
                         output_unquantized_inp1=True,
-                        transpose_scale=False,
+                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
                     )
-                    if _use_aiter_bpreshuffle_gfx95:
-                        q_quanted = materialize_bpreshuffle_fp8_scale_tuple(q_quanted)
                     q = q_quanted
                 else:
                     q, _, k_nope, _ = fused_rms_fp8_group_quant(
@@ -366,10 +355,8 @@ class DeepseekMLARocmForwardMixin:
                         dtype_quant=torch.float8_e4m3fn,
                         res1=None,
                         output_unquantized_inp1=False,
-                        transpose_scale=False,
+                        transpose_scale=_use_aiter_bpreshuffle_gfx95,
                     )
-                    if _use_aiter_bpreshuffle_gfx95:
-                        q = materialize_bpreshuffle_fp8_scale_tuple(q)
             elif _use_aiter:
                 q, k_nope = fused_qk_rmsnorm_bf16(
                     q,

--- a/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
+++ b/test/registered/unit/layers/test_fp8_bpreshuffle_scale.py
@@ -5,8 +5,8 @@ import torch
 
 from sglang.srt.layers.quantization.fp8_utils import (
     materialize_bpreshuffle_fp8_scale,
-    materialize_bpreshuffle_fp8_scale_tuple,
     view_aiter_fused_rms_transposed_fp8_scale,
+    view_aiter_fused_rms_transposed_fp8_scale_tuple,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -89,17 +89,19 @@ class TestBpreshuffleScaleMaterialization(CustomTestCase):
 
     def test_tuple_helper_keeps_extra_tuple_payload(self):
         q_input = torch.ones((3, 8), dtype=torch.float32)
-        scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        logical_scale = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        aiter_scale = logical_scale.t().contiguous().view(logical_scale.shape)
         bf16_side = torch.ones((3, 8), dtype=torch.bfloat16)
 
-        q_out, scale_out, bf16_out = materialize_bpreshuffle_fp8_scale_tuple(
-            (q_input, scale, bf16_side)
+        q_out, scale_out, bf16_out = view_aiter_fused_rms_transposed_fp8_scale_tuple(
+            (q_input, aiter_scale, bf16_side)
         )
 
         self.assertIs(q_out, q_input)
         self.assertIs(bf16_out, bf16_side)
-        self.assertTrue(torch.equal(scale_out, scale))
-        self.assertEqual(scale_out.stride(), (1, scale.shape[0]))
+        self.assertTrue(torch.equal(scale_out, logical_scale))
+        self.assertEqual(scale_out.stride(), (1, logical_scale.shape[0]))
+        self.assertEqual(scale_out.data_ptr(), aiter_scale.data_ptr())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

On gfx95 (ROCm >= 7.2), the CK bpreshuffle FP8 block-scale GEMM requires its per-token activation scale in M-major physical layout. Every producer of that scale on the ROCm MLA/MHA prefill and decode paths (`fused_rms_fp8_group_quant`, `fused_flatten_fp8_group_quant`, the inline per-1x128 quant in `aiter_w8a8_block_fp8_linear`) was requesting the row-major layout and then paying for a separate fp32 `direct_copy` kernel (`scale.t().contiguous().t()`) to reshuffle it afterward.

The underlying AITER quant ops can already emit the M-major bytes directly via `transpose_scale=True` -- they just hand them back through a `[M, G]` view whose row-major `(G, 1)` strides don't describe the actual storage. This PR requests the transposed layout directly at every producer and fixes up the view with a zero-copy `as_strided` restride instead of materializing a copy, removing one full-size scale copy per quantized projection on this path.

## Modifications

- `fp8_utils.py`: add `view_aiter_fused_rms_transposed_fp8_scale` / `_tuple`, small helpers that restride an AITER `transpose_scale=True` scale (or a `(q_input, x_scale, ...)` tuple containing one) back to logical `[M, G]` indexing over the same bytes, with `(1, M)` strides matching the physical storage. `materialize_bpreshuffle_fp8_scale` (the copying version) is kept -- `layernorm.py` and `deepseek_v2.py` still need it -- but `materialize_bpreshuffle_fp8_scale_tuple`, whose only callers move to the new helper, is removed.
- `aiter_w8a8_block_fp8_linear`: for the inline per-1x128 quant path, ask the quant kernel for M-major bytes directly (`transpose_scale=_use_aiter_bpreshuffle_gfx95 and not use_triton`) instead of quantizing row-major and copying afterward; restride the result with the new helper. For pre-quantized input, both the CK and Triton branches already ended up applying the identical restride, so they're collapsed into one unconditional `if`.
- `forward_mha_rocm.py` / `forward_mla_rocm.py`: pass `transpose_scale=_use_aiter_bpreshuffle_gfx95` to the fused-RMS / fused-flatten quant calls and drop the post-hoc `materialize_bpreshuffle_fp8_scale_tuple()` calls that used to follow them.
- `communicator.py` (`LayerCommunicator.prepare_attn`): same change -- request the transposed scale from `fused_rms_fp8_group_quant` and restride it in place with `view_aiter_fused_rms_transposed_fp8_scale_tuple` instead of materializing a copy, in both the residual and no-residual branches.
- `test_fp8_bpreshuffle_scale.py`: updated to exercise the new view helper (feeding it AITER's actual transposed-byte layout) instead of the removed materializing tuple helper.

This does not change behavior on any non-bpreshuffle path (CUDA, gfx95 without CK bpreshuffle support, or ROCm < 7.2): the transposed-scale request and the restride are both gated on `_use_aiter_bpreshuffle_gfx95`.

## Evaluation Setup

Evaluated with `zai-org/GLM-5.2-FP8`, TP8, DSA attention with the Tilelang prefill/decode backend, on MI350X and MI355X. Server launch command:

```bash
SGLANG_USE_AITER=1 \
ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
python3 -m sglang.launch_server \
  --model zai-org/GLM-5.2-FP8 \
  --port 8000 \
  --tensor-parallel-size 8 \
  --attention-backend dsa \
  --dsa-prefill-backend tilelang \
  --dsa-decode-backend tilelang \
  --kv-cache-dtype fp8_e4m3 \
  --tool-call-parser glm47 \
  --reasoning-parser glm45 \
  --trust-remote-code \
  --disable-radix-cache \
  --mem-fraction-static 0.85
```

## Accuracy Tests

Verified analytically that the restride is a faithful, zero-copy substitute for the removed copy: for both consumers (CK bpreshuffle GEMM and the Triton GEMM, which previously performed the identical `as_strided` correction inline), the corrected scale is bit-identical to the old materialized tensor, and applying the restride twice (e.g. once at a producer, once again inside `aiter_w8a8_block_fp8_linear`) preserves the original data pointer. Traced every consumer between each producer and the GEMM (tensor-parallel row/column splits, DCP/CP all-gather, the DSA 3-tuple repack) to confirm none of them touch or re-view the scale in a way that would be invalidated by carrying corrected strides instead of a contiguous copy.

## Speed Tests and Profiling

Removes one full per-token-scale copy (an fp32 `direct_copy` kernel launch) per quantized projection on the gfx95 CK-bpreshuffle path, for each of the q/kv/o projection scale producers on the ROCm MHA and MLA prefill/decode paths plus `LayerCommunicator.prepare_attn`.

A kernel-level trace of a decode step on MI355X confirms this: without the patch, the `direct_copy` restride shows up as four separate `void at::native::elementwise_kernel_manual_unroll<...>` launches per decode loop (one per scale producer), averaging 3.71 us each (3.87, 3.63, 3.62, 3.72 us) -- all eliminated by this change.

Uplift = (without - with) / without.

### ISL 1024 / OSL 1024 -- mean_itl_ms (lower is better)

| Batch size (max_concurrency) | ITL without patch (ms) | ITL with patch (ms) | Uplift |
|---:|---:|---:|---:|
| 4   | 14.4717 | 13.8914 | 4.01% |
| 8   | 16.3054 | 15.6992 | 3.72% |
| 16  | 18.5914 | 17.8717 | 3.87% |
| 32  | 24.1141 | 23.0236 | 4.52% |
| 64  | 30.3418 | 29.1956 | 3.78% |
| 128 | 39.3066 | 38.4849 | 2.09% |
| **ISL total (avg over batch sizes)** | **23.8552** | **23.0277** | **3.47%** |

ITL improves at every batch size, with a fairly flat ~2-4.5% improvement across the board.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31611070709](https://github.com/sgl-project/sglang/actions/runs/31611070709)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31611070587](https://github.com/sgl-project/sglang/actions/runs/31611070587)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->