### PR TITLE
[PD Disagg] Add bootstrap timeout to NIXL prefill sender

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2750,6 +2750,7 @@ class NixlKVSender(CommonKVSender):
         self._send_failed = False
         self._send_error: Optional[Exception] = None
         self._transfer_start_time: Optional[float] = None
+        self.init_time = time.time()
 
     def send(
         self,
@@ -2790,6 +2791,10 @@ class NixlKVSender(CommonKVSender):
         if self._send_failed:
             return KVPoll.Failed  # type: ignore
         status = self.kv_mgr.check_status(self.bootstrap_room)
+        if status == KVPoll.Bootstrapping:
+            timeout_result = self._check_bootstrap_timeout()
+            if timeout_result is not None:
+                return timeout_result
         # Hold Success until all staging chunks transferred: a deferred chunk
         # can still be pending, and concluding now would drop it.
         if (

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -340,6 +340,38 @@ class TestNixlKVSenderChunkPolicy(CustomTestCase):
         self.assertTrue(sender.should_send_kv_chunk(3, last_chunk=False))
 
 
+class TestNixlKVSenderBootstrapTimeout(CustomTestCase):
+    @patch("sglang.srt.disaggregation.nixl.conn.time.time", return_value=123.0)
+    def test_init_records_bootstrap_start_time(self, mock_time):
+        with patch(
+            "sglang.srt.disaggregation.nixl.conn.CommonKVSender.__init__",
+            return_value=None,
+        ):
+            sender = NixlKVSender(MagicMock(), "decode:8998", 11, [0], 0)
+
+        self.assertEqual(sender.init_time, 123.0)
+
+    @patch("sglang.srt.disaggregation.common.conn.time.time", return_value=20.0)
+    def test_bootstrap_timeout_records_failure_and_updates_status(self, mock_time):
+        mgr = MagicMock()
+        mgr.bootstrap_timeout = 5
+        mgr.check_status.return_value = KVPoll.Bootstrapping
+        mgr._staging_outstanding = {}
+
+        sender = object.__new__(NixlKVSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 11
+        sender.init_time = 10.0
+        sender._send_failed = False
+        sender._transfer_start_time = None
+        sender._transfer_metric = MagicMock()
+
+        self.assertEqual(sender.poll(), KVPoll.Failed)
+        mgr.record_failure.assert_called_once()
+        self.assertIn("timed out", mgr.record_failure.call_args[0][1])
+        mgr.update_status.assert_called_once_with(11, KVPoll.Failed)
+
+
 class TestNixlAbortHandling(CustomTestCase):
     def _make_manager(self, request_status=None):
         mgr = object.__new__(NixlKVManager)


### PR DESCRIPTION
## Motivation

Part of #34510 Step 1. Related to #17845.

`CommonKVSender` already implements the Prefill bootstrap timeout. Mooncake starts the deadline when its sender is created and checks it while the request is bootstrapping. NIXL does neither, so a request can remain in `KVPoll.Bootstrapping` indefinitely if Decode destination metadata never arrives.

## Changes

- Record `NixlKVSender` initialization time.
- Call `_check_bootstrap_timeout()` while `poll()` reports `KVPoll.Bootstrapping`.
- Add CPU regression tests for deadline initialization and the timeout failure path.

The existing helper records the failure, changes the room status to `KVPoll.Failed`, and returns `KVPoll.Failed`. This patch does not change the common protocol, transport abstraction, or wire format.

## Tests

- `python3 -m compileall -q python/sglang/srt/disaggregation/nixl/conn.py test/registered/unit/disaggregation/test_nixl_backend_basic.py`
- `isort --check-only python/sglang/srt/disaggregation/nixl/conn.py test/registered/unit/disaggregation/test_nixl_backend_basic.py` (isort 7.0.0)
- `black --check python/sglang/srt/disaggregation/nixl/conn.py test/registered/unit/disaggregation/test_nixl_backend_basic.py` (Black 26.1.0)
- `ruff check --select=F401,F821,UP037 python/sglang/srt/disaggregation/nixl/conn.py test/registered/unit/disaggregation/test_nixl_backend_basic.py` (Ruff 0.15.1)
- `git diff --check HEAD^ HEAD`

The focused registered unit-test target was not run locally because this lightweight environment does not include NumPy, PyTorch, pyzmq, or pytest.

## Accuracy and performance

Not applicable. This change affects only the Prefill bootstrap control path and does not modify model execution or KV transfer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31674506695](https://github.com/sgl-project/sglang/actions/runs/31674506695)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31674506531](https://github.com/sgl-project/sglang/actions/runs/31674506531)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->