### PR TITLE
[Fix] Streaming: drop only the unknown tool call, not the batch around it

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -50,6 +50,10 @@ class BaseFormatDetector(ABC):
         # Critical for serving layer to calculate remaining content when streaming ends.
         # Each index corresponds to a tool_id. Example: ['{"location": "San Francisco"', '{"temp": 72']
         self.streamed_args_for_tool: List[str] = []
+        # Set once a call is dropped for naming an unknown tool. The calls
+        # behind it still arrive separator-first, so the separator branches
+        # have to stay reachable even though no tool has completed yet.
+        self._dropped_tool_call: bool = False
 
         # Token configuration (override in subclasses)
         self.bot_token = ""
@@ -122,6 +126,14 @@ class BaseFormatDetector(ABC):
                 return i
         return 0
 
+    def _in_tool_call_sequence(self) -> bool:
+        """Whether the buffer may legitimately open with a tool call separator.
+
+        True once anything has been consumed from the batch -- a completed tool
+        or a call dropped for naming an unknown tool.
+        """
+        return self.current_tool_id > 0 or self._dropped_tool_call
+
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
@@ -149,7 +161,7 @@ class BaseFormatDetector(ABC):
         if not (
             self.has_tool_call(current_text)
             or (
-                self.current_tool_id > 0
+                self._in_tool_call_sequence()
                 and current_text.startswith(self.tool_call_separator)
             )
         ):
@@ -178,7 +190,7 @@ class BaseFormatDetector(ABC):
                 # appear inside array parameters of the current tool, and we must not
                 # mistakenly identify that as the start of a new tool.
                 used_separator_branch = False
