### PR TITLE
[PD] Add the missing Prefill bootstrap timeout for NIXL

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -2745,6 +2745,7 @@ class NixlKVSender(CommonKVSender):
             pp_rank,
             req_has_disagg_prefill_dp_rank,
         )
+        self.init_time = time.time()
         self.has_sent = False
         self.chunk_id = 0
         self._send_failed = False
@@ -2790,6 +2791,10 @@ class NixlKVSender(CommonKVSender):
         if self._send_failed:
             return KVPoll.Failed  # type: ignore
         status = self.kv_mgr.check_status(self.bootstrap_room)
+        if status == KVPoll.Bootstrapping:
+            timeout_result = self._check_bootstrap_timeout()
+            if timeout_result is not None:
+                return timeout_result
         # Hold Success until all staging chunks transferred: a deferred chunk
         # can still be pending, and concluding now would drop it.
         if (


### PR DESCRIPTION
- RFC: [PD disaggregation: single protocol layer, per-backend transport #33861](https://github.com/sgl-project/sglang/issues/33861)
- Staged implementation plan and PR tracking: [PD shared-protocol implementation plan #34510](https://github.com/sgl-project/sglang/issues/34510)

## Background

RFC #33861 proposes gradually consolidating the duplicated PD request/room protocol logic in Mooncake, NIXL, and Mori into a single common protocol layer, while keeping third-party engine-specific behavior in each backend Transport.

Before extracting the common protocol layer, Step 1 of the implementation plan in #34510 aligns clear, non-controversial semantic gaps through small, independent, backend-local PRs. This PR addresses the first gap: the missing bootstrap timeout in the NIXL Prefill Sender.

The bootstrap timeout covers the following case:

> Prefill has created the Sender/room for a request, but Decode destination metadata never arrives. The Sender should not remain in `KVPoll.Bootstrapping` indefinitely; it should transition to `KVPoll.Failed` after the existing `SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT` deadline.

## Current Problem

`CommonKVSender` already provides `_check_bootstrap_timeout()`:

```python
# python/sglang/srt/disaggregation/common/conn.py
def _check_bootstrap_timeout(self) -> Optional[KVPoll]:
    if self.init_time is None:
        return None
    elapsed = time.time() - self.init_time
    if elapsed < self.kv_mgr.bootstrap_timeout:
        return None

    self.kv_mgr.record_failure(
        self.bootstrap_room,
        f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s "
        f"in KVPoll.Bootstrapping",
    )
    self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
    return KVPoll.Failed
```

This helper:

1. Computes the bootstrap wait time from the Sender's `init_time`;
2. Returns `None` while the request remains within the deadline;
3. Records a failure reason after the deadline;
4. Updates the room to `KVPoll.Failed`;
5. Returns `KVPoll.Failed`.

However, the current NIXL Sender has two missing pieces:

1. `NixlKVSender.__init__()` does not record the start of the Prefill bootstrap deadline;
2. `NixlKVSender.poll()` does not call the existing helper while the room is in `KVPoll.Bootstrapping`.

NIXL currently records `_transfer_start_time` only for actual KV/state transfer latency:

```python
if self._transfer_start_time is None and (
    len(kv_indices) > 0 or state_indices is not None
):
    self._transfer_start_time = time.perf_counter()
```

That timer starts when the first meaningful KV/state chunk is submitted. It does not include the bootstrap phase spent waiting for Decode metadata, so it cannot replace `init_time`.

Similarly, the `init_time` set by `NixlKVReceiver.send_metadata()` belongs to the Decode Receiver waiting timeout. It is not the Prefill Sender bootstrap deadline.

As a result, if Decode destination metadata never arrives, a NIXL Prefill room can remain in `KVPoll.Bootstrapping` indefinitely.

## Existing Behavior in the Other Backends

### Mooncake

Mooncake records the bootstrap start time when creating the Sender:

```python
# python/sglang/srt/disaggregation/mooncake/conn.py
super().__init__(
    mgr,
    bootstrap_addr,
    bootstrap_room,
    dest_tp_ranks,
    pp_rank,
    req_has_disagg_prefill_dp_rank,
)
self.conclude_state = None
self.init_time = time.time()
self._init_trace_ctx()
```

Its `poll()` calls the common helper while the room remains in `KVPoll.Bootstrapping`:

```python
# python/sglang/srt/disaggregation/mooncake/conn.py
elif status == KVPoll.Bootstrapping:
    timeout_result = self._check_bootstrap_timeout()
    if timeout_result is not None:
        return timeout_result
```

Mooncake therefore cannot wait indefinitely for missing Decode metadata.

### Mori

Mori also records the bootstrap start time when creating the Sender:

```python
# python/sglang/srt/disaggregation/mori/conn.py
super().__init__(
    mgr,
    bootstrap_addr,
    bootstrap_room,
    dest_tp_ranks,
    pp_rank,
    req_has_disagg_prefill_dp_rank,
)
self.transfer_statuses = []
self.pending_infos = None
self.conclude_state = None
self.status_notified = False
self.init_time = time.time()
```

Mori does not call `_check_bootstrap_timeout()` directly. Instead, it performs the equivalent check inline in its own `poll()`:

```python
# python/sglang/srt/disaggregation/mori/conn.py
if status == KVPoll.Bootstrapping:
    elapsed = time.time() - self.init_time
    if elapsed >= self.kv_mgr.bootstrap_timeout:
        reason = (
            f"Request {self.bootstrap_room} timed out after {elapsed:.1f}s "
            "in KVPoll.Bootstrapping"
        )
        sent_status, _ = self._finalize_failure(reason)
        return sent_status
    return status
```

Mori uses an inline implementation because its Sender currently owns backend-specific terminalization. In addition to updating the local room state, `_finalize_failure()`:

- Records the Mori failure reason;
- Sets `conclude_state`;
- Uses `_notify_lock/status_notified` to emit the terminal status at most once;
- Notifies Decode through the Mori control channel when destination information is already available.

The common `_check_bootstrap_timeout()` helper only records a local failure and updates the Manager status. It does not understand Mori's remote notification or terminal-once state. Mori therefore implements the same deadline semantics while retaining its backend-local failure finalization.

This PR only aligns NIXL with the bootstrap deadline already implemented by Mooncake and Mori. It does not change Mori's terminalization behavior.

## Changes

This PR only changes `NixlKVSender`.

### 1. Record the bootstrap start time when creating the Sender

```python
# python/sglang/srt/disaggregation/nixl/conn.py
super().__init__(
    mgr,
    bootstrap_addr,
    bootstrap_room,
    dest_tp_ranks,
    pp_rank,
    req_has_disagg_prefill_dp_rank,
)
self.init_time = time.time()
```

### 2. Call the existing timeout helper while Bootstrapping

```python
# python/sglang/srt/disaggregation/nixl/conn.py
status = self.kv_mgr.check_status(self.bootstrap_room)
if status == KVPoll.Bootstrapping:
    timeout_result = self._check_bootstrap_timeout()
    if timeout_result is not None:
        return timeout_result
```

The timeout check runs only when `status == KVPoll.Bootstrapping`. Once enough Decode metadata has arrived and the room transitions to `WaitingForInput`, this deadline no longer applies.

## Behavior After This Change

Before:

```text
Create NixlKVSender
→ request_status[room] = Bootstrapping
→ Decode metadata never arrives
→ poll() returns Bootstrapping indefinitely
```

After:

```text
Create NixlKVSender
→ init_time = current time
→ request_status[room] = Bootstrapping
→ Decode metadata does not arrive before the deadline
→ _check_bootstrap_timeout()
→ record_failure(...)
→ request_status[room] = Failed
→ poll() returns Failed
```

The deadline continues to use the existing environment variable:

```text
SGLANG_DISAGGREGATION_BOOTSTRAP_TIMEOUT=300
```

Users can continue to relax the deadline through the existing environment variable. This PR adds no new configuration.

## Testing

To keep the implementation PR diff minimal, the CPU regression test is currently stored on a dedicated branch in the fork:

```text
branch: https://github.com/jambow0320/sglang/tree/rfc-pd-test
path: test/registered/unit/disaggregation/rfc-test/test_nixl_sender_bootstrap_timeout.py
```

Test scenario:

```text
Sender creation time: 10s
Current poll time: 20s
bootstrap_timeout: 5s
Decode metadata: missing
```

Assertions:

- `sender.init_time == 10.0`;
- `sender.poll() == KVPoll.Failed`;
- `request_status[room] == KVPoll.Failed`;
- The failure reason contains `timed out`.

Test results:

```text
Test from the dedicated test branch + source from this PR:
1 passed

The same test + source before this fix:
1 failed
Failure: sender.init_time is None
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31676012627](https://github.com/sgl-project/sglang/actions/runs/31676012627)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31676012346](https://github.com/sgl-project/sglang/actions/runs/31676012346)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->