### PR TITLE
Prevent Qwen3.5 MTP draft from inheriting GPTQ quantization

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1517,7 +1517,7 @@ class ModelConfig:
                         break
 
             # Verify quantization configurations.
-            if self.quantization is None:
+            if self.quantization is None and not self.is_draft_quantization_explicit:
                 self.quantization = quant_method
             elif self.quantization != quant_method:
                 # Check if the CLI-specified quantization is compatible with HF config's quant_method

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -99,6 +99,10 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         if self.is_multimodal:
             config = config.text_config
 
+        needs_quant_draft = get_spec().speculative_draft_model_quantization
+        if quant_config is not None and not needs_quant_draft:
+            quant_config = None
+
         # Deep-copy so MTP mutations below don't leak into the target's config.
         config = copy.deepcopy(config)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4192,19 +4192,11 @@ class ServerArgs:
         if envs.SGLANG_USE_MODELSCOPE.get():
             self._handle_modelscope_paths()
 
-        # In speculative scenario:
-        # - If `speculative_draft_model_quantization` is specified, the draft model uses this quantization method.
-        # - Otherwise, the draft model defaults to the same quantization as the target model.
-        if self._speculative_draft_quantization_explicitly_set is None:
-            self._speculative_draft_quantization_explicitly_set = (
-                self.speculative_draft_model_quantization is not None
-            )
-        if self.speculative_draft_model_quantization is None:
-            self.speculative_draft_model_quantization = self.quantization
+        draft_quant_was_explicit = self.speculative_draft_model_quantization is not None
 
-        # Resolve --quantization unquant before model config validation. Record
-        # the explicit opt-out so later auto-detection does not re-enable
-        # quantization.
+        # Resolve --quantization unquant before we inherit the draft quant from
+        # the target model. Otherwise an explicit `--speculative-draft-model-
+        # quantization unquant` would get overwritten by the target's quant.
         if self.quantization == "unquant":
             self.quantization = None
             self._quantization_explicitly_unset = True
@@ -4212,6 +4204,19 @@ class ServerArgs:
             self._quantization_explicitly_unset = False
         if self.speculative_draft_model_quantization == "unquant":
             self.speculative_draft_model_quantization = None
+
+        # In speculative scenario:
+        # - If `speculative_draft_model_quantization` is specified, the draft model uses this quantization method.
+        # - Otherwise, the draft model defaults to the same quantization as the target model.
+        if self._speculative_draft_quantization_explicitly_set is None:
+            self._speculative_draft_quantization_explicitly_set = (
+                draft_quant_was_explicit
+            )
+        if (
+            self.speculative_draft_model_quantization is None
+            and not self._speculative_draft_quantization_explicitly_set
+        ):
+            self.speculative_draft_model_quantization = self.quantization
 
     def _handle_modelscope_paths(self):
         """Resolve model / tokenizer / speculative-draft paths from the local

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -93,6 +93,17 @@ class TestPrepareServerArgs(CustomTestCase):
 
         self.assertFalse(reconstructed._speculative_draft_quantization_explicitly_set)
 
+    def test_unquant_draft_does_not_auto_detect_target_quant(self):
+        server_args = ServerArgs(
+            model_path="dummy",
+            quantization="gptq",
+            speculative_draft_model_quantization="unquant",
+        )
+        server_args._handle_missing_default_values()
+
+        self.assertIsNone(server_args.speculative_draft_model_quantization)
+        self.assertTrue(server_args._speculative_draft_quantization_explicitly_set)
+
     def test_config_nested_dict_args_are_json(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             f.write("mm-process-config:\n  image:\n    resize: 128\n")


### PR DESCRIPTION
## Motivation

On RTX Pro 6000 with Qwen3.5 speculative NEXTN serving, using the model from
[Qwen/Qwen3.5-35B-A3B-GPTQ-Int4](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-GPTQ-Int4), I launched the server with:

```bash
SGLANG_MAMBA_CONV_DTYPE=float16 python3 -m sglang.launch_server \
  --model-path ~/autodl-tmp/models/Qwen3.5-35B-A3B-GPTQ-Int4/ \
  --host 0.0.0.0 \
  --port 30000 \
  --quantization moe_wna16 \
  --speculative-algorithm NEXTN \
  --speculative-draft-model-path ~/autodl-tmp/models/Qwen3.5-35B-A3B-GPTQ-Int4/ \
  --speculative-draft-model-quantization unquant \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --disable-piecewise-cuda-graph \
  --max-running-requests 1 \
  --dtype float16
```

Before the fix, the draft path still inherited the target checkpoint quantization:

```text
Load weight end. elapsed=4.86 s, type=Qwen3_5ForCausalLMMTP, quant=gptq, bits=4
```

So `--speculative-draft-model-quantization unquant` was not taking effect for the Qwen3.5 MTP draft model, and the draft path could still inherit GPTQ quantization instead of staying unquantized.

This can hurt MTP quality directly. On GSM8K with speculative MTP enabled at `steps=3`, the expected accept length is around 3.5, but with this bug the observed accept length drops below 3, which means the draft model is losing a large part of its speculative benefit.

## Modifications

- Preserve explicit draft quantization intent through `ServerArgs` / `ModelConfig`.
- Prevent draft-model quantization auto-detection when `--speculative-draft-model-quantization unquant` is explicitly set.
- Add a Qwen3.5 MTP runtime fallback to avoid inheriting target checkpoint quantization.
- Add a regression test to verify the draft config stays unquantized instead of falling back to the target model quantization.

## Accuracy Tests

- Reproduced the issue on RTX Pro 6000 with Qwen3.5.
- Verified from logs that the draft model loaded as `quant=gptq, bits=4` before the fix.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31672997539](https://github.com/sgl-project/sglang/actions/runs/31672997539)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31672997420](https://github.com/sgl-project/sglang/actions/runs/31672997420)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->