### PR TITLE
fix(dsa): use int64 page offsets in index buffer accessors

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
+++ b/python/sglang/kernels/ops/attention/dsa/index_buf_accessor.py
@@ -60,7 +60,7 @@ class GetK:
         cls, pool: "DSATokenToKVPool", buf, seq_len: int, page_indices: torch.Tensor
     ):
         """
-        :param page_indices: (num_pages,), int32
+        :param page_indices: (num_pages,), int32/int64
         :return: (seq_len, index_head_dim), uint8
         """
 
@@ -76,9 +76,12 @@ class GetK:
         # flat_buf: (whatever,), uint8
         flat_buf = buf.flatten()
 
-        # flat_indices: (num_pages, num_k_bytes_per_page), int32, element := an index into flat_buf that we want to access
-        flat_indices = (page_indices * buf_numel_per_page)[:, None] + torch.arange(
-            num_k_bytes_per_page, dtype=torch.int32, device="cuda"
+        # flat_indices: (num_pages, num_k_bytes_per_page), int64
+        # element := an index into flat_buf that we want to access
+        flat_indices = (
+            page_indices.to(torch.int64) * buf_numel_per_page
+        )[:, None] + torch.arange(
+            num_k_bytes_per_page, dtype=torch.int64, device="cuda"
         )[None, :]
         flat_indices = flat_indices.flatten()[: seq_len * num_k_bytes_per_token]
 
@@ -132,7 +135,7 @@ class GetS:
         cls, pool: "DSATokenToKVPool", buf, seq_len: int, page_indices: torch.Tensor
     ):
         """
-        :param page_indices: (num_pages,), int32
+        :param page_indices: (num_pages,), int32/int64
         :return: (seq_len, index_head_dim // quant_block_size), uint8
         """
         buf_numel_per_page = buf.shape[1]
