### PR TITLE
[Scheduler] Concurrent chunked prefill via --long-prefill-token-threshold

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -2162,7 +2162,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             batch = self.ngram_embedding_manager.prepare_for_forward(
-                batch, chunked_req=self.chunked_req
+                batch, chunked_reqs=self.chunked_reqs
             )
             self.cur_batch_for_debug = batch
 
@@ -2201,7 +2201,7 @@ class SchedulerDisaggregationDecodeMixin:
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             batch = self.ngram_embedding_manager.prepare_for_forward(
-                batch, chunked_req=self.chunked_req
+                batch, chunked_reqs=self.chunked_reqs
             )
             self.cur_batch_for_debug = batch
             # overlap + spec + grammar is unsupported (would desync DP ranks).
@@ -2253,7 +2253,7 @@ class SchedulerDisaggregationDecodeMixin:
         # Process pending prebuilt batch: output processing + filter + merge
         new_prebuilt_batch = self.get_new_prebuilt_batch(running_batch)
         if new_prebuilt_batch:
-            assert self.chunked_req is None
+            assert not self.chunked_reqs
             self.batch_result_processor.process_batch_result_prebuilt(
                 new_prebuilt_batch
             )

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -585,7 +585,7 @@ class SchedulerDisaggregationPrefillMixin:
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             batch = self.ngram_embedding_manager.prepare_for_forward(
-                batch, chunked_req=self.chunked_req
+                batch, chunked_reqs=self.chunked_reqs
             )
             self.cur_batch_for_debug = batch
 
@@ -624,7 +624,7 @@ class SchedulerDisaggregationPrefillMixin:
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             batch = self.ngram_embedding_manager.prepare_for_forward(
-                batch, chunked_req=self.chunked_req
+                batch, chunked_reqs=self.chunked_reqs
             )
             self.cur_batch_for_debug = batch
 
@@ -774,10 +774,10 @@ class SchedulerDisaggregationPrefillMixin:
                 req.inflight_middle_chunks -= 1
 
                 # Still chunking iff its next chunk was launched: either it is
-                # still self.chunked_req, or its final chunk (extend_range
-                # reaching the end of the input) is in flight. A yielded req
-                # is neither, so do its deferred release here.
-                still_chunking = self.chunked_req is req or (
+                # still mid-prefill, or its final chunk (extend_range reaching
+                # the end of the input) is in flight. A yielded req is neither,
+                # so do its deferred release here.
+                still_chunking = req in self.chunked_reqs or (
                     req.extend_range is not None
                     and req.extend_range.end >= len(req.origin_input_ids)
                 )
@@ -1060,17 +1060,18 @@ class SchedulerDisaggregationPrefillMixin:
         running_batch: ScheduleBatch,
     ) -> None:
         chunked_req_to_exclude = set()
-        if (req := self.chunked_req) is not None:
+        yielded: List[Req] = []
+        for req in self.chunked_reqs:
             chunked_req_to_exclude.add(req)
             maybe_cache_unfinished_req(req, self.tree_cache, chunked=True)
 
             if not self.check_bootstrap(req):
                 if is_aborted(req):
                     # bootstrap failed
-                    self.chunked_req = None
+                    yielded.append(req)
                 elif self.has_bootstrapped_waiting_req():
                     # optimistic request yields to waiting requests
-                    self.chunked_req = None
+                    yielded.append(req)
                     if not self.enable_overlap:
                         self.optimistic_release_and_requeue(req)
                 # else: still bootstrapping, keep computing without sending
@@ -1083,14 +1084,16 @@ class SchedulerDisaggregationPrefillMixin:
             else:
                 self.send_kv_chunk(req)
 
-            if self.chunked_req is not None:
-                running_batch.batch_is_full = False
+        if yielded:
+            self.chunked_reqs = [r for r in self.chunked_reqs if r not in yielded]
+        if self.chunked_reqs:
+            running_batch.batch_is_full = False
 
         if last_batch and last_batch.forward_mode.is_extend():
-            if last_batch.chunked_req:
-                # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
-                # We need to discard it.
-                chunked_req_to_exclude.add(last_batch.chunked_req)
+            if last_batch.chunked_reqs:
+                # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked reqs.
+                # We need to discard them.
+                chunked_req_to_exclude.update(last_batch.chunked_reqs)
 
             last_bs = last_batch.batch_size()
             last_batch.filter_batch(chunked_req_to_exclude=list(chunked_req_to_exclude))

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -122,7 +122,7 @@ def unified_memory_disagg_move_gate(scheduler):
     transfer concludes, and for part of that lifetime the request is in NEITHER
     end's queue -- so queue emptiness alone is not enough:
 
-    - PREFILL: scheduling the final chunk clears `chunked_req` while earlier
+    - PREFILL: scheduling the final chunk drops it from `chunked_reqs` while earlier
       chunks may still be draining, and the request only reaches the inflight
       queue later, in the result path.
     - DECODE: `pop_preallocated` publishes one request's destinations and keeps

--- a/python/sglang/srt/dllm/mixin/scheduler.py
+++ b/python/sglang/srt/dllm/mixin/scheduler.py
@@ -327,7 +327,9 @@ class SchedulerDllmMixin:
             req.init_next_round_input(self.tree_cache)
             res = adder.add_one_req(
                 req,
-                has_chunked_req=True,
+                # DLLM manages its own staging queue and never claims a
+                # chunked slot from the adder.
+                num_chunked_reqs=1,
                 truncation_align_size=self.truncation_align_size,
             )
 

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -59,6 +59,7 @@ from http import HTTPStatus
 from typing import (
     TYPE_CHECKING,
     Any,
+    Collection,
     Dict,
     List,
     Literal,
@@ -1968,21 +1969,41 @@ def compute_extend_logprob_start_len(
     return min(resolved_start - prefix_len, extend_len)
 
 
-def _compute_chunked_req_next_prompt_token(
-    chunked_req: Optional[Req],
-    vocab_size: int,
-) -> Optional[int]:
+def _next_prompt_token_after_fill(req: Req, vocab_size: int) -> Optional[int]:
     """Return the next real prompt token after the fill boundary, skipping
     multimodal placeholder (hash) tokens that lie outside the model vocab."""
-    if chunked_req is None:
-        return None
-    fill_len = chunked_req.extend_range.end
-    origin_ids = chunked_req.origin_input_ids
+    fill_len = req.extend_range.end
+    origin_ids = req.origin_input_ids
     if fill_len >= len(origin_ids):
         return None
     if origin_ids[fill_len] < vocab_size:
         return int(origin_ids[fill_len])
     return None
+
+
+def _compute_chunked_next_prompt_tokens(
+    reqs: List[Req],
+    chunked_reqs: Optional[Collection[Req]],
+    vocab_size: int,
+) -> Optional[List[Optional[int]]]:
+    """Per-batch-row next prompt token, positionally aligned with ``reqs``.
+
+    Only mid-prefill requests get an entry; every other row is ``None``. EAGLE
+    uses it to keep the draft model's chain consistent across chunk boundaries
+    (see ``_eagle_prefill_tail_tokens`` and PR #26329): for a middle chunk the
+    true next token is the next *prompt* token, not the sampled one.
+
+    Returns ``None`` when no row needs a substitution, so the consumer can skip
+    the whole path.
+    """
+    if not chunked_reqs:
+        return None
+    mid_prefill = set(chunked_reqs)
+    tokens: List[Optional[int]] = [
+        _next_prompt_token_after_fill(req, vocab_size) if req in mid_prefill else None
+        for req in reqs
+    ]
+    return tokens if any(t is not None for t in tokens) else None
 
 
 @dataclasses.dataclass
@@ -2014,9 +2035,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # This is an optimization to reduce the overhead of the prefill check.
     batch_is_full: bool = False
 
-    # For chunked prefill in PP
-    chunked_req: Optional[Req] = None
-    chunked_req_next_prompt_token: Optional[int] = None
+    # For chunked prefill in PP. `chunked_reqs` holds the requests in this
+    # batch whose prefill does not finish here; `chunked_next_prompt_tokens` is
+    # positionally aligned with `reqs` (None on rows that need no substitution,
+    # and None entirely when no row does).
+    chunked_reqs: Collection[Req] = ()
+    chunked_next_prompt_tokens: Optional[List[Optional[int]]] = None
     contains_last_prefill_chunk: bool = True
 
     # For DP attention
@@ -2183,7 +2207,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         model_config: ModelConfig,
         enable_overlap: bool,
         spec_algorithm: SpeculativeAlgorithm,
-        chunked_req: Optional[Req] = None,
+        chunked_reqs: Optional[Collection[Req]] = None,
         dllm_config: Optional[DllmConfig] = None,
     ):
         return_logprob = any(req.return_logprob for req in reqs)
@@ -2204,9 +2228,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             return_hidden_states=return_hidden_states_mode.need_capture(),
             return_hidden_states_mode=return_hidden_states_mode,
             is_prefill_only=all(req.is_prefill_only for req in reqs),
-            chunked_req=chunked_req,
-            chunked_req_next_prompt_token=_compute_chunked_req_next_prompt_token(
-                chunked_req,
+            chunked_reqs=tuple(chunked_reqs or ()),
+            chunked_next_prompt_tokens=_compute_chunked_next_prompt_tokens(
+                reqs,
+                chunked_reqs,
                 model_config.vocab_size,
             ),
             dllm_config=dllm_config,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1136,7 +1136,7 @@ class PrefillAdder:
             else:
                 self.tree_cache.dec_lock_ref(last_node)
 
-    def add_one_req_ignore_eos(self, req: Req):
+    def add_one_req_ignore_eos(self, req: Req, num_chunked_reqs: int):
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
@@ -1215,6 +1215,15 @@ class PrefillAdder:
         ):
             return AddReqResult.OTHER
 
+        # The per-request ceiling composes with the ignore_eos path exactly as
+        # in add_one_req: applied before the chunked/non-chunked split, so a
+        # request under the ceiling still admits whole.
+        chunk_tokens_limit = self.rem_chunk_tokens
+        if self.long_prefill_token_threshold > 0 and chunk_tokens_limit is not None:
+            chunk_tokens_limit = min(
+                chunk_tokens_limit, self.long_prefill_token_threshold
+            )
+
         if self.dllm_config is not None:
             if self.rem_dllm_tokens <= 0:
                 return AddReqResult.OTHER
@@ -1226,8 +1235,8 @@ class PrefillAdder:
 
             self._add_dllm_req(req, 0)
         elif (
-            self.rem_chunk_tokens is None  # chunked prefill is disabled
-            or cand_extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
+            chunk_tokens_limit is None  # chunked prefill is disabled
+            or cand_extend_input_len <= chunk_tokens_limit  # it is the last chunk
         ):
             if (
                 tile_stop := self._check_prefill_tile_budget(cand_extend_input_len)
@@ -1247,11 +1256,20 @@ class PrefillAdder:
                 mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
             )
         else:
-            if self.rem_chunk_tokens <= 0:
+            if chunk_tokens_limit <= 0:
                 return AddReqResult.OTHER
 
+            # This request would be left mid-prefill. The capacity rule is the
+            # same as in add_one_req, and likewise gated on the ceiling so the
+            # disabled path is byte-identical.
+            if (
+                self.long_prefill_token_threshold > 0
+                and num_chunked_reqs >= self.max_concurrent_chunked_reqs
+            ):
+                return AddReqResult.SKIP
+
             # Chunked prefill
-            trunc_len = self.rem_chunk_tokens
+            trunc_len = chunk_tokens_limit
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
@@ -1262,12 +1280,22 @@ class PrefillAdder:
             )
             self.can_run_list.append(req)
             self.new_chunked_reqs.append(req)
+            reserving = self.long_prefill_token_threshold > 0
             self._update_prefill_budget(
                 0,
                 trunc_len,
                 0,
                 req.retracted_stain,
                 mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
+                # Reserve-to-completion, as in add_one_req: the lifetime
+                # budget carries the whole remaining prefill + decode
+                # headroom from the first chunk on.
+                reserve_total_len=cand_extend_input_len if reserving else None,
+                reserve_max_new_tokens=(
+                    min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
+                    if reserving
+                    else None
+                ),
             )
 
         return self.budget_state()
@@ -1295,7 +1323,7 @@ class PrefillAdder:
             return AddReqResult.OTHER
 
         if req.sampling_params.ignore_eos and getattr(self.tree_cache, "disable", True):
-            return self.add_one_req_ignore_eos(req)
+            return self.add_one_req_ignore_eos(req, num_chunked_reqs)
 
         # Reserve page_size for page-alignment overhead: the paged allocator may
         # consume one extra page per request (see alloc_extend), which

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -542,7 +542,10 @@ class PrefillAdder:
         self.req_states = None
         self.can_run_list = []
         self.preempt_list = []
-        self.new_chunked_req = None
+        # Requests this pass leaves mid-prefill. The scheduler carries them
+        # to the next pass; `chunked_reqs_in_batch` is the subset that actually
+        # got a chunk here (a parked request is in neither list's intersection).
+        self.new_chunked_reqs: List[Req] = []
         self.log_hit_tokens = 0
         self.reprocessed_log_hit_tokens = 0
         self.log_device_hit_tokens = 0
@@ -1187,7 +1190,7 @@ class PrefillAdder:
                 len(req.prefix_indices), len(req.prefix_indices) + trunc_len
             )
             self.can_run_list.append(req)
-            self.new_chunked_req = req
+            self.new_chunked_reqs.append(req)
             self._update_prefill_budget(
                 0,
                 trunc_len,
@@ -1199,8 +1202,18 @@ class PrefillAdder:
         return self.budget_state()
 
     def add_one_req(
-        self, req: Req, has_chunked_req: bool, truncation_align_size: Optional[int]
+        self,
+        req: Req,
+        num_chunked_reqs: int,
+        truncation_align_size: Optional[int],
     ):
+        """Admit one waiting request.
+
+        ``num_chunked_reqs`` is how many requests are already mid-prefill,
+        counting both those carried over from earlier passes and those this
+        pass has newly chunked. It bounds how many more may be left
+        mid-prefill; see ``max_concurrent_chunked_reqs``.
+        """
         # TODO support cp with multiple requests
         # Enabling context parallelism currently presents precision issues;
         # therefore, the prefill-batch setting is temporarily set to 1.
@@ -1412,7 +1425,7 @@ class PrefillAdder:
                 )
 
                 self.can_run_list.append(req)
-                self.new_chunked_req = req
+                self.new_chunked_reqs.append(req)
 
                 self._req_inc_lock_ref(req)
                 self._update_prefill_budget(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -499,6 +499,9 @@ class AddReqResult(Enum):
     CONTINUE = auto()  # Continue to add requests
     NO_TOKEN = auto()  # No token left
     OTHER = auto()  # Other reasons to stop adding requests
+    # Not admitted, but only because the mid-prefill capacity is full; later
+    # waiting requests may still fit and must keep being considered.
+    SKIP = auto()
 
 
 class PrefillAdder:
@@ -520,6 +523,8 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        long_prefill_token_threshold: int = 0,
+        max_concurrent_chunked_reqs: int = 1,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
@@ -617,6 +622,16 @@ class PrefillAdder:
         # Snapshot of scheduler waiting_queue length at the start of this
         # prefill pass. Used by PrefillDelayer's queue-based trigger.
         self.waiting_queue_len = waiting_queue_len
+
+        # Per-request prefill ceiling (vLLM's long_prefill_token_threshold):
+        # no request takes more than this many prompt tokens in one pass, so
+        # up to chunked_prefill_size // threshold requests can be mid-prefill
+        # concurrently. 0 disables the cap (one request may drain the pool).
+        self.long_prefill_token_threshold = long_prefill_token_threshold
+        # How many requests may be mid-prefill at once. Mid-prefill requests
+        # pin their computed KV and cannot be retracted, so the bound also
+        # caps the reserved-but-uncomputed KV held for them.
+        self.max_concurrent_chunked_reqs = max_concurrent_chunked_reqs
 
     def _admitted_extend_lens(self) -> List[int]:
         return [int(getattr(req, "extend_input_len", 0)) for req in self.can_run_list]
@@ -866,18 +881,34 @@ class PrefillAdder:
         mamba_gap_reserve: int = 0,
         host_hit_len: int = 0,
         storage_hit_len: int = 0,
+        reserve_total_len: Optional[int] = None,
+        reserve_max_new_tokens: Optional[int] = None,
     ):
         # TODO(lsyin): check this workaround logic, which only ensures the prefill will not out of memory, and may be too conservative
         extend_input_len = self.ceil_paged_tokens(extend_input_len)
 
         # alloc_extend reserves an extra page_size per request to make sure the budget doesn't over-commit
         page_overhead = self.page_size
+        # Reserve-to-completion: a request left mid-prefill pins its computed
+        # KV and cannot be retracted, so its whole remaining prefill (plus
+        # decode headroom) is charged to the lifetime budget at admission --
+        # not chunk by chunk -- or later admissions can consume the headroom
+        # the request needs to finish and deadlock it. The per-pass budgets
+        # (cur_rem, rem_input, rem_chunk) still see only this pass's chunk.
+        # Defaults keep the non-reserving callers byte-identical.
+        reserve_len = (
+            extend_input_len
+            if reserve_total_len is None
+            else self.ceil_paged_tokens(reserve_total_len)
+        )
+        if reserve_max_new_tokens is None:
+            reserve_max_new_tokens = max_new_tokens
         # `mamba_gap_reserve` (shared Mamba pool only; 0 otherwise) charges the new
         # mamba state's shared-gap cost to BOTH full budgets: the slot is allocated
         # immediately (counts against `cur_rem`) and held for the request lifetime
         # (counts against `rem_total`). See `_mamba_gap_budget_for_req`.
         self.rem_total_token_offset += (
-            extend_input_len + max_new_tokens + page_overhead + mamba_gap_reserve
+            reserve_len + reserve_max_new_tokens + page_overhead + mamba_gap_reserve
         )
         self.cur_rem_token_offset += (
             extend_input_len + page_overhead + mamba_gap_reserve
@@ -997,6 +1028,23 @@ class PrefillAdder:
             else AddReqResult.CONTINUE
         )
 
