### PR TITLE
fix: reasoning_tokens counted when no thinking block is opened

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -519,6 +519,7 @@ class ModelConfig:
         # Cache attributes
         self.hf_eos_token_id = self._get_hf_eos_token_id()
         # Set by scheduler when reasoning_parser is enabled
+        self.think_start_ids: Optional[List[int]] = None
         self.think_end_ids: Optional[List[int]] = None
 
         # multimodal

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -145,6 +145,8 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 # This ensures pad_values don't overlap with valid text token IDs.
 MM_PAD_SHIFT_VALUE = 1_000_000
 
+PROMPT_THINK_SCAN_TOKENS = 256
+
 logger = logging.getLogger(__name__)
 
 
@@ -907,8 +909,12 @@ class Req(ReqDllmMixin):
         self.require_reasoning = require_reasoning
 
         # State indicating whether the reasoning phase has finished (only meaningful when require_reasoning is True)
+        self._is_reasoning_started = False
         self._is_reasoning_over = False
         self.reasoning_tokens = 0
+        self._pending_reasoning_tokens = 0
+        self._think_start_matcher: Optional[TokenSequenceMatcher] = None
+        self._think_start_match_len = 0
         self._think_end_matcher: Optional[TokenSequenceMatcher] = None
         self._think_end_match_len = 0
 
@@ -1820,7 +1826,28 @@ class Req(ReqDllmMixin):
             error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
         )
 
-    def update_reasoning_tokens(self, token_id, think_end_ids):
+    def _init_reasoning_state(self, think_start_ids, think_end_ids):
+        self._think_end_matcher = TokenSequenceMatcher(think_end_ids)
+        if not think_start_ids:
+            self._is_reasoning_started = True
+            return
+        self._think_start_matcher = TokenSequenceMatcher(think_start_ids)
+        self._is_reasoning_started = self._prompt_opens_reasoning()
+
+    def _prompt_opens_reasoning(self) -> bool:
+        """Whether the last thinking delimiter of the prompt tail leaves a block open."""
+        is_open = False
+        start_len = end_len = 0
+        for token in self.origin_input_ids[-PROMPT_THINK_SCAN_TOKENS:]:
+            start_len = self._think_start_matcher.advance(start_len, token)
+            end_len = self._think_end_matcher.advance(end_len, token)
+            if start_len == len(self._think_start_matcher):
+                is_open, start_len = True, 0
+            if end_len == len(self._think_end_matcher):
+                is_open, end_len = False, 0
+        return is_open
+
+    def update_reasoning_tokens(self, token_id, think_start_ids, think_end_ids):
         if self._is_reasoning_over:
             return
 
@@ -1828,18 +1855,29 @@ class Req(ReqDllmMixin):
             token_id = [token_id]
 
         if self._think_end_matcher is None:
-            self._think_end_matcher = TokenSequenceMatcher(think_end_ids)
+            self._init_reasoning_state(think_start_ids, think_end_ids)
+            unseen = max(0, len(self.output_ids) - len(token_id))
+            token_id = list(self.output_ids[:unseen]) + token_id
 
-        matched = self._think_end_match_len
-        for position, token in enumerate(token_id):
-            matched = self._think_end_matcher.advance(matched, token)
-            if matched == len(self._think_end_matcher):
-                self.reasoning_tokens += position + 1
+        for token in token_id:
+            if not self._is_reasoning_started:
+                self._pending_reasoning_tokens += 1
+                self._think_start_match_len = self._think_start_matcher.advance(
+                    self._think_start_match_len, token
+                )
+                if self._think_start_match_len == len(self._think_start_matcher):
+                    self._is_reasoning_started = True
+                    self.reasoning_tokens += self._pending_reasoning_tokens
+                    self._pending_reasoning_tokens = 0
+                continue
+
+            self.reasoning_tokens += 1
+            self._think_end_match_len = self._think_end_matcher.advance(
+                self._think_end_match_len, token
+            )
+            if self._think_end_match_len == len(self._think_end_matcher):
                 self._is_reasoning_over = True
                 return
