### PR TITLE
[ray] expose get_scheduler_actor_name so callers can look up the schedulers

### DIFF
--- a/python/sglang/srt/ray/__init__.py
+++ b/python/sglang/srt/ray/__init__.py
@@ -1,3 +1,3 @@
-from sglang.srt.ray.engine import RayEngine
+from sglang.srt.ray.engine import RayEngine, get_scheduler_actor_name
 
-__all__ = ["RayEngine"]
+__all__ = ["RayEngine", "get_scheduler_actor_name"]

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -177,24 +177,24 @@ def _validate_custom_placement_group(pg: PlacementGroup, world_size: int) -> Non
 
 def get_scheduler_actor_name(
     *,
-    pg: PlacementGroup,
-    bundle_idx: int,
     rank0_node_ip: str,
     dp_rank: int,
     pp_rank: int,
     tp_rank: int,
+    port: int,
+    bundle_idx: int,
 ) -> str:
-    """Return the Ray actor name RayEngine gives a SchedulerActor.
+    """Return the Ray actor name for a SchedulerActor.
 
-    The name is fully determined by the placement group, the bundle index and
-    the actor's ranks, so a caller that supplied the placement group can rebuild
-    it and ``ray.get_actor()`` the schedulers instead of scanning
-    ``list_named_actors``.
+    The name is fully determined by the engine's node, http port, ranks and
+    bundle index, so a caller that launched the engine can rebuild it and
+    ``ray.get_actor()`` the schedulers instead of scanning
+    ``ray.util.list_named_actors()`` for substring matches.
     """
     return (
         f"sglang_scheduler_node{rank0_node_ip}"
         f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-        f"_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+        f"_port{port}_bundle{bundle_idx}"
     )
 
 
@@ -227,12 +227,12 @@ def _create_scheduler_actor(
         num_cpus=0,
         num_gpus=1,
         name=get_scheduler_actor_name(
-            pg=pg,
-            bundle_idx=bundle_idx,
             rank0_node_ip=rank0_node_ip,
             dp_rank=dp_rank,
             pp_rank=pp_rank,
             tp_rank=tp_rank,
+            port=server_args.port,
+            bundle_idx=bundle_idx,
         ),
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,

--- a/python/sglang/srt/ray/engine.py
+++ b/python/sglang/srt/ray/engine.py
@@ -175,6 +175,29 @@ def _validate_custom_placement_group(pg: PlacementGroup, world_size: int) -> Non
         )
 
 
+def get_scheduler_actor_name(
+    *,
+    pg: PlacementGroup,
+    bundle_idx: int,
+    rank0_node_ip: str,
+    dp_rank: int,
+    pp_rank: int,
+    tp_rank: int,
+) -> str:
+    """Return the Ray actor name RayEngine gives a SchedulerActor.
+
+    The name is fully determined by the placement group, the bundle index and
+    the actor's ranks, so a caller that supplied the placement group can rebuild
+    it and ``ray.get_actor()`` the schedulers instead of scanning
+    ``list_named_actors``.
+    """
+    return (
+        f"sglang_scheduler_node{rank0_node_ip}"
+        f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
+        f"_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+    )
+
+
 def _create_scheduler_actor(
     pg: PlacementGroup,
     bundle_idx: int,
@@ -203,10 +226,13 @@ def _create_scheduler_actor(
     return SchedulerActor.options(
         num_cpus=0,
         num_gpus=1,
-        name=(
-            f"sglang_scheduler_node{rank0_node_ip}"
-            f"_dp{dp_rank}_pp{pp_rank}_tp{tp_rank}"
-            f"_pg{pg.id.hex()[:8]}_bundle{bundle_idx}"
+        name=get_scheduler_actor_name(
+            pg=pg,
+            bundle_idx=bundle_idx,
+            rank0_node_ip=rank0_node_ip,
+            dp_rank=dp_rank,
+            pp_rank=pp_rank,
+            tp_rank=tp_rank,
         ),
         scheduling_strategy=PlacementGroupSchedulingStrategy(
             placement_group=pg,


### PR DESCRIPTION
## Motivation

`RayEngine` names each `SchedulerActor`, but the name format is inlined in `_create_scheduler_actor`. A process outside the engine that wants handles to those schedulers — e.g. an RL trainer that supplied the placement group and wants to push weights straight into the scheduler actors — has no supported way to address them, and ends up scanning `ray.util.list_named_actors()` for substring matches.

## Modifications

- Extract the name format into `get_scheduler_actor_name(*, rank0_node_ip, dp_rank, pp_rank, tp_rank, port, bundle_idx)` and call it from `_create_scheduler_actor`.
- Re-export it from `sglang.srt.ray`.
- Key the name by the engine's http port instead of `_pg{hex}`. The placement-group id is only knowable inside `RayEngine`, so an external caller cannot reproduce it; the port is assigned per host, so `(node ip, port)` uniquely identifies an engine and keeps engines co-located on one node distinct.

With this, a caller that knows the node ip, ranks, port and bundle indices it handed to `RayEngine` can rebuild the name and `ray.get_actor()` directly.

Note this does change the actor names `RayEngine` produces (`_pg{hex}` → `_port{port}`). Nothing in-tree reads the names — `_create_scheduler_actor` was the only place the format appeared.

## Checklist

- [x] Format the code
- [x] No new dependencies

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31641744701](https://github.com/sgl-project/sglang/actions/runs/31641744701)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31641744995](https://github.com/sgl-project/sglang/actions/runs/31641744995)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->