### PR TITLE
Retain SWA down to the last state checkpoint

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -3381,6 +3381,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req_to_token_pool=self.req_to_token_pool,
             token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
             is_chunk_cache=self.tree_cache.is_chunk_cache(),
+            retain_floor=self.tree_cache.swa_retain_floor(req),
         )
 
     def __str__(self):

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -377,6 +377,14 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
     def supports_swa(self) -> bool:
         return False
 
+    def swa_retain_floor(self, req) -> int | None:
+        # Caches that pair SWA with a second state stream (mamba/conv checkpoints)
+        # cannot free SWA to the window behind the tail: a match lands on a
+        # checkpoint, not on the tail, so the window that matters sits behind the
+        # last checkpoint. Those caches override this; everyone else has nothing
+        # deeper than the tail to protect.
+        return None
+
     def swa_reprefill_tail_tokens(self) -> int:
         # Only the unified_kv compress-only HiCache layout needs to hold back a
         # trailing sliding window for re-prefill; every other cache keeps SWA

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -378,11 +378,10 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         return False
 
     def swa_retain_floor(self, req) -> int | None:
-        # Caches that pair SWA with a second state stream (mamba/conv checkpoints)
-        # cannot free SWA to the window behind the tail: a match lands on a
-        # checkpoint, not on the tail, so the window that matters sits behind the
-        # last checkpoint. Those caches override this; everyone else has nothing
-        # deeper than the tail to protect.
+        # A match lands on a state checkpoint rather than on the tail, so a cache
+        # that pairs SWA with mamba/conv checkpoints has to keep the window behind
+        # the last checkpoint. Those caches override this. Everyone else has
+        # nothing deeper than the tail to protect.
         return None
 
     def swa_reprefill_tail_tokens(self) -> int:

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -53,6 +53,7 @@ def free_swa_out_of_window_slots(
     req_to_token_pool: ReqToTokenPool,
     token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
     is_chunk_cache: bool = False,
+    retain_floor: int | None = None,
 ) -> None:
     if req.kv is None:
         return
