### PR TITLE
Add distributed exact prompt Top-N logprobs

### DIFF
--- a/benchmark/kernels/bench_distributed_logprob.py
+++ b/benchmark/kernels/bench_distributed_logprob.py
@@ -1,0 +1,272 @@
+"""TP benchmark for exact input logprobs without full-vocab AllGather.
+
+Example:
+
+  torchrun --standalone --nproc-per-node=4 \
+    benchmark/kernels/bench_distributed_logprob.py --rows 2048 8192
+"""
+
+import argparse
+import gc
+import json
+import os
+from dataclasses import asdict, dataclass
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.logprob_processor import (
+    compute_distributed_row_log_normalizer,
+    compute_row_log_normalizer,
+    get_distributed_token_scores,
+)
+
+
+class TorchTpGroup:
+    def __init__(self):
+        self.device_group = dist.group.WORLD
+
+    def all_reduce(self, tensor: torch.Tensor) -> torch.Tensor:
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.device_group)
+        return tensor
+
+
+@dataclass
+class BenchResult:
+    rows: int
+    vocab_size: int
+    tp_size: int
+    baseline_ms: float
+    distributed_ms: float
+    speedup: float
+    baseline_peak_mib: float
+    distributed_peak_mib: float
+    peak_reduction: float
+    max_abs_error: float
+    baseline_allgather_receive_mib_per_rank: float
+    distributed_scalar_receive_mib_per_rank: float
+
+
+def shard_bounds(vocab_size: int, rank: int, world_size: int) -> tuple[int, int, int]:
+    padded_vocab = ((vocab_size + 63) // 64) * 64
+    assert padded_vocab % world_size == 0
+    width = padded_vocab // world_size
+    start = rank * width
+    end = min(start + width, vocab_size)
+    return start, end, width
+
+
+def make_local_logits(
+    rows: int,
+    vocab_size: int,
+    rank: int,
+    world_size: int,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, int, int]:
+    start, end, width = shard_bounds(vocab_size, rank, world_size)
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260809 + rank)
+    logits = torch.randn((rows, width), device="cuda", dtype=dtype, generator=generator)
+    valid_width = end - start
+    if valid_width < width:
+        logits[:, valid_width:] = 1e4
+    return logits, start, end
+
+
+def max_across_ranks(value: float) -> float:
+    tensor = torch.tensor(value, device="cuda", dtype=torch.float64)
+    dist.all_reduce(tensor, op=dist.ReduceOp.MAX)
+    return tensor.item()
+
+
+def time_cuda(fn, warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        output = fn()
+        del output
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        output = fn()
+        del output
+    end.record()
+    end.synchronize()
+    return start.elapsed_time(end) / iterations
+
+
+def peak_memory_mib(fn) -> float:
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.synchronize()
+    base = torch.cuda.memory_allocated()
+    torch.cuda.reset_peak_memory_stats()
+    output = fn()
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated()
+    del output
+    return (peak - base) / (1024**2)
+
+
+def run_correctness(group: TorchTpGroup, rank: int, world_size: int) -> dict:
+    rows, vocab_size = 17, 154883
+    start, end, width = shard_bounds(vocab_size, rank, world_size)
+
+    # Every rank constructs the same small reference, then takes its shard.
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(1234)
+    full = torch.randn((rows, vocab_size), device="cuda", generator=generator)
+    full = full + 1e4
+    local = torch.empty((rows, width), device="cuda", dtype=torch.float32)
+    local.fill_(1e6)
+    if end > start:
+        local[:, : end - start] = full[:, start:end]
+
+    row_max, row_log_sum = compute_distributed_row_log_normalizer(
+        local, end - start, group
+    )
+    row_indices = torch.arange(rows, device="cuda").repeat_interleave(world_size)
+    owner_tokens = torch.tensor(
+        [min((owner * width) + 3, vocab_size - 1) for owner in range(world_size)],
+        device="cuda",
+    )
+    token_ids = owner_tokens.repeat(rows)
+    raw_scores = get_distributed_token_scores(
+        local, row_indices, token_ids, start, end, group
+    )
+    got = (raw_scores - row_max[row_indices]) - row_log_sum[row_indices]
+    reference = torch.log_softmax(full, dim=-1)[row_indices, token_ids]
+    max_abs_error = max_across_ranks((got - reference).abs().max().item())
+    return {
+        "rows": rows,
+        "vocab_size": vocab_size,
+        "max_abs_error": max_abs_error,
+        "padding_excluded": True,
+        "owners_covered": world_size,
+    }
+
+
+def run_benchmark(
+    group: TorchTpGroup,
+    rank: int,
+    world_size: int,
+    rows: int,
+    vocab_size: int,
+    warmup: int,
+    iterations: int,
+) -> BenchResult:
+    local_logits, vocab_start, vocab_end = make_local_logits(
+        rows, vocab_size, rank, world_size, torch.bfloat16
+    )
+    local_width = local_logits.shape[1]
+    valid_width = vocab_end - vocab_start
+    target_ids = torch.arange(rows, device="cuda", dtype=torch.long) % vocab_size
+    row_indices = torch.arange(rows, device="cuda", dtype=torch.long)
+
+    def baseline():
+        gathered = torch.empty(
+            (world_size * rows, local_width),
+            device="cuda",
+            dtype=local_logits.dtype,
+        )
+        dist.all_gather_into_tensor(gathered, local_logits)
+        full_logits = (
+            gathered.view(world_size, rows, local_width)
+            .permute(1, 0, 2)
+            .reshape(rows, world_size * local_width)[:, :vocab_size]
+            .float()
+        )
+        row_max, row_log_sum = compute_row_log_normalizer(full_logits)
+        raw_scores = full_logits[row_indices, target_ids]
+        return (raw_scores - row_max) - row_log_sum
+
+    def distributed():
+        local_fp32 = local_logits.float()
+        row_max, row_log_sum = compute_distributed_row_log_normalizer(
+            local_fp32, valid_width, group
+        )
+        raw_scores = get_distributed_token_scores(
+            local_fp32,
+            row_indices,
+            target_ids,
+            vocab_start,
+            vocab_end,
+            group,
+        )
+        return (raw_scores - row_max) - row_log_sum
+
+    reference = baseline()
+    candidate = distributed()
+    torch.cuda.synchronize()
+    max_abs_error = max_across_ranks((candidate - reference).abs().max().item())
+    del reference, candidate
+
+    baseline_ms = max_across_ranks(time_cuda(baseline, warmup, iterations))
+    distributed_ms = max_across_ranks(time_cuda(distributed, warmup, iterations))
+    baseline_peak_mib = max_across_ranks(peak_memory_mib(baseline))
+    distributed_peak_mib = max_across_ranks(peak_memory_mib(distributed))
+
+    full_bf16_bytes = rows * vocab_size * 2
+    baseline_receive = full_bf16_bytes * (world_size - 1) / world_size
+    # MAX, SUM, and selected-score SUM. Ring all-reduce receives
+    # 2*(p-1)/p times the tensor size per rank.
+    scalar_receive = 3 * (2 * (world_size - 1) / world_size) * rows * 4
+
+    return BenchResult(
+        rows=rows,
+        vocab_size=vocab_size,
+        tp_size=world_size,
+        baseline_ms=baseline_ms,
+        distributed_ms=distributed_ms,
+        speedup=baseline_ms / distributed_ms,
+        baseline_peak_mib=baseline_peak_mib,
+        distributed_peak_mib=distributed_peak_mib,
+        peak_reduction=baseline_peak_mib / distributed_peak_mib,
+        max_abs_error=max_abs_error,
+        baseline_allgather_receive_mib_per_rank=baseline_receive / (1024**2),
+        distributed_scalar_receive_mib_per_rank=scalar_receive / (1024**2),
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rows", type=int, nargs="+", default=[2048, 8192])
+    parser.add_argument("--vocab-size", type=int, default=154880)
+    parser.add_argument("--warmup", type=int, default=3)
+    parser.add_argument("--iterations", type=int, default=10)
+    args = parser.parse_args()
+
+    local_rank = int(os.environ["LOCAL_RANK"])
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group("nccl")
+    group = TorchTpGroup()
+    try:
+        correctness = run_correctness(group, dist.get_rank(), dist.get_world_size())
+        results = [
+            asdict(
+                run_benchmark(
+                    group,
+                    dist.get_rank(),
+                    dist.get_world_size(),
+                    rows,
+                    args.vocab_size,
+                    args.warmup,
+                    args.iterations,
+                )
+            )
+            for rows in args.rows
+        ]
+        if dist.get_rank() == 0:
+            print(
+                json.dumps(
+                    {"correctness": correctness, "benchmarks": results}, indent=2
+                ),
+                flush=True,
+            )
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1190,6 +1190,24 @@ class Envs:
     # Tokenizer, request state, embeddings, and reasoning controls
     # ===================================================================
     SGLANG_EMBEDDINGS_SPARSE_HEAD = EnvStr(None)
+    # Logprob processor
+    SGLANG_ENABLE_LOGPROB_CHUNK = EnvBoolWithAlias(
+        True, deprecated_name="SGLANG_ENABLE_LOGITS_PROCESSER_CHUNK"
+    )
+    SGLANG_LOGPROB_CHUNK_SIZE = EnvIntWithAlias(
+        2048, deprecated_name="SGLANG_LOGITS_PROCESSER_CHUNK_SIZE"
+    )
+    # Compute input logprobs from logits via per-row logsumexp instead of
+    # materializing the full-vocab log-softmax. Escape hatch only; the two
+    # paths are mathematically identical.
+    SGLANG_ENABLE_FAST_INPUT_LOGPROBS = EnvBool(True)
+    # Compute prompt/input logprobs directly from TP-sharded vocabulary logits.
+    # Set to false to retain the gathered fast-input-logprob path for rollout
+    # comparison or as an operational escape hatch.
+    SGLANG_ENABLE_DISTRIBUTED_INPUT_LOGPROBS = EnvBool(True)
+
+    # Tool-Call behavior
+    SGLANG_TOOL_STRICT_LEVEL = EnvInt(ToolStrictLevel.OFF)
     # Think tokens budget: negative means unlimited, >= 0 caps thinking tokens
     SGLANG_MAX_THINK_TOKENS = EnvInt(-1)
     SGLANG_PATCH_TOKENIZER = EnvBool(True)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -40,6 +40,7 @@ from sglang.srt.layers.dp_attention import (
     get_dp_hidden_size,
 )
 from sglang.srt.layers.logprob_processor import (
+    DistributedLogprobContext,
     InputLogprobProcessor,
     LogprobStage,
     get_token_ids_logprobs_raw,
@@ -414,6 +415,9 @@ class LogitsProcessor(nn.Module):
             get_logits_fn=self._get_logits,
             logits_metadata=logits_metadata,
             skip_chunking_for_dp_attn=self.do_tensor_parallel_all_gather_dp_attn,
+            distributed_context=self._get_distributed_logprob_context(
+                lm_head, logits_metadata
+            ),
         )
 
         logits_output = LogitsProcessorOutput(
@@ -688,6 +692,74 @@ class LogitsProcessor(nn.Module):
                     logits / self.final_logit_softcapping
                 )
 
+        return logits
+
+    def _get_distributed_logprob_context(
+        self,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+    ) -> Optional[DistributedLogprobContext]:
+        """Return the narrow sharded prompt-logprob path when layout is safe."""
+        if (
+            not self.input_logprob_processor.enable_fast_input_logprobs
+            or not self.input_logprob_processor.enable_distributed_input_logprobs
+            or not self.do_tensor_parallel_all_gather
+            or self.do_tensor_parallel_all_gather_dp_attn
+            or logits_metadata.extend_return_top_logprob
+            or not isinstance(lm_head, VocabParallelEmbedding)
+            or not lm_head.enable_tp
+            or lm_head.num_added_embeddings != 0
+            or lm_head.org_vocab_size != self.vocab_size
+        ):
+            return None
+
+        tp_group = (
+            get_parallel().attn_tp_group
+            if self.use_attn_tp_group
+            else get_parallel().tp_group
+        )
+        if lm_head.tp_size != tp_group.world_size:
+            return None
+
+        shard = lm_head.shard_indices
+        return DistributedLogprobContext(
+            tp_group=tp_group,
+            vocab_start_index=shard.org_vocab_start_index,
+            vocab_end_index=shard.org_vocab_end_index,
+            vocab_size=self.vocab_size,
+            get_local_logits_fn=self._get_local_logits_for_distributed_logprobs,
+            gather_sampled_logits_fn=self._gather_sampled_logits,
+        )
+
+    def _get_local_logits_for_distributed_logprobs(
+        self,
+        hidden_states: torch.Tensor,
+        lm_head: VocabParallelEmbedding,
+        logits_metadata: LogitsMetadata,
+    ) -> torch.Tensor:
+        """Compute transformed fp32 rank-local logits without vocab gather."""
+        assert not self.do_tensor_parallel_all_gather_dp_attn
+        logits = self._compute_lm_head(hidden_states, lm_head)
+        if self.logit_scale is not None:
+            logits.mul_(self.logit_scale)
+        logits = logits.float()
+        if self.final_logit_softcapping:
+            if not (_is_npu or _is_cpu):
+                fused_softcap(logits, self.final_logit_softcapping)
+            else:
+                logits = self.final_logit_softcapping * torch.tanh(
+                    logits / self.final_logit_softcapping
+                )
+        return logits
+
+    def _gather_sampled_logits(self, local_logits: torch.Tensor) -> torch.Tensor:
+        """Preserve the sampler's full-vocab contract for sampled rows only."""
+        if self.use_attn_tp_group:
+            logits = self._gather_attn_tp_logits(local_logits)
+        else:
+            logits = self._logits_gatherer(local_logits)
+        if logits.shape[-1] > self.vocab_size:
+            logits = logits[:, : self.vocab_size]
         return logits
 
     def _compute_lm_head(

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -705,7 +705,6 @@ class LogitsProcessor(nn.Module):
             or not self.input_logprob_processor.enable_distributed_input_logprobs
             or not self.do_tensor_parallel_all_gather
             or self.do_tensor_parallel_all_gather_dp_attn
-            or logits_metadata.extend_return_top_logprob
             or not isinstance(lm_head, VocabParallelEmbedding)
             or not lm_head.enable_tp
             or lm_head.num_added_embeddings != 0

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -210,9 +210,7 @@ def get_distributed_topk(
     if max_k < 0:
         raise ValueError(f"max_k must be non-negative, got {max_k}")
     if max_k > vocab_size:
-        raise ValueError(
-            f"max_k={max_k} exceeds global vocabulary size {vocab_size}"
-        )
+        raise ValueError(f"max_k={max_k} exceeds global vocabulary size {vocab_size}")
     if not 0 <= valid_vocab_size <= local_logits.shape[1]:
         raise ValueError(
             f"valid_vocab_size={valid_vocab_size} is incompatible with "

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -815,8 +815,7 @@ class InputLogprobProcessor:
             fused_kernel, fused_max_k = row_logsumexp_topk, FUSED_TOPK_MAX_K
 
         use_distributed_logprobs = (
-            distributed_context is not None
-            and self.enable_fast_input_logprobs
+            distributed_context is not None and self.enable_fast_input_logprobs
         )
 
         for i in range(num_chunks):
@@ -955,16 +954,14 @@ class InputLogprobProcessor:
                             distributed_context.vocab_size,
                             distributed_context.tp_group,
                         )
-                        top_values = (
-                            top_values - row_max[:, None]
-                        ) - row_log_sum[:, None]
+                        top_values = (top_values - row_max[:, None]) - row_log_sum[
+                            :, None
+                        ]
                         split_len_topk = append_distributed_topk_chunk(
                             top_values,
                             top_indices,
                             top_k_nums,
-                            logits_metadata.extend_logprob_pruned_lens_cpu[
-                                chunk_slice
-                            ],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
                             top_logprobs_val,
                             top_logprobs_idx,
                             split_len_topk,
@@ -996,9 +993,7 @@ class InputLogprobProcessor:
                             empty_values,
                             empty_indices,
                             top_k_nums,
-                            logits_metadata.extend_logprob_pruned_lens_cpu[
-                                chunk_slice
-                            ],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
                             top_logprobs_val,
                             top_logprobs_idx,
                             split_len_topk,

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import dataclasses
 import logging
 from enum import Enum, auto
-from typing import TYPE_CHECKING, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 import torch
 
@@ -62,6 +62,33 @@ class LogprobResult:
             )
 
 
+@dataclasses.dataclass(frozen=True)
+class DistributedLogprobContext:
+    """TP-sharded input-logprob callbacks and contiguous vocab ownership."""
+
+    tp_group: Any
+    vocab_start_index: int
+    vocab_end_index: int
+    vocab_size: int
+    get_local_logits_fn: Callable
+    gather_sampled_logits_fn: Callable
+
+
+@dataclasses.dataclass(frozen=True)
+class _TokenIdsChunkEntry:
+    token_ids: Optional[List[int]]
+    num_rows: int
+    continue_previous: bool
+
+
+@dataclasses.dataclass(frozen=True)
+class _TokenIdsChunkPlan:
+    row_indices: torch.Tensor
+    token_ids: torch.Tensor
+    entries: List[_TokenIdsChunkEntry]
+    next_split_pruned_len: int
+
+
 def compute_row_log_normalizer(
     logits: torch.Tensor,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -80,6 +107,163 @@ def compute_row_log_normalizer(
     row_log_sum = torch.logsumexp(x - row_max[:, None], dim=-1)
     row_log_sum = torch.where(row_max.isinf(), 0.0, row_log_sum)
     return row_max, row_log_sum
+
+
+def compute_distributed_row_log_normalizer(
+    local_logits: torch.Tensor,
+    valid_vocab_size: int,
+    tp_group: Any,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Compute a global row normalizer without gathering vocab logits.
+
+    ``local_logits`` follows rank-local contiguous vocab order. Columns after
+    ``valid_vocab_size`` are padding and do not participate. The exchanged
+    tensors are one fp32 max and one fp32 exponential sum per row.
+    """
+    if not 0 <= valid_vocab_size <= local_logits.shape[1]:
+        raise ValueError(
+            f"valid_vocab_size={valid_vocab_size} is incompatible with "
+            f"local logits width {local_logits.shape[1]}"
+        )
+
+    if valid_vocab_size == 0:
+        local_max = torch.full(
+            (local_logits.shape[0],),
+            float("-inf"),
+            dtype=torch.float32,
+            device=local_logits.device,
+        )
+        local_log_sum = torch.zeros_like(local_max)
+    else:
+        valid_logits = local_logits[:, :valid_vocab_size]
+        local_max, local_log_sum = compute_row_log_normalizer(valid_logits)
+
+    global_max = local_max.clone()
+    torch.distributed.all_reduce(
+        global_max,
+        op=torch.distributed.ReduceOp.MAX,
+        group=tp_group.device_group,
+    )
+
+    if valid_vocab_size == 0:
+        local_exp_sum = torch.zeros_like(global_max)
+    else:
+        local_exp_sum = torch.exp((local_max - global_max) + local_log_sum)
+    global_exp_sum = tp_group.all_reduce(local_exp_sum)
+    return global_max, torch.log(global_exp_sum)
+
+
+def get_distributed_token_scores(
+    local_logits: torch.Tensor,
+    row_indices: torch.Tensor,
+    token_ids: torch.Tensor,
+    vocab_start_index: int,
+    vocab_end_index: int,
+    tp_group: Any,
+) -> torch.Tensor:
+    """Look up raw token scores from contiguous TP vocab shards.
+
+    Exactly one rank contributes each requested token score; all other ranks
+    contribute zero. A SUM reduction therefore returns the selected score on
+    every rank while exchanging only one fp32 value per request.
+    """
+    if row_indices.ndim != 1 or token_ids.ndim != 1:
+        raise ValueError("row_indices and token_ids must be one-dimensional")
+    if row_indices.shape != token_ids.shape:
+        raise ValueError("row_indices and token_ids must have the same shape")
+    if row_indices.numel() == 0:
+        return local_logits.new_empty(0, dtype=torch.float32)
+
+    owned = (token_ids >= vocab_start_index) & (token_ids < vocab_end_index)
+    local_width = local_logits.shape[1]
+    if local_width == 0:
+        local_scores = local_logits.new_zeros(token_ids.shape, dtype=torch.float32)
+    else:
+        local_indices = (token_ids - vocab_start_index).clamp(
+            min=0, max=local_width - 1
+        )
+        selected = local_logits[row_indices, local_indices].float()
+        local_scores = torch.where(owned, selected, torch.zeros_like(selected))
+    return tp_group.all_reduce(local_scores)
+
+
+def _build_token_ids_chunk_plan(
+    token_ids_logprobs: List[Optional[List[int]]],
+    pruned_lens: List[int],
+    split_pruned_len: int,
+    num_rows: int,
+    device: torch.device,
+) -> _TokenIdsChunkPlan:
+    """Flatten ragged explicit-token probes into one collective request."""
+    request_rows: List[int] = []
+    request_token_ids: List[int] = []
+    entries: List[_TokenIdsChunkEntry] = []
+    pt = 0
+    next_split_pruned_len = 0
+
+    for n, (token_ids, original_pruned_len) in enumerate(
+        zip(token_ids_logprobs, pruned_lens)
+    ):
+        current_split = split_pruned_len if n == 0 else 0
+        pruned_len = original_pruned_len - current_split
+        continue_previous = current_split > 0
+
+        if pruned_len <= 0:
+            entries.append(_TokenIdsChunkEntry(token_ids, 0, False))
+            continue
+
+        available_rows = min(pruned_len, max(num_rows - pt, 0))
+        if available_rows < pruned_len:
+            next_split_pruned_len = current_split + available_rows
+
+        if token_ids:
+            for row in range(pt, pt + available_rows):
+                request_rows.extend([row] * len(token_ids))
+                request_token_ids.extend(token_ids)
+
+        entries.append(
+            _TokenIdsChunkEntry(token_ids, available_rows, continue_previous)
+        )
+        pt += pruned_len
+
+    return _TokenIdsChunkPlan(
+        row_indices=torch.tensor(request_rows, dtype=torch.long, device=device),
+        token_ids=torch.tensor(request_token_ids, dtype=torch.long, device=device),
+        entries=entries,
+        next_split_pruned_len=next_split_pruned_len,
+    )
+
+
+def _append_token_ids_chunk_from_flat_scores(
+    plan: _TokenIdsChunkPlan,
+    flat_scores: torch.Tensor,
+    token_ids_logprobs_val: List,
+    token_ids_logprobs_idx: List,
+) -> None:
+    """Restore the existing per-sequence/per-row response shape."""
+    score_pt = 0
+    for entry in plan.entries:
+        token_ids = entry.token_ids
+        width = len(token_ids) if token_ids else 0
+        count = entry.num_rows * width
+        if width:
+            values = flat_scores[score_pt : score_pt + count].reshape(
+                entry.num_rows, width
+            )
+            val = values.tolist()
+            idx = [token_ids for _ in range(entry.num_rows)]
+        else:
+            val, idx = [], []
+        score_pt += count
+
+        if entry.continue_previous:
+            token_ids_logprobs_val[-1].extend(val)
+            token_ids_logprobs_idx[-1].extend(idx)
+        else:
+            token_ids_logprobs_val.append(val)
+            token_ids_logprobs_idx.append(idx)
+
+    assert score_pt == flat_scores.numel()
 
 
 def get_top_logprobs_raw(
@@ -447,6 +631,9 @@ class InputLogprobProcessor:
             envs.SGLANG_ENABLE_FAST_INPUT_LOGPROBS.get()
             and not _deterministic_inference_enabled()
         )
+        self.enable_distributed_input_logprobs = (
+            envs.SGLANG_ENABLE_DISTRIBUTED_INPUT_LOGPROBS.get()
+        )
 
     def forward(
         self,
@@ -458,6 +645,7 @@ class InputLogprobProcessor:
         get_logits_fn: Callable,
         logits_metadata: LogitsMetadata,
         skip_chunking_for_dp_attn: bool = False,
+        distributed_context: Optional[DistributedLogprobContext] = None,
     ) -> Tuple[LogprobResult, torch.Tensor]:
         # Non-chunked = one chunk covering every row. DP-attention must stay
         # single-chunk: the collective schedule cannot depend on per-rank rows.
@@ -479,6 +667,7 @@ class InputLogprobProcessor:
             get_logits_fn,
             logits_metadata,
             chunk_size,
+            distributed_context,
         )
 
     def _forward_by_chunk(
@@ -491,6 +680,7 @@ class InputLogprobProcessor:
         get_logits_fn: Callable,
         logits_metadata: LogitsMetadata,
         chunk_size: int,
+        distributed_context: Optional[DistributedLogprobContext] = None,
     ) -> Tuple[LogprobResult, torch.Tensor]:
         """Compute input logprobs chunk by chunk to cap peak memory."""
         total_size = pruned_states.shape[0]
@@ -524,6 +714,12 @@ class InputLogprobProcessor:
 
             fused_kernel, fused_max_k = row_logsumexp_topk, FUSED_TOPK_MAX_K
 
+        use_distributed_logprobs = (
+            distributed_context is not None
+            and self.enable_fast_input_logprobs
+            and not logits_metadata.extend_return_top_logprob
+        )
+
         for i in range(num_chunks):
             start_idx = i * chunk_size
             end_idx = min((i + 1) * chunk_size, total_size)
@@ -548,17 +744,27 @@ class InputLogprobProcessor:
             # writing through the shared graph logits buffer would alias
             # chunks whose shape happens to match the buffer.
             chunk_states = pruned_states[start_idx:end_idx]
-            chunk_logits = get_logits_fn(
-                chunk_states,
-                lm_head,
-                logits_metadata,
-                use_logits_buffer=num_chunks == 1,
-            )
+            if use_distributed_logprobs:
+                chunk_logits = distributed_context.get_local_logits_fn(
+                    chunk_states, lm_head, logits_metadata
+                )
+            else:
+                chunk_logits = get_logits_fn(
+                    chunk_states,
+                    lm_head,
+                    logits_metadata,
+                    use_logits_buffer=num_chunks == 1,
+                )
 
             # Initialize sampled_logits on first chunk
             if i == 0:
+                sampled_vocab_size = (
+                    distributed_context.vocab_size
+                    if use_distributed_logprobs
+                    else chunk_logits.shape[1]
+                )
                 sampled_logits = torch.empty(
-                    (sample_indices.shape[0], chunk_logits.shape[1]),
+                    (sample_indices.shape[0], sampled_vocab_size),
                     dtype=chunk_logits.dtype,
                     device=chunk_logits.device,
                 )
@@ -570,7 +776,12 @@ class InputLogprobProcessor:
             )
             if chunk_sample_mask.any():
                 chunk_sample_indices = sample_indices[chunk_sample_mask] - start_idx
-                sampled_logits[chunk_sample_mask] = chunk_logits[chunk_sample_indices]
+                chunk_sampled_logits = chunk_logits[chunk_sample_indices]
+                if use_distributed_logprobs:
+                    chunk_sampled_logits = distributed_context.gather_sampled_logits_fn(
+                        chunk_sampled_logits
+                    )
+                sampled_logits[chunk_sample_mask] = chunk_sampled_logits
 
             # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
             chunk_logprobs = chunk_logits[chunk_indices]
@@ -581,6 +792,89 @@ class InputLogprobProcessor:
             chunk_slice = slice(
                 token_to_seq_idx[start_idx], token_to_seq_idx[end_idx - 1] + 1
             )
+
+            if use_distributed_logprobs:
+                valid_vocab_size = (
+                    distributed_context.vocab_end_index
+                    - distributed_context.vocab_start_index
+                )
+                if chunk_logprobs.shape[0] > 0:
+                    row_max, row_log_sum = compute_distributed_row_log_normalizer(
+                        chunk_logprobs,
+                        valid_vocab_size,
+                        distributed_context.tp_group,
+                    )
+
+                    target_token_ids = (
+                        logits_metadata.extend_input_logprob_token_ids_gpu[mask_indices]
+                    ).long()
+                    target_rows = torch.arange(
+                        chunk_logprobs.shape[0],
+                        device=chunk_logprobs.device,
+                        dtype=torch.long,
+                    )
+
+                    explicit_plan = None
+                    lookup_rows = target_rows
+                    lookup_token_ids = target_token_ids
+                    if logits_metadata.extend_token_ids_logprob:
+                        explicit_plan = _build_token_ids_chunk_plan(
+                            logits_metadata.token_ids_logprobs[chunk_slice],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
+                            split_len_token_ids,
+                            chunk_logprobs.shape[0],
+                            chunk_logprobs.device,
+                        )
+                        lookup_rows = torch.cat(
+                            (lookup_rows, explicit_plan.row_indices)
+                        )
+                        lookup_token_ids = torch.cat(
+                            (lookup_token_ids, explicit_plan.token_ids)
+                        )
+
+                    raw_scores = get_distributed_token_scores(
+                        chunk_logprobs,
+                        lookup_rows,
+                        lookup_token_ids,
+                        distributed_context.vocab_start_index,
+                        distributed_context.vocab_end_index,
+                        distributed_context.tp_group,
+                    )
+                    normalized_scores = (
+                        raw_scores - row_max[lookup_rows]
+                    ) - row_log_sum[lookup_rows]
+                    num_targets = target_rows.numel()
+                    token_logprobs.append(normalized_scores[:num_targets])
+
+                    if explicit_plan is not None:
+                        _append_token_ids_chunk_from_flat_scores(
+                            explicit_plan,
+                            normalized_scores[num_targets:],
+                            token_ids_logprobs_val,
+                            token_ids_logprobs_idx,
+                        )
+                        split_len_token_ids = explicit_plan.next_split_pruned_len
+                else:
+                    token_logprobs.append(
+                        chunk_logprobs.new_empty(0, dtype=torch.float32)
+                    )
+                    if logits_metadata.extend_token_ids_logprob:
+                        explicit_plan = _build_token_ids_chunk_plan(
+                            logits_metadata.token_ids_logprobs[chunk_slice],
+                            logits_metadata.extend_logprob_pruned_lens_cpu[chunk_slice],
+                            split_len_token_ids,
+                            0,
+                            chunk_logprobs.device,
+                        )
+                        _append_token_ids_chunk_from_flat_scores(
+                            explicit_plan,
+                            chunk_logprobs.new_empty(0, dtype=torch.float32),
+                            token_ids_logprobs_val,
+                            token_ids_logprobs_idx,
+                        )
+                        split_len_token_ids = explicit_plan.next_split_pruned_len
+                del chunk_logprobs
+                continue
 
             chunk_precomputed_topk = None
             if self.enable_fast_input_logprobs:

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -187,6 +187,101 @@ def get_distributed_token_scores(
     return tp_group.all_reduce(local_scores)
 
 
+def get_distributed_topk(
+    local_logits: torch.Tensor,
+    valid_vocab_size: int,
+    max_k: int,
+    vocab_start_index: int,
+    vocab_size: int,
+    tp_group: Any,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Return global top-k raw logits from contiguous TP vocab shards.
+
+    Each rank first selects at most ``max_k`` of its *valid* local columns.
+    Values and absolute token ids are then all-gathered and reduced locally.
+    This exchanges ``O(rows * tp_size * max_k)`` candidates instead of a
+    full-vocabulary tensor.  Padding columns are represented by ``-inf`` and
+    an out-of-vocabulary sentinel, so they cannot win the final top-k.
+
+    Ties retain the backend's ``torch.topk`` behavior.  In particular, equal
+    logits that straddle shards are valid top-k members but their relative
+    order is not promised to match a monolithic full-vocab ``topk``.
+    """
+    if max_k < 0:
+        raise ValueError(f"max_k must be non-negative, got {max_k}")
+    if not 0 <= valid_vocab_size <= local_logits.shape[1]:
+        raise ValueError(
+            f"valid_vocab_size={valid_vocab_size} is incompatible with "
+            f"local logits width {local_logits.shape[1]}"
+        )
+
+    rows = local_logits.shape[0]
+    if max_k == 0:
+        return (
+            local_logits.new_empty((rows, 0), dtype=torch.float32),
+            torch.empty((rows, 0), dtype=torch.long, device=local_logits.device),
+        )
+
+    local_values = torch.full(
+        (rows, max_k),
+        float("-inf"),
+        dtype=torch.float32,
+        device=local_logits.device,
+    )
+    local_indices = torch.full(
+        (rows, max_k),
+        vocab_size,
+        dtype=torch.long,
+        device=local_logits.device,
+    )
+    local_k = min(max_k, valid_vocab_size)
+    if local_k:
+        values, indices = local_logits[:, :valid_vocab_size].topk(local_k, dim=-1)
+        local_values[:, :local_k] = values.float()
+        local_indices[:, :local_k] = indices + vocab_start_index
+
+    candidate_values = tp_group.all_gather(local_values, dim=1)
+    candidate_indices = tp_group.all_gather(local_indices, dim=1)
+    values, candidate_positions = candidate_values.topk(max_k, dim=-1)
+    indices = candidate_indices.gather(1, candidate_positions)
+    return values, indices
+
+
+def append_distributed_topk_chunk(
+    values: torch.Tensor,
+    indices: torch.Tensor,
+    top_k_nums: List[int],
+    pruned_lens: List[int],
+    top_logprobs_val: List,
+    top_logprobs_idx: List,
+    split_pruned_len: int,
+) -> int:
+    """Restore prompt top-k responses from row-major distributed results."""
+    pt = 0
+    next_split_pruned_len = 0
+    for n, (k, original_pruned_len) in enumerate(zip(top_k_nums, pruned_lens)):
+        current_split = split_pruned_len if n == 0 else 0
+        pruned_len = original_pruned_len - current_split
+        if pruned_len <= 0:
+            top_logprobs_val.append([])
+            top_logprobs_idx.append([])
+            continue
+
+        available_rows = min(pruned_len, max(values.shape[0] - pt, 0))
+        val = values[pt : pt + available_rows, :k].tolist()
+        idx = indices[pt : pt + available_rows, :k].tolist()
+        if current_split:
+            top_logprobs_val[-1].extend(val)
+            top_logprobs_idx[-1].extend(idx)
+        else:
+            top_logprobs_val.append(val)
+            top_logprobs_idx.append(idx)
+        if available_rows < pruned_len:
+            next_split_pruned_len = current_split + available_rows
+        pt += pruned_len
+    return next_split_pruned_len
+
+
 def _build_token_ids_chunk_plan(
     token_ids_logprobs: List[Optional[List[int]]],
     pruned_lens: List[int],
@@ -246,14 +341,19 @@ def _append_token_ids_chunk_from_flat_scores(
         token_ids = entry.token_ids
         width = len(token_ids) if token_ids else 0
         count = entry.num_rows * width
-        if width:
+        if token_ids is None:
+            val, idx = [], []
+        elif width:
             values = flat_scores[score_pt : score_pt + count].reshape(
                 entry.num_rows, width
             )
             val = values.tolist()
             idx = [token_ids for _ in range(entry.num_rows)]
         else:
-            val, idx = [], []
+            # [] requests a zero-width result for every prompt row; None is
+            # the opt-out sentinel and returns no rows at all.
+            val = [[] for _ in range(entry.num_rows)]
+            idx = [[] for _ in range(entry.num_rows)]
         score_pt += count
 
         if entry.continue_previous:
@@ -717,7 +817,6 @@ class InputLogprobProcessor:
         use_distributed_logprobs = (
             distributed_context is not None
             and self.enable_fast_input_logprobs
-            and not logits_metadata.extend_return_top_logprob
         )
 
         for i in range(num_chunks):
@@ -846,6 +945,31 @@ class InputLogprobProcessor:
                     num_targets = target_rows.numel()
                     token_logprobs.append(normalized_scores[:num_targets])
 
+                    if logits_metadata.extend_return_top_logprob:
+                        top_k_nums = logits_metadata.top_logprobs_nums[chunk_slice]
+                        top_values, top_indices = get_distributed_topk(
+                            chunk_logprobs,
+                            valid_vocab_size,
+                            max(top_k_nums),
+                            distributed_context.vocab_start_index,
+                            distributed_context.vocab_size,
+                            distributed_context.tp_group,
+                        )
+                        top_values = (
+                            top_values - row_max[:, None]
+                        ) - row_log_sum[:, None]
+                        split_len_topk = append_distributed_topk_chunk(
+                            top_values,
+                            top_indices,
+                            top_k_nums,
+                            logits_metadata.extend_logprob_pruned_lens_cpu[
+                                chunk_slice
+                            ],
+                            top_logprobs_val,
+                            top_logprobs_idx,
+                            split_len_topk,
+                        )
+
                     if explicit_plan is not None:
                         _append_token_ids_chunk_from_flat_scores(
                             explicit_plan,
@@ -858,6 +982,27 @@ class InputLogprobProcessor:
                     token_logprobs.append(
                         chunk_logprobs.new_empty(0, dtype=torch.float32)
                     )
+                    if logits_metadata.extend_return_top_logprob:
+                        top_k_nums = logits_metadata.top_logprobs_nums[chunk_slice]
+                        empty_values = chunk_logprobs.new_empty(
+                            (0, max(top_k_nums)), dtype=torch.float32
+                        )
+                        empty_indices = torch.empty(
+                            (0, max(top_k_nums)),
+                            dtype=torch.long,
+                            device=chunk_logprobs.device,
+                        )
+                        split_len_topk = append_distributed_topk_chunk(
+                            empty_values,
+                            empty_indices,
+                            top_k_nums,
+                            logits_metadata.extend_logprob_pruned_lens_cpu[
+                                chunk_slice
+                            ],
+                            top_logprobs_val,
+                            top_logprobs_idx,
+                            split_len_topk,
+                        )
                     if logits_metadata.extend_token_ids_logprob:
                         explicit_plan = _build_token_ids_chunk_plan(
                             logits_metadata.token_ids_logprobs[chunk_slice],

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -209,6 +209,10 @@ def get_distributed_topk(
     """
     if max_k < 0:
         raise ValueError(f"max_k must be non-negative, got {max_k}")
+    if max_k > vocab_size:
+        raise ValueError(
+            f"max_k={max_k} exceeds global vocabulary size {vocab_size}"
+        )
     if not 0 <= valid_vocab_size <= local_logits.shape[1]:
         raise ValueError(
             f"valid_vocab_size={valid_vocab_size} is incompatible with "

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -47,6 +47,11 @@ class _TorchDistributedGroup:
         dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.device_group)
         return tensor
 
+    def all_gather(self, tensor, dim):
+        gathered = [torch.empty_like(tensor) for _ in range(dist.get_world_size())]
+        dist.all_gather(gathered, tensor, group=self.device_group)
+        return torch.cat(gathered, dim=dim)
+
 
 def _distributed_input_logprob_worker(rank, world_size, init_file):
     dist.init_process_group(
@@ -59,6 +64,9 @@ def _distributed_input_logprob_worker(rank, world_size, init_file):
         torch.manual_seed(17)
         rows, vocab, shard_width = 7, 11, 6
         full_logits = torch.randn(rows, vocab, dtype=torch.float32) * 3
+        # Force a winner on the nonzero shard. The random remainder keeps the
+        # test sensitive to ordinary cross-rank ordering as well.
+        full_logits[0, 10] = 20.0
         if rank == 0:
             local_logits = full_logits[:, :shard_width].clone()
             vocab_start, vocab_end = 0, 6
@@ -88,15 +96,18 @@ def _distributed_input_logprob_worker(rank, world_size, init_file):
             gather_sampled_logits_fn=gather_sampled_logits_fn,
         )
         sample_indices = torch.tensor([2, 5, 6], dtype=torch.long)
-        input_indices = torch.arange(6, dtype=torch.long)
-        target_ids = torch.tensor([0, 6, 10, 1, 7, 9], dtype=torch.long)
+        input_indices = torch.arange(7, dtype=torch.long)
+        target_ids = torch.tensor([0, 6, 10, 1, 7, 9, 4], dtype=torch.long)
         metadata = SimpleNamespace(
-            extend_return_top_logprob=False,
+            extend_return_top_logprob=True,
             extend_token_ids_logprob=True,
-            top_logprobs_nums=[0, 0, 0],
-            extend_logprob_pruned_lens_cpu=[3, 3, 0],
+            # Rank one has only five valid columns, exercising candidate
+            # padding for k=7. The middle request confirms k=0 does not
+            # disturb its row accounting.
+            top_logprobs_nums=[7, 0, 3],
+            extend_logprob_pruned_lens_cpu=[3, 3, 1],
             extend_input_logprob_token_ids_gpu=target_ids,
-            token_ids_logprobs=[[0, 6, 10], [2, 7], None],
+            token_ids_logprobs=[[0, 6, 10], [2, 7], []],
         )
 
         proc = InputLogprobProcessor()
@@ -130,7 +141,7 @@ def _distributed_input_logprob_worker(rank, world_size, init_file):
         expected_explicit = [
             reference[:3, [0, 6, 10]].tolist(),
             reference[3:6, [2, 7]].tolist(),
-            [],
+            [[]],
         ]
         _assert_nested_close(
             unittest.TestCase(),
@@ -143,8 +154,29 @@ def _distributed_input_logprob_worker(rank, world_size, init_file):
         assert result.token_ids_logprobs_idx == [
             [[0, 6, 10]] * 3,
             [[2, 7]] * 3,
-            [],
+            [[]],
         ]
+        reference_top_vals, reference_top_idx = reference.topk(7, dim=-1)
+        expected_top_vals = [
+            reference_top_vals[:3].tolist(),
+            [[]] * 3,
+            [reference_top_vals[6, :3].tolist()],
+        ]
+        expected_top_idx = [
+            reference_top_idx[:3].tolist(),
+            [[]] * 3,
+            [reference_top_idx[6, :3].tolist()],
+        ]
+        _assert_nested_close(
+            unittest.TestCase(),
+            expected_top_vals,
+            result.top_logprobs_val,
+            "distributed prompt top-k",
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        assert result.top_logprobs_idx == expected_top_idx
+        assert result.top_logprobs_idx[0][0][0] == 10
     finally:
         dist.destroy_process_group()
 
@@ -238,46 +270,11 @@ def _shape_of(nested):
 
 
 class TestFastInputLogprobs(CustomTestCase):
-    def test_distributed_path_falls_back_for_prompt_topk(self):
-        batch = _build_batch([(4, 1), (3, 0)], torch.float32)
-        proc = InputLogprobProcessor()
-        reference, reference_sampled = _run(proc, batch, True, None)
-
-        def unexpected_distributed_call(*args, **kwargs):
-            raise AssertionError("prompt top-k must retain the gathered path")
-
-        context = DistributedLogprobContext(
-            tp_group=None,
-            vocab_start_index=0,
-            vocab_end_index=VOCAB,
-            vocab_size=VOCAB,
-            get_local_logits_fn=unexpected_distributed_call,
-            gather_sampled_logits_fn=unexpected_distributed_call,
-        )
-        pruned_states, sample_indices, input_indices, token_to_seq, metadata = batch
-
-        def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
-            return states
-
-        got, got_sampled = proc.forward(
-            pruned_states=pruned_states,
-            sample_indices=sample_indices,
-            input_logprob_indices=input_indices,
-            token_to_seq_idx=token_to_seq,
-            lm_head=None,
-            get_logits_fn=get_logits_fn,
-            logits_metadata=metadata,
-            distributed_context=context,
-        )
-        self.assertEqual(reference.top_logprobs_idx, got.top_logprobs_idx)
-        self.assertEqual(reference.token_ids_logprobs_idx, got.token_ids_logprobs_idx)
-        torch.testing.assert_close(reference.token_logprobs, got.token_logprobs)
-        torch.testing.assert_close(reference_sampled, got_sampled)
-
     def test_distributed_exact_input_logprobs_cpu(self):
         # Real collectives, but Gloo/CPU only: validates TP=2 normalization,
-        # padding exclusion, local/remote token ownership, ragged explicit
-        # probes, chunk stitching, and sampled-row-only vocab gathering.
+        # padding exclusion, local/remote token ownership, heterogeneous
+        # prompt top-k, ragged explicit probes, chunk stitching, and
+        # sampled-row-only vocab gathering.
         with tempfile.TemporaryDirectory() as tmp_dir:
             mp.spawn(
                 _distributed_input_logprob_worker,

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -7,12 +7,17 @@ agree with the reference path to floating-point tolerance, with identical
 top-k indices, across chunk splits and heterogeneous per-sequence params.
 """
 
+import itertools
+import tempfile
 import unittest
 from types import SimpleNamespace
 
 import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
 
 from sglang.srt.layers.logprob_processor import (
+    DistributedLogprobContext,
     InputLogprobProcessor,
     compute_row_log_normalizer,
 )
@@ -32,6 +37,116 @@ TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
 SEQ_SPEC_MENU = ((1, 1), (3, 0), (4, 1), (5, 5), (6, 2))
 # 5 singletons + 5*5 ordered pairs + 4*5 wide cases at width 3.
 EXPECTED_CASES = 50
+
+
+class _TorchDistributedGroup:
+    def __init__(self):
+        self.device_group = dist.group.WORLD
+
+    def all_reduce(self, tensor):
+        dist.all_reduce(tensor, op=dist.ReduceOp.SUM, group=self.device_group)
+        return tensor
+
+
+def _distributed_input_logprob_worker(rank, world_size, init_file):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{init_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        torch.manual_seed(17)
+        rows, vocab, shard_width = 7, 11, 6
+        full_logits = torch.randn(rows, vocab, dtype=torch.float32) * 3
+        if rank == 0:
+            local_logits = full_logits[:, :shard_width].clone()
+            vocab_start, vocab_end = 0, 6
+        else:
+            # A deliberately dominant padding value catches accidental
+            # participation in the distributed normalizer.
+            padding = torch.full((rows, 1), 1e4)
+            local_logits = torch.cat((full_logits[:, 6:], padding), dim=1)
+            vocab_start, vocab_end = 6, vocab
+
+        group = _TorchDistributedGroup()
+
+        def get_local_logits_fn(states, lm_head, logits_metadata):
+            return states
+
+        def gather_sampled_logits_fn(local_sampled):
+            shards = [torch.empty_like(local_sampled) for _ in range(world_size)]
+            dist.all_gather(shards, local_sampled, group=group.device_group)
+            return torch.cat(shards, dim=-1)[:, :vocab]
+
+        context = DistributedLogprobContext(
+            tp_group=group,
+            vocab_start_index=vocab_start,
+            vocab_end_index=vocab_end,
+            vocab_size=vocab,
+            get_local_logits_fn=get_local_logits_fn,
+            gather_sampled_logits_fn=gather_sampled_logits_fn,
+        )
+        sample_indices = torch.tensor([2, 5, 6], dtype=torch.long)
+        input_indices = torch.arange(6, dtype=torch.long)
+        target_ids = torch.tensor([0, 6, 10, 1, 7, 9], dtype=torch.long)
+        metadata = SimpleNamespace(
+            extend_return_top_logprob=False,
+            extend_token_ids_logprob=True,
+            top_logprobs_nums=[0, 0, 0],
+            extend_logprob_pruned_lens_cpu=[3, 3, 0],
+            extend_input_logprob_token_ids_gpu=target_ids,
+            token_ids_logprobs=[[0, 6, 10], [2, 7], None],
+        )
+
+        proc = InputLogprobProcessor()
+        proc.enable_fast_input_logprobs = True
+        proc.enable_logprobs_chunk = True
+        proc.logprobs_chunk_size = 2
+
+        def unused_gathered_logits(*args, **kwargs):
+            raise AssertionError("distributed path unexpectedly gathered prompt rows")
+
+        result, sampled_logits = proc.forward(
+            pruned_states=local_logits,
+            sample_indices=sample_indices,
+            input_logprob_indices=input_indices,
+            token_to_seq_idx=[0, 0, 0, 1, 1, 1, 2],
+            lm_head=None,
+            get_logits_fn=unused_gathered_logits,
+            logits_metadata=metadata,
+            distributed_context=context,
+        )
+
+        reference = torch.log_softmax(full_logits, dim=-1)
+        expected_targets = reference[input_indices, target_ids]
+        torch.testing.assert_close(
+            result.token_logprobs, expected_targets, rtol=1e-5, atol=1e-5
+        )
+        torch.testing.assert_close(
+            sampled_logits, full_logits[sample_indices], rtol=0, atol=0
+        )
+
+        expected_explicit = [
+            reference[:3, [0, 6, 10]].tolist(),
+            reference[3:6, [2, 7]].tolist(),
+            [],
+        ]
+        _assert_nested_close(
+            unittest.TestCase(),
+            expected_explicit,
+            result.token_ids_logprobs_val,
+            "distributed explicit token IDs",
+            rtol=1e-5,
+            atol=1e-5,
+        )
+        assert result.token_ids_logprobs_idx == [
+            [[0, 6, 10]] * 3,
+            [[2, 7]] * 3,
+            [],
+        ]
+    finally:
+        dist.destroy_process_group()
 
 
 def _build_batch(seq_specs, dtype, vocab=VOCAB):
@@ -123,6 +238,54 @@ def _shape_of(nested):
 
 
 class TestFastInputLogprobs(CustomTestCase):
+    def test_distributed_path_falls_back_for_prompt_topk(self):
+        batch = _build_batch([(4, 1), (3, 0)], torch.float32)
+        proc = InputLogprobProcessor()
+        reference, reference_sampled = _run(proc, batch, True, None)
+
+        def unexpected_distributed_call(*args, **kwargs):
+            raise AssertionError("prompt top-k must retain the gathered path")
+
+        context = DistributedLogprobContext(
+            tp_group=None,
+            vocab_start_index=0,
+            vocab_end_index=VOCAB,
+            vocab_size=VOCAB,
+            get_local_logits_fn=unexpected_distributed_call,
+            gather_sampled_logits_fn=unexpected_distributed_call,
+        )
+        pruned_states, sample_indices, input_indices, token_to_seq, metadata = batch
+
+        def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
+            return states
+
+        got, got_sampled = proc.forward(
+            pruned_states=pruned_states,
+            sample_indices=sample_indices,
+            input_logprob_indices=input_indices,
+            token_to_seq_idx=token_to_seq,
+            lm_head=None,
+            get_logits_fn=get_logits_fn,
+            logits_metadata=metadata,
+            distributed_context=context,
+        )
+        self.assertEqual(reference.top_logprobs_idx, got.top_logprobs_idx)
+        self.assertEqual(reference.token_ids_logprobs_idx, got.token_ids_logprobs_idx)
+        torch.testing.assert_close(reference.token_logprobs, got.token_logprobs)
+        torch.testing.assert_close(reference_sampled, got_sampled)
+
+    def test_distributed_exact_input_logprobs_cpu(self):
+        # Real collectives, but Gloo/CPU only: validates TP=2 normalization,
+        # padding exclusion, local/remote token ownership, ragged explicit
+        # probes, chunk stitching, and sampled-row-only vocab gathering.
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            mp.spawn(
+                _distributed_input_logprob_worker,
+                args=(2, f"{tmp_dir}/init"),
+                nprocs=2,
+                join=True,
+            )
+
     def _sweep(self, dtype, rtol, atol):
         torch.manual_seed(0)
         proc = InputLogprobProcessor()

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -336,7 +336,9 @@ def _assert_tied_distributed_topk(test, full_logits, target_ids, result):
         test.assertEqual(len(values), 5)
         test.assertEqual(len(indices), 5)
         test.assertEqual(len(set(indices)), 5, "Top-N IDs must be distinct")
-        test.assertTrue(all(0 <= token_id < full_logits.shape[1] for token_id in indices))
+        test.assertTrue(
+            all(0 <= token_id < full_logits.shape[1] for token_id in indices)
+        )
         test.assertTrue(
             all(values[pos] >= values[pos + 1] for pos in range(len(values) - 1)),
             "Top-N values must remain rank-descending",

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -3,8 +3,10 @@
 The fast path (SGLANG_ENABLE_FAST_INPUT_LOGPROBS) computes token / top-k /
 token-ids logprobs directly from logits with a per-row logsumexp normalizer,
 never materializing the full-vocab log-softmax. Same math, so results must
-agree with the reference path to floating-point tolerance, with identical
-top-k indices, across chunk splits and heterogeneous per-sequence params.
+agree with the reference path to floating-point tolerance across chunk splits
+and heterogeneous per-sequence params. For distributed Top-N, cross-shard
+ties intentionally accept any valid equal-cutoff token IDs because
+``torch.topk`` does not promise a monolithic tie order.
 """
 
 import itertools
@@ -20,6 +22,7 @@ from sglang.srt.layers.logprob_processor import (
     DistributedLogprobContext,
     InputLogprobProcessor,
     compute_row_log_normalizer,
+    get_distributed_topk,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.logprob_test_utils import coverage_cases
@@ -177,6 +180,48 @@ def _distributed_input_logprob_worker(rank, world_size, init_file):
         )
         assert result.top_logprobs_idx == expected_top_idx
         assert result.top_logprobs_idx[0][0][0] == 10
+
+        # Cross-shard Nth-boundary ties are not required to select the same
+        # IDs as one monolithic torch.topk. They must, however, retain the
+        # exact target entry, N ranked scores, all strictly-above-cutoff IDs,
+        # and only distinct equal-cutoff alternatives for the remainder.
+        tie_full_logits = torch.tensor(
+            [
+                [10.0, 9.0, 8.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, -5.0, -6.0],
+                [9.0, 8.0, 7.0, 7.0, 7.0, 7.0, 7.0, 7.0, -4.0, -5.0, -6.0],
+            ]
+        )
+        if rank == 0:
+            tie_local_logits = tie_full_logits[:, :shard_width].clone()
+        else:
+            tie_padding = torch.full((2, 1), 1e4)
+            tie_local_logits = torch.cat((tie_full_logits[:, 6:], tie_padding), dim=1)
+
+        tie_metadata = SimpleNamespace(
+            extend_return_top_logprob=True,
+            extend_token_ids_logprob=False,
+            top_logprobs_nums=[5],
+            extend_logprob_pruned_lens_cpu=[2],
+            extend_input_logprob_token_ids_gpu=torch.tensor([8, 3]),
+        )
+        tie_proc = InputLogprobProcessor()
+        tie_proc.enable_fast_input_logprobs = True
+        tie_proc.enable_logprobs_chunk = True
+        tie_proc.logprobs_chunk_size = 1
+        tie_result, tie_sampled_logits = tie_proc.forward(
+            pruned_states=tie_local_logits,
+            sample_indices=torch.empty(0, dtype=torch.long),
+            input_logprob_indices=torch.arange(2, dtype=torch.long),
+            token_to_seq_idx=[0, 0],
+            lm_head=None,
+            get_logits_fn=unused_gathered_logits,
+            logits_metadata=tie_metadata,
+            distributed_context=context,
+        )
+        assert tie_sampled_logits.shape == (0, vocab)
+        _assert_tied_distributed_topk(
+            unittest.TestCase(), tie_full_logits, torch.tensor([8, 3]), tie_result
+        )
     finally:
         dist.destroy_process_group()
 
@@ -269,7 +314,63 @@ def _shape_of(nested):
     return None
 
 
+def _assert_tied_distributed_topk(test, full_logits, target_ids, result):
+    """Check the public distributed tie contract without assuming tie IDs."""
+    reference = torch.log_softmax(full_logits, dim=-1)
+    row_ids = torch.arange(full_logits.shape[0])
+    torch.testing.assert_close(
+        result.token_logprobs,
+        reference[row_ids, target_ids],
+        rtol=1e-6,
+        atol=1e-6,
+        msg="target-token logprobs remain exact across the tied cutoff",
+    )
+
+    test.assertEqual(len(result.top_logprobs_val), 1)
+    test.assertEqual(len(result.top_logprobs_idx), 1)
+    test.assertEqual(len(result.top_logprobs_val[0]), full_logits.shape[0])
+    test.assertEqual(len(result.top_logprobs_idx[0]), full_logits.shape[0])
+    for row, (values, indices) in enumerate(
+        zip(result.top_logprobs_val[0], result.top_logprobs_idx[0])
+    ):
+        test.assertEqual(len(values), 5)
+        test.assertEqual(len(indices), 5)
+        test.assertEqual(len(set(indices)), 5, "Top-N IDs must be distinct")
+        test.assertTrue(all(0 <= token_id < full_logits.shape[1] for token_id in indices))
+        test.assertTrue(
+            all(values[pos] >= values[pos + 1] for pos in range(len(values) - 1)),
+            "Top-N values must remain rank-descending",
+        )
+
+        returned = set(indices)
+        expected_values = reference[row, torch.tensor(indices)]
+        torch.testing.assert_close(
+            torch.tensor(values), expected_values, rtol=1e-6, atol=1e-6
+        )
+        cutoff = torch.topk(full_logits[row], 5).values[-1]
+        strictly_above = set(
+            torch.nonzero(full_logits[row] > cutoff, as_tuple=False).flatten().tolist()
+        )
+        equal_cutoff = set(
+            torch.nonzero(full_logits[row] == cutoff, as_tuple=False).flatten().tolist()
+        )
+        test.assertTrue(strictly_above <= returned)
+        test.assertTrue(returned - strictly_above <= equal_cutoff)
+        test.assertEqual(len(returned & equal_cutoff), 5 - len(strictly_above))
+
+
 class TestFastInputLogprobs(CustomTestCase):
+    def test_distributed_topk_rejects_over_vocab_k(self):
+        with self.assertRaisesRegex(ValueError, "exceeds global vocabulary size"):
+            get_distributed_topk(
+                torch.empty((1, 3)),
+                valid_vocab_size=3,
+                max_k=4,
+                vocab_start_index=0,
+                vocab_size=3,
+                tp_group=None,
+            )
+
     def test_distributed_exact_input_logprobs_cpu(self):
         # Real collectives, but Gloo/CPU only: validates TP=2 normalization,
         # padding exclusion, local/remote token ownership, heterogeneous


### PR DESCRIPTION
# Add distributed exact prompt Top-N logprobs

## Summary

Extend the distributed prompt-logprob path to `top_logprobs_num > 0` without
gathering the full prompt vocabulary logits.

Before this PR:

```text
TP-local logits [rows, vocab / TP]
              |
              +-- full-vocab AllGather --> [rows, vocab]
                                              |
                                              +-- global Top-N
                                              +-- normalize selected values
```

With this PR:

```text
TP-local logits [rows, vocab / TP]
              |
              +-- local Top-N --> [rows, N] values + global token IDs
              |                         |
              |                         +-- compact AllGather --> global Top-N
              |
              +-- distributed row MAX / exp-SUM ----------------> normalize
```

Each TP rank selects local Top-N over valid vocabulary columns, exchanges only
fp32 logits and absolute token IDs for those candidates, and selects global
Top-N locally. Candidate values use the existing distributed row normalizer.
The full-vocabulary gather remains only for sampled rows, where the sampler
requires it.

Response assembly preserves chunked prefill and heterogeneous per-request `k`,
including zero. Target-token and explicit token-ID results continue to use the
owner-sharded path.

## Performance evidence

Controlled TP4 GLM-5.2 on 4x GB200, one output token, concurrency one, prompt
Top-5, and nine explicit token probes. Every fresh server received one
full-workload warmup followed by five measured requests in A-B-B-A order
(N=10 per path).

| Input | Gathered median E2E | Distributed median E2E | E2E time saved | Speedup |
| ---: | ---: | ---: | ---: | ---: |
| 4K | 0.959 s | 0.497 s | 0.462 s (48.2%) | 1.93x |
| 8K | 1.698 s | 0.895 s | 0.803 s (47.3%) | 1.90x |
| 16K | 3.554 s | 1.646 s | 1.908 s (53.7%) | 2.16x |

Across 4K, 8K, and 16K, the distributed path saves 0.462, 0.803, and 1.908
seconds of client-observed whole-request E2E time at the median. Both paths
contain high samples, so median is the primary statistic and raw per-leg
samples are retained. The GPU-only logprob interval was not separately
instrumented.

All measured responses returned the expected prompt Top-N shape: 4,096 rows
and 20,475 valid entries at 4K, 8,192 and 40,955 at 8K, and 16,384 and 81,915
at 16K. Stable early-row Top-5 IDs matched the gathered path, with values
within `4.8e-7`; target and explicit-token scores agreed within `9.6e-7`.
Later rows of the long random GLM-5.2 DSA workload remain nondeterministic on
the unchanged server, so focused deterministic tests are the correctness
reference.

## Caveats

- The optimization applies only to the safe contiguous TP-vocabulary layout
  established by #34402. Existing fallback behavior remains for unsupported
  layouts and escape-hatch configurations.
- For non-tied rows, Top-N values and IDs match the full-vocabulary result.
  Returned scores are exact and rank-descending, and IDs are distinct. At an
  Nth-score tie across shards, all strictly higher-scoring IDs are returned;
  remaining equal-cutoff IDs are valid alternatives, so their membership and
  relative order are not promised to match one monolithic `torch.topk` call.
  The separately returned target-token logprob remains exact.

## Stacked on

This change is stacked on #34402
(`ead2bf163`, `Add distributed exact input
logprobs`). It uses that PR's owner-sharded target-token lookup, explicit-ID
lookup, and distributed row normalizer.

## Other tests

CPU Gloo TP=2 coverage validates:

- padded vocabulary exclusion;
- a forced winner from a different TP rank;
- `k=7`, `k=0`, and `k=3` in one chunked batch;
- explicit IDs that are local, remote, and an empty-ID request;
- sampled-row gathering and chunk stitching.

```bash
CUDA_VISIBLE_DEVICES=99 PYTHONPATH=python python -m unittest discover \
  -s test/registered/unit/layers -p test_logprob_fast_input.py -v
```

Result: 7 CPU tests passed; 7 existing CUDA-only tests skipped. The focused
CUDA run subsequently passed all 14 tests. `py_compile` and `git diff --check`
also pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31936547819](https://github.com/sgl-project/sglang/actions/runs/31936547819)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31936547791](https://github.com/sgl-project/sglang/actions/runs/31936547791)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
