### PR TITLE
feat(diffusion): rebuild MiniMax-H3 AdaLN outputs on demand

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -196,6 +196,7 @@ the cache stores the BF16 outputs of the original AdaLN linears.
 python -m sglang.multimodal_gen.tools.build_minimax_h3_adaln_cache \
   --transformer-path "$TRANSFORMER_PATH" \
   --model-variant fl2va \
+  --mode t2va \
   --num-inference-steps 50 \
   --flow-shift 12 \
   --audio-flow-shift 3 \
@@ -214,9 +215,10 @@ sglang serve \
 `$TRANSFORMER_PATH` is the `FL2VA/transformer` or `Ref2VA/transformer`
 directory in the normal SGLang/Hugging Face snapshot; the builder never
 downloads a second copy. A cache only covers the scheduler settings used to
-create it, including its step count, flow shifts, and condition noise values.
-SGLang rejects a request outside that coverage instead of silently changing
-conditioning. Cache mode supports the matching unquantized checkpoint only.
+create it, including its mode, step count, flow shifts, and condition noise
+values. SGLang rejects a request outside that coverage instead of silently
+changing conditioning. Cache mode supports the matching unquantized checkpoint
+only.
 
 ## 4. Generate video and audio
 

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -174,6 +174,50 @@ server environment.
 
 For MiniMax-H3, `--performance-mode speed` deliberately keeps the DiT eager. The current `torch.compile` path changes the model's numerical output, so it is not enabled implicitly by any recommended lossless preset. An explicit `--enable-torch-compile true` remains available for controlled experiments, but it should not be used to generate consistency ground truth.
 
+### Advanced: precomputed AdaLN cache
+
+The [model card](https://huggingface.co/MiniMaxAI/MiniMax-H3) notes that about
+13B H3 parameters are AdaLN branches whose outputs can be precomputed for
+inference. The public base checkpoint contains the original branches, not a
+ready-to-use cache. SGLang therefore keeps the standard path as the default.
+
+<Warning>
+This is an experimental deployment path. It is intentionally disabled unless
+you provide an explicitly generated cache; end-to-end numerical and peak-memory
+validation remains required before using it in production.
+</Warning>
+
+When an inference-only deployment has a fixed sampling schedule, build a cache
+from the already materialized transformer directory on CUDA, then pass it to
+the usual `sglang serve` command. This does not alter the denoising formula:
+the cache stores the BF16 outputs of the original AdaLN linears.
+
+```bash Command
+python -m sglang.multimodal_gen.tools.build_minimax_h3_adaln_cache \
+  --transformer-path "$TRANSFORMER_PATH" \
+  --model-variant fl2va \
+  --num-inference-steps 50 \
+  --flow-shift 12 \
+  --audio-flow-shift 3 \
+  --output /models/minimax-h3-fl2va-adaln-50step.safetensors
+
+sglang serve \
+  --model-path MiniMaxAI/MiniMax-H3 \
+  --model-variant fl2va \
+  --minimax-h3-adaln-cache-path /models/minimax-h3-fl2va-adaln-50step.safetensors \
+  --num-gpus 4 \
+  --tp-size 2 \
+  --ulysses-degree 2 \
+  --port 30010
+```
+
+`$TRANSFORMER_PATH` is the `FL2VA/transformer` or `Ref2VA/transformer`
+directory in the normal SGLang/Hugging Face snapshot; the builder never
+downloads a second copy. A cache only covers the scheduler settings used to
+create it, including its step count, flow shifts, and condition noise values.
+SGLang rejects a request outside that coverage instead of silently changing
+conditioning. Cache mode supports the matching unquantized checkpoint only.
+
 ## 4. Generate video and audio
 
 MiniMax-H3 uses the asynchronous OpenAI-compatible video endpoint. Choose a

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -77,7 +77,7 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 - `--model-path {MODEL}`: model path or Hugging Face model ID
 - `--served-model-name {NAME}`: stable model name exposed by serving APIs. Defaults to `--model-id` when set, otherwise `--model-path`.
 - `--model-variant {NAME}`: semantic checkpoint variant to load when one model repository contains multiple weight partitions. The pipeline maps this stable name to the repository layout before loading; for example, MiniMax-H3 accepts `fl2va` and `ref2va`. This is a server/load-time choice, unlike a request's `task`.
-- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose BF16 timestep embeddings are included in the cache. It requires unquantized weights and the matching model variant.
+- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose exact FP32 timestep plan is included in the cache. It requires unquantized weights and the matching model variant.
 - `--model-subfolder {PATH}`: advanced direct override for a component subfolder inside the model repository. Prefer `--model-variant` when the pipeline exposes semantic routing. If both are supplied, they must resolve to the same weight partition.
 - `--lora-path {PATH}` and `--lora-nickname {NAME}`: load a LoRA adapter
 - `--lora-weight-name {FILE}`: select one adapter file from a repository that contains multiple LoRA revisions. The Hub download is filtered to that file plus JSON metadata, so unused weights are not downloaded.

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -77,6 +77,7 @@ Use `sglang generate --help` and `sglang serve --help` for the full argument lis
 - `--model-path {MODEL}`: model path or Hugging Face model ID
 - `--served-model-name {NAME}`: stable model name exposed by serving APIs. Defaults to `--model-id` when set, otherwise `--model-path`.
 - `--model-variant {NAME}`: semantic checkpoint variant to load when one model repository contains multiple weight partitions. The pipeline maps this stable name to the repository layout before loading; for example, MiniMax-H3 accepts `fl2va` and `ref2va`. This is a server/load-time choice, unlike a request's `task`.
+- `--minimax-h3-adaln-cache-path {FILE}`: advanced MiniMax-H3-only inference cache. It replaces the checkpoint's AdaLN projection weights with precomputed outputs and only accepts requests whose BF16 timestep embeddings are included in the cache. It requires unquantized weights and the matching model variant.
 - `--model-subfolder {PATH}`: advanced direct override for a component subfolder inside the model repository. Prefer `--model-variant` when the pipeline exposes semantic routing. If both are supplied, they must resolve to the same weight partition.
 - `--lora-path {PATH}` and `--lora-nickname {NAME}`: load a LoRA adapter
 - `--lora-weight-name {FILE}`: select one adapter file from a repository that contains multiple LoRA revisions. The Hub download is filtered to that file plus JSON metadata, so unused weights are not downloaded.

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -224,6 +224,21 @@ class TransformerLoader(ComponentLoader):
                 component_server_args.model_variant
             )
             checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
