### PR TITLE
[PD] Start heartbeat checker for Mori decode

### DIFF
--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -341,6 +341,7 @@ class MoriKVManager(CommonKVManager):
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.room_to_bootstrap_addr: Dict[int, str] = {}
             self._start_decode_thread()
+            self._start_heartbeat_checker_thread()
 
     def _init_engine(self) -> IOEngine:
         if self.kv_args.ib_device:

--- a/test/registered/unit/disaggregation/test_mori_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_mori_backend_basic.py
@@ -40,11 +40,18 @@ def _fake_mori_modules():
     }
 
 
-with patch.dict(sys.modules, _fake_mori_modules()):
+_fake_modules = _fake_mori_modules()
+sys.modules.update(_fake_modules)
+try:
     from sglang.srt.disaggregation.common.conn import CommonKVManager
+    from sglang.srt.disaggregation.mori import conn as mori_conn
     from sglang.srt.disaggregation.mori.conn import MoriKVManager
     from sglang.srt.disaggregation.utils import DisaggregationMode
     from sglang.test.ci.ci_register import register_cpu_ci
+finally:
+    for name, module in _fake_modules.items():
+        if sys.modules.get(name) is module:
+            del sys.modules[name]
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
@@ -64,7 +71,7 @@ class TestMoriKVManager(unittest.TestCase):
             patch.object(
                 MoriKVManager, "_start_heartbeat_checker_thread"
             ) as start_heartbeat,
-            patch("sglang.srt.disaggregation.mori.conn.zmq.Context"),
+            patch.object(mori_conn.zmq, "Context"),
         ):
             lifecycle.attach_mock(start_decode, "decode")
             lifecycle.attach_mock(start_heartbeat, "heartbeat")

--- a/test/registered/unit/disaggregation/test_mori_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_mori_backend_basic.py
@@ -1,0 +1,83 @@
+"""Basic CPU unit tests for Mori disaggregation control paths."""
+
+import importlib.util
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+
+def _fake_mori_modules():
+    if importlib.util.find_spec("mori") is not None:
+        return {}
+
+    mori_module = types.ModuleType("mori")
+    mori_module.__path__ = []
+    cpp_module = types.ModuleType("mori.cpp")
+    io_module = types.ModuleType("mori.io")
+
+    cpp_module.TransferStatus = object
+    for name in (
+        "BackendType",
+        "EngineDesc",
+        "IOEngine",
+        "IOEngineConfig",
+        "MemoryDesc",
+        "MemoryLocationType",
+        "PollCqMode",
+        "RdmaBackendConfig",
+        "StatusCode",
+    ):
+        setattr(io_module, name, type(name, (), {}))
+
+    mori_module.cpp = cpp_module
+    mori_module.io = io_module
+    return {
+        "mori": mori_module,
+        "mori.cpp": cpp_module,
+        "mori.io": io_module,
+    }
+
+
+with patch.dict(sys.modules, _fake_mori_modules()):
+    from sglang.srt.disaggregation.common.conn import CommonKVManager
+    from sglang.srt.disaggregation.mori.conn import MoriKVManager
+    from sglang.srt.disaggregation.utils import DisaggregationMode
+    from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMoriKVManager(unittest.TestCase):
+    def test_decode_initialization_starts_heartbeat_checker(self):
+        manager = MoriKVManager.__new__(MoriKVManager)
+        manager.disaggregation_mode = DisaggregationMode.DECODE
+        engine = MagicMock()
+        lifecycle = MagicMock()
+
+        with (
+            patch.object(CommonKVManager, "__init__", return_value=None),
+            patch.object(MoriKVManager, "_init_engine", return_value=engine),
+            patch.object(MoriKVManager, "_register_local_buffers"),
+            patch.object(MoriKVManager, "_start_decode_thread") as start_decode,
+            patch.object(
+                MoriKVManager, "_start_heartbeat_checker_thread"
+            ) as start_heartbeat,
+            patch("sglang.srt.disaggregation.mori.conn.zmq.Context"),
+        ):
+            lifecycle.attach_mock(start_decode, "decode")
+            lifecycle.attach_mock(start_heartbeat, "heartbeat")
+
+            MoriKVManager.__init__(
+                manager,
+                SimpleNamespace(),
+                DisaggregationMode.DECODE,
+                SimpleNamespace(),
+            )
+
+        self.assertEqual(lifecycle.mock_calls, [call.decode(), call.heartbeat()])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`CommonKVManager` provides a decode-side heartbeat checker that fails rooms associated with an unavailable prefill node. Mooncake and NIXL start this checker during decode initialization, but Mori only starts its decode message thread. As a result, Mori decode workers do not run the shared prefill health checks.

This addresses the "Mori Decode heartbeat" item in #34510.

## Modifications

- Start the shared heartbeat checker after Mori's decode thread is initialized.
- Add a CPU-only unit test that stubs the optional Mori package and verifies the decode thread and heartbeat checker startup order.

## Testing

- `PYTHONPATH=python CUDA_VISIBLE_DEVICES=-1 SGLANG_CACHE_DIR=/tmp/sglang-test-cache HF_HUB_OFFLINE=1 python -m pytest -q test/registered/unit/disaggregation/test_mori_backend_basic.py`: 1 passed in 10.29s.
- `ruff check` on the new test and the repository's required `F401,F821,UP037` checks on both changed files: passed.
- `ruff format --check` on the new test: passed.
- `python3 -m py_compile` on both changed files: passed.
- `git diff --check`: passed.

The focused test used CPU-only PyTorch and torchvision packages with CUDA disabled and Hugging Face offline mode. It did not use a GPU, RDMA runtime, model download, CUDA build, or the full test suite. The warnings were existing Torch deprecation and unsupported CPU quantization notices.

## Accuracy Tests

Not applicable. This change only starts the existing control-plane heartbeat thread and does not affect model execution or outputs.

## Speed Tests and Profiling

Not run. The change reuses the heartbeat checker already used by the other disaggregation backends.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (Focused Ruff, compile, and whitespace checks passed; the full pre-commit environment is not installed locally.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; see above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31826554621](https://github.com/sgl-project/sglang/actions/runs/31826554621)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31826553985](https://github.com/sgl-project/sglang/actions/runs/31826553985)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->