-
-        self._think_end_match_len = matched
-        self.reasoning_tokens += len(token_id)
 
     def __repr__(self):
         return (

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -145,6 +145,7 @@ INIT_INCREMENTAL_DETOKENIZATION_OFFSET = 5
 # This ensures pad_values don't overlap with valid text token IDs.
 MM_PAD_SHIFT_VALUE = 1_000_000
 
+# Prompt tail to scan for a prefilled thinking delimiter.
 PROMPT_THINK_SCAN_TOKENS = 256
 
 logger = logging.getLogger(__name__)
@@ -1835,7 +1836,6 @@ class Req(ReqDllmMixin):
         self._is_reasoning_started = self._prompt_opens_reasoning()
 
     def _prompt_opens_reasoning(self) -> bool:
-        """Whether the last thinking delimiter of the prompt tail leaves a block open."""
         is_open = False
         start_len = end_len = 0
         for token in self.origin_input_ids[-PROMPT_THINK_SCAN_TOKENS:]:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -867,6 +867,20 @@ class Scheduler(
                     reasoning_parser.detector.think_end_token,
                 )
 
+            if reasoning_parser.detector.think_start_token:
+                think_start_ids = self.tokenizer.encode(
+                    reasoning_parser.detector.think_start_token,
+                    add_special_tokens=False,
+                )
+                if think_start_ids:
+                    self.model_config.think_start_ids = think_start_ids
+                else:
+                    logger.warning(
+                        "Reasoning parser think_start_token %r could not be encoded; "
+                        "reasoning_tokens will count from the first output token.",
+                        reasoning_parser.detector.think_start_token,
+                    )
+
     def init_mamba_backend(self) -> None:
         if initialize_mamba_selective_state_update_backend is not None:
             initialize_mamba_selective_state_update_backend(self.server_args)

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1107,7 +1107,11 @@ class SchedulerBatchResultProcessor:
     ):
         think_end_ids = self.model_config.think_end_ids
         if req.require_reasoning and think_end_ids:
-            req.update_reasoning_tokens(next_token_id, think_end_ids)
+            req.update_reasoning_tokens(
+                token_id=next_token_id,
+                think_start_ids=self.model_config.think_start_ids,
+                think_end_ids=think_end_ids,
+            )
 
     def _mamba_prefix_cache_update(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1105,11 +1105,12 @@ class SchedulerBatchResultProcessor:
         req: Req,
         next_token_id: Union[int, List[int]],
     ):
+        think_start_ids = self.model_config.think_start_ids
         think_end_ids = self.model_config.think_end_ids
         if req.require_reasoning and think_end_ids:
             req.update_reasoning_tokens(
                 token_id=next_token_id,
-                think_start_ids=self.model_config.think_start_ids,
+                think_start_ids=think_start_ids,
                 think_end_ids=think_end_ids,
             )
 

--- a/python/sglang/test/kits/reasoning_kit.py
+++ b/python/sglang/test/kits/reasoning_kit.py
@@ -32,6 +32,9 @@ class ReasoningTokenUsageMixin:
             parser.detector.think_end_token
         )
         assert cls.think_end_token_id is not None
+        cls.think_start_token_id = cls.tokenizer.convert_tokens_to_ids(
+            parser.detector.think_start_token
+        )
 
     def _reasoning_chat_request(self, enable_thinking, stream=False):
         api_key = getattr(self, "api_key", None)
@@ -113,6 +116,27 @@ class ReasoningTokenUsageMixin:
         reported = data["meta_info"]["reasoning_tokens"]
         actual = data["output_ids"].index(self.think_end_token_id) + 1
         self.assertEqual(reported, actual)
+
+    def test_reasoning_tokens_generate_without_thinking_delimiter(self):
+        api_key = getattr(self, "api_key", None)
+        headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+        resp = requests.post(
+            f"{self.base_url}/generate",
+            headers=headers,
+            json={
+                "text": "The capital city of France is",
+                "sampling_params": {"max_new_tokens": 32, "temperature": 0},
+                "require_reasoning": True,
+            },
+        )
+        self.assertEqual(resp.status_code, 200, resp.text)
+        data = resp.json()
+        reported = data["meta_info"]["reasoning_tokens"]
+
+        if self.think_start_token_id in data["output_ids"]:
+            self.assertGreater(reported, 0)
+        else:
+            self.assertEqual(reported, 0)
 
 
 class SeparateReasoningMixin:

--- a/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
+++ b/test/registered/unit/managers/test_batch_result_processor_hidden_states.py
@@ -29,7 +29,7 @@ def _make_processor(server_mode: str = "full") -> SchedulerBatchResultProcessor:
             enable_return_hidden_states=True,
             return_hidden_states_mode=server_mode,
         ),