+        if component_server_args.minimax_h3_adaln_online:
+            if cls_name != "MiniMaxH3DiTModel":
+                raise ValueError(
+                    "--minimax-h3-adaln-online is only supported by MiniMax H3"
+                )
+            if adaln_cache_path is not None:
+                raise ValueError(
+                    "--minimax-h3-adaln-online and --minimax-h3-adaln-cache-path "
+                    "are mutually exclusive"
+                )
+            # Keep the weights off-device; the model rebuilds the AdaLN
+            # outputs from the checkpoint for each request's timestep plan.
+            init_params["adaln_weight_files"] = safetensors_list
+            checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
+
         if (
             init_params["quant_config"] is None
             and component_server_args.transformer_weights_path is not None

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -237,6 +237,9 @@ class TransformerLoader(ComponentLoader):
             # Keep the weights off-device; the model rebuilds the AdaLN
             # outputs from the checkpoint for each request's timestep plan.
             init_params["adaln_weight_files"] = safetensors_list
+            init_params["adaln_plan_width"] = (
+                component_server_args.minimax_h3_adaln_plan_width
+            )
             checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
 
         if (

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from collections.abc import Callable
 from contextlib import nullcontext
 from typing import Any
 
@@ -48,6 +49,10 @@ def _resolve_checkpoint_load_device(
     if component_cpu_offload and runtime_quant_config is None:
         return torch.device("cpu")
     return runtime_device
+
+
+def _minimax_h3_adaln_cache_key_filter(name: str) -> bool:
+    return ".adaln_proj.linear." not in name
 
 
 def _default_quantized_attention_backend(
@@ -203,6 +208,22 @@ class TransformerLoader(ComponentLoader):
             "hf_config": config,
             "quant_config": quant_spec.runtime_quant_config,
         }
+        checkpoint_key_filter: Callable[[str], bool] | None = None
+        adaln_cache_path = component_server_args.minimax_h3_adaln_cache_path
+        if adaln_cache_path is not None:
+            if cls_name != "MiniMaxH3DiTModel":
+                raise ValueError(
+                    "--minimax-h3-adaln-cache-path is only supported by MiniMax H3"
+                )
+            if component_server_args.model_variant not in ("fl2va", "ref2va"):
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache requires --model-variant fl2va or ref2va"
+                )
+            init_params["adaln_cache_path"] = adaln_cache_path
+            init_params["adaln_cache_model_variant"] = (
+                component_server_args.model_variant
+            )
+            checkpoint_key_filter = _minimax_h3_adaln_cache_key_filter
         if (
             init_params["quant_config"] is None
             and component_server_args.transformer_weights_path is not None
@@ -273,6 +294,7 @@ class TransformerLoader(ComponentLoader):
                 output_dtype=None,
                 strict=False,
                 weight_load_plan=weight_load_plan,
+                checkpoint_key_filter=checkpoint_key_filter,
             )
 
         # post-hooks (e.g., patch scales (nunchaku))

--- a/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
+++ b/python/sglang/multimodal_gen/runtime/loader/fsdp_load.py
@@ -237,6 +237,7 @@ def maybe_load_fsdp_model(
     pin_cpu_memory: bool = True,
     strict: bool = True,
     weight_load_plan: WeightLoadPlan | None = None,
+    checkpoint_key_filter: Callable[[str], bool] | None = None,
 ) -> torch.nn.Module:
     """Load a model with optional FSDP (Fully Sharded Data Parallel) support.
 
@@ -347,6 +348,7 @@ def maybe_load_fsdp_model(
         and use_fsdp
         and weight_dir_list
         and preprocess_loaded_state_dict is None
+        and checkpoint_key_filter is None
         and not is_bnb_quantized
     ):
         preconverted_state_dict = (
@@ -361,6 +363,7 @@ def maybe_load_fsdp_model(
         and not use_fsdp
         and weight_dir_list
         and preprocess_loaded_state_dict is None
+        and checkpoint_key_filter is None
         and not is_bnb_quantized
     ):
         preconverted_state_dict = (
@@ -375,10 +378,14 @@ def maybe_load_fsdp_model(
         if weight_load_plan.load_full_state_dict_on_device:
             weight_iterator = safetensors_weights_iterator(
                 weight_dir_list,
+                key_filter=checkpoint_key_filter,
                 weight_load_plan=weight_load_plan,
             )
         else:
-            weight_iterator = safetensors_weights_iterator(weight_dir_list)
+            weight_iterator = safetensors_weights_iterator(
+                weight_dir_list,
+                key_filter=checkpoint_key_filter,
+            )
         if preprocess_loaded_state_dict is not None:
             weight_iterator = preprocess_loaded_state_dict(weight_iterator)
         if is_bnb_quantized:

--- a/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/weight_utils.py
@@ -228,6 +228,10 @@ def safetensors_weights_iterator(
         use_runai_model_streamer = (
             HAS_RUNAI_MODEL_STREAMER and envs.SGLANG_USE_RUNAI_MODEL_STREAMER
         )
+    if key_filter is not None:
+        # streamer filters after materializing all tensors, so it cannot skip
+        # a checkpoint partition at load time
+        use_runai_model_streamer = False
 
     # Validate files before loading
     corrupted_files, duplicate_files_by_key = _scan_safetensors_files(hf_weights_files)

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -8,10 +8,12 @@ contract accepts packed inference keyword arguments and returns packed logits.
 from __future__ import annotations
 
 import math
+import os
 from typing import Any
 
 import torch
 import torch.nn as nn
+from safetensors.torch import safe_open
 
 from sglang.kernels.ops.activation.activation import (
     silu_and_mul_with_activation_rounding_,
@@ -802,6 +804,94 @@ class MiniMaxH3AdalnProj(nn.Module):
         return self.split_output(x)
 
 
+class MiniMaxH3AdalnCache(nn.Module):
+    """Precomputed AdaLN outputs for a fixed set of BF16 timestep embeddings."""
+
+    _FORMAT_VERSION = "1"
+    adaln_inputs: torch.Tensor
+    block_params: torch.Tensor
+    final_params: torch.Tensor
+
+    def __init__(
+        self,
+        arch: MiniMaxH3DiTArchConfig,
+        *,
+        path: str,
+        model_variant: str | None,
+    ) -> None:
+        super().__init__()
+        self.path = path
+        self.model_variant = model_variant
+        self.num_layers = arch.num_layers
+        self.hidden_size = arch.hidden_size
+        self.time_embed_dim = arch.time_embed_dim
+
+    def load(self, device: torch.device) -> None:
+        if not os.path.isfile(self.path):
+            raise ValueError(f"MiniMax H3 AdaLN cache does not exist: {self.path}")
+
+        with safe_open(self.path, framework="pt", device="cpu") as cache_file:
+            metadata = cache_file.metadata() or {}
+            if metadata.get("format_version") != self._FORMAT_VERSION:
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache has an unsupported or missing format_version"
+                )
+            cache_variant = metadata.get("model_variant")
+            if self.model_variant is not None and cache_variant != self.model_variant:
+                raise ValueError(
+                    "MiniMax H3 AdaLN cache model_variant does not match the loaded "
+                    f"variant ({cache_variant!r} != {self.model_variant!r})"
+                )
+            adaln_inputs = cache_file.get_tensor("adaln_inputs")
+            block_params = cache_file.get_tensor("block_params")
+            final_params = cache_file.get_tensor("final_params")
+
+        expected_block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * self.hidden_size
+        expected_final_width = 2 * self.hidden_size
+        if (
+            adaln_inputs.dtype != _BF16_DTYPE
+            or adaln_inputs.ndim != 2
+            or adaln_inputs.shape[1] != self.time_embed_dim
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid adaln_inputs")
+        if block_params.dtype != _BF16_DTYPE or block_params.shape != (
+            adaln_inputs.shape[0],
+            self.num_layers,
+            expected_block_width,
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid block_params")
+        if final_params.dtype != _BF16_DTYPE or final_params.shape != (
+            adaln_inputs.shape[0],
+            expected_final_width,
+        ):
+            raise ValueError("MiniMax H3 AdaLN cache has invalid final_params")
+
+        self.register_buffer("adaln_inputs", adaln_inputs.to(device))
+        self.register_buffer("block_params", block_params.to(device))
+        self.register_buffer("final_params", final_params.to(device))
+
+    def lookup(self, adaln_input: torch.Tensor) -> torch.Tensor:
+        matches = (
+            self.adaln_inputs.unsqueeze(0).eq(adaln_input.unsqueeze(1)).all(dim=-1)
+        )
+        if not bool(matches.any(dim=1).all()):
+            raise ValueError(
+                "MiniMax H3 AdaLN cache does not cover the request timestep embedding"
+            )
+        return matches.to(torch.int64).argmax(dim=1)
+
+    def block(
+        self, index: int, cache_indices: torch.Tensor
+    ) -> tuple[torch.Tensor, ...]:
+        params = self.block_params.index_select(0, cache_indices)[:, index]
+        params = params.view(-1, 6, self.hidden_size)
+        return tuple(params.unbind(dim=1))
+
+    def final(self, cache_indices: torch.Tensor) -> tuple[torch.Tensor, ...]:
+        params = self.final_params.index_select(0, cache_indices)
+        return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
+
+
 class MiniMaxH3TokenRefinerBlock(nn.Module):
     """Standard pre-norm transformer block without AdaLN or RoPE."""
 
@@ -890,6 +980,7 @@ class MiniMaxH3DiTBlock(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        use_adaln_cache: bool = False,
     ) -> None:
         super().__init__()
         self.norm1 = _norm(arch.hidden_size, eps=arch.norm_eps)
@@ -900,13 +991,17 @@ class MiniMaxH3DiTBlock(nn.Module):
             prefix=f"{prefix}.attn",
         )
         self.mlp = MiniMaxH3MLP(arch, quant_config, prefix=f"{prefix}.mlp")
-        self.adaln_proj = MiniMaxH3AdalnProj(
-            arch,
-            arch.adaln_out_features,
-            quant_config,
-            prefix=f"{prefix}.adaln_proj",
-            expand_ratio=6,
-            modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+        self.adaln_proj = (
+            None
+            if use_adaln_cache
+            else MiniMaxH3AdalnProj(
+                arch,
+                arch.adaln_out_features,
+                quant_config,
+                prefix=f"{prefix}.adaln_proj",
+                expand_ratio=6,
+                modality_num=MINIMAX_H3_ADALN_MODALITY_NUM,
+            )
         )
         self.preserve_input_for_cache_dit = False
 
@@ -932,6 +1027,8 @@ class MiniMaxH3DiTBlock(nn.Module):
         norm2 -> scale/shift -> MLP -> gated residual.
         """
         if adaln_params is None:
+            if self.adaln_proj is None:
+                raise ValueError("MiniMax H3 AdaLN cache parameters are required")
             adaln_params = self.adaln_proj(adaln_input)
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = adaln_params
         # Cache-DiT retains the inputs to its Fn and Mn block ranges. Only the
@@ -984,6 +1081,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         quant_config: QuantizationConfig | None,
         *,
         prefix: str,
+        use_adaln_cache: bool = False,
     ) -> None:
         super().__init__()
         video_patch_dim = (
@@ -993,13 +1091,17 @@ class MiniMaxH3FinalLayer(nn.Module):
             * arch.patch_size[2]
         )
         self.norm = _norm(arch.hidden_size, eps=arch.final_norm_eps)
-        self.adaln_proj = MiniMaxH3AdalnProj(
-            arch,
-            arch.final_adaln_out_features,
-            quant_config,
-            prefix=f"{prefix}.adaln_proj",
-            expand_ratio=2,
-            modality_num=1,
+        self.adaln_proj = (
+            None
+            if use_adaln_cache
+            else MiniMaxH3AdalnProj(
+                arch,
+                arch.final_adaln_out_features,
+                quant_config,
+                prefix=f"{prefix}.adaln_proj",
+                expand_ratio=2,
+                modality_num=1,
+            )
         )
         self.video_out = ColumnParallelLinear(
             arch.hidden_size,
@@ -1026,6 +1128,7 @@ class MiniMaxH3FinalLayer(nn.Module):
         *,
         adaln_input: torch.Tensor,
         inverse_indices: torch.Tensor,
+        adaln_params: tuple[torch.Tensor, ...] | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Project all rows into TP-local video/audio output shards.
 
@@ -1034,7 +1137,11 @@ class MiniMaxH3FinalLayer(nn.Module):
         The model gathers output columns only after selecting live media rows,
         preserving the GEMM shape while reducing collective payload.
         """
-        shift, scale = self.adaln_proj(adaln_input)
+        if adaln_params is None:
+            if self.adaln_proj is None:
+                raise ValueError("MiniMax H3 AdaLN cache parameters are required")
+            adaln_params = self.adaln_proj(adaln_input)
+        shift, scale = adaln_params
         h = self.norm(x)
         h = _modulate_scale_shift(h, shift, scale, inverse_indices, dtype=_BF16_DTYPE)
         # Preserve full precision through both final output projections.
@@ -1058,7 +1165,8 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
 
     def _can_batch_block_adaln(self) -> bool:
         return (
-            get_tp_world_size() > 1
+            self.adaln_cache is None
+            and get_tp_world_size() > 1
             and not torch.compiler.is_compiling()
             and not envs.SGLANG_CACHE_DIT_ENABLED
             and not hasattr(self, "_sglang_cache_dit_adapter")
@@ -1134,8 +1242,14 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         config: MiniMaxH3DiTConfig,
         hf_config: dict[str, Any],
         quant_config: QuantizationConfig | None = None,
+        adaln_cache_path: str | None = None,
+        adaln_cache_model_variant: str | None = None,
     ) -> None:
         super().__init__(config=config, hf_config=hf_config)
+        if adaln_cache_path is not None and quant_config is not None:
+            raise ValueError(
+                "MiniMax H3 AdaLN cache is only compatible with unquantized weights"
+            )
         arch = self.config
         self.arch = arch
         self.hidden_size = arch.hidden_size
@@ -1197,6 +1311,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
                     arch,
                     quant_config,
                     prefix=f"blocks.{index}",
+                    use_adaln_cache=adaln_cache_path is not None,
                 )
                 for index in range(arch.num_layers)
             ]
@@ -1206,6 +1321,16 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             arch,
             quant_config,
             prefix="final_layer",
+            use_adaln_cache=adaln_cache_path is not None,
+        )
+        self.adaln_cache = (
+            None
+            if adaln_cache_path is None
+            else MiniMaxH3AdalnCache(
+                arch,
+                path=adaln_cache_path,
+                model_variant=adaln_cache_model_variant,
+            )
         )
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()
@@ -1256,6 +1381,8 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             raise ValueError(
                 f"rope.inv_freq must stay fp32 after load, got {rope_inv_freq.dtype}."
             )
+        if self.adaln_cache is not None:
+            self.adaln_cache.load(self.video_patch_proj.weight.device)
 
     @staticmethod
     def _pos_ids(pos_info: Any, key: str) -> torch.Tensor:
@@ -1685,7 +1812,14 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         hidden = decoder_input
         cu_seqlens = cu_seqlens.to(device)
         block_adaln_params = None
-        if self._can_batch_block_adaln():
+        adaln_cache_indices = None
+        if self.adaln_cache is not None:
+            adaln_cache_indices = self.adaln_cache.lookup(adaln_input)
+            block_adaln_params = tuple(
+                self.adaln_cache.block(index, adaln_cache_indices)
+                for index in range(len(self.blocks))
+            )
+        elif self._can_batch_block_adaln():
             local_adaln = torch.stack(
                 [block.adaln_proj.project_local(adaln_input) for block in self.blocks]
             )
@@ -1718,6 +1852,11 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             hidden,
             adaln_input=adaln_input,
             inverse_indices=block_inverse,
+            adaln_params=(
+                None
+                if adaln_cache_indices is None
+                else self.adaln_cache.final(adaln_cache_indices)
+            ),
         )
         if sp_ws > 1:
             from sglang.multimodal_gen.runtime.distributed.parallel_state import (

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -895,7 +895,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
         params = self.block_params[cache_plan_index, :num_timesteps, index]
-        params = params.view(-1, 6, self.hidden_size)
+        params = params.reshape(-1, 6, self.hidden_size)
         return tuple(params.unbind(dim=1))
 
     def final(
@@ -904,7 +904,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
         params = self.final_params[cache_plan_index, :num_timesteps]
-        return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
+        return tuple(params.reshape(-1, 2, self.hidden_size).unbind(dim=1))
 
 
 class MiniMaxH3TokenRefinerBlock(nn.Module):

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 import math
 import os
-from typing import Any
+import struct
+from contextlib import ExitStack
+from typing import Any, Callable
 
 import torch
 import torch.nn as nn
@@ -42,6 +44,7 @@ from sglang.multimodal_gen.runtime.distributed import (
 )
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     get_ring_ctx,
+    get_tp_rank,
     get_ulysses_ctx,
 )
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
@@ -66,9 +69,12 @@ from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
     current_platform,
 )
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
+
+logger = init_logger(__name__)
 
 _ARCH_DEFAULTS = MiniMaxH3DiTArchConfig()
 _BF16_DTYPE = torch.bfloat16
@@ -804,6 +810,20 @@ class MiniMaxH3AdalnProj(nn.Module):
         return self.split_output(x)
 
 
+# A ref2va request carrying both a visual and an audio reference reaches four
+# distinct timesteps in one step: video, audio, the imgvid condition and the
+# audio reference.
+MINIMAX_H3_ADALN_MAX_PLAN_WIDTH = 4
+
+
+def _plan_key(timesteps: torch.Tensor) -> tuple[int, ...]:
+    """One denoise step's unique timesteps as their exact fp32 bit patterns."""
+    return tuple(
+        struct.unpack("<I", struct.pack("<f", float(value)))[0]
+        for value in timesteps.tolist()
+    )
+
+
 class MiniMaxH3AdalnCache(nn.Module):
     """Precomputed AdaLN outputs for fixed FP32 timestep plans."""
 
@@ -817,16 +837,33 @@ class MiniMaxH3AdalnCache(nn.Module):
         self,
         arch: MiniMaxH3DiTArchConfig,
         *,
-        path: str,
-        model_variant: str | None,
+        path: str | None = None,
+        model_variant: str | None = None,
+        weight_files: list[str] | None = None,
+        max_plans: int = 64,
     ) -> None:
         super().__init__()
+        if (path is None) == (weight_files is None):
+            raise ValueError(
+                "MiniMax H3 AdaLN cache takes exactly one of path (prebuilt "
+                "sidecar) or weight_files (rebuild from the checkpoint)"
+            )
         self.path = path
         self.model_variant = model_variant
+        self.weight_files = weight_files
+        self.max_plans = max_plans
         self.num_layers = arch.num_layers
         self.hidden_size = arch.hidden_size
+        self.block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * arch.hidden_size
+        self.final_width = 2 * arch.hidden_size
+        # Rebuild path only: plan bit pattern -> slot, tracked on the host.
+        self._slots: dict[tuple[int, ...], int] = {}
+        self.rebuilds = 0
 
     def load(self, device: torch.device) -> None:
+        if self.path is None:
+            self._allocate(device)
+            return
         if not os.path.isfile(self.path):
             raise ValueError(f"MiniMax H3 AdaLN cache does not exist: {self.path}")
 
@@ -876,6 +913,144 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.register_buffer("plan_lengths", plan_lengths.to(device))
         self.register_buffer("block_params", block_params.to(device))
         self.register_buffer("final_params", final_params.to(device))
+
+    def _allocate(self, device: torch.device) -> None:
+        """Empty slab for the rebuild path; its pointers must never move.
+
+        ``plan_lengths`` starts at zero and that is what keeps unused slots out
+        of ``lookup``: a real plan always has at least one timestep, so a zero
+        length can never match. Breakable CUDA graph keys its replay signature
+        on tensor pointers, so this is allocated once and only written in place.
+        """
+        width = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH
+        self.register_buffer(
+            "plan_timesteps",
+            torch.zeros((self.max_plans, width), dtype=_FP32_DTYPE, device=device),
+        )
+        self.register_buffer(
+            "plan_lengths",
+            torch.zeros((self.max_plans,), dtype=torch.int64, device=device),
+        )
+        self.register_buffer(
+            "block_params",
+            torch.zeros(
+                (self.max_plans, width, self.num_layers, self.block_width),
+                dtype=_BF16_DTYPE,
+                device=device,
+            ),
+        )
+        self.register_buffer(
+            "final_params",
+            torch.zeros(
+                (self.max_plans, width, self.final_width),
+                dtype=_BF16_DTYPE,
+                device=device,
+            ),
+        )
+        logger.info(
+            "MiniMax H3 AdaLN rebuild slab: %d plans x %d timesteps = %.2f GiB",
+            self.max_plans,
+            width,
+            self.block_params.numel() * 2 / 2**30,
+        )
+
+    def build(
+        self,
+        step_timesteps: list[torch.Tensor],
+        *,
+        embed: Callable[[torch.Tensor], torch.Tensor],
+    ) -> None:
+        """Fill every plan this request will look up, in one streaming pass.
+
+        Each plan keeps its own timestep count as the GEMM batch size, because
+        cuBLAS selects kernels by shape and the selection is not monotonic in M:
+        against the runtime's M == 2, results at M == 4/8/16/64/96 are
+        bit-identical while M == 32 differs in 11760 of 96768 elements and
+        M == 1 (the GEMV path the first denoise step takes) differs in 69.
+        Rebuilding a plan at any other batch size silently perturbs the output.
+
+        The pass reads all 50 adaln_proj layers regardless of how many plans are
+        missing, so a request builds everything it needs before denoising rather
+        than filling in step by step.
+        """
+        wanted: dict[tuple[int, ...], torch.Tensor] = {}
+        for timesteps in step_timesteps:
+            wanted.setdefault(_plan_key(timesteps), timesteps)
+        missing = {k: v for k, v in wanted.items() if k not in self._slots}
+        if not missing:
+            return
+        if len(self._slots) + len(missing) > self.max_plans:
+            # Every plan a request looks up has to stay resident for the whole
+            # denoise loop, so an overflow means the capacity is too small --
+            # evicting part of it would only move the failure into lookup().
+            self._slots.clear()
+            self.plan_lengths.zero_()
+        if len(missing) > self.max_plans:
+            raise ValueError(
+                f"MiniMax H3 AdaLN rebuild needs {len(missing)} plans but "
+                f"max_plans is {self.max_plans}"
+            )
+
+        device = self.block_params.device
+        slots = []
+        for key, timesteps in missing.items():
+            slot = len(self._slots)
+            self._slots[key] = slot
+            slots.append((slot, timesteps.numel(), embed(timesteps.to(device))))
+            self.plan_timesteps[slot, : timesteps.numel()] = timesteps.to(device)
+
+        # adaln_proj is a ColumnParallelLinear: each rank owns a slice of the
+        # output features and all-gathers afterwards. The rebuild has to do the
+        # same rather than read the full width in one go -- a sharded GEMM has a
+        # different N, so cuBLAS picks a different kernel and the outputs stop
+        # matching. It also cuts per-rank checkpoint reads to 1/tp.
+        tp_size = get_tp_world_size()
+        tp_rank = get_tp_rank() if tp_size > 1 else 0
+
+        with ExitStack() as stack:
+            handles = [
+                stack.enter_context(safe_open(f, framework="pt", device=str(device)))
+                for f in self.weight_files
+            ]
+            index = {name: h for h in handles for name in h.keys()}
+
+            def read_shard(name: str, out_features: int) -> torch.Tensor:
+                if tp_size == 1:
+                    return index[name].get_tensor(name)
+                shard = out_features // tp_size
+                start = tp_rank * shard
+                return index[name].get_slice(name)[start : start + shard]
+
+            def project(adaln_input: torch.Tensor, weight, bias) -> torch.Tensor:
+                out = nn.functional.linear(adaln_input, weight, bias)
+                return tensor_model_parallel_all_gather(out) if tp_size > 1 else out
+
+            for layer in range(self.num_layers):
+                prefix = f"blocks.{layer}.adaln_proj.linear"
+                weight = read_shard(f"{prefix}.weight", self.block_width)
+                bias = read_shard(f"{prefix}.bias", self.block_width)
+                for slot, length, adaln_input in slots:
+                    self.block_params[slot, :length, layer] = project(
+                        adaln_input, weight, bias
+                    )
+                del weight, bias
+            prefix = "final_layer.adaln_proj.linear"
+            weight = read_shard(f"{prefix}.weight", self.final_width)
+            bias = read_shard(f"{prefix}.bias", self.final_width)
+            for slot, length, adaln_input in slots:
+                self.final_params[slot, :length] = project(adaln_input, weight, bias)
+            del weight, bias
+
+        for slot, length, _ in slots:
+            self.plan_lengths[slot] = length
+        self.rebuilds += 1
+        logger.info(
+            "MiniMax H3 AdaLN: rebuilt %d plan(s), %d/%d resident, pass #%d",
+            len(missing),
+            len(self._slots),
+            self.max_plans,
+            self.rebuilds,
+        )
 
     def lookup(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
         num_timesteps = unique_timesteps.shape[0]
@@ -1178,6 +1353,21 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
     reverse_param_names_mapping = _ARCH_DEFAULTS.reverse_param_names_mapping
     lora_param_names_mapping = _ARCH_DEFAULTS.lora_param_names_mapping
 
+    def prepare_adaln_plans(self, step_timesteps: list[torch.Tensor]) -> None:
+        """Fill the AdaLN cache for this request before denoising starts.
+
+        No-op for a prebuilt sidecar; the rebuild path needs the model's own
+        timestep embedding so a filled plan is bit-identical to what resident
+        adaln_proj weights would have produced.
+        """
+        if self.adaln_cache is None or self.adaln_cache.weight_files is None:
+            return
+
+        def embed(timesteps: torch.Tensor) -> torch.Tensor:
+            return nn.functional.silu(self.time_embedder(timesteps)).to(_BF16_DTYPE)
+
+        self.adaln_cache.build(step_timesteps, embed=embed)
+
     def _can_batch_block_adaln(self) -> bool:
         return (
             self.adaln_cache is None
@@ -1259,12 +1449,18 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         quant_config: QuantizationConfig | None = None,
         adaln_cache_path: str | None = None,
         adaln_cache_model_variant: str | None = None,
+        adaln_weight_files: list[str] | None = None,
     ) -> None:
         super().__init__(config=config, hf_config=hf_config)
-        if adaln_cache_path is not None and quant_config is not None:
+        if (
+            adaln_cache_path is not None or adaln_weight_files is not None
+        ) and quant_config is not None:
             raise ValueError(
                 "MiniMax H3 AdaLN cache is only compatible with unquantized weights"
             )
+        self._adaln_precomputed = (
+            adaln_cache_path is not None or adaln_weight_files is not None
+        )
         arch = self.config
         self.arch = arch
         self.hidden_size = arch.hidden_size
@@ -1326,7 +1522,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
                     arch,
                     quant_config,
                     prefix=f"blocks.{index}",
-                    use_adaln_cache=adaln_cache_path is not None,
+                    use_adaln_cache=self._adaln_precomputed,
                 )
                 for index in range(arch.num_layers)
             ]
@@ -1336,16 +1532,17 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             arch,
             quant_config,
             prefix="final_layer",
-            use_adaln_cache=adaln_cache_path is not None,
+            use_adaln_cache=self._adaln_precomputed,
         )
         self.adaln_cache = (
-            None
-            if adaln_cache_path is None
-            else MiniMaxH3AdalnCache(
+            MiniMaxH3AdalnCache(
                 arch,
                 path=adaln_cache_path,
                 model_variant=adaln_cache_model_variant,
+                weight_files=adaln_weight_files,
             )
+            if self._adaln_precomputed
+            else None
         )
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -805,10 +805,11 @@ class MiniMaxH3AdalnProj(nn.Module):
 
 
 class MiniMaxH3AdalnCache(nn.Module):
-    """Precomputed AdaLN outputs for a fixed set of BF16 timestep embeddings."""
+    """Precomputed AdaLN outputs for fixed FP32 timestep plans."""
 
-    _FORMAT_VERSION = "1"
-    adaln_inputs: torch.Tensor
+    _FORMAT_VERSION = "2"
+    plan_timesteps: torch.Tensor
+    plan_lengths: torch.Tensor
     block_params: torch.Tensor
     final_params: torch.Tensor
 
@@ -824,7 +825,6 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.model_variant = model_variant
         self.num_layers = arch.num_layers
         self.hidden_size = arch.hidden_size
-        self.time_embed_dim = arch.time_embed_dim
 
     def load(self, device: torch.device) -> None:
         if not os.path.isfile(self.path):
@@ -842,53 +842,68 @@ class MiniMaxH3AdalnCache(nn.Module):
                     "MiniMax H3 AdaLN cache model_variant does not match the loaded "
                     f"variant ({cache_variant!r} != {self.model_variant!r})"
                 )
