### PR TITLE
[SM120] dspark: widen SWA index width to an instantiated sparse-MLA shape

### DIFF
--- a/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
@@ -229,21 +229,15 @@ def compute_dspark_window_gather_triton(
     )
 
 
-# The SM120 sparse-MLA kernels only instantiate a fixed set of index widths, and
-# aligning to page_index_aligned_size alone can land outside it: DSPARK's
-# swa_window + block_size aligns to 192, which no prefill variant provides, so the
-# host gate rejects it (a hard abort, not a fallback). Widen to the next
-# instantiated width instead. The tail is -1 and the kernel masks per row through
-# topk_length, so this only costs padding -- measured identical end-to-end against
-# an exact-192 build at bs=1/8/32.
-# 128 must stay in the set -- it is the only width the DSv4 dual (SWA extra-cache)
-# dispatch instantiates, and rounding it up to 512 breaks the MTP path.
+# FlashInfer's SM120 sparse-MLA prefill instantiates only these widths and aborts on
+# anything else; DSPARK's swa_window + block_size lands on 192. Widen to the next
+# instantiated width -- the padded tail is -1 and masked per row via topk_length.
+# 128 must stay: it is the only width the DSv4 dual (SWA extra-cache) dispatch
+# instantiates, and widening it breaks MTP.
 _SM120_INDEX_WIDTHS = (128, 512, 1024, 2048)
 
 
 def _sm120_index_width(width: int) -> int:
-    # is_sm120_supported() is lru_cached; call it here rather than at import so
-    # arch detection does not pull CUDA into module import.
     if width in _SM120_INDEX_WIDTHS or not is_sm120_supported():
         return width
     return next((w for w in _SM120_INDEX_WIDTHS if w > width), width)

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_attn_metadata.py
@@ -9,6 +9,7 @@ import triton.language as tl
 
 from sglang.kernels.ops.speculative.dspark.dispatch import inputs_on_cuda
 from sglang.srt.utils import ceil_align
+from sglang.srt.utils.common import is_sm120_supported
 
 
 class DsparkWindowGather(msgspec.Struct, frozen=True):
@@ -228,6 +229,26 @@ def compute_dspark_window_gather_triton(
     )
 
 
