### PR TITLE
[diffusion] feat: track MiniMax-H3 in the nightly diffusion benchmark

### DIFF
--- a/scripts/ci/utils/diffusion/comparison_configs.json
+++ b/scripts/ci/utils/diffusion/comparison_configs.json
@@ -186,6 +186,34 @@
                     "extra_env": {}
                 }
             }
+        },
+        {
+            "id": "minimax_h3_t2va_5s",
+            "model": "MiniMaxAI/MiniMax-H3",
+            "task": "text-to-video",
+            "prompt": "At night, while their owner sleeps in a bedroom, three cats march in loudly playing tiny brass instruments, then abruptly file out.",
+            "width": 1344,
+            "height": 768,
+            "num_frames": 124,
+            "fps": 24,
+            "num_inference_steps": 50,
+            "seed": 1101,
+            "num_gpus": 4,
+            "sglang_request_extra": {
+                "task": "t2va",
+                "conditions": [],
+                "target": {"short_edge": 768, "aspect_ratio": "16:9", "duration_seconds": 5.0},
+                "flow_shift": 12.0,
+                "audio_flow_shift": 3.0,
+                "num_frames": null,
+                "fps": null
+            },
+            "frameworks": {
+                "sglang": {
+                    "serve_args": "--warmup-mode server --model-variant fl2va --tp-size 2 --ulysses-degree 2 --performance-mode speed --enable-torch-compile false",
+                    "extra_env": {}
+                }
+            }
         }
     ]
 }

--- a/scripts/ci/utils/diffusion/run_comparison.py
+++ b/scripts/ci/utils/diffusion/run_comparison.py
@@ -362,6 +362,16 @@ def _build_sglang_payload(case: dict) -> dict:
     ):
         if key in case:
             payload[key] = case[key]
+
+    # Model-specific request fields outside the common schema -- MiniMax-H3
+    # derives its shape from `target` and rejects an explicit num_frames, so a
+    # case needs to both add keys and drop common ones. A null value removes
+    # the key rather than sending null.
+    for key, value in (case.get("sglang_request_extra") or {}).items():
+        if value is None:
+            payload.pop(key, None)
+        else:
+            payload[key] = value
     return payload
 
 


### PR DESCRIPTION
## Motivation

MiniMax-H3 is the only joint video+audio model served here, and it has no nightly coverage — regressions in it stay invisible until someone runs it by hand.

## Harness change it needs first

`_build_sglang_payload` forwards a fixed whitelist, and H3 does not fit it in either direction. It derives its shape from `target` and **rejects** an explicit `num_frames`:

```
num_frames is not supported: MiniMax H3 derives the temporal shape from target.duration_seconds
```

So a case has to both *add* keys (`task`, `target`, `flow_shift`, `audio_flow_shift`) and *drop* common ones. `sglang_request_extra` does that, with a `null` value removing a key rather than sending `null`:

```python
for key, value in (case.get("sglang_request_extra") or {}).items():
    if value is None:
        payload.pop(key, None)
    else:
        payload[key] = value
```

No existing case sets it, so every other payload is byte-identical to before.

## The case

The cookbook's 4×H100 topology (TP2 + Ulysses2) at the 5-second 1344×768 profile. Compile stays off deliberately: H3's `torch.compile` path changes numerical output, so no lossless preset enables it.

## Verification

Ran the **exact** `serve_args` and the **exact** payload the harness builds, on 4×H200:

```
inference_time_s 77.1
peak_memory_mb   63492
size 1344x768, seconds 5.166667
client wall      80.5s
```

That is in line with the existing 720p video cases rather than an outlier for the nightly budget.

Payload the harness produces for this case, for review:

```json
{
  "model": "MiniMaxAI/MiniMax-H3",
  "size": "1344x768", "n": 1, "response_format": "b64_json",
  "num_inference_steps": 50, "seed": 1101,
  "task": "t2va", "conditions": [],
  "target": {"short_edge": 768, "aspect_ratio": "16:9", "duration_seconds": 5.0},
  "flow_shift": 12.0, "audio_flow_shift": 3.0
}
```

Note `num_frames` and `fps` are absent — removed by the null entries, which is the behaviour the model requires.

## Note

Timed on H200; the nightly runner is 4×H100, so expect a different absolute number. The topology is the cookbook's documented H100 recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31661900988](https://github.com/sgl-project/sglang/actions/runs/31661900988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31661900966](https://github.com/sgl-project/sglang/actions/runs/31661900966)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->