-            adaln_inputs = cache_file.get_tensor("adaln_inputs")
+            plan_timesteps = cache_file.get_tensor("plan_timesteps")
+            plan_lengths = cache_file.get_tensor("plan_lengths")
             block_params = cache_file.get_tensor("block_params")
             final_params = cache_file.get_tensor("final_params")
 
         expected_block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * self.hidden_size
         expected_final_width = 2 * self.hidden_size
         if (
-            adaln_inputs.dtype != _BF16_DTYPE
-            or adaln_inputs.ndim != 2
-            or adaln_inputs.shape[1] != self.time_embed_dim
+            plan_timesteps.dtype != _FP32_DTYPE
+            or plan_timesteps.ndim != 2
+            or plan_lengths.dtype != torch.int64
+            or plan_lengths.shape != (plan_timesteps.shape[0],)
+            or (plan_lengths < 1).any()
+            or (plan_lengths > plan_timesteps.shape[1]).any()
         ):
-            raise ValueError("MiniMax H3 AdaLN cache has invalid adaln_inputs")
+            raise ValueError("MiniMax H3 AdaLN cache has invalid timestep plans")
         if block_params.dtype != _BF16_DTYPE or block_params.shape != (
-            adaln_inputs.shape[0],
+            plan_timesteps.shape[0],
+            plan_timesteps.shape[1],
             self.num_layers,
             expected_block_width,
         ):
             raise ValueError("MiniMax H3 AdaLN cache has invalid block_params")
         if final_params.dtype != _BF16_DTYPE or final_params.shape != (
-            adaln_inputs.shape[0],
+            plan_timesteps.shape[0],
+            plan_timesteps.shape[1],
             expected_final_width,
         ):
             raise ValueError("MiniMax H3 AdaLN cache has invalid final_params")
 
