### PR TITLE
[AMD][DI][Mooncake] Cap free GPU memory to guard against KFD PeerDirect accounting corruption

### DIFF
--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -434,7 +434,23 @@ def get_available_gpu_memory(
             # memory metric instead.
             free_gpu_memory = psutil.virtual_memory().available
         else:
-            free_gpu_memory, _ = torch.cuda.mem_get_info(gpu_id)
+            free_gpu_memory, total_gpu_memory = torch.cuda.mem_get_info(gpu_id)
+            if is_hip():
+                # ROCm/KFD accounting can be corrupted so that mem_get_info()
+                # reports MORE free than physically exists: registering the same
+                # GPU buffer as an RDMA MR (ibv_reg_mr / PeerDirect) across
+                # multiple NICs makes KFD under-count used memory by one buffer
+                # per extra NIC, inflating "free" (and underflowing "used").
+                # Downstream KV-pool sizing then over-allocates and OOMs.
+                # Cap free at a physically-sound upper bound: total minus what
+                # this process has actually allocated via torch. This clamps the
+                # inflated value without affecting a healthy driver, where
+                # free <= total - allocated already holds.
+                used_memory = float(torch.cuda.memory_allocated(gpu_id))
+                free_gpu_memory = min(
+                    float(free_gpu_memory),
+                    max(0.0, float(total_gpu_memory) - used_memory),
+                )
 
     elif device == "xpu":
         num_gpus = torch.xpu.device_count()


### PR DESCRIPTION
## Motivation

On ROCm/AMD, `torch.cuda.mem_get_info()` (hipMemGetInfo) can report **more free GPU memory than physically exists**, causing KV-cache pool sizing to over-allocate and OOM.

Root cause is in the amdgpu/KFD driver memory accounting: registering the **same** GPU buffer as an RDMA memory region (`ibv_reg_mr`, PeerDirect / GPUDirect) across **multiple NICs** makes KFD under-count "used" memory by one buffer per extra NIC. This is standard in disaggregated serving, where Mooncake registers the device KV pool on every HCA.

Minimal HIP + ibverbs repro (no Mooncake/sglang), MI355X, 8 GB buffer, `hipMemGetInfo` after each `ibv_reg_mr`:

```
after 8GB hipMalloc:  free=299.81  used=9.41   (correct)
after reg on NIC #1:  free=299.81  used=9.41   (correct)
after reg on NIC #2:  free=308.40  used=0.82   (+8GB back - WRONG)
after reg on NIC #3:  free=316.99  used underflows (uint64)
after reg on NIC #4:  free=325.58  total=309   (free now EXCEEDS physical total)
```

Inflation = `(nNIC - 1) * buffer_size`. SGLang reads this poisoned value and sizes the KV pool from it, leading to OOM. (The real fix belongs in the driver; reported to AMD separately.)

## Change

In `get_available_gpu_memory`, on **HIP only**, cap the reported free memory at a physically-sound upper bound: `min(driver_free, total - torch.cuda.memory_allocated())`. This clamps the inflated value while being a no-op on a healthy driver (where `free <= total - allocated` already holds). Mirrors the existing guard in the XPU branch.

Verified against the real corrupted numbers above: 308.40 and 325.58 GB both clamp back to the correct 299.81 GB; the healthy case is unchanged.

## Scope
- HIP/ROCm only; NVIDIA CUDA path unchanged.
- Uses per-process `memory_allocated`, so under multi-process GPU sharing the cap can only be equal-or-looser; it never falsely tightens a healthy case.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31652091298](https://github.com/sgl-project/sglang/actions/runs/31652091298)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31652091158](https://github.com/sgl-project/sglang/actions/runs/31652091158)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->