### PR TITLE
fix(lora): build the MoE LoRA align JIT kernel on ROCm

### DIFF
--- a/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
+++ b/python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu
@@ -6,10 +6,26 @@
 
 #include <sgl_kernel/utils.cuh>
 
+#ifndef USE_ROCM
 #include <cub/cub.cuh>
+#else
+#include <hipcub/hipcub.hpp>
+#endif
 #include <tvm/ffi/container/tensor.h>
 
 #include <algorithm>
+#include <bit>
+
+#ifdef USE_ROCM
+// The JIT build does not run hipify, so this file maps the CUDA spellings it
+// uses onto HIP itself. Deliberately local rather than in utils.cuh: that
+// header sits in nearly every kernel's dependency closure, which the build
+// cache is keyed on, so editing it rebuilds every JIT module.
+namespace cub = hipcub;
+#define cudaDevAttrMaxSharedMemoryPerBlockOptin hipDeviceAttributeSharedMemPerBlockOptin
+#define cudaFuncSetAttribute hipFuncSetAttribute
+#define cudaFuncAttributeMaxDynamicSharedMemorySize hipFuncAttributeMaxDynamicSharedMemorySize
+#endif
 
 #ifndef WARP_SIZE
 #define WARP_SIZE 32
@@ -529,7 +545,8 @@ struct MoeLoraAlignBlockSizeKernel {
 
       dim3 blockDim(num_thread + fill_threads);
       auto kernel = moe::moe_lora_align_block_size_small_batch_expert_kernel<scalar_t, fill_threads>;
-      RuntimeDeviceCheck(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
+      const auto fptr = std::bit_cast<const void*>(kernel);
+      RuntimeDeviceCheck(cudaFuncSetAttribute(fptr, cudaFuncAttributeMaxDynamicSharedMemorySize, shared_mem));
 
       LaunchKernel(dim3(max_loras), blockDim, stream, shared_mem)(
           kernel,

--- a/test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py
+++ b/test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py
@@ -9,9 +9,10 @@ import torch
 # IMPORT PREBUILT KERNEL
 # ---------------------------------------------------------
 from sglang.kernels.ops.moe.moe_lora_align import moe_lora_align_block_size
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 register_cuda_ci(est_time=28, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=30, stage="jit-kernel-unit", runner_config="amd")
 
 
 def round_up(x, base):


### PR DESCRIPTION
## Problem

`moe_lora_align_block_size` is JIT-compiled, and the JIT build does not run hipify. On ROCm the kernel therefore fails to compile: `cub/cub.cuh` does not exist, `cudaDevAttrMaxSharedMemoryPerBlockOptin` / `cudaFuncSetAttribute` / `cudaFuncAttributeMaxDynamicSharedMemorySize` have no HIP spellings in the JIT tree, and `hipFuncSetAttribute` takes a `const void *` rather than a function pointer.

MoE LoRA inference reaches this kernel from `_compute_lora_alignment`, so serving a MoE model with a LoRA adapter on ROCm aborts on the first such forward:

```
python/sglang/kernels/jit/csrc/lora/moe_lora_align_kernel.cu:9:10: fatal error: 'cub/cub.cuh' file not found
```

## Change

On ROCm, include hipCUB, alias `cub` to `hipcub`, and map the three attribute spellings to HIP — all local to `moe_lora_align_kernel.cu`. The kernel is passed as `const void *` through `std::bit_cast`, matching `setup_kernel_smem_once` in `deepseek_v4/topk_v1.cuh`. CUDA keeps CUB and the same call contract.

The aliases are deliberately *not* added to `sgl_kernel/utils.cuh`. A JIT cache leaf is keyed on the content of its transitive dependency closure, and `utils.cuh` is in the closure of essentially every module (140 of the 190 JIT sources include it directly, the rest transitively via `tensor.h`). Editing it invalidates the whole cache. Measured on MI355X against a warm cache, appending a single comment to `utils.cuh` took three unrelated kernel tests from 5 s / 7 s / 5 s to 14 s / 89 s / 10 s; editing only `moe_lora_align_kernel.cu` left them at 5 s / 7 s / 5 s. That is what made an earlier revision of this fix time out `jit-kernel-unit-test` and `base-b-test-1-gpu-large` against the 30-minute step budget.

`test_moe_lora_align_block_size.py` is also registered for AMD CI. It was CUDA-only, so no job compiled this kernel on ROCm and the build break it fixes could not be caught.

## Validation

MI355X (`gfx950`), ROCm 7.2, `rocm/sgl-dev:v0.5.18-rocm720-mi35x-20260826`:

- `test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py`: 32 passed from a cold JIT cache, in 27 s. The same suite is 32 failed on the base commit, on `cub/cub.cuh` not found.
- This branch's `moe_lora_align_kernel.cu` compiles and links with the JIT's own ROCm flags with `MoeLoraAlignBlockSizeKernel<int32_t>` instantiated; the resulting object resolves `hipFuncSetAttribute` and `hipDeviceGetAttribute`.
- Qwen3-30B-A3B MoE LoRA RL on 8 GPUs (rank 32, EP4, colocated, `moe_runner_backend=triton`) completes two rollouts, four optimizer steps and an adapter republish with this as the only change on top of the base commit.

The same fix on `main` is #36379, where it is green on both the CUDA (`jit-kernel-unit-test`) and AMD MI300 (`jit-kernel-unit-test-amd`) runners. Now that `sglang-miles` carries the `python/sglang/kernels/jit/` layout, the two PRs are byte-identical.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33118719514](https://github.com/sgl-project/sglang/actions/runs/33118719514)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33118719357](https://github.com/sgl-project/sglang/actions/runs/33118719357)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33118719471](https://github.com/sgl-project/sglang/actions/runs/33118719471)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->