-        self.register_buffer("adaln_inputs", adaln_inputs.to(device))
+        self.register_buffer("plan_timesteps", plan_timesteps.to(device))
+        self.register_buffer("plan_lengths", plan_lengths.to(device))
         self.register_buffer("block_params", block_params.to(device))
         self.register_buffer("final_params", final_params.to(device))
 
-    def lookup(self, adaln_input: torch.Tensor) -> torch.Tensor:
-        matches = (
-            self.adaln_inputs.unsqueeze(0).eq(adaln_input.unsqueeze(1)).all(dim=-1)
-        )
-        if not bool(matches.any(dim=1).all()):
+    def lookup(self, unique_timesteps: torch.Tensor) -> torch.Tensor:
+        num_timesteps = unique_timesteps.shape[0]
+        matches = self.plan_lengths.eq(num_timesteps) & self.plan_timesteps[
+            :, :num_timesteps
+        ].eq(unique_timesteps).all(dim=-1)
+        if not bool(matches.any()):
             raise ValueError(
-                "MiniMax H3 AdaLN cache does not cover the request timestep embedding"
+                "MiniMax H3 AdaLN cache does not cover the request timestep plan"
             )
-        return matches.to(torch.int64).argmax(dim=1)
+        return matches.to(torch.int64).argmax()
 
     def block(
-        self, index: int, cache_indices: torch.Tensor
+        self,
+        index: int,
+        cache_plan_index: torch.Tensor,
+        num_timesteps: int,
     ) -> tuple[torch.Tensor, ...]:
