### PR TITLE
[Diffusion][GLM-Image] Retune QK head LayerNorm for SM103

### DIFF
--- a/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
+++ b/python/sglang/kernels/ops/diffusion/triton/layernorm_modulate.py
@@ -344,7 +344,7 @@ def _is_bf16_cuda(t: torch.Tensor) -> bool:
 def _qk_head_launch_config() -> tuple[int, int]:
     arch = get_jit_cuda_arch()
     if arch.major == 10 and arch.minor == 3:
-        return 16, 1
+        return 32, 1
     if arch.major * 10 + arch.minor >= 120:
         return 8, 4
     return 64, 2
@@ -464,7 +464,7 @@ def fused_qk_head_layernorm(
     launch, bit-exact vs the eager aten kernel."""
     head_dim = q.shape[-1]
     n_rows = q.numel() // head_dim
-    # Architecture sweeps at the production GLM shape select 16 rows / 1 warp
+    # Architecture sweeps at the production GLM shape select 32 rows / 1 warp
     # on B300 (SM103) and 8 rows / 4 warps on RTX 5090 (SM120). Preserve the
     # independently tuned H100/H200 launch on all other architectures.
     rows, num_warps = _qk_head_launch_config()


### PR DESCRIPTION
## Summary

Retune the fused Q/K head LayerNorm launch for B300 / SM103 from 16 rows per program to 32 rows per program, while leaving the independent SM120 and Hopper choices unchanged.

The production GLM-Image shape is bit-exact under both launch configurations. The B300 sweep selected `ROWS=32, num_warps=1`.

## B300 result

GLM-Image, 1024px, 30 steps, native backend:

| mode | denoise | e2e |
|---|---:|---:|
| eager + BCG | 3.043391 s | 20.58473 s |
| torch.compile | 3.049033 s | 21.94464 s |

BCG is 0.18% faster in denoise. Pure eager after the retune measured 3.06985 s.

Microbenchmark at the production shape:

- current SM103 config (`ROWS=16`): 213.074 us
- candidate (`ROWS=32`): 45.035 us

Nsight Compute for the selected kernel reports 82.37% memory throughput, 28.95% compute throughput, 180 registers/thread and 11.45% achieved occupancy; the workload is bandwidth/launch-shape limited rather than compute limited.

## Validation

- B300 bit-exact QK head LayerNorm tests passed
- pre-commit: passed

Performance was measured on commit `9deb6952afa483e38f96385a375b96f463da5303`; this PR was rebased and retested on the latest main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31628641809](https://github.com/sgl-project/sglang/actions/runs/31628641809)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #31630117390](https://github.com/sgl-project/sglang/actions/runs/31630117390)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->