### PR TITLE
[Diffusion][Cosmos3] Enable breakable CUDA graph

### DIFF
--- a/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/prompt_padding.py
+++ b/python/sglang/multimodal_gen/runtime/breakable_cuda_graph/prompt_padding.py
@@ -274,6 +274,16 @@ PromptPadder = Callable[[dict, Any, tuple], dict]
 _PROMPT_PADDERS: list[tuple[Callable[[Any, dict], bool], PromptPadder]] = []
 
 
+def _cosmos3_padder(
+    call_kwargs: dict, _current_model: Any, buckets: tuple[int, ...]
+) -> dict:
+    out = pad_masked_prompt_kwargs(call_kwargs, buckets)
+    text_mask = first_tensor(out.get("text_mask"))
+    if text_mask is not None and out.get("max_text_seq_len") is not None:
+        out["max_text_seq_len"] = int(text_mask.shape[1])
+    return out
+
+
 def register_prompt_padder(
     predicate: Callable[[Any, dict], bool], padder: PromptPadder
 ) -> None:
@@ -304,4 +314,9 @@ def _ensure_model_padders_registered() -> None:
         minimax_h3,
         qwen_image,
         zimage,
+    )
+
+    register_prompt_padder(
+        lambda model, _kwargs: transformer_class_name_matches(model, "cosmos3"),
+        _cosmos3_padder,
     )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/cosmos3.py
@@ -19,6 +19,12 @@ import torch
 import torch.nn as nn
 
 from sglang.multimodal_gen.configs.sample.sampling_params import DataType
+from sglang.multimodal_gen.runtime.breakable_cuda_graph import (
+    prompt_padding as bcg_utils,
+)
+from sglang.multimodal_gen.runtime.breakable_cuda_graph.runner import (
+    DiffusionBreakableCudaGraphRunner,
+)
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.distributed.communication_op import (
     cfg_model_parallel_all_reduce,
@@ -799,6 +805,12 @@ class Cosmos3DenoisingStage(PipelineStage):
         self.scheduler = scheduler
         self.server_args = server_args
         self._logged_parallel_config = False
+        self._bcg_runner = None
+
+        if server_args is not None and server_args.enable_breakable_cuda_graph:
+            self._bcg_runner = DiffusionBreakableCudaGraphRunner(
+                transformer, get_local_torch_device()
+            )
         self._logged_cfg_split = False
 
         # Apply torch.compile if enabled
@@ -895,6 +907,7 @@ class Cosmos3DenoisingStage(PipelineStage):
         action_noisy_mask: torch.Tensor | None = None,
         action_fps: float | None = None,
         action_start_frame_offset: int = 1,
+        forward_batch: Req | None = None,
     ) -> torch.Tensor | tuple[torch.Tensor, ...]:
         """Run transformer forward pass.
 
@@ -911,24 +924,56 @@ class Cosmos3DenoisingStage(PipelineStage):
         """
         if current_timestep is None:
             current_timestep = int(timestep.flatten()[0].item())
-        with set_forward_context(current_timestep=current_timestep, attn_metadata=None):
-            return self.transformer(
-                hidden_states=latents,
-                encoder_hidden_states=None,  # Not used by Cosmos3
-                timestep=timestep,
-                text_ids=text_ids,
-                text_mask=text_mask,
-                fps=fps,
-                cache_key=cache_key,
-                noisy_frame_mask=noisy_frame_mask,
-                max_text_seq_len=max_text_seq_len,
-                sound_latents=sound_latents,
-                action_latents=action_latents,
-                action_domain_ids=action_domain_ids,
-                action_noisy_mask=action_noisy_mask,
-                action_fps=action_fps,
-                action_start_frame_offset=action_start_frame_offset,
-            )
+        call_kwargs = dict(
+            hidden_states=latents,
+            encoder_hidden_states=None,
+            timestep=timestep,
+            text_ids=text_ids,
+            text_mask=text_mask,
+            fps=fps,
+            cache_key=cache_key,
+            noisy_frame_mask=noisy_frame_mask,
+            max_text_seq_len=max_text_seq_len,
+            sound_latents=sound_latents,
+            action_latents=action_latents,
+            action_domain_ids=action_domain_ids,
+            action_noisy_mask=action_noisy_mask,
+            action_fps=action_fps,
+            action_start_frame_offset=action_start_frame_offset,
+        )
+        with set_forward_context(
+            current_timestep=current_timestep,
+            attn_metadata=None,
+            forward_batch=(
+                forward_batch
+                if forward_batch is not None
+                else getattr(self, "_current_forward_batch", None)
+            ),
+        ):
+            if self._bcg_runner is not None:
+                buckets = self.server_args.resolved_bcg_text_buckets()
+                if bool(
+                    getattr(
+                        (
+                            forward_batch
+                            if forward_batch is not None
+                            else getattr(self, "_current_forward_batch", None)
+                        ),
+                        "is_warmup",
+                        False,
+                    )
+                ):
+                    for bucket in buckets:
+                        self._bcg_runner.capture(
+                            **bcg_utils.select_prompt_padder(
+                                self.transformer, call_kwargs
+                            )(call_kwargs, self.transformer, (bucket,))
+                        )
+                call_kwargs = bcg_utils.select_prompt_padder(
+                    self.transformer, call_kwargs
+                )(call_kwargs, self.transformer, buckets)
+            transformer = self._bcg_runner or self.transformer
+            return transformer(**call_kwargs)
 
     def _manage_device_placement(self, server_args: ServerArgs):
         """Move transformer to GPU if CPU offload is enabled."""