-        model_config=SimpleNamespace(think_end_ids=None),
+        model_config=SimpleNamespace(think_start_ids=None, think_end_ids=None),
         token_to_kv_pool_allocator=Mock(),
         tree_cache=None,
         hisparse_coordinator=None,

--- a/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
+++ b/test/registered/unit/managers/test_batch_result_processor_mamba_boundary.py
@@ -55,7 +55,7 @@ def _make_processor() -> SchedulerBatchResultProcessor:
         enable_overlap=True,
         enable_overlap_mlx=False,
         server_args=SimpleNamespace(),
-        model_config=SimpleNamespace(think_end_ids=None),
+        model_config=SimpleNamespace(think_start_ids=None, think_end_ids=None),
         token_to_kv_pool_allocator=MagicMock(),
         tree_cache=None,
         hisparse_coordinator=None,

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -211,6 +211,15 @@ class TestReasoningTokenAccounting(CustomTestCase):
         self.assertEqual(req.reasoning_tokens, 0)
         self.assertFalse(req._is_reasoning_over)
 
+    def test_scalar_token_ids(self):
+        req, processor = self._make_reasoning_setup()
+
+        for token in (5, 6, 9, 7, 8, 10):
+            processor._maybe_update_reasoning_tokens(req, token)
+
+        self.assertEqual(req.reasoning_tokens, 5)
+        self.assertTrue(req._is_reasoning_over)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
+++ b/test/registered/unit/managers/test_batch_result_processor_spec_grammar.py
@@ -66,7 +66,7 @@ def _make_processor() -> SchedulerBatchResultProcessor:
         enable_overlap=False,
         enable_overlap_mlx=False,
         server_args=SimpleNamespace(enable_metrics=False),
-        model_config=SimpleNamespace(think_end_ids=None),
+        model_config=SimpleNamespace(think_start_ids=None, think_end_ids=None),
         token_to_kv_pool_allocator=None,
         tree_cache=None,
         hisparse_coordinator=None,
@@ -82,13 +82,15 @@ def _make_processor() -> SchedulerBatchResultProcessor:
     )
 
 
-def _make_req(terminate_after: int) -> Req:
+def _make_req(terminate_after: int, origin_input_ids=None) -> Req:
     sp = SamplingParams(max_new_tokens=256, temperature=0)
     sp.normalize(None)
     req = Req(
         rid="r0",
         origin_input_text="",
-        origin_input_ids=[1, 2, 3],
+        origin_input_ids=(
+            origin_input_ids if origin_input_ids is not None else [1, 2, 3]
+        ),
         sampling_params=sp,
     )
     req.grammar = _FakeGrammar(terminate_after=terminate_after)
@@ -135,17 +137,79 @@ class TestSpecV2GrammarTruncation(CustomTestCase):
 
 
 class TestReasoningTokenAccounting(CustomTestCase):
-    def test_multi_token_end_can_span_decode_steps(self):
-        req = _make_req(terminate_after=99)
+    THINK_START = [5, 6]
+    THINK_END = [7, 8]
+
+    def _make_reasoning_setup(self, origin_input_ids=None, with_start_ids=True):
+        req = _make_req(terminate_after=99, origin_input_ids=origin_input_ids)
         req.require_reasoning = True
         processor = _make_processor()
-        processor.model_config.think_end_ids = [7, 8]
+        if with_start_ids:
+            processor.model_config.think_start_ids = self.THINK_START
+        processor.model_config.think_end_ids = self.THINK_END
+        return req, processor
+
+    def test_multi_token_end_can_span_decode_steps(self):
+        req, processor = self._make_reasoning_setup(with_start_ids=False)
 
         processor._maybe_update_reasoning_tokens(req, [10, 7])
         processor._maybe_update_reasoning_tokens(req, [8, 11])
 
         self.assertEqual(req.reasoning_tokens, 3)
         self.assertTrue(req._is_reasoning_over)
