### PR TITLE
[DeepEP] Use static FP8 communication for W4AFP8 normal dispatch

### DIFF
--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -1102,10 +1102,16 @@ class MaybeTboDeepEPDispatcher(BaseDispatcher):
     def _execute(self, name, tbo_subbatch_index: Optional[int] = None, **kwargs):
         return getattr(self._inners[tbo_subbatch_index or 0], name)(**kwargs)
 
-    def dispatch(self, **kwargs) -> DispatchOutput:
+    def dispatch(
+        self, static_scale: Optional[torch.Tensor] = None, **kwargs
+    ) -> DispatchOutput:
+        if static_scale is not None:
+            kwargs["static_scale"] = static_scale
         return self._execute("dispatch", **kwargs)
 
-    def dispatch_a(self, **kwargs):
+    def dispatch_a(self, static_scale: Optional[torch.Tensor] = None, **kwargs):
+        if static_scale is not None:
+            kwargs["static_scale"] = static_scale
         return self._execute("dispatch_a", **kwargs)
 
     def dispatch_b(self, **kwargs):

--- a/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
+++ b/python/sglang/srt/layers/moe/cutlass_w4a8_moe.py
@@ -347,10 +347,20 @@ def cutlass_w4a8_moe_deepep_normal(
         a.shape[1],
         BLOCK_SIZE=512,
     )
-    gateup_input = torch.empty(
-        gateup_input_pre_reorder.shape, dtype=torch.float8_e4m3fn, device=device
-    )
-    per_tensor_quant_fp8(gateup_input_pre_reorder, gateup_input, a1_scale.float(), True)
+    if gateup_input_pre_reorder.dtype == torch.float8_e4m3fn:
+        gateup_input = gateup_input_pre_reorder
+    else:
+        gateup_input = torch.empty(
+            gateup_input_pre_reorder.shape,
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        per_tensor_quant_fp8(
+            gateup_input_pre_reorder,
+            gateup_input,
+            a1_scale.float(),
+            True,
+        )
     del gateup_input_pre_reorder
     local_topk_ids = topk_ids_
     local_topk_ids = (

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -259,20 +259,34 @@ class DeepEPMoE(FusedMoE):
                 topk_output,
             )
 
+        static_scale = self._get_normal_dispatch_static_scale()
         dispatch_output = self.dispatcher.dispatch(
-            hidden_states=hidden_states, topk_output=topk_output
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+            static_scale=static_scale,
         )
         combine_input = self.run_moe_core(dispatch_output)
         return self.dispatcher.combine(combine_input=combine_input)
+
+    def _get_normal_dispatch_static_scale(self) -> Optional[torch.Tensor]:
+        if (
+            get_moe_a2a_backend().is_deepep()
+            and getattr(self, "use_w4afp8", False)
+            and getattr(self, "w13_input_scale", None) is not None
+        ):
+            return self.w13_input_scale.float()
+        return None
 
     def dispatch(
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
     ):
+        static_scale = self._get_normal_dispatch_static_scale()
         return self.dispatcher.dispatch(
             hidden_states=hidden_states,
             topk_output=topk_output,
+            static_scale=static_scale,
         )
 
     def run_moe_core(

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -5,6 +5,7 @@ from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple, Union
 
+from sglang.kernels.ops.quantization.per_tensor_quant_fp8 import per_tensor_quant_fp8
 from sglang.srt.distributed.parallel_state import get_tp_group
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
@@ -394,6 +395,7 @@ class _DeepEPDispatcherImplBase:
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        static_scale: Optional[torch.Tensor] = None,
     ):
         raise NotImplementedError
 
@@ -507,10 +509,25 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        static_scale: Optional[torch.Tensor] = None,
     ):
         topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
         topk_ids = topk_ids.to(torch.int64)
-        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and self.use_fp8:
+        if static_scale is not None:
+            hidden_states_fp8 = torch.empty(
+                hidden_states.shape,
+                dtype=torch.float8_e4m3fn,
+                device=hidden_states.device,
+            )
+            if hidden_states.shape[0] > 0:
+                per_tensor_quant_fp8(
+                    hidden_states,
+                    hidden_states_fp8,
+                    static_scale,
+                    True,
+                )
+            hidden_states = hidden_states_fp8
+        elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and self.use_fp8:
             # TODO hard code 128 block quant,use fp8 communication
             hidden_states = sglang_per_token_group_quant_fp8(
                 hidden_states,
@@ -673,6 +690,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        static_scale: Optional[torch.Tensor] = None,
     ):
         buffer = self._get_buffer()
         topk_weights, topk_ids = topk_output.topk_weights, topk_output.topk_ids
