### PR TITLE
[AMD] Bound GSM8K concurrency in the Qwen3.5-FP8 AR-fusion test (fixes stage-c mamba-cache stall)

### DIFF
--- a/benchmark/gsm8k/bench_sglang.py
+++ b/benchmark/gsm8k/bench_sglang.py
@@ -126,6 +126,18 @@ def main(args):
     )
     latency = time.perf_counter() - tic
 
+    # A request whose generation never completed (server crash, watchdog kill,
+    # dropped connection) leaves "answer" unset on its state. Indexing it raises
+    # a bare KeyError: 'answer' that looks like a parsing bug and hides the real
+    # failure, so surface the request failures instead.
+    failed = [i for i, s in enumerate(states) if "answer" not in s]
+    if failed:
+        raise RuntimeError(
+            f"{len(failed)}/{len(states)} GSM8K requests did not return an "
+            f"answer (first failing indices: {failed[:10]}). The server most "
+            f"likely died or stopped responding mid-run -- check the server log."
+        )
+
     preds = []
     for i in range(len(states)):
         preds.append(get_answer_value(states[i]["answer"]))

--- a/test/registered/amd/perf/mi35x/test_qwen35_fp8_ar_fusion_mi35x.py
+++ b/test/registered/amd/perf/mi35x/test_qwen35_fp8_ar_fusion_mi35x.py
@@ -41,6 +41,15 @@ QWEN35_FP8_MODEL_PATH = os.environ.get(
 )
 SERVER_LAUNCH_TIMEOUT = 4800
 GSM8K_NUM_QUESTIONS = int(os.environ.get("GSM8K_NUM_QUESTIONS", "1319"))
+# Cap in-flight requests instead of firing all GSM8K_NUM_QUESTIONS at once.
+# Qwen3.5 is a hybrid model: the server caps max_running_requests at
+# max_mamba_cache_size (1013 for this config on MI35x). Submitting 1319
+# concurrent requests to each of the two servers this test runs side by side
+# pins the mamba state cache at 100% with requests still queued, and decode
+# stops making progress until the 1200s scheduler watchdog kills both servers.
+# The accuracy signal is identical at lower concurrency; this only bounds how
+# much work is admitted at once.
+GSM8K_PARALLEL = int(os.environ.get("GSM8K_PARALLEL", "256"))
 ACCURACY_THRESHOLD = 0.94
 
 # bench_sglang.py lives at the repo root (this file is 5 levels below), not under
@@ -149,7 +158,7 @@ class TestQwen35Fp8ArFusionMI35x(CustomTestCase):
             "--num-questions",
             str(GSM8K_NUM_QUESTIONS),
             "--parallel",
-            str(GSM8K_NUM_QUESTIONS),
+            str(GSM8K_PARALLEL),
             "--num-shots",
             "5",
             "--data-path",


### PR DESCRIPTION
## Problem

`stage-c-test-large-8-gpu-amd-mi35x-rocm720` shard 0 fails on `test_qwen35_fp8_ar_fusion_mi35x.py`. The surfaced error is misleading:

```
AssertionError: GSM8K benchmark failed:
...
  File "benchmark/gsm8k/bench_sglang.py", line 131, in main
    preds.append(get_answer_value(states[i]["answer"]))
KeyError: 'answer'
```

