### PR TITLE
fix(openai): accept a single tool-call object under tool_choice=required

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2038,12 +2038,28 @@ class OpenAIServingChat(OpenAIServingBase):
                 finish_reason["matched"] = None
             try:
                 tool_call_data = orjson.loads(text)
+                # Models frequently emit a single call object instead of the
+                # array the json_schema constraint asks for. Accept it — the
+                # old code iterated the dict's keys and crashed below with
+                # "string indices must be integers".
+                if isinstance(tool_call_data, dict):
+                    tool_call_data = [tool_call_data]
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
+                    if not isinstance(tool, dict) or not isinstance(
+                        tool.get("name"), str
+                    ):
+                        raise ValueError(
+                            f"tool call entry {i} is not an object with a "
+                            f"'name' field (got {type(tool).__name__})"
+                        )
+                    arguments = json.dumps(
+                        tool.get("parameters") or {}, ensure_ascii=False
+                    )
                     call_info = ToolCallItem(
                         tool_index=i,
                         name=tool["name"],
-                        parameters=json.dumps(tool["parameters"], ensure_ascii=False),
+                        parameters=arguments,
                     )
                     tool_id = self._process_tool_call_id(
                         call_info, history_tool_calls_cnt
@@ -2054,9 +2070,7 @@ class OpenAIServingChat(OpenAIServingBase):
                             index=i,
                             function=FunctionResponse(
                                 name=tool["name"],
-                                arguments=json.dumps(
-                                    tool["parameters"], ensure_ascii=False
-                                ),
+                                arguments=arguments,
                             ),
                         )
                     )

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2046,12 +2046,27 @@ class OpenAIServingChat(OpenAIServingBase):
                     tool_call_data = [tool_call_data]
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
+                    if isinstance(tool, dict) and not isinstance(
+                        tool.get("name"), str
+                    ):
+                        # Bare-parameters object: the model skipped the
+                        # {name, parameters} wrapper entirely. Unambiguous
+                        # only when the target tool is known — a named
+                        # tool_choice, or exactly one tool on offer.
+                        target = None
+                        if isinstance(tool_choice, ToolChoice):
+                            target = tool_choice.function.name
+                        elif len(tools) == 1:
+                            target = tools[0].function.name
+                        if target is not None and "parameters" not in tool:
+                            tool = {"name": target, "parameters": tool}
                     if not isinstance(tool, dict) or not isinstance(
                         tool.get("name"), str
                     ):
                         raise ValueError(
                             f"tool call entry {i} is not an object with a "
-                            f"'name' field (got {type(tool).__name__})"
+                            f"'name' field (got {type(tool).__name__}: "
+                            f"{str(tool)[:120]})"
                         )
                     arguments = json.dumps(
                         tool.get("parameters") or {}, ensure_ascii=False

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -175,6 +175,38 @@ class ServingChatTestCase(unittest.TestCase):
         )
         self.assertEqual(result.finish_reason["type"], "tool_calls")
 
+    def test_required_tool_call_maps_bare_parameters_to_sole_tool(self):
+        """Models also emit just the parameters object with no {name,
+        parameters} wrapper; with a single tool on offer the target is
+        unambiguous."""
+        self.chat.tool_call_parser = None
+        tool = Mock()
+        tool.function.name = "web_search"
+        result = self.chat._process_tool_calls(
+            '{"q": "weather berlin"}',
+            [tool],
+            {"type": "stop", "matched": None},
+            tool_choice="required",
+        )
+        self.assertIsNotNone(result.tool_calls)
+        self.assertEqual(result.tool_calls[0].function.name, "web_search")
+        self.assertEqual(
+            result.tool_calls[0].function.arguments, '{"q": "weather berlin"}'
+        )
+
+    def test_required_tool_call_bare_parameters_ambiguous_falls_back(self):
+        """With several tools and no named tool_choice the bare object is
+        ambiguous — keep the text fallback instead of guessing."""
+        self.chat.tool_call_parser = None
+        result = self.chat._process_tool_calls(
+            '{"q": "weather berlin"}',
+            [Mock(), Mock()],
+            {"type": "stop", "matched": None},
+            tool_choice="required",
+        )
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.finish_reason["type"], "stop")
+
     def test_required_tool_call_rejects_non_object_entries(self):
         """A JSON array of bare strings is not a tool call payload — fall back
         to text with the original finish reason instead of raising TypeError."""

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -156,6 +156,50 @@ class ServingChatTestCase(unittest.TestCase):
         self.fastapi_request = Mock(spec=Request)
         self.fastapi_request.headers = {}
 
