### PR TITLE
[DCP] Share one pack kernel between both a2a backends

### DIFF
--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -402,14 +402,7 @@ def _dcp_pack_a2a_send_kernel(
     WORDS: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """Scatter one (batch, head) partial into its peer's send slot.
-
-    Payload and LSE have independent destinations, so one kernel serves a
-    transport that wants them interleaved in a single buffer (pynccl
-    all_to_all_single, whose peer axis must be outermost) and one that wants
-    them in separate tensors with the peer axis inside (FlashInfer's
-    decode_cp_a2a_alltoall).
-    """
+    """Scatter one (batch, head) partial into its peer's send slot."""
     b = tl.program_id(0).to(tl.int64)
     h = tl.program_id(1).to(tl.int64)
     peer = h // H_PER_RANK
@@ -445,12 +438,8 @@ def dcp_pack_a2a_send(
 ) -> None:
     """Scatter ``[B, H, D]`` partials + ``[B, H]`` LSE into a transport's send slots.
 
-    ``dst_o`` is ``[N, B_max, H // N, D]`` and ``dst_lse`` is ``[N, B_max, H // N]``
-    in *any* stride order, so a transport that wants the two interleaved in one
-    buffer and one that wants them separate are both just views. Rows beyond
-    ``B`` are left untouched.
-
-    Everything moves as fp32 words, so one kernel serves bf16/fp16/fp8 outputs.
+    ``dst_o`` is ``[N, B_max, H // N, D]`` and ``dst_lse`` ``[N, B_max, H // N]``,
+    in any stride order. Rows beyond ``B`` are left untouched.
     """
     B, H, D = cp_attn_out.shape
     N, B_max, H_per_rank = dst_lse.shape
@@ -466,7 +455,6 @@ def dcp_pack_a2a_send(
             f"match out {tuple(cp_attn_out.shape)}"
         )
 
-    # fp32-word views; the payload's last dim must be contiguous to reinterpret.
     out_words = cp_attn_out.view(torch.float32)
     dst_o_words = dst_o.view(torch.float32)
     words = D // lpd

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -386,28 +386,41 @@ def _lse_pack_dim(output_dtype: torch.dtype) -> int:
 def _dcp_pack_a2a_send_kernel(
     out_ptr,
     lse_ptr,
-    send_ptr,
+    dst_o_ptr,
+    dst_lse_ptr,
     out_stride_B,
     out_stride_H,
     lse_stride_B,
     lse_stride_H,
-    send_stride_N,
-    send_stride_B,
-    send_stride_H,
+    dst_o_stride_N,
+    dst_o_stride_B,
+    dst_o_stride_H,
+    dst_lse_stride_N,
+    dst_lse_stride_B,
+    dst_lse_stride_H,
     H_PER_RANK: tl.constexpr,
     WORDS: tl.constexpr,
     BLOCK: tl.constexpr,
 ):
-    """Scatter one (batch, head) partial into its peer's a2a send slot."""
+    """Scatter one (batch, head) partial into its peer's send slot.
+
+    Payload and LSE have independent destinations, so one kernel serves a
+    transport that wants them interleaved in a single buffer (pynccl
+    all_to_all_single, whose peer axis must be outermost) and one that wants
+    them in separate tensors with the peer axis inside (FlashInfer's
+    decode_cp_a2a_alltoall).
+    """
     b = tl.program_id(0).to(tl.int64)
     h = tl.program_id(1).to(tl.int64)
+    peer = h // H_PER_RANK
+    h_local = h % H_PER_RANK
 
     src = out_ptr + b * out_stride_B + h * out_stride_H
     dst = (
-        send_ptr
-        + (h // H_PER_RANK) * send_stride_N
-        + b * send_stride_B
-        + (h % H_PER_RANK) * send_stride_H
+        dst_o_ptr
+        + peer * dst_o_stride_N
+        + b * dst_o_stride_B
+        + h_local * dst_o_stride_H
     )
 
     for start in tl.range(0, WORDS, BLOCK):
@@ -415,48 +428,64 @@ def _dcp_pack_a2a_send_kernel(
         mask = offs < WORDS
         tl.store(dst + offs, tl.load(src + offs, mask=mask), mask=mask)
 
-    tl.store(dst + WORDS, tl.load(lse_ptr + b * lse_stride_B + h * lse_stride_H))
+    tl.store(
+        dst_lse_ptr
+        + peer * dst_lse_stride_N
+        + b * dst_lse_stride_B
+        + h_local * dst_lse_stride_H,
+        tl.load(lse_ptr + b * lse_stride_B + h * lse_stride_H),
+    )
 
 
 def dcp_pack_a2a_send(
     cp_attn_out: torch.Tensor,
     cp_attn_lse: torch.Tensor,
-    send_combined: torch.Tensor,
+    dst_o: torch.Tensor,
+    dst_lse: torch.Tensor,
 ) -> None:
-    """Pack ``[B, H, D]`` partials + ``[B, H]`` LSE into the a2a send buffer.
+    """Scatter ``[B, H, D]`` partials + ``[B, H]`` LSE into a transport's send slots.
 
-    ``send_combined`` is ``[N, B_max, H // N, D + lse_pack_dim]``; rows beyond
+    ``dst_o`` is ``[N, B_max, H // N, D]`` and ``dst_lse`` is ``[N, B_max, H // N]``
+    in *any* stride order, so a transport that wants the two interleaved in one
+    buffer and one that wants them separate are both just views. Rows beyond
     ``B`` are left untouched.
+
+    Everything moves as fp32 words, so one kernel serves bf16/fp16/fp8 outputs.
     """
     B, H, D = cp_attn_out.shape
-    N, B_max, H_per_rank, row_width = send_combined.shape
-    lpd = _lse_pack_dim(send_combined.dtype)
+    N, B_max, H_per_rank = dst_lse.shape
+    lpd = _lse_pack_dim(cp_attn_out.dtype)
 
-    if cp_attn_lse.dtype != torch.float32:
-        raise ValueError(f"cp_attn_lse must be float32, got {cp_attn_lse.dtype}")
+    if cp_attn_lse.dtype != torch.float32 or dst_lse.dtype != torch.float32:
+        raise ValueError("LSE tensors must be float32")
     if D % lpd:
         raise ValueError(f"head dim {D} must be a multiple of the LSE pack dim {lpd}")
-    if row_width != D + lpd or H_per_rank * N != H or B > B_max:
+    if dst_o.shape != (N, B_max, H_per_rank, D) or H_per_rank * N != H or B > B_max:
         raise ValueError(
-            f"send buffer {tuple(send_combined.shape)} does not match "
-            f"out {tuple(cp_attn_out.shape)}"
+            f"destination {tuple(dst_o.shape)} / {tuple(dst_lse.shape)} does not "
+            f"match out {tuple(cp_attn_out.shape)}"
         )
 
+    # fp32-word views; the payload's last dim must be contiguous to reinterpret.
     out_words = cp_attn_out.view(torch.float32)
-    send_words = send_combined.view(torch.float32)
+    dst_o_words = dst_o.view(torch.float32)
     words = D // lpd
 
     _dcp_pack_a2a_send_kernel[(B, H)](
         out_words,
         cp_attn_lse,
-        send_words,
+        dst_o_words,
+        dst_lse,
         out_words.stride(0),
         out_words.stride(1),
         cp_attn_lse.stride(0),
         cp_attn_lse.stride(1),
-        send_words.stride(0),
-        send_words.stride(1),
-        send_words.stride(2),
+        dst_o_words.stride(0),
+        dst_o_words.stride(1),
+        dst_o_words.stride(2),
+        dst_lse.stride(0),
+        dst_lse.stride(1),
+        dst_lse.stride(2),
         H_PER_RANK=H_per_rank,
         WORDS=words,
         BLOCK=min(1024, triton.next_power_of_2(words)),

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -417,11 +417,12 @@ def init_fi_a2a_workspace(
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
     # the stream and barriers cross-rank, neither of which is capturable.
     #
-    # Note(kpham-sgl): the send buffers are allocated here, not on first use.
-    # The DCP a2a runs once per MLA layer inside the decode graph, and nothing
-    # eager touches it first -- the FlashInfer autotune pass skips the exchange
-    # (_select_local_dcp_heads_for_autotune). So a lazy allocation lands during
-    # capture and comes from the graph's private pool.
+    # Note(kpham-sgl): the DCP a2a runs once per MLA layer inside the decode
+    # graph, and nothing eager touches it first -- the FlashInfer autotune pass
+    # skips the exchange (_select_local_dcp_heads_for_autotune). So the send
+    # buffers are allocated here rather than on first use, which would land in
+    # capture and take memory from the graph's private pool; and once captured
+    # graphs bake in their addresses, they can never be freed to grow.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return
@@ -509,8 +510,7 @@ def _fi_a2a_send_buffers(
 ):
     """Send tensors for the FlashInfer exchange, sliced to ``batch``.
 
-    Note(kpham-sgl): cached entries are never replaced. Captured graphs bake in
-    these addresses, so freeing one to grow it would strand those pointers.
+    Cached entries are never replaced -- see init_fi_a2a_workspace().
     """
     state = _FI_A2A_STATE
     cache = state["send_buffers"]

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -20,6 +20,7 @@ PR #25090 vs #14194):
   - cp_lse_ag_out_rs_mla: Triton (log2/exp2) correction / reduce-scatter
 """
 
+import logging
 import warnings
 from typing import Optional
 
@@ -37,6 +38,8 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.runtime_context import get_parallel
+
+logger = logging.getLogger(__name__)
 
 
 def _warn_deprecated_dcp_accessor(name: str, replacement: str) -> None:
@@ -384,9 +387,38 @@ def all_gather_kv_cache_for_dcp(
 _FI_A2A_STATE: Optional[dict] = None
 
 
-def init_fi_a2a_workspace(cp_group: "GroupCoordinator") -> None:
+def _alloc_fi_a2a_send(
+    *,
+    batch: int,
+    h_per_rank: int,
+    cp_size: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+):
+    partial_o = torch.empty(
+        batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
+    )
+    # Entry 1 is never read by the exchange but is still transported, so define
+    # it once here rather than re-zeroing the tensor on every call.
+    softmax_stats = torch.zeros(
+        batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
+    )
+    return partial_o, softmax_stats
+
+
+def init_fi_a2a_workspace(
+    cp_group: "GroupCoordinator",
+    *,
+    max_batch: int = 0,
+    h_per_rank: int = 0,
+    head_dim: int = 0,
+    dtype: Optional[torch.dtype] = None,
+) -> None:
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
-    # the stream and barriers cross-rank, neither of which is capturable.
+    # the stream and barriers cross-rank, neither of which is capturable. The
+    # send buffers are allocated here for the same reason -- allocating them on
+    # first use puts them in the capturing graph's private memory pool.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return
@@ -443,14 +475,29 @@ def init_fi_a2a_workspace(cp_group: "GroupCoordinator") -> None:
     # REQUIRED barrier before the first alltoall: every rank must finish init,
     # else a rank writes a peer's FIFO before it is ready -> deadlock.
     dist.barrier(group=cp_group.device_group)
+    # dtype is None only when the caller could not derive the send shape (a
+    # non-MLA model); the exchange is MLA-only, so that config never gets here.
+    send_buffers = {}
+    if dtype is not None:
+        send_buffers[(h_per_rank, cp_size, head_dim, dtype)] = _alloc_fi_a2a_send(
+            batch=max_batch,
+            h_per_rank=h_per_rank,
+            cp_size=cp_size,
+            head_dim=head_dim,
+            dtype=dtype,
+            device=torch.cuda.current_device(),
+        )
+
     _FI_A2A_STATE = {
         "workspace": workspace,
         "cp_rank": cp_rank,
-        "send_buffers": {},
+        "max_batch": max_batch,
+        "send_buffers": send_buffers,
     }
 
 
 def _fi_a2a_send_buffers(
+    *,
     batch: int,
     h_per_rank: int,
     cp_size: int,
@@ -458,24 +505,52 @@ def _fi_a2a_send_buffers(
     dtype: torch.dtype,
     device: torch.device,
 ):
-    """Persistent send tensors for the FlashInfer exchange, sliced to ``batch``.
+    """Send tensors for the FlashInfer exchange, sliced to ``batch``.
 
-    The exchange does not write its inputs, so slots past the LSE stay zero
-    after the one-time allocation. Buffers grow on demand and never shrink.
+    Normally a slice of what init_fi_a2a_workspace() pre-allocated. Cached
+    entries are never replaced: captured CUDA graphs bake in their addresses,
+    so freeing one would strand the pointers baked into those graphs.
     """
+    state = _FI_A2A_STATE
+    cache = state["send_buffers"]
     key = (h_per_rank, cp_size, head_dim, dtype)
-    cache = _FI_A2A_STATE["send_buffers"]
     entry = cache.get(key)
-    if entry is None or entry[0].shape[0] < batch:
-        partial_o = torch.empty(
-            batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
+
+    if entry is None:
+        # The shape derived at init did not match what the model produced, so
+        # this allocation may land inside graph capture. Size it for max_batch
+        # so it is the only one for this shape.
+        logger.warning(
+            "fi_a2a send buffers were pre-sized for %s but the model produced "
+            "%s; allocating now. Fix the derivation in "
+            "_pre_initialize_fi_a2a_workspace to keep this out of CUDA-graph "
+            "capture.",
+            sorted(str(k) for k in cache),
+            key,
         )
-        softmax_stats = torch.zeros(
-            batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
+        entry = _alloc_fi_a2a_send(
+            batch=max(batch, state["max_batch"]),
+            h_per_rank=h_per_rank,
+            cp_size=cp_size,
+            head_dim=head_dim,
+            dtype=dtype,
+            device=device,
         )
-        entry = (partial_o, softmax_stats)
         cache[key] = entry
-    return entry[0][:batch], entry[1][:batch]
+
+    if entry[0].shape[0] >= batch:
+        return entry[0][:batch], entry[1][:batch]
+
+    # Eager decode above the captured max. Hand back a transient pair instead of
+    # growing the cached one, which would free memory captured graphs point at.
+    return _alloc_fi_a2a_send(
+        batch=batch,
+        h_per_rank=h_per_rank,
+        cp_size=cp_size,
+        head_dim=head_dim,
+        dtype=dtype,
+        device=device,
+    )
 
 
 def dcp_a2a_lse_reduce(
@@ -569,7 +644,12 @@ def _dcp_fi_a2a_lse_reduce(
     H_per_rank = H // N
 
     partial_o, softmax_stats = _fi_a2a_send_buffers(
-        B, H_per_rank, N, D, cp_attn_out.dtype, cp_attn_out.device
+        batch=B,
+        h_per_rank=H_per_rank,
+        cp_size=N,
+        head_dim=D,
+        dtype=cp_attn_out.dtype,
+        device=cp_attn_out.device,
     )
     dcp_pack_a2a_send(
         cp_attn_out,

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -20,7 +20,6 @@ PR #25090 vs #14194):
   - cp_lse_ag_out_rs_mla: Triton (log2/exp2) correction / reduce-scatter
 """
 
-import logging
 import warnings
 from typing import Optional
 
@@ -38,8 +37,6 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.runtime_context import get_parallel
-
-logger = logging.getLogger(__name__)
 
 
 def _warn_deprecated_dcp_accessor(name: str, replacement: str) -> None:
@@ -387,39 +384,9 @@ def all_gather_kv_cache_for_dcp(
 _FI_A2A_STATE: Optional[dict] = None
 
 
-def _alloc_fi_a2a_send(
-    *,
-    batch: int,
-    h_per_rank: int,
-    cp_size: int,
-    head_dim: int,
-    dtype: torch.dtype,
-    device: torch.device,
-):
-    partial_o = torch.empty(
-        batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
-    )
-    # Note(kpham-sgl): the a2a wants softmax_stats as [..., cp_size, S] with
-    # S >= 2, but never reads it -- it moves the field as opaque bytes, and S=2
-    # is the one size that skips TMA for it. So slot 0 carries our LSE and slot
-    # 1 is dead weight we still ship; zero it once here, not per call.
-    softmax_stats = torch.zeros(
-        batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
-    )
-    return partial_o, softmax_stats
-
-
-def init_fi_a2a_workspace(
-    cp_group: "GroupCoordinator",
-    *,
-    max_batch: int = 0,
-    h_per_rank: int = 0,
-    head_dim: int = 0,
-    dtype: Optional[torch.dtype] = None,
-) -> None:
+def init_fi_a2a_workspace(cp_group: "GroupCoordinator") -> None:
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
-    # the stream and barriers cross-rank, neither of which is capturable. Send
-    # buffers too -- allocated lazily they would come from the graph's pool.
+    # the stream and barriers cross-rank, neither of which is capturable.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return
@@ -476,75 +443,10 @@ def init_fi_a2a_workspace(
     # REQUIRED barrier before the first alltoall: every rank must finish init,
     # else a rank writes a peer's FIFO before it is ready -> deadlock.
     dist.barrier(group=cp_group.device_group)
-    send_buffers = {}
-    if dtype is not None:
-        send_buffers[(h_per_rank, cp_size, head_dim, dtype)] = _alloc_fi_a2a_send(
-            batch=max_batch,
-            h_per_rank=h_per_rank,
-            cp_size=cp_size,
-            head_dim=head_dim,
-            dtype=dtype,
-            device=torch.cuda.current_device(),
-        )
-
     _FI_A2A_STATE = {
         "workspace": workspace,
         "cp_rank": cp_rank,
-        "max_batch": max_batch,
-        "send_buffers": send_buffers,
     }
-
-
-def _fi_a2a_send_buffers(
-    *,
-    batch: int,
-    h_per_rank: int,
-    cp_size: int,
-    head_dim: int,
-    dtype: torch.dtype,
-    device: torch.device,
-):
-    """Send tensors for the FlashInfer exchange, sliced to ``batch``.
-
-    Cached entries are never replaced -- see init_fi_a2a_workspace().
-    """
-    state = _FI_A2A_STATE
-    cache = state["send_buffers"]
-    key = (h_per_rank, cp_size, head_dim, dtype)
-    entry = cache.get(key)
-
-    if entry is None:
-        # Sized for max_batch so this stays the only allocation for the shape.
-        logger.warning(
-            "fi_a2a send buffers were pre-sized for %s but the model produced "
-            "%s; allocating now. Fix the derivation in "
-            "_pre_initialize_fi_a2a_workspace to keep this out of CUDA-graph "
-            "capture.",
-            sorted(str(k) for k in cache),
-            key,
-        )
-        entry = _alloc_fi_a2a_send(
-            batch=max(batch, state["max_batch"]),
-            h_per_rank=h_per_rank,
-            cp_size=cp_size,
-            head_dim=head_dim,
-            dtype=dtype,
-            device=device,
-        )
-        cache[key] = entry
-
-    if entry[0].shape[0] >= batch:
-        return entry[0][:batch], entry[1][:batch]
-
-    # Eager decode above the captured max: transient, leave the cached one be.
-    return _alloc_fi_a2a_send(
-        batch=batch,
-        h_per_rank=h_per_rank,
-        cp_size=cp_size,
-        head_dim=head_dim,
-        dtype=dtype,
-        device=device,
-    )
 
 
 def dcp_a2a_lse_reduce(
@@ -637,13 +539,14 @@ def _dcp_fi_a2a_lse_reduce(
     assert H % N == 0, f"num_heads ({H}) must be divisible by dcp_size ({N})"
     H_per_rank = H // N
 
-    partial_o, softmax_stats = _fi_a2a_send_buffers(
-        batch=B,
-        h_per_rank=H_per_rank,
-        cp_size=N,
-        head_dim=D,
-        dtype=cp_attn_out.dtype,
-        device=cp_attn_out.device,
+    # Note(kpham-sgl): empty(), not zeros() -- the pack below fills partial_o and
+    # stats slot 0, and slot 1 is never read by anyone. The a2a moves the stats
+    # field as opaque bytes and we only ever read slot 0 back off the wire.
+    partial_o = torch.empty(
+        B, H_per_rank, N, D, dtype=cp_attn_out.dtype, device=cp_attn_out.device
+    )
+    softmax_stats = torch.empty(
+        B, H_per_rank, N, 2, dtype=torch.float32, device=cp_attn_out.device
     )
     dcp_pack_a2a_send(
         cp_attn_out,

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -399,8 +399,7 @@ def _alloc_fi_a2a_send(
     partial_o = torch.empty(
         batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
     )
-    # Entry 1 is never read by the exchange but is still transported, so define
-    # it once here rather than re-zeroing the tensor on every call.
+    # Slot 1 is transported but never read; zero it once instead of per call.
     softmax_stats = torch.zeros(
         batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
     )
@@ -416,9 +415,13 @@ def init_fi_a2a_workspace(
     dtype: Optional[torch.dtype] = None,
 ) -> None:
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
-    # the stream and barriers cross-rank, neither of which is capturable. The
-    # send buffers are allocated here for the same reason -- allocating them on
-    # first use puts them in the capturing graph's private memory pool.
+    # the stream and barriers cross-rank, neither of which is capturable.
+    #
+    # Note(kpham-sgl): the send buffers are allocated here, not on first use.
+    # The DCP a2a runs once per MLA layer inside the decode graph, and nothing
+    # eager touches it first -- the FlashInfer autotune pass skips the exchange
+    # (_select_local_dcp_heads_for_autotune). So a lazy allocation lands during
+    # capture and comes from the graph's private pool.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return
@@ -475,8 +478,7 @@ def init_fi_a2a_workspace(
     # REQUIRED barrier before the first alltoall: every rank must finish init,
     # else a rank writes a peer's FIFO before it is ready -> deadlock.
     dist.barrier(group=cp_group.device_group)
-    # dtype is None only when the caller could not derive the send shape (a
-    # non-MLA model); the exchange is MLA-only, so that config never gets here.
+    # dtype is None when the caller could not derive the shape (non-MLA).
     send_buffers = {}
     if dtype is not None:
         send_buffers[(h_per_rank, cp_size, head_dim, dtype)] = _alloc_fi_a2a_send(
@@ -507,9 +509,8 @@ def _fi_a2a_send_buffers(
 ):
     """Send tensors for the FlashInfer exchange, sliced to ``batch``.
 
-    Normally a slice of what init_fi_a2a_workspace() pre-allocated. Cached
-    entries are never replaced: captured CUDA graphs bake in their addresses,
-    so freeing one would strand the pointers baked into those graphs.
+    Note(kpham-sgl): cached entries are never replaced. Captured graphs bake in
+    these addresses, so freeing one to grow it would strand those pointers.
     """
     state = _FI_A2A_STATE
     cache = state["send_buffers"]
@@ -517,9 +518,7 @@ def _fi_a2a_send_buffers(
     entry = cache.get(key)
 
     if entry is None:
-        # The shape derived at init did not match what the model produced, so
-        # this allocation may land inside graph capture. Size it for max_batch
-        # so it is the only one for this shape.
+        # Sized for max_batch so this stays the only allocation for the shape.
         logger.warning(
             "fi_a2a send buffers were pre-sized for %s but the model produced "
             "%s; allocating now. Fix the derivation in "
@@ -541,8 +540,7 @@ def _fi_a2a_send_buffers(
     if entry[0].shape[0] >= batch:
         return entry[0][:batch], entry[1][:batch]
 
-    # Eager decode above the captured max. Hand back a transient pair instead of
-    # growing the cached one, which would free memory captured graphs point at.
+    # Eager decode above the captured max: transient, leave the cached one be.
     return _alloc_fi_a2a_send(
         batch=batch,
         h_per_rank=h_per_rank,

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -417,12 +417,9 @@ def init_fi_a2a_workspace(
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
     # the stream and barriers cross-rank, neither of which is capturable.
     #
-    # Note(kpham-sgl): the DCP a2a runs once per MLA layer inside the decode
-    # graph, and nothing eager touches it first -- the FlashInfer autotune pass
-    # skips the exchange (_select_local_dcp_heads_for_autotune). So the send
-    # buffers are allocated here rather than on first use, which would land in
-    # capture and take memory from the graph's private pool; and once captured
-    # graphs bake in their addresses, they can never be freed to grow.
+    # Note(kpham-sgl): the DCP a2a only ever runs inside the decode graph, so a
+    # lazy alloc would come from the graph's private pool, and once captured its
+    # address can never be freed to grow.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -460,10 +460,8 @@ def _fi_a2a_send_buffers(
 ):
     """Persistent send tensors for the FlashInfer exchange, sliced to ``batch``.
 
-    The exchange does not write its inputs, so ``softmax_stats`` slots past the
-    LSE stay zero after the one-time allocation and only slot 0 is refreshed per
-    call. Buffers are grown on demand and never shrink, which also keeps their
-    addresses stable for graph capture.
+    The exchange does not write its inputs, so slots past the LSE stay zero
+    after the one-time allocation. Buffers grow on demand and never shrink.
     """
     key = (h_per_rank, cp_size, head_dim, dtype)
     cache = _FI_A2A_STATE["send_buffers"]
@@ -522,8 +520,6 @@ def dcp_a2a_lse_reduce(
         )
         recv_combined = torch.empty_like(send_combined)
 
-    # One buffer, two views: payload rows and the trailing fp32 LSE lane. Keeps
-    # the exchange to a single collective.
     send_words = send_combined.view(torch.float32)
     dcp_pack_a2a_send(
         cp_attn_out,
@@ -572,10 +568,6 @@ def _dcp_fi_a2a_lse_reduce(
     assert H % N == 0, f"num_heads ({H}) must be divisible by dcp_size ({N})"
     H_per_rank = H // N
 
-    # FlashInfer wants the peer axis inside the heads: partial_o
-    # [B, H_pr, cp_size, D] and softmax_stats [B, H_pr, cp_size, S>=2] with the
-    # LSE in lane 0. That is only a stride permutation of what the pack kernel
-    # already writes, so pack straight into it instead of permuting first.
     partial_o, softmax_stats = _fi_a2a_send_buffers(
         B, H_per_rank, N, D, cp_attn_out.dtype, cp_attn_out.device
     )
@@ -594,8 +586,6 @@ def _dcp_fi_a2a_lse_reduce(
         N,
     )
 
-    # The combine kernel takes strides, so the returned tensors are read in
-    # place: no contiguous() on either side.
     recv_output = o_out.permute(2, 0, 1, 3)
     recv_lse = stats_out[..., 0].permute(2, 0, 1)
 

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -446,7 +446,38 @@ def init_fi_a2a_workspace(cp_group: "GroupCoordinator") -> None:
     _FI_A2A_STATE = {
         "workspace": workspace,
         "cp_rank": cp_rank,
+        "send_buffers": {},
     }
+
+
+def _fi_a2a_send_buffers(
+    batch: int,
+    h_per_rank: int,
+    cp_size: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+):
+    """Persistent send tensors for the FlashInfer exchange, sliced to ``batch``.
+
+    The exchange does not write its inputs, so ``softmax_stats`` slots past the
+    LSE stay zero after the one-time allocation and only slot 0 is refreshed per
+    call. Buffers are grown on demand and never shrink, which also keeps their
+    addresses stable for graph capture.
+    """
+    key = (h_per_rank, cp_size, head_dim, dtype)
+    cache = _FI_A2A_STATE["send_buffers"]
+    entry = cache.get(key)
+    if entry is None or entry[0].shape[0] < batch:
+        partial_o = torch.empty(
+            batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
+        )
+        softmax_stats = torch.zeros(
+            batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
+        )
+        entry = (partial_o, softmax_stats)
+        cache[key] = entry
+    return entry[0][:batch], entry[1][:batch]
 
 
 def dcp_a2a_lse_reduce(
@@ -491,7 +522,15 @@ def dcp_a2a_lse_reduce(
         )
         recv_combined = torch.empty_like(send_combined)
 
-    dcp_pack_a2a_send(cp_attn_out, cp_attn_lse, send_combined)
+    # One buffer, two views: payload rows and the trailing fp32 LSE lane. Keeps
+    # the exchange to a single collective.
+    send_words = send_combined.view(torch.float32)
+    dcp_pack_a2a_send(
+        cp_attn_out,
+        cp_attn_lse,
+        send_combined[:, :, :, :D],
+        send_words[:, :, :, D // lpd],
+    )
 
     # Transport as raw bytes (uint8): the output may be fp8 (fp8 KV cache),
     # which pynccl's dtype enum can't send; byte a2a is exact for equal chunks.
@@ -533,16 +572,19 @@ def _dcp_fi_a2a_lse_reduce(
     assert H % N == 0, f"num_heads ({H}) must be divisible by dcp_size ({N})"
     H_per_rank = H // N
 
-    # FlashInfer sends partial_o[..., peer, :] to `peer`; head h -> peer h//H_per_rank,
-    # so the peer axis is the outer head split: [B,N,H_pr,D] -> [B,H_pr,N,D].
-    partial_o = cp_attn_out.view(B, N, H_per_rank, D).permute(0, 2, 1, 3).contiguous()
-    # softmax_stats: fp32 [B, H_per_rank, N, S=2] (FI requires S>=2 & even);
-    # carry the LSE in lane 0, lane 1 is ignored by the combine.
-    lse_view = cp_attn_lse.view(B, N, H_per_rank).permute(0, 2, 1)  # [B,H_pr,N]
-    softmax_stats = torch.zeros(
-        B, H_per_rank, N, 2, dtype=torch.float32, device=cp_attn_out.device
+    # FlashInfer wants the peer axis inside the heads: partial_o
+    # [B, H_pr, cp_size, D] and softmax_stats [B, H_pr, cp_size, S>=2] with the
+    # LSE in lane 0. That is only a stride permutation of what the pack kernel
+    # already writes, so pack straight into it instead of permuting first.
+    partial_o, softmax_stats = _fi_a2a_send_buffers(
+        B, H_per_rank, N, D, cp_attn_out.dtype, cp_attn_out.device
     )
-    softmax_stats[..., 0] = lse_view
+    dcp_pack_a2a_send(
+        cp_attn_out,
+        cp_attn_lse,
+        partial_o.permute(2, 0, 1, 3),
+        softmax_stats[..., 0].permute(2, 0, 1),
+    )
 
     o_out, stats_out = decode_cp_a2a_alltoall(
         partial_o,
@@ -552,9 +594,10 @@ def _dcp_fi_a2a_lse_reduce(
         N,
     )
 
-    # o_out[b,hpr,src] = rank src's partial for local head hpr -> combine layout.
-    recv_output = o_out.permute(2, 0, 1, 3).contiguous()  # [N, B, H_per_rank, D]
-    recv_lse = stats_out[..., 0].permute(2, 0, 1).contiguous()  # [N, B, H_per_rank]
+    # The combine kernel takes strides, so the returned tensors are read in
+    # place: no contiguous() on either side.
+    recv_output = o_out.permute(2, 0, 1, 3)
+    recv_lse = stats_out[..., 0].permute(2, 0, 1)
 
     combined, _ = dcp_lse_combine_triton(
         recv_output, recv_lse, is_lse_base_on_e=is_lse_base_on_e

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -399,7 +399,10 @@ def _alloc_fi_a2a_send(
     partial_o = torch.empty(
         batch, h_per_rank, cp_size, head_dim, dtype=dtype, device=device
     )
-    # Slot 1 is transported but never read; zero it once instead of per call.
+    # Note(kpham-sgl): the a2a wants softmax_stats as [..., cp_size, S] with
+    # S >= 2, but never reads it -- it moves the field as opaque bytes, and S=2
+    # is the one size that skips TMA for it. So slot 0 carries our LSE and slot
+    # 1 is dead weight we still ship; zero it once here, not per call.
     softmax_stats = torch.zeros(
         batch, h_per_rank, cp_size, 2, dtype=torch.float32, device=device
     )
@@ -415,11 +418,8 @@ def init_fi_a2a_workspace(
     dtype: Optional[torch.dtype] = None,
 ) -> None:
     # Call once per process BEFORE CUDA-graph capture: the FlashInfer init syncs
-    # the stream and barriers cross-rank, neither of which is capturable.
-    #
-    # Note(kpham-sgl): the DCP a2a only ever runs inside the decode graph, so a
-    # lazy alloc would come from the graph's private pool, and once captured its
-    # address can never be freed to grow.
+    # the stream and barriers cross-rank, neither of which is capturable. Send
+    # buffers too -- allocated lazily they would come from the graph's pool.
     global _FI_A2A_STATE
     if _FI_A2A_STATE is not None:
         return
@@ -476,7 +476,6 @@ def init_fi_a2a_workspace(
     # REQUIRED barrier before the first alltoall: every rank must finish init,
     # else a rank writes a peer's FIFO before it is ready -> deadlock.
     dist.barrier(group=cp_group.device_group)
-    # dtype is None when the caller could not derive the shape (non-MLA).
     send_buffers = {}
     if dtype is not None:
         send_buffers[(h_per_rank, cp_size, head_dim, dtype)] = _alloc_fi_a2a_send(

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -25,6 +25,7 @@ import torch
 
 from sglang.srt.batch_overlap.two_batch_overlap import TboCudaGraphRunnerPlugin
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
+from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.dp_attention import (
@@ -278,19 +279,41 @@ class BaseRunner(ABC):
         )
 
     def _pre_initialize_fi_a2a_workspace(self):
-        """Allocate the FlashInfer MNNVL all-to-all workspace for the fi_a2a DCP
-        comm backend; must run before CG capture (it syncs the stream + barriers
-        cross-rank, uncapturable) and raises early on non-MNNVL platforms.
+        """Allocate the FlashInfer MNNVL all-to-all workspace and send buffers for
+        the fi_a2a DCP comm backend; must run before CG capture (the init syncs
+        the stream + barriers cross-rank, uncapturable, and buffers allocated
+        during capture come from the graph's private pool). Raises early on
+        non-MNNVL platforms.
         """
-        if (
-            not get_parallel().dcp_enabled
-            or get_parallel().dcp_comm_backend != "fi_a2a"
-        ):
+        ps = get_parallel()
+        if not ps.dcp_enabled or ps.dcp_comm_backend != "fi_a2a":
             return
 
         from sglang.srt.layers.dcp import init_fi_a2a_workspace
 
-        init_fi_a2a_workspace(get_parallel().dcp_group)
+        mr = self.model_runner
+        if mr.model_config.attention_arch != AttentionArch.MLA:
+            # The exchange is only reachable from the MLA decode path, so leave
+            # the send buffers unsized rather than guess at a non-MLA shape.
+            init_fi_a2a_workspace(ps.dcp_group)
+            return
+
+        server_args = mr.server_args
+        # One reduce row per decode token. is_dcp_mla_decode_phase() also fires
+        # on TARGET_VERIFY, so scale by the draft width; batches past this (eager
+        # decode above the captured max) fall back to a transient allocation.
+        max_reqs = (
+            server_args.cuda_graph_config.decode.max_bs
+            or server_args.max_running_requests
+            or 1
+        )
+        init_fi_a2a_workspace(
+            ps.dcp_group,
+            max_batch=max_reqs * mr.decode_num_tokens_per_req(),
+            h_per_rank=mr.model_config.num_attention_heads // ps.attn_tp_size,
+            head_dim=mr.model_config.kv_lora_rank,
+            dtype=mr.dtype,
+        )
 
     def _flashinfer_autotune(self, *, buffers, batch_size):
         """Run flashinfer autotune.

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -280,9 +280,8 @@ class BaseRunner(ABC):
 
     def _pre_initialize_fi_a2a_workspace(self):
         """Allocate the FlashInfer MNNVL all-to-all workspace and send buffers for
-        the fi_a2a DCP comm backend; must run before CG capture (the init syncs
-        the stream + barriers cross-rank, uncapturable, and buffers allocated
-        during capture come from the graph's private pool). Raises early on
+        the fi_a2a DCP comm backend; must run before CG capture (it syncs the
+        stream + barriers cross-rank, uncapturable) and raises early on
         non-MNNVL platforms.
         """
         ps = get_parallel()
@@ -293,15 +292,13 @@ class BaseRunner(ABC):
 
         mr = self.model_runner
         if mr.model_config.attention_arch != AttentionArch.MLA:
-            # The exchange is only reachable from the MLA decode path, so leave
-            # the send buffers unsized rather than guess at a non-MLA shape.
+            # The exchange is only reachable from the MLA decode path.
             init_fi_a2a_workspace(ps.dcp_group)
             return
 
         server_args = mr.server_args
-        # One reduce row per decode token. is_dcp_mla_decode_phase() also fires
-        # on TARGET_VERIFY, so scale by the draft width; batches past this (eager
-        # decode above the captured max) fall back to a transient allocation.
+        # One reduce row per decode token, and is_dcp_mla_decode_phase() also
+        # fires on TARGET_VERIFY, so scale by the draft width.
         max_reqs = (
             server_args.cuda_graph_config.decode.max_bs
             or server_args.max_running_requests

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -25,7 +25,6 @@ import torch
 
 from sglang.srt.batch_overlap.two_batch_overlap import TboCudaGraphRunnerPlugin
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
-from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.dp_attention import (
@@ -279,36 +278,19 @@ class BaseRunner(ABC):
         )
 
     def _pre_initialize_fi_a2a_workspace(self):
-        """Allocate the FlashInfer MNNVL all-to-all workspace and send buffers for
-        the fi_a2a DCP comm backend; must run before CG capture (it syncs the
-        stream + barriers cross-rank, uncapturable) and raises early on
-        non-MNNVL platforms.
+        """Allocate the FlashInfer MNNVL all-to-all workspace for the fi_a2a DCP
+        comm backend; must run before CG capture (it syncs the stream + barriers
+        cross-rank, uncapturable) and raises early on non-MNNVL platforms.
         """
-        ps = get_parallel()
-        if not ps.dcp_enabled or ps.dcp_comm_backend != "fi_a2a":
+        if (
+            not get_parallel().dcp_enabled
+            or get_parallel().dcp_comm_backend != "fi_a2a"
+        ):
             return
 
         from sglang.srt.layers.dcp import init_fi_a2a_workspace
 
-        mr = self.model_runner
-        if mr.model_config.attention_arch != AttentionArch.MLA:
-            # The exchange is only reachable from the MLA decode path.
-            init_fi_a2a_workspace(ps.dcp_group)
-            return
-
-        server_args = mr.server_args
-        max_reqs = (
-            server_args.cuda_graph_config.decode.max_bs
-            or server_args.max_running_requests
-            or 1
-        )
-        init_fi_a2a_workspace(
-            ps.dcp_group,
-            max_batch=max_reqs * mr.decode_num_tokens_per_req(),
-            h_per_rank=mr.model_config.num_attention_heads // ps.attn_tp_size,
-            head_dim=mr.model_config.kv_lora_rank,
-            dtype=mr.dtype,
-        )
+        init_fi_a2a_workspace(get_parallel().dcp_group)
 
     def _flashinfer_autotune(self, *, buffers, batch_size):
         """Run flashinfer autotune.

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -297,8 +297,6 @@ class BaseRunner(ABC):
             return
 
         server_args = mr.server_args
-        # One reduce row per decode token, and is_dcp_mla_decode_phase() also
-        # fires on TARGET_VERIFY, so scale by the draft width.
         max_reqs = (
             server_args.cuda_graph_config.decode.max_bs
             or server_args.max_running_requests

--- a/test/registered/kernels/test_dcp_lse_combine.py
+++ b/test/registered/kernels/test_dcp_lse_combine.py
@@ -507,8 +507,6 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
                 out = torch.randn(B, H, D, device=self.device, dtype=torch.bfloat16)
                 lse = torch.randn(B, H, device=self.device, dtype=torch.float32)
 
-                # FlashInfer's decode_cp_a2a_alltoall layout: payload and LSE in
-                # separate tensors with the peer axis inside the heads.
                 partial_o = torch.empty(
                     B, H_per_rank, N, D, dtype=torch.bfloat16, device=self.device
                 )

--- a/test/registered/kernels/test_dcp_lse_combine.py
+++ b/test/registered/kernels/test_dcp_lse_combine.py
@@ -473,7 +473,12 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
                 got = torch.zeros(
                     N, max_bs, H_per_rank, D + lpd, dtype=dtype, device=self.device
                 )
-                dcp_pack_a2a_send(out, lse, got)
+                dcp_pack_a2a_send(
+                    out,
+                    lse,
+                    got[:, :, :, :D],
+                    got.view(torch.float32)[:, :, :, D // lpd],
+                )
 
                 want = torch.zeros_like(got)
                 want[:, :B, :, :D] = out.view(B, N, H_per_rank, D).permute(1, 0, 2, 3)
@@ -491,6 +496,43 @@ class TestDCPA2AReduceWithCUDAGraphBuffers(CustomTestCase):
                 lane = got.view(torch.float32)[:, :B, :, D // lpd]
                 self.assertTrue(
                     torch.equal(lane, lse.view(B, N, H_per_rank).permute(1, 0, 2))
+                )
+
+    def test_pack_serves_the_split_peer_inside_layout(self):
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_pack_a2a_send
+
+        for N, B, H_per_rank, D in ((2, 4, 8, 128), (4, 1, 16, 512)):
+            with self.subTest(N=N, B=B, H_per_rank=H_per_rank, D=D):
+                H = H_per_rank * N
+                out = torch.randn(B, H, D, device=self.device, dtype=torch.bfloat16)
+                lse = torch.randn(B, H, device=self.device, dtype=torch.float32)
+
+                # FlashInfer's decode_cp_a2a_alltoall layout: payload and LSE in
+                # separate tensors with the peer axis inside the heads.
+                partial_o = torch.empty(
+                    B, H_per_rank, N, D, dtype=torch.bfloat16, device=self.device
+                )
+                stats = torch.zeros(
+                    B, H_per_rank, N, 2, dtype=torch.float32, device=self.device
+                )
+                dcp_pack_a2a_send(
+                    out,
+                    lse,
+                    partial_o.permute(2, 0, 1, 3),
+                    stats[..., 0].permute(2, 0, 1),
+                )
+
+                want_o = out.view(B, N, H_per_rank, D).permute(0, 2, 1, 3)
+                want_lse = lse.view(B, N, H_per_rank).permute(0, 2, 1)
+                self.assertTrue(
+                    torch.equal(
+                        partial_o.view(torch.uint8),
+                        want_o.contiguous().view(torch.uint8),
+                    )
+                )
+                self.assertTrue(torch.equal(stats[..., 0], want_lse))
+                self.assertTrue(
+                    torch.equal(stats[..., 1], torch.zeros_like(stats[..., 1]))
                 )
 
     def test_buffers_have_fixed_data_ptrs(self):


### PR DESCRIPTION
## Motivation

#34614 fused the pack/unpack copies on the pynccl `a2a` path but left `fi_a2a` (FlashInfer MNNVL) untouched, so it still paid four materializing copies plus a zero-fill per MLA layer per decode step:

```python
partial_o = out.view(B, N, H_pr, D).permute(0, 2, 1, 3).contiguous()   # copy
softmax_stats = torch.zeros(B, H_pr, N, 2, ...)                        # FillFunctor
softmax_stats[..., 0] = lse_view                                       # copy
o_out, stats_out = decode_cp_a2a_alltoall(...)
recv_o   = o_out.permute(2, 0, 1, 3).contiguous()                      # copy
recv_lse = stats_out[..., 0].permute(2, 0, 1).contiguous()             # copy
```

#34614 is what created the asymmetry — before it, both paths did ~4 copies. This finishes the job rather than duplicating the fix.

## Modifications

**One pack kernel for both transports.** `dcp_pack_a2a_send` now takes independently strided payload and LSE destinations instead of one interleaved buffer. pynccl's `all_to_all_single` chunks a flat buffer by byte offset so the peer axis must be outermost (LSE interleaved into each row's trailing fp32 word, keeping the exchange to one collective); FlashInfer wants the peer axis inside the heads with payload and stats separate. Peer-axis placement is just a stride argument, so one kernel serves both and neither needs a layout copy.

The receive side needs no work at all — `dcp_lse_combine_triton` already takes arbitrary strides, so `o_out` / `stats_out` are read in place.

**`zeros()` -> `empty()` for `softmax_stats`.** Nothing ever reads slot 1: we write slot 0 and read `stats_out[..., 0]` back, and the exchange moves the field as opaque bytes without interpreting it. The zeroing was never needed, and dropping it removes the per-call `FillFunctor`.

## Accuracy

DeepSeek-V3.1, 4x GB300, real MNNVL, `dcp_size=4`: **GSM8K 0.980, 0 invalid.**

Verified against a torch oracle on all 4 ranks, both LSE bases, at `B=8 H_per_rank=12 D=512`: max error 7.8e-3 — a bf16 payload against an fp32 reference, so rounding, not drift.

Unit tests: 24 passed + 5 subtests, including a new case asserting the shared kernel reproduces FlashInfer's split/peer-inside layout bit-for-bit.

## Profile

DSV3 on 4xGB300 

Before
<img width="1136" height="448" alt="Screenshot 2026-08-13 at 2 20 31 PM" src="https://github.com/user-attachments/assets/9302035f-f373-4cdf-a3ed-c6270bfda62c" />



After
<img width="779" height="362" alt="Screenshot 2026-08-13 at 2 18 51 PM" src="https://github.com/user-attachments/assets/ac9b015d-8860-4691-9296-d4342a1183ef" />

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

`fi_a2a` requires MNNVL fabric, so CI cannot exercise this path; the evidence above is from a 4x GB300 devbox.

`combine` is now the only caller-side work left around the exchange. Folding it in needs the reduction to happen as peer data arrives, which only FlashInfer can do — filing that upstream separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