@@ -929,8 +947,9 @@ class DeepEPDispatcher(BaseDispatcher):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        static_scale: Optional[torch.Tensor] = None,
     ) -> DispatchOutput:
-        self.dispatch_a(hidden_states, topk_output)
+        self.dispatch_a(hidden_states, topk_output, static_scale=static_scale)
         if self._deepep_dispatch_hooks is not None:
             self._deepep_dispatch_hooks(self)
         ret = self.dispatch_b()
@@ -940,11 +959,13 @@ class DeepEPDispatcher(BaseDispatcher):
         self,
         hidden_states: torch.Tensor,
         topk_output: TopKOutput,
+        static_scale: Optional[torch.Tensor] = None,
     ):
         self._update_stage(_Stage.INITIAL, _Stage.AFTER_DISPATCH_A)
         inner_state = self._get_impl().dispatch_a(
             hidden_states=hidden_states,
             topk_output=topk_output,
+            static_scale=static_scale,
         )
         self._dispatch_intermediate_state = inner_state
 

--- a/python/sglang/srt/layers/quantization/w4afp8.py
+++ b/python/sglang/srt/layers/quantization/w4afp8.py
@@ -7,6 +7,7 @@ import torch
 from torch.nn import Module
 from torch.nn.parameter import Parameter
 
+from sglang.srt.layers.moe import get_moe_a2a_backend
 from sglang.srt.layers.quantization.base_config import (
     FusedMoEMethodBase,
     QuantizationConfig,
@@ -284,12 +285,13 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
         layer.w2_input_scale = Parameter(new_w2_input_scale, requires_grad=False)
 
         if hasattr(layer, "dispatcher"):
-            # The normal kernel requantizes BF16 inputs with the checkpoint's
-            # static activation scale. The low-latency kernel instead consumes
-            # DeepEP's FP8 payload together with its per-token-group scales.
+            # DeepEP normal dispatch uses the checkpoint's static activation scale.
+            # Low-latency dispatch consumes DeepEP's per-token-group scales.
             layer.dispatcher.set_quant_config(
                 {
-                    "normal_dispatcher_output_dtype": "bf16",
+                    "normal_dispatcher_output_dtype": (
+                        "fp8" if get_moe_a2a_backend().is_deepep() else "bf16"
+                    ),
                     "low_latency_dispatcher_output_dtype": "fp8",
                 }
             )
@@ -385,47 +387,55 @@ class W4AFp8MoEMethod(FusedMoEMethodBase):
         layer: DeepEPMoE,
         dispatch_output: DeepEPNormalDispatchOutput,
     ) -> torch.Tensor:
-        hidden_states, topk_idx, topk_weights = (
-            dispatch_output.hidden_states,
-            dispatch_output.topk_ids,
-            dispatch_output.topk_weights,
-        )
-        if isinstance(hidden_states, tuple):
-            hidden_states = hidden_states[0]
+        hidden_states = dispatch_output.hidden_states
+        hidden_states_scale = dispatch_output.hidden_states_scale
+        topk_idx = dispatch_output.topk_ids
+        topk_weights = dispatch_output.topk_weights
 
-        if hidden_states.dtype != torch.bfloat16:
+        num_tokens = hidden_states.shape[0]
+        if num_tokens == 0:
+            return hidden_states.to(torch.bfloat16)
+
+        if get_moe_a2a_backend().is_deepep():
+            if hidden_states.dtype != torch.float8_e4m3fn:
+                raise RuntimeError(
+                    "W4AFP8 DeepEP normal requires static FP8 dispatcher output, "
+                    f"but got {hidden_states.dtype}."
+                )
+            if hidden_states_scale is not None:
+                raise RuntimeError(
+                    "W4AFP8 DeepEP normal requires static FP8 without "
+                    "per-token-group scales."
+                )
+        elif hidden_states.dtype != torch.bfloat16:
             raise RuntimeError(
-                "W4AFP8 DeepEP normal requires BF16 dispatcher output, "
+                "W4AFP8 non-DeepEP normal requires BF16 dispatcher output, "
                 f"but got {hidden_states.dtype}."
             )
 
