### PR TITLE
[PD] Batch final DSV4 SWA transfer

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -45,8 +45,10 @@ from sglang.srt.disaggregation.utils import (
     DisaggregationMode,
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
+    pack_state_types,
     resolve_dcp_dst_entry_indices,
     resolve_state_component_dst_index,
+    unpack_state_types,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs
@@ -140,6 +142,7 @@ class KVArgsRegisterInfo:
     dst_state_dim_per_tensor: List[List[int]]
     dst_kv_layer_ids: List[int]
     dst_state_layer_ids: List[List[int]]
+    dst_state_types: List[StateType] = dataclasses.field(default_factory=list)
     dst_dcp_size: int = 1
     dst_dcp_rank: int = 0
     requires_dcp_relayout: bool = False
@@ -176,6 +179,7 @@ class KVArgsRegisterInfo:
                 if len(msg) > 13 and msg[13] != b""
                 else []
             ),
+            dst_state_types=unpack_state_types(msg[18]) if len(msg) > 18 else [],
             staging_base_ptr=(
                 struct.unpack("Q", msg[14])[0]
                 if len(msg) > 14 and len(msg[14]) == 8
@@ -924,23 +928,17 @@ class MooncakeKVManager(CommonKVManager):
             dst_device_data_ptrs=dst_device_kv_ptrs,
         )
 
-    def _find_draft_swa_component_index(
-        self, prefill_state_indices: List
-    ) -> Optional[int]:
+    def _swa_state_component_indices(self, prefill_state_indices: List) -> List[int]:
         state_types = self.kv_args.state_types
-        for state_type in (StateType.SWA, StateType.SWA_RING):
-            matching_indices = [
-                index
-                for index, item in enumerate(state_types)
-                if item == state_type
-                and index < len(prefill_state_indices)
-                and prefill_state_indices[index] is not None
-            ]
-            if len(matching_indices) >= 2:
-                return matching_indices[-1]
-        return None
+        return [
+            index
+            for index, item in enumerate(state_types)
+            if item in (StateType.SWA, StateType.SWA_RING)
+            and index < len(prefill_state_indices)
+            and prefill_state_indices[index] is not None
+        ]
 
