### PR TITLE
fix: stream MiMo tool call arguments incrementally

### DIFF
--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -16,12 +16,16 @@ import html
 import json
 import logging
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
-from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
+from sglang.srt.function_call.core_types import (
+    StreamingParseResult,
+    ToolCallItem,
+    _GetInfoFunc,
+)
 from sglang.srt.function_call.utils import safe_literal_eval
 
 logger = logging.getLogger(__name__)
@@ -156,6 +160,21 @@ class MiMoDetector(BaseFormatDetector):
             r"<parameter=([^>]+)>(.*?)</parameter>", re.DOTALL
         )
 
+        # Streaming state. MiMo emits XML-like tool calls, while the OpenAI API
+        # expects a JSON argument string. Keep completed parameters plus the
+        # currently open string parameter so we can expose a stable JSON prefix
+        # before the closing </tool_call> arrives.
+        self.function_start_token = "<function="
+        self.function_end_token = "</function>"
+        self.parameter_start_token = "<parameter="
+        self.parameter_end_token = "</parameter>"
+        self._in_tool_call = False
+        self._reject_current_tool = False
+        self._raw_tool_prefix = ""
+        self._streaming_tool_name: Optional[str] = None
+        self._completed_args: Dict[str, Any] = {}
+        self._streamed_json_len = 0
+
     def has_tool_call(self, text: str) -> bool:
         return self.bot_token in text
 
@@ -195,57 +214,255 @@ class MiMoDetector(BaseFormatDetector):
     def parse_streaming_increment(
         self, new_text: str, tools: List[Tool]
     ) -> StreamingParseResult:
-        """
-        Streaming parsing: buffer until complete tool call block.
-        """
+        """Incrementally parse MiMo tool calls into OpenAI JSON deltas."""
         self._buffer += new_text
-        current_text = self._buffer
+        normal_parts: List[str] = []
+        calls = []
 
-        start = current_text.find(self.bot_token)
-        if start == -1:
-            if self.current_tool_id > 0:
-                # Already processing tool calls, keep buffering
-                # (more tool calls might come, don't discard text yet)
-                return StreamingParseResult(normal_text="")
-            else:
-                # No tool calls seen yet, return as normal text
-                self._buffer = ""
-                return StreamingParseResult(normal_text=current_text)
+        if not hasattr(self, "_tool_indices"):
+            self._tool_indices = self._get_tool_indices(tools)
 
-        # Find end token AFTER the start token
-        end = current_text.find(self.eot_token, start)
+        while True:
+            if not self._in_tool_call:
+                start = self._buffer.find(self.bot_token)
+                if start == -1:
+                    partial_len = self._ends_with_partial_token(
+                        self._buffer, self.bot_token
+                    )
+                    if partial_len:
+                        normal_parts.append(self._buffer[:-partial_len])
+                        self._buffer = self._buffer[-partial_len:]
+                    else:
+                        normal_parts.append(self._buffer)
+                        self._buffer = ""
+                    break
+
+                normal_parts.append(self._buffer[:start])
+                self._buffer = self._buffer[start + len(self.bot_token) :]
+                self._in_tool_call = True
+                self._raw_tool_prefix = self.bot_token
+
+            if self._reject_current_tool:
+                if not self._forward_rejected_tool(normal_parts):
+                    break
+                continue
+
+            if self._streaming_tool_name is None:
+                function_start = self._buffer.find(self.function_start_token)
+                if function_start == -1:
+                    # A closed block with no function is malformed. Preserve the
+                    # legacy behavior and forward it as normal text.
+                    if self.eot_token in self._buffer:
+                        self._reject_current_tool = True
+                        if not self._forward_rejected_tool(normal_parts):
+                            break
+                        continue
+                    break
+
+                name_end = self._buffer.find(
+                    ">", function_start + len(self.function_start_token)
+                )
+                if name_end == -1:
+                    break
+
+                function_name = self._buffer[
+                    function_start + len(self.function_start_token) : name_end
+                ].strip()
+                consumed_header = self._buffer[: name_end + 1]
+                self._buffer = self._buffer[name_end + 1 :]
+
+                if (
+                    function_name not in self._tool_indices
+                    and not envs.SGLANG_FORWARD_UNKNOWN_TOOLS.get()
+                ):
+                    logger.warning("Unknown function: %s", function_name)
+                    self._raw_tool_prefix += consumed_header
+                    self._reject_current_tool = True
+                    if not self._forward_rejected_tool(normal_parts):
+                        break
+                    continue
+
+                self.current_tool_id += 1
+                while len(self.prev_tool_call_arr) <= self.current_tool_id:
+                    self.prev_tool_call_arr.append({})
+                while len(self.streamed_args_for_tool) <= self.current_tool_id:
+                    self.streamed_args_for_tool.append("")
+
+                self._streaming_tool_name = function_name
+                self.current_tool_name_sent = True
+                self.prev_tool_call_arr[self.current_tool_id] = {
+                    "name": function_name,
+                    "arguments": {},
+                }
+                self._raw_tool_prefix = ""
+                calls.append(
+                    self._make_tool_call_item(
+                        name=function_name,
+                        parameters="",
+                    )
+                )
+
+            calls.extend(self._stream_arguments(tools))
+            if self._in_tool_call:
+                break
+
+        return StreamingParseResult(
+            normal_text="".join(normal_parts),
+            calls=calls,
+        )
+
+    def _make_tool_call_item(
+        self, parameters: str, name: Optional[str] = None
+    ) -> ToolCallItem:
+        return ToolCallItem(
+            tool_index=self.current_tool_id,
+            name=name,
+            parameters=parameters,
+        )
+
+    def _forward_rejected_tool(self, normal_parts: List[str]) -> bool:
+        """Forward an unknown or malformed complete tool block as normal text."""
+        end = self._buffer.find(self.eot_token)
         if end == -1:
