### PR TITLE
Fix deterministic DSV4 top-k fallback on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
@@ -24,7 +24,14 @@ constexpr uint32_t kMaxTopK = 1024;
 // init below index up to RADIX + 1 == 257 threads, so a block sized after a
 // small topk would silently skip part of the histogram.
 constexpr uint32_t kTopKBlockSize = kMaxTopK;
+#ifdef USE_ROCM
+// Match the ROCm AOT kernel. gfx1100 exposes 64 KiB LDS per workgroup, and
+// this kernel also owns static histograms/counters and the top-k index buffer.
+// Reserving the CUDA path's full 64 KiB dynamically would exceed that limit.
+constexpr uint32_t kSMEM = 12 * 1024 * sizeof(uint32_t);  // 48KB (bytes)
+#else
 constexpr uint32_t kSMEM = 16 * 1024 * sizeof(uint32_t);  // 64KB (bytes)
+#endif
 
 struct TopKParams {
   const float* __restrict__ scores;
@@ -41,12 +48,24 @@ struct TopKParams {
 SGL_DEVICE uint8_t convert_to_uint8(float x) {
   __half h = __float2half_rn(x);
   uint16_t bits = __half_as_ushort(h);
+#ifdef USE_ROCM
+  // IEEE -0.0 and +0.0 compare equal. Normalize their radix keys so the
+  // deterministic boundary-tie rule, rather than the sign bit, picks indices.
+  if ((bits & 0x7FFFu) == 0) {
+    bits = 0;
+  }
+#endif
   uint16_t key = (bits & 0x8000) ? static_cast<uint16_t>(~bits) : static_cast<uint16_t>(bits | 0x8000);
   return static_cast<uint8_t>(key >> 8);
 }
 
 SGL_DEVICE uint32_t convert_to_uint32(float x) {
   uint32_t bits = __float_as_uint(x);
+#ifdef USE_ROCM
+  if ((bits & 0x7FFFFFFFu) == 0) {
+    bits = 0;
+  }
+#endif
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
@@ -54,6 +73,137 @@ SGL_DEVICE int32_t page_to_indices(const int32_t* __restrict__ page_table, uint3
   const uint32_t mask = (1u << page_bits) - 1u;
   return (page_table[i >> page_bits] << page_bits) | (i & mask);
 }
+
+#ifdef USE_ROCM
+SGL_DEVICE void canonicalize_topk_indices(
+    const float* __restrict__ input, int32_t* values, const uint32_t length, const uint32_t topk) {
+  const auto tx = threadIdx.x;
+  constexpr uint32_t kMinWaveSize = 32;
+  constexpr uint32_t kMaxNumWaves = (kTopKBlockSize + kMinWaveSize - 1) / kMinWaveSize;
+  alignas(128) __shared__ uint32_t s_boundary_key;
+  alignas(128) __shared__ uint32_t s_num_greater;
+  alignas(128) __shared__ uint32_t s_num_equal;
+  alignas(128) __shared__ uint32_t s_ties_seen;
+  alignas(128) __shared__ uint32_t s_output_count;
+  alignas(128) __shared__ uint32_t s_wave_counts[kMaxNumWaves];
+  alignas(128) __shared__ uint32_t s_wave_offsets[kMaxNumWaves];
+
+  if (tx == 0) {
+    s_boundary_key = ~uint32_t{0};
+    s_num_greater = 0;
+    s_num_equal = 0;
+  }
+  __syncthreads();
+
+  for (uint32_t i = tx; i < topk; i += kTopKBlockSize) {
+    ::atomicMin(&s_boundary_key, convert_to_uint32(input[values[i]]));
+  }
+  __syncthreads();
+
+  const auto boundary_key = s_boundary_key;
+  const auto lane = tx % warpSize;
+  const auto wave = tx / warpSize;
+  const auto num_waves = (kTopKBlockSize + warpSize - 1) / warpSize;
+  for (uint32_t tile = 0; tile < length; tile += kTopKBlockSize) {
+    const auto index = tile + tx;
+    uint32_t key = 0;
+    if (index < length) {
+      key = convert_to_uint32(input[index]);
+    }
+    const auto greater_mask = static_cast<unsigned long long>(__ballot(index < length && key > boundary_key));
+    const auto equal_mask = static_cast<unsigned long long>(__ballot(index < length && key == boundary_key));
+    if (lane == 0) {
+      ::atomicAdd(&s_num_greater, static_cast<uint32_t>(__popcll(greater_mask)));
+      ::atomicAdd(&s_num_equal, static_cast<uint32_t>(__popcll(equal_mask)));
+    }
+  }
+  __syncthreads();
+
+  const auto tie_needed = topk - s_num_greater;
+  if (length <= 2 * kTopKBlockSize || s_num_equal > tie_needed) {
+    if (tx == 0) {
+      s_ties_seen = 0;
+      s_output_count = 0;
+    }
+    __syncthreads();
+
+    // Compact in logical-index order. Exact-score ties crossing the top-k
+    // boundary consume the first `tie_needed` indices, matching the stable
+    // tie rule without relying on atomic scheduling in radix_topk().
+    for (uint32_t tile = 0; tile < length; tile += kTopKBlockSize) {
+      const auto index = tile + tx;
+      uint32_t key = 0;
+      if (index < length) {
+        key = convert_to_uint32(input[index]);
+      }
+      const bool equal = index < length && key == boundary_key;
+      const auto equal_mask = static_cast<unsigned long long>(__ballot(equal));
+      if (lane == 0) {
+        s_wave_counts[wave] = static_cast<uint32_t>(__popcll(equal_mask));
+      }
+      __syncthreads();
+
+      if (tx == 0) {
+        auto offset = s_ties_seen;
+        for (uint32_t wave_id = 0; wave_id < num_waves; ++wave_id) {
+          s_wave_offsets[wave_id] = offset;
+          offset += s_wave_counts[wave_id];
+        }
+        s_ties_seen = offset;
+      }
+      __syncthreads();
+
+      const auto lower_mask = lane == 0 ? 0ull : ((1ull << lane) - 1ull);
+      const auto tie_rank = s_wave_offsets[wave] + static_cast<uint32_t>(__popcll(equal_mask & lower_mask));
+      const bool selected = index < length && (key > boundary_key || (equal && tie_rank < tie_needed));
+      const auto selected_mask = static_cast<unsigned long long>(__ballot(selected));
+      if (lane == 0) {
+        s_wave_counts[wave] = static_cast<uint32_t>(__popcll(selected_mask));
+      }
+      __syncthreads();
+
+      if (tx == 0) {
+        auto offset = s_output_count;
+        for (uint32_t wave_id = 0; wave_id < num_waves; ++wave_id) {
+          s_wave_offsets[wave_id] = offset;
+          offset += s_wave_counts[wave_id];
+        }
+        s_output_count = offset;
+      }
+      __syncthreads();
+
+      if (selected) {
+        const auto position = s_wave_offsets[wave] + static_cast<uint32_t>(__popcll(selected_mask & lower_mask));
+        values[position] = static_cast<int32_t>(index);
+      }
+      __syncthreads();
+    }
+    return;
+  }
+
+  // The API intentionally leaves top-k unordered. Sort a fixed, power-of-two
+  // buffer so runtime top-k values need not themselves be powers of two.
+  if (tx >= topk) {
+    values[tx] = static_cast<int32_t>(0x7FFFFFFFu);
+  }
+  __syncthreads();
+  for (uint32_t size = 2; size <= kMaxTopK; size <<= 1) {
+    for (uint32_t stride = size >> 1; stride > 0; stride >>= 1) {
+      const auto peer = tx ^ stride;
+      if (peer > tx) {
+        const bool ascending = (tx & size) == 0;
+        const auto lhs = values[tx];
+        const auto rhs = values[peer];
+        if ((ascending && lhs > rhs) || (!ascending && lhs < rhs)) {
+          values[tx] = rhs;
+          values[peer] = lhs;
+        }
+      }
+      __syncthreads();
+    }
+  }
+}
+#endif
 
 [[maybe_unused]]
 SGL_DEVICE void naive_transform(
@@ -89,6 +239,9 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
   alignas(128) __shared__ uint32_t s_threshold_bin_id;
   alignas(128) __shared__ uint32_t s_num_input[2];
   alignas(128) __shared__ int32_t s_last_remain;
+#ifdef USE_ROCM
+  alignas(128) __shared__ uint32_t s_num_exact_ties;
+#endif
 
   extern __shared__ uint32_t s_input_idx[][kSMEM / (2 * sizeof(int32_t))];
 
@@ -167,6 +320,144 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
     __syncthreads();
   }
 
+#ifdef USE_ROCM
+  if (s_num_input[0] > SMEM_INPUT_SIZE) {
+    // The fast path keeps the coarse-threshold candidates in LDS. A dense
+    // FP16 bin can exceed that bounded buffer (for example at long context),
+    // and clipping it silently drops valid high-scoring FP32 values. Re-scan
+    // the row one radix byte at a time only for this overflow case. Elements
+    // above the FP16 threshold were already emitted and remain disjoint from
+    // every set handled below.
+    const auto coarse_threshold_bin = threshold_bin;
+    uint32_t score_prefix = 0;
+
+    if (tx < RADIX + 1) {
+      s_histogram[tx] = 0;
+    }
+    __syncthreads();
+    for (uint32_t idx = tx; idx < length; idx += BLOCK_SIZE) {
+      const auto value = input[idx];
+      if (convert_to_uint8(value) == coarse_threshold_bin) {
+        const auto bin = (convert_to_uint32(value) >> 24) & 0xFFu;
+        ::atomicAdd(&s_histogram[bin], 1);
+      }
+    }
+    __syncthreads();
+
+#pragma unroll 4
+    for (int score_round = 0; score_round < 4; ++score_round) {
+      run_cumsum();
+      if (tx < RADIX && s_histogram[tx] > remain_topk && s_histogram[tx + 1] <= remain_topk) {
+        s_threshold_bin_id = tx;
+      }
+      __syncthreads();
+
+      const auto score_threshold_bin = s_threshold_bin_id;
+      const auto num_greater = s_histogram[score_threshold_bin + 1];
+      const auto num_equal = s_histogram[score_threshold_bin] - num_greater;
+      remain_topk -= num_greater;
+      const bool include_equal = remain_topk == num_equal;
+      const bool done = remain_topk == 0 || include_equal;
+      const auto score_offset = 24 - score_round * 8;
+      const auto previous_score_prefix = score_prefix;
+      score_prefix |= score_threshold_bin << score_offset;
+
+      if (!done) {
+        if (tx < RADIX + 1) {
+          s_histogram[tx] = 0;
+        }
+      }
+      __syncthreads();
+
+      for (uint32_t idx = tx; idx < length; idx += BLOCK_SIZE) {
+        const auto value = input[idx];
+        if (convert_to_uint8(value) != coarse_threshold_bin) {
+          continue;
+        }
+        const auto exact_key = convert_to_uint32(value);
+        if (score_round > 0 && (exact_key >> (score_offset + 8)) != (previous_score_prefix >> (score_offset + 8))) {
+          continue;
+        }
+        const auto bin = (exact_key >> score_offset) & 0xFFu;
+        if (bin > score_threshold_bin || (include_equal && bin == score_threshold_bin)) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          output[pos] = idx;
+        } else if (!done && bin == score_threshold_bin) {
+          if (score_round < 3) {
+            const auto next_bin = (exact_key >> (score_offset - 8)) & 0xFFu;
+            ::atomicAdd(&s_histogram[next_bin], 1);
+          } else {
+            const auto index_bin = 0xFFu - ((idx >> 24) & 0xFFu);
+            ::atomicAdd(&s_histogram[index_bin], 1);
+          }
+        }
+      }
+      __syncthreads();
+
+      if (done) {
+        return;
+      }
+    }
+
+    // The score threshold itself is tied and only remain_topk entries fit.
+    // Continue radix selection on the inverted raw index, so larger keys mean
+    // smaller logical indices. Unlike the fast path, this never materializes
+    // the potentially unbounded tie set in LDS.
+    uint32_t index_prefix = 0;
+#pragma unroll 4
+    for (int index_round = 0; index_round < 4; ++index_round) {
+      run_cumsum();
+      if (tx < RADIX && s_histogram[tx] > remain_topk && s_histogram[tx + 1] <= remain_topk) {
+        s_threshold_bin_id = tx;
+      }
+      __syncthreads();
+
+      const auto index_threshold_bin = s_threshold_bin_id;
+      const auto num_greater = s_histogram[index_threshold_bin + 1];
+      const auto num_equal = s_histogram[index_threshold_bin] - num_greater;
+      remain_topk -= num_greater;
+      const bool include_equal = remain_topk == num_equal;
+      const bool done = remain_topk == 0 || include_equal;
+      const auto index_offset = 24 - index_round * 8;
+      const auto previous_index_prefix = index_prefix;
+      index_prefix |= index_threshold_bin << index_offset;
+
+      if (!done) {
+        if (tx < RADIX + 1) {
+          s_histogram[tx] = 0;
+        }
+      }
+      __syncthreads();
+
+      for (uint32_t idx = tx; idx < length; idx += BLOCK_SIZE) {
+        const auto exact_key = convert_to_uint32(input[idx]);
+        if (exact_key != score_prefix) {
+          continue;
+        }
+        const auto inverted_index = ~idx;
+        if (index_round > 0 &&
+            (inverted_index >> (index_offset + 8)) != (previous_index_prefix >> (index_offset + 8))) {
+          continue;
+        }
+        const auto bin = (inverted_index >> index_offset) & 0xFFu;
+        if (bin > index_threshold_bin || (include_equal && bin == index_threshold_bin)) {
+          const auto pos = ::atomicAdd(&s_counter, 1);
+          output[pos] = idx;
+        } else if (!done && bin == index_threshold_bin && index_round < 3) {
+          const auto next_bin = (inverted_index >> (index_offset - 8)) & 0xFFu;
+          ::atomicAdd(&s_histogram[next_bin], 1);
+        }
+      }
+      __syncthreads();
+
+      if (done) {
+        return;
+      }
+    }
+    return;
+  }
+#endif
+
   // stage 2: refine with 8bit radix passes
 #pragma unroll 4
   for (int round = 0; round < 4; ++round) {
@@ -181,6 +472,11 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
       s_threshold_bin_id = tx;
       s_num_input[r_idx ^ 1] = 0;
       s_last_remain = remain_topk - s_histogram[tx + 1];
+#ifdef USE_ROCM
+      if (round == 3) {
+        s_num_exact_ties = s_histogram[tx] - s_histogram[tx + 1];
+      }
+#endif
     }
     __syncthreads();
 
@@ -204,6 +500,11 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
       if (tx < RADIX + 1) {
         s_histogram[tx] = 0;
       }
+#ifdef USE_ROCM
+      if (round == 3 && tx == 0) {
+        s_num_input[r_idx ^ 1] = 0;
+      }
+#endif
       __syncthreads();
       for (uint32_t i = tx; i < num_input; i += BLOCK_SIZE) {
         const auto idx = s_input_idx[r_idx][i];
@@ -215,10 +516,24 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
           output[pos] = idx;
         } else if (bin == threshold_bin) {
           if (round == 3) {
+#ifdef USE_ROCM
+            const auto tie_needed = static_cast<uint32_t>(s_last_remain);
+            if (tie_needed == s_num_exact_ties) {
+              const auto pos = ::atomicAdd(&s_counter, 1);
+              output[pos] = idx;
+            } else {
+              // A strict subset of an exact-score boundary tie belongs to
+              // top-k. Seed an index radix pass so lower logical indices win,
+              // matching the exact tie rule in the CUDA top-k v2 kernel.
+              const auto index_bin = 0xFFu - ((idx >> 24) & 0xFFu);
+              ::atomicAdd(&s_histogram[index_bin], 1);
+            }
+#else
             const auto pos = ::atomicAdd(&s_last_remain, -1);
             if (pos > 0) {
               output[topk - pos] = idx;
             }
+#endif
           } else {
             const auto pos = ::atomicAdd(&s_num_input[r_idx ^ 1], 1);
             if (pos < SMEM_INPUT_SIZE) {
@@ -232,6 +547,69 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
         }
       }
       __syncthreads();
+
+#ifdef USE_ROCM
+      if (round == 3 && static_cast<uint32_t>(s_last_remain) < s_num_exact_ties) {
+        uint32_t tie_remain = static_cast<uint32_t>(s_last_remain);
+        uint32_t source = r_idx;
+        uint32_t source_size = num_input;
+
+#pragma unroll 4
+        for (int index_round = 0; index_round < 4; ++index_round) {
+          run_cumsum();
+          if (tx < RADIX && s_histogram[tx] > tie_remain && s_histogram[tx + 1] <= tie_remain) {
+            s_threshold_bin_id = tx;
+          }
+          __syncthreads();
+
+          const auto index_threshold_bin = s_threshold_bin_id;
+          const auto num_greater = s_histogram[index_threshold_bin + 1];
+          const auto num_equal = s_histogram[index_threshold_bin] - num_greater;
+          tie_remain -= num_greater;
+          const bool include_equal = tie_remain == num_equal;
+          const bool done = tie_remain == 0 || include_equal;
+          const auto next = source ^ 1;
+
+          if (!done) {
+            if (tx < RADIX + 1) {
+              s_histogram[tx] = 0;
+            }
+            if (tx == 0) {
+              s_num_input[next] = 0;
+            }
+          }
+          __syncthreads();
+
+          const auto index_offset = 24 - index_round * 8;
+          for (uint32_t i = tx; i < source_size; i += BLOCK_SIZE) {
+            const auto idx = s_input_idx[source][i];
+            if (index_round == 0 && (convert_to_uint32(input[idx]) & 0xFFu) != threshold_bin) {
+              continue;
+            }
+            const auto index_bin = 0xFFu - ((idx >> index_offset) & 0xFFu);
+            if (index_bin > index_threshold_bin || (include_equal && index_bin == index_threshold_bin)) {
+              const auto pos = ::atomicAdd(&s_counter, 1);
+              output[pos] = idx;
+            } else if (!done && index_bin == index_threshold_bin && index_round < 3) {
+              const auto pos = ::atomicAdd(&s_num_input[next], 1);
+              if (pos < SMEM_INPUT_SIZE) {
+                [[likely]] s_input_idx[next][pos] = idx;
+                const auto next_bin = 0xFFu - ((idx >> (index_offset - 8)) & 0xFFu);
+                ::atomicAdd(&s_histogram[next_bin], 1);
+              }
+            }
+          }
+          __syncthreads();
+
+          if (done) {
+            break;
+          }
+          source = next;
+          const auto raw_source_size = s_num_input[source];
+          source_size = raw_source_size < SMEM_INPUT_SIZE ? raw_source_size : SMEM_INPUT_SIZE;
+        }
+      }
+#endif
     }
   }
 }