-    def send_kvcache_with_draft_swa(
+    def send_kvcache_with_swa_states(
         self,
         req: TransferInfo,
         prefill_kv_indices: npt.NDArray[np.int32],
@@ -948,19 +946,17 @@ class MooncakeKVManager(CommonKVManager):
         dst_kv_indices: npt.NDArray[np.int32],
         prefill_state_indices: List,
         target_rank_registration_info: KVArgsRegisterInfo,
-    ) -> Optional[Tuple[int, int]]:
-        """Batch the final target KV and DSV4 draft SWA into one RDMA submit.
+    ) -> Optional[Tuple[int, set[int]]]:
+        """Batch the final target KV and SWA states into one RDMA submit.
 
         Returns ``None`` when the request is not eligible. Otherwise returns the
-        transfer status and the source state-component index consumed here.
+        transfer status and source state-component indices consumed here.
         """
         if self.enable_custom_mem_pool or not self.is_mla_backend:
             return None
 
-        component_index = self._find_draft_swa_component_index(
-            prefill_state_indices
-        )
-        if component_index is None:
+        component_indices = self._swa_state_component_indices(prefill_state_indices)
+        if not component_indices:
             return None
 
         self._validate_envelope_kv_layout(
@@ -970,37 +966,6 @@ class MooncakeKVManager(CommonKVManager):
         )
 
         state_types = self.kv_args.state_types
-        state_type = state_types[component_index]
-        dst_component_index = resolve_state_component_dst_index(
-            state_types,
-            target_rank_registration_info.dst_state_types,
-            component_index,
-        )
-        if (
-            dst_component_index
-            >= len(target_rank_registration_info.dst_state_data_ptrs)
-            or dst_component_index >= len(req.dst_state_indices)
-        ):
-            return -1, component_index
-
-        src_state_indices = list(prefill_state_indices[component_index])
-        dst_state_indices = list(req.dst_state_indices[dst_component_index])
-        if len(src_state_indices) != len(dst_state_indices):
-            if self._requires_exact_state_index_match(state_type):
-                raise RuntimeError(
-                    f"{state_type.upper()} state index length mismatch: "
-                    f"prefill={len(src_state_indices)}, "
-                    f"dst={len(dst_state_indices)}"
-                )
-            logger.warning(
-                "len(prefill_state_indices) = %s, len(dst_state_indices) = %s",
-                len(src_state_indices),
-                len(dst_state_indices),
-            )
-            common_len = min(len(src_state_indices), len(dst_state_indices))
-            src_state_indices = src_state_indices[:common_len]
-            dst_state_indices = dst_state_indices[:common_len]
-
         kv_block_groups = self._build_kvcache_transfer_block_groups(
             src_data_ptrs=self.kv_args.kv_data_ptrs,
             dst_data_ptrs=dst_kv_ptrs,
@@ -1010,18 +975,53 @@ class MooncakeKVManager(CommonKVManager):
             src_layer_ids=self.kv_args.kv_layer_ids,
             dst_layer_ids=target_rank_registration_info.dst_kv_layer_ids,
         )
-        state_block_groups = self._build_kvcache_transfer_block_groups(
-            src_data_ptrs=self.kv_args.state_data_ptrs[component_index],
-            dst_data_ptrs=target_rank_registration_info.dst_state_data_ptrs[
-                dst_component_index
-            ],
-            item_lens=self.kv_args.state_item_lens[component_index],
-            prefill_data_indices=np.asarray(src_state_indices, dtype=np.int32),
-            dst_data_indices=np.asarray(dst_state_indices, dtype=np.int32),
-            state_type=state_type,
-        )
-        if kv_block_groups is None or state_block_groups is None:
-            return -1, component_index
+        if kv_block_groups is None:
+            return -1, set(component_indices)
+
+        state_block_groups = []
+        for component_index in component_indices:
+            state_type = state_types[component_index]
+            dst_component_index = resolve_state_component_dst_index(
+                state_types,
+                target_rank_registration_info.dst_state_types,
+                component_index,
+            )
+            if dst_component_index >= len(
+                target_rank_registration_info.dst_state_data_ptrs
+            ) or dst_component_index >= len(req.dst_state_indices):
+                return -1, set(component_indices)
+
+            src_state_indices = list(prefill_state_indices[component_index])
+            dst_state_indices = list(req.dst_state_indices[dst_component_index])
+            if len(src_state_indices) != len(dst_state_indices):
+                if self._requires_exact_state_index_match(state_type):
+                    raise RuntimeError(
+                        f"{state_type.upper()} state index length mismatch: "
+                        f"prefill={len(src_state_indices)}, "
+                        f"dst={len(dst_state_indices)}"
+                    )
+                logger.warning(
+                    "len(prefill_state_indices) = %s, len(dst_state_indices) = %s",
+                    len(src_state_indices),
+                    len(dst_state_indices),
+                )
+                common_len = min(len(src_state_indices), len(dst_state_indices))
+                src_state_indices = src_state_indices[:common_len]
+                dst_state_indices = dst_state_indices[:common_len]
+
+            block_groups = self._build_kvcache_transfer_block_groups(
+                src_data_ptrs=self.kv_args.state_data_ptrs[component_index],
+                dst_data_ptrs=target_rank_registration_info.dst_state_data_ptrs[
+                    dst_component_index
+                ],
+                item_lens=self.kv_args.state_item_lens[component_index],
+                prefill_data_indices=np.asarray(src_state_indices, dtype=np.int32),
+                dst_data_indices=np.asarray(dst_state_indices, dtype=np.int32),
+                state_type=state_type,
+            )
+            if block_groups is None:
+                return -1, set(component_indices)
+            state_block_groups.extend(block_groups)
 
         transfer_blocks = [
             block
@@ -1030,7 +1030,7 @@ class MooncakeKVManager(CommonKVManager):
         ]
         return (
             self._transfer_data(req.mooncake_session_id, transfer_blocks),
-            component_index,
+            set(component_indices),
         )
 
     def send_kvcache_dcp(
@@ -1889,7 +1889,7 @@ class MooncakeKVManager(CommonKVManager):
                         skip_kv, skip_state = self._get_dsa_cache_transfer_skip_flags(
                             target_rank_registration_info
                         )
-                        batched_state_component_index = None
+                        batched_state_component_indices = None
                         if (
                             len(kv_chunk.prefill_kv_indices) == 0
                             or not self.kv_args.kv_data_ptrs
@@ -1930,7 +1930,7 @@ class MooncakeKVManager(CommonKVManager):
                                 and not skip_state
                                 and chunked_dst_device_kv_indice is None
                             ):
-                                batched_result = self.send_kvcache_with_draft_swa(
+                                batched_result = self.send_kvcache_with_swa_states(
                                     req,
                                     kv_chunk.prefill_kv_indices,
                                     target_rank_registration_info.dst_kv_ptrs,
@@ -1951,7 +1951,7 @@ class MooncakeKVManager(CommonKVManager):
                                     dst_attn_tp_size=target_rank_registration_info.dst_attn_tp_size,
                                 )
                             else:
-                                ret, batched_state_component_index = batched_result
+                                ret, batched_state_component_indices = batched_result
                         elif (
                             self.enable_staging
                             and staging_strategy is not None
@@ -2016,11 +2016,7 @@ class MooncakeKVManager(CommonKVManager):
                                     kv_chunk.state_indices,
                                     executor,
                                     target_rank_registration_info,
-                                    (
-                                        {batched_state_component_index}
-                                        if batched_state_component_index is not None
-                                        else None
-                                    ),
+                                    batched_state_component_indices,
                                 )
                                 if state_rc != 0:
                                     with self.session_lock:
@@ -2552,6 +2548,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_state_types = pack_state_types(self.kv_mgr.kv_args.state_types)
             packed_kv_layer_ids = b"".join(
                 struct.pack("I", layer_id)
                 for layer_id in self.kv_mgr.kv_args.kv_layer_ids
@@ -2604,6 +2601,7 @@ class MooncakeKVReceiver(CommonKVReceiver):
                             staging_total_size_str,
                             dst_dcp_size,
                             dst_dcp_rank,
+                            packed_state_types,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -46,6 +46,7 @@ from sglang.srt.disaggregation.utils import (
     build_transfer_entry_pairs,
     compute_mamba_state_slice_byte_blocks,
     resolve_dcp_dst_entry_indices,
+    resolve_state_component_dst_index,
 )
 from sglang.srt.distributed.parallel_state import get_mooncake_transfer_engine
 from sglang.srt.environ import envs

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -654,30 +654,20 @@ class MooncakeKVManager(CommonKVManager):
             mooncake_session_id, list(src_addrs), list(dst_addrs), list(lengths)
         )
 
-    def _send_kvcache_generic(
+    def _build_kvcache_transfer_block_groups(
         self,
-        mooncake_session_id: str,
         src_data_ptrs: list[int],
         dst_data_ptrs: list[int],
         item_lens: list[int],
         prefill_data_indices: npt.NDArray[np.int32],
         dst_data_indices: npt.NDArray[np.int32],
-        executor: concurrent.futures.ThreadPoolExecutor,
         state_type: Optional[StateType] = None,
         force_flat: bool = False,
         src_layer_ids: Optional[List[int]] = None,
         dst_layer_ids: Optional[List[int]] = None,
         dst_device_data_indices: Optional[npt.NDArray[np.int32]] = None,
         dst_device_data_ptrs: Optional[set[int]] = None,
-    ) -> int:
-        """
-        Generic KV cache transfer supporting both MHA and MLA architectures.
-        This method is used by both send_kvcache (full pool) and maybe_send_extra.
-
-        ``force_flat`` uses the MLA-style flat (single-buffer-per-layer) layout
-        even on a non-MLA backend, for K-only state buffers (e.g. MiniMax sparse
-        index) whose per-layer list must not be half-split into K/V.
-        """
+    ) -> Optional[List[List[Tuple[int, int, int]]]]:
         # Host and device buffers may use different destination page spaces.
         # Build both transfer plans once, then select per destination buffer.
         prefill_kv_blocks, dst_kv_blocks = group_concurrent_contiguous(
@@ -733,7 +723,7 @@ class MooncakeKVManager(CommonKVManager):
                     "Prefill transfer kvcache error, layers_current_pp_stage is out of range: "
                     f"layers_current_pp_stage={layers_current_pp_stage}, len(dst_k_ptrs)={len(dst_k_ptrs)}"
                 )
-                return -1
+                return None
             layers_params = [
                 (
                     src_k_ptrs[layer_id],
@@ -773,27 +763,61 @@ class MooncakeKVManager(CommonKVManager):
                 transfer_blocks.append((src_addr, dst_addr, length))
             return transfer_blocks
 
-        # Worker function for processing a single layer
-        def process_layer(src_ptr: int, dst_ptr: int, item_len: int) -> int:
-            transfer_blocks = set_transfer_blocks(src_ptr, dst_ptr, item_len)
-            return self._transfer_data(mooncake_session_id, transfer_blocks)
+        return [
+            set_transfer_blocks(src_ptr, dst_ptr, item_len)
+            for src_ptr, dst_ptr, item_len in layers_params
+        ]
 
-        # Worker function for processing all layers in a batch
-        def process_layers(layers_params: List[Tuple[int, int, int]]) -> int:
-            transfer_blocks = []
-            for src_ptr, dst_ptr, item_len in layers_params:
-                transfer_blocks.extend(set_transfer_blocks(src_ptr, dst_ptr, item_len))
+    def _send_kvcache_generic(
+        self,
+        mooncake_session_id: str,
+        src_data_ptrs: list[int],
+        dst_data_ptrs: list[int],
+        item_lens: list[int],
+        prefill_data_indices: npt.NDArray[np.int32],
+        dst_data_indices: npt.NDArray[np.int32],
+        executor: concurrent.futures.ThreadPoolExecutor,
+        state_type: Optional[StateType] = None,
+        force_flat: bool = False,
+        src_layer_ids: Optional[List[int]] = None,
+        dst_layer_ids: Optional[List[int]] = None,
+        dst_device_data_indices: Optional[npt.NDArray[np.int32]] = None,
+        dst_device_data_ptrs: Optional[set[int]] = None,
+    ) -> int:
+        """
+        Generic KV cache transfer supporting both MHA and MLA architectures.
+        This method is used by both send_kvcache (full pool) and maybe_send_extra.
+
+        ``force_flat`` uses the MLA-style flat (single-buffer-per-layer) layout
+        even on a non-MLA backend, for K-only state buffers (e.g. MiniMax sparse
+        index) whose per-layer list must not be half-split into K/V.
+        """
+        transfer_block_groups = self._build_kvcache_transfer_block_groups(
+            src_data_ptrs=src_data_ptrs,
+            dst_data_ptrs=dst_data_ptrs,
+            item_lens=item_lens,
+            prefill_data_indices=prefill_data_indices,
+            dst_data_indices=dst_data_indices,
+            state_type=state_type,
+            force_flat=force_flat,
+            src_layer_ids=src_layer_ids,
+            dst_layer_ids=dst_layer_ids,
+            dst_device_data_indices=dst_device_data_indices,
+            dst_device_data_ptrs=dst_device_data_ptrs,
+        )
+        if transfer_block_groups is None:
+            return -1
+
+        def process_blocks(transfer_blocks: List[Tuple[int, int, int]]) -> int:
             return self._transfer_data(mooncake_session_id, transfer_blocks)
 
         if self.enable_custom_mem_pool:
             futures = [
                 executor.submit(
-                    process_layer,
-                    src_ptr,
-                    dst_ptr,
-                    item_len,
+                    process_blocks,
+                    transfer_blocks,
                 )
-                for (src_ptr, dst_ptr, item_len) in layers_params
+                for transfer_blocks in transfer_block_groups
             ]
             for future in concurrent.futures.as_completed(futures):
                 status = future.result()
@@ -805,7 +829,13 @@ class MooncakeKVManager(CommonKVManager):
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads
-            return process_layers(layers_params)
+            return process_blocks(
+                [
+                    block
+                    for transfer_blocks in transfer_block_groups
+                    for block in transfer_blocks
+                ]
+            )
 
     def _validate_envelope_kv_layout(
         self,
@@ -891,6 +921,115 @@ class MooncakeKVManager(CommonKVManager):
             dst_layer_ids=dst_layer_ids,
             dst_device_data_indices=dst_device_kv_indices,
             dst_device_data_ptrs=dst_device_kv_ptrs,
+        )
+
+    def _find_draft_swa_component_index(
+        self, prefill_state_indices: List
+    ) -> Optional[int]:
+        state_types = self.kv_args.state_types
+        for state_type in (StateType.SWA, StateType.SWA_RING):
+            matching_indices = [
+                index
+                for index, item in enumerate(state_types)
+                if item == state_type
+                and index < len(prefill_state_indices)
+                and prefill_state_indices[index] is not None
+            ]
+            if len(matching_indices) >= 2:
+                return matching_indices[-1]
+        return None
+
+    def send_kvcache_with_draft_swa(
+        self,
+        req: TransferInfo,
+        prefill_kv_indices: npt.NDArray[np.int32],
+        dst_kv_ptrs: list[int],
+        dst_kv_indices: npt.NDArray[np.int32],
+        prefill_state_indices: List,
+        target_rank_registration_info: KVArgsRegisterInfo,
+    ) -> Optional[Tuple[int, int]]:
+        """Batch the final target KV and DSV4 draft SWA into one RDMA submit.
+
+        Returns ``None`` when the request is not eligible. Otherwise returns the
+        transfer status and the source state-component index consumed here.
+        """
+        if self.enable_custom_mem_pool or not self.is_mla_backend:
+            return None
+
+        component_index = self._find_draft_swa_component_index(
+            prefill_state_indices
+        )
+        if component_index is None:
+            return None
+
+        self._validate_envelope_kv_layout(
+            dst_kv_ptrs,
+            target_rank_registration_info.dst_kv_item_len,
+            target_rank_registration_info.dst_attn_tp_size,
+        )
+
+        state_types = self.kv_args.state_types
+        state_type = state_types[component_index]
+        dst_component_index = resolve_state_component_dst_index(
+            state_types,
+            target_rank_registration_info.dst_state_types,
+            component_index,
+        )
+        if (
+            dst_component_index
+            >= len(target_rank_registration_info.dst_state_data_ptrs)
+            or dst_component_index >= len(req.dst_state_indices)
+        ):
+            return -1, component_index
+
+        src_state_indices = list(prefill_state_indices[component_index])
+        dst_state_indices = list(req.dst_state_indices[dst_component_index])
+        if len(src_state_indices) != len(dst_state_indices):
+            if self._requires_exact_state_index_match(state_type):
+                raise RuntimeError(
+                    f"{state_type.upper()} state index length mismatch: "
+                    f"prefill={len(src_state_indices)}, "
+                    f"dst={len(dst_state_indices)}"
+                )
+            logger.warning(
+                "len(prefill_state_indices) = %s, len(dst_state_indices) = %s",
+                len(src_state_indices),
+                len(dst_state_indices),
+            )
+            common_len = min(len(src_state_indices), len(dst_state_indices))
+            src_state_indices = src_state_indices[:common_len]
+            dst_state_indices = dst_state_indices[:common_len]
+
+        kv_block_groups = self._build_kvcache_transfer_block_groups(
+            src_data_ptrs=self.kv_args.kv_data_ptrs,
+            dst_data_ptrs=dst_kv_ptrs,
+            item_lens=self.kv_args.kv_item_lens,
+            prefill_data_indices=prefill_kv_indices,
+            dst_data_indices=dst_kv_indices,
+            src_layer_ids=self.kv_args.kv_layer_ids,
+            dst_layer_ids=target_rank_registration_info.dst_kv_layer_ids,
+        )
+        state_block_groups = self._build_kvcache_transfer_block_groups(
+            src_data_ptrs=self.kv_args.state_data_ptrs[component_index],
+            dst_data_ptrs=target_rank_registration_info.dst_state_data_ptrs[
+                dst_component_index
+            ],
+            item_lens=self.kv_args.state_item_lens[component_index],
+            prefill_data_indices=np.asarray(src_state_indices, dtype=np.int32),
+            dst_data_indices=np.asarray(dst_state_indices, dtype=np.int32),
+            state_type=state_type,
+        )
+        if kv_block_groups is None or state_block_groups is None:
+            return -1, component_index
+
+        transfer_blocks = [
+            block
+            for block_group in kv_block_groups + state_block_groups
+            for block in block_group
+        ]
+        return (
+            self._transfer_data(req.mooncake_session_id, transfer_blocks),
+            component_index,
         )
 
     def send_kvcache_dcp(
@@ -1267,10 +1406,13 @@ class MooncakeKVManager(CommonKVManager):
         prefill_state_indices: List,
         executor: concurrent.futures.ThreadPoolExecutor,
         target_rank_registration_info: Optional[KVArgsRegisterInfo] = None,
+        skip_component_indices: Optional[set[int]] = None,
     ):
         rc = 0
         state_types = getattr(self.kv_args, "state_types", [])
         for i, st in enumerate(state_types):
+            if skip_component_indices and i in skip_component_indices:
+                continue
             indices = (
                 prefill_state_indices[i] if i < len(prefill_state_indices) else None
             )
@@ -1746,6 +1888,7 @@ class MooncakeKVManager(CommonKVManager):
                         skip_kv, skip_state = self._get_dsa_cache_transfer_skip_flags(
                             target_rank_registration_info
                         )
+                        batched_state_component_index = None
                         if (
                             len(kv_chunk.prefill_kv_indices) == 0
                             or not self.kv_args.kv_data_ptrs
@@ -1779,17 +1922,35 @@ class MooncakeKVManager(CommonKVManager):
                             or self.attn_tp_size
                             == target_rank_registration_info.dst_attn_tp_size
                         ):
-                            ret = self.send_kvcache(
-                                req.mooncake_session_id,
-                                kv_chunk.prefill_kv_indices,
-                                target_rank_registration_info.dst_kv_ptrs,
-                                chunked_dst_kv_indice,
-                                executor,
-                                dst_layer_ids=target_rank_registration_info.dst_kv_layer_ids,
-                                dst_device_kv_indices=chunked_dst_device_kv_indice,
-                                dst_kv_item_len=target_rank_registration_info.dst_kv_item_len,
-                                dst_attn_tp_size=target_rank_registration_info.dst_attn_tp_size,
-                            )
+                            batched_result = None
+                            if (
+                                kv_chunk.is_last_chunk
+                                and kv_chunk.state_indices
+                                and not skip_state
+                                and chunked_dst_device_kv_indice is None
+                            ):
+                                batched_result = self.send_kvcache_with_draft_swa(
+                                    req,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    kv_chunk.state_indices,
+                                    target_rank_registration_info,
+                                )
+                            if batched_result is None:
+                                ret = self.send_kvcache(
+                                    req.mooncake_session_id,
+                                    kv_chunk.prefill_kv_indices,
+                                    target_rank_registration_info.dst_kv_ptrs,
+                                    chunked_dst_kv_indice,
+                                    executor,
+                                    dst_layer_ids=target_rank_registration_info.dst_kv_layer_ids,
+                                    dst_device_kv_indices=chunked_dst_device_kv_indice,
+                                    dst_kv_item_len=target_rank_registration_info.dst_kv_item_len,
+                                    dst_attn_tp_size=target_rank_registration_info.dst_attn_tp_size,
+                                )
+                            else:
+                                ret, batched_state_component_index = batched_result
                         elif (
                             self.enable_staging
                             and staging_strategy is not None
@@ -1854,6 +2015,11 @@ class MooncakeKVManager(CommonKVManager):
                                     kv_chunk.state_indices,
                                     executor,
                                     target_rank_registration_info,
+                                    (
+                                        {batched_state_component_index}
+                                        if batched_state_component_index is not None
+                                        else None
+                                    ),
                                 )
                                 if state_rc != 0:
                                     with self.session_lock:

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1010,6 +1010,21 @@ def resolve_dcp_dst_entry_indices(
     ]
 
 
+def pack_state_types(state_types) -> bytes:
+    return ",".join(
+        state_type.value if isinstance(state_type, Enum) else str(state_type)
+        for state_type in (state_types or [])
+    ).encode("ascii")
+
+
+def unpack_state_types(data: bytes):
+    from sglang.srt.disaggregation.base.conn import StateType
+
+    if not data:
+        return []
+    return [StateType(value) for value in data.decode("ascii").split(",") if value]
+
+
 def resolve_state_component_dst_index(src_state_types, dst_state_types, src_index: int):
     """Map a source state component to the matching destination component.
 

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1010,6 +1010,41 @@ def resolve_dcp_dst_entry_indices(
     ]
 
 
+def resolve_state_component_dst_index(src_state_types, dst_state_types, src_index: int):
+    """Map a source state component to the matching destination component.
+
+    Older registrations did not carry state_types; keep positional behavior in
+    that case. When available, match by StateType occurrence so optional target
+    components (for example C128_STATE) do not shift draft state components.
+    """
+    if not dst_state_types:
+        return src_index
+    if not src_state_types:
+        raise RuntimeError(
+            "Destination state_types are present but source state_types are empty."
+        )
+    if src_index >= len(src_state_types):
+        raise RuntimeError(
+            f"Source state component index {src_index} exceeds "
+            f"state_types length {len(src_state_types)}."
+        )
+
+    state_type = src_state_types[src_index]
+    occurrence = sum(
+        1 for item in src_state_types[: src_index + 1] if item == state_type
+    )
+    seen = 0
+    for dst_index, dst_state_type in enumerate(dst_state_types):
+        if dst_state_type == state_type:
+            seen += 1
+            if seen == occurrence:
+                return dst_index
+
+    raise RuntimeError(
+        f"Decode peer is missing state component {state_type} occurrence {occurrence}."
+    )
+
+
 def append_state_component(
     kv_args: KVArgs,
     state_type: StateType,

--- a/test/registered/unit/disaggregation/test_mooncake_dspark_transfer_batch.py
+++ b/test/registered/unit/disaggregation/test_mooncake_dspark_transfer_batch.py
@@ -1,0 +1,81 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import StateType
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMooncakeDSparkTransferBatch(unittest.TestCase):
+    def _manager(self):
+        manager = MooncakeKVManager.__new__(MooncakeKVManager)
+        manager.enable_custom_mem_pool = False
+        manager.is_mla_backend = True
+        manager.is_hybrid_mla_backend = False
+        manager.pp_size = 1
+        manager.kv_args = SimpleNamespace(
+            kv_data_ptrs=[100],
+            kv_item_lens=[4],
+            kv_layer_ids=[40],
+            state_types=[StateType.SWA, StateType.C128_STATE, StateType.SWA],
+            state_data_ptrs=[[200], [300], [400]],
+            state_item_lens=[[8], [16], [8]],
+        )
+        manager._validate_envelope_kv_layout = MagicMock()
+        manager._transfer_data = MagicMock(return_value=0)
+        return manager
+
+    def test_only_repeated_swa_has_a_draft_component(self):
+        manager = self._manager()
+        self.assertEqual(
+            manager._find_draft_swa_component_index([[1], [2], [3]]), 2
+        )
+
+        manager.kv_args.state_types = [StateType.SWA, StateType.C128_STATE]
+        self.assertIsNone(manager._find_draft_swa_component_index([[1], [2]]))
+
+    def test_target_kv_and_draft_swa_share_one_submit(self):
+        manager = self._manager()
+        req = SimpleNamespace(
+            mooncake_session_id="session",
+            dst_state_indices=[[11], [12], [7]],
+        )
+        registration = SimpleNamespace(
+            dst_kv_item_len=4,
+            dst_attn_tp_size=1,
+            dst_kv_layer_ids=[40],
+            dst_state_types=[
+                StateType.SWA,
+                StateType.C128_STATE,
+                StateType.SWA,
+            ],
+            dst_state_data_ptrs=[[600], [700], [800]],
+        )
+
+        result = manager.send_kvcache_with_draft_swa(
+            req=req,
+            prefill_kv_indices=np.asarray([1, 2], dtype=np.int32),
+            dst_kv_ptrs=[500],
+            dst_kv_indices=np.asarray([3, 4], dtype=np.int32),
+            prefill_state_indices=[[9], [10], [5]],
+            target_rank_registration_info=registration,
+        )
+
+        self.assertEqual(result, (0, 2))
+        manager._validate_envelope_kv_layout.assert_called_once_with([500], 4, 1)
+        manager._transfer_data.assert_called_once_with(
+            "session",
+            [
+                (104, 512, 8),
+                (440, 856, 8),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_mooncake_dspark_transfer_batch.py
+++ b/test/registered/unit/disaggregation/test_mooncake_dspark_transfer_batch.py
@@ -30,16 +30,14 @@ class TestMooncakeDSparkTransferBatch(unittest.TestCase):
         manager._transfer_data = MagicMock(return_value=0)
         return manager
 
-    def test_only_repeated_swa_has_a_draft_component(self):
+    def test_finds_all_available_swa_components(self):
         manager = self._manager()
-        self.assertEqual(
-            manager._find_draft_swa_component_index([[1], [2], [3]]), 2
-        )
+        self.assertEqual(manager._swa_state_component_indices([[1], [2], [3]]), [0, 2])
 
         manager.kv_args.state_types = [StateType.SWA, StateType.C128_STATE]
-        self.assertIsNone(manager._find_draft_swa_component_index([[1], [2]]))
+        self.assertEqual(manager._swa_state_component_indices([[1], [2]]), [0])
 
-    def test_target_kv_and_draft_swa_share_one_submit(self):
+    def test_target_kv_and_swa_states_share_one_submit(self):
         manager = self._manager()
         req = SimpleNamespace(
             mooncake_session_id="session",
@@ -57,7 +55,7 @@ class TestMooncakeDSparkTransferBatch(unittest.TestCase):
             dst_state_data_ptrs=[[600], [700], [800]],
         )
 
-        result = manager.send_kvcache_with_draft_swa(
+        result = manager.send_kvcache_with_swa_states(
             req=req,
             prefill_kv_indices=np.asarray([1, 2], dtype=np.int32),
             dst_kv_ptrs=[500],
@@ -66,12 +64,13 @@ class TestMooncakeDSparkTransferBatch(unittest.TestCase):
             target_rank_registration_info=registration,
         )
 
-        self.assertEqual(result, (0, 2))
+        self.assertEqual(result, (0, {0, 2}))
         manager._validate_envelope_kv_layout.assert_called_once_with([500], 4, 1)
         manager._transfer_data.assert_called_once_with(
             "session",
             [
                 (104, 512, 8),
+                (272, 688, 8),
                 (440, 856, 8),
             ],
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Reduce Mooncake PD transfer overhead for DeepSeek-V4 DSpark by batching the final target KV transfer and draft SWA state transfer into a single RDMA submit when the last chunk is sent. This avoids issuing a separate transfer for draft SWA after target KV has already been transferred.

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

Refactored Mooncake KV transfer block construction into a reusable helper so both normal KV transfer and the new batched path share the same layer mapping and contiguous-block planning logic.

Added a DSpark-specific fast path for the final chunk: when the request has draft SWA state, uses MLA backend, is not using custom mem pool, and is on the normal KV transfer path, it builds one combined transfer block list containing both target KV blocks and draft SWA blocks, then submits them together.

After the combined transfer succeeds, the draft SWA state component is skipped in maybe_send_extra() to avoid duplicate state transfer. The fallback path remains unchanged for non-eligible cases, including DCP, staging, device KV indices, custom mem pool, and non-MLA paths.

Added a focused unit test covering draft SWA component detection and verifying target KV plus draft SWA are submitted in one transfer call.

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31707419487](https://github.com/sgl-project/sglang/actions/runs/31707419487)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31707419181](https://github.com/sgl-project/sglang/actions/runs/31707419181)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->