### PR TITLE
[AMD][CI] Add GPT-OSS perf benchmarks to the ROCm 7.2 nightly

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -500,6 +500,20 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
+      # Shares this job with the accuracy step above: it already serves the same
+      # two models, and an MI30x job spends ~49 min pulling the image and
+      # installing dependencies before it runs anything.
+      - name: Performance Test ROCm 7.2 (8-GPU GPT-OSS)
+        if: ${{ !cancelled() }}
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-gpt-oss --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
   nightly-accuracy-8-gpu-mi35x-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-8-gpu-mi35x-rocm720,'))
     runs-on: linux-mi35x-gpu-8
@@ -531,6 +545,18 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      # Shares this job with the accuracy step above rather than taking its own,
+      # so the container setup and the GPT-OSS weight cache are paid for once.
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU GPT-OSS)
+        if: ${{ !cancelled() }}
+        timeout-minutes: 120
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-gpt-oss --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -493,6 +493,7 @@ jobs:
       - name: Accuracy Test ROCm 7.2 (8-GPU GPT-OSS)
         timeout-minutes: 180
         run: |
+          > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
@@ -507,6 +508,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 120
         run: |
+          > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
@@ -542,6 +544,7 @@ jobs:
       - name: Accuracy Test MI35x ROCm 7.2 (8-GPU GPT-OSS)
         timeout-minutes: 180
         run: |
+          > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-mi35x --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
@@ -554,6 +557,7 @@ jobs:
         if: ${{ !cancelled() }}
         timeout-minutes: 120
         run: |
+          > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-gpt-oss --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?