+# The SM120 sparse-MLA kernels only instantiate a fixed set of index widths, and
+# aligning to page_index_aligned_size alone can land outside it: DSPARK's
+# swa_window + block_size aligns to 192, which no prefill variant provides, so the
+# host gate rejects it (a hard abort, not a fallback). Widen to the next
+# instantiated width instead. The tail is -1 and the kernel masks per row through
+# topk_length, so this only costs padding -- measured identical end-to-end against
+# an exact-192 build at bs=1/8/32.
+# 128 must stay in the set -- it is the only width the DSv4 dual (SWA extra-cache)
+# dispatch instantiates, and rounding it up to 512 breaks the MTP path.
+_SM120_INDEX_WIDTHS = (128, 512, 1024, 2048)
+
+
+def _sm120_index_width(width: int) -> int:
+    # is_sm120_supported() is lru_cached; call it here rather than at import so
+    # arch detection does not pull CUDA into module import.
+    if width in _SM120_INDEX_WIDTHS or not is_sm120_supported():
+        return width
+    return next((w for w in _SM120_INDEX_WIDTHS if w > width), width)
+
+
 def build_dspark_swa_page_indices(
     *,
     req_to_token: torch.Tensor,
@@ -260,7 +281,9 @@ def build_dspark_swa_page_indices(
     block_full_locs = out_loc[: bs * block_size].view(bs, block_size)
     block_swa_locs = full_to_swa_mapping[block_full_locs].to(torch.int32)
 
-    target_width = ceil_align(swa_window + block_size, page_index_aligned_size)
+    target_width = _sm120_index_width(
+        ceil_align(swa_window + block_size, page_index_aligned_size)
+    )
 
     swa_page_indices = _compact_dspark_window_then_block(
         window_swa_locs=window_swa_locs,
@@ -386,7 +409,9 @@ def build_dspark_swa_page_indices_triton(
     out_loc = out_loc[: bs * block_size].contiguous()
     context_lens = context_lens.to(device=device, dtype=torch.int32).contiguous()
     rt_stride = req_to_token.stride(0)
-    target_width = ceil_align(swa_window + block_size, page_index_aligned_size)
+    target_width = _sm120_index_width(
+        ceil_align(swa_window + block_size, page_index_aligned_size)
+    )
     n_q = bs * block_size
     swa_page_indices = torch.empty(
         (n_q, target_width), dtype=torch.int32, device=device


### PR DESCRIPTION
## Purpose

DSPARK does not start on consumer Blackwell (SM120). CUDA graph capture aborts:

```
Check failed: (ok) is false: Unsupported sparse-MLA prefill configuration:
model=DSV4 num_heads=16 topk=192 page_block_size=64 topk_extra=0 extra_page_block_size=0
```

`build_dspark_swa_page_indices` derives its index width from `swa_window + block_size`,
which lands on **192** for the DSPARK shape (128 sliding-window entries + the draft
block). FlashInfer's SM120 sparse-MLA prefill matrix instantiates `topk` in
`{128, 512, 1024, 2048}`, so the host gate rejects 192 — and it rejects it by aborting
the process, not by falling back. `num_heads=16` itself is supported.

## What this does

Widen an uninstantiated index width to the next instantiated one. The padded tail is
`-1` and the kernel already masks per row through `topk_length`, so the extra columns
are inert.

`128` stays in the set deliberately: it is the only width the DSv4 dual (SWA
extra-cache) dispatch instantiates, and widening it breaks the MTP path.

## Relationship to flashinfer-ai/flashinfer#4380

The exact-192 shape is the better long-term answer and now exists upstream — #4380
added `topk` 192/256 for DSV4 decode and single-cache prefill, and vLLM builds on it in
vllm-project/vllm#51538 by carrying the true dense width (aligned to the kernel's
64-entry tile) instead of rounding.

That path is not available here yet:

| FlashInfer | prefill dispatch widths |
| --- | --- |
| 0.6.15.post1 (pinned by sglang) | 128, 512, 1024, 2048 |
| v0.6.17 (latest stable) | 128, 512, 1024, 2048 |
| nightly 0.6.18 | 128, **192**, **256**, 512, 1024, 2048 |

sglang pins `flashinfer_python==0.6.15.post1`, so this change is what works on the
pinned dependency. When the pin moves to a release carrying #4380, switching to the
exact width is a one-line follow-up.

I prototyped that follow-up (probe `_DECODE_DSV4_DISPATCH` at runtime, use 192 when
present, fall back otherwise) and measured it — see below. It made no measurable
difference, so it is not included here rather than carrying the extra complexity and
its two fragile assumptions (intersecting across head counts, and using the decode
table as a proxy because FlashInfer exposes no prefill capability query).

## Measurements

4x RTX 6000D (SM120), TP4, `deepseek-ai/DeepSeek-V4-Flash-0731`,
`--moe-runner-backend flashinfer_mxfp4 --speculative-algorithm DSPARK`,
`--mem-fraction-static 0.80`. ISL 8192 / OSL 1024.

Rounded 512 (this PR) vs exact 192 (nightly-0.6.18 build), same tree, same FlashInfer:

| bs | width | throughput (tok/s) | TPOT (ms) | ITL (ms) |
| --- | --- | --- | --- | --- |
| 1 | 192 | 91.00 | 10.87 | 9.82 |
| 1 | 512 | 92.13 | 10.73 | 9.82 |
| 8 | 192 | 313.41 | 18.00 | 10.62 |
| 8 | 512 | 311.69 | 17.09 | 10.63 |
| 32 | 192 | 520.8 / 522.2 | 37.7 / 39.0 | 21.4 / 22.4 |
| 32 | 512 | 524.5 / 522.7 | 38.4 / 38.4 | 21.2 / 21.9 |

Identical within run-to-run noise at every batch size (bs=32 was repeated twice per
arm; the within-arm spread is as large as the between-arm difference).

Accuracy, `sgl-eval run aime25 --n-repeats 16 --max-tokens 200000` (480 samples):

| arch | pass@1 | spread | truncated |
| --- | --- | --- | --- |
| SM120, 4x RTX 6000D | **98.54%** (473/480) | 96.7–100%, stdev 1.71% | 0 |
| SM100, 4x B200 (reference, no patch needed) | 98.96% (475/480) | 93.3–100%, stdev 2.01% | 0 |

The SM120 row is re-measured on the exact commit in this PR. An earlier run of the same
eval on the pre-cleanup variant of this patch (module-level arch detection instead of the
lazy call) gave 98.33% / stdev 3.65%, i.e. the same result within noise.

Without this change the SM120 server never reaches ready state, so there is no
same-arch baseline to compare against.

## Regression check

No effect off SM120: `_sm120_index_width` returns its argument unchanged when
`is_sm120_supported()` is false, and arch detection is called inside the function so it
does not pull CUDA into module import.

On SM120 with `DeepSeek-V4-Flash` (fp8), FlashInfer 0.6.18, GSM8K 50q:

| config | accuracy | TPOT (ISL 8K, bs1) |
| --- | --- | --- |
| deep_gemm MoE | 0.980 | 12.41 ms |
| MTP-2 | 0.960 | 6.97 ms |

Both match their pre-existing baselines.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31684742437](https://github.com/sgl-project/sglang/actions/runs/31684742437)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31684742223](https://github.com/sgl-project/sglang/actions/runs/31684742223)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->
