### PR TITLE
[diffusion] feat: publish an index of nightly comparison runs

### DIFF
--- a/scripts/ci/utils/diffusion/publish_comparison_results.py
+++ b/scripts/ci/utils/diffusion/publish_comparison_results.py
@@ -14,6 +14,7 @@ Usage:
 """
 
 import argparse
+import json
 import os
 import sys
 import time
@@ -25,6 +26,7 @@ from pathlib import Path
 if __package__:
     from ..publish_traces import (
         create_blobs,
+        make_github_request,
         create_commit,
         create_tree,
         get_branch_sha,
@@ -38,6 +40,7 @@ else:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from publish_traces import (
         create_blobs,
+        make_github_request,
         create_commit,
         create_tree,
         get_branch_sha,
@@ -76,6 +79,47 @@ def _collect_chart_files(charts_dir: str) -> list[tuple[str, bytes]]:
     return files
 
 
+def _build_run_index(run_target: str, token: str, keep: int = 90) -> bytes:
+    """List the published run files and return an index.json body.
+
+    The site cannot discover these files itself: listing the directory needs
+    the contents API, whose anonymous 60/hour budget is shared per egress IP,
+    so viewers behind a shared proxy get permanent 403s. Publishing a stable
+    index alongside the runs lets the page read everything from
+    raw.githubusercontent.com instead, which is CORS-enabled and unmetered.
+    """
+    names = {os.path.basename(run_target)}
+    try:
+        branch_sha = get_branch_sha(REPO_OWNER, REPO_NAME, BRANCH, token)
+        tree_sha = get_tree_sha(REPO_OWNER, REPO_NAME, branch_sha, token)
+        url = (
+            f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}"
+            f"/git/trees/{tree_sha}?recursive=1"
+        )
+        tree = json.loads(make_github_request(url, token))
+        for item in tree.get("tree", []):
+            path = item.get("path", "")
+            base = os.path.basename(path)
+            if (
+                path.startswith(f"{STORAGE_PREFIX}/")
+                and "/" not in path[len(STORAGE_PREFIX) + 1 :]
+                and base.endswith(".json")
+                and base != "index.json"
+            ):
+                names.add(base)
+    except Exception as exc:  # an index is a convenience, never a publish blocker
+        print(f"Warning: could not list existing runs for the index ({exc})")
+
+    # filenames start with the UTC date, so lexical order is chronological
+    recent = sorted(names, reverse=True)[:keep]
+    body = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "prefix": STORAGE_PREFIX,
+        "runs": recent,
+    }
+    return json.dumps(body, indent=2).encode() + b"\n"
+
+
 def publish_comparison(
     results_path: str,
     dashboard_path: str | None = None,
@@ -109,6 +153,11 @@ def publish_comparison(
     results_target = f"{STORAGE_PREFIX}/{date_prefix}_{run_id}.json"
     with open(results_path, "rb") as f:
         files_to_upload.append((results_target, f.read()))
+
+    # Stable index so the site can enumerate runs without the contents API
+    files_to_upload.append(
+        (f"{STORAGE_PREFIX}/index.json", _build_run_index(results_target, token))
+    )
 
     # Dashboard markdown: always overwrite latest
     if dashboard_path and os.path.exists(dashboard_path):

--- a/scripts/ci/utils/diffusion/publish_comparison_results.py
+++ b/scripts/ci/utils/diffusion/publish_comparison_results.py
@@ -26,13 +26,13 @@ from pathlib import Path
 if __package__:
     from ..publish_traces import (
         create_blobs,
-        make_github_request,
         create_commit,
         create_tree,
         get_branch_sha,
         get_tree_sha,
         is_permission_error,
         is_rate_limit_error,
+        make_github_request,
         update_branch_ref,
         verify_token_permissions,
     )
@@ -40,13 +40,13 @@ else:
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
     from publish_traces import (
         create_blobs,
-        make_github_request,
         create_commit,
         create_tree,
         get_branch_sha,
         get_tree_sha,
         is_permission_error,
         is_rate_limit_error,
+        make_github_request,
         update_branch_ref,
         verify_token_permissions,
     )


### PR DESCRIPTION
## Problem

Runs are published as `diffusion-comparisons/<date>_<run_id>.json`, so any consumer that wants the history must first enumerate the directory. From a browser the only way to do that is the contents API, and its anonymous budget is **60/hour shared per egress IP** — viewers behind a shared proxy get permanent 403s.

The practical consequence is that consumers stop reading this repo live and start mirroring it through a scheduled job, which adds latency between a nightly finishing and anyone seeing it.

## Change

Write `diffusion-comparisons/index.json` in the same commit as each run:

```json
{
  "generated_at": "2026-08-13T...",
  "prefix": "diffusion-comparisons",
  "runs": ["2026-08-12_31648935157.json", "2026-08-12_31501558607.json", ...]
}
```

The publisher already holds a token, so listing the tree costs it nothing extra, and it rides along in the existing tree/commit — no additional commit, no new race.

With a stable path, a consumer can read the index and every run it names from `raw.githubusercontent.com`, which is CORS-enabled and unmetered — no contents API, no mirror job.

## Notes

- **Best-effort by design.** If the listing fails it logs a warning and the index falls back to just this run; publishing results is never blocked by index construction.
- Filenames begin with the UTC date, so lexical sort is chronological. Capped at the 90 most recent to keep the file small.
- `index.json` itself and the `charts/` subdirectory are excluded from the listing.

## Verification

Ran the builder against the live repo (read-only):

```
prefix: diffusion-comparisons
runs listed: 90
newest 3: ['2026-08-13_99999999.json', '2026-08-12_31648935157.json', '2026-08-12_31501558607.json']
includes the new run: True
excludes index.json: True
excludes charts/: True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31662702442](https://github.com/sgl-project/sglang/actions/runs/31662702442)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31662702219](https://github.com/sgl-project/sglang/actions/runs/31662702219)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->