-                if self.current_tool_id > 0 and current_text.startswith(
+                if self._in_tool_call_sequence() and current_text.startswith(
                     self.tool_call_separator
                 ):
                     start_idx = len(self.tool_call_separator)
@@ -217,12 +229,17 @@ class BaseFormatDetector(ABC):
 
                 # Validate tool name if present
                 if "name" in obj and obj["name"] not in self._tool_indices:
-                    # Invalid tool name - reset state
-                    self._buffer = ""
-                    self.current_tool_id = -1
+                    # Drop this call, but only this call. Clearing the whole
+                    # buffer would also discard the calls batched behind it,
+                    # and popping streamed_args_for_tool would delete the
+                    # record of the previous, already-streamed tool.
                     self.current_tool_name_sent = False
-                    if self.streamed_args_for_tool:
-                        self.streamed_args_for_tool.pop()
+                    if is_current_complete:
+                        logger.warning(
+                            f"Model attempted to call undefined function: {obj['name']}"
+                        )
+                        self._buffer = current_text[start_idx + end_idx :]
+                        self._dropped_tool_call = True
                     return StreamingParseResult()
 
                 # Handle parameters/arguments consistency

--- a/test/registered/unit/function_call/test_streaming_unknown_tool_name.py
+++ b/test/registered/unit/function_call/test_streaming_unknown_tool_name.py
@@ -1,0 +1,170 @@
+"""Streaming counterpart to test_unknown_tool_name.py.
+
+``parse_base_json`` drops only the call that names an unknown tool and keeps
+going (``continue``). The streaming state machine used to clear the whole
+buffer instead, which also discarded every call batched behind the bad one --
+and when the bad call came first, the client received no tool calls at all.
+"""
+
+import logging
+
+import pytest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.hermes_detector import HermesDetector
+from sglang.srt.function_call.json_array_parser import JsonArrayParser
+from sglang.srt.function_call.llama32_detector import Llama32Detector
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(5, "base-a-test-cpu")
+
+TOOLS = [
+    Tool(function=Function(name="get_weather", parameters={})),
+    Tool(function=Function(name="get_time", parameters={})),
+]
+
+WEATHER = '{"name": "get_weather", "arguments": {"city": "Tokyo"}}'
+TIME = '{"name": "get_time", "arguments": {"tz": "JST"}}'
+UNKNOWN = '{"name": "rm_rf", "arguments": {"path": "/"}}'
+
+
+def _stream(detector, text, chunk_size=1):
+    """Feed ``text`` through the detector and rebuild what a client would see."""
+    calls = {}
+    order = []
+    for i in range(0, len(text), chunk_size):
+        result = detector.parse_streaming_increment(text[i : i + chunk_size], TOOLS)
+        for call in result.calls or []:
+            if call.tool_index not in calls:
+                calls[call.tool_index] = {"name": None, "arguments": ""}
+                order.append(call.tool_index)
+            if call.name:
+                calls[call.tool_index]["name"] = call.name
+            if call.parameters:
+                calls[call.tool_index]["arguments"] += call.parameters
+    return [(idx, calls[idx]["name"], calls[idx]["arguments"]) for idx in order]
+
+
+def _json_array(*calls):
+    return "[" + ",".join(c.replace('"arguments"', '"parameters"') for c in calls) + "]"
+
+
+def _tag_wrapped(*calls):
+    return "".join(f"<tool_call>\n{c}\n</tool_call>\n" for c in calls)
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 17])
+def test_unknown_tool_first_does_not_drop_the_rest(chunk_size):
+    """The batch opens with an unknown tool. Every valid call behind it used to
+    disappear, leaving tool_choice="required" with nothing to return."""
+    streamed = _stream(
+        JsonArrayParser(), _json_array(UNKNOWN, WEATHER, TIME), chunk_size
+    )
+
+    assert [name for _, name, _ in streamed] == ["get_weather", "get_time"]
+    assert [idx for idx, _, _ in streamed] == [0, 1]
+    assert streamed[0][2] == '{"city": "Tokyo"}'
+    assert streamed[1][2] == '{"tz": "JST"}'
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 17])
+def test_unknown_tool_in_the_middle_does_not_drop_the_rest(chunk_size):
+    streamed = _stream(
+        JsonArrayParser(), _json_array(WEATHER, UNKNOWN, TIME), chunk_size
+    )
+
+    assert [name for _, name, _ in streamed] == ["get_weather", "get_time"]
+    assert [idx for idx, _, _ in streamed] == [0, 1]
+
+
+@pytest.mark.parametrize("detector_cls", [Qwen25Detector, HermesDetector])
+def test_tag_wrapped_format_does_not_merge_calls(detector_cls):
+    """Formats that wrap each call in its own tag resynchronise on the next
+    tag, so instead of losing the trailing call they replayed it at index 0:
+    the reset sent current_tool_id back to -1 and popped the previous tool's
+    entry. The client saw a single call whose name had been overwritten and
+    whose arguments were two JSON objects concatenated.
+    """
+    text = _tag_wrapped(WEATHER, UNKNOWN, TIME)
+    streamed = _stream(detector_cls(), text)
+
+    assert [(idx, name) for idx, name, _ in streamed] == [
+        (0, "get_weather"),
+        (1, "get_time"),
+    ]
+    assert [args for _, _, args in streamed] == [
+        '{"city": "Tokyo"}',
+        '{"tz": "JST"}',
+    ]
+
+
+def test_dropped_call_does_not_reuse_a_delivered_index():
+    """Whatever the format, an index handed to the client must never be
+    reused by a later call."""
+    for text, cls in (
+        (_json_array(WEATHER, UNKNOWN, TIME), JsonArrayParser),
+        (_tag_wrapped(WEATHER, UNKNOWN, TIME), Qwen25Detector),
+    ):
+        streamed = _stream(cls(), text)
+        indices = [idx for idx, _, _ in streamed]
+        assert len(indices) == len(set(indices)), f"index collision: {streamed}"
+
+
+def test_previous_tool_bookkeeping_survives_a_dropped_call():
+    """The reset popped streamed_args_for_tool, deleting the record of the
+    previous, already-streamed tool. serving_chat._check_for_unstreamed_tool_args
+    bails out when that list is empty, so the end-of-stream flush went missing."""
+    detector = JsonArrayParser()
+    _stream(detector, _json_array(WEATHER, UNKNOWN))
+
+    assert len(detector.prev_tool_call_arr) == len(detector.streamed_args_for_tool)
+    assert detector.streamed_args_for_tool == ['{"city": "Tokyo"}']
+
+
+def test_unknown_tool_is_still_dropped():
+    """The unknown call itself must not reach the client."""
+    streamed = _stream(JsonArrayParser(), _json_array(WEATHER, UNKNOWN, TIME))
+
+    assert "rm_rf" not in [name for _, name, _ in streamed]
+
+
+def test_unknown_tool_is_logged_once(caplog):
+    """Non-streaming warns via parse_base_json; streaming was silent, so an
+    operator had no signal that calls were being discarded."""
+    with caplog.at_level(
+        logging.WARNING, logger="sglang.srt.function_call.base_format_detector"
+    ):
+        _stream(JsonArrayParser(), _json_array(WEATHER, UNKNOWN, TIME))
+
+    matching = [
+        m
+        for m in caplog.messages
+        if "Model attempted to call undefined function: rm_rf" in m
+    ]
+    assert len(matching) == 1, f"expected exactly one warning, got {matching}"
+
+
+def test_llama32_separator_format_recovers():
+    """Llama 3.2 separates calls with ';' rather than wrapping each one, so it
+    hit the same buffer-clearing loss as the JSON array format."""
+    text = f"<|python_tag|>{UNKNOWN};{WEATHER}"
+    streamed = _stream(Llama32Detector(), text)
+
+    assert [name for _, name, _ in streamed] == ["get_weather"]
+
+
+def test_all_valid_calls_are_unaffected():
+    """Baseline: nothing about the ordinary parallel path changes."""
+    streamed = _stream(JsonArrayParser(), _json_array(WEATHER, TIME))
+
+    assert [(idx, name) for idx, name, _ in streamed] == [
+        (0, "get_weather"),
+        (1, "get_time"),
+    ]
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