-            # Incomplete tool call, return text before start and keep buffering
-            normal_text = current_text[:start]
-            self._buffer = current_text[start:]
-            return StreamingParseResult(normal_text=normal_text)
+            return False
 
-        # Parse the complete tool call block
-        result = self.detect_and_parse(current_text[: end + len(self.eot_token)], tools)
+        normal_parts.append(
+            self._raw_tool_prefix + self._buffer[: end + len(self.eot_token)]
+        )
+        self._buffer = self._buffer[end + len(self.eot_token) :]
+        self._reset_streaming_state()
+        return True
 
-        if result.calls:
-            # Valid tool call - initialize tracking if first one
-            if self.current_tool_id == -1:
-                self.current_tool_id = 0
-                self.prev_tool_call_arr = []
-                self.streamed_args_for_tool = [""]
+    @staticmethod
+    def _is_streamable_string_param(
+        function_name: str, param_name: str, tools: List[Tool]
+    ) -> bool:
+        return _get_param_type(function_name, param_name, tools).lower() in {
+            "string",
+            "str",
+            "text",
+            "varchar",
+            "char",
+            "enum",
+        }
 
-            while len(self.prev_tool_call_arr) <= self.current_tool_id:
-                self.prev_tool_call_arr.append({})
-            while len(self.streamed_args_for_tool) <= self.current_tool_id:
-                self.streamed_args_for_tool.append("")
+    @staticmethod
+    def _without_incomplete_html_entity(value: str) -> str:
+        """Hold a trailing entity that html.unescape could change next chunk."""
+        match = re.search(
+            r"&(?:#[xX][0-9a-fA-F]*|#[0-9]*|[A-Za-z][A-Za-z0-9]*)?$", value
+        )
+        return value[: match.start()] if match else value
 
-            call = result.calls[0]
-            self.prev_tool_call_arr[self.current_tool_id] = {
-                "name": call.name,
-                "arguments": json.loads(call.parameters) if call.parameters else {},
-            }
-            self.streamed_args_for_tool[self.current_tool_id] = call.parameters
-            call.tool_index = self.current_tool_id
-            self.current_tool_id += 1
+    def _stream_arguments(self, tools: List[Tool]) -> List[ToolCallItem]:
+        """Emit the stable JSON prefix for the current MiMo tool call."""
+        calls = []
+        is_complete = self.eot_token in self._buffer
+        end = self._buffer.find(self.eot_token) if is_complete else len(self._buffer)
+        args_text = self._buffer[:end]
 
