### PR TITLE
[DCP] Fuse the a2a pack/unpack copies in the MLA LSE reduce

### DIFF
--- a/python/sglang/kernels/ops/attention/__init__.py
+++ b/python/sglang/kernels/ops/attention/__init__.py
@@ -116,6 +116,8 @@ for _mod, _fn in [
     ("flash_mla_sm120", "flash_mla_with_kvcache_sm120"),
     ("dcp_kernels", "create_dcp_kv_indices"),
     ("dcp_kernels", "correct_attn_out"),
+    ("dcp_kernels", "dcp_lse_combine_triton"),
+    ("dcp_kernels", "dcp_pack_a2a_send"),
     ("pa_page_table", "_build_pa_page_table"),
     ("nsa_triton_decode", "triton_sparse_attn_decode"),
 ]:

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -398,12 +398,7 @@ def _dcp_pack_a2a_send_kernel(
     WORDS: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """Scatter one (batch, head) partial into its peer's a2a send slot.
-
-    Grid: (B, H). Head h belongs to peer h // H_PER_RANK. Everything is moved as
-    fp32 words so the same kernel serves bf16/fp16/fp8 outputs: the payload is
-    copied verbatim and the fp32 LSE lands in the trailing word.
-    """
+    """Scatter one (batch, head) partial into its peer's a2a send slot."""
     b = tl.program_id(0).to(tl.int64)
     h = tl.program_id(1).to(tl.int64)
 
@@ -430,9 +425,8 @@ def dcp_pack_a2a_send(
 ) -> None:
     """Pack ``[B, H, D]`` partials + ``[B, H]`` LSE into the a2a send buffer.
 
-    ``send_combined`` is ``[N, B_max, H // N, D + lse_pack_dim]`` in the output
-    dtype; rows beyond ``B`` are left untouched (the receiver slices to ``B``).
-    Replaces a permute-contiguous plus two strided ``copy_`` launches.
+    ``send_combined`` is ``[N, B_max, H // N, D + lse_pack_dim]``; rows beyond
+    ``B`` are left untouched.
     """
     B, H, D = cp_attn_out.shape
     N, B_max, H_per_rank, row_width = send_combined.shape
@@ -448,7 +442,6 @@ def dcp_pack_a2a_send(
             f"out {tuple(cp_attn_out.shape)}"
         )
 
-    # fp32 views: [B, H, WORDS] and [N, B_max, H_per_rank, WORDS + 1].
     out_words = cp_attn_out.view(torch.float32)
     send_words = send_combined.view(torch.float32)
     words = D // lpd

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -383,6 +383,94 @@ def _lse_pack_dim(output_dtype: torch.dtype) -> int:
 
 
 @triton.jit
+def _dcp_pack_a2a_send_kernel(
+    out_ptr,
+    lse_ptr,
+    send_ptr,
+    out_stride_B,
+    out_stride_H,
+    lse_stride_B,
+    lse_stride_H,
+    send_stride_N,
+    send_stride_B,
+    send_stride_H,
+    H_PER_RANK: tl.constexpr,
+    WORDS: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """Scatter one (batch, head) partial into its peer's a2a send slot.
+
+    Grid: (B, H). Head h belongs to peer h // H_PER_RANK. Everything is moved as
+    fp32 words so the same kernel serves bf16/fp16/fp8 outputs: the payload is
+    copied verbatim and the fp32 LSE lands in the trailing word.
+    """
+    b = tl.program_id(0).to(tl.int64)
+    h = tl.program_id(1).to(tl.int64)
+
+    src = out_ptr + b * out_stride_B + h * out_stride_H
+    dst = (
+        send_ptr
+        + (h // H_PER_RANK) * send_stride_N
+        + b * send_stride_B
+        + (h % H_PER_RANK) * send_stride_H
+    )
+
+    for start in tl.range(0, WORDS, BLOCK):
+        offs = start + tl.arange(0, BLOCK)
+        mask = offs < WORDS
+        tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
+
+    tl.store(dst + WORDS, tl.load(lse_ptr + b * lse_stride_B + h * lse_stride_H))
+
+
+def dcp_pack_a2a_send(
+    cp_attn_out: torch.Tensor,
+    cp_attn_lse: torch.Tensor,
+    send_combined: torch.Tensor,
+) -> None:
+    """Pack ``[B, H, D]`` partials + ``[B, H]`` LSE into the a2a send buffer.
+
+    ``send_combined`` is ``[N, B_max, H // N, D + lse_pack_dim]`` in the output
+    dtype; rows beyond ``B`` are left untouched (the receiver slices to ``B``).
+    Replaces a permute-contiguous plus two strided ``copy_`` launches.
+    """
+    B, H, D = cp_attn_out.shape
+    N, B_max, H_per_rank, row_width = send_combined.shape
+    lpd = _lse_pack_dim(send_combined.dtype)
+
+    if cp_attn_lse.dtype != torch.float32:
+        raise ValueError(f"cp_attn_lse must be float32, got {cp_attn_lse.dtype}")
+    if D % lpd:
+        raise ValueError(f"head dim {D} must be a multiple of the LSE pack dim {lpd}")
+    if row_width != D + lpd or H_per_rank * N != H or B > B_max:
+        raise ValueError(
+            f"send buffer {tuple(send_combined.shape)} does not match "
+            f"out {tuple(cp_attn_out.shape)}"
+        )
+
+    # fp32 views: [B, H, WORDS] and [N, B_max, H_per_rank, WORDS + 1].
+    out_words = cp_attn_out.view(torch.float32)
+    send_words = send_combined.view(torch.float32)
+    words = D // lpd
+
+    _dcp_pack_a2a_send_kernel[(B, H)](
+        out_words,
+        cp_attn_lse,
+        send_words,
+        out_words.stride(0),
+        out_words.stride(1),
+        cp_attn_lse.stride(0),
+        cp_attn_lse.stride(1),
+        send_words.stride(0),
+        send_words.stride(1),
+        send_words.stride(2),
+        H_PER_RANK=H_per_rank,
+        WORDS=words,
+        BLOCK=min(1024, triton.next_power_of_2(words)),
+    )
+
+
+@triton.jit
 def _dcp_lse_combine_kernel(
     recv_output_ptr,
     recv_lse_ptr,

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -500,7 +500,6 @@ def dcp_a2a_lse_reduce(
         send_combined.reshape(-1).view(torch.uint8),
     )
 
-    # The combine kernel takes strides, so it reads the packed buffer in place.
     recv_output = recv_combined[:, :B, :, :D]
     recv_lse = recv_combined.view(torch.float32)[:, :B, :, D // lpd]
 

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -30,6 +30,7 @@ from sglang.kernels.ops.attention.dcp_kernels import (
     _lse_pack_dim,
     correct_attn_out,
     dcp_lse_combine_triton,
+    dcp_pack_a2a_send,
 )
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
@@ -476,34 +477,10 @@ def dcp_a2a_lse_reduce(
     out_dtype = cp_attn_out.dtype
     lpd = _lse_pack_dim(out_dtype)  # 2 for bf16/fp16
 
-    # Reshape [B, H, D] -> [N, B, H/N, D] — split heads across ranks
-    reshaped_out = cp_attn_out.view(B, N, H_per_rank, D).permute(1, 0, 2, 3)
-    reshaped_lse = cp_attn_lse.view(B, N, H_per_rank).permute(1, 0, 2)
-
     if cuda_graph_buffers is not None:
-        # CUDA graph path with pre-allocated fused buffers.
         send_combined = cuda_graph_buffers["send_combined"]
         recv_combined = cuda_graph_buffers["recv_combined"]
-        send_lse_stg = cuda_graph_buffers["send_lse"]
-        recv_lse_stg = cuda_graph_buffers["recv_lse"]
-
-        send_combined[:, :B, :, :D].copy_(reshaped_out)
-        send_lse_stg[:, :B, :].copy_(reshaped_lse)
-        send_combined[:, :, :, D:].copy_(
-            send_lse_stg.view(out_dtype).view(N, -1, H_per_rank, lpd)
-        )
-
-        cp_group.all_to_all_single(
-            recv_combined.reshape(-1).view(torch.uint8),
-            send_combined.reshape(-1).view(torch.uint8),
-        )
-        recv_output = recv_combined[:, :B, :, :D]
-        recv_lse_stg.view(out_dtype).view(N, -1, H_per_rank, lpd).copy_(
-            recv_combined[:, :, :, D:]
-        )
-        recv_lse = recv_lse_stg[:, :B, :]
     else:
-        send_lse_contig = reshaped_lse.contiguous()  # [N, B, H_per_rank] fp32
         send_combined = torch.empty(
             N,
             B,
@@ -514,30 +491,18 @@ def dcp_a2a_lse_reduce(
         )
         recv_combined = torch.empty_like(send_combined)
 
-        send_combined[:, :, :, :D].copy_(reshaped_out)
-        send_combined[:, :, :, D:].copy_(
-            send_lse_contig.view(out_dtype).view(N, B, H_per_rank, lpd)
-        )
+    dcp_pack_a2a_send(cp_attn_out, cp_attn_lse, send_combined)
 
-        # Transport as raw bytes (uint8): the output may be fp8 (fp8 KV cache),
-        # which pynccl's dtype enum can't send; byte a2a is exact for equal chunks.
-        cp_group.all_to_all_single(
-            recv_combined.reshape(-1).view(torch.uint8),
-            send_combined.reshape(-1).view(torch.uint8),
-        )
+    # Transport as raw bytes (uint8): the output may be fp8 (fp8 KV cache),
+    # which pynccl's dtype enum can't send; byte a2a is exact for equal chunks.
+    cp_group.all_to_all_single(
+        recv_combined.reshape(-1).view(torch.uint8),
+        send_combined.reshape(-1).view(torch.uint8),
+    )
 
-        recv_output = recv_combined[:, :, :, :D]
-        recv_lse_stg = torch.empty(
-            N,
-            B,
-            H_per_rank,
-            dtype=torch.float32,
-            device=cp_attn_out.device,
-        )
-        recv_lse_stg.view(out_dtype).view(N, B, H_per_rank, lpd).copy_(
-            recv_combined[:, :, :, D:]
-        )
-        recv_lse = recv_lse_stg
+    # The combine kernel takes strides, so it reads the packed buffer in place.
+    recv_output = recv_combined[:, :B, :, :D]
+    recv_lse = recv_combined.view(torch.float32)[:, :B, :, D // lpd]
 
     combined, _ = dcp_lse_combine_triton(
         recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e

--- a/test/registered/kernels/test_dcp_lse_combine.py
+++ b/test/registered/kernels/test_dcp_lse_combine.py
@@ -452,6 +452,58 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
         self.assertEqual(result.shape, (B, H_per_rank, D))
         self.assertFalse(torch.isnan(result).any())
 
+    def test_pack_matches_the_copy_formulation_it_replaces(self):
+        """The packed row is payload words followed by the fp32 LSE in the
+        trailing word. Pin the layout against the permute+bitcast copies it
+        replaces: a wrong lane index or word count still produces a
+        well-formed buffer, and only shows up as garbage weights after the
+        all-to-all."""
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            _lse_pack_dim,
+            dcp_pack_a2a_send,
+        )
+
+        for N, B, H_per_rank, D, dtype in (
+            (2, 4, 8, 128, torch.bfloat16),
+            (4, 3, 2, 64, torch.float16),
+            (8, 1, 12, 512, torch.bfloat16),
+        ):
+            with self.subTest(N=N, B=B, H_per_rank=H_per_rank, D=D, dtype=dtype):
+                H = H_per_rank * N
+                lpd = _lse_pack_dim(dtype)
+                max_bs = B + 5
+                out = torch.randn(B, H, D, device=self.device, dtype=dtype)
+                lse = torch.randn(B, H, device=self.device, dtype=torch.float32)
+
+                got = torch.zeros(
+                    N, max_bs, H_per_rank, D + lpd, dtype=dtype, device=self.device
+                )
+                dcp_pack_a2a_send(out, lse, got)
+
+                # Reference: the permute + fp32->out-dtype bitcast copies.
+                want = torch.zeros_like(got)
+                want[:, :B, :, :D] = out.view(B, N, H_per_rank, D).permute(1, 0, 2, 3)
+                want[:, :B, :, D:] = (
+                    lse.view(B, N, H_per_rank)
+                    .permute(1, 0, 2)
+                    .contiguous()
+                    .view(dtype)
+                    .view(N, B, H_per_rank, lpd)
+                )
+                # Compare raw bytes: an fp32 LSE reinterpreted as output-dtype
+                # lanes is frequently a NaN bit pattern, and torch.equal reports
+                # NaN != NaN even when the bits are identical.
+                self.assertTrue(
+                    torch.equal(got.view(torch.uint8), want.view(torch.uint8))
+                )
+
+                # And the LSE reads back bit-exactly through the fp32 lane the
+                # combine kernel indexes.
+                lane = got.view(torch.float32)[:, :B, :, D // lpd]
+                self.assertTrue(
+                    torch.equal(lane, lse.view(B, N, H_per_rank).permute(1, 0, 2))
+                )
+
     def test_buffers_have_fixed_data_ptrs(self):
         """Pre-allocated buffer data_ptr must not change -- required for graph replay."""
         from sglang.srt.layers.dcp import dcp_a2a_lse_reduce

--- a/test/registered/kernels/test_dcp_lse_combine.py
+++ b/test/registered/kernels/test_dcp_lse_combine.py
@@ -453,11 +453,6 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
         self.assertFalse(torch.isnan(result).any())
 
     def test_pack_matches_the_copy_formulation_it_replaces(self):
-        """The packed row is payload words followed by the fp32 LSE in the
-        trailing word. Pin the layout against the permute+bitcast copies it
-        replaces: a wrong lane index or word count still produces a
-        well-formed buffer, and only shows up as garbage weights after the
-        all-to-all."""
         from sglang.kernels.ops.attention.dcp_kernels import (
             _lse_pack_dim,
             dcp_pack_a2a_send,
@@ -480,7 +475,6 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
                 )
                 dcp_pack_a2a_send(out, lse, got)
 
-                # Reference: the permute + fp32->out-dtype bitcast copies.
                 want = torch.zeros_like(got)
                 want[:, :B, :, :D] = out.view(B, N, H_per_rank, D).permute(1, 0, 2, 3)
                 want[:, :B, :, D:] = (
@@ -490,15 +484,10 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
                     .view(dtype)
                     .view(N, B, H_per_rank, lpd)
                 )
-                # Compare raw bytes: an fp32 LSE reinterpreted as output-dtype
-                # lanes is frequently a NaN bit pattern, and torch.equal reports
-                # NaN != NaN even when the bits are identical.
                 self.assertTrue(
                     torch.equal(got.view(torch.uint8), want.view(torch.uint8))
                 )
 
-                # And the LSE reads back bit-exactly through the fp32 lane the
-                # combine kernel indexes.
                 lane = got.view(torch.float32)[:, :B, :, D // lpd]
                 self.assertTrue(
                     torch.equal(lane, lse.view(B, N, H_per_rank).permute(1, 0, 2))


### PR DESCRIPTION
## Motivation

Follow-up to #34240. That PR removed two no-op launches from the DCP MLA verify path; profiling the same window showed the rest of it is the a2a buffer plumbing — four elementwise copies per MLA layer, per decode step, all on the critical path between the attention epilogue and the NCCL all-to-all:

| kernel | what it moves |
|---|---|
| `direct_copy` | `reshaped_lse.contiguous()` — permute-contiguous of the fp32 LSE |
| `direct_copy` | payload into `send_combined[..., :D]` |
| `direct_copy` | LSE bits into `send_combined[..., D:]` |
| `direct_copy` | received LSE back out of `recv_combined[..., D:]` |

## Modifications

**Send: one Triton kernel instead of three copies.** `dcp_pack_a2a_send` scatters each `(batch, head)` partial straight into its peer's slot in the fused buffer. It moves everything as fp32 *words*, so one kernel serves bf16/fp16/fp8 outputs with no per-dtype bitcast path, and the fp32 LSE simply lands in the trailing word.

**Receive: nothing to unpack.** `dcp_lse_combine_triton` already takes strides for both operands, so it now reads the payload as a strided slice of `recv_combined` and the LSE as a strided fp32 view of the same buffer. The staging tensor and its copy are gone.

**One body instead of two branches.** The pre-allocated-buffer and dynamic-allocation paths differed only in where the buffers come from, so they are unified.

While doing that, note the pre-allocated path is currently reachable **only from tests** — neither production call site (`forward_mla.py`, `forward_mla_rocm.py`) passes `cuda_graph_buffers`, so the live path is the one that allocates per call. Left as is here, but worth knowing: the "CUDA graph path" comment reads as though it were the hot path, and it is not.

## Accuracy Tests

DeepSeek-V3.1, 8xH200, `--dcp-size 8 --tp-size 8 --dcp-comm-backend a2a`, i.e. `test_dsv31_dcp8_gsm8k.py::TestDSV31DCP8TP8GSM8K` with a2a forced so the changed path is actually exercised (the default `ag_rs` does not touch it):

| | baseline | patched |
|---|---|---|
| GSM8K score (gate 0.90) | 0.975 | **0.980** |
| pytest | 9 passed | 9 passed |

The 0.005 delta is one question in 200 and is batching nondeterminism, not this change — see below.

**Stronger than the eval: the output is bit-identical.** Same inputs through `dcp_a2a_lse_reduce` before and after, 3 shapes x both LSE bases:

```
N2_B4_H8_D128_eTrue    bit-identical=True   max|diff|=0.000e+00
N2_B4_H8_D128_eFalse   bit-identical=True   max|diff|=0.000e+00
N8_B3_H12_D512_eTrue   bit-identical=True   max|diff|=0.000e+00
N8_B3_H12_D512_eFalse  bit-identical=True   max|diff|=0.000e+00
N4_B1_H2_D64_eTrue     bit-identical=True   max|diff|=0.000e+00
N4_B1_H2_D64_eFalse    bit-identical=True   max|diff|=0.000e+00
```

## Speed Tests and Profiling

Before

<img width="633" height="364" alt="Screenshot 2026-08-12 at 3 00 47 PM" src="https://github.com/user-attachments/assets/836f418a-bc23-4f0a-b6f1-3d9a98aff819" />

After
<img width="669" height="364" alt="Screenshot 2026-08-12 at 3 01 01 PM" src="https://github.com/user-attachments/assets/0364b68c-c916-4c2d-beb7-97c253e0f174" />


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Test added to `test/registered/kernels/test_dcp_lse_combine.py`: pins the packed row layout against the permute+bitcast copies it replaces, across three shapes and two dtypes. It fails on `main` (the function does not exist) and passes with this change. The whole file passes on 8xH200: 23 passed + 3 subtests.

It compares via `uint8` views deliberately — an fp32 LSE reinterpreted as output-dtype lanes is frequently a NaN bit pattern, and `torch.equal` reports NaN != NaN even when the bits match. Comparing the tensors directly makes the test fail roughly one run in three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31645038345](https://github.com/sgl-project/sglang/actions/runs/31645038345)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31645038121](https://github.com/sgl-project/sglang/actions/runs/31645038121)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->