### PR TITLE
[Fix] Harden DeepSeek-V4 tool-call streaming

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -70,6 +70,18 @@ class DeepSeekV32Detector(BaseFormatDetector):
     Reference: DeepSeek V3.2 format specification
     """
 
+    # Tags that indicate a tool-call section (without the closing ">" so
+    # that partial tags streaming in are also detected).  Shared between
+    # parse_streaming_increment (trap check) and finish (tag stripping).
+    _DSML_TOOL_TAGS = [
+        "<｜DSML｜invoke",
+        "<｜DSML｜tool_calls",
+        "<｜DSML｜function_calls",
+        "</｜DSML｜invoke",
+        "</｜DSML｜tool_calls",
+        "</｜DSML｜function_calls",
+    ]
+
     def __init__(self):
         super().__init__()
         self.bot_token = "<｜DSML｜function_calls>"
@@ -127,8 +139,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
         if invoke_content_stripped.startswith("{"):
             if allow_partial:
                 # Remove incomplete invoke end call prefix in case they are captured by param
+                # Use removesuffix (not rstrip) — rstrip treats the argument as a character
+                # set, which truncates values ending with chars in the token (e.g. "find /tmp"
+                # stripped to "find /" by rstrip("parameter")).
                 for token in reversed(self.prefix_invoke_end_call):
-                    invoke_content_stripped = invoke_content_stripped.rstrip(token)
+                    invoke_content_stripped = invoke_content_stripped.removesuffix(
+                        token
+                    )
                 return invoke_content_stripped
             elif invoke_content_stripped.endswith("}"):
                 return invoke_content_stripped
@@ -162,8 +179,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
             remaining_content = invoke_content[last_match_end:]
 
             # Remove incomplete parameter_end_call prefix in case they are captured by param
+            # Use removesuffix (not rstrip) — see rationale above.
             for token in reversed(self.prefix_parameter_end_call):
-                remaining_content = remaining_content.rstrip(token)
+                remaining_content = remaining_content.removesuffix(token)
 
             # Match start of a parameter tag + value (potentially incomplete)
             # Regex: <tag name="..." string="...">VALUE... (no end tag)
@@ -236,16 +254,23 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self._buffer += new_text
         current_text = self._buffer
 
-        # Check if buffer contains any DSML markers or ends with potential tag prefix
-        # This handles partial/streaming DSML content
-        dsml_markers = ["｜DSML｜", "<｜", "</｜"]
-        potentially_dsml = any(marker in current_text for marker in dsml_markers)
+        # Check if buffer contains any DSML tool-call markers or ends with a
+        # partial tag prefix.  Use specific tool-call tags instead of bare
+        # "｜DSML｜" to avoid trapping response text that merely mentions DSML
+        # sub-tags (e.g. <｜DSML｜parameter> in explanatory text).
+        potentially_dsml = any(tag in current_text for tag in self._DSML_TOOL_TAGS)
 
-        # Also check if text ends with start of a tag (to handle "<" arriving separately)
-        dsml_prefixes = ["<", "<｜", "</", "</｜"]
-        ends_with_prefix = any(
-            current_text.rstrip().endswith(prefix) for prefix in dsml_prefixes
-        )
+        # Check if text ends with a partial prefix of any DSML tool-call tag.
+        # Find the last "<" in the text; everything from there to the end is a
+        # candidate partial tag.  If any complete tag starts with this tail,
+        # we buffer and wait for more data.
+        stripped = current_text.rstrip()
+        last_lt = stripped.rfind("<")
+        if last_lt != -1:
+            tail = stripped[last_lt:]
+            ends_with_prefix = any(tag.startswith(tail) for tag in self._DSML_TOOL_TAGS)
+        else:
+            ends_with_prefix = False
 
         if (
             not self.has_tool_call(current_text)
@@ -368,14 +393,46 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
-            # Re-emit verbatim rather than swallowing the turn; the preamble is
-            # still inside current_text unless a completed call advanced past it.
-            # Calls are dropped on purpose: the failure can land between a tool's
-            # name and its arguments, and a half-formed call is worse than none.
-            self._buffer = ""
-            if not current_text.startswith(preamble):
-                current_text = preamble + current_text
-            return StreamingParseResult(normal_text=current_text)
+            # Do NOT clear self._buffer — retaining it lets the next chunk
+            # retry parsing with more data.  Reset transient tool state so
+            # a partial parse doesn't corrupt the next attempt.
+            self.current_tool_id = -1
+            self.current_tool_name_sent = False
+            self.prev_tool_call_arr = []
+            self.streamed_args_for_tool = [""]
+            return StreamingParseResult(normal_text=preamble)
+
+    def finish(self, tools: list[Tool]) -> StreamingParseResult:
+        """Flush any text trapped in the buffer when the stream ends.
+
+        If the buffer contains DSML markers but no invoke was ever matched
+        (e.g. a DSML sub-tag appeared in response text), the text was never
+        flushed as normal_text.  This method returns it so the client
+        receives the content instead of silently losing it.
+
+        DSML tool-call tags (e.g. <｜DSML｜tool_calls>) are delimiters, not
+        content — they are stripped from the flushed text to prevent leaking
+        raw markup into the response.
+        """
+        if not self._buffer:
+            return StreamingParseResult()
+        buffered = self._buffer
+        self._buffer = ""
+        # If we successfully parsed tool calls, the buffer holds only
+        # trailing whitespace or closing tags — don't emit those.
+        if self.current_tool_id != -1 and self.prev_tool_call_arr:
+            return StreamingParseResult()
+        # No tool calls were parsed — the buffer is trapped text.
+        # Strip everything from the earliest DSML tool-call tag onward:
+        # tags are delimiters, not content.  Use _DSML_TOOL_TAGS (without
+        # ">") so partial tags like "<｜DSML｜tool_calls" are also stripped.
+        earliest = len(buffered)
+        for tag in self._DSML_TOOL_TAGS:
+            idx = buffered.find(tag)
+            if idx != -1 and idx < earliest:
+                earliest = idx
+        buffered = buffered[:earliest]
+        return StreamingParseResult(normal_text=buffered)
 
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -216,9 +216,23 @@ class BaseReasoningFormatDetector:
 
             reasoning_text = current_text[:end_idx]
 
-            self._buffer = ""
             self._in_reasoning = False
             normal_text = current_text[end_idx + len(self.think_end_token) :]
+
+            # Hold back a partial tool_start_token suffix (e.g. "<" or
+            # "<｜DSML｜tool_c") so the tag doesn't split across chunks
+            # and leak into content via the tool parser's early return.
+            if self.tool_start_token and normal_text:
+                holdback = self._ends_with_partial_token(
+                    normal_text, self.tool_start_token
+                )
+                if holdback:
+                    self._buffer = normal_text[-holdback:]
+                    normal_text = normal_text[:-holdback]
+                else:
+                    self._buffer = ""
+            else:
+                self._buffer = ""
 
             return StreamingParseResult(
                 normal_text=normal_text, reasoning_text=reasoning_text
@@ -257,8 +271,19 @@ class BaseReasoningFormatDetector:
             else:
                 return StreamingParseResult()
 
-        # If we're not in a reasoning block return as normal text
+        # If we're not in a reasoning block return as normal text,
+        # but hold back a partial tool_start_token suffix so the tag
+        # doesn't get split across chunks and leak into content.
         if not self._in_reasoning:
+            if self.tool_start_token:
+                holdback = self._ends_with_partial_token(
+                    current_text, self.tool_start_token
+                )
+                if holdback:
+                    self._buffer = current_text[-holdback:]
+                    return StreamingParseResult(
+                        normal_text=current_text[: len(current_text) - holdback]
+                    )
             self._buffer = ""
             return StreamingParseResult(normal_text=current_text)
 
@@ -1158,7 +1183,7 @@ class DeepSeekV4Detector(BaseReasoningFormatDetector):
             dsv4_thinking_end_token,
             think_excluded_tokens=[dsv4_eos_token, dsv4_dsml_token],
             # Leading "<" included: has_tool_call() matches on it.
-            tool_start_token=f"<{dsv4_dsml_token}",
+            tool_start_token=f"<{dsv4_dsml_token}tool_calls",
             force_reasoning=force_reasoning,
             stream_reasoning=stream_reasoning,
             continue_final_message=continue_final_message,

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -103,8 +103,10 @@ class TestDeepSeekV4Streaming(CustomTestCase):
         self.assertEqual(len(result.calls), 2)
 
     def test_parse_error_neither_swallows_nor_duplicates(self):
-        """An unexpected parse error must not empty the turn, and the dropped
-        buffer must not come back on the next delta."""
+        """An unexpected parse error must retain the buffer for retry; only
+        the preamble (text before the first DSML tag) is emitted as
+        normal_text so the tool-call text is neither swallowed permanently
+        nor duplicated across deltas."""
         detector = DeepSeekV4Detector()
 
         with patch.object(
@@ -113,14 +115,18 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             side_effect=RuntimeError("boom"),
         ):
             first = detector.parse_streaming_increment(_weather_call(), self.tools)
-            self.assertEqual(detector._buffer, "")
-            second = detector.parse_streaming_increment(" tail", self.tools)
+            # Buffer is retained for retry — NOT cleared
+            self.assertNotEqual(detector._buffer, "")
 
-        self.assertIn("get_weather", first.normal_text)
-        self.assertNotIn("get_weather", second.normal_text)
-        # No half-formed call: the failure can land between a tool's name and its
-        # arguments, so an argument-less named call must not reach the client.
+        # Mock removed — the retained buffer should now parse successfully
+        # on the next delta, proving the retry works.
+        second = detector.parse_streaming_increment(" tail", self.tools)
+
+        # _weather_call() has no preamble, so first.normal_text is empty.
         self.assertEqual(first.calls, [])
+        # The tool call is emitted as a call, NOT as normal_text
+        self.assertNotIn("get_weather", second.normal_text)
+        self.assertTrue(any(c.name == "get_weather" for c in second.calls))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1,6 +1,7 @@
 import json
 import unittest
 import warnings
+from unittest.mock import patch
 
 from sglang.srt.entrypoints.openai.protocol import (
     Function,
@@ -2257,6 +2258,172 @@ class TestDeepSeekV4Detector(unittest.TestCase):
         self.assertEqual(len(tool_calls_by_index), 1)
         self.assertEqual(tool_calls_by_index[0]["name"], "submit")
         self.assertEqual(json.loads(tool_calls_by_index[0]["parameters"]), {})
+
+    # ------------------------------------------------------------------
+    # Bug 1: Exception handler must NOT clear buffer — retain for retry
+    # ------------------------------------------------------------------
+
+    def test_streaming_error_does_not_clear_buffer(self):
+        """A parser failure must retain the buffer so the next chunk can retry.
+        The buffer is NOT cleared — only transient tool state is reset."""
+        text = '<｜DSML｜tool_calls><｜DSML｜invoke name="search">'
+        with patch.object(
+            self.detector,
+            "_parse_parameters_from_xml",
+            side_effect=RuntimeError("boom"),
+        ):
+            with self.assertLogs(
+                "sglang.srt.function_call.deepseekv32_detector", level="ERROR"
+            ):
+                result = self.detector.parse_streaming_increment(text, self.tools)
+
+        # Buffer should NOT be empty — text retained for retry
+        self.assertNotEqual(self.detector._buffer, "")
+        # Transient tool state should be reset
+        self.assertEqual(self.detector.current_tool_id, -1)
+
+    def test_exception_does_not_lose_tool_call_text(self):
+        """On exception, the buffered tool call text must still be processable
+        by a subsequent chunk that completes the invoke."""
+        detector = DeepSeekV4Detector()
+        chunk1 = '<｜DSML｜tool_calls><｜DSML｜invoke name="search">'
+        with patch.object(
+            detector,
+            "_parse_parameters_from_xml",
+            side_effect=RuntimeError("transient"),
+        ):
+            with self.assertLogs(
+                "sglang.srt.function_call.deepseekv32_detector", level="ERROR"
+            ):
+                detector.parse_streaming_increment(chunk1, self.tools)
+
+        chunk2 = (
+            '<｜DSML｜parameter name="query" string="true">hello</｜DSML｜parameter>'
+            "</｜DSML｜invoke></｜DSML｜tool_calls>"
+        )
+        result = detector.parse_streaming_increment(chunk2, self.tools)
+        names = [c.name for c in result.calls if c.name]
+        self.assertIn("search", names)
+
+    # ------------------------------------------------------------------
+    # Bug 2: rstrip character-set bug — use removesuffix instead
+    # ------------------------------------------------------------------
+
+    def test_rstrip_does_not_truncate_streaming_param(self):
+        """Intermediate streaming parameter values ending with chars in
+        {p,a,r,m,e,t} must not be truncated by rstrip(partial_tag)."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment(
+            '<｜DSML｜tool_calls><｜DSML｜invoke name="search">',
+            self.tools,
+        )
+        detector.parse_streaming_increment(
+            '<｜DSML｜parameter name="query" string="true">find /tmp',
+            self.tools,
+        )
+        intermediate_args = detector.prev_tool_call_arr[0].get("arguments", "")
+        self.assertIn("find /tmp", intermediate_args)
+
+    def test_rstrip_does_not_truncate_opt(self):
+        """Intermediate streaming value ending with 'opt' — 'p','t' in char set."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment(
+            '<｜DSML｜tool_calls><｜DSML｜invoke name="search">', self.tools
+        )
+        detector.parse_streaming_increment(
+            '<｜DSML｜parameter name="query" string="true">ls /opt',
+            self.tools,
+        )
+        intermediate_args = detector.prev_tool_call_arr[0].get("arguments", "")
+        self.assertIn("ls /opt", intermediate_args)
+
+    # ------------------------------------------------------------------
+    # Bug 3: potentially_dsml trap + missing finish() flush
+    # ------------------------------------------------------------------
+
+    def test_dsml_subtag_in_response_does_not_trap_subsequent_text(self):
+        """When a DSML sub-tag (not a tool call) appears in response text,
+        subsequent non-DSML text must still be flushed as normal_text."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment(
+            'Here is the format: <｜DSML｜parameter name="x">value uses DSML.',
+            self.tools,
+        )
+        r2 = detector.parse_streaming_increment(
+            "Now let me find the file.",
+            self.tools,
+        )
+        self.assertEqual(r2.normal_text, "Now let me find the file.")
+
+    def test_finish_flushes_trapped_buffer_as_normal_text(self):
+        """finish() clears the buffer at stream end."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment("response text<｜DSML｜tool", self.tools)
+        detector.parse_streaming_increment("_calls>", self.tools)
+        self.assertTrue(hasattr(detector, "finish"))
+        result = detector.finish(self.tools)
+        self.assertEqual(detector._buffer, "")
+
+    def test_finish_with_clean_buffer_returns_empty(self):
+        """finish() on a clean buffer should return empty result."""
+        detector = DeepSeekV4Detector()
+        result = detector.finish(self.tools)
+        self.assertEqual(result.normal_text, "")
+        self.assertEqual(result.calls, [])
+
+    def test_finish_after_successful_tool_call(self):
+        """finish() after a successful tool call should not re-emit text."""
+        detector = DeepSeekV4Detector()
+        chunks = [
+            '<｜DSML｜tool_calls><｜DSML｜invoke name="search">',
+            '<｜DSML｜parameter name="query" string="true">hello</｜DSML｜parameter>',
+            "</｜DSML｜invoke></｜DSML｜tool_calls>",
+        ]
+        for chunk in chunks:
+            detector.parse_streaming_increment(chunk, self.tools)
+        result = detector.finish(self.tools)
+        self.assertEqual(result.normal_text, "")
+
+    def test_finish_does_not_leak_dsml_tool_calls_tag(self):
+        """finish() must not emit <｜DSML｜tool_calls> as normal_text."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment(
+            "Let me find the file.<｜DSML｜tool_calls>", self.tools
+        )
+        result = detector.finish(self.tools)
+        self.assertIn("Let me find the file.", result.normal_text)
+        self.assertNotIn("｜DSML｜", result.normal_text)
+
+    def test_finish_does_not_leak_partial_invoke_tag(self):
+        """finish() must not emit <｜DSML｜invoke...> as normal_text."""
+        detector = DeepSeekV4Detector()
+        detector.parse_streaming_increment(
+            'response text<｜DSML｜tool_calls><｜DSML｜invoke name="search"', self.tools
+        )
+        result = detector.finish(self.tools)
+        self.assertIn("response text", result.normal_text)
+        self.assertNotIn("｜DSML｜", result.normal_text)
+
+    def test_chunk_boundary_on_tool_calls_tag_does_not_leak(self):
+        """<｜DSML｜tool_calls> split across chunks must not leak the DSML
+        tag into normal_text, regardless of where the split occurs."""
+        bot = "<｜DSML｜tool_calls>"
+        invoke = '<｜DSML｜invoke name="search">'
+        param = '<｜DSML｜parameter name="query" string="true">hi</｜DSML｜parameter>'
+        close = "</｜DSML｜invoke></｜DSML｜tool_calls>"
+
+        for split in range(1, len(bot)):
+            chunk1 = f"response text{bot[:split]}"
+            chunk2 = f"{bot[split:]}{invoke}{param}{close}"
+            detector = DeepSeekV4Detector()
+            r1 = detector.parse_streaming_increment(chunk1, self.tools)
+            r2 = detector.parse_streaming_increment(chunk2, self.tools)
+            all_normal = (r1.normal_text or "") + (r2.normal_text or "")
+            self.assertNotIn(
+                "｜DSML｜tool_calls",
+                all_normal,
+                f"DSML tag leaked at split={split}, chunk1={repr(chunk1[-20:])}",
+            )
 
 
 class TestQwen3CoderDetector(unittest.TestCase):

