### PR TITLE
fix(moe): don't crash on a2a dispatch outputs without topk_output in mxfp4 path

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1386,7 +1386,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             return self.runner.run(dispatch_output, quant_info)
 
         x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
+        # deepep/mori dispatch outputs carry topk_ids/topk_weights directly and
+        # have no `.topk_output`. The runner branches above consume the dispatch
+        # output as-is; only the standard-only branches below (cpu/marlin/
+        # flashinfer) need it, and those never run with an a2a backend.
+        topk_output = getattr(dispatch_output, "topk_output", None)
         if _is_cpu:
             if use_intel_amx_backend(layer):
                 from sglang.srt.layers.moe.topk import apply_topk_weights_cpu


### PR DESCRIPTION
## Motivation

DeepEP/MoRI dispatch outputs carry `topk_ids`/`topk_weights` directly and do not expose `.topk_output`. `Mxfp4MoEMethod.apply` reads `dispatch_output.topk_output` unconditionally before branching, so combining an a2a backend with the mxfp4 MoE method raises `AttributeError` — even though the runner branches that actually execute in that configuration consume the dispatch output as-is and never use `topk_output`.

Hit in production while bringing up MoRI EP on an mxfp4-quantized MoE model (Kimi-K3 on 8x MI350X).

## Modifications

`python/sglang/srt/layers/quantization/mxfp4.py`: read the attribute defensively via `getattr(dispatch_output, "topk_output", None)`. The branches that do need it (cpu / marlin / flashinfer standard paths) never run with an a2a backend, so `None` never reaches a consumer.

## Accuracy Tests

No numerical change — the value is identical whenever the attribute exists; the fix only removes the crash when it does not.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit
- [x] Add unit or integration tests for new functionalities (not applicable — one-line defensive read; happy to add a test if maintainers want one)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31623779419](https://github.com/sgl-project/sglang/actions/runs/31623779419)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31623779207](https://github.com/sgl-project/sglang/actions/runs/31623779207)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->