-        params = self.block_params.index_select(0, cache_indices)[:, index]
+        params = self.block_params[cache_plan_index, :num_timesteps, index]
         params = params.view(-1, 6, self.hidden_size)
         return tuple(params.unbind(dim=1))
 
-    def final(self, cache_indices: torch.Tensor) -> tuple[torch.Tensor, ...]:
-        params = self.final_params.index_select(0, cache_indices)
+    def final(
+        self,
+        cache_plan_index: torch.Tensor,
+        num_timesteps: int,
+    ) -> tuple[torch.Tensor, ...]:
+        params = self.final_params[cache_plan_index, :num_timesteps]
         return tuple(params.view(-1, 2, self.hidden_size).unbind(dim=1))
 
 
@@ -1812,11 +1827,17 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         hidden = decoder_input
         cu_seqlens = cu_seqlens.to(device)
         block_adaln_params = None
-        adaln_cache_indices = None
+        adaln_cache_plan_index = None
         if self.adaln_cache is not None:
-            adaln_cache_indices = self.adaln_cache.lookup(adaln_input)
+            adaln_cache_plan_index = self.adaln_cache.lookup(
+                unique_timesteps.view(-1).to(device)
+            )
             block_adaln_params = tuple(
-                self.adaln_cache.block(index, adaln_cache_indices)
+                self.adaln_cache.block(
+                    index,
+                    adaln_cache_plan_index,
+                    adaln_input.shape[0],
+                )
                 for index in range(len(self.blocks))
             )
         elif self._can_batch_block_adaln():
@@ -1854,8 +1875,11 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             inverse_indices=block_inverse,
             adaln_params=(
                 None
-                if adaln_cache_indices is None
-                else self.adaln_cache.final(adaln_cache_indices)
+                if adaln_cache_plan_index is None
+                else self.adaln_cache.final(
+                    adaln_cache_plan_index,
+                    adaln_input.shape[0],
+                )
             ),
         )
         if sp_ws > 1:

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -812,7 +812,9 @@ class MiniMaxH3AdalnProj(nn.Module):
 
 # A ref2va request carrying both a visual and an audio reference reaches four
 # distinct timesteps in one step: video, audio, the imgvid condition and the
-# audio reference.
+# audio reference. That is the widest case, so it is the default; a deployment
+# serving only narrower tasks (t2va reaches 2, fl2va 3) can shrink the slab
+# proportionally via --minimax-h3-adaln-plan-width.
 MINIMAX_H3_ADALN_MAX_PLAN_WIDTH = 4
 
 
@@ -841,6 +843,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         model_variant: str | None = None,
         weight_files: list[str] | None = None,
         max_plans: int = 64,
+        max_plan_width: int = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH,
     ) -> None:
         super().__init__()
         if (path is None) == (weight_files is None):
@@ -852,6 +855,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         self.model_variant = model_variant
         self.weight_files = weight_files
         self.max_plans = max_plans
+        self.max_plan_width = max_plan_width
         self.num_layers = arch.num_layers
         self.hidden_size = arch.hidden_size
         self.block_width = 6 * MINIMAX_H3_ADALN_MODALITY_NUM * arch.hidden_size