@@ -961,6 +1006,7 @@ class Cosmos3DenoisingStage(PipelineStage):
 
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
         """Run the denoising loop with CFG and optional I2V conditioning."""
+        self._current_forward_batch = batch
         self._manage_device_placement(server_args)
 
         latents = batch.latents

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -156,6 +156,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_MODEL_IDS = frozenset(
         "ltx-2",
         "minimax-h3",
         "minimaxai/minimax-h3",
+        "nvidia/cosmos3-nano",
         "qwen/qwen-image",
         "qwen/qwen-image-2512",
         "qwen-image",
@@ -175,6 +176,7 @@ BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS = frozenset(
         "LTX2PipelineConfig",
         "MiniMaxH3PipelineConfig",
         "QwenImagePipelineConfig",
+        "Cosmos3Config",
         "SanaPipelineConfig",
         "ZImagePipelineConfig",
     }
@@ -597,7 +599,7 @@ class ServerArgs(DisaggServerArgsMixin):
             pipeline_config_name in BREAKABLE_CUDA_GRAPH_SUPPORTED_PIPELINE_CONFIGS
             and self._is_breakable_cuda_graph_supported_model()
         ):
-            if not self.warmup_resolutions:
+            if not self.warmup_resolutions and self.warmup_mode != "request":
                 self._default_bcg_warmup_resolution()
             return
 
@@ -1032,9 +1034,15 @@ class ServerArgs(DisaggServerArgsMixin):
         if self.warmup_resolutions is not None and self.warmup_mode in (None, "off"):
             self.warmup_mode = "request"
 
-        # BCG captures every graph during a synthetic warmup forward at startup
-        # so serving never records a fresh graph.
-        if self.enable_breakable_cuda_graph and self.disagg_role == RoleType.MONOLITHIC:
+        # BCG must capture before serving. Preserve an explicit request warmup:
+        # it is the only way to capture request-only dimensions such as the
+        # Cosmos3 image/video frame count. Otherwise use the synthetic startup
+        # warmup as the safe default.
+        if (
+            self.enable_breakable_cuda_graph
+            and self.disagg_role == RoleType.MONOLITHIC
+            and self.warmup_mode != "request"
+        ):
             self.warmup_mode = "server"
 
         # Disaggregated roles do not host the HTTP startup request. Preserve


### PR DESCRIPTION
## Summary

Enable breakable CUDA graph for Cosmos3 Nano and preserve request warmup for request-only dimensions such as frame count.

The Cosmos-specific prompt padder keeps `max_text_seq_len` consistent with the padded text mask. Warmup captures the requested text buckets before serving and forwards the current request context through the graph runner.

## B300 result

Cosmos3 Nano T2I, 1024px, 35 steps, native backend:

| mode | denoise | e2e |
|---|---:|---:|
| eager + BCG | 0.880527 s | 0.923572 s |
| torch.compile | 0.908647 s | 0.952747 s |

BCG is 3.09% faster in denoise and 3.06% faster end to end.

## Validation

- B300 Cosmos/BCG/server-args: `256 passed, 46 subtests passed`
- pre-commit: passed

Performance was measured on commit `9deb6952afa483e38f96385a375b96f463da5303`; this PR was rebased and retested on the latest main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31628635294](https://github.com/sgl-project/sglang/actions/runs/31628635294)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31630111122](https://github.com/sgl-project/sglang/actions/runs/31630111122)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->