-        num_tokens = hidden_states.shape[0]
-        if num_tokens > 0:
-            from sglang.srt.layers.moe.cutlass_w4a8_moe import (
-                cutlass_w4a8_moe_deepep_normal,
-            )
+        from sglang.srt.layers.moe.cutlass_w4a8_moe import (
+            cutlass_w4a8_moe_deepep_normal,
+        )
 
-            return cutlass_w4a8_moe_deepep_normal(
-                hidden_states,
-                layer.w13_weight,
-                layer.w2_weight,
-                layer.w13_weight_scale_inv,
-                layer.w2_weight_scale_inv,
-                topk_weights,
-                topk_idx,
-                self.a_strides1,
-                self.b_strides1,
-                self.c_strides1,
-                self.a_strides2,
-                self.b_strides2,
-                self.c_strides2,
-                self.s_strides13,
-                self.s_strides2,
-                self.expert_offsets,
-                self.problem_sizes1,
-                self.problem_sizes2,
-                layer.w13_input_scale,
-                layer.w2_input_scale,
-            )
-        else:
-            return hidden_states
+        return cutlass_w4a8_moe_deepep_normal(
+            hidden_states,
+            layer.w13_weight,
+            layer.w2_weight,
+            layer.w13_weight_scale_inv,
+            layer.w2_weight_scale_inv,
+            topk_weights,
+            topk_idx,
+            self.a_strides1,
+            self.b_strides1,
+            self.c_strides1,
+            self.a_strides2,
+            self.b_strides2,
+            self.c_strides2,
+            self.s_strides13,
+            self.s_strides2,
+            self.expert_offsets,
+            self.problem_sizes1,
+            self.problem_sizes2,
+            layer.w13_input_scale,
+            layer.w2_input_scale,
+        )

--- a/test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py
+++ b/test/registered/unit/layers/moe/test_w4afp8_deepep_dtype.py
@@ -6,8 +6,11 @@ from unittest.mock import Mock, patch
 
 import torch
 
+from sglang.srt.batch_overlap.two_batch_overlap import MaybeTboDeepEPDispatcher
 from sglang.srt.layers.moe import utils as moe_utils
+from sglang.srt.layers.moe.ep_moe.layer import DeepEPMoE
 from sglang.srt.layers.moe.token_dispatcher import deepep
+from sglang.srt.layers.moe.topk import StandardTopKOutput
 from sglang.srt.layers.moe.utils import (
     DeepEPMode,
     DispatcherOutputDtype,
@@ -32,7 +35,35 @@ class TestW4AFP8DeepEPDispatcherDtype(CustomTestCase):
             w2_input_scale=torch.ones(1),
         )
 
