### PR TITLE
Add thanhhao98 to CI_PERMISSIONS.json

### DIFF
--- a/.github/CI_PERMISSIONS.json
+++ b/.github/CI_PERMISSIONS.json
@@ -1357,6 +1357,13 @@
         "cooldown_interval_minutes": 60,
         "reason": "custom override"
     },
+    "thanhhao98": {
+        "can_tag_run_ci_label": true,
+        "can_rerun_failed_ci": true,
+        "can_rerun_stage": true,
+        "cooldown_interval_minutes": 0,
+        "reason": "custom override"
+    },
     "thecodingwizard": {
         "can_tag_run_ci_label": true,
         "can_rerun_failed_ci": true,


### PR DESCRIPTION
## Motivation

Grant CI permissions to @thanhhao98 so they can trigger and rerun CI on their own PRs. They are an active contributor to DCP and speculative decoding — #21637, #29365, #29218, #31468 — and are proposed as the DCP module codeowner in #34648.

## Modifications

Add one entry to `.github/CI_PERMISSIONS.json`, matching the standard `custom override` shape used for active contributors:

```json
"thanhhao98": {
    "can_tag_run_ci_label": true,
    "can_rerun_failed_ci": true,
    "can_rerun_stage": true,
    "cooldown_interval_minutes": 0,
    "reason": "custom override"
}
```

`python3 .github/update_ci_permission.py --sort-only` is a no-op on the result, and the `sort CI_PERMISSIONS.json` pre-commit hook passes.

## Accuracy Tests

N/A — CI configuration only.

## Speed Tests and Profiling

N/A — CI configuration only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31659100773](https://github.com/sgl-project/sglang/actions/runs/31659100773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31659100642](https://github.com/sgl-project/sglang/actions/runs/31659100642)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->