### PR TITLE
[Scheduler] Remove GPU rendezvous from symmetric DP metadata sync

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
@@ -1,21 +1,14 @@
-"""One-sided fixed-shape gather over torch symmetric memory.
-
-Each rank stores its row into every peer's buffer, then waits on a barrier. No
-communicator takes part, so unlike an all-gather this needs no ordering against
-the forward's collectives.
-"""
+"""One-sided fixed-shape gather over torch symmetric memory."""
 
 import logging
+import time
 from typing import Optional
 
 import torch
 
 logger = logging.getLogger(__name__)
 
-# A stuck peer raises instead of spinning forever.
 _BARRIER_TIMEOUT_MS = 10_000
-# A peer's stores for round N+1 land before its barrier(N+1) returns, so one
-# region would be overwritten while a slower rank still reads round N.
 _NUM_SLOTS = 2
 
 
@@ -34,8 +27,9 @@ class SymmMemGather:
     ):
         from torch._C._distributed_c10d import _SymmetricMemory
 
-        # Outside inference mode on purpose: a region created inside it is an
-        # inference tensor and rejects the in-place peer stores below.
+        if width != 7 or dtype != torch.int64:
+            raise ValueError("symmetric DP metadata gather requires 7 int64 fields")
+
         with torch.inference_mode(False):
             region = _SymmetricMemory.empty_strided_p2p(
                 (_NUM_SLOTS * world_size * width,),
@@ -49,15 +43,16 @@ class SymmMemGather:
         self._world_size = world_size
         self._width = width
         self._slot = 0
-        # Private stream: this exchange depends only on peer stores, never on
-        # the forward, so it must not inherit the schedule stream's WAR fence.
         self._stream = torch.cuda.Stream(device=device)
         self._staging = torch.zeros(width, dtype=dtype, device=device)
         self._host_in = torch.zeros(width, dtype=dtype).pin_memory()
         self._host_out = torch.zeros(world_size, width, dtype=dtype).pin_memory()
+        self._host_ready = torch.empty((), dtype=torch.uint32).pin_memory()
+        self._ready = torch.empty((), dtype=torch.uint32, device=device)
+        self._row_snapshot = torch.empty(world_size, width, dtype=dtype, device=device)
+        self._generation = 0
+        self._slot_generations = [None] * _NUM_SLOTS
         rank = self._handle.rank
-        # A peer row is a tensor view of that peer's memory; writing it is a
-        # store that never blocks on the peer.
         self._peer_rows = [
             [
                 self._handle.get_buffer(peer, (_NUM_SLOTS, world_size, width), dtype)[
@@ -67,6 +62,58 @@ class SymmMemGather:
             ]
             for slot in range(_NUM_SLOTS)
         ]
+
+        def allocate_control_region():
+            with torch.inference_mode(False):
+                control = _SymmetricMemory.empty_strided_p2p(
+                    (_NUM_SLOTS * world_size,),
+                    [1],
+                    torch.uint32,
+                    device,
+                    group_name,
+                ).view(_NUM_SLOTS, world_size)
+                control.zero_()
+            torch.cuda.current_stream(device).synchronize()
+            return control, _SymmetricMemory.rendezvous(control)
+
+        # The ready marker publishes a complete row; the ack protects slot reuse.
+        self._marker_region, self._marker_handle = allocate_control_region()
+        self._ack_region, self._ack_handle = allocate_control_region()
+        self._peer_row_ptrs = [
+            torch.tensor(
+                [row.data_ptr() for row in self._peer_rows[slot]],
+                dtype=torch.uint64,
+                device=device,
+            )
+            for slot in range(_NUM_SLOTS)
+        ]
+        self._peer_marker_ptrs = [
+            torch.tensor(
+                [
+                    self._marker_handle.get_buffer(
+                        peer, (_NUM_SLOTS, world_size), torch.uint32
+                    )[slot, rank].data_ptr()
+                    for peer in range(world_size)
+                ],
+                dtype=torch.uint64,
+                device=device,
+            )
+            for slot in range(_NUM_SLOTS)
+        ]
+        self._peer_ack_ptrs = [
+            torch.tensor(
+                [
+                    self._ack_handle.get_buffer(
+                        peer, (_NUM_SLOTS, world_size), torch.uint32
+                    )[slot, rank].data_ptr()
+                    for peer in range(world_size)
+                ],
+                dtype=torch.uint64,
+                device=device,
+            )
+            for slot in range(_NUM_SLOTS)
+        ]
+        torch.cuda.current_stream(device).synchronize()
         logger.info(
             "Symmetric-memory DP gather active: world=%d width=%d slots=%d",
             world_size,
@@ -78,15 +125,66 @@ class SymmMemGather:
         """Host row in, (world_size, width) host rows out."""
         slot = self._slot
         self._slot = (slot + 1) % _NUM_SLOTS
+        previous_generation = self._slot_generations[slot]
+        if previous_generation is not None:
+            self._wait_for_acks(slot, previous_generation)
+
         self._host_in.copy_(local_row_cpu)
         with torch.cuda.stream(self._stream):
             self._staging.copy_(self._host_in, non_blocking=True)
-            for row in self._peer_rows[slot]:
-                row.copy_(self._staging)
-            self._handle.barrier(0, _BARRIER_TIMEOUT_MS)
-            self._host_out.copy_(self._region[slot], non_blocking=True)
-        self._stream.synchronize()
-        return self._host_out
+            from sglang.srt.distributed.device_communicators.symm_mem_marker import (
+                copy_row_and_publish,
+            )
+
+            self._generation = self._generation % 0xFFFFFFFF + 1
+            self._slot_generations[slot] = self._generation
+            copy_row_and_publish(
+                self._peer_row_ptrs[slot],
+                self._peer_marker_ptrs[slot],
+                self._staging,
+                self._generation,
+            )
+
+        from sglang.srt.distributed.device_communicators.symm_mem_marker import (
+            publish_value,
+            snapshot_rows_acquire,
+        )
+
+        deadline = time.monotonic() + _BARRIER_TIMEOUT_MS / 1000
+        while True:
+            with torch.cuda.stream(self._stream):
+                snapshot_rows_acquire(
+                    self._region[slot],
+                    self._marker_region[slot],
+                    self._row_snapshot,
+                    self._ready,
+                    self._generation,
+                )
+                self._host_ready.copy_(self._ready, non_blocking=True)
+                self._host_out.copy_(self._row_snapshot, non_blocking=True)
+            self._stream.synchronize()
+            if self._host_ready.item() != 0:
+                with torch.cuda.stream(self._stream):
+                    publish_value(self._peer_ack_ptrs[slot], self._generation)
+                return self._host_out
+            if time.monotonic() >= deadline:
+                raise TimeoutError("symmetric-memory completion marker timeout")
+
+    def _wait_for_acks(self, slot: int, generation: int):
+        from sglang.srt.distributed.device_communicators.symm_mem_marker import (
+            all_values_acquire,
+        )
+
+        deadline = time.monotonic() + _BARRIER_TIMEOUT_MS / 1000
+        while True:
+            with torch.cuda.stream(self._stream):
+                all_values_acquire(self._ack_region[slot], self._ready, generation)
+                self._host_ready.copy_(self._ready, non_blocking=True)
+            self._stream.synchronize()
+            if self._host_ready.item() != 0:
+                return
+            if time.monotonic() >= deadline:
+                raise TimeoutError("symmetric-memory acknowledgement timeout")
 
 
 def maybe_create_symm_mem_gather(

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_gather.py
@@ -40,18 +40,15 @@ class SymmMemGather:
             ).view(_NUM_SLOTS, world_size, width)
         self._handle = _SymmetricMemory.rendezvous(region)
         self._region = region
-        self._world_size = world_size
-        self._width = width
         self._slot = 0
         self._stream = torch.cuda.Stream(device=device)
         self._staging = torch.zeros(width, dtype=dtype, device=device)
         self._host_in = torch.zeros(width, dtype=dtype).pin_memory()
         self._host_out = torch.zeros(world_size, width, dtype=dtype).pin_memory()
-        self._host_ready = torch.empty((), dtype=torch.uint32).pin_memory()
-        self._ready = torch.empty((), dtype=torch.uint32, device=device)
+        self._host_ready = torch.empty(world_size, dtype=torch.uint32).pin_memory()
+        self._ready = torch.empty(world_size, dtype=torch.uint32, device=device)
         self._row_snapshot = torch.empty(world_size, width, dtype=dtype, device=device)
         self._generation = 0
-        self._slot_generations = [None] * _NUM_SLOTS
         rank = self._handle.rank
         self._peer_rows = [
             [
@@ -63,22 +60,18 @@ class SymmMemGather:
             for slot in range(_NUM_SLOTS)
         ]
 
-        def allocate_control_region():
-            with torch.inference_mode(False):
-                control = _SymmetricMemory.empty_strided_p2p(
-                    (_NUM_SLOTS * world_size,),
-                    [1],
-                    torch.uint32,
-                    device,
-                    group_name,
-                ).view(_NUM_SLOTS, world_size)
-                control.zero_()
-            torch.cuda.current_stream(device).synchronize()
-            return control, _SymmetricMemory.rendezvous(control)
-
-        # The ready marker publishes a complete row; the ack protects slot reuse.
-        self._marker_region, self._marker_handle = allocate_control_region()
-        self._ack_region, self._ack_handle = allocate_control_region()
+        with torch.inference_mode(False):
+            marker_region = _SymmetricMemory.empty_strided_p2p(
+                (_NUM_SLOTS * world_size,),
+                [1],
+                torch.uint32,
+                device,
+                group_name,
+            ).view(_NUM_SLOTS, world_size)
+            marker_region.zero_()
+        torch.cuda.current_stream(device).synchronize()
+        self._marker_region = marker_region
+        self._marker_handle = _SymmetricMemory.rendezvous(marker_region)
         self._peer_row_ptrs = [
             torch.tensor(
                 [row.data_ptr() for row in self._peer_rows[slot]],
@@ -100,19 +93,6 @@ class SymmMemGather:
             )
             for slot in range(_NUM_SLOTS)
         ]
-        self._peer_ack_ptrs = [
-            torch.tensor(
-                [
-                    self._ack_handle.get_buffer(
-                        peer, (_NUM_SLOTS, world_size), torch.uint32
-                    )[slot, rank].data_ptr()
-                    for peer in range(world_size)
-                ],
-                dtype=torch.uint64,
-                device=device,
-            )
-            for slot in range(_NUM_SLOTS)
-        ]
         torch.cuda.current_stream(device).synchronize()
         logger.info(
             "Symmetric-memory DP gather active: world=%d width=%d slots=%d",
@@ -125,9 +105,6 @@ class SymmMemGather:
         """Host row in, (world_size, width) host rows out."""
         slot = self._slot
         self._slot = (slot + 1) % _NUM_SLOTS
-        previous_generation = self._slot_generations[slot]
-        if previous_generation is not None:
-            self._wait_for_acks(slot, previous_generation)
 
         self._host_in.copy_(local_row_cpu)
         with torch.cuda.stream(self._stream):
@@ -137,7 +114,6 @@ class SymmMemGather:
             )
 
             self._generation = self._generation % 0xFFFFFFFF + 1
-            self._slot_generations[slot] = self._generation
             copy_row_and_publish(
                 self._peer_row_ptrs[slot],
                 self._peer_marker_ptrs[slot],
@@ -146,7 +122,6 @@ class SymmMemGather:
             )
 
         from sglang.srt.distributed.device_communicators.symm_mem_marker import (
-            publish_value,
             snapshot_rows_acquire,
         )
 
@@ -163,28 +138,10 @@ class SymmMemGather:
                 self._host_ready.copy_(self._ready, non_blocking=True)
                 self._host_out.copy_(self._row_snapshot, non_blocking=True)
             self._stream.synchronize()
-            if self._host_ready.item() != 0:
-                with torch.cuda.stream(self._stream):
-                    publish_value(self._peer_ack_ptrs[slot], self._generation)
+            if self._host_ready.all().item():
                 return self._host_out
             if time.monotonic() >= deadline:
                 raise TimeoutError("symmetric-memory completion marker timeout")
-
-    def _wait_for_acks(self, slot: int, generation: int):
-        from sglang.srt.distributed.device_communicators.symm_mem_marker import (
-            all_values_acquire,
-        )
-
-        deadline = time.monotonic() + _BARRIER_TIMEOUT_MS / 1000
-        while True:
-            with torch.cuda.stream(self._stream):
-                all_values_acquire(self._ack_region[slot], self._ready, generation)
-                self._host_ready.copy_(self._ready, non_blocking=True)
-            self._stream.synchronize()
-            if self._host_ready.item() != 0:
-                return
-            if time.monotonic() >= deadline:
-                raise TimeoutError("symmetric-memory acknowledgement timeout")
 
 
 def maybe_create_symm_mem_gather(

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_marker.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_marker.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""System-scope publication and reuse markers for fixed-width DP metadata."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_row_and_publish(dst_rows, dst_markers, src, generation):
+    peer = tl.program_id(0)
+    dst_row = tl.load(dst_rows + peer)
+    dst_marker = tl.load(dst_markers + peer)
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .pred p;
+            .reg .u32 tid;
+            .reg .u64 value;
+            mov.u32 tid, %tid.x;
+            setp.ne.u32 p, tid, 0;
+            @p bra done;
+            ld.relaxed.gpu.global.u64 value, [$1 + 0];
+            st.relaxed.sys.global.u64 [$2 + 0], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 8];
+            st.relaxed.sys.global.u64 [$2 + 8], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 16];
+            st.relaxed.sys.global.u64 [$2 + 16], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 24];
+            st.relaxed.sys.global.u64 [$2 + 24], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 32];
+            st.relaxed.sys.global.u64 [$2 + 32], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 40];
+            st.relaxed.sys.global.u64 [$2 + 40], value;
+            ld.relaxed.gpu.global.u64 value, [$1 + 48];
+            st.relaxed.sys.global.u64 [$2 + 48], value;
+            fence.proxy.alias;
+            atom.global.release.sys.exch.b32 tid, [$3], $4;
+            done:
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r,l,l,l,r",
+        args=[src, dst_row, dst_marker, generation],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+def copy_row_and_publish(
+    dst_rows: torch.Tensor,
+    dst_markers: torch.Tensor,
+    src: torch.Tensor,
+    generation: int,
+):
+    _copy_row_and_publish[(dst_rows.numel(),)](
+        dst_rows, dst_markers, src, generation, num_warps=1
+    )
+
+
+@triton.jit
+def _publish_value(dst_ptrs, value):
+    peer = tl.program_id(0)
+    dst = tl.load(dst_ptrs + peer)
+    tl.inline_asm_elementwise(
+        """
+        {
+            .reg .pred p;
+            .reg .u32 tid;
+            mov.u32 tid, %tid.x;
+            setp.ne.u32 p, tid, 0;
+            @p bra done;
+            atom.global.release.sys.exch.b32 tid, [$1], $2;
+            done:
+            mov.u32 $0, 0;
+        }
+        """,
+        "=r,l,r",
+        args=[dst, value],
+        dtype=tl.int32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+def publish_value(dst_ptrs: torch.Tensor, value: int):
+    _publish_value[(dst_ptrs.numel(),)](dst_ptrs, value, num_warps=1)
+
+
+@triton.jit
+def _load_acquire(ptr, mask):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .pred p;
+            setp.eq.s32 p, $2, 1;
+            mov.u32 $0, 0;
+            @p atom.global.acquire.sys.cas.b32 $0, [$1], 0xffffffff, 0xffffffff;
+        }
+        """,
+        "=r,l,r",
+        args=[ptr, mask.to(tl.int32)],
+        dtype=tl.uint32,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _load_relaxed_sys(ptr, mask):
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .pred p;
+            setp.eq.s32 p, $2, 1;
+            mov.u64 $0, 0;
+            @p fence.proxy.alias;
+            @p ld.relaxed.sys.global.u64 $0, [$1];
+        }
+        """,
+        "=l,l,r",
+        args=[ptr, mask.to(tl.int32)],
+        dtype=tl.uint64,
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _snapshot_rows_acquire(
+    src_rows,
+    markers,
+    dst_rows,
+    ready,
+    generation,
+    world_size: tl.constexpr,
+    numel: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offsets = tl.arange(0, block_size)
+    active = offsets < numel
+    complete = active
+    for peer in range(world_size):
+        complete &= _load_acquire(markers + peer, active) == generation
+    values = _load_relaxed_sys(src_rows + offsets, complete)
+    tl.store(dst_rows + offsets, values, mask=complete)
+    tl.store(ready + offsets, complete.to(tl.uint32), mask=offsets == 0)
+
+
+def snapshot_rows_acquire(
+    src_rows: torch.Tensor,
+    markers: torch.Tensor,
+    dst_rows: torch.Tensor,
+    ready: torch.Tensor,
+    generation: int,
+):
+    _snapshot_rows_acquire[(1,)](
+        src_rows,
+        markers,
+        dst_rows,
+        ready,
+        generation,
+        markers.numel(),
+        src_rows.numel(),
+        triton.next_power_of_2(src_rows.numel()),
+        num_warps=4,
+    )
+
+
+@triton.jit
+def _all_values_acquire(
+    src,
+    ready,
+    expected,
+    numel: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    offsets = tl.arange(0, block_size)
+    active = offsets < numel
+    values = _load_acquire(src + offsets, active)
+    complete = tl.sum((values == expected).to(tl.int32), axis=0) == numel
+    tl.store(ready, complete.to(tl.uint32))
+
+
+def all_values_acquire(src: torch.Tensor, ready: torch.Tensor, expected: int):
+    _all_values_acquire[(1,)](
+        src,
+        ready,
+        expected,
+        src.numel(),
+        triton.next_power_of_2(src.numel()),
+        num_warps=1,
+    )

--- a/python/sglang/srt/distributed/device_communicators/symm_mem_marker.py
+++ b/python/sglang/srt/distributed/device_communicators/symm_mem_marker.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-"""System-scope publication and reuse markers for fixed-width DP metadata."""
+"""System-scope publication markers for fixed-width DP metadata."""
 
 import torch
 import triton
@@ -61,92 +61,53 @@ def copy_row_and_publish(
 
 
 @triton.jit
-def _publish_value(dst_ptrs, value):
+def _snapshot_row_acquire(src_rows, markers, dst_rows, ready, generation):
     peer = tl.program_id(0)
-    dst = tl.load(dst_ptrs + peer)
+    src = src_rows + peer * 7
+    marker = markers + peer
+    dst = dst_rows + peer * 7
+    peer_ready = ready + peer
     tl.inline_asm_elementwise(
         """
         {
-            .reg .pred p;
-            .reg .u32 tid;
+            .reg .pred p, incomplete;
+            .reg .u32 tid, observed, is_ready;
+            .reg .u64 value;
             mov.u32 tid, %tid.x;
             setp.ne.u32 p, tid, 0;
             @p bra done;
-            atom.global.release.sys.exch.b32 tid, [$1], $2;
+            mov.u32 is_ready, 0;
+            atom.global.acquire.sys.cas.b32 observed, [$2], 0xffffffff, 0xffffffff;
+            setp.ne.u32 incomplete, observed, $5;
+            @incomplete bra publish;
+            fence.proxy.alias;
+            ld.relaxed.sys.global.u64 value, [$1 + 0];
+            st.relaxed.gpu.global.u64 [$3 + 0], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 8];
+            st.relaxed.gpu.global.u64 [$3 + 8], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 16];
+            st.relaxed.gpu.global.u64 [$3 + 16], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 24];
+            st.relaxed.gpu.global.u64 [$3 + 24], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 32];
+            st.relaxed.gpu.global.u64 [$3 + 32], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 40];
+            st.relaxed.gpu.global.u64 [$3 + 40], value;
+            ld.relaxed.sys.global.u64 value, [$1 + 48];
+            st.relaxed.gpu.global.u64 [$3 + 48], value;
+            mov.u32 is_ready, 1;
+            publish:
+            st.relaxed.gpu.global.u32 [$4], is_ready;
             done:
             mov.u32 $0, 0;
         }
         """,
-        "=r,l,r",
-        args=[dst, value],
+        "=r,l,l,l,l,r",
+        args=[src, marker, dst, peer_ready, generation],
         dtype=tl.int32,
         is_pure=False,
         pack=1,
     )
-
-
-def publish_value(dst_ptrs: torch.Tensor, value: int):
-    _publish_value[(dst_ptrs.numel(),)](dst_ptrs, value, num_warps=1)
-
-
-@triton.jit
-def _load_acquire(ptr, mask):
-    return tl.inline_asm_elementwise(
-        """
-        {
-            .reg .pred p;
-            setp.eq.s32 p, $2, 1;
-            mov.u32 $0, 0;
-            @p atom.global.acquire.sys.cas.b32 $0, [$1], 0xffffffff, 0xffffffff;
-        }
-        """,
-        "=r,l,r",
-        args=[ptr, mask.to(tl.int32)],
-        dtype=tl.uint32,
-        is_pure=False,
-        pack=1,
-    )
-
-
-@triton.jit
-def _load_relaxed_sys(ptr, mask):
-    return tl.inline_asm_elementwise(
-        """
-        {
-            .reg .pred p;
-            setp.eq.s32 p, $2, 1;
-            mov.u64 $0, 0;
-            @p fence.proxy.alias;
-            @p ld.relaxed.sys.global.u64 $0, [$1];
-        }
-        """,
-        "=l,l,r",
-        args=[ptr, mask.to(tl.int32)],
-        dtype=tl.uint64,
-        is_pure=False,
-        pack=1,
-    )
-
-
-@triton.jit
-def _snapshot_rows_acquire(
-    src_rows,
-    markers,
-    dst_rows,
-    ready,
-    generation,
-    world_size: tl.constexpr,
-    numel: tl.constexpr,
-    block_size: tl.constexpr,
-):
-    offsets = tl.arange(0, block_size)
-    active = offsets < numel
-    complete = active
-    for peer in range(world_size):
-        complete &= _load_acquire(markers + peer, active) == generation
-    values = _load_relaxed_sys(src_rows + offsets, complete)
-    tl.store(dst_rows + offsets, values, mask=complete)
-    tl.store(ready + offsets, complete.to(tl.uint32), mask=offsets == 0)
 
 
 def snapshot_rows_acquire(
@@ -156,40 +117,11 @@ def snapshot_rows_acquire(
     ready: torch.Tensor,
     generation: int,
 ):
-    _snapshot_rows_acquire[(1,)](
+    _snapshot_row_acquire[(markers.numel(),)](
         src_rows,
         markers,
         dst_rows,
         ready,
         generation,
-        markers.numel(),
-        src_rows.numel(),
-        triton.next_power_of_2(src_rows.numel()),
-        num_warps=4,
-    )
-
-
-@triton.jit
-def _all_values_acquire(
-    src,
-    ready,
-    expected,
-    numel: tl.constexpr,
-    block_size: tl.constexpr,
-):
-    offsets = tl.arange(0, block_size)
-    active = offsets < numel
-    values = _load_acquire(src + offsets, active)
-    complete = tl.sum((values == expected).to(tl.int32), axis=0) == numel
-    tl.store(ready, complete.to(tl.uint32))
-
-
-def all_values_acquire(src: torch.Tensor, ready: torch.Tensor, expected: int):
-    _all_values_acquire[(1,)](
-        src,
-        ready,
-        expected,
-        src.numel(),
-        triton.next_power_of_2(src.numel()),
         num_warps=1,
     )

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -29,7 +29,7 @@ from sglang.srt.observability.metrics_collector import DPCooperationInfo
 from sglang.srt.runtime_context import get_parallel, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
-from sglang.srt.utils.common import require_mlp_tp_gather
+from sglang.srt.utils.common import is_cuda, require_mlp_tp_gather
 
 if TYPE_CHECKING:
     from sglang.srt.distributed.parallel_state import GroupCoordinator
@@ -44,7 +44,12 @@ _SYMM_GATHERERS: dict = {}
 
 def _maybe_symm_gatherer(group, device, width: int):
     """Symmetric-memory gatherer for this group, or None to use the collective."""
-    if not envs.SGLANG_USE_SYMM_MEM_DP_SYNC.get() or device == "cpu":
+    if (
+        not envs.SGLANG_USE_SYMM_MEM_DP_SYNC.get()
+        or device == "cpu"
+        or not is_cuda()
+        or torch.cuda.get_device_capability(device)[0] < 7
+    ):
         return None
     key = id(group)
     if key not in _SYMM_GATHERERS:

--- a/test/registered/unit/distributed/test_symm_mem_gather.py
+++ b/test/registered/unit/distributed/test_symm_mem_gather.py
@@ -1,0 +1,73 @@
+import sys
+import unittest
+from contextlib import nullcontext
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.distributed.device_communicators.symm_mem_gather import SymmMemGather
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+_MARKER_MODULE = "sglang.srt.distributed.device_communicators.symm_mem_marker"
+
+
+class TestSymmMemGather(unittest.TestCase):
+    def test_slot_reuse_waits_for_ack(self):
+        gatherer, marker = self._gatherer(ready_values=[1])
+        gatherer._generation = 2
+        gatherer._slot_generations = [1, 2]
+        gatherer._wait_for_acks = MagicMock()
+
+        with (
+            patch.dict(sys.modules, {_MARKER_MODULE: marker}),
+            patch("torch.cuda.stream", return_value=nullcontext()),
+        ):
+            gatherer.gather(MagicMock())
+
+        gatherer._wait_for_acks.assert_called_once_with(0, 1)
+        self.assertEqual(gatherer._slot_generations[0], 3)
+        marker.publish_value.assert_called_once()
+
+    def test_incomplete_snapshot_retries(self):
+        gatherer, marker = self._gatherer(ready_values=[0, 1])
+
+        with (
+            patch.dict(sys.modules, {_MARKER_MODULE: marker}),
+            patch("torch.cuda.stream", return_value=nullcontext()),
+        ):
+            gatherer.gather(MagicMock())
+
+        self.assertEqual(marker.snapshot_rows_acquire.call_count, 2)
+        marker.publish_value.assert_called_once()
+
+    @staticmethod
+    def _gatherer(ready_values):
+        gatherer = object.__new__(SymmMemGather)
+        gatherer._slot = 0
+        gatherer._generation = 0
+        gatherer._slot_generations = [None, None]
+        gatherer._stream = MagicMock()
+        gatherer._host_in = MagicMock()
+        gatherer._staging = MagicMock()
+        gatherer._host_out = MagicMock()
+        gatherer._host_ready = MagicMock()
+        gatherer._host_ready.item.side_effect = ready_values
+        gatherer._region = [MagicMock()]
+        gatherer._marker_region = [MagicMock()]
+        gatherer._row_snapshot = MagicMock()
+        gatherer._ready = MagicMock()
+        gatherer._peer_row_ptrs = [[MagicMock()]]
+        gatherer._peer_marker_ptrs = [[MagicMock()]]
+        gatherer._peer_ack_ptrs = [[MagicMock()]]
+
+        marker = ModuleType(_MARKER_MODULE)
+        marker.copy_row_and_publish = MagicMock()
+        marker.snapshot_rows_acquire = MagicMock()
+        marker.publish_value = MagicMock()
+        marker.all_values_acquire = MagicMock()
+        return gatherer, marker
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/distributed/test_symm_mem_gather.py
+++ b/test/registered/unit/distributed/test_symm_mem_gather.py
@@ -13,22 +13,6 @@ _MARKER_MODULE = "sglang.srt.distributed.device_communicators.symm_mem_marker"
 
 
 class TestSymmMemGather(unittest.TestCase):
-    def test_slot_reuse_waits_for_ack(self):
-        gatherer, marker = self._gatherer(ready_values=[1])
-        gatherer._generation = 2
-        gatherer._slot_generations = [1, 2]
-        gatherer._wait_for_acks = MagicMock()
-
-        with (
-            patch.dict(sys.modules, {_MARKER_MODULE: marker}),
-            patch("torch.cuda.stream", return_value=nullcontext()),
-        ):
-            gatherer.gather(MagicMock())
-
-        gatherer._wait_for_acks.assert_called_once_with(0, 1)
-        self.assertEqual(gatherer._slot_generations[0], 3)
-        marker.publish_value.assert_called_once()
-
     def test_incomplete_snapshot_retries(self):
         gatherer, marker = self._gatherer(ready_values=[0, 1])
 
@@ -39,33 +23,28 @@ class TestSymmMemGather(unittest.TestCase):
             gatherer.gather(MagicMock())
 
         self.assertEqual(marker.snapshot_rows_acquire.call_count, 2)
-        marker.publish_value.assert_called_once()
 
     @staticmethod
     def _gatherer(ready_values):
         gatherer = object.__new__(SymmMemGather)
         gatherer._slot = 0
         gatherer._generation = 0
-        gatherer._slot_generations = [None, None]
         gatherer._stream = MagicMock()
         gatherer._host_in = MagicMock()
         gatherer._staging = MagicMock()
         gatherer._host_out = MagicMock()
         gatherer._host_ready = MagicMock()
-        gatherer._host_ready.item.side_effect = ready_values
+        gatherer._host_ready.all.return_value.item.side_effect = ready_values
         gatherer._region = [MagicMock()]
         gatherer._marker_region = [MagicMock()]
         gatherer._row_snapshot = MagicMock()
         gatherer._ready = MagicMock()
         gatherer._peer_row_ptrs = [[MagicMock()]]
         gatherer._peer_marker_ptrs = [[MagicMock()]]
-        gatherer._peer_ack_ptrs = [[MagicMock()]]
 
         marker = ModuleType(_MARKER_MODULE)
         marker.copy_row_and_publish = MagicMock()
         marker.snapshot_rows_acquire = MagicMock()
-        marker.publish_value = MagicMock()
-        marker.all_values_acquire = MagicMock()
         return gatherer, marker
 
 


### PR DESCRIPTION
## Motivation

This PR follows #34373 and fixes the Qwen3.5 MTP hang that remains in its symmetric-memory path.

#34373 improves performance by moving host staging and the metadata exchange off the WAR-fenced schedule stream and onto a private stream. Symmetric memory itself is not the main end-to-end speedup. However, its GPU barrier is still a rank rendezvous: with DP attention and overlap scheduling, one rank can enter the previous forward collective first while another enters the next metadata barrier first.

```text
rank A: previous forward collective -> DP metadata barrier
rank B: DP metadata barrier         -> previous forward collective
```

Waiting for the whole forward stream removes this cycle, but also removes overlap with unrelated tail compute. This PR instead removes the blocking GPU rendezvous from the symmetric-memory path while preserving the private-stream execution shape from #34373.

## Changes

- Copy each rank's complete seven-field metadata row directly into every peer's double-buffered symmetric region.
- Publish a system-scope generation marker only after the complete row is visible.
- Acquire each peer's marker once, snapshot that peer's complete row, and retry until every marker matches the expected generation.
- Rely on the gather's serial, blocking call contract and two-slot rotation instead of a separate acknowledgement protocol for slot reuse.
- Enable the PTX marker path only on CUDA devices with SM70 or newer; unsupported backends retain the existing fallback.

The host staging and private-stream placement from #34373 are preserved. The Gloo and NCCL paths are unchanged. The commit stack separates the publication primitives, transport integration, targeted tests, and review-driven cleanup.

## Validation

Latest head `b7289f8727`:

- Targeted pre-commit checks pass.
- CPU coverage verifies that an incomplete snapshot is retried.
- GPU ordering soak and exact serving validation are pending after the marker-only cleanup.

Historical evidence from the predecessor marker/ACK implementation:

- A 16-rank, 4-node GB300 ordering soak completed 100,000 skewed rounds with NCCL issued in the opposite rank order, exact per-field validation, and no hang.
- Frozen integration snapshot `520eaf2cfa` completed all 57,344 requests in the exact 44-GPU A1/H1/H2/A2 run with zero request errors and no hang.
- An earlier exact 44-GPU long-serving run completed 71,680 / 71,680 requests with zero request errors and no hang.
- An earlier exact 44-GPU GSM8K 8-shot sanity run scored 189 / 200.

These runs establish the reproduction, ordering diagnosis, and performance potential of removing the GPU rendezvous, but they do not validate the latest marker-only head. The latest head must be rerun on GPU before the PR is marked ready for review.

## Performance

Historical setup: `nvidia/Qwen3.5-397B-A17B-NVFP4-V2`, 44 GB300 GPUs, 7 prefill workers (DP/TP/EP 4), 1 decode worker (DP/TP/EP 16), MTP3 with 4 draft tokens, `trtllm_mha`, DeepEP low-latency, random ISL 8192 / OSL 1024.

At frozen integration snapshot `520eaf2cfa`, the Gloo baseline and predecessor marker/ACK path were run as A1/H1/H2/A2 on the same allocation. All four formal rounds completed 2x concurrency with identical request corpora and zero errors.

| Concurrency | Gloo mean TPOT | Marker/ACK mean TPOT | TPOT change | Gloo output TPS | Marker/ACK output TPS |
| ---: | ---: | ---: | ---: | ---: | ---: |
| 3072 | 24.321 ms | 23.168 ms | **-4.740%** | 57,841.9 | 58,778.2 |
| 4096 | 27.657 ms | 26.069 ms | **-5.739%** | 61,608.4 | 62,941.7 |

The paired TPOT changes were `-4.546%` / `-4.934%` at concurrency 3072 and `-5.316%` / `-6.161%` at concurrency 4096. Request-level bootstrap intervals were `[-5.316%, -4.150%]` and `[-6.251%, -5.228%]`, respectively.

These absolute TPOT values are not directly comparable with the 4-GPU numbers in #34373. They also belong to the predecessor snapshot, not the latest head. The latest marker-only implementation is expected to preserve the same host/private-stream mechanism with less protocol work, but its TPOT still needs to be measured.

## Checklist

- [x] Latest-head targeted pre-commit checks.
- [x] Historical multi-rank ordering soak and exact serving evidence.
- [ ] Latest-head multi-rank GPU ordering soak.
- [ ] Latest-head exact serving no-hang, accuracy, and performance validation.
- [ ] Documentation update. No user-facing API or configuration changes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829045715](https://github.com/sgl-project/sglang/actions/runs/34829045715)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829045581](https://github.com/sgl-project/sglang/actions/runs/34829045581)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
