### PR TITLE
[Fix] Gemma4: pick a deterministic-capable attention backend under --enable-deterministic-inference

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1057,7 +1057,15 @@ def _llama4_overrides(server_args: Any, hf_config: Any) -> dict:
 )
 def _gemma4_overrides(server_args: Any, hf_config: Any) -> dict:
     overrides: Dict[str, Any] = {}
-    default_attention_backend = "trtllm_mha" if is_sm100_supported() else "triton"
+    # trtllm_mha is not deterministic-capable: with
+    # --enable-deterministic-inference it would make
+    # _deterministic_attention_backend raise as if the user had picked it
+    # explicitly. triton is the Gemma4-compatible backend that supports
+    # deterministic inference (radix cache included), so prefer it there.
+    if is_sm100_supported() and not server_args.enable_deterministic_inference:
+        default_attention_backend = "trtllm_mha"
+    else:
+        default_attention_backend = "triton"
     if server_args.is_attention_backend_not_set():
         logger.info(
             f"Use {default_attention_backend} as default attention backend for Gemma4"

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2027,6 +2027,7 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                 device="cuda",
                 attention_backend=None,
                 is_attention_backend_not_set=lambda: True,
+                enable_deterministic_inference=False,
                 # keep the (now-absorbed) quant/moe blocks inert so these
                 # assertions stay attention-only
                 moe_runner_backend="triton",
@@ -2045,6 +2046,13 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )
             self.assertEqual(
                 _gemma4_overrides(_args(), None), {"attention_backend": "trtllm_mha"}
+            )
+            # Deterministic inference: trtllm_mha would be rejected by
+            # _deterministic_attention_backend, so the Gemma4 default must
+            # switch to triton even on SM100.
+            self.assertEqual(
+                _gemma4_overrides(_args(enable_deterministic_inference=True), None),
+                {"attention_backend": "triton"},
             )
             self.assertEqual(
                 _minicpm_v4_6_overrides(_args(), None),


### PR DESCRIPTION
## Motivation

Fixes the startup failure half of #34683: on SM100, launching `google/gemma-4-12B-it` with `--enable-deterministic-inference` and no explicit `--attention-backend` fails at argument resolution with

```
ValueError: Currently only ['ascend', 'fa3', 'fa4', 'flashinfer', 'triton'] attention backends are supported for deterministic inference, but you explicitly specified 'trtllm_mha'.
```

The user never specified `trtllm_mha`: `_gemma4_overrides` injects it as the Gemma-4 default on SM100 before `_deterministic_attention_backend` validates the resolved value, and the validation cannot distinguish a model-injected default from a user choice. As a result deterministic inference is unusable for Gemma-4 on Blackwell without manually discovering `--attention-backend triton` — which matters because the radix-cache-hit greedy flips documented in #34683 (18/40 prompts on the default config) make deterministic mode the designed escape hatch.

## Modifications

`_gemma4_overrides` now picks `triton` as the Gemma-4 default attention backend when `enable_deterministic_inference` is set (previously `trtllm_mha` unconditionally on SM100). triton is the Gemma-4-compatible backend that supports deterministic inference and keeps the radix cache enabled there (`RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND`). Default (non-deterministic) behavior is unchanged. Unit test added in `test/registered/unit/test_model_overrides.py`.

Note: `_llama4_overrides` has the same pattern (forces `trtllm_mha` on SM100) and should hit the same failure; not touched here because I could not validate Llama-4 end-to-end on this hardware.

## Accuracy Tests

On 1x B200 (SM100), `google/gemma-4-12B-it`:

- Before: `--enable-deterministic-inference` fails to boot (ValueError above). After: boots, logs `Use triton as default attention backend for Gemma4`, radix cache stays enabled.
- Cache-hit invariance with the fix (the #34683 repro): 40 InstructCoder prompts (seed 1234), greedy, each sent cold then re-sent warm — **0/40 output flips**, max |Δlogprob| = 0 on the single-prompt logprob probe. Same sweep on the default (non-deterministic) config flips 18/40.
- Default path unchanged: without `--enable-deterministic-inference` the resolved backend is still `trtllm_mha` and outputs are bit-identical to pre-patch runs (identical greedy text and identical per-position logprob deltas, including the same max |Δlogprob| = 0.100713 warm-path value).
- `python -m unittest test_model_overrides` — 73/73 pass (includes the new assertions).

## Speed Tests and Profiling

No kernel or runtime change; the patch only affects backend selection when deterministic inference is enabled. 40-prompt sweep wall-clock, deterministic config, resolved-identical before/after (explicit `--attention-backend triton` pre-patch vs implicit selection post-patch): warm pass 71.9 s → 71.7 s (noise). Default-config sweep: cold 45.8 s / warm 46.3 s, unchanged behavior.

## Checklist

- [x] Format your code according to the Format code with pre-commit guide (black 26.1.0, isort 7.0.0, ruff 0.15.1 with the repo's selectors — clean on both changed files).
- [x] Add unit tests (extended `test/registered/unit/test_model_overrides.py`).
- [ ] Update documentation (no doc change needed for a backend-selection bug fix).
- [x] Provide accuracy and speed results (above).
- [x] Follow the SGLang code style guidance.

---

*Disclosure: this fix and the underlying investigation were prepared with AI assistance, and validated end-to-end on hardware as described above.*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31673725039](https://github.com/sgl-project/sglang/actions/runs/31673725039)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31673724798](https://github.com/sgl-project/sglang/actions/runs/31673724798)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->