@@ -76,6 +77,14 @@ def free_swa_out_of_window_slots(
         # boundary (page_floor(seq_len)) so the last leaf is never all-tombstone.
         # No extra page margin is needed.
         evict_threshold = pre_len - max(sliding_window_size, page_size)
+    if retain_floor is not None:
+        # A prefix match needs a full window of live SWA below the match point, and
+        # the deepest position anything can match at is the last state checkpoint.
+        # Freeing to the window behind the *tail* therefore strands checkpoints that
+        # are still reachable. The caller decides where that floor is; this function
+        # only promises not to free past it.
+        evict_threshold = min(evict_threshold, retain_floor)
+
     new_swa_evicted_seqlen = max(
         req.kv.swa_evicted_seqlen,
         evict_threshold,

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -77,12 +77,10 @@ def free_swa_out_of_window_slots(
         # boundary (page_floor(seq_len)) so the last leaf is never all-tombstone.
         # No extra page margin is needed.
         evict_threshold = pre_len - max(sliding_window_size, page_size)
-    if retain_floor is not None:
-        # A prefix match needs a full window of live SWA below the match point, and
-        # the deepest position anything can match at is the last state checkpoint.
-        # Freeing to the window behind the *tail* therefore strands checkpoints that
-        # are still reachable. The caller decides where that floor is; this function
-        # only promises not to free past it.
+    if retain_floor is not None and not is_chunk_cache:
+        # The caller owns where the floor is (see BasePrefixCache.swa_retain_floor);
+        # this only promises not to free past it. Chunk cache has no tree, so a
+        # retained checkpoint could never be matched and holding it is pure cost.
         evict_threshold = min(evict_threshold, retain_floor)
 
     new_swa_evicted_seqlen = max(

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -755,6 +755,7 @@ class SWAComponent(TreeComponent):
                 page_size=self.cache.page_size,
                 req_to_token_pool=self.cache.req_to_token_pool,
                 token_to_kv_pool_allocator=self.cache.token_to_kv_pool_allocator,
+                retain_floor=self.cache.swa_retain_floor(req),
             )
         insert_params.swa_evicted_seqlen = req.kv.swa_evicted_seqlen
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -2093,6 +2093,14 @@ class UnifiedRadixCache(BasePrefixCache):
         )
         return swa.sliding_window_size if unified_compress_only_hicache else 0
 
+    def swa_retain_floor(self, req) -> int | None:
+        if not self.is_mamba_enabled or self._sliding_window_size is None:
+            return None
+        checkpoint = req.mamba_last_track_seqlen
+        if checkpoint is None:
+            return None
+        return checkpoint - self._sliding_window_size
+
     def supports_swa(self) -> bool:
         return self.is_swa_enabled
 

--- a/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
+++ b/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
@@ -228,6 +228,33 @@ class TestSWAEvictionBoundary(unittest.TestCase):
         self.assertLessEqual(req.kv.swa_evicted_seqlen, checkpoint - window)
         self.assertEqual(req.kv.swa_evicted_seqlen % page_size, 0)
 
+    def test_retain_floor_ignored_for_chunk_cache(self):
+        """Chunk cache builds no tree, so a retained checkpoint could never be
+        matched. Holding it would cost SWA slots for nothing."""
+        page_size, window = 8, 16
+        seq_len = 200
+        tree, allocator, pool = _build_swa_tree(
+            page_size=page_size, sliding_window_size=window
+        )
+        kv = _swa_alloc(allocator, seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), 0, tree)
+        batch = _make_batch(tree, allocator, pool)
+
+        free_swa_out_of_window_slots(
+            req,
+            seq_len - 1,
+            sliding_window_size=window,
+            page_size=page_size,
+            req_to_token_pool=batch.req_to_token_pool,
+            token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,
+            is_chunk_cache=True,
+            retain_floor=16,
+        )
+
+        expected = (seq_len - 1 - window) // page_size * page_size
+        self.assertEqual(req.kv.swa_evicted_seqlen, expected)
+
     def test_retain_floor_none_matches_old_behaviour(self):
         """retain_floor=None must reproduce the pre-change frontier exactly, so a
         cache without a second state stream is unaffected."""

--- a/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
+++ b/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
@@ -21,6 +21,7 @@ import torch
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.mem_cache.allocator.swa import SWATokenToKVPoolAllocator
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.common import free_swa_out_of_window_slots
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
@@ -195,6 +196,119 @@ class TestSWAEvictionBoundary(unittest.TestCase):
                 req, is_insert=True, kv_len_to_handle=req._kv_committed_len
             )
             tree.sanity_check()