@@ -922,7 +926,7 @@ class MiniMaxH3AdalnCache(nn.Module):
         length can never match. Breakable CUDA graph keys its replay signature
         on tensor pointers, so this is allocated once and only written in place.
         """
-        width = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH
+        width = self.max_plan_width
         self.register_buffer(
             "plan_timesteps",
             torch.zeros((self.max_plans, width), dtype=_FP32_DTYPE, device=device),
@@ -989,6 +993,13 @@ class MiniMaxH3AdalnCache(nn.Module):
             raise ValueError(
                 f"MiniMax H3 AdaLN rebuild needs {len(missing)} plans but "
                 f"max_plans is {self.max_plans}"
+            )
+        widest = max(timesteps.numel() for timesteps in missing.values())
+        if widest > self.max_plan_width:
+            raise ValueError(
+                f"MiniMax H3 AdaLN rebuild hit a {widest}-timestep plan but the "
+                f"slab was allocated for {self.max_plan_width}; raise "
+                "--minimax-h3-adaln-plan-width (t2va needs 2, fl2va 3, ref2va 4)"
             )
 
         device = self.block_params.device
@@ -1450,6 +1461,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         adaln_cache_path: str | None = None,
         adaln_cache_model_variant: str | None = None,
         adaln_weight_files: list[str] | None = None,
+        adaln_plan_width: int = MINIMAX_H3_ADALN_MAX_PLAN_WIDTH,
     ) -> None:
         super().__init__(config=config, hf_config=hf_config)
         if (
@@ -1540,6 +1552,7 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
                 path=adaln_cache_path,
                 model_variant=adaln_cache_model_variant,
                 weight_files=adaln_weight_files,
+                max_plan_width=adaln_plan_width,
             )
             if self._adaln_precomputed
             else None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
@@ -449,6 +449,11 @@ def minimax_h3_denoise_loop(
         imgvid_cond_noise_aug=float(imgvid_cond_noise_aug_for_inference),
         audio_ref_cond_noise_aug=float(audio_cond_noise_aug_for_inference),
     )
+    # Every step's timesteps are settled by now. Rebuilding AdaLN reads all
+    # 24.2 GiB of adaln_proj whatever is missing, so fill the whole request in
+    # one pass here instead of topping up step by step inside the loop.
+    model.prepare_adaln_plans([entry[0] for entry in timestep_plan])
+
     # match the scheduler's device-fp32 math once, then reuse one denoised
     # scratch per modality instead of allocating intermediates every step
     video_sigmas = torch.tensor(sigmas_video, dtype=torch.float32, device=device)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
@@ -61,7 +61,7 @@ def _cached_decode_mean_std(
     return mean, std
 
 
-def _reverse_normalize_latents_(
+def _reverse_normalize_latents(
     latents: torch.Tensor,
     *,
     mean_values,
@@ -89,7 +89,12 @@ def _reverse_normalize_latents_(
         )
     view_shape = [1] * latents.ndim
     view_shape[1] = int(mean.shape[0])
-    return latents.mul_(std.view(*view_shape)).add_(mean.view(*view_shape))
+    # 故意不用原地：batch.latents / batch.audio_latents 是去噪阶段在 InferenceMode
+    # 内分配的 inference tensor，而 --vae-cpu-offload 会让本 stage 跑在
+    # torch.inference_mode(False) 下（PipelineExecutor._stage_needs_version_counters），
+    # 此时原地写 inference tensor 直接抛错。保持 mul 再 add 的两步舍入顺序，
+    # 不用 addcmul，避免引入 FMA 带来的数值差异。
+    return latents * std.view(*view_shape) + mean.view(*view_shape)
 
 
 def _crop_to_target_canvas(batch: Req, frames: torch.Tensor) -> torch.Tensor:
@@ -276,7 +281,7 @@ class MiniMaxH3DecodingStage(DecodingStage):
             if audio_vae.training:
                 audio_vae.eval()
             audio_arch_config = server_args.pipeline_config.audio_vae_config.arch_config
-            audio_decode_latent = _reverse_normalize_latents_(
+            audio_decode_latent = _reverse_normalize_latents(
                 audio_latent,
                 mean_values=audio_arch_config.latents_mean,
                 std_values=audio_arch_config.latents_std,
@@ -332,7 +337,7 @@ class MiniMaxH3DecodingStage(DecodingStage):
             if selected_video_vae.training:
                 selected_video_vae.eval()
             visual_arch_config = server_args.pipeline_config.vae_config.arch_config
-            visual_decode_latent = _reverse_normalize_latents_(
+            visual_decode_latent = _reverse_normalize_latents(
                 visual_latent,
                 mean_values=visual_arch_config.latents_mean,
                 std_values=visual_arch_config.latents_std,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/decoding.py
@@ -89,11 +89,12 @@ def _reverse_normalize_latents(
         )
     view_shape = [1] * latents.ndim
     view_shape[1] = int(mean.shape[0])
-    # 故意不用原地：batch.latents / batch.audio_latents 是去噪阶段在 InferenceMode
-    # 内分配的 inference tensor，而 --vae-cpu-offload 会让本 stage 跑在
-    # torch.inference_mode(False) 下（PipelineExecutor._stage_needs_version_counters），
-    # 此时原地写 inference tensor 直接抛错。保持 mul 再 add 的两步舍入顺序，
-    # 不用 addcmul，避免引入 FMA 带来的数值差异。
+    # Out of place on purpose. batch.latents / batch.audio_latents are
+    # inference tensors allocated inside the denoising stage's InferenceMode,
+    # while --vae-cpu-offload runs this stage under torch.inference_mode(False)
+    # (PipelineExecutor._stage_needs_version_counters), where writing to one in
+    # place raises. Keep the mul-then-add rounding order rather than addcmul so
+    # the result does not shift with FMA contraction.
     return latents * std.view(*view_shape) + mean.view(*view_shape)
 
 

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -297,6 +297,9 @@ class ServerArgs(DisaggServerArgsMixin):
     minimax_h3_adaln_cache_path: str | None = None
     # Rebuild AdaLN outputs per request from the checkpoint, no sidecar needed.
     minimax_h3_adaln_online: bool = False
+    # Widest timestep plan the rebuild slab is sized for; see
+    # MINIMAX_H3_ADALN_MAX_PLAN_WIDTH.
+    minimax_h3_adaln_plan_width: int = 4
     # Per-component transformer weight overrides (key = model_index.json component name).
     # Pipelines use this when a checkpoint ships separate quantized weights for
     # secondary DiT components; the generic loader consumes it without model-specific
@@ -1508,6 +1511,17 @@ class ServerArgs(DisaggServerArgsMixin):
                 "request instead of keeping the 24.2 GiB of adaln_proj weights "
                 "resident. Works with any step count or schedule and needs no "
                 "prebuilt artifact. Requires unquantized weights."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-plan-width",
+            type=int,
+            default=ServerArgs.minimax_h3_adaln_plan_width,
+            help=(
+                "Widest timestep plan --minimax-h3-adaln-online sizes its slab "
+                "for. The default 4 covers every task; a deployment serving "
+                "only t2va (2) or fl2va (3) can shrink the slab proportionally. "
+                "A request exceeding it is rejected rather than truncated."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -295,6 +295,8 @@ class ServerArgs(DisaggServerArgsMixin):
     transformer_weights_path: str | None = None
     # path to precomputed MiniMax H3 AdaLN outputs for inference-only serving.
     minimax_h3_adaln_cache_path: str | None = None
+    # Rebuild AdaLN outputs per request from the checkpoint, no sidecar needed.
+    minimax_h3_adaln_online: bool = False
     # Per-component transformer weight overrides (key = model_index.json component name).
     # Pipelines use this when a checkpoint ships separate quantized weights for
     # secondary DiT components; the generic loader consumes it without model-specific
@@ -1495,6 +1497,17 @@ class ServerArgs(DisaggServerArgsMixin):
                 "Semantic checkpoint variant to serve. Models with partitioned "
                 "checkpoints use this value to select the compatible weights "
                 "without exposing repository subfolder layout."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-online",
+            action=StoreBoolean,
+            default=ServerArgs.minimax_h3_adaln_online,
+            help=(
+                "Rebuild MiniMax H3 AdaLN outputs from the checkpoint per "
+                "request instead of keeping the 24.2 GiB of adaln_proj weights "
+                "resident. Works with any step count or schedule and needs no "
+                "prebuilt artifact. Requires unquantized weights."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -293,6 +293,8 @@ class ServerArgs(DisaggServerArgsMixin):
 
     # path to pre-quantized transformer weights (single .safetensors or directory).
     transformer_weights_path: str | None = None
+    # path to precomputed MiniMax H3 AdaLN outputs for inference-only serving.
+    minimax_h3_adaln_cache_path: str | None = None
     # Per-component transformer weight overrides (key = model_index.json component name).
     # Pipelines use this when a checkpoint ships separate quantized weights for
     # secondary DiT components; the generic loader consumes it without model-specific
@@ -1493,6 +1495,16 @@ class ServerArgs(DisaggServerArgsMixin):
                 "Semantic checkpoint variant to serve. Models with partitioned "
                 "checkpoints use this value to select the compatible weights "
                 "without exposing repository subfolder layout."
+            ),
+        )
+        parser.add_argument(
+            "--minimax-h3-adaln-cache-path",
+            type=str,
+            default=ServerArgs.minimax_h3_adaln_cache_path,
+            help=(
+                "Path to a precomputed MiniMax H3 AdaLN cache. This only "
+                "supports the matching unquantized H3 checkpoint and rejects "
+                "requests whose timestep embeddings are not present in the cache."
             ),
         )
         parser.add_argument(

--- a/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
+++ b/python/sglang/multimodal_gen/test/unit/test_fsdp_load.py
@@ -188,6 +188,7 @@ class TestOrdinaryWeightLoading(unittest.TestCase):
         rank_local_load.assert_not_called()
         weight_iterator.assert_called_once_with(
             ["model.safetensors"],
+            key_filter=None,
             weight_load_plan=load_plan,
         )
 

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.multimodal_gen.configs.models.dits.minimax_h3 import (
+    MiniMaxH3DiTArchConfig,
+)
+from sglang.multimodal_gen.runtime.models.dits.minimax_h3 import (
+    MiniMaxH3AdalnCache,
+)
+
+
+def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
+    arch = MiniMaxH3DiTArchConfig(
+        num_layers=2,
+        hidden_size=4,
+        time_embed_dim=3,
+    )
+    cache_path = tmp_path / "adaln.safetensors"
+    adaln_inputs = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).bfloat16()
+    block_params = (
+        torch.arange(2 * 2 * 72, dtype=torch.float32).reshape(2, 2, 72).bfloat16()
+    )
+    final_params = torch.arange(16, dtype=torch.float32).reshape(2, 8).bfloat16()
+    save_file(
+        {
+            "adaln_inputs": adaln_inputs,
+            "block_params": block_params,
+            "final_params": final_params,
+        },
+        cache_path,
+        metadata={"format_version": "1", "model_variant": "fl2va"},
+    )
+
+    cache = MiniMaxH3AdalnCache(
+        arch,
+        path=str(cache_path),
+        model_variant="fl2va",
+    )
+    cache.load(torch.device("cpu"))
+
+    cache_indices = cache.lookup(adaln_inputs.flip(0))
+    block = cache.block(1, cache_indices)
+    final = cache.final(cache_indices)
+
+    assert torch.equal(torch.cat(block, dim=-1), block_params.flip(0)[:, 1])
+    assert torch.equal(torch.cat(final, dim=-1), final_params.flip(0))

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -48,5 +48,12 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
     block = cache.block(1, cache_plan_index, 2)
     final = cache.final(cache_plan_index, 2)
 
-    assert torch.equal(torch.cat(block, dim=-1), block_params[1, :, 1])
+    # block() hands the forward pass six [num_timesteps * modality, hidden]
+    # chunks, while the checkpoint stores a plan as one flat
+    # [num_timesteps, 6 * modality * hidden] row -- same elements, and the
+    # modality axis folds into the leading one rather than staying separate.
+    assert torch.equal(
+        torch.cat(block, dim=-1).reshape(block_params[1, :, 1].shape),
+        block_params[1, :, 1],
+    )
     assert torch.equal(torch.cat(final, dim=-1), final_params[1])

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_adaln_cache.py
@@ -18,19 +18,23 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
         time_embed_dim=3,
     )
     cache_path = tmp_path / "adaln.safetensors"
-    adaln_inputs = torch.tensor([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]).bfloat16()
+    plan_timesteps = torch.tensor([[0.0, 0.0], [1.0, 2.0]])
+    plan_lengths = torch.tensor([1, 2], dtype=torch.int64)
     block_params = (
-        torch.arange(2 * 2 * 72, dtype=torch.float32).reshape(2, 2, 72).bfloat16()
+        torch.arange(2 * 2 * 2 * 72, dtype=torch.float32)
+        .reshape(2, 2, 2, 72)
+        .bfloat16()
     )
-    final_params = torch.arange(16, dtype=torch.float32).reshape(2, 8).bfloat16()
+    final_params = torch.arange(32, dtype=torch.float32).reshape(2, 2, 8).bfloat16()
     save_file(
         {
-            "adaln_inputs": adaln_inputs,
+            "plan_timesteps": plan_timesteps,
+            "plan_lengths": plan_lengths,
             "block_params": block_params,
             "final_params": final_params,
         },
         cache_path,
-        metadata={"format_version": "1", "model_variant": "fl2va"},
+        metadata={"format_version": "2", "model_variant": "fl2va"},
     )
 
     cache = MiniMaxH3AdalnCache(
@@ -40,9 +44,9 @@ def test_minimax_h3_adaln_cache_matches_bf16_embedding(tmp_path):
     )
     cache.load(torch.device("cpu"))
 
-    cache_indices = cache.lookup(adaln_inputs.flip(0))
-    block = cache.block(1, cache_indices)
-    final = cache.final(cache_indices)
+    cache_plan_index = cache.lookup(plan_timesteps[1])
+    block = cache.block(1, cache_plan_index, 2)
+    final = cache.final(cache_plan_index, 2)
 
-    assert torch.equal(torch.cat(block, dim=-1), block_params.flip(0)[:, 1])
-    assert torch.equal(torch.cat(final, dim=-1), final_params.flip(0))
+    assert torch.equal(torch.cat(block, dim=-1), block_params[1, :, 1])
+    assert torch.equal(torch.cat(final, dim=-1), final_params[1])

--- a/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
@@ -23,11 +23,24 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.m
 )
 
 _HIDDEN_SIZE = 5376
-_TIME_EMBED_DIM = 2688
 _TIMESTEP_INPUT_DIM = 256
 _NUM_BLOCKS = 50
 _BLOCK_PARAM_WIDTH = 18 * _HIDDEN_SIZE
 _FINAL_PARAM_WIDTH = 2 * _HIDDEN_SIZE
+_CACHE_MODES = {
+    "t2va": ("video", "audio"),
+    "fl2va": ("video", "audio", "image"),
+    "ref2va-image": ("video", "audio", "image"),
+    "ref2va-audio": ("video", "audio", "audio_ref"),
+    "ref2va-mixed": ("video", "audio", "image", "audio_ref"),
+}
+_MODE_VARIANTS = {
+    "t2va": "fl2va",
+    "fl2va": "fl2va",
+    "ref2va-image": "ref2va",
+    "ref2va-audio": "ref2va",
+    "ref2va-mixed": "ref2va",
+}
 
 
 def _parse_args() -> argparse.Namespace:
@@ -37,6 +50,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--transformer-path", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
     parser.add_argument("--model-variant", choices=("fl2va", "ref2va"), required=True)
+    parser.add_argument("--mode", choices=tuple(_CACHE_MODES), default="t2va")
     parser.add_argument("--num-inference-steps", type=int, default=50)
     parser.add_argument("--flow-shift", type=float, default=12.0)
     parser.add_argument("--audio-flow-shift", type=float, default=3.0)
@@ -54,15 +68,15 @@ def _parse_args() -> argparse.Namespace:
         "--timesteps",
         type=float,
         nargs="+",
-        help="Override the scheduler-derived timestep coverage.",
+        help="Override the scheduler-derived timestep plan.",
     )
     parser.add_argument("--device", default="cuda")
     return parser.parse_args()
 
 
-def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
+def _cache_timestep_plans(args: argparse.Namespace) -> list[torch.Tensor]:
     if args.timesteps is not None:
-        return torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)
+        return [torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)]
 
     video_sigmas = minimax_h3_time_shift_sigmas(
         num_steps=args.num_inference_steps,
@@ -72,19 +86,31 @@ def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
         num_steps=args.num_inference_steps,
         shift_scale=args.audio_flow_shift,
     )
-    candidates = []
+    fields = _CACHE_MODES[args.mode]
+    plans = []
     for video_sigma, audio_sigma in zip(video_sigmas[:-1], audio_sigmas[:-1]):
         video_timestep = 1.0 - video_sigma
         audio_timestep = 1.0 - audio_sigma
-        candidates.extend(
-            (
-                video_timestep,
-                audio_timestep,
-                max(video_timestep, args.imgvid_cond_noise_aug),
-                max(audio_timestep, args.audio_cond_noise_aug),
-            )
+        candidates = {
+            "video": video_timestep,
+            "audio": audio_timestep,
+            "image": max(video_timestep, args.imgvid_cond_noise_aug),
+            "audio_ref": max(audio_timestep, args.audio_cond_noise_aug),
+        }
+        plans.append(
+            torch.tensor(
+                [candidates[field] for field in fields], dtype=torch.float32
+            ).unique(sorted=True)
         )
-    return torch.tensor(candidates, dtype=torch.float32).unique(sorted=True)
+
+    deduplicated = []
+    seen = set()
+    for plan in plans:
+        key = tuple(plan.tolist())
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(plan)
+    return deduplicated
 
 
 def _time_embed(
@@ -125,6 +151,9 @@ def main() -> None:
     args = _parse_args()
     if args.num_inference_steps < 2 and args.timesteps is None:
         raise ValueError("--num-inference-steps must be at least 2")
+    mode_variant = _MODE_VARIANTS[args.mode]
+    if args.model_variant != mode_variant:
+        raise ValueError(f"--mode {args.mode} requires {mode_variant}")
     device = torch.device(args.device)
     if device.type != "cuda" or not torch.cuda.is_available():
         raise ValueError("MiniMax H3 AdaLN cache must be built on CUDA")
@@ -133,17 +162,18 @@ def main() -> None:
     with index_path.open() as f:
         weight_map = json.load(f)["weight_map"]
 
-    timesteps = _cache_timesteps(args)
-    if timesteps.numel() == 0:
-        raise ValueError("AdaLN cache must cover at least one timestep")
-    adaln_inputs = torch.empty(
-        (timesteps.numel(), _TIME_EMBED_DIM), dtype=torch.bfloat16
-    )
+    plans = _cache_timestep_plans(args)
+    if not plans or any(plan.numel() == 0 for plan in plans):
+        raise ValueError("AdaLN cache must cover at least one timestep plan")
+    max_plan_length = max(plan.numel() for plan in plans)
+    plan_timesteps = torch.zeros((len(plans), max_plan_length), dtype=torch.float32)
+    plan_lengths = torch.tensor([plan.numel() for plan in plans], dtype=torch.int64)
     block_params = torch.empty(
-        (timesteps.numel(), _NUM_BLOCKS, _BLOCK_PARAM_WIDTH), dtype=torch.bfloat16
+        (len(plans), max_plan_length, _NUM_BLOCKS, _BLOCK_PARAM_WIDTH),
+        dtype=torch.bfloat16,
     )
     final_params = torch.empty(
-        (timesteps.numel(), _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
+        (len(plans), max_plan_length, _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
     )
 
     with ExitStack() as stack:
@@ -171,60 +201,64 @@ def main() -> None:
                 ("proj_out", "bias"),
             )
         }
-        adaln_input = F.silu(_time_embed(timesteps.to(device), **time_kwargs)).to(
-            torch.bfloat16
-        )
-        adaln_inputs.copy_(adaln_input.cpu())
+        adaln_inputs = []
+        for plan_index, plan in enumerate(plans):
+            plan_length = plan.numel()
+            plan_timesteps[plan_index, :plan_length].copy_(plan)
+            adaln_inputs.append(
+                F.silu(_time_embed(plan.to(device), **time_kwargs)).to(torch.bfloat16)
+            )
 
         for index in range(_NUM_BLOCKS):
             prefix = f"blocks.{index}.adaln_proj.linear"
-            block_params[:, index].copy_(
-                F.linear(
-                    adaln_input,
-                    _load_tensor(
-                        f"{prefix}.weight",
-                        weight_map=weight_map,
-                        files=files,
-                        device=device,
-                    ),
-                    _load_tensor(
-                        f"{prefix}.bias",
-                        weight_map=weight_map,
-                        files=files,
-                        device=device,
-                    ),
-                ).cpu()
+            weight = _load_tensor(
+                f"{prefix}.weight",
+                weight_map=weight_map,
+                files=files,
+                device=device,
             )
+            bias = _load_tensor(
+                f"{prefix}.bias",
+                weight_map=weight_map,
+                files=files,
+                device=device,
+            )
+            for plan_index, adaln_input in enumerate(adaln_inputs):
+                plan_length = adaln_input.shape[0]
+                block_params[plan_index, :plan_length, index].copy_(
+                    F.linear(adaln_input, weight, bias).cpu()
+                )
 
         prefix = "final_layer.adaln_proj.linear"
-        final_params.copy_(
-            F.linear(
-                adaln_input,
-                _load_tensor(
-                    f"{prefix}.weight",
-                    weight_map=weight_map,
-                    files=files,
-                    device=device,
-                ),
-                _load_tensor(
-                    f"{prefix}.bias",
-                    weight_map=weight_map,
-                    files=files,
-                    device=device,
-                ),
-            ).cpu()
+        weight = _load_tensor(
+            f"{prefix}.weight",
+            weight_map=weight_map,
+            files=files,
+            device=device,
         )
+        bias = _load_tensor(
+            f"{prefix}.bias",
+            weight_map=weight_map,
+            files=files,
+            device=device,
+        )
+        for plan_index, adaln_input in enumerate(adaln_inputs):
+            plan_length = adaln_input.shape[0]
+            final_params[plan_index, :plan_length].copy_(
+                F.linear(adaln_input, weight, bias).cpu()
+            )
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     save_file(
         {
-            "adaln_inputs": adaln_inputs,
+            "plan_timesteps": plan_timesteps,
+            "plan_lengths": plan_lengths,
             "block_params": block_params,
             "final_params": final_params,
         },
         str(args.output),
         metadata={
-            "format_version": "1",
+            "format_version": "2",
             "model_variant": args.model_variant,
         },
     )

--- a/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
+++ b/python/sglang/multimodal_gen/tools/build_minimax_h3_adaln_cache.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Build an inference-only AdaLN cache from a local MiniMax H3 transformer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from safetensors.torch import safe_open, save_file
+
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.denoise_loop import (
+    MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    MINIMAX_H3_IMGVID_COND_TIMESTEP,
+)
+from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.minimax_h3.time_request import (
+    minimax_h3_time_shift_sigmas,
+)
+
+_HIDDEN_SIZE = 5376
+_TIME_EMBED_DIM = 2688
+_TIMESTEP_INPUT_DIM = 256
+_NUM_BLOCKS = 50
+_BLOCK_PARAM_WIDTH = 18 * _HIDDEN_SIZE
+_FINAL_PARAM_WIDTH = 2 * _HIDDEN_SIZE
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Build a MiniMax H3 inference-only AdaLN cache from local weights."
+    )
+    parser.add_argument("--transformer-path", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--model-variant", choices=("fl2va", "ref2va"), required=True)
+    parser.add_argument("--num-inference-steps", type=int, default=50)
+    parser.add_argument("--flow-shift", type=float, default=12.0)
+    parser.add_argument("--audio-flow-shift", type=float, default=3.0)
+    parser.add_argument(
+        "--imgvid-cond-noise-aug",
+        type=float,
+        default=MINIMAX_H3_IMGVID_COND_TIMESTEP,
+    )
+    parser.add_argument(
+        "--audio-cond-noise-aug",
+        type=float,
+        default=MINIMAX_H3_AUDIO_REF_COND_TIMESTEP,
+    )
+    parser.add_argument(
+        "--timesteps",
+        type=float,
+        nargs="+",
+        help="Override the scheduler-derived timestep coverage.",
+    )
+    parser.add_argument("--device", default="cuda")
+    return parser.parse_args()
+
+
+def _cache_timesteps(args: argparse.Namespace) -> torch.Tensor:
+    if args.timesteps is not None:
+        return torch.tensor(args.timesteps, dtype=torch.float32).unique(sorted=True)
+
+    video_sigmas = minimax_h3_time_shift_sigmas(
+        num_steps=args.num_inference_steps,
+        shift_scale=args.flow_shift,
+    )
+    audio_sigmas = minimax_h3_time_shift_sigmas(
+        num_steps=args.num_inference_steps,
+        shift_scale=args.audio_flow_shift,
+    )
+    candidates = []
+    for video_sigma, audio_sigma in zip(video_sigmas[:-1], audio_sigmas[:-1]):
+        video_timestep = 1.0 - video_sigma
+        audio_timestep = 1.0 - audio_sigma
+        candidates.extend(
+            (
+                video_timestep,
+                audio_timestep,
+                max(video_timestep, args.imgvid_cond_noise_aug),
+                max(audio_timestep, args.audio_cond_noise_aug),
+            )
+        )
+    return torch.tensor(candidates, dtype=torch.float32).unique(sorted=True)
+
+
+def _time_embed(
+    timesteps: torch.Tensor,
+    *,
+    proj_in_weight: torch.Tensor,
+    proj_in_bias: torch.Tensor,
+    proj_out_weight: torch.Tensor,
+    proj_out_bias: torch.Tensor,
+) -> torch.Tensor:
+    half = _TIMESTEP_INPUT_DIM // 2
+    freqs = torch.exp(
+        -math.log(10000.0)
+        * torch.arange(half, dtype=torch.float32, device=timesteps.device)
+        / half
+    )
+    args = timesteps[:, None] * freqs[None]
+    t_freq = torch.cat((torch.cos(args), torch.sin(args)), dim=-1)
+    return F.linear(
+        F.silu(F.linear(t_freq, proj_in_weight, proj_in_bias)),
+        proj_out_weight,
+        proj_out_bias,
+    )
+
+
+def _load_tensor(
+    name: str,
+    *,
+    weight_map: dict[str, str],
+    files: dict[str, Any],
+    device: torch.device,
+) -> torch.Tensor:
+    tensor_file = files[weight_map[name]]
+    return tensor_file.get_tensor(name).to(device)
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.num_inference_steps < 2 and args.timesteps is None:
+        raise ValueError("--num-inference-steps must be at least 2")
+    device = torch.device(args.device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        raise ValueError("MiniMax H3 AdaLN cache must be built on CUDA")
+
+    index_path = args.transformer_path / "model.safetensors.index.json"
+    with index_path.open() as f:
+        weight_map = json.load(f)["weight_map"]
+
+    timesteps = _cache_timesteps(args)
+    if timesteps.numel() == 0:
+        raise ValueError("AdaLN cache must cover at least one timestep")
+    adaln_inputs = torch.empty(
+        (timesteps.numel(), _TIME_EMBED_DIM), dtype=torch.bfloat16
+    )
+    block_params = torch.empty(
+        (timesteps.numel(), _NUM_BLOCKS, _BLOCK_PARAM_WIDTH), dtype=torch.bfloat16
+    )
+    final_params = torch.empty(
+        (timesteps.numel(), _FINAL_PARAM_WIDTH), dtype=torch.bfloat16
+    )
+
+    with ExitStack() as stack:
+        files = {
+            filename: stack.enter_context(
+                safe_open(
+                    str(args.transformer_path / filename),
+                    framework="pt",
+                    device="cpu",
+                )
+            )
+            for filename in set(weight_map.values())
+        }
+        time_kwargs = {
+            f"{module}_{name}": _load_tensor(
+                f"time_embedder.{module}.{name}",
+                weight_map=weight_map,
+                files=files,
+                device=device,
+            )
+            for module, name in (
+                ("proj_in", "weight"),
+                ("proj_in", "bias"),
+                ("proj_out", "weight"),
+                ("proj_out", "bias"),
+            )
+        }
+        adaln_input = F.silu(_time_embed(timesteps.to(device), **time_kwargs)).to(
+            torch.bfloat16
+        )
+        adaln_inputs.copy_(adaln_input.cpu())
+
+        for index in range(_NUM_BLOCKS):
+            prefix = f"blocks.{index}.adaln_proj.linear"
+            block_params[:, index].copy_(
+                F.linear(
+                    adaln_input,
+                    _load_tensor(
+                        f"{prefix}.weight",
+                        weight_map=weight_map,
+                        files=files,
+                        device=device,
+                    ),
+                    _load_tensor(
+                        f"{prefix}.bias",
+                        weight_map=weight_map,
+                        files=files,
+                        device=device,
+                    ),
+                ).cpu()
+            )
+
+        prefix = "final_layer.adaln_proj.linear"
+        final_params.copy_(
+            F.linear(
+                adaln_input,
+                _load_tensor(
+                    f"{prefix}.weight",
+                    weight_map=weight_map,
+                    files=files,
+                    device=device,
+                ),
+                _load_tensor(
+                    f"{prefix}.bias",
+                    weight_map=weight_map,
+                    files=files,
+                    device=device,
+                ),
+            ).cpu()
+        )
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    save_file(
+        {
+            "adaln_inputs": adaln_inputs,
+            "block_params": block_params,
+            "final_params": final_params,
+        },
+        str(args.output),
+        metadata={
+            "format_version": "1",
+            "model_variant": args.model_variant,
+        },
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Motivation

Builds on #33991 — its four commits plus two test-assertion fixes for them are included here and should be rebased away once it lands. Three commits are this PR's own. (#34575, previously part of this stack, merged on 2026-08-13 and is now upstream.)

#33991 makes MiniMax-H3 drop the `adaln_proj` weights — 39.3% of the DiT, 13.0B parameters / 24.2 GiB — by precomputing their outputs into a sidecar file. That unlocks a large win: with those weights gone the DiT fits on-device at `tp_size=1`, so no layerwise offload is needed at all.

The sidecar's problem is its identity: one artifact per `(mode, steps, flow_shift, audio_flow_shift, imgvid_cond_noise_aug, audio_cond_noise_aug)` combination. Distilled 4-step and 8-step variants multiply that set again. Worse, the H3 synthetic warmup runs `t2va` even on the `fl2va` partition, so its timestep plan never matches an `fl2va` sidecar and a single artifact always misses, failing the request outright rather than degrading.

A request's whole timestep plan is settled before the denoise loop starts (`prepare_timestep_plan`), so the outputs can simply be rebuilt on demand and the artifact dropped entirely.

## Modifications

- Rebuild AdaLN outputs from the checkpoint at the start of each request, behind `--minimax-h3-adaln-online`, off by default. One streaming pass fills every plan the request will look up, reading a layer at a time straight into GPU memory so the transient peak is one layer (496 MiB) rather than 24.2 GiB.
- Reuse `MiniMaxH3AdalnCache` rather than adding a class: an empty slab with `plan_lengths=0` is invisible to `lookup()`, so storage, lookup and the model forward are untouched. Plans are memoized across requests.
- Rebuild each plan at exactly the batch size it is consumed at. cuBLAS picks kernels by GEMM shape and not monotonically: against the runtime's `M==2`, `M==4/8/16/64/96` are bit-identical while `M==32` differs in 11760 of 96768 elements and `M==1` differs in 69.
- Under `tp_size>1`, read only this rank's column shard and all-gather, mirroring `ColumnParallelLinear`. Required for correctness, and it cuts per-rank checkpoint reads to `1/tp`.
- Add `--minimax-h3-adaln-plan-width` (default 4, no behavior change unless set). The slab is allocated once at a fixed width because its pointers must stay stable for breakable CUDA graph, so the width has to cover the widest plan the deployment will see — 4, a `ref2va` request carrying both a visual and an audio reference. `t2va` reaches only 2 and was paying 1.16 GiB for slots it can never fill. A plan wider than the slab is now rejected with a message naming the right width.
- One pre-existing fix `--vae-cpu-offload` needs to work at all on H3, kept as a separate commit: an out-of-place latent reverse-normalisation in the decode stage.

## Accuracy Tests

Output is bit-identical (same mp4 md5) to resident `adaln_proj` weights across `t2va` / `fl2va` / `ref2va`, at `tp1/ul8` and `tp2/ul4`, 1344x768, 124 frames, 50 steps. The `tp2` case is compared against fully resident weights rather than against another cache. Slab width 2 and 4 also produce identical output, which is the acceptance criterion for that flag — the width only shapes the slab and never enters the computation.

Rebasing this branch onto current main left output unchanged: the same `t2va` run before and after produces md5 `13805bb7`, with whole-card peak identical to the hundredth of a GiB.

Full `multimodal_gen` unit suite on the rebased branch: 1521 passed, 5 failed. Those five fail identically on unmodified `b784726`.

## Speed Tests and Profiling

8x RTX PRO 5000 (sm_120), `t2va`, 1344x768, 124 frames, 50 steps, 3 repetitions, 1.72% noise floor:

| | e2e | whole-card peak | headroom |
|---|---|---|---|
| `tp1/ul8` layerwise offload r35 | 135.74 s | 70.34 GiB | 0.78 GiB |
| `tp1/ul8`, DiT fully resident, slab 2 | **127.03 s** | 66.90 GiB | 4.22 GiB |

6.4% faster with 5x the headroom. `tp2/ul4` whole-card peak drops 59.43 -> 49.56 GiB. A rebuild pass costs 2.4 s at 10.9 GiB/s; with memoization a repeat schedule pays nothing.

Nsight, 50-step capture, `cudaProfilerApi` range, 8 ranks aggregated:

| | layerwise r35 | DiT resident | delta |
|---|---|---|---|
| host-to-device | 292,268 ms | **9.3 ms** | gone |
| `ncclDevKernel_SendRecv` | 219,963 ms | 150,634 ms | **-31.5%** |
| `flash_fwd` + cutlass GEMM | 841,137 ms | 852,105 ms | +1.3% |

Compute is unchanged — the +1.3% runs opposite to the speedup, so it is clock jitter, not work. What changes is communication, and the two numbers line up: the all2all saves (219,963 - 150,634) / 8 = **8.67 s per rank**, against an end-to-end delta of **8.71 s**.

So the win is not "fewer bytes copied" but bandwidth contention: the per-step H2D stream overlaps with compute, yet it shares the interconnect with Ulysses all2all, and freeing it lifts every link at once. A control run with `NCCL_P2P_LEVEL=SYS`, which converts 112 SHM links to direct P2P, cuts nccl kernel time by only 4.1% and moves the denoise loop 0.0% — improving a subset of links does not shift the critical path, while removing the shared-bandwidth contention does.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31774774919](https://github.com/sgl-project/sglang/actions/runs/31774774919)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31774774869](https://github.com/sgl-project/sglang/actions/runs/31774774869)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->