### PR TITLE
Fix DP-aware routing for OpenAI Responses API

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1550,6 +1550,13 @@ class ResponsesRequest(BaseModel):
         default=None, description="Cache salt for request caching"
     )
 
+    # For DP routing - external router assigns a specific DP worker.
+    routed_dp_rank: Optional[int] = None
+    # For PD disaggregation - hint telling decode which prefill DP worker has the KV cache.
+    disagg_prefill_dp_rank: Optional[int] = None
+    # Deprecated: use routed_dp_rank instead. Kept for released gateway compatibility.
+    data_parallel_rank: Optional[int] = None
+
     # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
@@ -1610,6 +1617,11 @@ class ResponsesRequest(BaseModel):
             cls._normalize_input_item_for_validation(item) for item in input_value
         ]
         return values
+
+    @model_validator(mode="before")
+    @classmethod
+    def _handle_deprecated_dp_rank(cls, values):
+        return _migrate_deprecated_dp_rank(values)
 
     @staticmethod
     def _normalize_input_item_for_validation(item):

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -427,6 +427,12 @@ class OpenAIServingResponses(OpenAIServingChat):
                         else {}
                     )
 
+                    # Preserve the external router's DP placement decision across
+                    # the Responses-to-GenerateReqInput conversion.
+                    effective_routed_dp_rank = self.extract_routed_dp_rank_from_header(
+                        raw_request, request.routed_dp_rank
+                    )
+
                     adapted_request = GenerateReqInput(
                         **prompt_kwargs,
                         **logprob_kwargs,
@@ -456,6 +462,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=request.extra_key,
                         cache_salt=request.cache_salt,
+                        routed_dp_rank=effective_routed_dp_rank,
+                        disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
                         require_reasoning=require_reasoning,
@@ -2570,6 +2578,8 @@ class OpenAIServingResponses(OpenAIServingChat):
                 top_logprobs_num=adapted_request.top_logprobs_num,
                 return_text_in_logprobs=adapted_request.return_text_in_logprobs,
                 return_hidden_states=adapted_request.return_hidden_states,
+                routed_dp_rank=adapted_request.routed_dp_rank,
+                disagg_prefill_dp_rank=adapted_request.disagg_prefill_dp_rank,
                 background=adapted_request.background,
                 require_reasoning=adapted_request.require_reasoning,
             )

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -28,6 +28,30 @@ def _in_progress_response(request: ResponsesRequest) -> ResponsesResponse:
 
 
 class ResponsesRequestTestCase(CustomTestCase):