--- a/test/registered/unit/parser/test_reasoning_parser.py
+++ b/test/registered/unit/parser/test_reasoning_parser.py
@@ -246,7 +246,7 @@ class TestDeepSeekV4Detector(CustomTestCase):
         """Without tool_start_token the DSML block stays in reasoning_content and
         the tool call detector never sees it."""
         detector = ReasoningParser(model_type="deepseek-v4").detector
-        self.assertEqual(detector.tool_start_token, "<｜DSML｜")
+        self.assertEqual(detector.tool_start_token, "<｜DSML｜tool_calls")
 
         result = detector.parse_streaming_increment(
             '<think>pick a tool<｜DSML｜tool_calls><｜DSML｜invoke name="s">'


### PR DESCRIPTION
## Motivation

#34458 made DeepSeek-V4 reasoning and tool-call streaming parsing chunk-invariant. Four additional streaming robustness bugs remain on top of that work, causing tool call loss, value truncation, text trapping, and DSML tag leakage in production serving. This PR fixes all four.

## Modifications

### Bug 1: Exception handler clears buffer — tool call permanently lost

`DeepSeekV32Detector.parse_streaming_increment`'s `except` handler set `self._buffer = ""`, permanently discarding the in-progress tool call text. The next chunk could not retry parsing.

**Fix**: Retain `self._buffer`; reset transient tool state (`current_tool_id`, `current_tool_name_sent`, `prev_tool_call_arr`, `streamed_args_for_tool`) so the next chunk retries with a clean slate. Return only `preamble` (text before the first DSML tag) as `normal_text`.

**Files**: `python/sglang/srt/function_call/deepseekv32_detector.py`

### Bug 2: `str.rstrip(token)` character-set truncation

`rstrip(token)` treats the argument as a **character set**, not a substring. `rstrip("parameter")` truncated streaming values ending with any char in `{p, a, r, m, e, t}` — e.g. `"find /tmp"` became `"find /"`.

**Fix**: Use `str.removesuffix(token)` in both the JSON partial and XML partial paths.

**Files**: `python/sglang/srt/function_call/deepseekv32_detector.py`

### Bug 3: `potentially_dsml` trap + missing `finish()` flush

The broad `potentially_dsml` check (any `｜DSML｜` marker in buffer) trapped all subsequent text when a non-tool-call DSML sub-tag (e.g. `<｜DSML｜parameter>`) appeared in response prose. Additionally, `DeepSeekV32Detector` had no `finish()` override, so text trapped in the buffer at stream end was silently discarded.

**Fix**:
- Narrow `potentially_dsml` to tool-call tags only (`invoke`, `tool_calls`, `function_calls` — opening and closing variants), extracted as `_DSML_TOOL_TAGS` class constant.
- Narrow `ends_with_prefix` to check partial prefixes against the same tag list using `rfind("<")` + `startswith`.
- Add `finish(self, tools)` override to `DeepSeekV32Detector` that flushes trapped buffer text at stream end, stripping DSML delimiters using earliest-position logic across `_DSML_TOOL_TAGS` (so partial tags without `>` are also stripped).

**Files**: `python/sglang/srt/function_call/deepseekv32_detector.py`

### Bug 4: Broad `tool_start_token` causes premature reasoning termination

`tool_start_token = "<｜DSML｜"` matched any DSML sub-tag in reasoning content, causing premature reasoning-to-normal transition when `<｜DSML｜parameter>` or similar appeared in explanatory text.

**Fix**:
- Narrow to `"<｜DSML｜tool_calls"` — the actual wrapper tag V4 uses.
- Add holdback for partial `tool_start_token` suffix at `think_end` boundary and non-reasoning boundary, using #34458's `_ends_with_partial_token` helper.

**Files**: `python/sglang/srt/parser/reasoning_parser.py`

### Tokenizer Alignment

Verified with the DeepSeek-V4-Flash tokenizer:
- `｜DSML｜` is a single special token (id=128825)
- No full DSML tags are special tokens — `<｜DSML｜tool_calls>` is 6 regular tokens
- Both `tool_calls` (V4) and `function_calls` (V32) block names exist
- `_DSML_TOOL_TAGS` covers both variants + `invoke` (opening and closing)

## Accuracy Tests

This PR fixes streaming parsing logic, not model forward code. No model output accuracy impact — the fixes ensure tool calls that were previously lost/truncated are now correctly parsed. All 38 unit tests pass:

```
test/registered/unit/function_call/test_deepseekv4_detector.py — 4 passed
test/registered/unit/function_call/test_function_call_parser.py::TestDeepSeekV4Detector — 17 passed
test/registered/unit/parser/test_reasoning_parser.py — 17 passed (TestDeepSeekV4Detector + TestBufferLossBugFix + TestStreamingChunkSizeInvariance)
```

Test breakdown:
- 11 new regression tests covering all 4 bugs (Bug 1: 2 tests, Bug 2: 2 tests, Bug 3: 7 tests including chunk boundary iteration)
- 1 existing #34458 test updated (`test_parse_error_neither_swallows_nor_duplicates`): moved second call outside mock scope to test real retry behavior
- 1 existing #34458 test updated (`test_dsml_block_is_routed_out_of_reasoning`): `tool_start_token` assertion updated to narrowed value

## Speed Tests and Profiling

No inference speed impact — changes are in streaming text parsing only (no GPU kernels, no model forward modifications).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Relationship to Prior Work

- Builds on top of #34458 ([Fix] Make DeepSeek-V4 reasoning and tool-call streaming parsing chunk-invariant, already merged). Fixes 4 streaming robustness issues not covered by that refactor.
- Supersedes #34280 (fix(parser): harden DSV4 reasoning and tool streaming), which addressed the same bugs but was based on pre-#34458 code.

cc @hnyls2002 (reviewer of #34458)

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR. **

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31620389452](https://github.com/sgl-project/sglang/actions/runs/31620389452)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31620389222](https://github.com/sgl-project/sglang/actions/runs/31620389222)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->