### PR TITLE
fix: preserve output logprobs without input logprobs

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2621,11 +2621,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         recv_obj: BatchStrOutput,
         recv_obj_index: int,
     ):
-        if recv_obj.input_token_logprobs_val is None:
-            return
-
         if (
-            len(recv_obj.input_token_logprobs_val) > 0
+            recv_obj.input_token_logprobs_val is not None
+            and len(recv_obj.input_token_logprobs_val) > 0
             and recv_obj.input_token_logprobs_val[recv_obj_index] is not None
         ):
             state.input_token_logprobs_val.extend(
@@ -2634,12 +2632,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             state.input_token_logprobs_idx.extend(
                 recv_obj.input_token_logprobs_idx[recv_obj_index]
             )
-        state.output_token_logprobs_val.extend(
-            recv_obj.output_token_logprobs_val[recv_obj_index]
-        )
-        state.output_token_logprobs_idx.extend(
-            recv_obj.output_token_logprobs_idx[recv_obj_index]
-        )
+        if (
+            recv_obj.output_token_logprobs_val is not None
+            and recv_obj.output_token_logprobs_val[recv_obj_index] is not None
+        ):
+            state.output_token_logprobs_val.extend(
+                recv_obj.output_token_logprobs_val[recv_obj_index]
+            )
+            state.output_token_logprobs_idx.extend(
+                recv_obj.output_token_logprobs_idx[recv_obj_index]
+            )
 
         if top_logprobs_num > 0:
             if len(recv_obj.input_top_logprobs_val) > 0:

--- a/test/registered/unit/managers/test_flat_raw_top_logprobs.py
+++ b/test/registered/unit/managers/test_flat_raw_top_logprobs.py
@@ -57,6 +57,7 @@ _EXACT_VAL_ROWS = [None, [-0.5, -2.5], [-0.25, -1.5], [-0.125, -4.0]]
 class _TokenizerManagerStub:
     """Borrow the real logprob meta_info methods without a full manager."""
 
+    convert_logprob_style = TokenizerManager.convert_logprob_style
     add_logprob_to_meta_info = TokenizerManager.add_logprob_to_meta_info
     detokenize_logprob_tokens = TokenizerManager.detokenize_logprob_tokens
     detokenize_top_logprobs_tokens = TokenizerManager.detokenize_top_logprobs_tokens
@@ -541,6 +542,32 @@ class TestMetaInfoFromSchedulerArrays(CustomTestCase):
         self.assertIs(
             again["input_top_logprobs_val_flat"], first["input_top_logprobs_val_flat"]
         )
+
+
+class TestTokenizerManagerLogprobs(CustomTestCase):
+    def test_output_logprobs_without_input_logprobs(self):
+        state = _make_state(return_logprob=True, top_logprobs_num=0)
+        recv_obj = SimpleNamespace(
+            input_token_logprobs_val=None,
+            input_token_logprobs_idx=None,
+            output_token_logprobs_val=[[-0.25]],
+            output_token_logprobs_idx=[[42]],
+        )
+        meta_info = {}
+
+        _TokenizerManagerStub().convert_logprob_style(
+            meta_info,
+            state,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            return_text_in_logprobs=False,
+            recv_obj=recv_obj,
+            recv_obj_index=0,
+        )
+
+        self.assertEqual(meta_info["input_token_logprobs"], [])
+        self.assertEqual(meta_info["output_token_logprobs"], [(-0.25, 42, None)])
+        self.assertEqual(meta_info["output_token_logprobs_length"], 1)
 
 
 def _make_batch_token_id_output(**overrides) -> BatchTokenIDOutput:


### PR DESCRIPTION
## Motivation

SGLang drops generated-token logprobs in the Python Engine API path when prompt/input logprobs are not requested.

`convert_logprob_style()` currently returns when `input_token_logprobs_val` is `None`, even if valid output logprobs are present. Consequently, downstream consumers such as Dynamo receive no logprobs for output-only requests like `logprobs=true, top_logprobs=0`.

Downstream context: https://github.com/ai-dynamo/dynamo/pull/12820


## Modifications

- Process input logprobs only when input logprob data is present.
- Process output logprobs independently when output logprob data is present.
- Add a regression test for output logprobs without input logprobs.

## Before and After

Launch SGLang without its tokenizer so top-logprob candidates contain token IDs and logprobs but no decoded token text:

```bash
python3 -m sglang.launch_server \
  --model-path Qwen/Qwen3-0.6B \
  --host 0.0.0.0 \
  --port 30000 \
  --skip-tokenizer-init
```
SGLang returns the candidate’s token ID and logprob, but its decoded text is missing:
```json
{
  "output_top_logprobs": [
    [
      [-0.42, 1234, null]
    ]
  ]
}
```
Send a request for one top-logprob candidate:

```bash
curl -s http://localhost:30000/generate \
  -H "Content-Type: application/json" \
  -d '{
    "input_ids": [45764, 23811],
    "sampling_params": {
      "temperature": 0,
      "max_new_tokens": 1
    },
    "return_logprob": true,
    "top_logprobs_num": 1,
    "logprob_start_len": -1
  }'
```
**Before this PR**, Dynamo could pass the incomplete candidate metadata into the OpenAI response:

```json
{
  "token": null,
  "bytes": null,
  "logprob": -0.42
}
```

**After this PR**, Dynamo uses the candidate token ID to fill in the missing text and bytes while preserving the original logprob:

```json
{
  "token": "A",
  "bytes": [65],
  "logprob": -0.42
}
```


## Accuracy Tests

This does not change model computation or generated text. It only preserves already-computed output logprob metadata.

Validation:

- New focused SGLang unit test: 1 passed.
- Adjacent SGLang tokenizer-manager tests: 28 passed, 2 skipped.
- Dynamo GPU end-to-end matrix passed for:
  - Non-streaming: `top_logprobs=0`, `top_logprobs=1`, and omitted.
  - Streaming: `top_logprobs=0` and `top_logprobs=1`.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31640510083](https://github.com/sgl-project/sglang/actions/runs/31640510083)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31640509938](https://github.com/sgl-project/sglang/actions/runs/31640509938)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->