-        w4afp8.W4AFp8MoEMethod(SimpleNamespace()).process_weights_after_loading(layer)
+        with patch.object(w4afp8, "get_moe_a2a_backend", create=True) as backend:
+            backend.return_value.is_deepep.return_value = True
+            w4afp8.W4AFp8MoEMethod(SimpleNamespace()).process_weights_after_loading(
+                layer
+            )
+
+        dispatcher.set_quant_config.assert_called_once_with(
+            {
+                "normal_dispatcher_output_dtype": "fp8",
+                "low_latency_dispatcher_output_dtype": "fp8",
+            }
+        )
+
+    def test_w4afp8_preserves_bf16_normal_dtype_for_non_deepep(self):
+        dispatcher = Mock()
+        layer = SimpleNamespace(
+            dispatcher=dispatcher,
+            w2_weight=torch.empty(0),
+            w13_weight_scale_inv=torch.ones((1, 1, 4)),
+            w2_weight_scale_inv=torch.ones((1, 1, 4)),
+            w13_input_scale=torch.ones(1),
+            w2_input_scale=torch.ones(1),
+        )
+
+        with patch.object(w4afp8, "get_moe_a2a_backend", create=True) as backend:
+            backend.return_value.is_deepep.return_value = False
+            w4afp8.W4AFp8MoEMethod(SimpleNamespace()).process_weights_after_loading(
+                layer
+            )
 
         dispatcher.set_quant_config.assert_called_once_with(
             {
@@ -43,7 +74,7 @@ class TestW4AFP8DeepEPDispatcherDtype(CustomTestCase):
 
     def test_mode_specific_dtype_selection(self):
         quant_config = {
-            "normal_dispatcher_output_dtype": "bf16",
+            "normal_dispatcher_output_dtype": "fp8",
             "low_latency_dispatcher_output_dtype": "fp8",
         }
 
@@ -80,30 +111,224 @@ class TestW4AFP8DeepEPDispatcherDtype(CustomTestCase):
             deepep._DeepEPDispatcherImplLowLatency.dispatch_mode,
             DeepEPMode.LOW_LATENCY,
         )
-        self.assertEqual(normal_dtype, DispatcherOutputDtype.BF16)
+        self.assertEqual(normal_dtype, DispatcherOutputDtype.FP8)
         self.assertEqual(low_latency_dtype, DispatcherOutputDtype.FP8)
 
-    def test_normal_rejects_fp8_and_preserves_empty_bf16(self):
+    def test_static_scale_is_taken_from_current_w4afp8_deepep_layer(self):
+        scale = torch.ones(1, dtype=torch.float32)
+        layer = SimpleNamespace(use_w4afp8=True, w13_input_scale=scale)
+
+        with patch("sglang.srt.layers.moe.ep_moe.layer.get_moe_a2a_backend") as backend:
+            backend.return_value.is_deepep.return_value = True
+            actual = DeepEPMoE._get_normal_dispatch_static_scale(layer)
+
+        self.assertIs(actual, scale)
+
+    def test_static_scale_is_none_outside_target_path(self):
+        scale = torch.ones(1, dtype=torch.float32)
+        layer = SimpleNamespace(use_w4afp8=True, w13_input_scale=scale)
+
+        with patch("sglang.srt.layers.moe.ep_moe.layer.get_moe_a2a_backend") as backend:
+            backend.return_value.is_deepep.return_value = False
+            self.assertIsNone(DeepEPMoE._get_normal_dispatch_static_scale(layer))
+
+        layer.use_w4afp8 = False
+        with patch("sglang.srt.layers.moe.ep_moe.layer.get_moe_a2a_backend") as backend:
+            backend.return_value.is_deepep.return_value = True
+            self.assertIsNone(DeepEPMoE._get_normal_dispatch_static_scale(layer))
+
+    def test_forward_impl_passes_static_scale_to_dispatcher(self):
+        hidden_states = Mock()
+        topk_output = Mock()
+        scale = Mock()
+        dispatch_output = Mock()
+        combine_input = Mock()
+        dispatcher = Mock()
+        dispatcher.dispatch.return_value = dispatch_output
+        layer = SimpleNamespace(
+            deprecate_flag=False,
+            dispatcher=dispatcher,
+            run_moe_core=Mock(return_value=combine_input),
+            _get_normal_dispatch_static_scale=Mock(return_value=scale),
+        )
+
+        DeepEPMoE.forward_impl(layer, hidden_states, topk_output)
+
+        dispatcher.dispatch.assert_called_once_with(
+            hidden_states=hidden_states,
+            topk_output=topk_output,
+            static_scale=scale,
+        )
+        dispatcher.combine.assert_called_once_with(combine_input=combine_input)
+
+    def test_tbo_forwards_only_non_none_static_scale(self):
+        wrapper = SimpleNamespace(_execute=Mock(return_value=Mock()))
+        scale = torch.ones(1, dtype=torch.float32)
+
+        MaybeTboDeepEPDispatcher.dispatch(
+            wrapper,
+            static_scale=scale,
+            hidden_states=Mock(),
+            topk_output=Mock(),
+        )
+        self.assertIs(wrapper._execute.call_args.kwargs["static_scale"], scale)
+
+        wrapper._execute.reset_mock()
+        MaybeTboDeepEPDispatcher.dispatch(
+            wrapper,
+            static_scale=None,
+            hidden_states=Mock(),
+            topk_output=Mock(),
+        )
+        self.assertNotIn("static_scale", wrapper._execute.call_args.kwargs)
+
+    def test_normal_dispatch_a_uses_static_per_tensor_fp8_before_comm(self):
+        impl = object.__new__(deepep._DeepEPDispatcherImplNormal)
+        impl.async_finish = False
+        impl.use_fp8 = True
+        hidden_states = torch.ones((2, 8), dtype=torch.bfloat16)
+        scale = torch.ones(1, dtype=torch.float32)
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((2, 1), dtype=torch.float32),
+            topk_ids=torch.zeros((2, 1), dtype=torch.int64),
+            router_logits=None,
+        )
+
+        with (
+            patch.object(deepep, "per_tensor_quant_fp8", create=True) as quant,
+            patch.object(deepep.deep_gemm_wrapper, "ENABLE_JIT_DEEPGEMM", False),
+        ):
+            state = impl.dispatch_a(
+                hidden_states,
+                topk_output,
+                static_scale=scale,
+            )
+
+        quant.assert_called_once_with(hidden_states, state[0], scale, True)
+        self.assertEqual(state[0].dtype, torch.float8_e4m3fn)
+        self.assertFalse(isinstance(state[0], tuple))
+
+    def test_normal_dispatch_a_preserves_bf16_without_static_scale(self):
+        impl = object.__new__(deepep._DeepEPDispatcherImplNormal)
+        impl.async_finish = False
+        impl.use_fp8 = False
+        hidden_states = torch.ones((2, 8), dtype=torch.bfloat16)
+        topk_output = StandardTopKOutput(
+            topk_weights=torch.ones((2, 1), dtype=torch.float32),
+            topk_ids=torch.zeros((2, 1), dtype=torch.int64),
+            router_logits=None,
+        )
+
+        state = impl.dispatch_a(
+            hidden_states,
+            topk_output,
+            static_scale=None,
+        )
+
+        self.assertIs(state[0], hidden_states)
+
+    def test_normal_requires_static_fp8_and_preserves_empty_bf16(self):
         method = w4afp8.W4AFp8MoEMethod(SimpleNamespace())
         empty_topk_ids = torch.empty((0, 1), dtype=torch.int64)
         empty_topk_weights = torch.empty((0, 1), dtype=torch.float32)
 