+
+    def test_output_without_thinking_block_reports_no_reasoning(self):
+        req, processor = self._make_reasoning_setup()
+
+        processor._maybe_update_reasoning_tokens(req, [10, 11])
+        processor._maybe_update_reasoning_tokens(req, [12, 13])
+
+        self.assertEqual(req.reasoning_tokens, 0)
+        self.assertFalse(req._is_reasoning_over)
+
+    def test_start_emitted_in_output_counts_from_first_token(self):
+        req, processor = self._make_reasoning_setup()
+
+        processor._maybe_update_reasoning_tokens(req, [10, 5])
+        processor._maybe_update_reasoning_tokens(req, [6, 11])
+        processor._maybe_update_reasoning_tokens(req, [7, 8, 12])
+
+        self.assertEqual(req.reasoning_tokens, 6)
+        self.assertTrue(req._is_reasoning_over)
+
+    def test_prefilled_start_in_prompt_opens_the_block(self):
+        req, processor = self._make_reasoning_setup(origin_input_ids=[1, 5, 6])
+
+        processor._maybe_update_reasoning_tokens(req, [10, 11])
+
+        self.assertEqual(req.reasoning_tokens, 2)
+        self.assertFalse(req._is_reasoning_over)
+
+    def test_prompt_start_closed_by_a_later_end_does_not_open_the_block(self):
+        req, processor = self._make_reasoning_setup(origin_input_ids=[5, 6, 9, 7, 8])
+
+        processor._maybe_update_reasoning_tokens(req, [10, 11])
+
+        self.assertEqual(req.reasoning_tokens, 0)
+
+    def test_token_appended_without_counting_is_still_seen(self):
+        req, processor = self._make_reasoning_setup()
+        req.output_ids.append(5)
+        req.output_ids.extend([6, 11])
+
+        processor._maybe_update_reasoning_tokens(req, [6, 11])
+
+        self.assertEqual(req.reasoning_tokens, 3)
+        self.assertTrue(req._is_reasoning_started)
+
+    def test_end_delimiter_without_a_start_is_not_reasoning(self):
+        req, processor = self._make_reasoning_setup()
+
+        processor._maybe_update_reasoning_tokens(req, [10, 11])
+        processor._maybe_update_reasoning_tokens(req, [7, 8, 12])
+
+        self.assertEqual(req.reasoning_tokens, 0)
+        self.assertFalse(req._is_reasoning_over)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`usage.reasoning_tokens` counts from the first output token until the end-of-thinking delimiter, without checking that a thinking block was ever opened.

```bash
curl http://localhost:30000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "inkling-small",
  "messages": [{"role": "user", "content": "What is 1+3? Answer with just the number."}],
  "reasoning_effort": "none", "max_tokens": 128, "temperature": 0
}'
```

Before — the model answers without thinking, yet 4 of 5 completion tokens are billed as reasoning (Inkling's `<|end_message|>` terminates every message block, so a plain answer "closes" a thinking block that never opened):

```json
"message": {"content": "4", "reasoning_content": null},
"usage": {"completion_tokens": 5, "reasoning_tokens": 4}
```

After:

```json
"message": {"content": "4", "reasoning_content": null},
"usage": {"completion_tokens": 5, "reasoning_tokens": 0}
```

For models like Qwen3 the delimiter never arrives instead, so `reasoning_tokens == completion_tokens`.

## Modifications

- A thinking block opens only on the start delimiter; an end delimiter alone never counts.
- Templates that prefill the start delimiter (e.g. `<think>` at the end of the generation prompt) are detected by replaying the prompt tail.
- Tokens before the start delimiter count once the block opens, matching the parser's text split.
- First invocation reconciles `output_ids` tokens that bypassed the counter (e.g. the PD handoff token).
- No recognizable start delimiter → previous behavior.

No GPU-path changes; ~140ns/token steady state (unchanged), +33µs once per request.

## Verification

Live servers (Inkling-Small bf16, Qwen3-30B-A3B), temperature 0. Inkling "after" values come from replaying the captured output token streams through the patched counter. Numbers are `reasoning_tokens`; `x / y` reads reasoning / completion:

| case | before | after |
|---|---|---|
| Inkling, `reasoning_effort: "none"` | 4 / 5 completion | **0** |
| Inkling, raw `/generate` + `require_reasoning` | 64 / 64 | **0** |
| Inkling, thinking (default effort) | 13 | 13 |
| Qwen3, raw `/generate` + `require_reasoning` | 64 / 64 | **0** |
| Qwen3, `enable_thinking=true` | 192 | 192 |
| Qwen3, prompt prefills `<think>` | 207 (= end index + 1) | 207 |
| Qwen3, `enable_thinking=false` | 0 | 0 |

The four regression cases in `test_batch_result_processor_spec_grammar.py` fail on the pre-fix code and pass on this branch.

## Checklist

- [x] Format your code with `black`
- [x] Add unit tests