--- a/python/sglang/test/nightly_bench_utils.py
+++ b/python/sglang/test/nightly_bench_utils.py
@@ -73,6 +73,46 @@ def generate_markdown_report(
     return summary
 
 
+def generate_simple_markdown_report(
+    results: List[BenchmarkResult], default_gpu_config: str = ""
+) -> str:
+    """Generate a markdown report without the H100-priced cost columns.
+
+    Drops the leading result when it is a warmup run, which the caller requests
+    by repeating the first batch size.
+    """
+    model_header = results[0].model_path
+    if results[0].run_name and results[0].run_name != "default":
+        model_header += f" ({results[0].run_name})"
+
+    gpu_config = os.getenv("GPU_CONFIG", default_gpu_config)
+    if gpu_config:
+        model_header += f" [{gpu_config}]"
+
+    summary = f"### {model_header}\n"
+    summary += "| batch size | input len | latency (s) | input throughput (tok/s) | output throughput (tok/s) | ITL (ms) |\n"
+    summary += "| ---------- | --------- | ----------- | ------------------------ | ------------------------- | -------- |\n"
+
+    report_results = (
+        results[1:]
+        if len(results) > 1 and results[0].batch_size == results[1].batch_size
+        else results
+    )
+
+    for result in report_results:
+        itl = (
+            1 / (result.output_throughput / result.batch_size) * 1000
+            if result.output_throughput > 0
+            else 0
+        )
+        summary += (
+            f"| {result.batch_size} | {result.input_len} | {result.latency:.2f} | "
+            f"{result.input_throughput:.2f} | {result.output_throughput:.2f} | {itl:.2f} |\n"
+        )
+
+    return summary
+
+
 def save_results_as_pydantic_models(
     results: List,
     pydantic_result_filename: str,

--- a/test/registered/amd/perf/mi30x/test_gpt_oss_perf_amd.py
+++ b/test/registered/amd/perf/mi30x/test_gpt_oss_perf_amd.py
@@ -1,0 +1,106 @@
+"""MI30x nightly performance benchmark for GPT-OSS (8-GPU).
+
+Benchmarks the bf16 GPT-OSS conversions (lmsys/gpt-oss-20b-bf16,
+lmsys/gpt-oss-120b-bf16) with the same TP8 AITER server configuration the
+MI30x GPT-OSS accuracy test uses, so a throughput change here points at the
+serving stack rather than at a different recipe.
+
+MI30x cannot serve the MXFP4 checkpoints natively, which is why the model
+paths differ from the MI35x benchmark.
+
+Registry: nightly-perf-8-gpu-gpt-oss suite
+
+Example usage:
+    python3 test_gpt_oss_perf_amd.py
+"""
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+# Register for AMD CI - MI30x GPT-OSS perf benchmark (~60 min for both sizes)
+register_amd_ci(est_time=3600, suite="nightly-perf-8-gpu-gpt-oss", nightly=True)
+
+RESULT_DIR = "performance_results_gpt_oss_mi30x"
+
+GPT_OSS_20B_MODEL_PATH = os.environ.get(
+    "GPT_OSS_20B_BF16_MODEL_PATH", "lmsys/gpt-oss-20b-bf16"
+)
+GPT_OSS_120B_MODEL_PATH = os.environ.get(
+    "GPT_OSS_120B_BF16_MODEL_PATH", "lmsys/gpt-oss-120b-bf16"
+)
+
+# Matches test/registered/amd/accuracy/mi30x/test_gpt_oss_eval_amd.py.
+SERVER_ARGS = [
+    "--trust-remote-code",
+    "--tp",
+    "8",
+    "--attention-backend",
+    "triton",
+    "--chunked-prefill-size",
+    "130172",
+    "--max-running-requests",
+    "128",
+    "--mem-fraction-static",
+    "0.85",
+]
+
+ENV_VARS = {"SGLANG_USE_AITER": "1"}
+
+
+class TestNightlyGptOssPerformanceAMD(unittest.TestCase):
+    """MI30x nightly performance benchmark for the bf16 GPT-OSS models."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # The leading duplicate is a warmup: this benchmark launches its own
+        # server, so nothing else has paid for JIT and autotuning first.
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+        cls.models = [GPT_OSS_20B_MODEL_PATH, GPT_OSS_120B_MODEL_PATH]
+
+        cls.runner = NightlyBenchmarkRunner(RESULT_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_result_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_one_batch(self):
+        """Benchmark every GPT-OSS size."""
+        failures = []
+        env = os.environ.copy()
+        env.update(ENV_VARS)
+
+        try:
+            for model_path in self.models:
+                with self.subTest(model=model_path):
+                    results, success, _ = self.runner.run_benchmark_for_model(
+                        model_path=model_path,
+                        batch_sizes=self.batch_sizes,
+                        input_lens=self.input_lens,
+                        output_lens=self.output_lens,
+                        other_args=SERVER_ARGS,
+                        extra_bench_args=["--trust-remote-code"],
+                        env=env,
+                    )
+
+                    if results:
+                        self.runner.full_report += (
+                            generate_simple_markdown_report(results, "MI30x") + "\n"
+                        )
+
+                    if not success:
+                        failures.append(f"benchmark failed for {model_path}")
+        finally:
+            self.runner.write_final_report()
+
+        if failures:
+            self.fail("\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/perf/mi35x/test_gpt_oss_perf_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_gpt_oss_perf_mi35x.py
@@ -1,0 +1,107 @@
+"""MI35x nightly performance benchmark for GPT-OSS (8-GPU).
+
+Benchmarks the MXFP4 GPT-OSS checkpoints (openai/gpt-oss-20b,
+openai/gpt-oss-120b) with the same TP8 AITER server configuration the MI35x
+GPT-OSS accuracy test uses, so a throughput change here points at the
+serving stack rather than at a different recipe.
+
+Registry: nightly-perf-8-gpu-mi35x-gpt-oss suite
+
+Example usage:
+    python3 test_gpt_oss_perf_mi35x.py
+"""
+
+import os
+import unittest
+
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.nightly_bench_utils import generate_simple_markdown_report
+from sglang.test.nightly_utils import NightlyBenchmarkRunner
+from sglang.test.test_utils import DEFAULT_URL_FOR_TEST, _parse_int_list_env
+
+# Register for AMD CI - MI35x GPT-OSS perf benchmark (~60 min for both sizes)
+register_amd_ci(est_time=3600, suite="nightly-perf-8-gpu-mi35x-gpt-oss", nightly=True)
+
+RESULT_DIR = "performance_results_gpt_oss_mi35x"
+
+# MI35x serves the MXFP4 checkpoints directly; MI30x uses the bf16 conversions.
+GPT_OSS_20B_MODEL_PATH = os.environ.get("GPT_OSS_20B_MODEL_PATH", "openai/gpt-oss-20b")
+GPT_OSS_120B_MODEL_PATH = os.environ.get(
+    "GPT_OSS_120B_MODEL_PATH", "openai/gpt-oss-120b"
+)
+
+# Matches test/registered/amd/accuracy/mi35x/test_gpt_oss_eval_mi35x.py.
+SERVER_ARGS = [
+    "--trust-remote-code",
+    "--tp",
+    "8",
+    "--attention-backend",
+    "triton",
+    "--chunked-prefill-size",
+    "130172",
+    "--max-running-requests",
+    "128",
+    "--mem-fraction-static",
+    "0.85",
+]
+
+# AITER's MXFP4 fused MoE for gpt-oss uses the separated gate/up tile layout;
+# other AITER MXFP4 callers default to interleave, so opt out explicitly.
+ENV_VARS = {
+    "SGLANG_USE_AITER": "1",
+    "SGLANG_USE_AITER_MOE_GU_ITLV": "1",
+}
+
+
+class TestNightlyGptOssPerformanceMI35x(unittest.TestCase):
+    """MI35x nightly performance benchmark for the MXFP4 GPT-OSS models."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        # The leading duplicate is a warmup: this benchmark launches its own
+        # server, so nothing else has paid for JIT and autotuning first.
+        cls.batch_sizes = [1, 1, 8, 16, 64]
+        cls.input_lens = tuple(_parse_int_list_env("NIGHTLY_INPUT_LENS", "4096"))
+        cls.output_lens = tuple(_parse_int_list_env("NIGHTLY_OUTPUT_LENS", "512"))
+        cls.models = [GPT_OSS_20B_MODEL_PATH, GPT_OSS_120B_MODEL_PATH]
+
+        cls.runner = NightlyBenchmarkRunner(RESULT_DIR, cls.__name__, cls.base_url)
+        cls.runner.setup_result_directory()
+        cls.runner.full_report = f"## {cls.__name__}\n"
+
+    def test_bench_one_batch(self):
+        """Benchmark every GPT-OSS size."""
+        failures = []
+        env = os.environ.copy()
+        env.update(ENV_VARS)
+
+        try:
+            for model_path in self.models:
+                with self.subTest(model=model_path):
+                    results, success, _ = self.runner.run_benchmark_for_model(
+                        model_path=model_path,
+                        batch_sizes=self.batch_sizes,
+                        input_lens=self.input_lens,
+                        output_lens=self.output_lens,
+                        other_args=SERVER_ARGS,
+                        extra_bench_args=["--trust-remote-code"],
+                        env=env,
+                    )
+
+                    if results:
+                        self.runner.full_report += (
+                            generate_simple_markdown_report(results, "MI35x") + "\n"
+                        )
+
+                    if not success:
+                        failures.append(f"benchmark failed for {model_path}")
+        finally:
+            self.runner.write_final_report()
+
+        if failures:
+            self.fail("\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

GPT-OSS is one of the models in the reported ROCm 7.2 + Triton 3.7 slowdown, and it has no throughput coverage on AMD — DeepSeek-V4 is the only affected model that does.

## Modifications

Add one benchmark per architecture, each sweeping batch sizes 1/8/16/64 (plus a leading warmup) at ISL 4096 / OSL 512 through `bench_one_batch_server`:

| Test | Hardware and precision | Models |
|---|---|---|
| `test_gpt_oss_perf_mi35x.py` | MI35x (gfx950) TP8, native MXFP4 + AITER | `openai/gpt-oss-20b`, `openai/gpt-oss-120b` |
| `test_gpt_oss_perf_amd.py` | MI30x (gfx942) TP8, bf16 conversions | `lmsys/gpt-oss-20b-bf16`, `lmsys/gpt-oss-120b-bf16` |

Launch arguments match the corresponding accuracy tests, so a throughput change points at the serving stack rather than at a different recipe. The checkpoints differ per architecture for the same reason the accuracy tests already split them: MI30x does not serve the MXFP4 checkpoints natively, which is why the `lmsys/*-bf16` conversions exist.

**Both run as a step on the GPT-OSS accuracy job that already serves the same models**, not as separate jobs:

- MI30x → `nightly-accuracy-8-gpu-rocm720`
- MI35x → `nightly-accuracy-8-gpu-mi35x-rocm720`

That avoids paying container setup and the weight cache a second time. Because no new jobs are created, the workflow diff is just the two added steps — no `job_select` options and no `check-all-jobs` dependencies change.

Both steps also clear `github_summary.md` before running, matching the convention every other multi-step job here uses. Without that, the second step re-appends the first step's block to `GITHUB_STEP_SUMMARY`.

Also lift the duplicated cost-free AMD markdown renderer into `generate_simple_markdown_report()` in `nightly_bench_utils.py`; both new tests use the same output schema as the existing AMD perf sweeps.

The tests report benchmark data and fail on launch or benchmark errors. They intentionally carry no throughput thresholds: there is no nightly history yet from which to set defensible baselines. The numbers below are the first data points toward those baselines. DeepSeek-V4 gating is separate in [#34640](https://github.com/sgl-project/sglang/pull/34640).

## Validation run

**[nightly-test-amd-rocm720 run 31850998638](https://github.com/sgl-project/sglang/actions/runs/31850998638) — success**, dispatched against this branch:

```bash
gh workflow run nightly-test-amd-rocm720.yml \
  --ref cursor/amd-gpt-oss-kimi-k3-perf-tests-7e6c \
  -f job_filter='nightly-accuracy-8-gpu-rocm720,nightly-accuracy-8-gpu-mi35x-rocm720' \
  -f continue_on_error=true
```

The filter selected exactly the two jobs this PR touches and skipped the other 45. All four steps passed, with each new perf step running after its existing accuracy step in the same job:

| Job | Accuracy step | Perf step |
|---|---|---|
| `nightly-accuracy-8-gpu-rocm720` | success, 11.7 min | success, 6.5 min |
| `nightly-accuracy-8-gpu-mi35x-rocm720` | success, 18.4 min | success, 3.9 min |

Re-validating the summary-clearing fix in [run 31936282742](https://github.com/sgl-project/sglang/actions/runs/31936282742).

## Accuracy Tests

No model or kernel changes; the new tests reuse existing serving recipes and add no accuracy assertions. Both GPT-OSS accuracy steps still pass in the validation run, unaffected by the added perf step.

Static validation completed:
- registered-test registry validation, and both suites resolve to exactly one file
- workflow YAML parsing, duplicate job-name check, and no stale dispatch option or `check-all-jobs` dependency
- Ruff, Black, isort, codespell

## Speed Tests and Profiling

Measured in the validation run above, at ISL 4096 / OSL 512, TP8. **Each architecture runs two different model sizes**, so every table below holds two independent sweeps — 20b and 120b — not one model measured twice.

**MI35x (gfx950), MXFP4 — `openai/gpt-oss-20b`**

| BS | Latency (s) | Output tok/s | ITL (ms) |
|---:|---:|---:|---:|
| 1 | 1.14 | 463.69 | 2.16 |
| 8 | 1.43 | 3148.30 | 2.54 |
| 16 | 1.66 | 5793.03 | 2.76 |
| 64 | 2.82 | 17393.64 | 3.68 |

**MI35x (gfx950), MXFP4 — `openai/gpt-oss-120b`**

| BS | Latency (s) | Output tok/s | ITL (ms) |
|---:|---:|---:|---:|
| 1 | 1.65 | 319.90 | 3.13 |
| 8 | 2.06 | 2177.35 | 3.67 |
| 16 | 2.39 | 4040.90 | 3.96 |
| 64 | 4.21 | 11661.29 | 5.49 |

**MI30x (gfx942), bf16 — `lmsys/gpt-oss-20b-bf16`**

| BS | Latency (s) | Output tok/s | ITL (ms) |
|---:|---:|---:|---:|
| 1 | 1.61 | 328.27 | 3.05 |
| 8 | 2.25 | 2119.96 | 3.77 |
| 16 | 2.73 | 3889.67 | 4.11 |
| 64 | 5.41 | 11078.14 | 5.78 |

**MI30x (gfx942), bf16 — `lmsys/gpt-oss-120b-bf16`**

| BS | Latency (s) | Output tok/s | ITL (ms) |
|---:|---:|---:|---:|
| 1 | 2.29 | 230.71 | 4.33 |
| 8 | 3.41 | 1393.54 | 5.74 |
| 16 | 4.72 | 2165.65 | 7.39 |
| 64 | 10.52 | 4837.02 | 13.23 |

### 20b vs 120b on the same hardware

The two sweeps per architecture differ because the models differ — 120b has ~6x the parameters and ~1.4x the active parameters per token of 20b:

| Architecture | 20b at BS 64 | 120b at BS 64 | 20b/120b |
|---|---:|---:|---:|
| MI35x (MXFP4) | 17393.64 tok/s | 11661.29 tok/s | 1.49x |
| MI30x (bf16) | 11078.14 tok/s | 4837.02 tok/s | 2.29x |

### Cross-architecture note

The MI35x and MI30x tables are also not comparable to each other: they differ in silicon *and* checkpoint precision, and the precision split is forced (MI30x cannot serve MXFP4 natively). Per-GPU weight footprint from the run's `Load weight end` lines:

| Model | MI35x (MXFP4) | MI30x (bf16) | Extra traffic on MI30x |
|---|---:|---:|---:|
| 20b | 2.33 GB | 5.00 GB | 2.15x |
| 120b | 11.52 GB | 27.40 GB | 2.38x |

For 120b at BS 64 the MI35x/MI30x throughput ratio (2.41x) lands almost exactly on that weight-traffic ratio (2.38x), which is what bandwidth-bound decode should do. Each table gates its own architecture over time; neither is a regression against the other.

### Added nightly cost

The sweeps are short because both models load and serve quickly:

| Step | Measured | Added cost |
|---|---:|---:|
| MI30x perf step | 6.5 min | 0.87 GPU-h |
| MI35x perf step | 3.9 min | 0.52 GPU-h |
| **Total** | | **≈1.4 GPU-h/night** |

Folding into the accuracy jobs rather than creating standalone jobs avoids repeating container setup and dependency install, which cost 9.0 min on MI30x and 6.0 min on MI35x in this run: standalone jobs would have made the same coverage ≈3.4 GPU-h/night.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb8c607c-a213-472c-8c96-8b8150a77e6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb8c607c-a213-472c-8c96-8b8150a77e6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31936281541](https://github.com/sgl-project/sglang/actions/runs/31936281541)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31936281293](https://github.com/sgl-project/sglang/actions/runs/31936281293)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->