-        self._buffer = current_text[end + len(self.eot_token) :]
-        return result
+        function_end = args_text.find(self.function_end_token)
+        if function_end != -1:
+            args_text = args_text[:function_end]
+
+        last_closed_end = 0
+        for match in self.param_regex.finditer(args_text):
+            param_name = match.group(1).strip()
+            if param_name not in self._completed_args:
+                self._completed_args[param_name] = _convert_param_value(
+                    match.group(2),
+                    param_name,
+                    self._streaming_tool_name or "",
+                    tools,
+                )
+            last_closed_end = match.end()
+
+        partial_name: Optional[str] = None
+        partial_value: Optional[str] = None
+        tail = args_text[last_closed_end:]
+        parameter_start = tail.find(self.parameter_start_token)
+        if parameter_start != -1:
+            name_end = tail.find(">", parameter_start + len(self.parameter_start_token))
+            if name_end != -1:
+                candidate_name = tail[
+                    parameter_start + len(self.parameter_start_token) : name_end
+                ].strip()
+                raw_value = tail[name_end + 1 :]
+                if self._is_streamable_string_param(
+                    self._streaming_tool_name or "", candidate_name, tools
+                ):
+                    marker_hold = self._ends_with_partial_token(
+                        raw_value, self.parameter_end_token
+                    )
+                    if marker_hold:
+                        raw_value = raw_value[:-marker_hold]
+                    raw_value = self._without_incomplete_html_entity(raw_value)
+                    decoded_value = html.unescape(raw_value)
+
+                    # _convert_param_value treats the exact literal "null" as
+                    # JSON null even for string schemas. Do not commit to an
+                    # opening JSON string until the value diverges from it.
+                    if not "null".startswith(decoded_value.lower()):
+                        partial_name = candidate_name
+                        partial_value = decoded_value
+
+        # Do not emit a lone opening brace before any argument content is
+        # stable. This also lets the literal "null" remain undecided until its
+        # parameter closes.
+        if not is_complete and not self._completed_args and partial_value is None:
+            return []
+
+        snapshot_parts = [
+            f"{json.dumps(key, ensure_ascii=False)}: "
+            f"{json.dumps(value, ensure_ascii=False)}"
+            for key, value in self._completed_args.items()
+        ]
+        if partial_name is not None and partial_value is not None:
+            key_json = json.dumps(partial_name, ensure_ascii=False)
+            escaped_value = json.dumps(partial_value, ensure_ascii=False)[1:-1]
+            snapshot_parts.append(f'{key_json}: "{escaped_value}')
+
+        snapshot = "{" + ", ".join(snapshot_parts) + "}"
+        argument_diff: Optional[str] = None
+
+        if is_complete:
+            final_json = json.dumps(self._completed_args, ensure_ascii=False)
+            streamed = self.streamed_args_for_tool[self.current_tool_id]
+            if final_json.startswith(streamed):
+                argument_diff = final_json[len(streamed) :]
+            else:
+                logger.warning(
+                    "MiMo streamed arguments are not a prefix of final arguments "
+                    "for tool '%s'",
+                    self._streaming_tool_name,
+                )
+
+            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = dict(
+                self._completed_args
+            )
+            self._buffer = self._buffer[end + len(self.eot_token) :]
+        else:
+            # The final brace is not stable until all parameters are known.
+            stable_end = len(snapshot) - 1
+            if stable_end > self._streamed_json_len:
+                argument_diff = snapshot[self._streamed_json_len : stable_end]
+                self._streamed_json_len = stable_end
+
+        if argument_diff:
+            self.streamed_args_for_tool[self.current_tool_id] += argument_diff
+            calls.append(self._make_tool_call_item(parameters=argument_diff))
+        if is_complete:
+            self._reset_streaming_state()
+        return calls
+
+    def _reset_streaming_state(self):
+        self._in_tool_call = False
+        self._reject_current_tool = False
+        self._raw_tool_prefix = ""
+        self._streaming_tool_name = None
+        self._completed_args = {}
+        self._streamed_json_len = 0
+        self.current_tool_name_sent = False
 
     def _parse_tool_call(
         self, tool_call_body: str, tools: List[Tool]

--- a/test/registered/unit/function_call/test_mimo_detector.py
+++ b/test/registered/unit/function_call/test_mimo_detector.py
@@ -1,0 +1,225 @@
+"""CPU-only tests for the MiMo tool-call streaming parser."""
+
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.environ import envs
+from sglang.srt.function_call.mimo_detector import MiMoDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestMiMoDetector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="file",
+                    description="Write a file",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "action": {"type": "string"},
+                            "content": {"type": "string"},
+                            "path": {"type": "string"},
+                        },
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="typed",
+                    description="Exercise typed parameters",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "count": {"type": "integer"},
+                            "ratio": {"type": "number"},
+                            "enabled": {"type": "boolean"},
+                            "payload": {"type": "object"},
+                            "text": {"type": "string"},
+                        },
+                    },
+                ),
+            ),
+        ]
+
+    @staticmethod
+    def _collect(detector, chunks, tools):
+        normal_text = ""
+        calls_by_index = {}
+        calls_per_chunk = []
+
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, tools)
+            normal_text += result.normal_text
+            calls_per_chunk.append(result.calls)
+            for call in result.calls:
+                assembled = calls_by_index.setdefault(
+                    call.tool_index, {"name": None, "arguments": ""}
+                )
+                if call.name is not None:
+                    assembled["name"] = call.name
+                assembled["arguments"] += call.parameters
+
+        return normal_text, calls_by_index, calls_per_chunk
+
+    def test_streams_long_string_before_tool_call_closes(self):
+        detector = MiMoDetector()
+        chunks = [
+            "before<tool",
+            "_call><function=file><parameter=action>wri",
+            "te</parameter><parameter=content><!DOCTYPE html>\n",
+            '<div title="quoted">中文 &am',
+            "p; more</para",
+            "meter></function></tool_call>after",
+        ]
+
+        normal, calls, calls_per_chunk = self._collect(detector, chunks, self.tools)
+
+        self.assertEqual(normal, "beforeafter")
+        self.assertEqual(calls[0]["name"], "file")
+        self.assertEqual(
+            json.loads(calls[0]["arguments"]),
+            {
+                "action": "write",
+                "content": '<!DOCTYPE html>\n<div title="quoted">中文 & more',
+            },
+        )
+        self.assertEqual(calls_per_chunk[1][0].name, "file")
+        self.assertTrue(
+            any(call.parameters for call in calls_per_chunk[1]),
+            "arguments should start streaming before </parameter>",
+        )
+        self.assertTrue(
+            any(call.parameters for call in calls_per_chunk[3]),
+            "long string content should produce intermediate deltas",
+        )
+        self.assertFalse(
+            any("</para" in call.parameters for call in calls_per_chunk[4])
+        )
+
+    def test_typed_parameters_remain_compatible_with_non_streaming(self):
+        model_output = (
+            "<tool_call><function=typed>"
+            "<parameter=count>42</parameter>"
+            "<parameter=ratio>3.5</parameter>"
+            "<parameter=enabled>true</parameter>"
+            '<parameter=payload>{"key": [1, 2]}</parameter>'
+            "</function></tool_call>"
+        )
+        detector = MiMoDetector()
+
+        _, calls, _ = self._collect(
+            detector,
+            [model_output[:80], model_output[80:140], model_output[140:]],
+            self.tools,
+        )
+        non_stream = MiMoDetector().detect_and_parse(model_output, self.tools)
+
+        self.assertEqual(calls[0]["name"], "typed")
+        self.assertEqual(
+            json.loads(calls[0]["arguments"]),
+            json.loads(non_stream.calls[0].parameters),
+        )
+        self.assertEqual(
+            json.loads(calls[0]["arguments"]),
+            {
+                "count": 42,
+                "ratio": 3.5,
+                "enabled": True,
+                "payload": {"key": [1, 2]},
+            },
+        )
+
+    def test_character_by_character_boundaries_preserve_json_escaping(self):
+        detector = MiMoDetector()
+        model_output = (
+            "prefix<tool_call><function=file><parameter=content>"
+            'line 1\n"quoted" \\ slash &amp; 中文'
+            "</parameter></function></tool_call>suffix"
+        )
+
+        normal, calls, _ = self._collect(detector, list(model_output), self.tools)
+
+        self.assertEqual(normal, "prefixsuffix")
+        self.assertEqual(
+            json.loads(calls[0]["arguments"]),
+            {"content": 'line 1\n"quoted" \\ slash & 中文'},
+        )
+
+    def test_string_null_literal_is_not_streamed_as_a_string(self):
+        detector = MiMoDetector()
+        chunks = [
+            "<tool_call><function=typed><parameter=text>n",
+            "ul",
+            "l</parameter></function></tool_call>",
+        ]
+
+        _, calls, calls_per_chunk = self._collect(detector, chunks, self.tools)
+
+        self.assertEqual(len(calls_per_chunk[0]), 1)
+        self.assertEqual(calls_per_chunk[0][0].name, "typed")
+        self.assertEqual(calls_per_chunk[0][0].parameters, "")
+        self.assertEqual(calls_per_chunk[1], [])
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"text": None})
+
+    def test_drains_multiple_calls_and_interleaved_text_from_one_chunk(self):
+        detector = MiMoDetector()
+        chunk = (
+            "<tool_call><function=file>"
+            "<parameter=path>a.txt</parameter>"
+            "</function></tool_call>middle"
+            "<tool_call><function=file>"
+            "<parameter=path>b.txt</parameter>"
+            "</function></tool_call>tail"
+        )
+
+        normal, calls, calls_per_chunk = self._collect(detector, [chunk], self.tools)
+
+        self.assertEqual(normal, "middletail")
+        self.assertEqual(sorted(calls), [0, 1])
+        self.assertEqual(json.loads(calls[0]["arguments"]), {"path": "a.txt"})
+        self.assertEqual(json.loads(calls[1]["arguments"]), {"path": "b.txt"})
+        self.assertEqual(
+            [call.name for call in calls_per_chunk[0] if call.name],
+            ["file", "file"],
+        )
+
+    def test_empty_arguments_are_emitted_as_valid_json(self):
+        detector = MiMoDetector()
+
+        _, calls, _ = self._collect(
+            detector,
+            ["<tool_call><function=file></function></tool_call>"],
+            self.tools,
+        )
+
+        self.assertEqual(calls[0], {"name": "file", "arguments": "{}"})
+
+    def test_unknown_tool_is_forwarded_as_normal_text_by_default(self):
+        detector = MiMoDetector()
+        tool_block = (
+            "<tool_call><function=missing>"
+            "<parameter=value>partial content</parameter>"
+            "</function></tool_call>"
+        )
+
+        with envs.SGLANG_FORWARD_UNKNOWN_TOOLS.override(False):
+            normal, calls, _ = self._collect(
+                detector,
+                [tool_block[:35], tool_block[35:] + "tail"],
+                self.tools,
+            )
+
+        self.assertEqual(normal, tool_block + "tail")
+        self.assertEqual(calls, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

MiMo emits XML-like tool calls, but its streaming parser currently buffers the entire `<tool_call>... </tool_call>` block before returning a tool call. As a result, OpenAI-compatible clients receive long function arguments only after generation finishes instead of as streaming deltas.

## Modifications

- Replace full-block buffering with a stateful incremental MiMo parser.
- Emit the function name as soon as the `<function=...>` header is complete.
- Stream stable JSON prefixes for string parameters while preserving escaping.
- Defer non-string values until their parameter closes so integer, number, boolean, object, and array types remain correct.
- Handle chunk boundaries inside tags and HTML entities, literal `null`, multiple tool calls, empty arguments, and unknown-tool fallback.
- Add CPU-only unit coverage for the streaming state transitions and compatibility cases.

## Accuracy Tests

`python3 test/registered/unit/function_call/test_mimo_detector.py`

Result: 7 tests passed.

## Speed Tests and Profiling

No model execution or kernel path is changed. The parser now exposes arguments as they are generated, reducing perceived tool-call latency for long string parameters.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31673840544](https://github.com/sgl-project/sglang/actions/runs/31673840544)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31673840354](https://github.com/sgl-project/sglang/actions/runs/31673840354)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->