+    def _reserve_completion_for_parked_req(self, req: Req) -> None:
+        """Hold a parked mid-prefill request's completion reservation.
+
+        A parked request gets no chunk this pass, but it stays mid-prefill
+        with its computed KV pinned and unretractable. Its whole remaining
+        prefill (plus decode headroom) must stay charged to the lifetime
+        budget, or admissions later in this pass could consume the headroom
+        it needs to finish and deadlock it.
+        """
+        remaining = len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+        self.rem_total_token_offset += (
+            self.ceil_paged_tokens(remaining)
+            + min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
+            + self.page_size
+            + self._mamba_gap_budget_for_req(req)
+        )
+
     def add_chunked_req(self, req: Req):
         if self.dllm_config is not None:
             _rem_tokens = self._get_dllm_remain_tokens()
@@ -1011,9 +1059,23 @@ class PrefillAdder:
             # The chunked_req must be added to the list; otherwise, it will cause a memory leak.
             # Therefore, in certain cases where _rem_tokens <= 0, it should be replaced with rem_chunk_tokens.
             if _rem_tokens <= 0:
+                if self.rem_chunk_tokens <= 0 and self.long_prefill_token_threshold > 0:
+                    # The per-pass chunk pool is drained (earlier requests
+                    # took it). Park the request: it stays carried and retries
+                    # next pass when the pool refills. It is NOT appended to
+                    # can_run_list, so inflight accounting skips it.
+                    self._reserve_completion_for_parked_req(req)
+                    return req
                 if self.is_hybrid_swa:
+                    if self.long_prefill_token_threshold > 0:
+                        self._reserve_completion_for_parked_req(req)
                     return req
                 _rem_tokens = self.rem_chunk_tokens
+
+            # Per-request ceiling, applied to continued chunks as well: one
+            # carried request cannot drain the pool ahead of the others.
+            if self.long_prefill_token_threshold > 0:
+                _rem_tokens = min(_rem_tokens, self.long_prefill_token_threshold)
 
         # A mid-chunk rank prefills this pass regardless of the delayer
         # verdict, so report prefillable=True and ignore the result.
@@ -1033,6 +1095,7 @@ class PrefillAdder:
         new_len = min(cand_extend_input_len, _rem_tokens)
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
+        reserving = self.long_prefill_token_threshold > 0 and self.dllm_config is None
         self._update_prefill_budget(
             0,
             req.extend_range.length,
@@ -1043,6 +1106,14 @@ class PrefillAdder:
             ),
             req.retracted_stain,
             mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
+            # Reserve-to-completion: the lifetime budget carries the whole
+            # remaining prefill + decode headroom, not just this chunk.
+            reserve_total_len=cand_extend_input_len if reserving else None,
+            reserve_max_new_tokens=(
+                min(req.sampling_params.max_new_tokens, CLIP_MAX_NEW_TOKENS)
+                if reserving
+                else None
+            ),
         )
 
         # Return if chunked prefill not finished
@@ -1309,6 +1380,19 @@ class PrefillAdder:
                         return AddReqResult.NO_TOKEN
                     chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
 
+            if self.long_prefill_token_threshold > 0 and chunk_tokens_limit is not None:
+                # vLLM-compatible per-request ceiling: no request prefills
+                # more than the threshold in one pass, so up to
+                # chunked_prefill_size // threshold requests can be
+                # mid-prefill at once. Applied after the post-lock SWA
+                # re-check (the tighter cap wins) and before the
+                # chunked/non-chunked split, so a request whose whole
+                # remaining prompt fits under the threshold still admits
+                # whole rather than being chunked by the ceiling.
+                chunk_tokens_limit = min(
+                    chunk_tokens_limit, self.long_prefill_token_threshold
+                )
+
             # Negotiate only after every KV-budget gate (a NO_TOKEN rank must
             # report not-prefillable via finalize()) and before init_load_back
             # (a delay verdict must not start KV load-back).
@@ -1396,6 +1480,22 @@ class PrefillAdder:
                 if trunc_len <= 0:
                     return AddReqResult.OTHER
 
+                # This request would be left mid-prefill. Mid-prefill
+                # requests pin their computed KV and cannot be retracted, so
+                # their count is a hard bound. When every slot is taken,
+                # refuse only THIS request and keep scanning the queue: a
+                # shorter prompt behind it may still fit whole. (Ordered
+                # after the trunc_len check so a drained pool still stops
+                # the pass with OTHER, and gated on the ceiling so the
+                # disabled path is byte-identical -- without the ceiling the
+                # single-slot invariant holds only as a side effect of the
+                # pool being drained.)
+                if (
+                    self.long_prefill_token_threshold > 0
+                    and num_chunked_reqs >= self.max_concurrent_chunked_reqs
+                ):
+                    return AddReqResult.SKIP
+
                 # When truncation align size is set, we want to assert that the prefill prefix length is multiple of truncation align size
                 # A typical use case is when deterministic inference is enabled with flashinfer attention backend,
                 # we need the prefill prefix length to be multiple of attention split size
@@ -1428,6 +1528,7 @@ class PrefillAdder:
                 self.new_chunked_reqs.append(req)
 
                 self._req_inc_lock_ref(req)
+                reserving = self.long_prefill_token_threshold > 0
                 self._update_prefill_budget(
                     prefix_len,
                     trunc_len,
@@ -1436,6 +1537,23 @@ class PrefillAdder:
                     mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
                     host_hit_len=req.host_hit_length,
                     storage_hit_len=req.storage_hit_length,
+                    # Reserve-to-completion: the lifetime budget carries the
+                    # whole remaining prefill + decode headroom from the first
+                    # chunk on, so later admissions cannot consume the
+                    # headroom this request needs to finish.
+                    reserve_total_len=(
+                        len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+                        if reserving
+                        else None
+                    ),
+                    reserve_max_new_tokens=(
+                        min(
+                            req.sampling_params.max_new_tokens,
+                            CLIP_MAX_NEW_TOKENS,
+                        )
+                        if reserving
+                        else None
+                    ),
                 )
 
         return self.budget_state()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -25,7 +25,18 @@ from collections import deque
 from contextlib import contextmanager, nullcontext
 from functools import partial
 from http import HTTPStatus
