### PR TITLE
[AMD][CI] Fix multimodal 2-GPU partition count on AMD

### DIFF
--- a/.github/workflows/pr-test-amd-rocm720.yml
+++ b/.github/workflows/pr-test-amd-rocm720.yml
@@ -813,7 +813,12 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
+        # 9 partitions: 2 parametrized + one per standalone file. run_suite.py
+        # assigns partitions >= (total - len(STANDALONE_FILES)) to standalone
+        # files and exits 1 when total < that count, so this list and
+        # --total-partitions below must grow with STANDALONE_FILES["2-gpu"]
+        # in python/sglang/multimodal_gen/test/server/gpu_cases.py.
+        part: [0, 1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi300') }}
     steps:
       - name: Checkout code
@@ -910,7 +915,7 @@ jobs:
             ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
               --suite 2-gpu \
               --partition-id ${{ matrix.part }} \
-              --total-partitions 3 \
+              --total-partitions 9 \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
           # Post-test diagnostics

--- a/.github/workflows/pr-test-amd.yml
+++ b/.github/workflows/pr-test-amd.yml
@@ -803,7 +803,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        part: [0, 1, 2]  # 3 partitions: 2 parametrized + 1 standalone (single_test_file/test_disagg_server.py)
+        # 9 partitions: 2 parametrized + one per standalone file. run_suite.py
+        # assigns partitions >= (total - len(STANDALONE_FILES)) to standalone
+        # files and exits 1 when total < that count, so this list and
+        # --total-partitions below must grow with STANDALONE_FILES["2-gpu"]
+        # in python/sglang/multimodal_gen/test/server/gpu_cases.py.
+        part: [0, 1, 2, 3, 4, 5, 6, 7, 8]
     runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi300') }}
     steps:
       - name: Checkout code
@@ -900,7 +905,7 @@ jobs:
             ci_sglang python3 sglang/multimodal_gen/test/run_suite.py \
               --suite 2-gpu \
               --partition-id ${{ matrix.part }} \
-              --total-partitions 3 \
+              --total-partitions 9 \
               ${{ needs.check-changes.outputs.continue_on_error == 'true' && '--continue-on-error' || '' }}
 
           # Post-test diagnostics


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

`run_suite.py` splits the mm_gen `2-gpu` suite into `total_partitions - len(STANDALONE_FILES["2-gpu"])` parametrized partitions plus one partition per standalone file, and bails when that subtraction goes negative:

```python
parametrized_partitions = args.total_partitions - len(standalone_files)

if parametrized_partitions < 0:
    print(
        f"Error: total_partitions ({args.total_partitions}) must be >= "
        f"standalone files ({len(standalone_files)})"
    )
    return 1
```

Both AMD workflows still pass `--total-partitions 3`, with a comment describing a single standalone file. `STANDALONE_FILES["2-gpu"]` has since grown to seven, so every partition of `multimodal-gen-test-2-gpu-amd` exits immediately with:

```
Error: total_partitions (3) must be >= standalone files (7)
```

No test runs. `--continue-on-error` does not mask it, because the guard returns 1 ahead of test execution — which is why the daily ROCm 7.2 cron has been failing all three partitions despite passing that flag (e.g. [run 31203793861](https://github.com/sgl-project/sglang/actions/runs/31203793861)).

This became more urgent with #34204, which promoted `pr-test-amd-rocm720.yml` to the blocking PR gate with `continue_on_error` defaulting to `false`. Any PR touching `python/sglang/multimodal_gen/**` now gets three red jobs and a red `pr-test-amd-rocm720-finish`.

## Modifications

Raise the 2-GPU multimodal job to 9 partitions in `pr-test-amd.yml` (the ROCm 7.0 shadow) and `pr-test-amd-rocm720.yml` (the ROCm 7.2 gate): `--total-partitions 9` and `part: [0..8]`.

Nine restores the originally intended 2 parametrized partitions and gives each of the 7 standalone files its own partition. Setting it to exactly 7 would satisfy the guard but leave `parametrized_partitions == 0`, so `partition_id < parametrized_partitions` would never hold and the parametrized cases would be silently dropped while the job reported green — worth avoiding.

The stale comment is replaced with the invariant and a pointer to `gpu_cases.py`, so the next person to add a standalone file knows both numbers must move. The 1-GPU job is untouched: it passes `--total-partitions 4` against 2 standalone files, which still yields 2 parametrized partitions.

## Verification

Simulating the real assignment against `STANDALONE_FILES` parsed from `gpu_cases.py`, for both workflows:

```
parts=[0, 1, 2, 3, 4, 5, 6, 7, 8]  total=9  standalone=7  parametrized=2
  len(matrix) == total-partitions : True
  parametrized partitions > 0     : True
  all standalone files covered    : True
  no out-of-range partition       : True
```

`actionlint` reports no new findings on either file (the diff against `main` is line-number shifts on the pre-existing self-hosted-runner-label warnings).

Note this PR cannot verify itself: the `multimodal_gen` paths filter does not include `.github/workflows/**`, so a workflow-only change leaves these jobs skipped. They need a stage-targeted `workflow_dispatch` against this branch to confirm.

## Follow-up

Hardcoded counts will drift again. The CUDA side already solved this — `pr-test-multimodal-gen.yml` derives both the matrix and the partition count from a `compute-diffusion-partitions` job wrapping `scripts/ci/utils/diffusion/compute_diffusion_partitions.py`. Porting that to the AMD workflows would remove the class of bug, but it needs AMD-appropriate timing parameters and has to preserve the AMD-only `-k` filters, so it is better as its own change than bundled into an urgent unblock.

Worth a reviewer's judgement: on `pr-test-amd-rocm720.yml` this job is `max-parallel: 1` with a 180-minute per-partition ceiling, so 9 serialized partitions raise the worst-case wall clock on a blocking gate. Actual time will be far below the ceiling (7 of the 9 partitions run a single file each), but if it proves too slow, raising `max-parallel` or giving the standalone partitions a shorter timeout would bound it. `pr-test-amd.yml` has no `max-parallel`, so the shadow fans out and is unaffected.

## Accuracy Tests

Not applicable — CI configuration only. This restores test execution that is currently not happening at all.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Notes on the checklist: there are no unit tests or docs to add for a CI partition-count fix; the verification above stands in for them.

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a250a478-10b8-4c0a-9df1-589da6507831?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a250a478-10b8-4c0a-9df1-589da6507831&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31636774219](https://github.com/sgl-project/sglang/actions/runs/31636774219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31636773943](https://github.com/sgl-project/sglang/actions/runs/31636773943)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->