### PR TITLE
[CI] Split Kimi K2.5 performance batches by config

### DIFF
--- a/test/registered/gb300/test_kimi_k25_nvfp4.py
+++ b/test/registered/gb300/test_kimi_k25_nvfp4.py
@@ -38,6 +38,11 @@ DP_EAGLE_ARGS = [
     "--speculative-num-draft-tokens=2",
 ]
 
+PERFORMANCE_BATCH_SIZES = {
+    "TP4+EAGLE3": [1, 8],
+    "TP4+DP4+DPA+EAGLE3": [16],
+}
+
 
 class TestKimiK25Nvfp4(unittest.TestCase):
     """Kimi-K2.5 NVFP4 + EAGLE3 on GB300 (4x GB300 NVL4, tp=4)."""
@@ -60,25 +65,35 @@ class TestKimiK25Nvfp4(unittest.TestCase):
             ),
         ]
 
-        run_combined_tests(
-            models=variants,
-            test_name="Kimi-K2.5-NVFP4",
-            # Pinned to what `ns eval --benchmarks=mmmu-pro:1` sent implicitly --
-            # its `:1` suffix means temperature 0.7, not greedy -- so the baseline
-            # carries over unchanged. Do not "simplify" these away.
-            accuracy_params=AccuracyTestParams(
-                dataset="mmmu_pro_vision",
-                baseline_accuracy=0.69,
-                repeat=1,
-                max_tokens=32768,
-                temperature=0.7,
-                seed=0,
-                sgl_eval_thinking=False,
-            ),
-            performance_params=PerformanceTestParams(
-                result_dir="performance_results_gb300",
-            ),
+        failures = []
+        # Pinned to what `ns eval --benchmarks=mmmu-pro:1` sent implicitly --
+        # its `:1` suffix means temperature 0.7, not greedy -- so the baseline
+        # carries over unchanged. Do not "simplify" these away.
+        accuracy_params = AccuracyTestParams(
+            dataset="mmmu_pro_vision",
+            baseline_accuracy=0.69,
+            repeat=1,
+            max_tokens=32768,
+            temperature=0.7,
+            seed=0,
+            sgl_eval_thinking=False,
         )
+        for variant in variants:
+            try:
+                run_combined_tests(
+                    models=[variant],
+                    test_name=f"Kimi-K2.5-NVFP4 ({variant.variant})",
+                    accuracy_params=accuracy_params,
+                    performance_params=PerformanceTestParams(
+                        batch_sizes=PERFORMANCE_BATCH_SIZES[variant.variant],
+                        result_dir="performance_results_gb300",
+                    ),
+                )
+            except AssertionError as e:
+                failures.append(f"{variant.variant}: {e}")
+
+        if failures:
+            raise AssertionError("Kimi-K2.5-NVFP4 failures:\n" + "\n".join(failures))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The Kimi K2.5 NVFP4 GB300 test previously applied the default batch sizes `[1, 8, 16]` to both launch configs. That produced six performance combinations, including batches that are not intended for each config.

## Modifications

- Run `TP4+EAGLE3` performance tests only at batch sizes 1 and 8.
- Run `TP4+DP4+DPA+EAGLE3` performance tests only at batch size 16.
- Keep the existing MMMU-Pro accuracy validation for both configs.
- Aggregate per-config assertion failures so one failure does not prevent the other config from running.

## Accuracy Tests

Not run locally because the test requires a 4-GPU GB300 runner. The existing MMMU-Pro dataset, baseline, sampling parameters, and per-config accuracy coverage are unchanged.

## Speed Tests and Profiling

Not run locally because the benchmark requires a 4-GPU GB300 runner. An isolated orchestration harness verified the exact performance matrix:

- `TP4+EAGLE3`: batch sizes 1 and 8
- `TP4+DP4+DPA+EAGLE3`: batch size 16

Additional checks:

- `python3 -m py_compile test/registered/gb300/test_kimi_k25_nvfp4.py`
- `uvx ruff check test/registered/gb300/test_kimi_k25_nvfp4.py`
- `uvx ruff format --check test/registered/gb300/test_kimi_k25_nvfp4.py`
- repository pre-commit hooks

## Checklist

- [x] Format code according to the contribution guide.
- [x] Validate the updated test orchestration with an isolated harness.
- [x] Documentation is not applicable to this test-only change.
- [x] Accuracy and speed runs are deferred to the required GB300 nightly runner.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31664763549](https://github.com/sgl-project/sglang/actions/runs/31664763549)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31664763446](https://github.com/sgl-project/sglang/actions/runs/31664763446)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->