### PR TITLE
Fix IndexError when reducing CPU tensors after monkey_patch_torch_red…

### DIFF
--- a/python/sglang/srt/utils/patch_torch.py
+++ b/python/sglang/srt/utils/patch_torch.py
@@ -71,9 +71,14 @@ def register_sgl_tp_rank(rank: int):
 
 def _reduce_tensor_modified(*args, **kwargs):
     output_fn, output_args = reductions._reduce_tensor_original(*args, **kwargs)
-    output_args = _modify_tuple(
-        output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid
-    )
+    # Only the CUDA form carries a device index at this position. A CPU tensor
+    # reduces to a shorter tuple with no device slot at all, so rewriting the
+    # position unconditionally raises IndexError. reduce_tensor is the reducer
+    # for every tensor once installed, CPU ones included.
+    if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
+        output_args = _modify_tuple(
+            output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid
+        )
     return output_fn, output_args
 
 

--- a/test/registered/unit/utils/test_patch_torch_cpu_tensor.py
+++ b/test/registered/unit/utils/test_patch_torch_cpu_tensor.py
@@ -1,0 +1,64 @@
+"""CPU tensors must survive the reduce_tensor monkey patch.
+
+monkey_patch_torch_reductions replaces the reducer for every tensor, not
+only the CUDA ones, so anything that ships a CPU tensor through torch
+multiprocessing in a patched process goes through _reduce_tensor_modified.
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+from torch.multiprocessing import reductions
+
+from sglang.srt.utils import MultiprocessingSerializer, patch_torch
+from sglang.srt.utils.patch_torch import (
+    _REDUCE_TENSOR_ARG_DEVICE_INDEX,
+    monkey_patch_torch_reductions,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestReduceTensorCpuGuard(unittest.TestCase):
+    def test_cpu_tensor_round_trips_after_patching(self):
+        """The reduced form of a CPU tensor has no device slot to rewrite."""
+        monkey_patch_torch_reductions()
+        expected = torch.arange(8, dtype=torch.float32)
+
+        payload = MultiprocessingSerializer.serialize(
+            {"weight": expected}, output_str=True
+        )
+        restored = MultiprocessingSerializer.deserialize(payload)
+
+        self.assertTrue(torch.equal(restored["weight"], expected))
+
+    def test_device_index_still_rewritten_for_cuda_shaped_args(self):
+        """The guard must not disarm the patch on the form it targets."""
+        cuda_shaped = ("cls", "storage", 0, 8, 0, "handle", 3, "event", False)
+        self.assertGreater(len(cuda_shaped), _REDUCE_TENSOR_ARG_DEVICE_INDEX)
+
+        with mock.patch.object(
+            reductions,
+            "_reduce_tensor_original",
+            create=True,
+            return_value=("rebuild", cuda_shaped),
+        ), mock.patch.object(
+            patch_torch, "_device_to_uuid", side_effect=lambda device: f"uuid-{device}"
+        ):
+            _, rewritten = patch_torch._reduce_tensor_modified(object())
+
+        self.assertEqual(rewritten[_REDUCE_TENSOR_ARG_DEVICE_INDEX], "uuid-3")
+        self.assertEqual(
+            rewritten[:_REDUCE_TENSOR_ARG_DEVICE_INDEX],
+            cuda_shaped[:_REDUCE_TENSOR_ARG_DEVICE_INDEX],
+        )
+        self.assertEqual(
+            rewritten[_REDUCE_TENSOR_ARG_DEVICE_INDEX + 1 :],
+            cuda_shaped[_REDUCE_TENSOR_ARG_DEVICE_INDEX + 1 :],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`monkey_patch_torch_reductions()` installs `_reduce_tensor_modified` as `reductions.reduce_tensor` and calls `init_reductions()`, which rebinds the `ForkingPickler` dispatch for `torch.Tensor` — every tensor in the process, not only the CUDA ones. The replacement rewrites argument 6 unconditionally:

```python
output_args = _modify_tuple(
    output_args, _REDUCE_TENSOR_ARG_DEVICE_INDEX, _device_to_uuid
)
```

Only the CUDA reduction carries a device index there. A CPU tensor reduces to a shorter tuple with no device slot at all, so `_modify_tuple` indexes past the end:

```
IndexError: tuple index out of range
  File "sglang/srt/utils/patch_torch.py", line 103, in _modify_tuple
    return *t[:index], modifier(t[index]), *t[index + 1 :]
```

It surfaces from inside `ForkingPickler`, which makes it read as a serialization bug rather than anything device related.

Anything that sends a CPU tensor through torch multiprocessing in a patched process hits this. The path that found it is the RL weight-update surface this patch exists for: `update_weights_from_tensor` and `load_lora_adapter_from_tensors` accept whatever the trainer serializes, and LoRA adapters in particular are naturally staged on the host — they are small, they are gathered across TP ranks before the push, and they do not need to occupy device memory in the meantime.

This is not specific to one trainer. [verl#4065](https://github.com/volcengine/verl/issues/4065), open since November 2025 with several independent "same bug" reports, is the identical traceback through `_reduce_tensor_modified` -> `_modify_tuple`, and the thread converges on the same diagnosis ("LoRA weights being kept on the CPU") and circulates this same arity guard as a local patch. Users are editing `patch_torch.py` in site-packages today, or steering to a merge-the-adapter path to avoid pushing host tensors at all.

The constant already documents its own fragility:

```python
# The signature has not been changed for years, and we will not need this when the next version is released,
# so it looks safe to use a constant.
_REDUCE_TENSOR_ARG_DEVICE_INDEX = 6
```

The assumption that holds is about the *position* of the device index. What does not hold is that a device index is present at all.

## Modifications

Guard the rewrite on the argument count:

```python
if len(output_args) > _REDUCE_TENSOR_ARG_DEVICE_INDEX:
    output_args = _modify_tuple(...)
```

CUDA tensors are unaffected — their reduced form is long enough and the device slot is still rewritten to a UUID, which is the entire point of the patch. CPU tensors pass through to the original reducer's output untouched.

Arity was chosen over an `is_cuda` check on the input tensor because it tests the actual precondition (`output_args` has a slot at index 6) rather than a proxy for it, and it therefore also covers any other non-CUDA reduced form reaching this function.

Added `test/registered/unit/utils/test_patch_torch_cpu_tensor.py` with two cases: a CPU tensor round-trips through `MultiprocessingSerializer` after patching, and — so the guard cannot silently disarm the patch — a CUDA-shaped argument tuple still gets its device index rewritten, verified with a mocked original reducer so the test stays on CPU CI. The first fails with the `IndexError` above without this change; the second passes either way.

## Accuracy Tests

Not applicable: no kernel or model forward code is touched. Behavior for CUDA tensors is unchanged by construction, and the second test pins that.

## Speed Tests and Profiling

Not applicable. The change adds one length comparison per tensor reduction.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31615984806](https://github.com/sgl-project/sglang/actions/runs/31615984806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31615984607](https://github.com/sgl-project/sglang/actions/runs/31615984607)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->