### PR TITLE
Pass uniform_q_len to the FlashInfer prefill plan

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -281,6 +281,7 @@ def fast_prefill_plan(
         fixed_split_size if fixed_split_size is not None else -1,
         False,  # disable_split_kv
         0,  # num_colocated_ctas
+        0,  # uniform_q_len
     ]
     self._plan_info = self._cached_module.plan(*args)
 


### PR DESCRIPTION
Targets #34585 (`qwen38`).

Ports the single `flashinfer_backend.py` hunk from #33997 (Bump FlashInfer to 0.6.17): FlashInfer 0.6.17's `plan()` takes an extra trailing `uniform_q_len` argument, so `fast_prefill_plan` has to pass it or the positional arg list no longer matches.

Nothing else from #33997 is included.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31665670815](https://github.com/sgl-project/sglang/actions/runs/31665670815)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31665670589](https://github.com/sgl-project/sglang/actions/runs/31665670589)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->