### PR TITLE
[Bugfix] Bound SGLANG_PORT search to valid TCP range

### DIFF
--- a/python/sglang/srt/utils/network.py
+++ b/python/sglang/srt/utils/network.py
@@ -13,17 +13,28 @@ import zmq
 
 logger = logging.getLogger(__name__)
 
+MAX_VALID_PORT = 65535
+
 
 def get_open_port() -> int:
     from sglang.srt.environ import envs
 
     port = envs.SGLANG_PORT.get()
     if port is not None:
-        while True:
+        if not (1 <= port <= MAX_VALID_PORT):
+            raise ValueError(
+                f"SGLANG_PORT must be between 1 and {MAX_VALID_PORT}, got {port}"
+            )
+        start_port = port
+        while port <= MAX_VALID_PORT:
             if is_port_available(port):
                 return port
-            logger.info("Port %d is already in use, trying port %d", port, port + 1)
+            if port < MAX_VALID_PORT:
+                logger.info("Port %d is already in use, trying port %d", port, port + 1)
             port += 1
+        raise RuntimeError(
+            f"No available TCP port at or above SGLANG_PORT={start_port}"
+        )
     sock = try_bind_socket()
     port = sock.getsockname()[1]
     sock.close()
@@ -48,9 +59,6 @@ def find_process_using_port(port: int) -> Optional[psutil.Process]:
                 pass
 
     return None
-
-
-MAX_VALID_PORT = 65535
 
 
 def wait_port_available(

--- a/test/registered/utils/test_socket_utils.py
+++ b/test/registered/utils/test_socket_utils.py
@@ -153,6 +153,29 @@ class TestSocketUtilities(CustomTestCase):
         finally:
             sock.close()
 
+    def test_get_open_port_rejects_invalid_env_port(self):
+        """SGLANG_PORT must be a concrete, valid TCP port."""
+        for invalid_port in (-1, 0, 65536):
+            with self.subTest(invalid_port=invalid_port):
+                with patch.dict(
+                    os.environ, {"SGLANG_PORT": str(invalid_port)}
+                ), self.assertRaisesRegex(ValueError, "must be between 1 and 65535"):
+                    get_open_port()
+
+    @patch(
+        "sglang.srt.utils.network.is_port_available",
+        side_effect=(False, AssertionError("scanned beyond port 65535")),
+    )
+    def test_get_open_port_stops_at_max_port(self, mock_is_port_available):
+        """An occupied port 65535 must fail instead of scanning forever."""
+        with patch.dict(os.environ, {"SGLANG_PORT": "65535"}):
+            with self.assertRaisesRegex(
+                RuntimeError, "No available TCP port at or above SGLANG_PORT=65535"
+            ):
+                get_open_port()
+
+        mock_is_port_available.assert_called_once_with(65535)
+
 
 class TestReservePort(CustomTestCase):
     def test_reserve_port_returns_port_and_socket(self):


### PR DESCRIPTION
## Motivation

`SGLANG_PORT` is a base-port hint: when that port is occupied, `get_open_port()` searches upward to preserve a predictable range for deployments behind firewalls. The previous unbounded loop continued past TCP port 65535. `is_port_available()` treats the resulting `OverflowError` as unavailable, so `SGLANG_PORT=65535` with that port occupied caused an infinite loop; values outside the TCP port range were also not rejected up front.

This PR keeps the existing upward-only behavior while bounding it to valid TCP ports. Out-of-range integer values now raise `ValueError`, and exhausting the range raises a clear `RuntimeError` instead of scanning forever. Non-integer values retain the existing `EnvInt` warning-and-fallback behavior. The search intentionally does not wrap or fall back to a random port because that would violate the documented predictable-range behavior.

I searched current open PRs for `get_open_port`, `SGLANG_PORT`, `SGLANG_PORT=65535`, occupied/invalid port handling, and bounded TCP port search. No open PR covers this change.

AI assistance was used to research, implement, test, and review this change. This is intentionally a draft so the account owner can complete the final human review before marking it ready.

## Modifications

- Validate that `SGLANG_PORT` is in the inclusive range 1–65535.
- Bound upward availability checks at port 65535 and report range exhaustion.
- Add CPU regression coverage for invalid configured ports and an occupied port 65535. The latter uses a bounded sentinel, so it fails quickly on the old implementation rather than hanging the test suite.

## Accuracy Tests

Not applicable. This changes port selection only and does not affect model outputs.

Focused CPU tests:

```bash
pytest -q test/registered/utils/test_socket_utils.py \
  -k 'get_open_port_rejects_invalid_env_port or get_open_port_stops_at_max_port'
```

Result: `2 passed, 3 subtests passed`.

Additional checks passed:

- Black formatting check
- isort check
- codespell
- Ruff `F401,F821,UP037`
- `git diff --check`
- `scripts/ci/check_registered_tests.py`
- `scripts/ci/check_no_registered_tests_in_package.py`

The full socket utility file could not run in the local sandbox because real `socket.bind` calls are denied there; the two mocked regression tests passed, and the remaining failures were environment permission errors rather than assertions in this change.

## Speed Tests and Profiling

Not applicable. The normal path performs the same availability checks as before; this change only adds constant-time range validation and a terminal bound.

## Checklist

- [x] Format your code according to the project checks listed above.
- [x] Add focused unit tests.
- [x] No documentation update is needed; the documented upward-search behavior is preserved.
- [x] Accuracy and speed benchmarks are not applicable to this control-path fix.
- [x] Follow the existing SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31685836295](https://github.com/sgl-project/sglang/actions/runs/31685836295)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31685835891](https://github.com/sgl-project/sglang/actions/runs/31685835891)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->