### PR TITLE
fix(moe): size mori/pplx dispatch-token checks for the DP-attention gather

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6911,13 +6911,25 @@ class ServerArgs:
                     "(chunked_prefill_size, or the decode cuda-graph batch size)"
                 )
 
+    def _moe_tokens_per_forward(self, per_rank_tokens: int) -> int:
+        """Tokens the MoE sees in one forward, given a per-DP-rank token count.
+
+        DP attention gathers every DP rank's batch before the MoE, and
+        chunked_prefill_size was already divided by dp_size above. An a2a
+        backend with preallocated buffers must be sized for the gathered sum,
+        otherwise dispatch/combine silently truncate to the buffer capacity.
+        """
+        if resolved_view(self).enable_dp_attention:
+            return per_rank_tokens * self.dp_size
+        return per_rank_tokens
+
     def _required_mori_dispatch_tokens_per_rank(self) -> int:
         """Max tokens a single rank dispatches through MoRI in one forward."""
-        return self.chunked_prefill_size
+        return self._moe_tokens_per_forward(self.chunked_prefill_size)
 
     def _required_pplx_dispatch_tokens_per_rank(self) -> int:
         """Max tokens a single rank dispatches through pplx in one forward."""
-        required = self.chunked_prefill_size
+        required = self._moe_tokens_per_forward(self.chunked_prefill_size)
         if self.cuda_graph_max_bs_decode is not None:
             required = max(required, self.cuda_graph_max_bs_decode)
         return required


### PR DESCRIPTION
## Motivation

With DP attention enabled, `chunked_prefill_size` is divided by `dp_size` during argument normalization (`server_args.py`, the "DP attention is enabled. chunked prefill size is adjusted" path). The MoE however runs **after** the DP gather and sees the sum of all DP ranks' tokens again. The MoRI/pplx buffer-capacity validations compare only the per-rank chunk size against `SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK` / `SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK`, so a configuration can pass startup validation while dispatch/combine silently truncate to the preallocated buffer capacity at runtime.

## Modifications

`python/sglang/srt/server_args.py`:
- new helper `_moe_tokens_per_forward(per_rank_tokens)` that scales a per-DP-rank token count back up by `dp_size` when DP attention is enabled
- `_required_mori_dispatch_tokens_per_rank` and `_required_pplx_dispatch_tokens_per_rank` route through it

This only tightens startup validation; no runtime behavior changes for configs that were actually correct.

## Accuracy Tests

Verified on an 8x MI350X node running Kimi-K3 with `--moe-a2a-backend mori`: with DP attention the old check accepted a config whose gathered token count exceeded the dispatch buffer; with this change the assert fires at startup with an actionable message instead.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit
- [x] Add unit or integration tests for new functionalities (validation-only change; happy to add a ServerArgs unit test if desired)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31623780876](https://github.com/sgl-project/sglang/actions/runs/31623780876)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31623780766](https://github.com/sgl-project/sglang/actions/runs/31623780766)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->