### PR TITLE
[AMD] Speed up Wan2.2 DiT FP8 attention per-tensor quantization

### DIFF
--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -29,9 +29,27 @@ _fp8_dtype = torch.float8_e4m3fn
 # fmha_fwd_hd128_fp8_gfx950 ASM kernel. Support full MHA with q/k/v head_dim == 128 -- e.g., Wan 2.2 self- and cross-attention.
 _FMHA_FP8_HEAD_DIM = 128
 
+_FP8_MAX = torch.finfo(_fp8_dtype).max
+
 
 if _use_fp8_attn:
     logger.info("DiT FP8 attention enabled via SGLANG_DIFFUSION_AITER_FP8_ATTN=1")
+
+
+@torch.compile(dynamic=False)
+def _per_tensor_quant_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Bit-exact drop-in for ``aiter.per_tensor_quant(x, quant_dtype=fp8)``, 5.6x
+    faster on [1, 90000, 40, 128] bf16 (3.43 ms -> 0.61 ms on gfx950).
+
+    aiter's reference upcasts to fp32 and runs abs/max/div/cast as four more eager
+    kernels; its fused HIP/Triton paths decompose over rows of ``size(-1)``, which
+    at head_dim 128 is one workgroup per 128 elements contending on one atomic.
+    ``dynamic=False`` is load-bearing: with ``dynamic=True`` this is both slower
+    and no longer bit-exact.
+    """
+    min_val, max_val = torch.aminmax(x)
+    scale = torch.maximum(-min_val.float(), max_val.float()) / _FP8_MAX
+    return (x.float() / scale).to(_fp8_dtype), scale.reshape(1)
 
 
 def _can_use_fmha_fp8_prefill(
@@ -165,9 +183,9 @@ class AITerImpl(AttentionImpl):
         """
         if _use_fp8_attn:
             if query.dtype != _fp8_dtype:
-                q_fp8, q_scale = aiter.per_tensor_quant(query, quant_dtype=_fp8_dtype)
-                k_fp8, k_scale = aiter.per_tensor_quant(key, quant_dtype=_fp8_dtype)
-                v_fp8, v_scale = aiter.per_tensor_quant(value, quant_dtype=_fp8_dtype)
+                q_fp8, q_scale = _per_tensor_quant_fp8(query)
+                k_fp8, k_scale = _per_tensor_quant_fp8(key)
+                v_fp8, v_scale = _per_tensor_quant_fp8(value)
             else:
                 q_fp8, k_fp8, v_fp8 = query, key, value
                 one = torch.tensor(1.0, dtype=torch.float32, device=query.device)

--- a/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py
@@ -8,6 +8,8 @@ import os
 
 import aiter
 import torch