+    def test_required_tool_call_accepts_single_object(self):
+        """Models frequently emit one call object instead of the array the
+        json_schema constraint asks for; the old code iterated the dict's
+        keys and crashed with "string indices must be integers"."""
+        self.chat.tool_call_parser = None
+        result = self.chat._process_tool_calls(
+            '{"name": "add", "parameters": {"a": 1, "b": 2}}',
+            [],
+            {"type": "stop", "matched": None},
+            tool_choice="required",
+        )
+        self.assertIsNotNone(result.tool_calls)
+        self.assertEqual(len(result.tool_calls), 1)
+        self.assertEqual(result.tool_calls[0].function.name, "add")
+        self.assertEqual(
+            result.tool_calls[0].function.arguments, '{"a": 1, "b": 2}'
+        )
+        self.assertEqual(result.finish_reason["type"], "tool_calls")
+
+    def test_required_tool_call_rejects_non_object_entries(self):
+        """A JSON array of bare strings is not a tool call payload — fall back
+        to text with the original finish reason instead of raising TypeError."""
+        self.chat.tool_call_parser = None
+        result = self.chat._process_tool_calls(
+            '["add"]',
+            [],
+            {"type": "stop", "matched": None},
+            tool_choice="required",
+        )
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.remaining_text, '["add"]')
+        self.assertEqual(result.finish_reason["type"], "stop")
+
+    def test_required_tool_call_non_json_falls_back_to_text(self):
+        self.chat.tool_call_parser = None
+        result = self.chat._process_tool_calls(
+            "Sorry, I cannot call a tool here.",
+            [],
+            {"type": "stop", "matched": None},
+            tool_choice="required",
+        )
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.finish_reason["type"], "stop")
+
     def test_parsers_follow_the_control_plane_overlay(self):
         """Template detection records the parsers on the manager, not on its
         ServerArgs — the instance keeps what the launcher passed."""


### PR DESCRIPTION
## Motivation

Partially addresses #34604 (the `string indices must be integers` class, 106 of ~190 daily parser failures we see in production with Kimi-K3).

With `tool_choice=required`/named, the json_schema constraint asks the model for an **array** of `{name, parameters}` objects — but models frequently emit a **single object** instead. `orjson.loads` then returns a dict, `enumerate()` iterates its **keys**, and `tool["name"]` raises `TypeError: string indices must be integers`. The whole response falls back to raw text, so the client sees a turn without tool calls even though the model produced a perfectly usable call.

## Modifications

`python/sglang/srt/entrypoints/openai/serving_chat.py` (`_process_tool_calls`, required path):
- wrap a single dict payload into a one-element list and process it normally (functional fix — these calls now succeed)
- validate each entry is an object with a string `name`; malformed entries now produce an actionable `ValueError` message in the log instead of a cryptic `TypeError`
- tolerate missing `parameters` (defaults to `{}`) instead of raising `KeyError`

`test/registered/unit/entrypoints/openai/test_serving_chat.py`: unit tests for the single-object success case, the non-object-entry fallback and the non-JSON fallback.

## Accuracy Tests

Behavior for well-formed array payloads is unchanged (same serialization, same IDs). New behavior only in cases that previously raised.

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit
- [x] Add unit or integration tests for new functionalities

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31718759743](https://github.com/sgl-project/sglang/actions/runs/31718759743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31718759457](https://github.com/sgl-project/sglang/actions/runs/31718759457)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->