### PR TITLE
[Scheduler] Expose DP-attention MLP sync transport

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, Optional
 
@@ -37,6 +38,9 @@ if TYPE_CHECKING:
 
 
 _ENABLE_METRICS_DP_ATTENTION = envs.SGLANG_ENABLE_METRICS_DP_ATTENTION.get()
+_MLP_SYNC_TRANSPORT_LOGGED = False
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_elastic_world_dp_size(
@@ -196,6 +200,35 @@ class MLPSyncBatchInfo:
             )
 
 
+def _log_mlp_sync_transport_once(
+    *,
+    group: torch.distributed.ProcessGroup,
+    group_kind: str,
+    device: torch.device | str,
+    overlap_schedule: bool,
+    sync_info: MLPSyncBatchInfo,
+) -> None:
+    global _MLP_SYNC_TRANSPORT_LOGGED
+    if _MLP_SYNC_TRANSPORT_LOGGED:
+        return
+
+    logger.info(
+        "Entering DP-attention MLP sync collective: "
+        "backend=%s, group=%s, group_size=%s, global_rank=%s, group_rank=%s, "
+        "device=%s, overlap_schedule=%s, num_tokens=%s, forward_mode=%s",
+        torch.distributed.get_backend(group),
+        group_kind,
+        torch.distributed.get_world_size(group),
+        torch.distributed.get_rank(),
+        torch.distributed.get_rank(group),
+        device,
+        overlap_schedule,
+        sync_info.num_tokens,
+        sync_info.local_forward_mode,
+    )
+    _MLP_SYNC_TRANSPORT_LOGGED = True
+
+
 def _update_gather_batch(
     batch: ScheduleBatch,
     mlp_sync_info: MLPSyncBatchInfo,
@@ -306,15 +339,18 @@ def prepare_mlp_sync_batch_raw(
 
         world = get_world_group()
         group = torch.distributed.group.WORLD
+        group_kind = "world"
         device = world.device
     elif len(offload_tags) == 0 and (
         disable_overlap_schedule
         or envs.SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH.get()
     ):
         group = tp_group.device_group
+        group_kind = "device"
         device = tp_group.device
     else:
         group = tp_group.cpu_group
+        group_kind = "cpu"
         device = "cpu"
 
     local_can_run_tbo, local_forward_mode = tbo_preparer.prepare_all_gather(local_batch)
@@ -340,6 +376,13 @@ def prepare_mlp_sync_batch_raw(
     )
 
     if not skip_all_gather:
+        _log_mlp_sync_transport_once(
+            group=group,
+            group_kind=group_kind,
+            device=device,
+            overlap_schedule=not disable_overlap_schedule,
+            sync_info=mlp_sync_info,
+        )
         mlp_sync_info.all_gather(
             device=device,
             group=group,

--- a/test/registered/unit/managers/scheduler_components/test_dp_attn.py
+++ b/test/registered/unit/managers/scheduler_components/test_dp_attn.py
@@ -1,0 +1,125 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler_components import dp_attn  # noqa: E402
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _GatherReached(Exception):
+    pass
+
+
+class TestMLPSyncTransportLog(CustomTestCase):
+    def test_reports_backend_and_rank_once(self):
+        group = object()
+        sync_info = SimpleNamespace(num_tokens=64, local_forward_mode=1)
+        previous_logged = dp_attn._MLP_SYNC_TRANSPORT_LOGGED
+        dp_attn._MLP_SYNC_TRANSPORT_LOGGED = False
+
+        try:
+            with (
+                patch.object(
+                    dp_attn.torch.distributed, "get_backend", return_value="gloo"
+                ),
+                patch.object(
+                    dp_attn.torch.distributed, "get_world_size", return_value=16
+                ),
+                patch.object(dp_attn.torch.distributed, "get_rank", side_effect=[3, 3]),
+                patch.object(dp_attn.logger, "info") as log_info,
+            ):
+                for _ in range(2):
+                    dp_attn._log_mlp_sync_transport_once(
+                        group=group,
+                        group_kind="cpu",
+                        device="cpu",
+                        overlap_schedule=True,
+                        sync_info=sync_info,
+                    )
+        finally:
+            dp_attn._MLP_SYNC_TRANSPORT_LOGGED = previous_logged
+
+        log_info.assert_called_once()
+        self.assertEqual(
+            log_info.call_args.args[1:],
+            ("gloo", "cpu", 16, 3, 3, "cpu", True, 64, 1),
+        )
+
+
+class TestPrepareMLPSyncBatchRaw(CustomTestCase):
+    def _run_group_selection(self, *, force_device_group: bool):
+        tp_group = SimpleNamespace(
+            cpu_group=object(),
+            device_group=object(),
+            device="cuda:0",
+        )
+
+        with (
+            dp_attn.envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.override(False),
+            dp_attn.envs.SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH.override(
+                force_device_group
+            ),
+            patch.object(dp_attn, "world_dp_gather_enabled", return_value=False),
+            patch.object(dp_attn, "check_cuda_graph_backend", return_value=False),
+            patch.object(
+                dp_attn.TboDPAttentionPreparer,
+                "prepare_all_gather",
+                return_value=(True, dp_attn.ForwardMode.IDLE.value),
+            ),
+            patch.object(dp_attn, "_log_mlp_sync_transport_once") as log_transport,
+            patch.object(
+                dp_attn.MLPSyncBatchInfo,
+                "all_gather",
+                side_effect=_GatherReached,
+            ) as all_gather,
+            self.assertRaises(_GatherReached),
+        ):
+            dp_attn.prepare_mlp_sync_batch_raw(
+                local_batch=None,
+                model_runner=None,
+                dp_size=2,
+                attn_tp_size=8,
+                attn_cp_size=1,
+                tp_group=tp_group,
+                get_idle_batch=lambda: None,
+                disable_cuda_graph=True,
+                require_mlp_tp_gather=True,
+                disable_overlap_schedule=False,
+                offload_tags=set(),
+            )
+
+        return tp_group, log_transport, all_gather
+
+    def test_overlap_default_selects_cpu_group(self):
+        tp_group, log_transport, all_gather = self._run_group_selection(
+            force_device_group=False
+        )
+
+        all_gather.assert_called_once_with(
+            device="cpu",
+            group=tp_group.cpu_group,
+            use_all_reduce=False,
+        )
+        self.assertEqual(log_transport.call_args.kwargs["group_kind"], "cpu")
+
+    def test_overlap_env_selects_device_group(self):
+        tp_group, log_transport, all_gather = self._run_group_selection(
+            force_device_group=True
+        )
+
+        all_gather.assert_called_once_with(
+            device="cuda:0",
+            group=tp_group.device_group,
+            use_all_reduce=False,
+        )
+        self.assertEqual(log_transport.call_args.kwargs["group_kind"], "device")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

#34582 reports a 100% reproducible two-node startup hang in the first DP-attention MLP-sync `all_gather_into_tensor`.

The reported stack identifies the collective call, but not its backend. Under the reported overlap-scheduler configuration, the source selects `tp_group.cpu_group` unless `SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH` is enabled. On CUDA, that CPU group is Gloo, so a standalone NCCL all-gather does not cover the default path.

This draft adds the runtime evidence needed to distinguish a transport/group problem from rank participation or ordering divergence before changing synchronization behavior.

## Modifications

- Log the actual backend, group kind and size, global/group rank, device, overlap mode, token count, and local forward mode immediately before the first MLP-sync collective in each scheduler process.
- Add CPU unit coverage for both overlap-scheduler selection paths:
  - default configuration selects `tp_group.cpu_group`;
  - the opt-in environment variable selects `tp_group.device_group`.

This commit does not change the selected transport or collective semantics.

## Validation

- `python3 -m py_compile` for the changed Python files.
- `python3 scripts/ci/check_registered_tests.py`.
- `ruff 0.15.1`, `black 26.1.0`, `isort 7.0.0`, and `codespell 2.4.1` passed on the changed files.
- `git diff --check` passed.
- The focused unit test was not executed locally because this checkout's Python environment does not contain the SGLang runtime dependencies; CI validation is pending.

## Follow-up

Run the reporter's stable two-node reproduction on this branch and compare the per-rank `Entering DP-attention MLP sync collective` records. That will establish the actual backend/group and whether every rank reaches the same first collective before selecting a behavior change.

Related GPU metadata-sync work shows that switching overlap scheduling to a device collective is not automatically safe, so this draft deliberately does not flip the default transport.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31662552728](https://github.com/sgl-project/sglang/actions/runs/31662552728)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31662552604](https://github.com/sgl-project/sglang/actions/runs/31662552604)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->