+
+    # -- Retention floor: never free past the last state checkpoint --
+
+    def test_retain_floor_clamps_eviction(self):
+        """A hybrid cache keeps SWA down to the last state checkpoint, not to the
+        window behind the tail, because that is where a prefix match lands. The
+        floor must clamp the frontier even though the tail has moved far past it."""
+        page_size, window = 8, 16
+        tree, allocator, pool = _build_swa_tree(
+            page_size=page_size, sliding_window_size=window
+        )
+        seq_len = 200
+        checkpoint = 96
+        kv = _swa_alloc(allocator, seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), 0, tree)
+        batch = _make_batch(tree, allocator, pool)
+
+        free_swa_out_of_window_slots(
+            req,
+            seq_len - 1,
+            sliding_window_size=window,
+            page_size=page_size,
+            req_to_token_pool=batch.req_to_token_pool,
+            token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,
+            retain_floor=checkpoint - window,
+        )
+
+        # Without the floor this would reach page_floor(199 - 16) = 176.
+        self.assertLessEqual(req.kv.swa_evicted_seqlen, checkpoint - window)
+        self.assertEqual(req.kv.swa_evicted_seqlen % page_size, 0)
+
+    def test_retain_floor_none_matches_old_behaviour(self):
+        """retain_floor=None must reproduce the pre-change frontier exactly, so a
+        cache without a second state stream is unaffected."""
+        page_size, window = 8, 16
+        seq_len = 200
+        frontiers = []
+        for floor in (None, "absent"):
+            tree, allocator, pool = _build_swa_tree(
+                page_size=page_size, sliding_window_size=window
+            )
+            kv = _swa_alloc(allocator, seq_len)
+            pool.write((0, slice(0, seq_len)), kv)
+            req = _make_req(0, list(range(seq_len)), 0, tree)
+            batch = _make_batch(tree, allocator, pool)
+            kwargs = {} if floor == "absent" else {"retain_floor": None}
+            free_swa_out_of_window_slots(
+                req,
+                seq_len - 1,
+                sliding_window_size=window,
+                page_size=page_size,
+                req_to_token_pool=batch.req_to_token_pool,
+                token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,
+                **kwargs,
+            )
+            frontiers.append(req.kv.swa_evicted_seqlen)
+
+        expected = (seq_len - 1 - max(window, page_size)) // page_size * page_size
+        self.assertEqual(frontiers[0], expected)
+        self.assertEqual(frontiers[1], expected)
+
+    def test_retain_floor_above_threshold_is_inert(self):
+        """The floor is a min(), so a checkpoint that is already inside the window
+        must not hold anything extra."""
+        page_size, window = 8, 16
+        seq_len = 200
+        tree, allocator, pool = _build_swa_tree(
+            page_size=page_size, sliding_window_size=window
+        )
+        kv = _swa_alloc(allocator, seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), 0, tree)
+        batch = _make_batch(tree, allocator, pool)
+
+        free_swa_out_of_window_slots(
+            req,
+            seq_len - 1,
+            sliding_window_size=window,
+            page_size=page_size,
+            req_to_token_pool=batch.req_to_token_pool,
+            token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,
+            retain_floor=seq_len,
+        )
+
+        expected = (seq_len - 1 - max(window, page_size)) // page_size * page_size
+        self.assertEqual(req.kv.swa_evicted_seqlen, expected)
+
+    def test_retain_floor_does_not_unfree(self):
+        """The frontier only advances. A floor arriving after slots were already
+        freed must not claim them back, which would double-free on the next pass."""
+        page_size, window = 8, 16
+        tree, allocator, pool = _build_swa_tree(
+            page_size=page_size, sliding_window_size=window
+        )
+        seq_len = 200
+        kv = _swa_alloc(allocator, seq_len)
+        pool.write((0, slice(0, seq_len)), kv)
+        req = _make_req(0, list(range(seq_len)), 0, tree)
+        batch = _make_batch(tree, allocator, pool)
+        common_kwargs = dict(
+            sliding_window_size=window,
+            page_size=page_size,
+            req_to_token_pool=batch.req_to_token_pool,
+            token_to_kv_pool_allocator=batch.token_to_kv_pool_allocator,
+        )
+
+        free_swa_out_of_window_slots(req, seq_len - 1, **common_kwargs)
+        advanced = req.kv.swa_evicted_seqlen
+        self.assertGreater(advanced, 0)
+
+        free_swa_out_of_window_slots(req, seq_len - 1, retain_floor=0, **common_kwargs)
+        self.assertEqual(req.kv.swa_evicted_seqlen, advanced)
 
     # -- Eviction formula: page_size == 1 --
 


### PR DESCRIPTION
## Motivation

A hybrid SWA + mamba model throws away most of its decode-region prefix reuse at the default `--mamba-track-interval`. Measured on one GPU with 32 prompts, counting how many get a decode-region cache hit on their second turn:

```
page_size  track_interval    prompts reusing the decode region
   128          256              16/32  ->  32/32
   128          512               5/32  ->  32/32
    64          256               9/32  ->  32/32
```