Fixes #34677.

When a parallel tool call batch contains a name that was not offered, the
streaming state machine discards or corrupts the valid calls around it, while
the non-streaming path in the same class handles the identical output
correctly.

`parse_base_json` skips just the bad entry and continues. The streaming branch
does this instead:

```python
if "name" in obj and obj["name"] not in self._tool_indices:
    # Invalid tool name - reset state
    self._buffer = ""
    self.current_tool_id = -1
    self.current_tool_name_sent = False
    if self.streamed_args_for_tool:
        self.streamed_args_for_tool.pop()
    return StreamingParseResult()
```

- `self._buffer = ""` discards the calls batched behind the bad one.
- `current_tool_id = -1` makes the next valid call restart at index 0, colliding
  with a call already delivered.
- `.pop()` deletes the record of the *previous*, already-streamed tool, which
  also disables the end-of-stream flush in
  `serving_chat._check_for_unstreamed_tool_args` (it returns early on an empty
  `streamed_args_for_tool`).

On current main, offering `get_weather` and `get_time` and streaming a batch
that also names `rm_rf`:

```
tool_choice="required", unknown first   -> client receives no tool calls at all
Qwen2.5, unknown in the middle          -> {0: {'name': 'get_time',
                                               'arguments': '{"city": "Tokyo"}{"tz": "JST"}'}}
```

The second is not a dropped call but a corrupt one: the name is overwritten and
the arguments are two JSON objects concatenated.

## Modification

Drop only the offending call:

- advance the buffer past that one object instead of clearing it, once the
  object is complete;
- leave `current_tool_id` and `streamed_args_for_tool` untouched, so delivered
  indices are never reused and the previous tool's bookkeeping survives;
- log the discard, matching the warning `parse_base_json` already emits.

Because the batch continues without a completed tool, the two places that gate
on `current_tool_id > 0` have to accept a separator after a dropped call as
well. That condition is now `_in_tool_call_sequence()`, backed by a
`_dropped_tool_call` flag.

Deliberately unchanged: the unknown call itself is still dropped, and the
streaming path still ignores `SGLANG_FORWARD_UNKNOWN_TOOLS`. Making streaming
honour that flag is a behaviour change worth its own PR; this one only stops the
collateral damage to the valid calls.

## Accuracy

New `test/registered/unit/function_call/test_streaming_unknown_tool_name.py`,
the streaming counterpart to the existing `test_unknown_tool_name.py`. Run
locally with the real detectors, character-by-character and at chunk sizes 3 and
17:

```
pre-fix : 11 failed, 3 passed
post-fix: 14 passed
```

The three that pass either way are negative-branch guards — the unknown call
must stay dropped, and the all-valid baseline must not move.

Covered failure modes:

- unknown call first, JSON array — all calls used to be lost
- unknown call in the middle, JSON array — trailing calls used to be lost
- Qwen2.5 and Hermes — two calls used to merge into one at index 0
- Llama 3.2 `;`-separated — same loss as the JSON array format
- `prev_tool_call_arr` / `streamed_args_for_tool` stay the same length
- exactly one warning per dropped call

`test_unknown_tool_name.py` and `test_parallel_tool_calls.py` still pass.
Several other files in that directory do not collect in my local environment
(missing optional deps, plus tokenizer downloads that hang offline); those are
unaffected by this change — the collection errors are identical with and without
it — and I am relying on `base-a-test-cpu` for them.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31672514030](https://github.com/sgl-project/sglang/actions/runs/31672514030)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31672513810](https://github.com/sgl-project/sglang/actions/runs/31672513810)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->