### PR TITLE
[misc] update CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -545,6 +545,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "caihuali95": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "cctry": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Motivation

Grant CI permissions to a new contributor so they can label and rerun their own runs instead of waiting on a maintainer. Same shape as the other entries: label, rerun-failed, rerun-stage, no cooldown.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31624945168](https://github.com/sgl-project/sglang/actions/runs/31624945168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31624944977](https://github.com/sgl-project/sglang/actions/runs/31624944977)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->