-        fp8_dispatch_output = SimpleNamespace(
+        empty_fp8_dispatch_output = SimpleNamespace(
             hidden_states=torch.empty((0, 128), dtype=torch.float8_e4m3fn),
+            hidden_states_scale=None,
             topk_ids=empty_topk_ids,
             topk_weights=empty_topk_weights,
         )
-        with self.assertRaisesRegex(RuntimeError, "requires BF16"):
-            method.apply_deepep_normal(SimpleNamespace(), fp8_dispatch_output)
-
-        bf16_dispatch_output = SimpleNamespace(
-            hidden_states=torch.empty((0, 128), dtype=torch.bfloat16),
-            topk_ids=empty_topk_ids,
-            topk_weights=empty_topk_weights,
+        output = method.apply_deepep_normal(
+            SimpleNamespace(), empty_fp8_dispatch_output
         )
-        output = method.apply_deepep_normal(SimpleNamespace(), bf16_dispatch_output)
         self.assertEqual(output.dtype, torch.bfloat16)
         self.assertEqual(output.shape, (0, 128))
+
+        empty_bf16_dispatch_output = SimpleNamespace(
+            hidden_states=torch.empty((0, 128), dtype=torch.bfloat16),
+            hidden_states_scale=None,
+            topk_ids=empty_topk_ids,
+            topk_weights=empty_topk_weights,
+        )
+        output = method.apply_deepep_normal(
+            SimpleNamespace(), empty_bf16_dispatch_output
+        )
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(output.shape, (0, 128))
+
+        nonempty_bf16_dispatch_output = SimpleNamespace(
+            hidden_states=torch.empty((1, 128), dtype=torch.bfloat16),
+            hidden_states_scale=None,
+            topk_ids=torch.zeros((1, 1), dtype=torch.int64),
+            topk_weights=torch.ones((1, 1), dtype=torch.float32),
+        )
+        with (
+            patch.object(w4afp8, "get_moe_a2a_backend", create=True) as backend,
+            self.assertRaisesRegex(RuntimeError, "requires static FP8"),
+        ):
+            backend.return_value.is_deepep.return_value = True
+            method.apply_deepep_normal(SimpleNamespace(), nonempty_bf16_dispatch_output)
+
+    def test_normal_rejects_fp8_with_per_token_group_scales(self):
+        method = w4afp8.W4AFp8MoEMethod(SimpleNamespace())
+        dispatch_output = SimpleNamespace(
+            hidden_states=torch.empty((1, 128), dtype=torch.float8_e4m3fn),
+            hidden_states_scale=torch.ones((1, 1), dtype=torch.float32),
+            topk_ids=torch.zeros((1, 1), dtype=torch.int64),
+            topk_weights=torch.ones((1, 1), dtype=torch.float32),
+        )
+
+        with (
+            patch.object(w4afp8, "get_moe_a2a_backend", create=True) as backend,
+            self.assertRaisesRegex(RuntimeError, "without per-token-group scales"),
+        ):
+            backend.return_value.is_deepep.return_value = True
+            method.apply_deepep_normal(SimpleNamespace(), dispatch_output)
+
+    def test_non_deepep_normal_preserves_bf16_cutlass_path(self):
+        method = w4afp8.W4AFp8MoEMethod(SimpleNamespace())
+        for name in (
+            "a_strides1",
+            "b_strides1",
+            "c_strides1",
+            "a_strides2",
+            "b_strides2",
+            "c_strides2",
+            "s_strides13",
+            "s_strides2",
+            "expert_offsets",
+            "problem_sizes1",
+            "problem_sizes2",
+        ):
+            setattr(method, name, Mock())
+        layer = SimpleNamespace(
+            w13_weight=Mock(),
+            w2_weight=Mock(),
+            w13_weight_scale_inv=Mock(),
+            w2_weight_scale_inv=Mock(),
+            w13_input_scale=Mock(),
+            w2_input_scale=Mock(),
+        )
+        dispatch_output = SimpleNamespace(
+            hidden_states=torch.empty((1, 128), dtype=torch.bfloat16),
+            hidden_states_scale=None,
+            topk_ids=torch.zeros((1, 1), dtype=torch.int64),
+            topk_weights=torch.ones((1, 1), dtype=torch.float32),
+        )
+        expected = torch.empty((1, 128), dtype=torch.bfloat16)
+
+        with (
+            patch.object(w4afp8, "get_moe_a2a_backend", create=True) as backend,
+            patch(
+                "sglang.srt.layers.moe.cutlass_w4a8_moe."
+                "cutlass_w4a8_moe_deepep_normal",
+                return_value=expected,
+            ),
+        ):
+            backend.return_value.is_deepep.return_value = False
+            actual = method.apply_deepep_normal(layer, dispatch_output)
+
+        self.assertIs(actual, expected)
 
     def test_low_latency_requires_fp8_scales(self):
         method = w4afp8.W4AFp8MoEMethod(SimpleNamespace())

--- a/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
+++ b/test/registered/unit/layers/moe/test_w4afp8_deepep_post_reorder.py
@@ -68,6 +68,7 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
         strides = torch.zeros((num_experts, 3), dtype=torch.int64)
         expert_offsets = torch.zeros(num_experts + 1, dtype=torch.int32)
         problem_sizes = torch.zeros((num_experts, 3), dtype=torch.int32)
+        quant_mock = Mock()
         layer = SimpleNamespace(
             w13_weight=torch.zeros(
                 (num_experts, intermediate_size * 2, hidden_size // 2),
@@ -110,35 +111,45 @@ class TestW4AFP8DeepEPNormalPostReorder(CustomTestCase):
             patch.object(
                 w4a8_moe,
                 "per_tensor_quant_fp8",
-                new=lambda *args, **kwargs: None,
+                new=quant_mock,
             ),
             patch.object(w4a8_moe, "silu_and_mul", new=lambda *args, **kwargs: None),
         ):
-            output = w4a8_moe.cutlass_w4a8_moe_deepep_normal(
-                torch.ones((num_tokens, hidden_size), dtype=torch.bfloat16),
-                layer.w13_weight,
-                layer.w2_weight,
-                layer.w13_weight_scale_inv,
-                layer.w2_weight_scale_inv,
-                topk_weights,
-                topk_ids,
-                strides,
-                strides,
-                strides,
-                strides,
-                strides,
-                strides,
-                strides,
-                strides,
-                expert_offsets,
-                problem_sizes,
-                problem_sizes,
-                layer.w13_input_scale,
-                layer.w2_input_scale,
-            )
+            for input_dtype, expected_quant_calls in (
+                (torch.float8_e4m3fn, 1),
+                (torch.bfloat16, 2),
+            ):
+                with self.subTest(input_dtype=input_dtype):
+                    quant_mock.reset_mock()
+                    output = w4a8_moe.cutlass_w4a8_moe_deepep_normal(
+                        torch.ones((num_tokens, hidden_size), dtype=input_dtype),
+                        layer.w13_weight,
+                        layer.w2_weight,
+                        layer.w13_weight_scale_inv,
+                        layer.w2_weight_scale_inv,
+                        topk_weights,
+                        topk_ids,
+                        strides,
+                        strides,
+                        strides,
+                        strides,
+                        strides,
+                        strides,
+                        strides,
+                        strides,
+                        expert_offsets,
+                        problem_sizes,
+                        problem_sizes,
+                        layer.w13_input_scale,
+                        layer.w2_input_scale,
+                    )
 
-        self.assertEqual(output.shape, (num_tokens, hidden_size))
-        self.assertEqual(output.dtype, torch.bfloat16)
+                    self.assertEqual(output.shape, (num_tokens, hidden_size))
+                    self.assertEqual(output.dtype, torch.bfloat16)
+                    self.assertEqual(quant_mock.call_count, expected_quant_calls)
+                    self.assertEqual(
+                        quant_mock.call_args.args[0].shape[-1], intermediate_size
+                    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

For W4AFP8 MoE on the DeepEP normal-dispatch path, the dispatcher previously
sent BF16 hidden states over the all-to-all and re-quantized them on the
receiving side using the checkpoint's static activation scale. This doubles the
communication volume (BF16 instead of FP8) and re-does a quantization that the
weights were already calibrated against.

Since W4AFP8 carries a single static `w13_input_scale` from the checkpoint,
we can quantize hidden states to FP8 *before* dispatch and communicate the FP8
payload directly, removing the BF16 transport and the redundant re-quantization.

## Changes

- **`token_dispatcher/deepep.py`**: `dispatch()` of the normal dispatcher now
  accepts an optional `static_scale`. When provided, hidden states are
  per-tensor quantized to FP8 (`float8_e4m3fn`) with that scale before the
  all-to-all, so the dispatch payload is FP8 instead of BF16. The low-latency
  path is left unchanged (it already consumes DeepEP's per-token-group scales).
- **`ep_moe/layer.py`**: `DeepEPMoE` computes and forwards the static
  `w13_input_scale` to `dispatch()` when running a W4AFP8 model on DeepEP.
- **`cutlass_w4a8_moe.py`**: `cutlass_w4a8_moe_deepep_normal` now accepts an
  already-FP8 `gateup_input_pre_reorder` and skips the redundant per-tensor
  FP8 quantization in that case.
- **`quantization/w4afp8.py`**: `W4AFp8MoEMethod` configures the dispatcher's
  `normal_dispatcher_output_dtype` to `fp8` (instead of `bf16`) for the DeepEP
  backend, and `postprocess_dispatch` validates that a static FP8 payload
  (no per-token-group scale) was produced.
- **`batch_overlap/two_batch_overlap.py`**: thread `static_scale` through the
  TBO dispatcher wrapper so the overlap path benefits from the same FP8 dispatch.
- **Tests**: extend `test_w4afp8_deepep_dtype.py` and
  `test_w4afp8_deepep_post_reorder.py` to cover the static-FP8 normal-dispatch
  path (dtype assertions + post-reorder correctness).

## How it works

```
Before:  hidden_states(BF16) --a2a--> per_tensor_quant_fp8 --> W4A8 GEMM
After:   hidden_states --quant(static_scale)--> FP8 --a2a--> W4A8 GEMM
```

The all-to-all now transmits FP8 (half the bytes of BF16), and the receiver
no longer re-quantizes — the static scale used for dispatch is the same one the
weights were calibrated with.

## Checklist

- [x] Code follows the project style (ruff/black conventions in place).
- [x] Existing W4AFP8 + DeepEP unit tests extended for the new path.
- [ ] CI (will rely on the project CI run on this PR).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31676535100](https://github.com/sgl-project/sglang/actions/runs/31676535100)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31676534754](https://github.com/sgl-project/sglang/actions/runs/31676534754)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->