### PR TITLE
Add codeowners for the DCP module

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /python/sglang/srt/layers/attention/mamba @yizhang2077 @hebiao064
 /python/sglang/srt/layers/attention/dsa @1am9trash @hubertlu-tw @kkHuang-amd @HaiShaw @Fridge003 @YAMY1234 @rainj-me
 /python/sglang/srt/layers/attention/vision.py @mickqian @yuan-luo @yhyang201
+/python/sglang/srt/layers/dcp @thanhhao98 @kpham-sgl @YAMY1234 @Fridge003
 /python/sglang/srt/layers/quantization @ch-wan @BBuf @Edwardf0t1 @FlamingoPg @AniZpZ @HaiShaw @b8zhong @OrangeRedeng @TamirBaydasov @Alisehen @mmangkad @TallMessiWu
 /python/sglang/srt/layers/quantization/quark @kkHuang-amd @yichiche @hubertlu-tw @1am9trash @BowenBao
 /python/sglang/srt/lora @Ying1123 @Fridge003 @lifuhuang @yushengsu-thu @jybsuper


### PR DESCRIPTION
## Motivation

`python/sglang/srt/layers/dcp/` has no CODEOWNERS entry today, so DCP changes fall through to the broad `/python/sglang/srt/layers` owners. @thanhhao98 authored the consolidation that created the directory (#29365) and the A2A + FlashInfer-MNNVL comm backends / q-replicate Helix support (#21637); @kpham-sgl, @YAMY1234 and @Fridge003 are co-maintaining the module.

## Modifications

Add one line to `.github/CODEOWNERS`, in the alphabetical `layers/` block:

```
/python/sglang/srt/layers/dcp @thanhhao98 @kpham-sgl @YAMY1234 @Fridge003
```

This follows the existing convention for `layers/` subdirectories (`attention/mamba`, `attention/dsa`, `quantization/quark`), where the subdirectory entry lists the specific owning team rather than repeating the parent's owners.

## Accuracy Tests

N/A — repository metadata only.

## Speed Tests and Profiling

N/A — repository metadata only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31659634509](https://github.com/sgl-project/sglang/actions/runs/31659634509)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31659634416](https://github.com/sgl-project/sglang/actions/runs/31659634416)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->