### PR TITLE
fix(openai): skip the required-tool JSON fallback for non-JSON output

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -122,6 +122,12 @@ def parse_tool_call_arguments(arguments: str) -> Dict[str, Any]:
     return parsed_arguments
 
 
+def _looks_like_json_payload(text: str) -> bool:
+    """Whether ``text`` could be the start of a JSON object or array."""
+    stripped = text.lstrip()
+    return stripped.startswith("{") or stripped.startswith("[")
+
+
 def normalize_assistant_tool_call_arguments(
     message: Dict[str, Any], *, strict: bool = True
 ) -> None:
@@ -2031,8 +2037,17 @@ class OpenAIServingChat(OpenAIServingBase):
                     logger.error(f"Tool call parsing error: {e}")
                     return ToolCallProcessingResult(None, text, finish_reason)
 
-        # json_schema constraint → JSON array output for required/named
-        if is_required:
+        # json_schema constraint → JSON array output for required/named.
+        #
+        # Only detectors that supply neither a structural tag nor native
+        # required-parsing are constrained that way; see
+        # FunctionCallParser.get_structure_constraint. Everything else was told
+        # to emit its own format and the parser above already had its shot at
+        # the text, so what reaches here is ordinary content — a refusal, or an
+        # empty turn once reasoning was stripped. Handing that to orjson.loads
+        # only ever produced a logged exception and the same text passthrough
+        # we fall through to below, so require something JSON-shaped first.
+        if is_required and _looks_like_json_payload(text):
             original_finish_type = finish_reason["type"]
             if finish_reason["type"] == "stop":
                 finish_reason["type"] = "tool_calls"

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -2977,6 +2977,72 @@ class TestProcessToolCallsWithRequiredToolChoice(unittest.TestCase):
         self.assertIsNone(tool_calls)
 
 
+class TestRequiredToolChoiceNonJsonOutput(unittest.TestCase):
+    """A detector that supplies a structural tag is constrained to its own
+    native format, never to the JSON array the ``is_required`` branch expects.
+    When such a model answers in prose -- or returns nothing at all once
+    reasoning is stripped -- the branch used to hand that text to
+    ``orjson.loads`` anyway, so every one of those turns burned an
+    ``ERROR``-level "Tool call parsing error" on a payload that could not have
+    been JSON. Reported as ~85 errors/day on Kimi-K3 in sgl-project/sglang#34604.
+    """
+
+    def setUp(self):
+        tm = _MockTokenizerManager()
+        tm.server_args.tool_call_parser = "kimi_k2"
+        self.chat = OpenAIServingChat(tm, _MockTemplateManager())
+        self.tools = [{"type": "function", "function": {"name": "get_weather"}}]
+
+    def _process(self, text: str):
+        with patch("sglang.srt.entrypoints.openai.serving_chat.logger") as logger_mock:
+            result = self.chat._process_tool_calls(
+                text=text,
+                tools=self.tools,
+                finish_reason={"type": "stop", "matched": None},
+                tool_choice="required",
+            )
+        return result, logger_mock
+
+    def test_prose_answer_is_returned_as_content_without_logging(self):
+        result, logger_mock = self._process("Sorry, I cannot call a tool here.")
+
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.remaining_text, "Sorry, I cannot call a tool here.")
+        self.assertEqual(result.finish_reason, {"type": "stop", "matched": None})
+        logger_mock.error.assert_not_called()
+
+    def test_empty_output_is_not_parsed_as_json(self):
+        """orjson rejects an empty buffer with "Input is a zero-length, empty
+        document" -- the third error class in the same report."""
+        result, logger_mock = self._process("")
+
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.finish_reason, {"type": "stop", "matched": None})
+        logger_mock.error.assert_not_called()
+
+    def test_malformed_json_payload_is_still_reported(self):
+        """The guard keys off the payload looking JSON-shaped, so a genuinely
+        truncated array must keep reaching the parser and keep logging --
+        otherwise a constraint violation would pass silently."""
+        result, logger_mock = self._process('[{"name": "get_weather"')
+
+        self.assertIsNone(result.tool_calls)
+        self.assertEqual(result.finish_reason, {"type": "stop", "matched": None})
+        logger_mock.error.assert_called_once()
+
+    def test_json_array_behind_leading_whitespace_still_parses(self):
+        """The guard keys off the payload, not off which constraint was used,
+        so a structural-tag detector that emits the array anyway keeps working
+        -- and orjson skips leading whitespace, so the guard must too."""
+        result, _ = self._process(
+            '\n  [{"name": "get_weather", "parameters": {"city": "Tokyo"}}]'
+        )
+
+        self.assertIsNotNone(result.tool_calls)
+        self.assertEqual(result.tool_calls[0].function.name, "get_weather")
+        self.assertEqual(result.finish_reason["type"], "tool_calls")
+
+
 class TestNormalizeToolContent(unittest.TestCase):
     """Unit tests for normalize_tool_content()."""
 