+import triton
+import triton.language as tl
 
 from sglang.multimodal_gen.runtime.layers.attention.backends.attention_backend import (
     AttentionBackend,
@@ -36,20 +38,132 @@ if _use_fp8_attn:
     logger.info("DiT FP8 attention enabled via SGLANG_DIFFUSION_AITER_FP8_ATTN=1")
 
 
-@torch.compile(dynamic=False)
+@triton.jit
+def _per_tensor_quant_fp8_kernel(
+    x_ptr,
+    y_ptr,
+    scale_ptr,
+    scratch_ptr,  # int32[3]: [0] = barrier counter, [1]/[2] = amax bits (ping-pong)
+    n_elements,
+    gen,  # launch generation, monotonically increasing
+    INV_FP8_MAX: tl.constexpr,
+    BLOCK: tl.constexpr,
+    NUM_PROGRAMS: tl.constexpr,
+    MAX_SPIN: tl.constexpr,
+):
+    """Grid-wide amax reduction plus rescale-and-cast, in a single launch.
+
+    The grid is persistent (one program per CU) and the two phases are separated
+    by a grid-wide barrier, so all ``NUM_PROGRAMS`` programs must be co-resident.
+    No host-side scratch reset is needed: the amax slot ping-pongs between two
+    generations, and each launch clears the slot the next one reduces into.
+    """
+    pid = tl.program_id(0)
+    cur = 1 + (gen % 2)
+    nxt = 1 + ((gen + 1) % 2)
+    stride = NUM_PROGRAMS * BLOCK
+
+    # phase 1: per-program amax, folded into one global atomic_max
+    local_amax = 0.0
+    start = pid * BLOCK
+    while start < n_elements:
+        off = start + tl.arange(0, BLOCK)
+        mask = off < n_elements
+        x = tl.load(x_ptr + off, mask=mask, other=0.0).to(tl.float32)
+        local_amax = tl.maximum(local_amax, tl.max(tl.abs(x)))
+        start += stride
+
+    # amax is non-negative, so int ordering of the bit pattern matches float order
+    tl.atomic_max(scratch_ptr + cur, local_amax.to(tl.int32, bitcast=True))
+
+    # Grid-wide barrier. The spin has to be a *bounded* loop: with the trip count
+    # driven only by the atomic, the compiler hoists the load out of the loop and
+    # the kernel hangs on any grid large enough that a program actually spins.
+    tl.debug_barrier()
+    tl.atomic_add(scratch_ptr, 1)
+    target = (gen + 1) * NUM_PROGRAMS
+    i = 0
+    while i < MAX_SPIN:
+        if tl.atomic_add(scratch_ptr, 0) >= target:
+            i = MAX_SPIN
+        else:
+            i += 1
+
+    amax = tl.atomic_add(scratch_ptr + cur, 0).to(tl.float32, bitcast=True)
+    # Multiply by the reciprocal rather than divide: torch lowers ``amax / 448.0``
+    # that way, and the two differ by 1 ULP -- enough to move the elements that
+    # saturate and so to break bit-exactness with aiter.
+    scale = amax * INV_FP8_MAX
+
+    if pid == 0:
+        tl.store(scale_ptr, scale)
+        tl.store(scratch_ptr + nxt, 0)
+
+    # phase 2: rescale + cast
+    start = pid * BLOCK
+    while start < n_elements:
+        off = start + tl.arange(0, BLOCK)
+        mask = off < n_elements
+        x = tl.load(x_ptr + off, mask=mask, other=0.0).to(tl.float32)
+        y = tl.fdiv(x, scale, ieee_rounding=True)
+        tl.store(y_ptr + off, y.to(y_ptr.dtype.element_ty), mask=mask)
+        start += stride
+
+
+_QUANT_MAX_PROGRAMS = 256  # gfx950 CU count
+_QUANT_BLOCK = 16384  # with num_warps=4, swept best on the Wan2.2 q/k/v shapes
+_QUANT_NUM_WARPS = 4
+
+# Per device: the persistent grid size and the int32[3] barrier/amax scratch.
+_quant_grid: dict[torch.device, int] = {}
+_quant_scratch: dict[torch.device, torch.Tensor] = {}
+_quant_gen: dict[torch.device, int] = {}
+
+
 def _per_tensor_quant_fp8(x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-    """Bit-exact drop-in for ``aiter.per_tensor_quant(x, quant_dtype=fp8)``, 5.6x
-    faster on [1, 90000, 40, 128] bf16 (3.43 ms -> 0.61 ms on gfx950).
+    """Bit-exact drop-in for ``aiter.per_tensor_quant(x, quant_dtype=fp8)``, 6.6x
+    faster on [1, 90000, 40, 128] bf16 (3.36 ms -> 0.50 ms on gfx950).
 
     aiter's reference upcasts to fp32 and runs abs/max/div/cast as four more eager
     kernels; its fused HIP/Triton paths decompose over rows of ``size(-1)``, which
     at head_dim 128 is one workgroup per 128 elements contending on one atomic.
-    ``dynamic=False`` is load-bearing: with ``dynamic=True`` this is both slower
-    and no longer bit-exact.
+    The reduction has to be decomposed over elements instead, which is what the
+    persistent kernel above does -- in one launch, at the ~2.3 GB traffic floor.
     """
-    min_val, max_val = torch.aminmax(x)
-    scale = torch.maximum(-min_val.float(), max_val.float()) / _FP8_MAX
-    return (x.float() / scale).to(_fp8_dtype), scale.reshape(1)
+    xc = x.contiguous()
+    y = torch.empty_like(xc, dtype=_fp8_dtype)
+    scale = torch.empty(1, dtype=torch.float32, device=xc.device)
+
+    device = xc.device
+    grid = _quant_grid.get(device)
+    if grid is None:
+        # The barrier requires a co-resident grid, so never ask for more
+        # programs than the device has CUs (partitioned GPUs report fewer).
+        grid = min(
+            _QUANT_MAX_PROGRAMS,
+            torch.cuda.get_device_properties(device).multi_processor_count,
+        )
+        _quant_grid[device] = grid
+        _quant_scratch[device] = torch.zeros(3, dtype=torch.int32, device=device)
+        _quant_gen[device] = 0
+    gen = _quant_gen[device]
+    _quant_gen[device] = gen + 1
+
+    _per_tensor_quant_fp8_kernel[(grid,)](
+        xc,
+        y,
+        scale,
+        _quant_scratch[device],
+        xc.numel(),
+        gen,
+        INV_FP8_MAX=1.0 / _FP8_MAX,
+        BLOCK=_QUANT_BLOCK,
+        NUM_PROGRAMS=grid,
+        MAX_SPIN=100_000_000,
+        num_warps=_QUANT_NUM_WARPS,
+        num_stages=1,
+    )
+    return y.view(x.shape), scale
 
 
 def _can_use_fmha_fp8_prefill(


### PR DESCRIPTION
## Motivation

When the DiT FP8 attention path is enabled (`SGLANG_DIFFUSION_AITER_FP8_ATTN=1`), the AITER attention backend quantizes q/k/v with `aiter.per_tensor_quant`. That function is a PyTorch reference implementation: it upcasts the activation to fp32 and then runs `abs` / `max` / `div` / `cast` as four more eager kernels. For the Wan2.2 self-attention shape (`[1, 90000, 40, 128]` bf16, 0.9 GB) that is five kernels and ~14 GB of memory traffic per tensor, against a ~2.3 GB floor. Profiling a Wan2.2-T2V-A14B run showed this tail accounting for 9.5% of total GPU time — the second largest block after the FMHA kernel itself.

The obvious fix is to switch to one of aiter's fused per-tensor quant kernels, but neither is usable here. `per_tensor_quant_hip` and `per_tensor_quant_triton` are per-token kernels reused for per-tensor: both decompose over rows of `size(-1)` and reduce the amax with a single `atomicMax`. With `head_dim=128` that is one workgroup per 128 elements — 3.6M workgroups contending on one fp32. Measured runtime scales linearly with row count, making the "fused" kernels 12x *slower* than the eager reference at this shape:

| view | rows (grid) | HIP | Triton |
|---|---:|---:|---:|
| `[..., 128]` (natural) | 3,600,000 | 41.9 ms | 42.4 ms |
| `[-1, 1024]` | 450,000 | 5.35 ms | 5.42 ms |
| `[-1, 16384]` | 28,125 | 0.61 ms | 0.63 ms |

The reduction needs to be decomposed over elements, not rows. This PR does that with a single persistent Triton kernel.

## Modifications

- Add `_per_tensor_quant_fp8_kernel` and its `_per_tensor_quant_fp8` wrapper to `python/sglang/multimodal_gen/runtime/layers/attention/backends/aiter.py`: a dynamic per-tensor FP8 E4M3 quantizer that does the grid-wide amax, a grid-wide barrier, and the rescale-and-cast in **one** launch. The grid is persistent (one program per CU) and the reduction decomposes over elements, so it reaches the ~2.3 GB traffic floor.
- Use it for the q/k/v quantization in `AITerImpl.forward` in place of `aiter.per_tensor_quant`. No other behavior changes; the BF16 path and the shape-eligibility fallback are untouched. `AITerImpl.forward` is already `@torch.compiler.disable`, so the raw launch never lands inside a compiled region.
- The grid is capped at the device CU count (`multi_processor_count`), so the barrier cannot deadlock on a partitioned GPU.

Two details are load-bearing and look like cleanups; both are noted in comments:

- **The scale is a reciprocal-multiply, not a divide.** Torch lowers `amax / 448.0` that way. A correctly-rounded IEEE divide differs by 1 ULP, which moves the elements that saturate and costs bit-exactness (174 differing elements out of 460.8M on the Wan2.2 shape).
- **The barrier spin is a bounded loop.** With the trip count driven only by the atomic, the compiler hoists the load out of the loop; the kernel then survives a 64-program grid (the counter is already at target on the first read) and hangs from 96 up.

## Accuracy Tests

The new implementation is **bit-exact** with `aiter.per_tensor_quant` — not merely close. Verified two ways.

Standalone, against the aiter reference (`ndiff` = number of differing elements):

| shape | layout | ndiff | scale match |
|---|---|---:|---|
| `[1, 90000, 40, 128]` | contiguous | 0 / 460,800,000 | exact |
| `[1, 90000, 40, 128]` | transposed (non-contiguous) | 0 / 460,800,000 | exact |
| `[1, 512, 40, 128]` | contiguous | 0 / 2,621,440 | exact |
| `[1, 512, 40, 128]` | transposed (non-contiguous) | 0 / 2,621,440 | exact |
| `[1, 90001, 40, 128]` | contiguous | 0 / 460,805,120 | exact |
| `[1, 90001, 40, 128]` | transposed (non-contiguous) | 0 / 460,805,120 | exact |

The last shape is deliberately not a multiple of the kernel's `BLOCK`, to cover the masked tail.

In-pipeline, by instrumenting the backend to run both implementations on the real model activations during a Wan2.2-T2V-A14B request: **480 q/k/v tensors, every one `ndiff=0` with identical scales.**

Note on output determinism: the generated mp4 is not byte-reproducible across runs of this pipeline even with no code change (two unmodified baseline runs produced different hashes), so output hashing is not a valid equivalence check here. The tensor-level comparison above is the meaningful one.

## Benchmarking and Profiling
### Kernel level

`[1, 90000, 40, 128]` bf16 -> fp8 on MI355X (gfx950), the Wan2.2 self-attention shape. 2.15 GiB is the traffic floor (read twice, write fp8 once):

| implementation | time | GB/s | vs current |
|---|---:|---:|---:|
| `aiter.per_tensor_quant` (current) | 3.363 ms | 685 | 1.00x |
| `aiter.per_tensor_quant_hip` | 41.91 ms | — | 0.08x |
| `torch.aminmax` eager (no `torch.compile`) | 2.764 ms | 834 | 1.22x |
| `torch.aminmax` under `torch.compile` | 0.594 ms | 3880 | 5.66x |
| **this PR (single Triton kernel)** | **0.499 ms** | **4621** | **6.74x** |

The eager row is there to answer the obvious question about the `torch.aminmax` formulation: on its own it is worth only 1.22x over the reference, and essentially all of its win came from inductor fusing the rescale and the cast. The Triton kernel gets to the same place without depending on codegen, and folds the two remaining passes into one launch.

`[1, 512, 40, 128]` bf16 (cross-attention), where the shape is too small to be bandwidth-bound and launch overhead dominates:

| implementation | time | vs current |
|---|---:|---:|
| `aiter.per_tensor_quant` (current) | 0.073 ms | 1.00x |
| `torch.aminmax` under `torch.compile` | 0.054 ms | 1.35x |
| **this PR** | **0.027 ms** | **2.72x** |

**In situ**, from a torch-profiler trace of Wan2.2-T2V-A14B denoising (same window for both, 963 quant calls each). Inductor emits four kernels per quant — two that carry the traffic, two trivial scalar reductions — against one here:

| | `torch.compile` | this PR |
|---|---:|---:|
| kernels per quant | 4 | **1** |
| quant kernel launches | 3852 | **963** |
| quant GPU time | 416.25 ms | **358.16 ms** |
| per call | 432.2 us | **371.9 us** |
| total kernel time in window | 20039.7 ms | 20023.8 ms |

-58.1 ms (-14.0%) on the quant kernels, and 2889 fewer launches.

### End to end

```
PROMPT="A cat and a dog baking a cake together in a kitchen. \
The cat is carefully measuring flour, while the dog is stirring the batter with a wooden spoon. \
The kitchen is cozy, with sunlight streaming through the window."

AITER_ENABLE_FMHA_OPUS=1 SGLANG_USE_ROCM_VAE_CONV2D_BF16=1 SGLANG_USE_ROCM_FLYDSL=1 SGLANG_DIFFUSION_AITER_FP8_ATTN=1 sglang generate \
  --model-path "${MODEL}" \
  --log-level info \
  --prompt "${PROMPT}" \
  --negative-prompt " " \
  --720p \
  --num-inference-steps 8 \
  --num-frames 193 \
  --seed 42 \
  --save-output \
  --num-gpus 1 \
  --dit-layerwise-offload true \
  --dit-cpu-offload false \
  --vae-cpu-offload false \
  --text-encoder-cpu-offload false \
  --warmup-mode request \
  --enable-torch-compile true 2>&1 | tee "wan2.2_t2v_$(date +%Y%m%d_%H%M%S).log" 
```

Wan2.2-T2V-A14B, 720p / 193 frames / 8 steps on MI355X, warmup excluded. `A` = main, `B` = `A` + #34424 (ROCm VAE Conv2D spatial-parallel fix), `C` = `B` + this PR.

**1 GPU**

| config | Encoding (s) | Denoising (s) | Decoding (s) | Total (s) |
|---|---:|---:|---:|---:|
| A: baseline | 0.10 | 88.94 | 12.62 | 101.65 |
| B: #34424 | 0.10 | 88.92 | 5.14 | 94.15 |
| C: #34424 + this PR | 0.10 | 81.11 | 4.85 | 86.05 |
| **C - B** | 0.00 | **-7.81 (-8.8%)** | -0.29 | -8.10 (-8.6%) |

**2 GPU (CFG parallel)**

| config | Encoding (s) | Denoising (s) | Decoding (s) | Total (s) |
|---|---:|---:|---:|---:|
| B: #34424 | 0.17 | 45.07 | 8.60 | 53.84 |
| C: #34424 + this PR | 0.17 | 41.19 | 4.37 | 45.72 |
| **C - B** | 0.00 | **-3.88 (-8.6%)** | -4.23 | -8.12 (-15.1%) |

Warmup-included end to end, for reference: 1 GPU A 105.23 s -> B 97.67 s (that delta is #34424's VAE fix, not this PR); 2 GPU C 45.73 s.

**Denoising is the column attributable to this PR**, and it is consistent across both configurations: -8.8% on 1 GPU and -8.6% on 2 GPU. This change only touches the DiT attention path, so the 2 GPU Decoding delta (8.60 s -> 4.37 s) is **not** caused by it — the 1 GPU run, with the same patch applied, shows Decoding essentially flat (5.14 s -> 4.85 s). Treat the 2 GPU Total of -15.1% as coincidental; the defensible claim is the -8.6~8.8% on Denoising.

Repeatability: three separate runs of configuration `C` at 2 GPU gave Denoising of 41.209 s / 41.217 s / 41.229 s (0.05% spread), against 45.172 s / 45.093 s for `B`.

The tables above were measured with the `torch.compile` formulation. Swapping it for the Triton kernel does **not** move the end-to-end number, and it is worth being explicit that it does not:

| Denoising (s), 1 GPU, warmup excluded | run 1 | run 2 | mean |
|---|---:|---:|---:|
| `torch.aminmax` under `torch.compile` | 81.076 | 81.107 | 81.09 |
| this PR (single Triton kernel) | 81.023 | 80.979 | **81.00** |

-0.09 s, -0.11% — inside run-to-run noise. That is exactly what the kernel-level -58.1 ms predicts: once the reduction is decomposed correctly, quant is ~0.29% of denoising GPU time and there is nothing left to win there.

So the case for the Triton kernel is not the remaining 0.11%. It is that the win no longer rests on inductor: the eager row in the kernel table is 1.22x, so under the `torch.compile` version the entire 5.7x was codegen that a torch or inductor upgrade could silently regress (`dynamic=True`, for instance, already both slowed it down and broke bit-exactness). One explicit kernel, four launches down to one, and the performance is a property of the code in the tree.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34043377002](https://github.com/sgl-project/sglang/actions/runs/34043377002)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34043376745](https://github.com/sgl-project/sglang/actions/runs/34043376745)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34043377006](https://github.com/sgl-project/sglang/actions/runs/34043377006)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
