### PR TITLE
[CI] Fix argument quoting in AMD install_with_retry

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -45,14 +45,17 @@ fi
 docker exec ci_sglang chown -R root:root /sgl-data/pip-cache 2>/dev/null || true
 docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache --upgrade pip
 
-# Helper function to install with retries and fallback PyPI mirror
+# Helper function to install with retries and fallback PyPI mirror.
+# Executes the argument vector as-is (no eval): flattening into a string and
+# re-parsing dropped the caller's quoting, so "sgl-eval @ git+..." reached pip
+# as three requirements and 'httpx>=0.25.0' turned its > into a redirection.
 install_with_retry() {
   local max_attempts=3
-  local cmd="$@"
+  local -a cmd=("$@")
 
   for attempt in $(seq 1 $max_attempts); do
-    echo "Attempt $attempt/$max_attempts: $cmd"
-    if eval "$cmd"; then
+    echo "Attempt $attempt/$max_attempts: ${cmd[*]}"
+    if "${cmd[@]}"; then
       echo "Success!"
       return 0
     fi
@@ -61,9 +64,9 @@ install_with_retry() {
       echo "Failed, retrying in 5 seconds..."
       sleep 5
       # Try with alternative PyPI index on retry
-      if [[ "$cmd" =~ "pip install" ]] && [ $attempt -eq 2 ]; then
-        cmd="$cmd --index-url https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com"
-        echo "Using fallback PyPI mirror: $cmd"
+      if [[ "${cmd[*]}" =~ "pip install" ]] && [ $attempt -eq 2 ]; then
+        cmd+=(--index-url https://mirrors.aliyun.com/pypi/simple/ --trusted-host mirrors.aliyun.com)
+        echo "Using fallback PyPI mirror: ${cmd[*]}"
       fi
     fi
   done


### PR DESCRIPTION
## Motivation

Every multimodal-gen AMD lane (`PR Test ROCm 7.2 (AMD)`) currently fails in **Install dependencies**, on every PR (reproduced on this branch, `kan/unify_shmem`, and #34713):

```
Attempt 3/3: docker exec ci_sglang pip install ... sgl-eval @ git+https://github.com/sgl-project/sgl-eval.git@6690895...
ERROR: Invalid requirement: '@': Expected package name at the start of dependency specifier
```

The call site quotes correctly (`install_with_retry docker exec ci_sglang pip install ... "$SGL_EVAL_SPEC"`), but the helper flattens its argument vector into a string (`local cmd="$@"`) and runs it through `eval`, which re-splits on whitespace — the spec reaches pip as three requirements and pip aborts on the bare `@`.

Same root cause, second symptom: `'httpx>=0.25.0'` re-parses with `>` as a **redirection**, so that line has been silently installing unpinned `httpx` and writing a file named `=0.25.0` in the workdir.

## Modifications

Keep the argv as an array and execute it directly (`"${cmd[@]}"`); the PyPI-mirror fallback appends array elements instead of string-concatenating. All five call sites in the script pass plain argument vectors, so `eval` semantics were never needed.

Verified with `bash -n` plus an argv simulation: the spec stays one argument, `httpx>=0.25.0` stays a literal.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.io/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.io/developer_guide/contribution_guide.html#running-unit-tests) (CI shell helper; the AMD lane itself is the test).
- [x] Update documentation as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31688064048](https://github.com/sgl-project/sglang/actions/runs/31688064048)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31688065750](https://github.com/sgl-project/sglang/actions/runs/31688065750)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->