-from typing import TYPE_CHECKING, Any, Deque, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    AbstractSet,
+    Any,
+    Deque,
+    Dict,
+    List,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
 from sglang.srt.runtime_context import (
     attention_backends,
@@ -2927,6 +2938,25 @@ class Scheduler(
     def stash_chunked_request(self, req: Req):
         maybe_cache_unfinished_req(req, self.tree_cache, chunked=True)
 
+    def _count_inflight_chunk(self, batch_reqs: AbstractSet[Req]) -> None:
+        """Mark the chunked request as having a chunk in flight this batch.
+
+        Only counts a chunk that is actually in the batch. `add_chunked_req`
+        can *park* the request instead of prefilling it -- the hybrid-SWA
+        branch returns it without appending it to `can_run_list` when the SWA
+        pool cannot fit another page. A parked request produces no forward
+        result, so `process_batch_result_prefill` never runs the matching
+        decrement; the counter would ratchet up once per pass and a request
+        stuck above zero is treated as a middle chunk forever, never appending
+        a token and never finishing.
+
+        This mirrors the parked-chunk gate on the stash path in
+        `get_next_batch_to_run` (`extend_range.end > len(prefix_indices)`),
+        which detects the same condition from the request's own state.
+        """
+        if self.chunked_req is not None and self.chunked_req in batch_reqs:
+            self.chunked_req.inflight_middle_chunks += 1
+
     def process_pending_chunked_abort(self) -> None:
         """Abort an in-flight chunked-prefill request once it is safe to do so.
 
@@ -3383,8 +3413,7 @@ class Scheduler(
             assert self.chunked_req is None
             self.chunked_req = adder.new_chunked_req
 
-        if self.chunked_req is not None:
-            self.chunked_req.inflight_middle_chunks += 1
+        self._count_inflight_chunk(can_run_set)
 
         set_time_batch(can_run_list, "set_forward_entry_time")
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1182,8 +1182,14 @@ class Scheduler(
             self.chunked_prefill_size = None
         elif self.chunked_prefill_size is not None and self.chunked_prefill_size <= 0:
             self.chunked_prefill_size = None
-        self.chunked_req = None
-        self._pending_chunked_abort_req = None
+        # Requests that are mid-prefill: admitted, partially prefilled, and
+        # carried across passes until their prefill completes. Ordered oldest
+        # first, so budget is handed out in admission order.
+        self.chunked_reqs: List[Req] = []
+        self._pending_chunked_abort_reqs: List[Req] = []
+        # Upper bound on how many requests may be mid-prefill at once. Raised
+        # above 1 only when the per-request prefill cap is enabled.
+        self.max_concurrent_chunked_reqs = 1
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and get_schedule().enable_mixed_chunk
         )
@@ -2137,7 +2143,7 @@ class Scheduler(
             get_running_batch=lambda: self.running_batch,
             get_waiting_queue=lambda: self.waiting_queue,
             get_stats=lambda: self.metrics_reporter.stats,
-            get_chunked_req=lambda: self.chunked_req,
+            get_chunked_reqs=lambda: self.chunked_reqs,
             get_disagg_prefill_bootstrap_queue=lambda: self.disagg_prefill_bootstrap_queue,
             get_disagg_prefill_inflight_queue=lambda: self.disagg_prefill_inflight_queue,
             get_disagg_decode_prealloc_queue=lambda: self.disagg_decode_prealloc_queue,
@@ -2947,73 +2953,78 @@ class Scheduler(
 
         Derived from batch membership rather than from the batch size. The
         former `len(can_run_list) != 1` was a proxy for "the chunked request is
-        the sole member" and misreads the parked case: `chunked_req` is set but
-        was not admitted to the batch (see `_count_inflight_chunk`), so the one
-        request present does finish its prefill and does consume its token.
+        the sole member" and misreads the parked case: a request is mid-prefill
+        but was not admitted to the batch (see `_count_inflight_chunk`), so the
+        one request present does finish its prefill and does consume its token.
         """
-        return any(req is not self.chunked_req for req in can_run_list)
+        mid_prefill = set(self.chunked_reqs)
+        return any(req not in mid_prefill for req in can_run_list)
 
     def _count_inflight_chunk(self, batch_reqs: AbstractSet[Req]) -> None:
-        """Mark the chunked request as having a chunk in flight this batch.
+        """Mark mid-prefill requests as having a chunk in flight this batch.
 
-        Only counts a chunk that is actually in the batch. `add_chunked_req`
-        can *park* the request instead of prefilling it -- the hybrid-SWA
-        branch returns it without appending it to `can_run_list` when the SWA
-        pool cannot fit another page. A parked request produces no forward
-        result, so `process_batch_result_prefill` never runs the matching
-        decrement; the counter would ratchet up once per pass and a request
-        stuck above zero is treated as a middle chunk forever, never appending
-        a token and never finishing.
+        Only counts chunks that are actually in the batch. `add_chunked_req`
+        can *park* a request instead of prefilling it -- the hybrid-SWA branch
+        returns it without appending it to `can_run_list` when the SWA pool
+        cannot fit another page. A parked request produces no forward result,
+        so `process_batch_result_prefill` never runs the matching decrement;
+        the counter would ratchet up once per pass and a request stuck above
+        zero is treated as a middle chunk forever, never appending a token and
+        never finishing.
 
         This mirrors the parked-chunk gate on the stash path in
         `get_next_batch_to_run` (`extend_range.end > len(prefix_indices)`),
         which detects the same condition from the request's own state.
         """
-        if self.chunked_req is not None and self.chunked_req in batch_reqs:
-            self.chunked_req.inflight_middle_chunks += 1
+        for req in self.chunked_reqs:
+            if req in batch_reqs:
+                req.inflight_middle_chunks += 1
 
     def process_pending_chunked_abort(self) -> None:
         """Abort an in-flight chunked-prefill request once it is safe to do so.
 
-        ``abort_request`` only records the target in ``_pending_chunked_abort_req``
-        (tearing it down mid-iteration is unsafe). Clearing ``chunked_req`` here at
-        the top of the scheduling step stops the next chunk from launching; the
-        chunk already launched is drained when its result is resolved. Under overlap
-        the result lands a step later, so the batch-result processors keep
-        ``inflight_middle_chunks`` accounting intact and skip the aborted chunk:
-        ``process_batch_result_disagg_prefill`` via its ``is_aborted`` drop, and
-        ``process_batch_result_prefill`` via its chunked branch (the finished req
-        is excluded from streaming and its logprob offset is still accounted).
-        Mirrors ``handle_bootstrap_failure``.
+        ``abort_request`` only records the targets in ``_pending_chunked_abort_reqs``
+        (tearing them down mid-iteration is unsafe). Dropping a request from
+        ``chunked_reqs`` here at the top of the scheduling step stops its next
+        chunk from launching; the chunk already launched is drained when its
+        result is resolved. Under overlap the result lands a step later, so the
+        batch-result processors keep ``inflight_middle_chunks`` accounting intact
+        and skip the aborted chunk: ``process_batch_result_disagg_prefill`` via
+        its ``is_aborted`` drop, and ``process_batch_result_prefill`` via its
+        chunked branch (the finished req is excluded from streaming and its
+        logprob offset is still accounted). Mirrors ``handle_bootstrap_failure``.
         """
-        req = self._pending_chunked_abort_req
-        if req is None:
-            return
-        if self.chunked_req is not req:
-            # Already past chunked prefill; the running-batch abort path handles
-            # it. Drop the marker once the request is actually gone.
-            if req.finished() or req.req_pool_idx is None:
-                self._pending_chunked_abort_req = None
+        if not self._pending_chunked_abort_reqs:
             return
 
-        prepare_abort(req, "Aborted")
-        req.time_stats.trace_ctx.abort(abort_info={"reason": "Aborted"})
-        req.to_finish = None
-        if self.disaggregation_mode == DisaggregationMode.PREFILL:
-            self.clear_pending_chunk_send(req)
-            req.disagg_kv_sender.abort()
-            maybe_release_metadata_buffer(
-                req, self.req_to_metadata_buffer_idx_allocator
-            )
-            req.pending_bootstrap = False
-        if self.enable_hicache_storage:
-            self.tree_cache.release_aborted_request(req.rid)
-        release_kv_cache(req, self.tree_cache, is_insert=False)
+        still_pending: List[Req] = []
+        for req in self._pending_chunked_abort_reqs:
+            if req not in self.chunked_reqs:
+                # Already past chunked prefill; the running-batch abort path
+                # handles it. Keep the marker until the request is really gone.
+                if not (req.finished() or req.req_pool_idx is None):
+                    still_pending.append(req)
+                continue
 
-        self.chunked_req = None
-        self._pending_chunked_abort_req = None
-        self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
-        logger.debug(f"Abort chunked prefill request. {req.rid=}")
+            prepare_abort(req, "Aborted")
+            req.time_stats.trace_ctx.abort(abort_info={"reason": "Aborted"})
+            req.to_finish = None
+            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+                self.clear_pending_chunk_send(req)
+                req.disagg_kv_sender.abort()
+                maybe_release_metadata_buffer(
+                    req, self.req_to_metadata_buffer_idx_allocator
+                )
+                req.pending_bootstrap = False
+            if self.enable_hicache_storage:
+                self.tree_cache.release_aborted_request(req.rid)
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+
+            self.chunked_reqs.remove(req)
+            self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
+            logger.debug(f"Abort chunked prefill request. {req.rid=}")
+
+        self._pending_chunked_abort_reqs = still_pending
 
     def _build_hisparse_decode_batch(self, reqs):
         """Build a ScheduleBatch for hisparse requests transitioning from staging to decode."""
@@ -3085,18 +3096,18 @@ class Scheduler(
                 else:
                     self.stash_chunked_request(req)
 
-        if self.chunked_req is not None:
-            # Move the chunked request out of the batch so that we can merge
+        for chunked_req in self.chunked_reqs:
+            # Move mid-prefill requests out of the batch so that we can merge
             # only finished requests to running_batch.
-            chunked_req_to_exclude.add(self.chunked_req)
+            chunked_req_to_exclude.add(chunked_req)
 
             # Stash (cache) the previous chunk only when it produced new KV
             # beyond what is already cached. A parked chunk (add_chunked_req
             # hybrid-SWA early-return) leaves extend_range.end ==
             # len(prefix_indices), so there is nothing new to cache and
             # stashing would be a no-op.
-            if self.chunked_req.extend_range.end > len(self.chunked_req.prefix_indices):
-                self.stash_chunked_request(self.chunked_req)
+            if chunked_req.extend_range.end > len(chunked_req.prefix_indices):
+                self.stash_chunked_request(chunked_req)
 
         # HiSparse has its own prefill-to-decode transition; skip last_batch merge.
         if self.enable_hisparse:
@@ -3116,10 +3127,10 @@ class Scheduler(
             and last_batch
             and last_batch.forward_mode.is_extend()
         ):
-            if last_batch.chunked_req is not None:
-                # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
-                # We need to discard it.
-                chunked_req_to_exclude.add(last_batch.chunked_req)
+            if last_batch.chunked_reqs:
+                # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked reqs.
+                # We need to discard them.
+                chunked_req_to_exclude.update(last_batch.chunked_reqs)
 
             if self.dllm_config is not None and last_batch.reqs:
                 chunked_req_to_exclude.update(last_batch.reqs)
@@ -3186,7 +3197,7 @@ class Scheduler(
 
         # Handle ngram embedding
         ret = self.ngram_embedding_manager.prepare_for_forward(
-            ret, chunked_req=self.chunked_req
+            ret, chunked_reqs=self.chunked_reqs
         )
 
         if ret:
@@ -3248,14 +3259,14 @@ class Scheduler(
 
         if (
             running_batch.batch_is_full or len(self.waiting_queue) == 0
-        ) and self.chunked_req is None:
+        ) and not self.chunked_reqs:
             return None, running_batch
 
         running_bs = len(running_batch.reqs)
         # Skipped during a chunked prefill: that pass must proceed regardless.
         if (
             self.min_free_slots_delayer is not None
-            and self.chunked_req is None
+            and not self.chunked_reqs
             and self.min_free_slots_delayer.should_delay(
                 running_bs=running_bs,
                 num_allocatable_reqs=self.get_num_allocatable_reqs(running_bs),
@@ -3263,14 +3274,14 @@ class Scheduler(
         ):
             return None, running_batch
 
-        # Ignore the check if self.chunked_req is not None.
-        # In the non-PP case, when self.chunked_req is not None, num_allocatable_reqs should always be greater than 0,
+        # Ignore the check if any request is mid-prefill.
+        # In the non-PP case, when a request is mid-prefill, num_allocatable_reqs should always be greater than 0,
         # as the space for the chunked requests has just been released.
         # In PP case, chunked requests (or dllm requests) can start in one microbatch and end in another microbatch, so the max_running_requests per microbatch should not be strict.
         # Instead, we should always allow chunked requests to be added, otherwise, there will be a memory leak.
         if (
             self.get_num_allocatable_reqs(running_bs) <= 0
-            and self.chunked_req is None
+            and not self.chunked_reqs
             and not self.enable_priority_preemption
         ):
             running_batch.batch_is_full = True
@@ -3287,8 +3298,12 @@ class Scheduler(
 
         # Determine chunked_prefill_size for this batch
         chunked_prefill_size = self.chunked_prefill_size
-        if self.chunked_req is not None and self.enable_dynamic_chunking:
-            history_len = len(self.chunked_req.prefix_indices)
+        if self.chunked_reqs and self.enable_dynamic_chunking:
+            # Size the batch for the request that has made the least progress:
+            # the predictor maps history length to a chunk size that keeps step
+            # time even, and the shortest history is the most expensive chunk.
+            # (Dynamic chunking is PP-only, where concurrency stays at 1.)
+            history_len = min(len(r.prefix_indices) for r in self.chunked_reqs)
             dynamic_size = self.predict_next_chunk_size(history_len)
             if dynamic_size is not None:
                 chunked_prefill_size = dynamic_size
@@ -3320,9 +3335,15 @@ class Scheduler(
             prefill_tile_block_m=prefill_tile_block_m,
         )
 
-        if self.chunked_req is not None:
-            self.chunked_req.init_next_round_input()
-            self.chunked_req = adder.add_chunked_req(self.chunked_req)
+        # Re-admit the requests carried over from earlier passes, oldest first,
+        # so the longest-waiting prefill keeps priority on the budget. A
+        # request whose prefill finishes here drops out of the carried set.
+        carried_over, self.chunked_reqs = self.chunked_reqs, []
+        for chunked_req in carried_over:
+            chunked_req.init_next_round_input()
+            still_chunked = adder.add_chunked_req(chunked_req)
+            if still_chunked is not None:
+                self.chunked_reqs.append(still_chunked)
 
         if self.enable_lora:
             running_loras = {
@@ -3374,7 +3395,7 @@ class Scheduler(
             req.init_next_round_input(self.tree_cache)
             res = adder.add_one_req(
                 req,
-                has_chunked_req=(self.chunked_req is not None),
+                num_chunked_reqs=len(self.chunked_reqs) + len(adder.new_chunked_reqs),
                 truncation_align_size=self.truncation_align_size,
             )
 
@@ -3423,10 +3444,17 @@ class Scheduler(
             for req in adder.preempt_list:
                 self._add_request_to_queue(req)
 
-        if adder.new_chunked_req is not None:
-            # Update chunked prefill
-            assert self.chunked_req is None
-            self.chunked_req = adder.new_chunked_req
+        # Requests newly left mid-prefill by this pass join the carried set.
+        # The adder never hands back more than the capacity it was given, so
+        # the bound holds without a further check here.
+        assert (
+            len(self.chunked_reqs) + len(adder.new_chunked_reqs)
+            <= self.max_concurrent_chunked_reqs
+        ), (
+            f"chunked prefill over capacity: {len(self.chunked_reqs)} carried + "
+            f"{len(adder.new_chunked_reqs)} new > {self.max_concurrent_chunked_reqs}"
+        )
+        self.chunked_reqs.extend(adder.new_chunked_reqs)
 
         self._count_inflight_chunk(can_run_set)
 
@@ -3441,7 +3469,7 @@ class Scheduler(
             self.model_config,
             self.enable_overlap,
             self.spec_algorithm,
-            chunked_req=self.chunked_req,
+            chunked_reqs=self.chunked_reqs,
         )
 
         new_batch.contains_last_prefill_chunk = self._contains_last_prefill_chunk(
@@ -3466,11 +3494,7 @@ class Scheduler(
             running_batch.reqs,
             self.enable_priority_scheduling,
             num_pending_tokens=self.load_inquirer._get_num_pending_tokens(
-                chunk_deduct=(
-                    self.chunked_req.extend_range.length
-                    if self.chunked_req is not None
-                    else 0
-                ),
+                chunk_deduct=(sum(r.extend_range.length for r in self.chunked_reqs)),
             ),
         )
 
@@ -4137,7 +4161,7 @@ class Scheduler(
         # Batch running status
         idle = (
             self.running_batch.is_empty()
-            and self.chunked_req is None
+            and not self.chunked_reqs
             and not self.dllm_manager.any_staging_reqs()
             and (self.last_batch is None or self.last_batch.is_empty())
             and (not self.enable_overlap or len(self.result_queue) == 0)
@@ -4488,9 +4512,10 @@ class Scheduler(
         return RpcReqOutput(success=success, message="" if not exec else str(exec))
 
     def abort_request(self, recv_req: AbortReq):
-        if (chunked_req := self.chunked_req) is not None:
+        for chunked_req in self.chunked_reqs:
             if recv_req.abort_all or chunked_req.rid.startswith(recv_req.rid):
-                self._pending_chunked_abort_req = chunked_req
+                if chunked_req not in self._pending_chunked_abort_reqs:
+                    self._pending_chunked_abort_reqs.append(chunked_req)
 
         # todo hisparse, release resources for abort requests in hisparse coordinator
         # Delete requests in the waiting queue
@@ -4657,13 +4682,10 @@ class Scheduler(
         ):
             retract_reqs += [r for r in self.last_batch.reqs if not r.finished()]
 
-        if (
-            self.chunked_req is not None
-            and not self.chunked_req.finished()
-            and self.chunked_req not in retract_reqs
-            and self.disaggregation_mode != DisaggregationMode.PREFILL
-        ):
-            retract_reqs.append(self.chunked_req)
+        if self.disaggregation_mode != DisaggregationMode.PREFILL:
+            for chunked_req in self.chunked_reqs:
+                if not chunked_req.finished() and chunked_req not in retract_reqs:
+                    retract_reqs.append(chunked_req)
 
         self.last_batch = None
         self.cur_batch_for_debug = None
@@ -4693,14 +4715,14 @@ class Scheduler(
             else:
                 self._add_request_to_queue(req)
         self.running_batch.batch_is_full = False
-        # In disagg-PREFILL, keep a live mid-chunk chunked_req rather than retract it:
+        # In disagg-PREFILL, keep live mid-chunk requests rather than retract them:
         # freeing its KV under a live disagg KV-sender crashes pop_bootstrapped or
         # sends freed/reused KV to decode. Kept, it resumes prefill after the pause.
         # TODO(disagg-prefill-retract): tear the sender down (abort + release metadata
         # buffer + reset pending_bootstrap) before freeing KV, then retract for real.
         # Until then a weight-update pause leaves stale-weight prefix KV (off-policy).
         if self.disaggregation_mode != DisaggregationMode.PREFILL:
-            self.chunked_req = None
+            self.chunked_reqs = []
 
         # Surface the paused state to dashboards immediately. The scheduler
         # event loop short-circuits before reaching ``on_idle`` while paused,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2938,6 +2938,21 @@ class Scheduler(
     def stash_chunked_request(self, req: Req):
         maybe_cache_unfinished_req(req, self.tree_cache, chunked=True)
 
+    def _contains_last_prefill_chunk(self, can_run_list: List[Req]) -> bool:
+        """Whether any request in this batch consumes the sampled token.
+
+        False only for a batch of pure middle chunks, whose sampled tokens
+        nobody reads -- the case that lets PP skip output communication
+        entirely (`_pp_can_skip_output_comm`).
+
+        Derived from batch membership rather than from the batch size. The
+        former `len(can_run_list) != 1` was a proxy for "the chunked request is
+        the sole member" and misreads the parked case: `chunked_req` is set but
+        was not admitted to the batch (see `_count_inflight_chunk`), so the one
+        request present does finish its prefill and does consume its token.
+        """
+        return any(req is not self.chunked_req for req in can_run_list)
+
     def _count_inflight_chunk(self, batch_reqs: AbstractSet[Req]) -> None:
         """Mark the chunked request as having a chunk in flight this batch.
 
@@ -3429,8 +3444,8 @@ class Scheduler(
             chunked_req=self.chunked_req,
         )
 
-        new_batch.contains_last_prefill_chunk = (
-            self.chunked_req is None or len(can_run_list) != 1
+        new_batch.contains_last_prefill_chunk = self._contains_last_prefill_chunk(
+            can_run_list
         )
 
         if self.enable_hierarchical_cache:
@@ -3473,6 +3488,10 @@ class Scheduler(
                 running_batch.prepare_for_decode()
                 new_batch.mix_with_running(running_batch)
                 new_batch.decoding_reqs = running_batch.reqs
+                # Decode requests are merged in after the flag was computed
+                # above, and every one of them consumes the sampled token, so
+                # the batch is no longer pure middle chunks.
+                new_batch.contains_last_prefill_chunk = True
             running_batch = ScheduleBatch(
                 reqs=[], batch_is_full=running_batch.batch_is_full
             )

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -623,6 +623,10 @@ class Scheduler(
         # Init prefill-decodedisaggregation
         self.init_disaggregation()
 
+        # Raise the mid-prefill capacity when the per-request prefill ceiling
+        # is enabled (needs dllm_config and disaggregation_mode to be set).
+        self.init_chunked_prefill_concurrency()
+
         # Init overlap schedule
         self.init_overlap()
 
@@ -1188,7 +1192,8 @@ class Scheduler(
         self.chunked_reqs: List[Req] = []
         self._pending_chunked_abort_reqs: List[Req] = []
         # Upper bound on how many requests may be mid-prefill at once. Raised
-        # above 1 only when the per-request prefill cap is enabled.
+        # above 1 only when the per-request prefill cap is enabled (see
+        # init_chunked_prefill_concurrency).
         self.max_concurrent_chunked_reqs = 1
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and get_schedule().enable_mixed_chunk
@@ -1207,6 +1212,41 @@ class Scheduler(
                     "Dynamic chunking will be disabled."
                 )
                 self.enable_dynamic_chunking = False
+
+    def init_chunked_prefill_concurrency(self):
+        """Raise the mid-prefill capacity when the per-request ceiling is on.
+
+        With long_prefill_token_threshold F > 0, one pass hands at most F
+        prompt tokens to any single request, so up to
+        chunked_prefill_size // F requests can be mid-prefill at once
+        instead of one long prompt monopolizing the prefill budget.
+
+        Concurrency stays at 1 where the single-slot invariant is still
+        load-bearing: disagg prefill (the mixin shares this state and its KV
+        transfer bookkeeping assumes one in-flight chunk), PP > 1 (microbatch
+        accounting), and dLLM (the staging queue owns its mid-prefill
+        requests). Speculative decoding needs no gate: DSpark/EAGLE track
+        per-request state and never read the slot count.
+        """
+        threshold = get_schedule().long_prefill_token_threshold
+        if (
+            threshold <= 0
+            or self.chunked_prefill_size is None
+            or self.disaggregation_mode == DisaggregationMode.PREFILL
+            or self.ps.pp_size > 1
+            or self.dllm_config is not None
+        ):
+            return
+        self.max_concurrent_chunked_reqs = max(
+            1, self.chunked_prefill_size // threshold
+        )
+        if self.max_concurrent_chunked_reqs > 1:
+            logger.info(
+                f"Concurrent chunked prefill enabled: up to "
+                f"{self.max_concurrent_chunked_reqs} requests mid-prefill "
+                f"(chunked_prefill_size={self.chunked_prefill_size}, "
+                f"long_prefill_token_threshold={threshold})."
+            )
 
     def init_metrics_reporter(
         self, tp_rank: int, pp_rank: int, dp_rank: Optional[int]
@@ -3333,6 +3373,8 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            long_prefill_token_threshold=get_schedule().long_prefill_token_threshold,
+            max_concurrent_chunked_reqs=self.max_concurrent_chunked_reqs,
         )
 
         # Re-admit the requests carried over from earlier passes, oldest first,
@@ -3428,6 +3470,10 @@ class Scheduler(
                             req.mamba_pool_idx.unsqueeze(-1)
                         )
                         req.mamba_pool_idx = None
+                if res == AddReqResult.SKIP:
+                    # Only the mid-prefill capacity is full; later waiting
+                    # requests may still fit and must keep being considered.
+                    continue
                 break
 
         if mamba_allocator is not None:

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -195,7 +195,10 @@ class SchedulerBatchResultProcessor:
         batch: ScheduleBatch,
         result: Union[GenerationBatchResult, EmbeddingBatchResult],
     ):
-        skip_stream_req = None
+        # Requests whose prefill did not finish in this batch. A batch can hold
+        # several of them (DLLM stages many at once; concurrent chunked prefill
+        # does so in general), so this is a list rather than a single request.
+        skip_stream_reqs: List[Req] = []
         self.token_to_kv_pool_allocator.free_group_begin()
 
         if self.is_generation:
@@ -307,10 +310,10 @@ class SchedulerBatchResultProcessor:
                 else:
                     # being chunked reqs' prefill is not finished
                     req.inflight_middle_chunks -= 1
-                    # There is only at most one request being currently chunked.
-                    # Because this request does not finish prefill,
-                    # we don't want to stream the request currently being chunked.
-                    skip_stream_req = req
+                    # This request did not finish prefill, so it appended no new
+                    # token: streaming it would emit a duplicate. Collect every
+                    # such request — a batch may contain more than one.
+                    skip_stream_reqs.append(req)
 
                     # Incrementally update input logprobs.
                     if batch.return_logprob:
@@ -364,7 +367,7 @@ class SchedulerBatchResultProcessor:
 
         self.token_to_kv_pool_allocator.free_group_end()
         self.output_streamer.stream_output(
-            batch.reqs, batch.return_logprob, skip_stream_req
+            batch.reqs, batch.return_logprob, skip_stream_reqs
         )
 
         can_run_cuda_graph = result.can_run_cuda_graph

--- a/python/sglang/srt/managers/scheduler_components/load_inquirer.py
+++ b/python/sglang/srt/managers/scheduler_components/load_inquirer.py
@@ -44,7 +44,7 @@ class SchedulerLoadInquirer:
     get_running_batch: Callable
     get_waiting_queue: Callable
     get_stats: Callable
-    get_chunked_req: Callable
+    get_chunked_reqs: Callable
     get_disagg_prefill_bootstrap_queue: Callable
     get_disagg_prefill_inflight_queue: Callable
     get_disagg_decode_prealloc_queue: Callable
@@ -70,9 +70,11 @@ class SchedulerLoadInquirer:
                 0 is correct.
         """
         num_pending_tokens = sum(req.seqlen for req in self.get_waiting_queue())
-        if self.get_chunked_req() is not None:
-            req = self.get_chunked_req()
-            num_pending_tokens += req.seqlen - len(req.prefix_indices) - chunk_deduct
+        for req in self.get_chunked_reqs():
+            num_pending_tokens += req.seqlen - len(req.prefix_indices)
+        # `chunk_deduct` covers the chunks already planned for this pass across
+        # all mid-prefill requests, so subtract it once.
+        num_pending_tokens -= chunk_deduct
         return num_pending_tokens
 
     def get_num_waiting_uncached_tokens(self) -> int:
@@ -83,8 +85,7 @@ class SchedulerLoadInquirer:
         for req in self.get_waiting_queue():
             # if match-in-waiting-queue disabled, this metric returns seq_lens
             num_tokens += max(0, req.seqlen - req.num_matched_prefix_tokens)
-        cr = self.get_chunked_req()
-        if cr is not None:
+        for cr in self.get_chunked_reqs():
             num_tokens += max(0, cr.seqlen - len(cr.prefix_indices))
         return num_tokens
 

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Collection,
     List,
     Optional,
 )
@@ -104,11 +105,18 @@ class SchedulerOutputStreamer:
         self,
         reqs: List[Req],
         return_logprob: bool,
-        skip_req: Optional[Req] = None,
+        skip_reqs: Collection[Req] = (),
     ):
-        """Stream the output to detokenizer."""
+        """Stream the output to detokenizer.
+
+        ``skip_reqs`` holds the requests whose prefill did not finish this batch
+        (middle chunks): they appended no new token, so streaming them would
+        emit a duplicate. It is a collection rather than a single request
+        because a batch can carry several mid-prefill requests at once — DLLM
+        already does, and concurrent chunked prefill does in general.
+        """
         if self.is_generation:
-            self._stream_output_generation(reqs, return_logprob, skip_req)
+            self._stream_output_generation(reqs, return_logprob, skip_reqs)
         else:  # embedding or reward model
             self._stream_output_embedding(reqs)
 
@@ -130,20 +138,23 @@ class SchedulerOutputStreamer:
         self,
         reqs: List[Req],
         return_logprob: bool,
-        skip_req: Optional[Req] = None,
+        skip_reqs: Collection[Req] = (),
         is_idle_batch: bool = False,
     ):
+        # Identity membership, matching the previous `is not skip_req` checks:
+        # Req defines no __eq__/__hash__, so `in` compares by identity.
+        skipped = set(skip_reqs)
         return_hidden_states = any(
-            req.return_hidden_states for req in reqs if req is not skip_req
+            req.return_hidden_states for req in reqs if req not in skipped
         )
         return_routed_experts = any(
-            req.return_routed_experts for req in reqs if req is not skip_req
+            req.return_routed_experts for req in reqs if req not in skipped
         )
         return_indexer_topk = any(
-            req.return_indexer_topk for req in reqs if req is not skip_req
+            req.return_indexer_topk for req in reqs if req not in skipped
         )
         return_sampling_mask = any(
-            req.return_sampling_mask for req in reqs if req is not skip_req
+            req.return_sampling_mask for req in reqs if req not in skipped
         )
 
         acc = _GenerationStreamAccumulator(
@@ -160,7 +171,7 @@ class SchedulerOutputStreamer:
             rust_server_mode=self.rust_server is not None,
         )
         for req in reqs:
-            if req is skip_req:
+            if req in skipped:
                 continue
             if req.finished() and req.finished_output:
                 # With the overlap schedule, a request will try to output twice and hit this line twice

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -48,12 +48,19 @@ if TYPE_CHECKING:
 
 
 def _pp_can_skip_output_comm(batch: ScheduleBatch) -> bool:
-    """Check if output send/recv can be skipped for this batch."""
+    """Check if output send/recv can be skipped for this batch.
+
+    `contains_last_prefill_chunk` is the exact condition: it is False only when
+    no request in the batch consumes the sampled token. The former
+    `len(batch.reqs) == 1` term was a proxy for the same thing, back when the
+    flag itself was derived from the batch size; it is now redundant, and
+    keeping it would suppress the optimization for any batch of several middle
+    chunks.
+    """
     return (
         envs.SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM.get()
         and batch is not None
         and batch.forward_mode == ForwardMode.EXTEND
-        and len(batch.reqs) == 1
         and not batch.contains_last_prefill_chunk
         and not batch.return_logprob
     )

--- a/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
+++ b/python/sglang/srt/model_executor/model_runner_components/ngram_embedding_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Collection, Optional
 
 import torch
 
@@ -91,7 +91,7 @@ class NgramEmbeddingManager:
         self,
         batch: Optional[ScheduleBatch],
         *,
-        chunked_req: Optional[Req],
+        chunked_reqs: Collection[Req] = (),
     ) -> Optional[ScheduleBatch]:
         """Fill the token table for ngram embedding before a forward pass."""
         if batch is None or not self.enabled:
@@ -131,12 +131,13 @@ class NgramEmbeddingManager:
                 ),
                 ignore_tokens=None,
             )
-            # Mark the chunked (not-yet-finished) prefill request so sample()
-            # skips writing its pseudo next-token into the ngram token table.
-            # Use self.chunked_req identity (not req.is_chunked) to avoid
+            # Mark the chunked (not-yet-finished) prefill requests so sample()
+            # skips writing their pseudo next-token into the ngram token table.
+            # Use scheduler-tracked identity (not req.is_chunked) to avoid
             # overlap-scheduling timing issues.
-            if chunked_req is not None:
-                skip_token_table_update = [req is chunked_req for req in batch.reqs]
+            if chunked_reqs:
+                mid_prefill = set(chunked_reqs)
+                skip_token_table_update = [req in mid_prefill for req in batch.reqs]
                 batch.ne_skip_token_table_update = (
                     torch.tensor(
                         skip_token_table_update, dtype=torch.bool, device=device

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -803,6 +803,11 @@ class ServerArgs:
         "The maximum number of tokens in a chunk for the chunked prefill. Setting this to -1 means disabling chunked prefill.",
         NS("schedule"),
     ] = None
+    long_prefill_token_threshold: A[
+        int,
+        "For chunked prefill, the maximum number of prompt tokens a single request may prefill in one scheduled pass. Requests with a longer remaining prompt are prefilled in chunks of at most this size, so up to chunked_prefill_size // threshold requests can be mid-prefill concurrently instead of one long prompt monopolizing the prefill budget. 0 (default) disables the cap: a single request may consume the whole chunked_prefill_size budget. Mirrors vLLM's --long-prefill-token-threshold.",
+        NS("schedule"),
+    ] = 0
     enable_dynamic_chunking: A[
         bool,
         "Enable dynamic chunk size adjustment for pipeline parallelism. When enabled, chunk sizes are dynamically calculated based on fitted function to maintain consistent execution time across chunks.",
@@ -3659,6 +3664,7 @@ class ServerArgs:
         self._handle_kv4_compatibility()
         self._handle_mxfp8_kv_cache_compatibility()
         self._handle_page_size()
+        self._handle_long_prefill_token_threshold()
         self._handle_amd_specifics()
         self._handle_nccl_pre_warm()
         self._handle_grammar_backend()
@@ -6111,6 +6117,20 @@ class ServerArgs:
         )
 
         run_post_process_pass(self, _page_size_default)
+
+    def _handle_long_prefill_token_threshold(self):
+        if self.long_prefill_token_threshold < 0:
+            raise ValueError(
+                "--long-prefill-token-threshold must be >= 0, got "
+                f"{self.long_prefill_token_threshold}."
+            )
+        if self.long_prefill_token_threshold > 0 and (
+            self.chunked_prefill_size is None or self.chunked_prefill_size <= 0
+        ):
+            raise ValueError(
+                "--long-prefill-token-threshold requires chunked prefill to be "
+                "enabled (chunked_prefill_size > 0)."
+            )
 
     def _handle_amd_specifics(self):
         if is_hip():

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -23,6 +23,7 @@ from sglang.srt.utils import (
     is_hip,
     is_musa,
     is_npu,
+    is_pin_memory_available,
     is_xpu,
 )
 from sglang.srt.utils.async_probe import maybe_detect_oob
@@ -87,16 +88,25 @@ def _eagle_prefill_tail_tokens(
     """Per-seq tail token for EAGLE prefill rotation; uses next prompt token for
     non-final chunks (chunked-prefill chain consistency, see PR #26329)."""
     tail_tokens = next_token_ids.to(batch.input_ids.dtype)
-    next_prompt_token = batch.chunked_req_next_prompt_token
-    if next_prompt_token is not None:
-        for i, r in enumerate(batch.reqs):
-            if r is batch.chunked_req:
-                tail_tokens = tail_tokens.clone()
-                # Keep the scalar as a kernel argument. Assigning a Python scalar
-                # through scalar indexing issues a pageable H2D copy and
-                # synchronizes the current CUDA stream before draft extend.
-                tail_tokens[i : i + 1].fill_(next_prompt_token)
-                break
+    next_prompt_tokens = batch.chunked_next_prompt_tokens
+    if next_prompt_tokens is not None:
+        rows = [i for i, tok in enumerate(next_prompt_tokens) if tok is not None]
+        if rows:
+            tail_tokens = tail_tokens.clone()
+            # One pinned, non-blocking H2D copy for all substituted rows.
+            # Assigning Python scalars through indexing would issue a pageable
+            # copy per row and synchronize the current CUDA stream before draft
+            # extend.
+            pin = is_pin_memory_available(tail_tokens.device)
+            index = torch.tensor(rows, dtype=torch.int64, pin_memory=pin).to(
+                tail_tokens.device, non_blocking=True
+            )
+            values = torch.tensor(
+                [next_prompt_tokens[i] for i in rows],
+                dtype=tail_tokens.dtype,
+                pin_memory=pin,
+            ).to(tail_tokens.device, non_blocking=True)
+            tail_tokens.index_copy_(0, index, values)
     return tail_tokens
 
 

--- a/python/sglang/test/scripted_runtime/context/queries.py
+++ b/python/sglang/test/scripted_runtime/context/queries.py
@@ -9,8 +9,7 @@ if TYPE_CHECKING:
 
 def _get_all_reqs(ctx: ScriptedContext) -> Iterator[Req]:
     s = ctx.scheduler
-    if s.chunked_req is not None:
-        yield s.chunked_req
+    yield from s.chunked_reqs
     yield from s.waiting_queue
     if s.ps.pp_size > 1:
         for mb in (*s.mbs, *s.last_mbs, *s.running_mbs):
@@ -29,8 +28,8 @@ def list_active_reqs(ctx: ScriptedContext) -> List[Req]:
 
 def batch_composition(ctx: ScriptedContext) -> Dict[str, List[str]]:
     s = ctx.scheduler
-    chunked_rid = s.chunked_req.rid if s.chunked_req is not None else None
-    chunked = [chunked_rid] if chunked_rid is not None else []
+    chunked_rids = {r.rid for r in s.chunked_reqs}
+    chunked = sorted(chunked_rids)
     running = (
         [r.rid for r in s.running_batch.reqs] if s.running_batch is not None else []
     )
@@ -40,7 +39,7 @@ def batch_composition(ctx: ScriptedContext) -> Dict[str, List[str]]:
     batch = s.last_batch
     if batch is not None and not batch.is_empty() and batch.forward_mode is not None:
         bucket = prefill if batch.forward_mode.is_extend() else decode
-        bucket.extend(r.rid for r in batch.reqs if r.rid != chunked_rid)
+        bucket.extend(r.rid for r in batch.reqs if r.rid not in chunked_rids)
 
     return {
         "prefill": prefill,
@@ -53,7 +52,7 @@ def batch_composition(ctx: ScriptedContext) -> Dict[str, List[str]]:
 def is_idle(ctx: ScriptedContext) -> bool:
     s = ctx.scheduler
     return (
-        s.chunked_req is None
+        not s.chunked_reqs
         and len(s.waiting_queue) == 0
         and (s.running_batch is None or s.running_batch.is_empty())
     )
@@ -98,7 +97,7 @@ def is_finished(ctx: ScriptedContext, rid: str) -> bool:
 
 def is_chunking(ctx: ScriptedContext, rid: str) -> bool:
     s = ctx.scheduler
-    return s.chunked_req is not None and s.chunked_req.rid == rid
+    return any(r.rid == rid for r in s.chunked_reqs)
 
 
 def status(ctx: ScriptedContext, rid: str) -> str:
@@ -122,11 +121,11 @@ def remaining_prompt_tokens(ctx: ScriptedContext, rid: str) -> int:
 
 def chunks_done(ctx: ScriptedContext, rid: str) -> int:
     log = ctx._scheduler_hook._batch_log
-    held = sum(1 for record in log if record.chunked_rid == rid and rid in record.rids)
+    held = sum(1 for record in log if rid in record.chunked_rids and rid in record.rids)
     if held == 0:
         return 0
     completed = any(
-        rid in record.extend_rids and record.chunked_rid != rid for record in log
+        rid in record.extend_rids and rid not in record.chunked_rids for record in log
     )
     return held + (1 if completed else 0)
 
@@ -135,5 +134,5 @@ def chunked_parks(ctx: ScriptedContext, rid: str) -> int:
     return sum(
         1
         for record in ctx._scheduler_hook._batch_log
-        if record.chunked_rid == rid and rid not in record.rids
+        if rid in record.chunked_rids and rid not in record.rids
     )

--- a/python/sglang/test/scripted_runtime/scheduler_hook.py
+++ b/python/sglang/test/scripted_runtime/scheduler_hook.py
@@ -49,7 +49,7 @@ class ScriptedBatchRecord:
     mode: Optional[str]
     rids: Tuple[str, ...]
     extend_rids: Tuple[str, ...]
-    chunked_rid: Optional[str]
+    chunked_rids: Tuple[str, ...]
 
 
 def _drive_engine_through_warmup(ctx: ScriptedContext) -> Generator:
@@ -185,7 +185,6 @@ class ScriptedSchedulerHook:
     def on_run_batch(self, batch) -> None:
         if not self._is_driver:
             return
-        chunked = self.scheduler.chunked_req
         self._batch_log.append(
             ScriptedBatchRecord(
                 forward_iter=batch.forward_iter,
@@ -200,7 +199,7 @@ class ScriptedSchedulerHook:
                     if batch.forward_mode is not None and batch.forward_mode.is_extend()
                     else ()
                 ),
-                chunked_rid=chunked.rid if chunked is not None else None,
+                chunked_rids=tuple(r.rid for r in self.scheduler.chunked_reqs),
             )
         )
 

--- a/python/sglang/test/scripted_runtime_chunked_helpers.py
+++ b/python/sglang/test/scripted_runtime_chunked_helpers.py
@@ -109,7 +109,7 @@ def advance_to_nth_chunk(r, target_chunk: int, *, max_steps: int = DEFAULT_MAX_S
     # Drive until the hook has recorded `target_chunk` chunked-prefill batches.
     # chunks_done is accumulated from on_run_batch (every forward batch), so it
     # never misses a chunk the way sampling the instantaneous is_chunking flag
-    # once per yield can: on the step the req leaves chunked_req, is_chunking is
+    # once per yield can: on the step the req leaves chunked_reqs, is_chunking is
     # already False, so `seen` undercounted and the req could race to completion
     # on slower CI before the loop caught up.
     for _ in range(max_steps):

--- a/test/manual/chunked_prefill/test_scripted_abort.py
+++ b/test/manual/chunked_prefill/test_scripted_abort.py
@@ -449,18 +449,18 @@ class TestAbortBasic(ScriptedTestCase):
             prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2, prompt_token=250
         )
         yield from run_until(r, lambda h: h.is_chunking)
-        assert (1 if t.scheduler.chunked_req is not None else 0) == 1
+        assert (len(t.scheduler.chunked_reqs)) == 1
 
         t.abort(r)
         yield from _drain_until_released(t, r)
 
         for _ in range(12):
-            if t.scheduler.chunked_req is None and t.is_idle:
+            if not t.scheduler.chunked_reqs and t.is_idle:
                 break
             yield
 
         assert r.kv_pages == 0
-        assert (1 if t.scheduler.chunked_req is not None else 0) == 0
+        assert (len(t.scheduler.chunked_reqs)) == 0
         assert t.is_idle, "engine must be idle after the only chunked req is aborted"
 
     def test_chunked_req_then_abort_then_new_short_in_one_yield(self):
@@ -475,19 +475,17 @@ class TestAbortBasic(ScriptedTestCase):
         )
         yield from run_until(r1, lambda h: h.is_chunking)
         assert (
-            t.scheduler.chunked_req.rid if t.scheduler.chunked_req is not None else None
+            t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
         ) == r1.rid, (
             f"r1 should hold the chunked slot before abort; got "
-            f"{(t.scheduler.chunked_req.rid if t.scheduler.chunked_req is not None else None)!r}"
+            f"{(t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None)!r}"
         )
 
         t.abort(r1)
         r2 = t.start_req(prompt_len=16, max_new_tokens=2)
         yield from _drain_until_released(t, r1)
 
-        cur = (
-            t.scheduler.chunked_req.rid if t.scheduler.chunked_req is not None else None
-        )
+        cur = t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
         assert cur != r1.rid, f"chunked slot still points to aborted r1; got {cur!r}"
         assert r1.kv_pages == 0
         yield from run_until_finished(r2)
@@ -533,7 +531,7 @@ class TestAbortBasic(ScriptedTestCase):
             prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2, prompt_token=281
         )
         yield from run_until(r1, lambda h: h.is_chunking)
-        assert (1 if t.scheduler.chunked_req is not None else 0) == 1
+        assert (len(t.scheduler.chunked_reqs)) == 1
 
         t.abort(r1)
         yield from _drain_until_released(t, r1)

--- a/test/manual/chunked_prefill/test_scripted_invariants.py
+++ b/test/manual/chunked_prefill/test_scripted_invariants.py
@@ -393,16 +393,16 @@ class TestInvariantsBasic(ScriptedTestCase):
     def _script_chunked_in_flight_count_exactly_zero_after_finish(t: ScriptedContext):
         r = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         yield from run_until(r, lambda h: h.is_chunking)
-        assert (1 if t.scheduler.chunked_req is not None else 0) == 1, (
+        assert (len(t.scheduler.chunked_reqs)) == 1, (
             f"chunked_in_flight_count should be 1 mid-chunk; got "
-            f"{(1 if t.scheduler.chunked_req is not None else 0)}"
+            f"{(len(t.scheduler.chunked_reqs))}"
         )
         yield from run_until_finished(r)
         for _ in range(3):
             yield
-            assert (1 if t.scheduler.chunked_req is not None else 0) == 0, (
+            assert (len(t.scheduler.chunked_reqs)) == 0, (
                 f"chunked_in_flight_count must be 0 after finish; got "
-                f"{(1 if t.scheduler.chunked_req is not None else 0)}"
+                f"{(len(t.scheduler.chunked_reqs))}"
             )
 
     def test_extend_batch_idx_monotonic_invariant(self):
@@ -480,9 +480,7 @@ class TestInvariantsBasic(ScriptedTestCase):
             s = t.scheduler
             req = t.find_req_by_rid(r.rid)
             cur_inflight = req.inflight_middle_chunks if req is not None else 0
-            cur_is_chunked_slot = (
-                s.chunked_req is not None and s.chunked_req.rid == r.rid
-            )
+            cur_is_chunked_slot = any(cr.rid == r.rid for cr in s.chunked_reqs)
             cur_finished = req.finished() if req is not None else True
             if cur_inflight < prev_inflight:
                 observed_decrement = True

--- a/test/manual/chunked_prefill/test_scripted_multi_req.py
+++ b/test/manual/chunked_prefill/test_scripted_multi_req.py
@@ -197,7 +197,7 @@ class TestMultiReqBasic(ScriptedTestCase):
         r1 = t.start_req(prompt_len=16, max_new_tokens=2, rid="reuse-200")
         yield from run_until_finished(r1)
         for _ in range(200):
-            assert (1 if t.scheduler.chunked_req is not None else 0) == 0
+            assert (len(t.scheduler.chunked_reqs)) == 0
             yield
         r2 = t.start_req(prompt_len=16, max_new_tokens=2, rid="reuse-200")
         yield from run_until_finished(r2)
@@ -234,9 +234,7 @@ class TestMultiReqBasic(ScriptedTestCase):
         r2 = t.start_req(prompt_len=16, max_new_tokens=4)
         for _ in range(DEFAULT_MAX_STEPS):
             assert (
-                t.scheduler.chunked_req.rid
-                if t.scheduler.chunked_req is not None
-                else None
+                t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
             ) is None
             if r1.finished and r2.finished:
                 break
@@ -251,7 +249,7 @@ class TestMultiReqBasic(ScriptedTestCase):
         chunked = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         shorts = [t.start_req(prompt_len=16, max_new_tokens=2) for _ in range(5)]
         for _ in range(DEFAULT_MAX_STEPS * 5):
-            assert (1 if t.scheduler.chunked_req is not None else 0) <= 1
+            assert (len(t.scheduler.chunked_reqs)) <= 1
             if chunked.finished and all(s.finished for s in shorts):
                 break
             yield
@@ -317,11 +315,9 @@ class TestMultiReqBasic(ScriptedTestCase):
         reqs = [t.start_req(prompt_len=4, max_new_tokens=8) for _ in range(10)]
         for _ in range(DEFAULT_MAX_STEPS * 3):
             assert (
-                t.scheduler.chunked_req.rid
-                if t.scheduler.chunked_req is not None
-                else None
+                t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
             ) is None, "pure decode workload must never populate chunked_req"
-            assert (1 if t.scheduler.chunked_req is not None else 0) == 0
+            assert (len(t.scheduler.chunked_reqs)) == 0
             if all(r.finished for r in reqs):
                 return
             yield
@@ -358,7 +354,7 @@ class TestMultiReqBasic(ScriptedTestCase):
         r2 = t.start_req(prompt_len=VERY_LONG_PROMPT_LEN, max_new_tokens=2)
         for _ in range(DEFAULT_MAX_STEPS * 5):
             s = t.scheduler
-            chunked = s.chunked_req
+            chunked = s.chunked_reqs[0] if s.chunked_reqs else None
             running = s.running_batch
             if chunked is not None and running is not None:
                 assert chunked not in running.reqs, (

--- a/test/manual/chunked_prefill/test_scripted_radix.py
+++ b/test/manual/chunked_prefill/test_scripted_radix.py
@@ -300,7 +300,7 @@ class TestRadixNoTailChunked(ScriptedTestCase):
 
         observed_mid_chunk: bool = False
         for _ in range(800):
-            req = s.chunked_req
+            req = s.chunked_reqs[0] if s.chunked_reqs else None
             if req is not None and req.rid == r.rid:
                 observed_mid_chunk = True
                 prefix_len: int = len(req.prefix_indices)
@@ -457,7 +457,7 @@ class TestRadixPartialPage(ScriptedTestCase):
         yield from run_until(r, lambda h: h.is_chunking and h.chunks_done >= 1)
 
         for _ in range(800):
-            req = s.chunked_req
+            req = s.chunked_reqs[0] if s.chunked_reqs else None
             if req is not None and req.rid == r.rid:
                 prefix_len: int = len(req.prefix_indices)
                 protected_len: int = req.cache_protected_len

--- a/test/manual/chunked_prefill/test_scripted_regression.py
+++ b/test/manual/chunked_prefill/test_scripted_regression.py
@@ -285,7 +285,7 @@ class TestRegressionBasic(ScriptedTestCase):
             f"f38e69f87d: pause(retract) must re-queue the retracted "
             f"chunked-resume req; got status={r.status!r}"
         )
-        assert t.scheduler.chunked_req is None
+        assert not t.scheduler.chunked_reqs
         assert t.scheduler.running_batch.is_empty()
 
         t.continue_generation()
@@ -311,7 +311,7 @@ class TestRegressionBasic(ScriptedTestCase):
             f"{len(t.scheduler.running_batch.reqs)}"
         )
         assert (
-            t.scheduler.chunked_req.rid if t.scheduler.chunked_req is not None else None
+            t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
         ) is None
         for r in (r1, r2):
             assert r.status == "waiting"

--- a/test/manual/chunked_prefill/test_scripted_special_case.py
+++ b/test/manual/chunked_prefill/test_scripted_special_case.py
@@ -20,7 +20,7 @@ from sglang.test.scripted_runtime_chunked_helpers import (
 
 def _load_inquirer_pending_for_rid(t: ScriptedContext, rid: str) -> int:
     s = t.scheduler
-    chunked = s.chunked_req
+    chunked = s.chunked_reqs[0] if s.chunked_reqs else None
     if chunked is not None and chunked.rid == rid:
         return chunked.seqlen - len(chunked.prefix_indices)
     for req in s.waiting_queue:
@@ -98,13 +98,13 @@ class TestSpecialCaseBasic(ScriptedTestCase):
 
         t.abort(r)
         for _ in range(12):
-            if t.scheduler.chunked_req is None and r.kv_pages == 0 and r.lock_refs == 0:
+            if not t.scheduler.chunked_reqs and r.kv_pages == 0 and r.lock_refs == 0:
                 break
             yield
 
         assert (
-            t.scheduler.chunked_req is None
-        ), f"abort must clear the chunked slot; got {t.scheduler.chunked_req!r}"
+            not t.scheduler.chunked_reqs
+        ), f"abort must clear the chunked slot; got {t.scheduler.chunked_reqs!r}"
         assert r.kv_pages == 0
         assert r.lock_refs == 0
 
@@ -121,8 +121,8 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         for _ in range(DEFAULT_MAX_STEPS):
             if r.is_chunking:
                 cur = (
-                    t.scheduler.chunked_req.rid
-                    if t.scheduler.chunked_req is not None
+                    t.scheduler.chunked_reqs[0].rid
+                    if t.scheduler.chunked_reqs
                     else None
                 )
                 assert cur in (None, r.rid), (
@@ -137,7 +137,7 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         assert r.finished
         assert saw_match, "getter must return r.rid at least once while r.is_chunking"
         assert (
-            t.scheduler.chunked_req.rid if t.scheduler.chunked_req is not None else None
+            t.scheduler.chunked_reqs[0].rid if t.scheduler.chunked_reqs else None
         ) is None
 
     @unittest.skip(
@@ -258,8 +258,8 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         yield
 
         assert (
-            t.scheduler.chunked_req is None
-        ), f"pause(retract) must clear chunked_req; got {t.scheduler.chunked_req!r}"
+            not t.scheduler.chunked_reqs
+        ), f"pause(retract) must clear chunked_req; got {t.scheduler.chunked_reqs!r}"
         assert not r.finished, "retract must re-queue r, not finish or abort it"
         assert r.status == "waiting", (
             f"retracted chunked req must return to the waiting queue; "
@@ -324,7 +324,7 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         saw_chunking = False
         saw_dedup = False
         for _ in range(DEFAULT_MAX_STEPS):
-            chunked = t.scheduler.chunked_req
+            chunked = t.scheduler.chunked_reqs[0] if t.scheduler.chunked_reqs else None
             if r.is_chunking and chunked is not None and chunked.rid == r.rid:
                 saw_chunking = True
                 pending = _load_inquirer_pending_for_rid(t, r.rid)
@@ -366,7 +366,7 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         yield from run_until(r, lambda h: h.is_chunking)
         saw_chunking = False
         for _ in range(DEFAULT_MAX_STEPS):
-            chunked = s.chunked_req
+            chunked = s.chunked_reqs[0] if s.chunked_reqs else None
             if r.is_chunking and chunked is not None and chunked.rid == r.rid:
                 assert len(s.waiting_queue) == 0, (
                     "test requires an empty waiting_queue so the chunked req is "
@@ -401,7 +401,7 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         yield from run_until(r, lambda h: h.is_chunking)
         saw_chunking = False
         for _ in range(DEFAULT_MAX_STEPS):
-            chunked = s.chunked_req
+            chunked = s.chunked_reqs[0] if s.chunked_reqs else None
             if (
                 r.is_chunking
                 and chunked is not None
@@ -517,8 +517,8 @@ class TestSpecialCaseBasic(ScriptedTestCase):
         assert r.finished
         assert saw_chunking, "req should have occupied the chunked_req slot mid-chunk"
         assert (
-            s.chunked_req is None
-        ), f"chunked_req slot must clear after last chunk; got {s.chunked_req!r}"
+            not s.chunked_reqs
+        ), f"chunked_req slot must clear after last chunk; got {s.chunked_reqs!r}"
 
     def test_second_chunked_admit_blocked_when_chunked_req_set(self):
         self.server.execute_script(

--- a/test/registered/chunked_prefill/test_scripted_core_4gpu.py
+++ b/test/registered/chunked_prefill/test_scripted_core_4gpu.py
@@ -74,7 +74,7 @@ class TestScriptedPpChunkSweep(ScriptedTestCase):
                 mb is not None and not mb.is_empty() for mb in scheduler.mbs
             )
             queues_clear = (
-                scheduler.chunked_req is None
+                not scheduler.chunked_reqs
                 and len(scheduler.waiting_queue) == 0
                 and all(x.is_empty() for x in scheduler.running_mbs)
                 and (

--- a/test/registered/chunked_prefill/test_scripted_swa_1gpu.py
+++ b/test/registered/chunked_prefill/test_scripted_swa_1gpu.py
@@ -87,7 +87,7 @@ class TestScriptedSwaChunkedReqEarlyReturn(ScriptedTestCase):
         t.abort_all()
         for _ in range(_DRAIN_STEPS):
             if (
-                s.chunked_req is None
+                not s.chunked_reqs
                 and len(s.waiting_queue) == 0
                 and s.running_batch.is_empty()
             ):

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -237,7 +237,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.running_batch = MagicMock()
         scheduler.running_batch.is_empty.return_value = True
-        scheduler.chunked_req = None
+        scheduler.chunked_reqs = []
         scheduler.dllm_manager = MagicMock()
         scheduler.dllm_manager.any_staging_reqs.return_value = False
         scheduler.last_batch = None

--- a/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
+++ b/test/registered/unit/disaggregation/test_unified_memory_move_gate.py
@@ -5,13 +5,13 @@ exposed to the peer from the moment its address is published until the transfer
 concludes, and for part of that lifetime the request sits in NEITHER end's
 queue. Both cases below are exactly those windows: an earlier version of the
 predicates looked only at `disagg_prefill_inflight_queue` /
-`disagg_decode_transfer_queue` (plus `scheduler.chunked_req`) and returned True
+`disagg_decode_transfer_queue` (plus `scheduler.chunked_reqs`) and returned True
 here, letting compaction move pages under in-flight RDMA -- silent KV
 corruption with no crash.
 """
 
 import unittest
-from typing import List, Optional, Set
+from typing import List, Set
 
 from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
@@ -51,7 +51,7 @@ class _FakePreallocQueue:
 class _FakeScheduler:
     def __init__(self, mode: DisaggregationMode):
         self.disaggregation_mode = mode
-        self.chunked_req: Optional[object] = None
+        self.chunked_reqs: List[object] = []
         self.disagg_prefill_inflight_queue: List[object] = []
         self.disagg_prefill_pending_chunk_rids: Set[str] = set()
         self.disagg_decode_transfer_queue = _FakeTransferQueue()
@@ -86,22 +86,22 @@ class TestDecodeMoveGate(CustomTestCase):
 
 class TestPrefillMoveGate(CustomTestCase):
     def test_closed_after_final_chunk_clears_chunked_req(self):
-        """Scheduling the final chunk clears `scheduler.chunked_req`, but the
+        """Scheduling the final chunk clears `scheduler.chunked_reqs`, but the
         request only reaches `disagg_prefill_inflight_queue` later in the result
         path. Earlier middle chunks may still be draining in that window, so the
-        gate must not key off `chunked_req` alone.
+        gate must not key off `chunked_reqs` alone.
         """
         scheduler = _FakeScheduler(DisaggregationMode.PREFILL)
         gate = unified_memory_disagg_move_gate(scheduler)
         self.assertTrue(gate(), "idle prefill node should allow compaction")
 
         # A middle chunk went out for rid "r0".
-        scheduler.chunked_req = object()
+        scheduler.chunked_reqs = [object()]
         scheduler.disagg_prefill_pending_chunk_rids.add("r0")
         self.assertFalse(gate())
 
-        # Final chunk scheduled: chunked_req cleared, not yet inflight-queued.
-        scheduler.chunked_req = None
+        # Final chunk scheduled: chunked_reqs cleared, not yet inflight-queued.
+        scheduler.chunked_reqs = []
         self.assertFalse(scheduler.disagg_prefill_inflight_queue)
         self.assertFalse(gate())
 
@@ -123,12 +123,12 @@ class TestPrefillMoveGate(CustomTestCase):
         scheduler = _FakeScheduler(DisaggregationMode.PREFILL)
         gate = unified_memory_disagg_move_gate(scheduler)
 
-        scheduler.chunked_req = object()
+        scheduler.chunked_reqs = [object()]
         scheduler.disagg_prefill_pending_chunk_rids.add("r0")
         self.assertFalse(gate())
 
-        # Aborted mid-chunking: chunked_req dropped, no final send, never queued.
-        scheduler.chunked_req = None
+        # Aborted mid-chunking: chunked_reqs dropped, no final send, never queued.
+        scheduler.chunked_reqs = []
         scheduler.disagg_prefill_pending_chunk_rids.discard("r0")
         self.assertTrue(gate(), "abort cleanup must let compaction resume")
 

--- a/test/registered/unit/managers/test_contains_last_prefill_chunk.py
+++ b/test/registered/unit/managers/test_contains_last_prefill_chunk.py
@@ -1,0 +1,150 @@
+"""`contains_last_prefill_chunk` must mean "some request here consumes the
+sampled token".
+
+The flag gates the PP output-communication skip: a batch of nothing but middle
+chunks produces tokens nobody reads, so the send/recv can be dropped. It used
+to be derived from the batch size (`len(can_run_list) != 1`), which is only a
+proxy for "the chunked request is the sole member" and misreads the parked case
+-- `chunked_req` set but absent from the batch, so the request that *is* there
+does finish its prefill and does consume the token.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_pp_mixin import _pp_can_skip_output_comm
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _Req:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return self.name
+
+
+class _Batch:
+    """Minimal stand-in for ScheduleBatch as _pp_can_skip_output_comm reads it."""
+
+    def __init__(self, *, reqs, contains_last_prefill_chunk):
+        self.reqs = reqs
+        self.contains_last_prefill_chunk = contains_last_prefill_chunk
+        self.forward_mode = ForwardMode.EXTEND
+        self.return_logprob = False
+
+
+def _flag(chunked_req, can_run_list) -> bool:
+    """Run the scheduler's real derivation."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.chunked_req = chunked_req
+    return Scheduler._contains_last_prefill_chunk(scheduler, can_run_list)
+
+
+class TestContainsLastPrefillChunk(CustomTestCase):
+    def test_pure_middle_chunk_batch_is_false(self):
+        # The only member is the chunked request: nothing consumes the token,
+        # which is the case the PP skip exists for.
+        chunked = _Req("chunked")
+        self.assertFalse(_flag(chunked, [chunked]))
+
+    def test_chunked_req_alongside_others_is_true(self):
+        chunked, other = _Req("chunked"), _Req("other")
+        self.assertTrue(_flag(chunked, [chunked, other]))
+
+    def test_no_chunked_req_is_true(self):
+        self.assertTrue(_flag(None, [_Req("a")]))
+        self.assertTrue(_flag(None, [_Req("a"), _Req("b")]))
+
+    def test_parked_chunked_req_is_true(self):
+        # Regression. `chunked_req` is set but was parked -- it is not in the
+        # batch, so the single request present finishes its prefill and
+        # consumes the sampled token. The old size-based derivation returned
+        # False here, so PP would skip output comm and leave that request with
+        # placeholder zeros instead of its token.
+        chunked, present = _Req("parked"), _Req("present")
+        self.assertTrue(_flag(chunked, [present]))
+
+    def test_matches_size_derivation_except_when_parked(self):
+        # Equivalence sweep against the previous derivation, showing the only
+        # behavior change is the parked case.
+        def old(chunked_req, can_run_list):
+            return chunked_req is None or len(can_run_list) != 1
+
+        chunked, a, b = _Req("chunked"), _Req("a"), _Req("b")
+        for chunked_req, can_run_list in [
+            (None, [a]),
+            (None, [a, b]),
+            (chunked, [chunked]),
+            (chunked, [chunked, a]),
+            (chunked, [chunked, a, b]),
+            (chunked, [a, b]),  # parked, but >1 member: both say True
+        ]:
+            with self.subTest(chunked=chunked_req, batch=can_run_list):
+                self.assertEqual(
+                    old(chunked_req, can_run_list), _flag(chunked_req, can_run_list)
+                )
+
+        # The single divergence: parked, exactly one other request.
+        self.assertFalse(old(chunked, [a]))
+        self.assertTrue(_flag(chunked, [a]))
+
+
+class TestPPSkipOutputComm(CustomTestCase):
+    """The consumer: dropping the `len(batch.reqs) == 1` proxy must not let the
+    skip fire for a batch that has a finishing request in it."""
+
+    def setUp(self):
+        super().setUp()
+        patcher = patch(
+            "sglang.srt.managers.scheduler_pp_mixin.envs."
+            "SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM.get",
+            return_value=True,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_skips_pure_middle_chunk_batch(self):
+        batch = _Batch(reqs=[_Req("chunk")], contains_last_prefill_chunk=False)
+        self.assertTrue(_pp_can_skip_output_comm(batch))
+
+    def test_skips_multi_middle_chunk_batch(self):
+        # Newly reachable: with the size proxy gone, a batch of several middle
+        # chunks is also pure and can skip. Under a single chunked slot this
+        # cannot arise, so it is a no-op today.
+        batch = _Batch(reqs=[_Req("c1"), _Req("c2")], contains_last_prefill_chunk=False)
+        self.assertTrue(_pp_can_skip_output_comm(batch))
+
+    def test_does_not_skip_when_a_request_finishes(self):
+        batch = _Batch(reqs=[_Req("done")], contains_last_prefill_chunk=True)
+        self.assertFalse(_pp_can_skip_output_comm(batch))
+
+    def test_does_not_skip_mixed_chunk_batch(self):
+        # Mixed chunk merges decode requests in after the flag is computed, and
+        # the scheduler sets the flag True there; those requests consume tokens.
+        batch = _Batch(
+            reqs=[_Req("chunk"), _Req("decode")], contains_last_prefill_chunk=True
+        )
+        self.assertFalse(_pp_can_skip_output_comm(batch))
+
+    def test_does_not_skip_when_logprobs_requested(self):
+        batch = _Batch(reqs=[_Req("chunk")], contains_last_prefill_chunk=False)
+        batch.return_logprob = True
+        self.assertFalse(_pp_can_skip_output_comm(batch))
+
+    def test_does_not_skip_decode_batch(self):
+        batch = _Batch(reqs=[_Req("d")], contains_last_prefill_chunk=False)
+        batch.forward_mode = ForwardMode.DECODE
+        self.assertFalse(_pp_can_skip_output_comm(batch))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_contains_last_prefill_chunk.py
+++ b/test/registered/unit/managers/test_contains_last_prefill_chunk.py
@@ -42,10 +42,10 @@ class _Batch:
         self.return_logprob = False
 
 
-def _flag(chunked_req, can_run_list) -> bool:
+def _flag(chunked_reqs, can_run_list) -> bool:
     """Run the scheduler's real derivation."""
     scheduler = Scheduler.__new__(Scheduler)
-    scheduler.chunked_req = chunked_req
+    scheduler.chunked_reqs = list(chunked_reqs)
     return Scheduler._contains_last_prefill_chunk(scheduler, can_run_list)
 
 
@@ -54,15 +54,15 @@ class TestContainsLastPrefillChunk(CustomTestCase):
         # The only member is the chunked request: nothing consumes the token,
         # which is the case the PP skip exists for.
         chunked = _Req("chunked")
-        self.assertFalse(_flag(chunked, [chunked]))
+        self.assertFalse(_flag([chunked], [chunked]))
 
     def test_chunked_req_alongside_others_is_true(self):
         chunked, other = _Req("chunked"), _Req("other")
-        self.assertTrue(_flag(chunked, [chunked, other]))
+        self.assertTrue(_flag([chunked], [chunked, other]))
 
     def test_no_chunked_req_is_true(self):
-        self.assertTrue(_flag(None, [_Req("a")]))
-        self.assertTrue(_flag(None, [_Req("a"), _Req("b")]))
+        self.assertTrue(_flag([], [_Req("a")]))
+        self.assertTrue(_flag([], [_Req("a"), _Req("b")]))
 
     def test_parked_chunked_req_is_true(self):
         # Regression. `chunked_req` is set but was parked -- it is not in the
@@ -71,7 +71,7 @@ class TestContainsLastPrefillChunk(CustomTestCase):
         # False here, so PP would skip output comm and leave that request with
         # placeholder zeros instead of its token.
         chunked, present = _Req("parked"), _Req("present")
-        self.assertTrue(_flag(chunked, [present]))
+        self.assertTrue(_flag([chunked], [present]))
 
     def test_matches_size_derivation_except_when_parked(self):
         # Equivalence sweep against the previous derivation, showing the only
@@ -90,12 +90,13 @@ class TestContainsLastPrefillChunk(CustomTestCase):
         ]:
             with self.subTest(chunked=chunked_req, batch=can_run_list):
                 self.assertEqual(
-                    old(chunked_req, can_run_list), _flag(chunked_req, can_run_list)
+                    old(chunked_req, can_run_list),
+                    _flag([] if chunked_req is None else [chunked_req], can_run_list),
                 )
 
         # The single divergence: parked, exactly one other request.
         self.assertFalse(old(chunked, [a]))
-        self.assertTrue(_flag(chunked, [a]))
+        self.assertTrue(_flag([chunked], [a]))
 
 
 class TestPPSkipOutputComm(CustomTestCase):

--- a/test/registered/unit/managers/test_output_streamer_skip_reqs.py
+++ b/test/registered/unit/managers/test_output_streamer_skip_reqs.py
@@ -1,0 +1,130 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.managers.scheduler_components.output_streamer import (
+    SchedulerOutputStreamer,
+)
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _Req:
+    """Minimal stand-in for Req. Deliberately defines no __eq__/__hash__ so
+    membership tests compare by identity, exactly as the real Req does."""
+
+    def __init__(self, rid: str):
+        self.rid = rid
+        self.return_hidden_states = False
+        self.return_routed_experts = False
+        self.return_indexer_topk = False
+        self.return_sampling_mask = False
+        self.finished_output = None
+
+    def finished(self):
+        return False
+
+
+def _make_streamer() -> SchedulerOutputStreamer:
+    # The dataclass is slots=True, so instance attributes cannot be added or
+    # patched after construction; build it through the real constructor.
+    return SchedulerOutputStreamer(
+        send_to_detokenizer=MagicMock(),
+        tree_cache=MagicMock(),
+        ps=MagicMock(dp_rank=0, attn_tp_rank=0),
+        server_args=MagicMock(),
+        is_generation=True,
+        spec_algorithm=MagicMock(),
+        disaggregation_mode=MagicMock(),
+        enable_hicache_storage=lambda: False,
+        rust_server=None,
+    )
+
+
+def _accepted_rids(reqs, skip_reqs) -> list[str]:
+    """Run the generation stream path and report which reqs were streamed."""
+    streamer = _make_streamer()
+    accepted = []
+    acc = MagicMock()
+    acc.accept.side_effect = lambda req: accepted.append(req.rid)
+    acc.to_payload.return_value = None
+
+    with patch(
+        "sglang.srt.managers.scheduler_components.output_streamer."
+        "_GenerationStreamAccumulator",
+        return_value=acc,
+    ), patch.object(
+        SchedulerOutputStreamer, "_maybe_log_time_stats", lambda self, *, req: None
+    ):
+        streamer._stream_output_generation(reqs, False, skip_reqs)
+    return accepted
+
+
+class TestOutputStreamerSkipReqs(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        # _stream_output_generation reads the published serving bag
+        # (stream_interval); publish defaults for the whole test.
+        self._ctx = get_context().override_server_args()
+        self._ctx.__enter__()
+        self.addCleanup(lambda: self._ctx.__exit__(None, None, None))
+
+    def test_skips_every_mid_prefill_request(self):
+        # Regression: `skip_req` used to be a single Req, so with several
+        # mid-prefill requests in one batch only the last was suppressed and the
+        # rest were streamed despite having appended no new token. DLLM already
+        # stages many chunked requests at once, so this fired in production.
+        reqs = [_Req("chunk-a"), _Req("chunk-b"), _Req("done")]
+        accepted = _accepted_rids(reqs, skip_reqs=[reqs[0], reqs[1]])
+        self.assertEqual(accepted, ["done"])
+
+    def test_no_skips_streams_everything(self):
+        reqs = [_Req("a"), _Req("b")]
+        self.assertEqual(_accepted_rids(reqs, skip_reqs=[]), ["a", "b"])
+
+    def test_single_skip_matches_previous_behavior(self):
+        # The old scalar case must be unchanged.
+        reqs = [_Req("a"), _Req("mid"), _Req("b")]
+        accepted = _accepted_rids(reqs, skip_reqs=[reqs[1]])
+        self.assertEqual(accepted, ["a", "b"])
+
+    def test_skip_is_by_identity_not_equality(self):
+        # Two distinct requests could compare equal under a future __eq__;
+        # skipping must remove only the exact object handed in.
+        keep = _Req("same-rid")
+        skip = _Req("same-rid")
+        accepted = _accepted_rids([keep, skip], skip_reqs=[skip])
+        self.assertEqual(len(accepted), 1)
+
+    def test_flags_ignore_skipped_requests(self):
+        # The return_* flags drive payload allocation; a skipped request must
+        # not switch them on, or the payload reserves space nothing fills.
+        mid = _Req("mid")
+        mid.return_hidden_states = True
+        plain = _Req("plain")
+        streamer = _make_streamer()
+
+        captured = {}
+
+        def _capture(**kwargs):
+            captured.update(kwargs)
+            acc = MagicMock()
+            acc.to_payload.return_value = None
+            return acc
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.output_streamer."
+            "_GenerationStreamAccumulator",
+            side_effect=_capture,
+        ), patch.object(
+            SchedulerOutputStreamer, "_maybe_log_time_stats", lambda self, *, req: None
+        ):
+            streamer._stream_output_generation([mid, plain], False, [mid])
+
+        self.assertFalse(captured["return_hidden_states"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -408,7 +408,7 @@ class TestPrefillAdder(CustomTestCase):
         req1.sampling_params.ignore_eos = False
 
         result1 = adder.add_one_req(
-            req1, has_chunked_req=False, truncation_align_size=None
+            req1, num_chunked_reqs=0, truncation_align_size=None
         )
 
         self.assertEqual(len(adder.can_run_list), 1)
@@ -441,7 +441,7 @@ class TestPrefillAdder(CustomTestCase):
         req2.sampling_params.ignore_eos = False
 
         result2 = adder2.add_one_req(
-            req2, has_chunked_req=False, truncation_align_size=None
+            req2, num_chunked_reqs=0, truncation_align_size=None
         )
 
         self.assertEqual(len(adder2.can_run_list), 1)
@@ -457,7 +457,7 @@ class TestPrefillAdder(CustomTestCase):
         req3.sampling_params.ignore_eos = False
 
         result3 = adder2.add_one_req(
-            req3, has_chunked_req=False, truncation_align_size=None
+            req3, num_chunked_reqs=0, truncation_align_size=None
         )
 
         self.assertEqual(len(adder2.can_run_list), 2)
@@ -601,15 +601,13 @@ class TestPrefillAdder(CustomTestCase):
         # Pre-fix: a constant sliding-window reservation rejects the resume.
         with patch.object(adder, "_swa_reserved_tokens", return_value=WINDOW + PAGE):
             self.assertIs(
-                adder.add_one_req(
-                    req, has_chunked_req=False, truncation_align_size=None
-                ),
+                adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None),
                 AddReqResult.NO_TOKEN,
             )
         self.assertEqual(len(adder.can_run_list), 0)
 
         # Fix: min(extend + decode, window) reservation admits it.
-        adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
         self.assertIn(req, adder.can_run_list)
 
     def test_swa_new_tokens_clamps_remaining_not_total(self):
@@ -652,7 +650,7 @@ class TestPrefillAdder(CustomTestCase):
 
         result = adder.add_one_req(
             self._create_delayer_req(50),
-            has_chunked_req=False,
+            num_chunked_reqs=0,
             truncation_align_size=None,
         )
 
@@ -682,7 +680,7 @@ class TestPrefillAdder(CustomTestCase):
 
         result = adder.add_one_req(
             self._create_delayer_req(50),
-            has_chunked_req=False,
+            num_chunked_reqs=0,
             truncation_align_size=None,
         )
 
@@ -699,7 +697,7 @@ class TestPrefillAdder(CustomTestCase):
 
         result = adder.add_one_req(
             self._create_delayer_req(50),
-            has_chunked_req=False,
+            num_chunked_reqs=0,
             truncation_align_size=None,
         )
 
@@ -714,9 +712,7 @@ class TestPrefillAdder(CustomTestCase):
         adder = self._create_delayer_adder(available_tokens=100_000, delayer=delayer)
         req = self._create_delayer_req(50)
 
-        result = adder.add_one_req(
-            req, has_chunked_req=False, truncation_align_size=None
-        )
+        result = adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
 
         self.assertEqual(result, AddReqResult.CONTINUE)
         self.assertEqual(delayer.calls, [True])

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -886,6 +886,206 @@ class TestPrefillAdder(CustomTestCase):
             )._swa_req_never_fits(**req)
         )
 
+    # ---- long_prefill_token_threshold: concurrent chunked prefill ----
+    # The ceiling caps how many prompt tokens one request takes per pass, so
+    # up to chunked_prefill_size // threshold requests can be mid-prefill at
+    # once. Mid-prefill requests pin their computed KV and cannot be
+    # retracted, so admission reserves each one's FULL remaining prefill +
+    # decode headroom against the lifetime budget from the first chunk on.
+
+    def _create_long_req(self, rid, num_tokens, max_new_tokens=8):
+        req = self.create_mock_req(rid, priority=0, max_new_tokens=max_new_tokens)
+        req.full_untruncated_fill_ids = list(range(num_tokens))
+        req.last_node = MagicMock()
+        req.sampling_params.ignore_eos = False
+        req.set_extend_range = MagicMock(
+            side_effect=lambda start, end: setattr(
+                req, "extend_range", Range(start, end)
+            )
+        )
+        return req
+
+    def _create_concurrency_adder(
+        self, *, kv_tokens, chunk_pool, threshold, capacity
+    ) -> PrefillAdder:
+        self.mock_token_allocator.available_size.return_value = kv_tokens
+        return self.create_adder(
+            self.create_running_batch(),
+            page_size=1,
+            rem_chunk_tokens=chunk_pool,
+            rem_input_tokens=100_000_000,
+            long_prefill_token_threshold=threshold,
+            max_concurrent_chunked_reqs=capacity,
+        )
+
+    def test_threshold_chunks_new_long_req_at_ceiling(self):
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_long_req("long", 5000)
+
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+
+        req.set_extend_range.assert_called_once_with(0, 2048)
+        self.assertIn(req, adder.new_chunked_reqs)
+        self.assertIn(req, adder.can_run_list)
+
+    def test_threshold_admits_whole_req_under_ceiling(self):
+        # The ceiling is applied before the chunked/non-chunked split, so a
+        # request whose whole remaining prompt fits under it is NOT chunked.
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_long_req("short", 1000)
+
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+
+        req.set_extend_range.assert_called_once_with(0, 1000)
+        self.assertNotIn(req, adder.new_chunked_reqs)
+        self.assertIn(req, adder.can_run_list)
+
+    def test_capacity_allows_budget_over_threshold_concurrent_reqs(self):
+        # B // F requests each get exactly F tokens in one pass; the request
+        # that would exceed the capacity is refused with SKIP (not OTHER), so
+        # the scheduler keeps scanning the queue behind it. The pool is twice
+        # the aggregate take so the SKIP is attributable to capacity alone --
+        # a drained pool would return OTHER first (see the F=0 test below).
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=16384, threshold=2048, capacity=4
+        )
+        reqs = [self._create_long_req(f"long{i}", 5000) for i in range(4)]
+        for i, req in enumerate(reqs):
+            adder.add_one_req(req, num_chunked_reqs=i, truncation_align_size=None)
+
+        for req in reqs:
+            req.set_extend_range.assert_called_once_with(0, 2048)
+        self.assertEqual(len(adder.new_chunked_reqs), 4)
+
+        fifth = self._create_long_req("long4", 5000)
+        res = adder.add_one_req(fifth, num_chunked_reqs=4, truncation_align_size=None)
+        self.assertIs(res, AddReqResult.SKIP)
+        self.assertNotIn(fifth, adder.can_run_list)
+        fifth.set_extend_range.assert_not_called()
+
+    def test_capacity_full_skips_long_but_admits_short(self):
+        # The QoS property: with every mid-prefill slot taken by long
+        # prompts, a short prompt behind them still schedules whole instead
+        # of starving behind their remaining chunks.
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=2
+        )
+        carried = [self._create_long_req(f"carried{i}", 9000) for i in range(2)]
+        for req in carried:
+            self.assertIs(adder.add_chunked_req(req), req)
+        # Pool is now 8192 - 2*2048 = 4096 with both slots taken.
+
+        long_req = self._create_long_req("long", 5000)
+        res = adder.add_one_req(
+            long_req, num_chunked_reqs=2, truncation_align_size=None
+        )
+        self.assertIs(res, AddReqResult.SKIP)
+        self.assertNotIn(long_req, adder.can_run_list)
+
+        short_req = self._create_long_req("short", 1000)
+        adder.add_one_req(short_req, num_chunked_reqs=2, truncation_align_size=None)
+        short_req.set_extend_range.assert_called_once_with(0, 1000)
+        self.assertIn(short_req, adder.can_run_list)
+
+    def test_carried_chunked_req_capped_at_threshold(self):
+        # One carried request cannot drain the pool ahead of the others.
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_long_req("carried", 9000)
+
+        self.assertIs(adder.add_chunked_req(req), req)
+        req.set_extend_range.assert_called_once_with(0, 2048)
+
+        # Contrast: without the ceiling the same request takes the whole pool.
+        adder0 = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=0, capacity=1
+        )
+        req0 = self._create_long_req("carried", 9000)
+        self.assertIs(adder0.add_chunked_req(req0), req0)
+        req0.set_extend_range.assert_called_once_with(0, 8192)
+
+    def test_parked_carried_req_holds_completion_reservation(self):
+        # A carried request that finds the per-pass pool drained is parked:
+        # it stays mid-prefill (returned), gets no chunk, and its whole
+        # remaining prefill + decode headroom stays charged to the lifetime
+        # budget so later admissions cannot consume the headroom it needs.
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=0, threshold=2048, capacity=4
+        )
+        req = self._create_long_req("carried", 9000, max_new_tokens=8)
+        offset_before = adder.rem_total_token_offset
+
+        self.assertIs(adder.add_chunked_req(req), req)
+
+        self.assertNotIn(req, adder.can_run_list)
+        req.set_extend_range.assert_not_called()
+        self.assertEqual(adder.rem_total_token_offset - offset_before, 9000 + 8 + 1)
+
+        # Without the ceiling the same drained pool force-adds a zero-length
+        # chunk (stock behavior preserved on the disabled path).
+        adder0 = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=0, threshold=0, capacity=1
+        )
+        req0 = self._create_long_req("carried", 9000)
+        self.assertIs(adder0.add_chunked_req(req0), req0)
+        self.assertIn(req0, adder0.can_run_list)
+
+    def test_reserve_to_completion_blocks_second_long_req(self):
+        # Two 10K-token prompts in a 20K-token KV pool. With the ceiling on,
+        # the first chunked request reserves its full remaining prefill +
+        # decode headroom (10_009), so the second fails the KV gate. Without
+        # the ceiling only the chunk (8193) is charged and the second admits
+        # into the reserved headroom -- the mid-prefill deadlock class.
+        kv = 20_000
+        adder = self._create_concurrency_adder(
+            kv_tokens=kv, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req_a = self._create_long_req("a", 10_000, max_new_tokens=8)
+        adder.add_one_req(req_a, num_chunked_reqs=0, truncation_align_size=None)
+        self.assertIn(req_a, adder.new_chunked_reqs)
+        self.assertEqual(adder.rem_total_tokens, kv - 10_009)
+
+        req_b = self._create_long_req("b", 10_000, max_new_tokens=8)
+        res = adder.add_one_req(req_b, num_chunked_reqs=1, truncation_align_size=None)
+        self.assertIs(res, AddReqResult.NO_TOKEN)
+        self.assertNotIn(req_b, adder.can_run_list)
+
+        adder0 = self._create_concurrency_adder(
+            kv_tokens=kv, chunk_pool=8192, threshold=0, capacity=1
+        )
+        req_a0 = self._create_long_req("a", 10_000, max_new_tokens=8)
+        adder0.add_one_req(req_a0, num_chunked_reqs=0, truncation_align_size=None)
+        self.assertIn(req_a0, adder0.new_chunked_reqs)
+        self.assertEqual(adder0.rem_total_tokens, kv - 8193)
+        # The second request passes the KV gate under stock accounting (it
+        # then stops on the drained per-pass pool, retrying next pass while
+        # holding no reservation).
+        req_b0 = self._create_long_req("b", 10_000, max_new_tokens=8)
+        res0 = adder0.add_one_req(
+            req_b0, num_chunked_reqs=1, truncation_align_size=None
+        )
+        self.assertIsNot(res0, AddReqResult.NO_TOKEN)
+
+    def test_threshold_disabled_drained_pool_returns_other_not_skip(self):
+        # F=0 byte-identity: the capacity check is gated on the ceiling and
+        # ordered after the trunc_len check, so a drained pool stops the pass
+        # with OTHER exactly as stock -- never SKIP.
+        adder = self._create_concurrency_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=0, capacity=1
+        )
+        carried = self._create_long_req("carried", 9000)
+        self.assertIs(adder.add_chunked_req(carried), carried)  # drains the pool
+
+        req = self._create_long_req("long", 5000)
+        res = adder.add_one_req(req, num_chunked_reqs=1, truncation_align_size=None)
+        self.assertIs(res, AddReqResult.OTHER)
+        self.assertNotIn(req, adder.can_run_list)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -1086,6 +1086,92 @@ class TestPrefillAdder(CustomTestCase):
         self.assertIs(res, AddReqResult.OTHER)
         self.assertNotIn(req, adder.can_run_list)
 
+    # ---- ceiling composition with the ignore_eos path ----
+    # With the radix cache disabled, ignore_eos requests bypass add_one_req
+    # entirely (add_one_req_ignore_eos). The ceiling, the capacity check, and
+    # the completion reservation must hold there too, or two long ignore_eos
+    # prompts would overflow the mid-prefill capacity and trip the
+    # scheduler's adoption assert.
+
+    def _create_ignore_eos_adder(
+        self, *, kv_tokens, chunk_pool, threshold, capacity
+    ) -> PrefillAdder:
+        self.mock_tree_cache.disable = True
+        return self._create_concurrency_adder(
+            kv_tokens=kv_tokens,
+            chunk_pool=chunk_pool,
+            threshold=threshold,
+            capacity=capacity,
+        )
+
+    def _create_ignore_eos_req(self, rid, num_tokens, max_new_tokens=8):
+        req = self._create_long_req(rid, num_tokens, max_new_tokens)
+        req.sampling_params.ignore_eos = True
+        # add_req_state reads origin_input_ids, an instance attribute the
+        # spec=Req mock does not auto-provide.
+        req.origin_input_ids = list(range(num_tokens))
+        return req
+
+    def test_ignore_eos_chunked_at_ceiling(self):
+        adder = self._create_ignore_eos_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_ignore_eos_req("long", 5000)
+
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+
+        req.set_extend_range.assert_called_once_with(0, 2048)
+        self.assertIn(req, adder.new_chunked_reqs)
+
+    def test_ignore_eos_under_ceiling_admits_whole(self):
+        adder = self._create_ignore_eos_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_ignore_eos_req("short", 1000)
+
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+
+        req.set_extend_range.assert_called_once_with(0, 1000)
+        self.assertNotIn(req, adder.new_chunked_reqs)
+
+    def test_ignore_eos_capacity_full_skips(self):
+        adder = self._create_ignore_eos_adder(
+            kv_tokens=1_000_000, chunk_pool=16384, threshold=2048, capacity=2
+        )
+        for i in range(2):
+            req = self._create_ignore_eos_req(f"long{i}", 5000)
+            adder.add_one_req(req, num_chunked_reqs=i, truncation_align_size=None)
+        self.assertEqual(len(adder.new_chunked_reqs), 2)
+
+        third = self._create_ignore_eos_req("long2", 5000)
+        res = adder.add_one_req(third, num_chunked_reqs=2, truncation_align_size=None)
+        self.assertIs(res, AddReqResult.SKIP)
+        self.assertNotIn(third, adder.can_run_list)
+        third.set_extend_range.assert_not_called()
+
+    def test_ignore_eos_reserves_to_completion(self):
+        kv = 20_000
+        adder = self._create_ignore_eos_adder(
+            kv_tokens=kv, chunk_pool=8192, threshold=2048, capacity=4
+        )
+        req = self._create_ignore_eos_req("a", 10_000, max_new_tokens=8)
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+        self.assertIn(req, adder.new_chunked_reqs)
+        self.assertEqual(adder.rem_total_tokens, kv - 10_009)
+
+    def test_ignore_eos_threshold_disabled_takes_whole_pool(self):
+        # F=0 byte-identity on the ignore_eos path: one request takes the
+        # whole pool, exactly as stock.
+        adder = self._create_ignore_eos_adder(
+            kv_tokens=1_000_000, chunk_pool=8192, threshold=0, capacity=1
+        )
+        req = self._create_ignore_eos_req("long", 9000)
+
+        adder.add_one_req(req, num_chunked_reqs=0, truncation_align_size=None)
+
+        req.set_extend_range.assert_called_once_with(0, 8192)
+        self.assertIn(req, adder.new_chunked_reqs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_scheduler_chunked_concurrency.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_concurrency.py
@@ -1,0 +1,136 @@
+"""Capacity resolution and flag validation for concurrent chunked prefill.
+
+``--long-prefill-token-threshold F`` caps how many prompt tokens one request
+takes per scheduled pass, so up to ``chunked_prefill_size // F`` requests can
+be mid-prefill at once. ``Scheduler.init_chunked_prefill_concurrency``
+resolves that capacity and pins it to 1 where the single-slot invariant is
+still load-bearing (disagg prefill, PP > 1, dLLM).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+class TestLongPrefillTokenThresholdValidation(CustomTestCase):
+    """The validation handler runs after model-specific defaults resolve
+    ``chunked_prefill_size`` (a threshold without chunked prefill is only
+    known-invalid then), which is past the dummy-model early return in
+    ``__post_init__`` -- so these call the handler directly."""
+
+    def _args(self, *, threshold, chunked_prefill_size) -> ServerArgs:
+        args = ServerArgs(model_path="dummy")
+        args.long_prefill_token_threshold = threshold
+        args.chunked_prefill_size = chunked_prefill_size
+        return args
+
+    def test_negative_threshold_rejected(self):
+        with self.assertRaises(ValueError):
+            self._args(
+                threshold=-1, chunked_prefill_size=8192
+            )._handle_long_prefill_token_threshold()
+
+    def test_threshold_requires_chunked_prefill(self):
+        for chunk in (None, -1, 0):
+            with self.subTest(chunked_prefill_size=chunk):
+                with self.assertRaises(ValueError):
+                    self._args(
+                        threshold=2048, chunked_prefill_size=chunk
+                    )._handle_long_prefill_token_threshold()
+
+    def test_threshold_with_chunked_prefill_accepted(self):
+        args = self._args(threshold=2048, chunked_prefill_size=8192)
+        args._handle_long_prefill_token_threshold()
+        self.assertEqual(args.long_prefill_token_threshold, 2048)
+
+    def test_default_disabled(self):
+        args = ServerArgs(model_path="dummy")
+        self.assertEqual(args.long_prefill_token_threshold, 0)
+        args._handle_long_prefill_token_threshold()
+
+
+class TestInitChunkedPrefillConcurrency(CustomTestCase):
+    def _resolve(
+        self,
+        *,
+        threshold: int,
+        chunked_prefill_size=8192,
+        scheduler_chunk_size="__same__",
+        disaggregation_mode=DisaggregationMode.NULL,
+        pp_size: int = 1,
+        dllm_config=None,
+    ) -> int:
+        set_global_server_args_for_scheduler(
+            ServerArgs(
+                model_path="dummy",
+                chunked_prefill_size=chunked_prefill_size,
+                long_prefill_token_threshold=threshold,
+            )
+        )
+        s = Scheduler.__new__(Scheduler)
+        s.chunked_prefill_size = (
+            chunked_prefill_size
+            if scheduler_chunk_size == "__same__"
+            else scheduler_chunk_size
+        )
+        s.disaggregation_mode = disaggregation_mode
+        s.ps = SimpleNamespace(pp_size=pp_size)
+        s.dllm_config = dllm_config
+        s.max_concurrent_chunked_reqs = 1
+        Scheduler.init_chunked_prefill_concurrency(s)
+        return s.max_concurrent_chunked_reqs
+
+    def test_disabled_by_default(self):
+        self.assertEqual(self._resolve(threshold=0), 1)
+
+    def test_capacity_is_budget_over_threshold(self):
+        self.assertEqual(self._resolve(threshold=2048), 4)
+
+    def test_capacity_floors_at_one(self):
+        # A threshold above the whole pool still allows one mid-prefill
+        # request (identical to stock).
+        self.assertEqual(self._resolve(threshold=16384), 1)
+
+    def test_capacity_uses_floor_division(self):
+        self.assertEqual(self._resolve(threshold=3000), 2)
+
+    def test_disagg_prefill_stays_single_slot(self):
+        self.assertEqual(
+            self._resolve(
+                threshold=2048, disaggregation_mode=DisaggregationMode.PREFILL
+            ),
+            1,
+        )
+
+    def test_disagg_decode_allows_concurrency(self):
+        self.assertEqual(
+            self._resolve(
+                threshold=2048, disaggregation_mode=DisaggregationMode.DECODE
+            ),
+            4,
+        )
+
+    def test_pipeline_parallel_stays_single_slot(self):
+        self.assertEqual(self._resolve(threshold=2048, pp_size=2), 1)
+
+    def test_dllm_stays_single_slot(self):
+        self.assertEqual(self._resolve(threshold=2048, dllm_config=object()), 1)
+
+    def test_chunked_prefill_disabled_stays_single_slot(self):
+        # Unreachable from real config (validation rejects threshold without
+        # chunked prefill); the scheduler-side gate is defense in depth.
+        self.assertEqual(self._resolve(threshold=2048, scheduler_chunk_size=None), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
+++ b/test/registered/unit/managers/test_scheduler_chunked_req_gate.py
@@ -104,8 +104,10 @@ def _scheduler_for_get_next_batch(*, tree_cache, chunked_req) -> Scheduler:
     )
     s.update_running_batch = MagicMock(side_effect=lambda batch: batch)
     s.tree_cache = tree_cache
-    s.chunked_req = chunked_req
-    s._pending_chunked_abort_req = None
+    s.chunked_reqs = [chunked_req] if chunked_req is not None else []
+    s.max_concurrent_chunked_reqs = 1
+    s.enable_dynamic_chunking = False
+    s._pending_chunked_abort_reqs = []
     return s
 
 
@@ -166,8 +168,8 @@ class TestStashGatePreservesPrefixIndices(CustomTestCase):
         self.assertTrue(torch.equal(req.prefix_indices, expected))
 
     def test_no_chunked_req_never_mutates_state(self):
-        # The outer `if chunked_req is not None` guard must hold on the retract
-        # path that clears chunked_req.
+        # The outer `if chunked_reqs` guard must hold on the retract
+        # path that clears chunked_reqs.
         pool = _make_req_to_token_pool(self.NUM_SLOTS, self.MAX_CONTEXT)
         cache = _make_chunk_cache(pool)
         s = _scheduler_for_get_next_batch(tree_cache=cache, chunked_req=None)
@@ -175,7 +177,7 @@ class TestStashGatePreservesPrefixIndices(CustomTestCase):
         Scheduler.get_next_batch_to_run(
             s, running_batch=s.running_batch, last_batch=s.last_batch
         )
-        self.assertIsNone(s.chunked_req)
+        self.assertEqual(s.chunked_reqs, [])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_parked_chunk_accounting.py
+++ b/test/registered/unit/managers/test_scheduler_parked_chunk_accounting.py
@@ -97,7 +97,7 @@ def _count_via_scheduler(adder: PrefillAdder, chunked_req: Req) -> None:
     logic, so deleting the parked-chunk guard fails these tests.
     """
     scheduler = Scheduler.__new__(Scheduler)
-    scheduler.chunked_req = chunked_req
+    scheduler.chunked_reqs = [chunked_req]
     Scheduler._count_inflight_chunk(scheduler, set(adder.can_run_list))
 
 

--- a/test/registered/unit/managers/test_scheduler_parked_chunk_accounting.py
+++ b/test/registered/unit/managers/test_scheduler_parked_chunk_accounting.py
@@ -1,0 +1,142 @@
+"""Regression test: a parked chunked request must not be counted as in-flight.
+
+`PrefillAdder.add_chunked_req` can return the request *without* adding it to
+`can_run_list` (the hybrid-SWA branch, when the SWA pool cannot fit another
+page). The request is "parked": no KV is computed for it this pass and it
+produces no forward result. Incrementing `inflight_middle_chunks` for it leaks
+the counter upward, and a request stuck above zero is treated as a middle chunk
+forever -- it never appends a token and never finishes.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.managers.schedule_policy import PrefillAdder
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.base_prefix_cache import DecLockRefResult, IncLockRefResult
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+from sglang.srt.utils.common import Range
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+PAGE = 8
+WINDOW = 128
+PREFIX = 100
+
+
+def _make_req(rid: str, extend_len: int) -> Req:
+    req = MagicMock(spec=Req)
+    req.rid = rid
+    req.priority = 0
+    req.prefix_indices = list(range(PREFIX))
+    req.full_untruncated_fill_ids = list(range(PREFIX + extend_len))
+    req.origin_input_ids = list(range(PREFIX + extend_len))
+    req.output_ids = []
+    req.sampling_params = SimpleNamespace(max_new_tokens=40, ignore_eos=False)
+    req.retracted_stain = False
+    req.host_hit_length = 0
+    req.storage_hit_length = 0
+    req.swa_host_hit_length = 0
+    req.mamba_pool_idx = None
+    req.last_node = MagicMock()
+    req.inflight_middle_chunks = 0
+    req.finished.return_value = False
+    req.needs_host_load_back.return_value = False
+    req.set_extend_range = MagicMock(
+        side_effect=lambda s, e: setattr(req, "extend_range", Range(s, e))
+    )
+    return req
+
+
+def _make_adder(*, swa_available: int) -> PrefillAdder:
+    tree_cache = MagicMock()
+    tree_cache.full_evictable_size.return_value = 0
+    tree_cache.swa_evictable_size.return_value = 0
+    tree_cache.evictable_size.return_value = 0
+    tree_cache.disable = False
+    tree_cache.sliding_window_size = WINDOW
+    tree_cache.is_tree_cache.return_value = False
+    tree_cache.inc_lock_ref.return_value = IncLockRefResult()
+    tree_cache.dec_lock_ref.return_value = DecLockRefResult()
+
+    allocator = MagicMock()
+    allocator.full_available_size.return_value = 10_000_000
+    allocator.available_size.return_value = 10_000_000
+    allocator.swa_available_size.return_value = swa_available
+    allocator.size_swa = 10_000_000
+
+    running_batch = MagicMock()
+    running_batch.reqs = []
+
+    adder = PrefillAdder(
+        page_size=PAGE,
+        tree_cache=tree_cache,
+        token_to_kv_pool_allocator=allocator,
+        running_batch=running_batch,
+        new_token_ratio=1.0,
+        rem_input_tokens=100_000,
+        rem_chunk_tokens=512,
+        num_mixed_decode_tokens=0,
+        priority_scheduling_preemption_threshold=0,
+    )
+    adder.is_hybrid_swa = True
+    return adder
+
+
+def _count_via_scheduler(adder: PrefillAdder, chunked_req: Req) -> None:
+    """Run the scheduler's real accounting step over this pass's batch.
+
+    Calls Scheduler._count_inflight_chunk itself rather than restating its
+    logic, so deleting the parked-chunk guard fails these tests.
+    """
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.chunked_req = chunked_req
+    Scheduler._count_inflight_chunk(scheduler, set(adder.can_run_list))
+
+
+class TestParkedChunkAccounting(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        set_global_server_args_for_scheduler(ServerArgs(model_path="dummy"))
+
+    def test_parked_chunk_is_not_counted_as_inflight(self):
+        # SWA pool below one page: add_chunked_req parks the request.
+        adder = _make_adder(swa_available=PAGE // 2)
+        req = _make_req("parked", extend_len=100_000)
+
+        returned = adder.add_chunked_req(req)
+
+        # Parked: still the chunked req, but absent from the batch.
+        self.assertIs(returned, req)
+        self.assertNotIn(req, adder.can_run_list)
+
+        _count_via_scheduler(adder, returned)
+
+        # Nothing will decrement it, so it must never have been incremented.
+        self.assertEqual(req.inflight_middle_chunks, 0)
+
+    def test_prefilled_chunk_is_counted_as_inflight(self):
+        # Symmetric guard against over-gating: an ample SWA pool prefills the
+        # chunk normally, and that one must still be counted.
+        adder = _make_adder(swa_available=100_000)
+        req = _make_req("prefilled", extend_len=100_000)
+
+        returned = adder.add_chunked_req(req)
+
+        self.assertIs(returned, req)  # still truncated
+        self.assertIn(req, adder.can_run_list)
+
+        _count_via_scheduler(adder, returned)
+
+        self.assertEqual(req.inflight_middle_chunks, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -33,7 +33,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.enable_overlap = False
         scheduler.last_batch = None
         scheduler.cur_batch_for_debug = None
-        scheduler.chunked_req = None
+        scheduler.chunked_reqs = []
         scheduler.running_batch = MagicMock()
         scheduler.running_batch.reqs = []
         scheduler.running_batch.is_empty.return_value = True
@@ -119,11 +119,11 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler = self._new_scheduler()
         scheduler.last_batch = MagicMock()
         scheduler.cur_batch_for_debug = MagicMock()
-        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_reqs = [MagicMock()]
 
         original_last_batch = scheduler.last_batch
         original_cur_batch = scheduler.cur_batch_for_debug
-        original_chunked_req = scheduler.chunked_req
+        original_chunked_reqs = scheduler.chunked_reqs
 
         scheduler.pause_generation(PauseGenerationReqInput(mode="in_place"))
 
@@ -131,7 +131,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         # All state must be preserved — no mutation
         self.assertIs(scheduler.last_batch, original_last_batch)
         self.assertIs(scheduler.cur_batch_for_debug, original_cur_batch)
-        self.assertIs(scheduler.chunked_req, original_chunked_req)
+        self.assertIs(scheduler.chunked_reqs, original_chunked_reqs)
 
     def test_inplace_does_not_drain_overlap_queue(self):
         """in_place should not process the overlap result_queue."""
@@ -200,7 +200,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
             forward_mode=ForwardMode.EXTEND,
             with_tensors=True,
         )
-        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_reqs = [MagicMock()]
         requeue_log = self._spy_requeue(scheduler)
 
         scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
@@ -215,7 +215,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         )
         self.assertEqual(scheduler.running_batch.reqs, [])
         self.assertFalse(scheduler.running_batch.batch_is_full)
-        self.assertIsNone(scheduler.chunked_req)
+        self.assertEqual(scheduler.chunked_reqs, [])
         self.assertIsNone(scheduler.last_batch)
 
     def test_retract_with_empty_running_uses_last_batch_reqs(self):
@@ -229,7 +229,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
             forward_mode=ForwardMode.EXTEND,
             with_tensors=True,
         )
-        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_reqs = [MagicMock()]
         requeue_log = self._spy_requeue(scheduler)
 
         scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
@@ -239,7 +239,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         self.assertEqual(last_req.retraction_count, 1)
         self.assertEqual(scheduler.running_batch.reqs, [])
         self.assertFalse(scheduler.running_batch.batch_is_full)
-        self.assertIsNone(scheduler.chunked_req)
+        self.assertEqual(scheduler.chunked_reqs, [])
 
     def test_retract_fold_in_releases_via_scheduler_hisparse_coordinator(self):
         """retract of a folded-in last extend batch must release through the scheduler-owned hisparse coordinator."""
@@ -333,13 +333,13 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         """retract with nothing to retract still clears chunked_req and batch_is_full."""
         scheduler = self._new_scheduler()
         scheduler.running_batch = ScheduleBatch(reqs=[], batch_is_full=True)
-        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_reqs = [MagicMock()]
         requeue_log = self._spy_requeue(scheduler)
 
         scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
 
         self.assertEqual(requeue_log, [])
-        self.assertIsNone(scheduler.chunked_req)
+        self.assertEqual(scheduler.chunked_reqs, [])
         self.assertFalse(scheduler.running_batch.batch_is_full)
 
     def test_retract_all_finished_clears_fields_without_requeue(self):
@@ -351,7 +351,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
             scheduler, reqs=[req_finished_a, req_finished_b]
         )
         scheduler.running_batch.batch_is_full = True
-        scheduler.chunked_req = MagicMock()
+        scheduler.chunked_reqs = [MagicMock()]
         requeue_log = self._spy_requeue(scheduler)
 
         scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
@@ -361,7 +361,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         self.assertEqual(req_finished_b.retraction_count, 0)
         self.assertEqual(scheduler.running_batch.reqs, [])
         self.assertFalse(scheduler.running_batch.batch_is_full)
-        self.assertIsNone(scheduler.chunked_req)
+        self.assertEqual(scheduler.chunked_reqs, [])
 
     def test_retract_drain_happens_once_before_release(self):
         """retract with overlap drains the result_queue once before releasing reqs."""
@@ -410,14 +410,14 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
 
         chunked_req = MagicMock()
         chunked_req.finished.return_value = False
-        scheduler.chunked_req = chunked_req
+        scheduler.chunked_reqs = [chunked_req]
 
         with patch("sglang.srt.managers.scheduler.retract_all") as mock_retract_all:
             scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
 
         mock_retract_all.assert_not_called()
         scheduler._add_request_to_queue.assert_not_called()
-        self.assertIs(scheduler.chunked_req, chunked_req)
+        self.assertEqual(scheduler.chunked_reqs, [chunked_req])
 
     def test_retract_drains_overlap_queue(self):
         """retract with overlap enabled should drain the result_queue."""

--- a/test/registered/unit/spec/test_eagle_prefill_tail_tokens.py
+++ b/test/registered/unit/spec/test_eagle_prefill_tail_tokens.py
@@ -1,0 +1,118 @@
+"""Per-request EAGLE prefill tail-token substitution (PR #26329, pluralized).
+
+For a non-final prefill chunk the draft model's chain must continue from the
+next *prompt* token, not the sampled one. With concurrent chunked prefill,
+several rows of one batch can need the substitution at once; the consumer
+applies them all in a single index_copy_ instead of stopping at the first.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.schedule_batch import _compute_chunked_next_prompt_tokens
+from sglang.srt.speculative.eagle_utils import _eagle_prefill_tail_tokens
+from sglang.srt.utils.common import Range
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+VOCAB = 1000
+
+
+def _batch(next_prompt_tokens, dtype=torch.int64):
+    return SimpleNamespace(
+        input_ids=torch.zeros(4, dtype=dtype),
+        chunked_next_prompt_tokens=next_prompt_tokens,
+    )
+
+
+class _Req:
+    """Hashable Req stand-in (the production code builds a set of chunked
+    reqs; SimpleNamespace is unhashable)."""
+
+    def __init__(self, fill_end, origin_ids):
+        self.extend_range = Range(0, fill_end)
+        self.origin_input_ids = origin_ids
+
+
+def _req(fill_end, origin_ids):
+    return _Req(fill_end, origin_ids)
+
+
+class TestComputeChunkedNextPromptTokens(CustomTestCase):
+    def test_no_chunked_reqs_returns_none(self):
+        reqs = [_req(3, [1, 2, 3, 4])]
+        self.assertIsNone(_compute_chunked_next_prompt_tokens(reqs, [], VOCAB))
+        self.assertIsNone(_compute_chunked_next_prompt_tokens(reqs, None, VOCAB))
+
+    def test_positionally_aligned_with_reqs(self):
+        a, b, c, d = (
+            _req(2, [10, 11, 12]),
+            _req(2, [20, 21, 22]),
+            _req(2, [30, 31, 32]),
+            _req(2, [40, 41, 42]),
+        )
+        reqs = [a, b, c, d]
+        tokens = _compute_chunked_next_prompt_tokens(reqs, [d, b], VOCAB)
+        # Membership, not position or carry order, decides which rows map.
+        self.assertEqual(tokens, [None, 22, None, 42])
+
+    def test_final_chunk_boundary_maps_to_none(self):
+        r = _req(3, [10, 11, 12])  # fill consumed the whole prompt
+        self.assertIsNone(_compute_chunked_next_prompt_tokens([r], [r], VOCAB))
+
+    def test_placeholder_token_maps_to_none(self):
+        # Multimodal hash tokens lie outside the model vocab and must not be
+        # fed to the draft chain.
+        r = _req(1, [10, 5_000_000, 12])
+        self.assertIsNone(_compute_chunked_next_prompt_tokens([r], [r], VOCAB))
+
+
+class TestEaglePrefillTailTokens(CustomTestCase):
+    def test_no_map_returns_uncopied_conversion(self):
+        next_token_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+        result = _eagle_prefill_tail_tokens(_batch(None), next_token_ids)
+        # .to() with a matching dtype is the identity: no clone on the
+        # no-substitution path.
+        self.assertIs(result, next_token_ids)
+
+    def test_all_none_rows_returns_uncopied_conversion(self):
+        next_token_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+        result = _eagle_prefill_tail_tokens(
+            _batch([None, None, None, None]), next_token_ids
+        )
+        self.assertIs(result, next_token_ids)
+
+    def test_single_row_matches_stock_n1_behavior(self):
+        next_token_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+        result = _eagle_prefill_tail_tokens(
+            _batch([None, None, 555, None]), next_token_ids
+        )
+        self.assertIsNot(result, next_token_ids)
+        self.assertEqual(result.tolist(), [7, 8, 555, 10])
+        # The source tensor is not mutated through the clone.
+        self.assertEqual(next_token_ids.tolist(), [7, 8, 9, 10])
+
+    def test_multiple_rows_all_substituted(self):
+        # The N>1 case: every mid-prefill row must be substituted, not just
+        # the first -- the stock loop broke after the single slot's row.
+        next_token_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+        result = _eagle_prefill_tail_tokens(
+            _batch([111, None, 555, 999]), next_token_ids
+        )
+        self.assertEqual(result.tolist(), [111, 8, 555, 999])
+
+    def test_dtype_follows_input_ids(self):
+        next_token_ids = torch.tensor([7, 8, 9, 10], dtype=torch.int64)
+        result = _eagle_prefill_tail_tokens(
+            _batch([111, None, None, None], dtype=torch.int32), next_token_ids
+        )
+        self.assertEqual(result.dtype, torch.int32)
+        self.assertEqual(result.tolist(), [111, 8, 9, 10])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang can have at most **one** request mid-prefill at a time. A long prompt therefore monopolizes the prefill batch for its entire prefill, and every queued request — however small, however long it has waited — waits it out.

**Measured in production** (Sference fleet, SGLang backends):

- **Kimi-K3** (`chunked_prefill_size=8192`): with 642K–912K-token prompts in flight, **10.35% of requests exceeded 60 s TTFT**, vs 0.23–0.56% in adjacent hours without long prompts. p50 was unaffected — a pure tail/QoS failure.
- **DeepSeek-V4-Flash** (`chunked_prefill_size=4096`): 458K-token prompts ⇒ ~112 consecutive scheduler rounds in which no other request can prefill. Rolling TTFT p99 of 12–14 s, spiking to 27.7 s.

**This is a missing mechanism, not a tuning gap.** Driving the stock `PrefillAdder` (this branch's base) with three 500K-token requests, KV headroom pinned so it can never bind:

| config | per-request chunks | requests concurrently mid-prefill |
|---|---|---|
| `chunked_prefill_size=8192`, `max_prefill_tokens=16384` | `[8192, 0, 0]` | **1** |
| `chunked_prefill_size=8192`, `max_prefill_tokens=131072` | `[8192, 0, 0]` | **1** |
| `chunked_prefill_size=2048`, `max_prefill_tokens=1000000` | `[2048, 0, 0]` | **1** |

Requests 2 and 3 get zero tokens in every configuration. The cause is a single line in `PrefillAdder._update_prefill_budget`:

```python
self.rem_chunk_tokens -= extend_input_len   # fires for EVERY admitted request
```

`chunked_prefill_size` is not a per-request cap — it *initializes the shared per-pass pool*. The first chunked request drains the pool to 0 and `budget_state()` refuses everyone else. Raising `max_prefill_tokens` changes nothing (`rem_chunk_tokens` is the gate); raising `chunked_prefill_size` just enlarges the first request's chunk. Per-request share and batch total are the same number, so the concurrency ratio is always 1.

vLLM V1 has two independent variables — `token_budget` (batch) and `long_prefill_token_threshold` (per-request) — giving `budget // threshold` concurrent partial prefills, with progress tracked per request (`Request.num_computed_tokens`) and no chunked-request slot at all. `long_prefill_token_threshold` is live in vLLM V1 today (introduced in vllm-project/vllm#15419; enforced in both the running and waiting scheduling loops). SGLang has one variable where vLLM has two.

**Demand for this is documented and unanswered:** #8763/#8764 request exactly this knob (citing vLLM) and were stale-closed with no technical reply; #10063 was closed on a "priority scheduling covers it" claim that the thread itself disproves (priority cannot help: the long request is never preempted mid-prefill, so the queue still waits); #22831 measured a 454× p99 TTFT regression on this exact shape; #29438 predicted the failure mode addressed here — the single-slot invariant "holds only as a side effect of budget accounting."

## Modifications

Adds `--long-prefill-token-threshold F` (default `0` = disabled, byte-identical to stock), mirroring vLLM's flag name, semantics, and default:

- **Ceiling**: no request prefills more than `F` tokens in one scheduled pass; the freed budget goes to other requests. Applied after the post-lock SWA re-check (the tighter cap wins), before the chunked/non-chunked split (a request already under `F` is not chunked by it), composed with page alignment (round down to `page_size`, floor of one page).
- **Capacity**: `max_concurrent_chunked_reqs = max(1, chunked_prefill_size // F)`, resolved in `Scheduler.init_chunked_prefill_concurrency`. Pinned to 1 where the single-slot invariant is still load-bearing: disaggregated-prefill mode, `pp_size > 1`, dLLM. (Not gated on speculative decoding: DSPARK/EAGLE workers never read the scheduler's chunked-req slot; the one consumer that does, the EAGLE tail-token path, is made per-request in this PR.)
- **`chunked_req` → `chunked_reqs`** across the scheduler, batch, result processor, output streamer, load inquirer, PP mixin, disaggregation, and the scripted-test harness. Renamed outright — no compatibility property — so any missed read fails loudly instead of silently returning the first of N.
- **Reserve-to-completion admission**: a mid-prefill request's full remaining prefill + (clipped) `max_new_tokens` is charged to `rem_total_token_offset` at admission/carry/park, while the per-pass pools still see only the chunk. Stock *checks* the full cost at admission but *charges* only the chunk — that gap is the KV-overcommit deadlock class once N > 1 (mid-prefill requests are `inc_lock_ref`'d and invisible to `retract_decode`; they cannot be preempted, so admission must guarantee they can finish).
- **Parking**: a carried chunked request that finds the per-pass pool drained stays in `chunked_reqs`, is not appended to `can_run_list`, is not counted as in-flight, holds its completion reservation, and retries next pass. Newest parks first, so the oldest always advances.
- **`AddReqResult.SKIP`**: a request refused only because mid-prefill capacity is full no longer stops the scheduling pass — the waiting queue keeps scanning, so a short request behind several long ones still schedules. This is the QoS property the PR exists for.
- **Spec decoding**: `_compute_chunked_req_next_prompt_token` becomes per-request (`_compute_chunked_next_prompt_tokens`), and `_eagle_prefill_tail_tokens` substitutes all mid-prefill rows in one pinned non-blocking H2D copy + `index_copy_` (preserving the no-sync property its comment protects), instead of stopping at the first row.

The PR is stacked for commit-by-commit review; the first three commits are behavior-preserving bugfixes worth having at N=1:

1. **`skip_stream_req` → set.** The result processor tracked one skip request, but dLLM already runs N concurrent chunked requests today — so all but the last middle chunk are streamed to clients *right now*. Fixes a live bug.
2. **Don't count a parked chunked request as in-flight.** The hybrid-SWA park path can return a request without appending it to `can_run_list`; its `inflight_middle_chunks` was incremented with no matching decrement.
3. **`contains_last_prefill_chunk` from batch membership**, not the `len(can_run_list) != 1` proxy — exact under mixed chunks.
4. **Pluralize `chunked_req` at capacity 1** — mechanical rename, no behavior change.
5. **Enable N>1** — the ceiling/capacity/parking/reservation feature above.
6. **Per-request EAGLE tail tokens** + CPU tests.
7. **Thread the same three mechanisms through the `ignore_eos` admission path** (radix-cache-disabled; used routinely by bench-serving) — without it, two long `ignore_eos` prompts at F>0 would trip the scheduler's adoption capacity assert.

**Pre-existing gap flagged, not fixed here:** `multi_layer_eagle_worker_v2.py` never received the #26329 tail-token fix its single-layer sibling got, so it diverges on chunked prefill even at N=1. This PR widens that pre-existing gap to N>1 rather than creating it; happy to include the analogous fix here or in a follow-up, whichever reviewers prefer.

## Accuracy Tests

No kernel, model-forward, or sampling changes: at `F=0` (default) the change is byte-identical to stock by construction — every new branch is gated on `long_prefill_token_threshold > 0`, and the whole existing chunked-prefill unit suite passes unchanged. At `F>0`, chunk *boundaries* change but the token stream each request extends over does not; numerical equivalence (same completions with N>1 as with F=0) is exactly what the GPU suites below check — we cannot run GPU tests locally and ask maintainer CI / will run on our own nodes for:

- `test/manual/chunked_prefill/test_scripted_*.py` (real Qwen3-0.6B engine; updated to the pluralized slot)
- `test_scripted_kv_pressure.py` (exercises the deadlock risk the reservation targets)
- `test/registered/kv_canary/test_self_e2e_pr_26329.py` — the per-request rewrite preserves the `pr_fix_toggle.py` source-match line byte-for-byte, and the new unit tests were revert-checked (the multi-row substitution test fails when the fix is gutted to its stock single-row form); the e2e canary itself needs a GPU run to confirm it still fails when reverted
- `test_scripted_spec.py`, `test_scripted_pp.py`, `test_e2e_disagg.py`

## Speed Tests and Profiling

CPU probe driving the real `PrefillAdder` (three 500K-token requests, KV pinned at 50M blocks so it never binds), stock vs this branch:

| | per-request chunks | concurrent mid-prefill |
|---|---|---|
| stock, any config (table above) | `[8192, 0, 0]` | 1 |
| this branch, `F=0` (disabled) | `[8192, 0, 0]` | 1 (byte-identical) |
| this branch, `B=8192, F=2048` | `[2048, 2048, 2048]` | **3** |
| this branch, `B=8192, F=2000`, 5 requests | `[1984, 1984, 1984, 1984, 0]` | **4** (5th `SKIP`ped, pass continues) |
| mixed: 1×500K + 3×2K, `F=2048` | `[2048, 2000, 2000, 2000]` | shorts scheduled **whole**, same pass |

The mixed row is the production failure shape: short requests no longer starve behind a long one.

**Known trade-off (same as vLLM's):** an *uncontended* long prefill is capped at `F` and slowed `B/F`× with the remainder of the budget idling. We accepted this to match vLLM's knob exactly; a leftover top-up refinement can follow (it must never *complete* a request, or it retroactively invalidates that request's completion reservation). Also note: equal-length jobs get *worse* under any work-conserving split (FCFS is optimal for identical jobs) — the win is mixed traffic, which is the production shape.

**Test coverage added** (all CPU, `test/registered/unit/`): 13 new PrefillAdder tests (ceiling, capacity, SKIP-continue, parking, reservation, page alignment, SWA composition, `ignore_eos`, F=0 identity), 13 scheduler/validation tests (capacity resolution, gates, flag validation), 9 spec tail-token tests, and 18 tests across the three bugfix suites (skip-set streaming, parked-chunk accounting, exact last-chunk detection). Full `unit/managers` + `unit/disaggregation` + `unit/spec` + `dllm` + `unit/server_args` + `unit/mem_cache` suites run with failure sets byte-identical to stock main, and every behavioral test was verified to fail when its fix is reverted.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black 26.1.0 / isort 7.0.0 / ruff 0.15.1 at the pinned revs; clean on every commit, not just the tip)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (flag documented in `server_args.py` help text, which generates the server-arguments reference)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (GPU benchmarks pending — no local GPU; will run on our production nodes and post results, or earlier via maintainer CI)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32005113016](https://github.com/sgl-project/sglang/actions/runs/32005113016)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32005112796](https://github.com/sgl-project/sglang/actions/runs/32005112796)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->