Counting tokens rather than prompts, on the first row, over the same 32 second-turn requests:

```
reused prefix           110208  ->  124416 tokens   (+12.9%)
recomputed               18435  ->    4227 tokens   (-77.1%)
mean reuse fraction      0.845  ->   0.965
```

The gain is not deeper matches on requests that already hit, it is requests that were losing the whole generated region getting it back: 16 of 32 improved by 768 to 896 tokens each, none regressed, and the ones that already hit were at 98.5% reuse to begin with.

The cause is that SWA frees out-of-window slots relative to the **tail**, while a prefix match lands on a **state checkpoint**, which sits behind the tail. `evict_threshold = pre_len - max(window, page)` therefore strands checkpoints that are still reachable in the tree: the match needs a full window of live SWA below the checkpoint, and part of that window has already been freed. `swa_evicted_seqlen` only moves forward, so nothing gets it back.

Today the only way to get full reuse is to set the interval equal to the page size, which doubles checkpoint density and the mamba pool footprint. This change makes the two independent: keep the interval at 256 for the cheaper checkpoint storage and still reuse every decode-region prefix.

## Modifications

`free_swa_out_of_window_slots` takes an optional `retain_floor` and promises not to free past it. It stays ignorant of mamba; the caller decides where the floor is.

The floor is computed in one place, on the cache that knows about both components, and both call sites (decode-side eviction and the chunked-prefill insert path) ask it rather than each deriving it. `BasePrefixCache.swa_retain_floor` returns `None`, so a cache without a second state stream is unaffected.

## Accuracy

`test_unified_radix_cache_kl_hybrid_bitexact` asserts prefill and decode score every token identically at a `kl_div` floor of 1e-9, which makes it the right instrument here: the change **increases** how much state gets reused, so a wrong retention floor shows up as a nonzero KL on exactly the prompts that newly reuse.

Same tree, same diff, the only variable being whether the floor is applied. `hits` is the number of prompts whose second turn hit the decode region, `nonzero` counts per-prompt KL above zero:

```
                     floor off              floor on
SM90 (H200)      16/32 hits, 0 nonzero   32/32 hits, 0 nonzero
SM100 (B200)     17/32 hits, 0 nonzero   32/32 hits, 0 nonzero
```

Every prompt that newly reuses reads exactly 0, so the retained window is correct rather than merely present. The grid above repeats this at `page_size` 64, where the page size no longer coincides with the mamba chunk size, and reuse is still complete with the floor on.

On memory: peak device usage is unchanged (134.2 GB against 130.3 GB, and the direction is noise), but that metric does not answer the question, because the pools are preallocated from `mem-fraction-static` and holding more slots inside them does not move the device peak. What the change actually costs is SWA pool occupancy, which I did not measure. The analytic bound is the checkpoint spacing, and the probe that located this measured the extra retention at 127 to 255 tokens per request against a 511-token window, so on the config above it is under 1% of the SWA pool. Worth a reviewer's judgement rather than my assertion.

A cache with no mamba component is unaffected, checked at the seam rather than by sampling: `BasePrefixCache.swa_retain_floor` returns `None`, the unified override early-returns `None` when mamba is off, `retain_floor` is read in exactly one guarded branch, the original threshold line is untouched, and both call sites go through `swa_retain_floor`. With `retain_floor=None` the helper is byte-identical to before.

## TODO

- [ ] The prefill region is not covered yet. `req.mamba_last_track_seqlen` is cleared at the end of `cache_unfinished_req` once the checkpoint has been handed to the tree, so at the first decode step the floor reads `None` and no extra retention happens. Covering it needs the floor to come from the tree rather than from the request.
- [ ] Move the SWA pool sizing floor from `window` to `window + interval`, so the extra retention cannot bite under pool pressure.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31718123937](https://github.com/sgl-project/sglang/actions/runs/31718123937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31718123679](https://github.com/sgl-project/sglang/actions/runs/31718123679)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->