@@ -258,6 +636,9 @@ __global__ void topk_transform_kernel(const __grid_constant__ TopKParams params)
   } else {
     __shared__ int32_t s_topk_indices[kMaxTopK];
     radix_topk(score_ptr, s_topk_indices, seq_len, topk);
+#ifdef USE_ROCM
+    canonicalize_topk_indices(score_ptr, s_topk_indices, seq_len, topk);
+#endif
     const auto tx = threadIdx.x;
     if (tx < topk) {
       indices_ptr[tx] = page_to_indices(page_ptr, s_topk_indices[tx], page_bits);
@@ -275,7 +656,11 @@ void setup_kernel_smem_once(host::DebugInfo where = {}) {
   [[maybe_unused]]
   static const auto result = [] {
     const auto fptr = std::bit_cast<const void*>(f);
+#ifdef USE_ROCM
+    return ::hipFuncSetAttribute(fptr, ::hipFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#else
     return ::cudaFuncSetAttribute(fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#endif
   }();
   host::RuntimeDeviceCheck(result, where);
 }

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -45,6 +45,10 @@ def _jit_topk_v2_module():
     )
 
 
+def _has_dsv4_topk_aot() -> bool:
+    return hasattr(torch.ops.sgl_kernel, "deepseek_v4_topk_transform_512")
+
+
 def topk_transform_512(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,
@@ -53,7 +57,7 @@ def topk_transform_512(
     page_size: int,
     out_raw_indices: Optional[torch.Tensor] = None,
 ) -> None:
-    if is_hip_runtime():
+    if is_hip_runtime() and _has_dsv4_topk_aot():
         torch.ops.sgl_kernel.deepseek_v4_topk_transform_512(
             scores, seq_lens, page_tables, out_page_indices, page_size, out_raw_indices
         )

--- a/test/registered/kernels/ops/attention/test_topk_v1_rocm.py
+++ b/test/registered/kernels/ops/attention/test_topk_v1_rocm.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+"""ROCm correctness and determinism tests for DeepSeek-V4 JIT top-k v1."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+
+from sglang.srt.utils import is_hip
+
+if not is_hip():
+    pytest.skip(
+        "DeepSeek-V4 top-k v1 determinism is ROCm-only.", allow_module_level=True
+    )
+if not torch.cuda.is_available():
+    pytest.skip("Requires a GPU.", allow_module_level=True)
+
+import sglang.kernels.ops.attention.dsv4.topk as topk_module  # noqa: E402
+from sglang.test.ci.ci_register import register_amd_ci  # noqa: E402
+
+register_amd_ci(est_time=60, stage="jit-kernel-unit", runner_config="amd")
+
+DEFAULT_TOPK = 512
+CASES = ("signed_zero", "boundary_tie", "overflow_distinct", "ragged")
+
+
+@pytest.fixture
+def force_jit_fallback(monkeypatch):
+    """Exercise the path used when the ROCm AOT package lacks this operator."""
+    jit_calls = []
+    real_jit_module = topk_module._jit_topk_v1_module
+
+    def traced_jit_module():
+        jit_calls.append(True)
+        return real_jit_module()
+
+    monkeypatch.setattr(topk_module, "_has_dsv4_topk_aot", lambda: False)
+    monkeypatch.setattr(topk_module, "_jit_topk_v1_module", traced_jit_module)
+    return jit_calls
+
+
+def _make_case(name: str):
+    if name == "signed_zero":
+        scores = torch.zeros((1, 768), dtype=torch.float32)
+        scores[0, ::2] = -0.0
+        return scores, torch.tensor([768], dtype=torch.int32)
+
+    if name == "boundary_tie":
+        scores = torch.zeros((1, 768), dtype=torch.float32)
+        high = torch.randperm(768, generator=torch.Generator().manual_seed(991))[:500]
+        scores[0, high] = torch.arange(1, 501, dtype=torch.float32)
+        return scores, torch.tensor([768], dtype=torch.int32)
+
+    if name == "overflow_distinct":
+        # All values round into one FP16 coarse bin, but the highest FP32
+        # values lie beyond the legacy 6,144-entry LDS candidate buffer.
+        scores = torch.linspace(1.00001, 1.00040, 7000).unsqueeze(0)
+        return scores, torch.tensor([7000], dtype=torch.int32)
+
+    if name == "ragged":
+        scores = torch.full((5, 800), 54321.0, dtype=torch.float32)
+        seq_lens = torch.tensor([1, 511, 512, 513, 768], dtype=torch.int32)
+        for batch_id, length in enumerate(seq_lens.tolist()):
+            valid = torch.arange(length, dtype=torch.float32)
+            scores[batch_id, :length] = torch.remainder(valid * 37 + batch_id, 97)
+        return scores, seq_lens
+
+    raise AssertionError(f"unknown case: {name}")
+
+
+def _make_page_table(batch: int, width: int, page_size: int):
+    num_pages = (width + page_size - 1) // page_size
+    rows = []
+    for batch_id in range(batch):
+        generator = torch.Generator().manual_seed(1709 + batch_id)
+        rows.append(torch.randperm(num_pages, generator=generator, dtype=torch.int32))
+    return torch.stack(rows)
+
+
+def _reference_raw(
+    scores: torch.Tensor, seq_lens: torch.Tensor, topk: int
+) -> torch.Tensor:
+    result = torch.full((scores.shape[0], topk), -1, dtype=torch.int32)
+    for batch_id, length_value in enumerate(seq_lens.tolist()):
+        length = int(length_value)
+        if length <= topk:
+            selected = list(range(length))
+        else:
+            values = scores[batch_id, :length].tolist()
+            selected = sorted(
+                range(length), key=lambda index: (-float(values[index]), index)
+            )[:topk]
+            selected.sort()
+        result[batch_id, : len(selected)] = torch.tensor(selected, dtype=torch.int32)
+    return result
+
+
+def _reference_page(raw: torch.Tensor, page_table: torch.Tensor, page_size: int):
+    page_bits = page_size.bit_length() - 1
+    page_mask = page_size - 1
+    result = torch.full_like(raw, -1)
+    for batch_id in range(raw.shape[0]):
+        for column, raw_value in enumerate(raw[batch_id].tolist()):
+            if raw_value >= 0:
+                physical_page = int(page_table[batch_id, raw_value >> page_bits])
+                result[batch_id, column] = (physical_page << page_bits) | (
+                    raw_value & page_mask
+                )
+    return result
+
+
+def _run_and_check(
+    scores_cpu: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
+    page_size: int,
+    repeats: int,
+    topk: int = DEFAULT_TOPK,
+):
+    page_table_cpu = _make_page_table(
+        scores_cpu.shape[0], scores_cpu.shape[1], page_size
+    )
+    expected_raw = _reference_raw(scores_cpu, seq_lens_cpu, topk)
+    expected_page = _reference_page(expected_raw, page_table_cpu, page_size)
+
+    scores = scores_cpu.cuda()
+    seq_lens = seq_lens_cpu.cuda()
+    page_table = page_table_cpu.cuda()
+    page_out = torch.empty_like(expected_page, device="cuda")
+    raw_out = torch.empty_like(expected_raw, device="cuda")
+    ordered_outputs = set()
+
+    for _ in range(repeats):
+        topk_module.topk_transform_512(
+            scores, seq_lens, page_table, page_out, page_size, raw_out
+        )
+        torch.cuda.synchronize()
+        actual_raw = raw_out.cpu()
+        actual_page = page_out.cpu()
+        assert torch.equal(actual_raw, expected_raw)
+        assert torch.equal(actual_page, expected_page)
+        ordered_outputs.add(tuple(actual_raw.flatten().tolist()))
+
+    assert len(ordered_outputs) == 1
+
+    # The canonical page output must not depend on requesting the optional raw
+    # index buffer.
+    topk_module.topk_transform_512(
+        scores, seq_lens, page_table, page_out, page_size, None
+    )
+    torch.cuda.synchronize()
+    assert torch.equal(page_out.cpu(), expected_page)
+
+
+@pytest.mark.parametrize("page_size", [1, 64, 256])
+@pytest.mark.parametrize("case_name", CASES)
+@torch.inference_mode()
+def test_topk_v1_rocm_jit_fallback_is_exact_and_deterministic(
+    case_name: str, page_size: int, force_jit_fallback
+):
+    scores, seq_lens = _make_case(case_name)
+    _run_and_check(scores, seq_lens, page_size, repeats=8)
+    assert force_jit_fallback
+
+
+@torch.inference_mode()
+def test_topk_v1_rocm_max_benchmarked_length(force_jit_fallback):
+    scores = torch.linspace(-1.0, 1.0, 262144).unsqueeze(0)
+    seq_lens = torch.tensor([262144], dtype=torch.int32)
+    _run_and_check(scores, seq_lens, page_size=64, repeats=2)
+    assert force_jit_fallback
+
+
+@pytest.mark.parametrize("topk", [1, 7, 257, 513, 777, 1024])
+@torch.inference_mode()
+def test_topk_v1_rocm_runtime_topk_contract(topk: int, force_jit_fallback):
+    """Keep main's runtime top-k contract, including non-power-of-two sizes."""
+    scores = torch.linspace(-1.0, 1.0, 4096).unsqueeze(0)
+    seq_lens = torch.tensor([4096], dtype=torch.int32)
+    _run_and_check(scores, seq_lens, page_size=64, repeats=2, topk=topk)
+    assert force_jit_fallback
+
+
+@pytest.mark.parametrize("topk", [257, 777])
+@torch.inference_mode()
+def test_topk_v1_rocm_long_boundary_tie(topk: int, force_jit_fallback):
+    """Choose the lowest logical indices when a long row ties at the boundary."""
+    scores = torch.zeros((1, 4096), dtype=torch.float32)
+    seq_lens = torch.tensor([4096], dtype=torch.int32)
+    _run_and_check(scores, seq_lens, page_size=64, repeats=4, topk=topk)
+    assert force_jit_fallback
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
### Summary

- Fall back to the existing DSV4 Top-K v1 JIT implementation when the
  packaged ROCm AOT operator is not registered for the active target.
- Make that JIT path compile with HIP and fit 64-KiB-LDS devices.
- Make ROCm selected-set output deterministic across boundary ties, signed
  zeroes and coarse-bin overflow while preserving CUDA behavior.
- Add a registered AMD test for forced fallback, page mapping, ragged rows,
  runtime Top-K sizes, overflow, long rows and repeat determinism.

### Why this is needed

On an unmodified current SGLang checkout, a native gfx1100 installation whose
wheel does not contain the DSV4 AOT operator fails twice: the public Python
path raises `AttributeError`, and direct JIT v1 compilation calls the
CUDA-only `cudaFuncSetAttribute` and
`cudaFuncAttributeMaxDynamicSharedMemorySize` APIs.

The launchable ROCm path also needs deterministic handling at the exact
selection boundary. Atomic arrival order must not choose among equal scores,
signed `-0.0/+0.0` must compare equally, and a coarse FP16 bin larger than the
bounded LDS candidate buffer must not be silently clipped.

### Contract

DeepSeek-V4 uses `index_topk=512`. SGLang's current API supports runtime
`topk in (0, 1024]` and returns an unordered selected set; it does not promise
score-sorted output. This change canonicalizes the selected set by logical
index on ROCm, which provides a deterministic valid representation without
adding a score-order contract. CUDA code paths are unchanged.

### Implementation

- Use the HIP function-attribute API and a 48-KiB dynamic-LDS budget on ROCm.
- Resolve exact-score ties by lower logical index.
- Normalize signed zeroes before building ROCm radix keys.
- Rescan an overflowing coarse bin with full FP32 keys instead of clipping it.
- Use deterministic short-row compaction and fixed long-row ordering.
- Check AOT operator capability before dispatching; use JIT v1 when absent.

### Physical AMD validation

Exact source pair:

```text
base:  ad47dde65c0f5e4812e72c0eb8b3e98acbba8e1a
head:  5a69fd3e5f4ae687cb969ba8930bac9099b3e740
tree:  c1652c0ac80ded83e86e71a1195872ba6b883346
diff:  3 files, +586/-1
```

The tested parent is the upstream `main` fetched immediately before this
publication gate. It is 32 commits ahead of the previous qualified parent;
none of its 247 changed paths intersects the three candidate paths. Relative
to the previous candidate `3076f2cd3`, the range-diff is equal, stable patch ID
`8307236dde8e` is unchanged, and all three candidate-file SHA-256 values are
exact.

Immediately before push, upstream added one documentation-only commit that
renames the Qwen3.8 DSpark recipe. It changes two cookbook paths and has zero
intersection with this patch. The final publication source is therefore
`d21eefc94ff8e95ea70ba54ddde83b35ff26d340..bd52a2dbf40c1aa287834416fa065dd7f187774f`,
tree `4dc2bdb2a380685e28c94f40bd7adb12a2bc272e`. Its range-diff and stable
patch ID are equal to the exact physical pair above; the physical timings are
not relabelled as a run of the documentation-only replay.

Environment:

```text
GPU: Radeon PRO W7900 / native gfx1100 (independent GPU 0 and GPU 7 runs)
HSA_OVERRIDE_GFX_VERSION: unset in accepted GPU processes
HIP_VISIBLE_DEVICES: unset in accepted GPU processes
CUDA_VISIBLE_DEVICES: unset in accepted GPU processes
ROCR_VISIBLE_DEVICES: 0 or 7
ROCm: 7.2.53211-e1a6bc5663
PyTorch: 2.9.1+gitff65f5b
```

Unmodified parent blocker:

```text
exact red parent: ad47dde65c0f5e4812e72c0eb8b3e98acbba8e1a
AOT operator available: false
public path: AttributeError
direct JIT: HIP compile error on the two CUDA-only function-attribute symbols
```

Candidate:

```text
GPU 0: 21 passed, 5 warnings in 15.66s; exit 0; OOMKilled=false
GPU 7: 21 passed, 5 warnings in 15.69s; exit 0; OOMKilled=false
```

The test matrix covers forced AOT fallback, page sizes 1/64/256, signed
zeroes, exact boundary ties, dense-bin overflow, ragged rows, the
262144-token upper tested length, runtime
`topk={1,7,257,513,777,1024}`, and repeated output identity. The repository
registry checker passes; the file resolves to AMD
`jit-kernel-unit-test-amd` with a 60-second estimate.

The accepted parent and both candidate runs explicitly remove HSA/HIP/CUDA
visibility variables and select one physical card only through
`ROCR_VISIBLE_DEVICES`. A registry-only harness first missed the image's venv
on `PATH` and exited before running the checker; it is excluded. The rerun used
the explicit interpreter, and both the repository checker and suite validation
passed.

### Performance guard

This is a correctness and portability fix, not a speedup claim. On the same
source bytes in the predecessor qualification, the complete candidate versus
a launchable control was `+1.217%` p50 for page output and `+1.153%` for page
plus raw output. A matched ModelScope DeepSeek-V4-Flash-0731 TP8 A-B-A run
completed 27/27 S3072 requests; the full 21-layer Indexer bucket changed by
`+0.162186%` and `+0.179978%` in the two candidate brackets, inside the
predeclared 1% guard. That model gate used the same disclosed cached-BF16
lower shim on both sides and is predecessor/source-equivalent evidence, not an
exact-current native-FP8 throughput claim.

### Related work

- #31123 handles negative padded `seq_lens` on pre-rewrite history. Its
  contract is independent; a semantic v1 compatibility port passed beside
  this patch, but that scope is intentionally not included here.
- #28518 targets gfx1151 AOT/LDS enablement and does not provide this JIT-v1
  fallback, HIP attribute or deterministic selected-set behavior.
- #31115 is an opt-in deterministic CuTe-DSL DSA Top-K backend for CUDA
  SM90/SM100. It does not repair the existing gfx1100 DSV4 Top-K v1 path,
  missing-AOT fallback, HIP attributes, 64-KiB-LDS behavior or AMD registered
  coverage.

### Test plan

- [x] `git diff --check`
- [x] Python byte compilation
- [x] registered-test repository checker
- [x] registry collection and suite validation
- [x] physical gfx1100 parent red gate
- [x] physical gfx1100 candidate on GPU 0: 21/21
- [x] physical gfx1100 candidate on GPU 7: 21/21
- [x] predecessor operator latency guard
- [x] predecessor formal-checkpoint Indexer A-B-A guard

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31612796955](https://github.com/sgl-project/sglang/actions/runs/31612796955)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31612796402](https://github.com/sgl-project/sglang/actions/runs/31612796402)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->