### PR TITLE
[XPU][test] Add cache_salt=None to _make_req in test_lmcache_radix_cache.py

### DIFF
--- a/test/registered/xpu/test_lmcache_radix_cache.py
+++ b/test/registered/xpu/test_lmcache_radix_cache.py
@@ -70,6 +70,7 @@ def _make_req(rid, req_pool_idx, token_ids, tree):
         origin_input_ids=token_ids,
         output_ids=[],
         extra_key=None,
+        cache_salt=None,
         last_node=tree.root_node,
         cache_protected_len=0,
         priority=0,


### PR DESCRIPTION
## Summary

- Adds `cache_salt=None` to the `SimpleNamespace` request stand-in in `_make_req` at `test/registered/xpu/test_lmcache_radix_cache.py:64`.
- Fixes `AttributeError: 'types.SimpleNamespace' object has no attribute 'cache_salt'` on `stage-b-test-1-gpu-xpu`, introduced when #30827 added `cache_salt=req.cache_salt` to `RadixCache.cache_finished_req` (`python/sglang/srt/mem_cache/radix_cache.py:485`).
- #30827 patched the sibling stand-in in `test/registered/unit/mem_cache/test_swa_eviction_boundary.py` (this file's docstring says it mirrors that one) but missed the XPU sibling — one-line parity fix.

## Failing test

```
File "test/registered/xpu/test_lmcache_radix_cache.py", line 192, in test_store_then_load_back_through_match_prefix
    tree.cache_finished_req(req, kv_len_to_handle=len(token_ids))
File "python/sglang/srt/mem_cache/storage/lmcache/lmc_radix_cache.py", line 446, in cache_finished_req
    super().cache_finished_req(...)
File "python/sglang/srt/mem_cache/radix_cache.py", line 485, in cache_finished_req
    cache_salt=req.cache_salt,
AttributeError: 'types.SimpleNamespace' object has no attribute 'cache_salt'
```

## Blast radius

Observed on 11+ `stage-b-test-1-gpu-xpu` runs across many unrelated PRs since #30827 merged (2026-08-12 23:14Z) — e.g. runs [31660770721](https://github.com/sgl-project/sglang/actions/runs/31660770721), [31664149492](https://github.com/sgl-project/sglang/actions/runs/31664149492), [31662709715](https://github.com/sgl-project/sglang/actions/runs/31662709715), [31662394459](https://github.com/sgl-project/sglang/actions/runs/31662394459), [31661559239](https://github.com/sgl-project/sglang/actions/runs/31661559239), [31659060228](https://github.com/sgl-project/sglang/actions/runs/31659060228), [31658690490](https://github.com/sgl-project/sglang/actions/runs/31658690490), [31656310028](https://github.com/sgl-project/sglang/actions/runs/31656310028), [31655236650](https://github.com/sgl-project/sglang/actions/runs/31655236650), [31654038170](https://github.com/sgl-project/sglang/actions/runs/31654038170), [31651905553](https://github.com/sgl-project/sglang/actions/runs/31651905553).

## Test plan

- [ ] Re-run `stage-b-test-1-gpu-xpu` (`test/registered/xpu/test_lmcache_radix_cache.py::test_store_then_load_back_through_match_prefix`) and confirm it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31697254447](https://github.com/sgl-project/sglang/actions/runs/31697254447)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31758802269](https://github.com/sgl-project/sglang/actions/runs/31758802269)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->