+    def test_deprecated_data_parallel_rank_migrates_to_routed_rank(self):
+        with self.assertWarns(DeprecationWarning):
+            request = ResponsesRequest(
+                model="x",
+                input="hi",
+                data_parallel_rank=3,
+                store=False,
+            )
+
+        self.assertEqual(request.routed_dp_rank, 3)
+        self.assertEqual(request.data_parallel_rank, 3)
+
+    def test_explicit_routed_rank_takes_precedence(self):
+        with self.assertWarns(DeprecationWarning):
+            request = ResponsesRequest(
+                model="x",
+                input="hi",
+                routed_dp_rank=5,
+                data_parallel_rank=3,
+                store=False,
+            )
+
+        self.assertEqual(request.routed_dp_rank, 5)
+
     def test_function_tool_accepted(self):
         request = ResponsesRequest(
             model="x",

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -1,6 +1,6 @@
 import asyncio
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from openai.types.responses import (
     ResponseOutputMessage,
@@ -22,6 +22,7 @@ from sglang.srt.entrypoints.openai.serving_responses import (
     _should_emit_normal_text_as_message,
 )
 from sglang.srt.function_call.core_types import ToolCallItem
+from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -247,7 +248,116 @@ class ChatToolForwardingTestCase(CustomTestCase):
         self.assertEqual(engine_prompts, [[4, 5, 6]])
 
 
-class ReasoningRequestForwardingTestCase(unittest.TestCase):
+class DpRankForwardingTestCase(CustomTestCase):
+    def _capture_adapted_request(self, raw_request=None):
+        serving = make_serving()
+        serving.default_chat_template_kwargs = {}
+        rendered = MessageProcessingResult(
+            prompt="prompt",
+            prompt_ids=[1, 2, 3],
+            image_data=None,
+            audio_data=None,
+            video_data=None,
+            modalities=[],
+            stop=[],
+        )
+        captured = {}
+
+        async def fake_generate(
+            request_id,
+            request_prompt,
+            adapted_request,
+            sampling_params,
+            context,
+            **kwargs,
+        ):
+            captured["adapted_request"] = adapted_request
+            context.append_output(
+                {
+                    "text": "done",
+                    "meta_info": {
+                        "prompt_tokens": 1,
+                        "completion_tokens": 1,
+                        "cached_tokens": 0,
+                    },
+                }
+            )
+            yield context
+
+        serving._generate_with_builtin_tools = fake_generate
+        request = ResponsesRequest(
+            model="x",
+            input="answer",
+            routed_dp_rank=4,
+            disagg_prefill_dp_rank=2,
+            store=False,
+        )
+
+        with patch.object(
+            serving, "_apply_conversation_template", return_value=rendered
+        ):
+            response = asyncio.run(serving.create_responses(request, raw_request))
+
+        self.assertEqual(response.status, "completed")
+        return captured["adapted_request"]
+
+    def test_create_responses_forwards_body_dp_rank(self):
+        adapted_request = self._capture_adapted_request()
+
+        self.assertEqual(adapted_request.routed_dp_rank, 4)
+        self.assertEqual(adapted_request.disagg_prefill_dp_rank, 2)
+
+    def test_header_dp_rank_overrides_body_for_responses(self):
+        raw_request = Mock(headers={"x-data-parallel-rank": "6"})
+        adapted_request = self._capture_adapted_request(raw_request)
+
+        self.assertEqual(adapted_request.routed_dp_rank, 6)
+        self.assertEqual(adapted_request.disagg_prefill_dp_rank, 2)
+
+    def test_builtin_tool_continuation_preserves_dp_rank(self):
+        serving = make_serving()
+        captured_requests = []
+
+        def fake_generate_request(request, raw_request):
+            captured_requests.append(request)
+
+            async def generate():
+                yield {"text": "done"}
+
+            return generate()
+
+        serving.tokenizer_manager.generate_request = fake_generate_request
+        context = Mock()
+        context.need_builtin_tool_call.side_effect = [True, False]
+        context.call_tool = AsyncMock(return_value=["tool output"])
+        context.render_for_completion.return_value = [4, 5, 6]
+        request = GenerateReqInput(
+            input_ids=[1, 2, 3],
+            sampling_params={"max_new_tokens": 16},
+            routed_dp_rank=4,
+            disagg_prefill_dp_rank=2,
+        )
+
+        async def run_generation():
+            return [
+                output
+                async for output in serving._generate_with_builtin_tools(
+                    "resp_dp_rank",
+                    [1, 2, 3],
+                    request,
+                    request.sampling_params,
+                    context,
+                )
+            ]
+
+        asyncio.run(run_generation())
+
+        self.assertEqual(len(captured_requests), 2)
+        self.assertEqual(captured_requests[1].routed_dp_rank, 4)
+        self.assertEqual(captured_requests[1].disagg_prefill_dp_rank, 2)
+
+
+class ReasoningRequestForwardingTestCase(CustomTestCase):
     def test_create_responses_uses_processed_reasoning_state(self):
         serving = make_serving()
         serving.reasoning_parser = "deepseek-r1"


### PR DESCRIPTION
## Motivation

The model gateway injects the DP rank selected by DP-aware routing into the request body. The OpenAI Responses API currently drops these fields while parsing `ResponsesRequest`, so the selected DP rank does not reach the scheduler.

This makes `/v1/responses` inconsistent with the existing Completions and Chat Completions paths addressed by #14647.

Fixes #34675

## Modifications

- Add DP-aware rank fields to `ResponsesRequest`.
- Preserve deprecated `data_parallel_rank` compatibility.
- Forward the effective routed DP rank to `GenerateReqInput`.
- Preserve the existing header-over-body precedence.
- Preserve DP rank fields across builtin-tool continuation requests.
- Add unit tests for request parsing, header precedence, disaggregated prefill rank propagation, and continuation requests.

## Accuracy Tests

Not applicable. This change only preserves request-routing metadata and does not modify model computation or generated token values.

## Speed Tests and Profiling

Not applicable. This change only adds request metadata propagation and does not change the inference execution path.

## Checklist

- [x] Format checks passed with pre-commit.
- [x] Added registered unit tests.
- [x] Target unit tests passed: 58 passed.
- [x] No documentation change is required for this internal request-field propagation fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31677968532](https://github.com/sgl-project/sglang/actions/runs/31677968532)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31677968270](https://github.com/sgl-project/sglang/actions/runs/31677968270)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->