@@ -143,8 +146,8 @@ class GetS:
 
         flat_buf = buf.flatten()
         flat_indices = (
-            (page_indices * buf_numel_per_page)[:, None]
-            + torch.arange(num_s_bytes_per_page, dtype=torch.int32, device="cuda")[
+            (page_indices.to(torch.int64) * buf_numel_per_page)[:, None]
+            + torch.arange(num_s_bytes_per_page, dtype=torch.int64, device="cuda")[
                 None, :
             ]
             + s_offset_in_page
@@ -467,7 +470,7 @@ def _get_k_triton_kernel(
     token_offset_in_page = token_id % page_size
 
     # Load the page index from page_indices
-    page_index = tl.load(page_indices_ptr + page_idx)
+    page_index = tl.load(page_indices_ptr + page_idx).to(tl.int64)
 
     # Calculate source offset in buf
     # buf[page_index, token_offset_in_page * index_head_dim : ...]
@@ -544,7 +547,7 @@ def _get_s_triton_kernel(
     token_offset_in_page = token_id % page_size
 
     # Load the page index from page_indices
-    page_index = tl.load(page_indices_ptr + page_idx)
+    page_index = tl.load(page_indices_ptr + page_idx).to(tl.int64)
 
     # Calculate source offset in buf
     # Scales are stored after K data: page_size * index_head_dim offset
@@ -677,7 +680,7 @@ def _get_k_and_s_triton_kernel(
     page_index = tl.load(
         page_indices_ptr + page_idx + page_indices_base,
         mask=token_valid_mask & page_idx_valid_mask,
-    )
+    ).to(tl.int64)
 
     # ===== Load K data =====
     # The address calculation logic for K: page_index * total number of elements in a single page + K offset of the token within the page.

--- a/test/manual/layers/attention/dsa/test_index_buf_accessor.py
+++ b/test/manual/layers/attention/dsa/test_index_buf_accessor.py
@@ -479,6 +479,71 @@ class TestEdgeCases:
         torch.testing.assert_close(k_triton2, k_torch, rtol=0, atol=0)
         torch.testing.assert_close(s_triton2, s_torch, rtol=0, atol=0)
 
+    def test_page_stride_int32_overflow(self):
+        """Test page addressing after a 32-bit page-stride product wraps."""
+        device = torch.device("cuda")
+        page_size = 64
+        index_head_dim = 128
+        buf_numel_per_page = page_size * (index_head_dim + 4)
+
+        # The production failure starts once page offsets cross 2^31. Use the
+        # first page past 2^32 here so the buggy int32 product wraps to a small
+        # positive in-buffer offset instead of causing an illegal CUDA access.
+        wrap_page = ((1 << 32) + buf_numel_per_page - 1) // buf_numel_per_page
+        wrapped_base_offset = (wrap_page * buf_numel_per_page) % (1 << 32)
+        assert wrap_page == 508401
+        assert wrapped_base_offset == 4352
+
+        required_bytes = (wrap_page + 1) * buf_numel_per_page
+        free_bytes, _ = torch.cuda.mem_get_info(device)
+        if free_bytes < required_bytes + (512 << 20):
+            pytest.skip(
+                f"needs about 4.5 GiB free GPU memory, have {free_bytes >> 20} MiB"
+            )
+
+        try:
+            buf = torch.empty(
+                (wrap_page + 1, buf_numel_per_page),
+                dtype=torch.uint8,
+                device=device,
+            )
+        except torch.OutOfMemoryError:
+            pytest.skip("could not allocate the large index buffer")
+
+        pool = MockDSATokenToKVPool(
+            page_size=page_size, index_head_dim=index_head_dim, device=device
+        )
+        expected_k = torch.arange(
+            1, index_head_dim + 1, dtype=torch.uint8, device=device
+        )
+        expected_s = torch.tensor([17, 34, 51, 68], dtype=torch.uint8, device=device)
+
+        # Make every pre-fix wrapped read deterministic and different from the
+        # marker stored at the real high page.
+        flat_buf = buf.flatten()
+        flat_buf[
+            wrapped_base_offset : wrapped_base_offset + buf_numel_per_page
+        ].zero_()
+        buf[wrap_page, :index_head_dim].copy_(expected_k)
+        s_offset_in_page = page_size * index_head_dim
+        buf[wrap_page, s_offset_in_page : s_offset_in_page + 4].copy_(expected_s)
+
+        page_indices = torch.tensor([wrap_page], dtype=torch.int32, device=device)
+        seq_lens = torch.tensor([1], dtype=torch.int64, device=device)
+
+        k_torch = GetK.torch_fast(pool, buf, 1, page_indices)
+        s_torch = GetS.torch_fast(pool, buf, 1, page_indices)
+        k_triton = GetK.triton(pool, buf, 1, page_indices)
+        s_triton = GetS.triton(pool, buf, 1, page_indices)
+        k_fused, s_fused = GetKAndS.triton(
+            pool, buf, page_indices.unsqueeze(0), seq_lens, 1, 1
+        )
+
+        for actual_k in (k_torch, k_triton, k_fused):
+            torch.testing.assert_close(actual_k[0], expected_k, rtol=0, atol=0)
+        for actual_s in (s_torch, s_triton, s_fused):
+            torch.testing.assert_close(actual_s[0], expected_s, rtol=0, atol=0)
+
     def test_large_seq_len(self):
         """Test with large sequence length."""
         device = torch.device("cuda")


### PR DESCRIPTION
## Motivation

DSA index buffer accessors compute source addresses using:

`page_index * buf_numel_per_page`

`page_indices` are commonly stored as int32. For sufficiently large index
buffers, this multiplication overflows before pointer arithmetic is widened,
causing K/scale data to be read from the wrong page and potentially producing
corrupted model output.

With a page size of 64 and index head dimension of 128, the page stride is
8448 bytes, so the signed int32 boundary is reached around page 254,200.

## Changes

- Cast page indices to int64 before page-stride multiplication in:
  - Torch GetK/GetS reference implementations
  - Standalone Triton GetK kernel
  - Standalone Triton GetS kernel
  - Fused Triton GetKAndS kernel
- Add a large-buffer regression test that exercises address offsets beyond
  the 32-bit range.
- Keep the change limited to page-indexed source address calculation.

The existing SetKAndS write path already converts destination locations to
int64 and is not changed.

## Validation

Tested on NVIDIA H20:

- `86 passed` in `test_index_buf_accessor.py`
- The large-buffer overflow regression test passed
- The same regression test failed against the unpatched implementation, with
  all 128 expected K bytes read incorrectly

Command:

```bash
PYTHONPATH=python python3 -m pytest -q \
  test/manual/layers/attention/dsa/test_index_buf_accessor.py -s

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31689654010](https://github.com/sgl-project/sglang/actions/runs/31689654010)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31689653876](https://github.com/sgl-project/sglang/actions/runs/31689653876)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->