### PR TITLE
[Docs] Use Meta's canonical Muse Glimmer GGUF filename

### DIFF
--- a/docs/src/snippets/configs/meta-models/muse-glimmer.jsx
+++ b/docs/src/snippets/configs/meta-models/muse-glimmer.jsx
@@ -63,7 +63,7 @@ export const config = {
 
   modelNames: {
     "default|bf16": "meta-models/Muse-Glimmer-30B",
-    "default|gguf": "meta-models/Muse-Glimmer-30B-GGUF/muse-glimmer-30B-kquant-17gb.gguf",
+    "default|gguf": "meta-models/Muse-Glimmer-30B-GGUF/Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf",
     "default|nvfp4": "RadixArk/Muse-Glimmer-NVFP4",
     "default|mlx-q4": "RadixArk/Muse-Glimmer-q4-MLX",
     "default|mlx-q4km": "RadixArk/Muse-Glimmer-q4km-gs128-MLX",


### PR DESCRIPTION
## Motivation

`meta-models/Muse-Glimmer-30B-GGUF` has renamed its artifacts to a canonical scheme that encodes the quant type ([hub discussion #5](https://huggingface.co/meta-models/Muse-Glimmer-30B-GGUF/discussions/5/files)), and Meta asked downstream repos to conform:

| Old | New |
|---|---|
| `muse-glimmer-30B-kquant-17gb.gguf` | `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf` |
| `muse-glimmer-30B-kquant-dynamic.gguf` | `Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf` |
| `mmproj-kquant.gguf` | `mmproj-Muse-Glimmer-30B-Q4_K_M.gguf` |
| `dflash-kquant.gguf` | `dflash-Muse-Glimmer-30B-Q4_K_M.gguf` |

## Modifications

One line. The cookbook's GGUF cells resolve `MODEL_NAME` through `modelNames["default|gguf"]`, which was the only reference to an old name left in the tree (verified by grepping all four old names repo-wide).

The other three names are intentionally not added:

- **dynamic / Q4_K_XL** is not offered as a cookbook quantization option.
- **mmproj** is unusable — SGLang has no `mmproj` path, and the cookbook already documents the GGUF route as text-only.
- **the GGUF DFlash draft** is not used: the `rtx5090` + `gguf` + `dflash` cell takes the HF draft `meta-models/Muse-Glimmer-30B-assistant` with `--speculative-draft-load-format auto`.

## Accuracy Test

No functional change — this is a docs snippet string. Both spellings currently resolve on the Hub (the repo carries old and new side by side at `43c7ead`), so this tracks the rename ahead of the old names being removed rather than fixing a live break.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Update documentation as needed, including docstrings or example tutorials.
- [ ] Provide accuracy results — N/A, docs-only string change.
- [ ] Add unit tests — N/A, docs-only string change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31635605053](https://github.com/sgl-project/sglang/actions/runs/31635605053)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31635605016](https://github.com/sgl-project/sglang/actions/runs/31635605016)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->