### PR DESCRIPTION
## Motivation

Covers the part of #34604 that #34609 leaves open. That PR fixes the
`string indices must be integers` class (106 of ~190 daily failures); this one
covers the other two:

- 84x `Tool call parsing error: unexpected character: line 1 column 1 (char 0)`
- 1x `Tool call parsing error: Input is a zero-length, empty document`

## Root cause

The report points at `function_call/kimik3_detector.py`, but that file uses the
stdlib `json` and already guards its `json.loads`:

```python
try:
    arguments[key] = json.loads(raw_value)
except json.JSONDecodeError:
    arguments[key] = raw_value
```

Both error strings above are **orjson** messages — the stdlib says
`Expecting value`. They come from `serving_chat.py:2041`, in the
`tool_choice=required` fallback of `_process_tool_calls`:

```python
# json_schema constraint → JSON array output for required/named
if is_required:
    ...
    tool_call_data = orjson.loads(text)
```

Under required/named a request carries exactly one constraint, and
`FunctionCallParser.get_structure_constraint` picks which:

- the detector supplies a structural tag (kimi_k3, kimi_k2, GLM, …) → the model
  is constrained to its **own native format**
- otherwise → a **JSON-array json_schema**

The fallback assumes the second unconditionally. For a structural-tag detector,
reaching it means the parser above found no native tool call — the model
answered in prose, or the turn was empty once reasoning was stripped. That text
cannot be JSON, so `orjson.loads` can only raise, log an `ERROR`, and fall
through to returning the same text the guard now reaches directly. The log line
is the only observable effect.

Replaying the exact inputs against orjson reproduces the reported strings:

| input | orjson |
| --- | --- |
| `Sorry, I cannot call a tool here.` | `unexpected character: line 1 column 1 (char 0)` |
| `""` | `Input is a zero-length, empty document: line 1 column 1 (char 0)` |
| `[{"name": "get_weather"` | `unexpected end of data: line 1 column 24 (char 23)` |

## Modification

Require a JSON-shaped payload before taking the array path:

```python
if is_required and _looks_like_json_payload(text):
```

Gating on the payload rather than on `supports_structural_tag()` is deliberate:
a hard gate would stop parsing the array in the case where a structural-tag
model emits one anyway, which is a behavior regression. Keying off the shape
preserves every path that succeeds today and only drops the ones that cannot.

A genuinely malformed array still reaches the parser and is still logged, so a
real constraint violation stays visible.

## Accuracy

Four cases in a new `TestRequiredToolChoiceNonJsonOutput`. The return value is
unchanged before and after the fix for the prose and empty inputs — the
observable difference is the `ERROR`, so those cases assert on the log:

- prose under `required` → no `ERROR`, text returned as content, finish reason untouched
- empty output → same
- truncated `[{"name": "get_weather"` → still parsed, still logged (guards the
  predicate against degrading to always-false)
- array behind leading whitespace → still parsed (guards the `lstrip()`)

sglang's deps are CUDA-only, so I verified the orjson behavior and the predicate
in isolation locally and am relying on `base-a-test-cpu` for the suite itself.

## Notes

- No overlap with #34609: that PR hardens the loop *after* `orjson.loads`, this
  one changes whether it is called. The tests land in a separate class at the
  end of the file.
- `serving_responses.py:894` has the same defect, but it logs
  `"Required tool JSON parse error"`, which does not appear in the report — left
  for a follow-up rather than folded in here.

Fixes part of #34604.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31663274283](https://github.com/sgl-project/sglang/actions/runs/31663274283)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31663274061](https://github.com/sgl-project/sglang/actions/runs/31663274061)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->