That is a *symptom*. What actually happened ([run 31519319449, job 93872280493](https://github.com/sgl-project/sglang/actions/runs/31519319449/job/93872280493)):

- Both TP4 servers (`fused-ar-rms-per-group-quant` on GPUs 0-3 and `disable-fused-ar-quant-opt-out` on 4-7, launched **concurrently** by the test's `ThreadPoolExecutor`) hit the hard watchdog at 22:08:34-36 and took `SIGQUIT`.
- Every scheduler was parked in the same place — a HIP event that never signalled:
  ```
  process_batch_result_decode (batch_result_processor.py:811)
    -> torch.cuda.Event.synchronize (torch/cuda/streams.py:231)
      -> THCPEvent_synchronize -> libamdhip64 -> libhsa-runtime64
  ```
- The client then got `RemoteDisconnected`, so `states[i]["answer"]` was never set and the parser raised `KeyError`.

## Root cause (updated — reproduced on hardware)

I reproduced this on an 8-GPU MI355X node with the FP8 checkpoint. **The trigger is running the two TP4 servers concurrently, not the concurrency level on its own.**

**Single server, GPUs 0-3, parallel=1319** (the value this test uses):

```
acc=0.9719  errors=0  latency=70.1s  decode batches=27  watchdog=0
peak: mamba usage: 1.00, #running-req: 1012
```

It reaches the *exact* saturation point CI dies at — mamba cache 100%, 1012 of 1013 slots — and keeps retiring decode batches at ~474 tok/s. So saturating the mamba state cache is **not sufficient** to hang the server.

**Two servers, GPUs 0-3 + 4-7, both at parallel=1319 simultaneously** (what the test actually does):

```
server A: mamba usage: 1.00, #running-req: 1003, decode batches = 0
server B: mamba usage: 1.00, #running-req: 1003, decode batches = 0
all 8 GPUs: 100% utilisation      KV pool: 13% used
```

Both wedge within ~2 minutes, and py-spy on both TP0 schedulers gives the same stack as the CI failure:

```
synchronize (torch/cuda/streams.py:231)
process_batch_result_decode (scheduler_components/batch_result_processor.py:811)
process_batch_result (scheduler.py) -> pop_and_process -> event_loop_overlap
```

Killing both benchmark clients does **not** release them — they stay at `1.00 / 1003` with zero decode — so this is a server-side deadlock on a HIP event that never signals, not client backpressure.

A related observation from the same session: server B repeatedly failed to start at all while server A was resident, with `ncclCommInitRank` -> `NCCL error: unhandled cuda error` -> `[FATAL ERROR]: HIP failure: 'invalid argument'`, **even with distinct `--nccl-port` values**. It only came up when launched against an idle node. Launching both simultaneously failed every time. That is independent evidence that two 397B TP4 servers contend badly on one MI355X node.

So: mamba saturation is an amplifier, and co-tenancy of the two TP4 servers is the actual trigger.

## Changes

**1. Bound the in-flight request count** (`GSM8K_PARALLEL`, default 256, env-overridable). `--num-questions` is unchanged, so the accuracy signal is identical — this only limits how much work is admitted at once. For reference the MI35x MiniMax-M3 nightly uses `parallel=64` for the same 1319 questions.

**2. Report failed requests in `bench_sglang.py`** instead of letting the results parser raise `KeyError: 'answer'`. Any server death in any suite using this script currently surfaces as an opaque parse error; this names the failure and points at the server log.

## Notes / limitations

This PR bounds concurrency, which removes the trigger in practice, but on the evidence above the more principled fix may be to **stop running the two variants concurrently** (the test submits both to a `ThreadPoolExecutor`). I left that out to keep the diff small — serializing them roughly doubles wall time against the 4800s budget, so it is a maintainer call. Pinning `--max-running-requests` server-side in `COMMON_ARGS` is a third option.

What I have **not** shown: a two-server run at the reduced concurrency proving the cap prevents the deadlock. I could not re-initialise the second server after the wedge (the RCCL failure above), so "the cap prevents it" is inference from the single-server result, not a direct measurement. Flagging that explicitly rather than overclaiming.

The underlying question — why a decode step deadlocks on gfx950 when a second TP4 job is resident — is not answered here and looks like a genuine ROCm/RCCL contention issue worth its own investigation. Happy to file it separately with the repro recipe.

*(An earlier version of this description attributed the hang to mamba-cache saturation alone. The single-server run above disproves that; corrected.)*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31685453785](https://github.com/sgl-project/sglang/actions/runs/31685453785)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31685453378](https://github.com/sgl-project/sglang/actions/runs/31685453378)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->