### PR TITLE
[AMD][CI] Name extra-suite jobs after the ROCm stack they run

### DIFF
--- a/.github/workflows/pr-test-amd-extra.yml
+++ b/.github/workflows/pr-test-amd-extra.yml
@@ -19,6 +19,11 @@ name: PR Test Extra (AMD)
 #   - 2-gpu-large: multi-GPU (TP/PP/PD) mock-model + kv_canary e2e tests
 # kv_canary e2e is registered to the same extra-a stage as its CUDA siblings
 # (it now exercises the ROCm canary kernels end-to-end).
+#
+# Job display names mark the ROCm stack the way both callers mark their own
+# jobs: `-rocm720` for ROCm 7.2 (pr-test-amd-rocm720.yml) and no suffix for
+# ROCm 7.0 (pr-test-amd.yml). Direct pull_request runs get no `inputs`, so
+# they fall back to the ROCm 7.2 default and take the `-rocm720` suffix too.
 
 on:
   pull_request:
@@ -130,7 +135,7 @@ jobs:
   # setup across scarce AMD GPUs to shave only a couple minutes of test time,
   # so one GPU running the whole suite sequentially is the better trade.
   extra-a-test-1-gpu-small-amd:
-    name: ${{ format('extra-a-test-1-gpu-small-amd{0} (linux-{1}-1gpu-sglang)', inputs.rocm_version && inputs.rocm_version != 'rocm720' && format('-{0}', inputs.rocm_version) || '', inputs.runner_arch || 'mi300') }}
+    name: ${{ format('extra-a-test-1-gpu-small-amd{0} (linux-{1}-1gpu-sglang)', (inputs.rocm_version || 'rocm720') != 'rocm700' && format('-{0}', inputs.rocm_version || 'rocm720') || '', inputs.runner_arch || 'mi300') }}
     needs: [call-gate]
     if: ${{ !cancelled() && needs.call-gate.result == 'success' }}
     runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi300') }}
@@ -163,7 +168,7 @@ jobs:
   # pool as small (AMD GPUs carry enough VRAM that "large" here is a CUDA
   # memory-tier label, not a separate AMD runner pool).
   extra-a-test-1-gpu-large-amd:
-    name: ${{ format('extra-a-test-1-gpu-large-amd{0} (linux-{1}-1gpu-sglang)', inputs.rocm_version && inputs.rocm_version != 'rocm720' && format('-{0}', inputs.rocm_version) || '', inputs.runner_arch || 'mi300') }}
+    name: ${{ format('extra-a-test-1-gpu-large-amd{0} (linux-{1}-1gpu-sglang)', (inputs.rocm_version || 'rocm720') != 'rocm700' && format('-{0}', inputs.rocm_version || 'rocm720') || '', inputs.runner_arch || 'mi300') }}
     needs: [call-gate]
     if: ${{ !cancelled() && needs.call-gate.result == 'success' }}
     runs-on: ${{ format('linux-{0}-1gpu-sglang', inputs.runner_arch || 'mi300') }}
@@ -193,7 +198,7 @@ jobs:
   # Multi-GPU TP / PP / PD mock-model + kv_canary e2e tests. Mirrors CUDA's
   # extra-a 2-gpu-large stage; runs on the 2-GPU AMD pool.
   extra-a-test-2-gpu-large-amd:
-    name: ${{ format('extra-a-test-2-gpu-large-amd{0} (linux-{1}-2gpu-sglang)', inputs.rocm_version && inputs.rocm_version != 'rocm720' && format('-{0}', inputs.rocm_version) || '', inputs.runner_arch || 'mi300') }}
+    name: ${{ format('extra-a-test-2-gpu-large-amd{0} (linux-{1}-2gpu-sglang)', (inputs.rocm_version || 'rocm720') != 'rocm700' && format('-{0}', inputs.rocm_version || 'rocm720') || '', inputs.runner_arch || 'mi300') }}
     needs: [call-gate]
     if: ${{ !cancelled() && needs.call-gate.result == 'success' }}
     runs-on: ${{ format('linux-{0}-2gpu-sglang', inputs.runner_arch || 'mi300') }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

#34204 swapped the AMD PR gate to ROCm 7.2 and, in `pr-test-amd-extra.yml`, made the job display names suppress the suffix for `rocm720` and add `-rocm700` for ROCm 7.0. That inverts the convention both callers use for their own jobs: `pr-test-amd-rocm720.yml` suffixes every job `-rocm720`, and `pr-test-amd.yml` leaves them bare.

Two consequences today:

- A ROCm 7.2 PR shows `stage-b-test-1-gpu-small-amd-rocm720 (linux-mi300-1gpu-sglang)` next to an unsuffixed `extra-a-test-1-gpu-small-amd (linux-mi300-1gpu-sglang)`, even though both start the same ROCm 7.2 container.
- The six reusable-call job names changed stacks mid-history, so every name-keyed consumer starts a fresh series on 2026-08-12: `query_job_status.py --job` prefix reports (`amd-ci-job-monitor.yml`), `ci_failures_analysis.py` failure clusters, and the AMD nightly CI job matrix. The caller prefix (`call-pr-test-amd-extra` vs `call-pr-test-amd-extra-rocm720`) keeps 7.0 and 7.2 rows distinct, so nothing is conflated — but each of the six rows is orphaned from its own past.

## Modifications

Suffix on the stack instead of on "is this the default": `-rocm720` for ROCm 7.2, no suffix for ROCm 7.0. `pull_request` runs of the extra workflow get no `inputs`, so they resolve to the ROCm 7.2 default and are labelled `-rocm720`, matching the container the job actually starts.

| caller | before #34204 | on `main` today | this PR |
| --- | --- | --- | --- |
| `pr-test-amd-rocm720.yml` (7.2 gate) | `extra-a-test-1-gpu-small-amd-rocm720 (…)` | `extra-a-test-1-gpu-small-amd (…)` | `extra-a-test-1-gpu-small-amd-rocm720 (…)` |
| `pr-test-amd.yml` (7.0 shadow) | `extra-a-test-1-gpu-small-amd (…)` | `extra-a-test-1-gpu-small-amd-rocm700 (…)` | `extra-a-test-1-gpu-small-amd (…)` |
| direct `pull_request` (label-gated) | `extra-a-test-1-gpu-small-amd (…)`, ROCm 7.0 container | `extra-a-test-1-gpu-small-amd (…)`, ROCm 7.2 container | `extra-a-test-1-gpu-small-amd-rocm720 (…)`, ROCm 7.2 container |

Same for `extra-a-test-1-gpu-large-amd` and `extra-a-test-2-gpu-large-amd`. Both reusable-call rows go back to the names they carried before #34204, so their history reconnects.

Only job display names change; job ids, suite names (`run_suite.py --suite extra-a-test-*-amd`), the `rocm_version` inputs, and the containers are untouched. The one PR-visible change is the third row: the label-gated extra-a checks on a pull request gain the `-rocm720` suffix. They are gated behind `run-ci` + `run-ci-extra` and so shouldn't be required checks, but worth confirming against branch protection before merge.

`actionlint` is clean on the file.

## Accuracy Tests

N/A — CI job naming only.

## Speed Tests and Profiling

N/A — CI job naming only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43a452cd-e76f-4ebb-a290-7c1aa451693e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43a452cd-e76f-4ebb-a290-7c1aa451693e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31640177469](https://github.com/sgl-project/sglang/actions/runs/31640177469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31640177272](https://github.com/sgl-project/sglang/actions/runs/31640177272)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->