### PR TITLE
[Feature][DSpark] Support Speculators-format checkpoints and ragged multimodal CUDA graphs

### DIFF
--- a/python/sglang/benchmark/dspark_sps_profiler.py
+++ b/python/sglang/benchmark/dspark_sps_profiler.py
@@ -80,6 +80,11 @@ PROFILE_SEED = 42
 REQUIRED_SIMULATE_ACC_LEN = 1.0
 RANDOM_TOKEN_LOW = 1000
 RANDOM_TOKEN_HIGH_MARGIN = 1000
+# Compact verification changes the token budget in small increments. A 64-token
+# bin collapses most low-batch probes into the same bucket (for example, all
+# gamma=15 budgets for bs=1), so keep the fit resolution at one gamma=7 verify
+# row while still smoothing nearby off-diagonal cells.
+ADDITIVE_M_BIN_WIDTH = 8
 
 STATIC_CONDITIONING_CAVEAT = (
     "Profiled with SGLANG_RAGGED_VERIFY_MODE=static: a verify step of B tokens "
@@ -1160,7 +1165,10 @@ def build_additive_table_from_cells(*, cells: list[dict]) -> SpsAdditiveCostTabl
     )
 
 
-def ols_resid_backfit(cells: list, mbin_w: int = 64):
+def ols_resid_backfit(cells: list, mbin_w: int = ADDITIVE_M_BIN_WIDTH):
+    if mbin_w <= 0:
+        raise ValueError(f"mbin_w must be positive, got {mbin_w}.")
+
     def mbin(m):
         return round(m / mbin_w) * mbin_w
 

--- a/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -197,7 +197,11 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             b_g = -tl.exp(b_A_log) * softplus_x
 
         # Compute beta = sigmoid(b)
-        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+        # Match the production packed-decode path and fused_gdn_gating:
+        # sigmoid is materialized in the activation dtype before the FP32
+        # recurrent update. Keeping beta in FP32 here makes target-verify state
+        # drift from ordinary decode after every accepted token.
+        b_beta = (1.0 / (1.0 + tl.exp(-b_b))).to(b.dtype.element_ty).to(tl.float32)
 
         # fused ring-write: stash this step's raw inputs + in-kernel gate/beta
         # into the per-slot ring for the commit fold to replay. Must sit here --

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_verify_window.py
@@ -414,6 +414,7 @@ def _compact_verify_ids_gather_kernel(
     out_ptr,
     bs,
     gamma,
+    draft_block_stride,
     n,
     BLOCK: tl.constexpr,
 ):
@@ -424,7 +425,14 @@ def _compact_verify_ids_gather_kernel(
     within = tl.load(within_ptr + offs, mask=mask, other=0)
     valid = req < bs
     safe_req = tl.minimum(req, bs - 1)
-    anchor = tl.load(draft_block_ids_ptr + safe_req * gamma, mask=mask, other=0)
+    # draft_block_ids and draft_tokens do NOT share a row stride: draft_tokens is
+    # always (bs, gamma), but draft_block_ids is (bs, gamma) under the DeepSpec
+    # layout and (bs, gamma + 1) under the speculators bonus-anchor layout, where
+    # slot 0 holds the anchor. Indexing the block ids with gamma reads the right
+    # element only for req 0 and walks off the row for every later request.
+    anchor = tl.load(
+        draft_block_ids_ptr + safe_req * draft_block_stride, mask=mask, other=0
+    )
     wcol = tl.maximum(within - 1, 0)
     draft = tl.load(draft_tokens_ptr + safe_req * gamma + wcol, mask=mask, other=0)
     v = tl.where(within == 0, anchor, draft)
@@ -448,12 +456,25 @@ def compact_verify_ids_triton(
     gamma = draft_tokens.shape[1]
     draft_block_ids = draft_block_ids.to(device=device, dtype=torch.int64).contiguous()
     draft_tokens = draft_tokens.to(device=device, dtype=torch.int64).contiguous()
+    # Row stride of the block-ids tensor, which is gamma + 1 under the speculators
+    # bonus-anchor layout and gamma otherwise -- read it off the tensor rather than
+    # assuming it matches draft_tokens.
+    draft_block_stride = draft_block_ids.shape[1]
     n = layout.graph_num_tokens
     out = torch.empty(n, dtype=torch.int64, device=device)
     BLOCK = 256
     grid = (triton.cdiv(n, BLOCK),)
     _compact_verify_ids_gather_kernel[grid](
-        req, within, draft_block_ids, draft_tokens, out, bs, gamma, n, BLOCK=BLOCK
+        req,
+        within,
+        draft_block_ids,
+        draft_tokens,
+        out,
+        bs,
+        gamma,
+        draft_block_stride,
+        n,
+        BLOCK=BLOCK,
     )
     return out
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -30,7 +30,14 @@ def _resolve_speculative_algorithm_alias(
     """Resolve CLI speculative algorithm; NEXTN/EAGLE may become FROZEN_KV_MTP for Gemma4 assistant drafts."""
 
     is_gemma4_draft = False
-    if speculative_draft_model_path:
+    # Only EAGLE-family aliases need to inspect the draft architecture. Loading
+    # every draft config here rejects native speculators checkpoints before the
+    # actual model-config parser can normalize them.
+    if speculative_draft_model_path and speculative_algorithm in (
+        "EAGLE",
+        "EAGLE3",
+        "NEXTN",
+    ):
         from sglang.srt.utils.hf_transformers_utils import get_config
 
         cfg = get_config(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -398,7 +398,7 @@ def _handle_dspark(server_args: ServerArgs) -> None:
         # config it loads itself, before any graph is captured.
         logger.error(
             "Failed to read the DSpark draft config%s; assuming the DeepSpec "
-            "gamma-wide layout. A speculators (bonus-anchor) checkpoint will "
+            "gamma-wide layout. A bonus-anchor checkpoint will "
             "fail draft CUDA-graph capture until this read succeeds. Error: %s",
             (
                 " (gamma and block layout cannot be resolved)"
@@ -422,11 +422,11 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     # been serialized from another checkpoint and would mis-size CUDA graphs.
     server_args.speculative_dspark_bonus_anchor = bool(
         draft_checkpoint_config is not None
-        and draft_checkpoint_config.speculators_convention
+        and draft_checkpoint_config.bonus_anchor
     )
     if server_args.speculative_dspark_bonus_anchor:
         logger.info(
-            "DSpark draft checkpoint uses the speculators bonus-anchor layout; "
+            "DSpark draft checkpoint uses the bonus-anchor layout; "
             "the draft block is gamma + 1 slots wide (slot 0 is the anchor and "
             "is not sampled)."
         )

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -366,26 +366,63 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 f"got {server_args.speculative_dspark_block_size}."
             )
         gamma = int(server_args.speculative_dspark_block_size)
-    else:
-        from sglang.srt.speculative.dspark_components.dspark_config import (
-            DEFAULT_DSPARK_GAMMA,
-            read_draft_checkpoint_gamma,
+
+    # The block layout has to be resolved here, not lazily in the worker: it
+    # decides whether the draft forward is gamma or gamma + 1 slots wide, and
+    # that width sizes the draft CUDA-graph capture shape
+    # (resolve_num_tokens_per_req), which is fixed before the worker's own
+    # config is available. Resolve it unconditionally -- an explicit
+    # --speculative-dspark-block-size pins gamma but says nothing about the
+    # layout, so the branch above must not be allowed to skip this read.
+    from sglang.srt.speculative.dspark_components.dspark_config import (
+        DEFAULT_DSPARK_GAMMA,
+        read_draft_checkpoint_config,
+    )
+
+    draft_checkpoint_config = None
+    try:
+        draft_checkpoint_config = read_draft_checkpoint_config(server_args=server_args)
+    except Exception as e:
+        # Deliberately not fatal: leaving this False is exactly the pre-existing
+        # DeepSpec behaviour, so a config-read failure cannot regress checkpoints
+        # that worked before. For a speculators checkpoint it degrades into the
+        # loud draft-graph capture ValueError rather than silent wrong output,
+        # and DSparkWorkerV2 cross-checks the resolved value against the draft
+        # config it loads itself, before any graph is captured.
+        logger.error(
+            "Failed to read the DSpark draft config%s; assuming the DeepSpec "
+            "gamma-wide layout. A speculators (bonus-anchor) checkpoint will "
+            "fail draft CUDA-graph capture until this read succeeds. Error: %s",
+            (
+                " (gamma and block layout cannot be resolved)"
+                if gamma is None and server_args.speculative_num_draft_tokens is None
+                else " (block layout cannot be resolved)"
+            ),
+            e,
         )
 
-        try:
-            gamma = read_draft_checkpoint_gamma(server_args=server_args)
-        except Exception as e:
-            logger.warning(
-                "Failed to read DSpark gamma from draft model config; "
-                "cannot cross-check --speculative-num-draft-tokens. Error: %s",
-                e,
-            )
-        if gamma is None and server_args.speculative_num_draft_tokens is None:
-            gamma = DEFAULT_DSPARK_GAMMA
-            logger.warning(
-                "DSpark gamma is not set; defaulting to %d.",
-                gamma,
-            )
+    if gamma is None and draft_checkpoint_config is not None:
+        gamma = draft_checkpoint_config.resolve_gamma(default=None)
+    if gamma is None and server_args.speculative_num_draft_tokens is None:
+        gamma = DEFAULT_DSPARK_GAMMA
+        logger.warning(
+            "DSpark gamma is not set; defaulting to %d.",
+            gamma,
+        )
+
+    # This is an internal no-CLI field derived from the checkpoint being opened
+    # now. Do not preserve an incoming value when that read fails: it may have
+    # been serialized from another checkpoint and would mis-size CUDA graphs.
+    server_args.speculative_dspark_bonus_anchor = bool(
+        draft_checkpoint_config is not None
+        and draft_checkpoint_config.speculators_convention
+    )
+    if server_args.speculative_dspark_bonus_anchor:
+        logger.info(
+            "DSpark draft checkpoint uses the speculators bonus-anchor layout; "
+            "the draft block is gamma + 1 slots wide (slot 0 is the anchor and "
+            "is not sampled)."
+        )
 
     if gamma is not None:
         verify_window = int(gamma) + 1

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -421,8 +421,7 @@ def _handle_dspark(server_args: ServerArgs) -> None:
     # now. Do not preserve an incoming value when that read fails: it may have
     # been serialized from another checkpoint and would mis-size CUDA graphs.
     server_args.speculative_dspark_bonus_anchor = bool(
-        draft_checkpoint_config is not None
-        and draft_checkpoint_config.bonus_anchor
+        draft_checkpoint_config is not None and draft_checkpoint_config.bonus_anchor
     )
     if server_args.speculative_dspark_bonus_anchor:
         logger.info(

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -820,8 +820,10 @@ class FlashAttentionBackend(AttentionBackend):
             self._maybe_init_local_attn_metadata(forward_batch, metadata, device)
         elif forward_batch.forward_mode.is_target_verify():
             if self.topk <= 1:
-                ragged_layout = getattr(
-                    forward_batch.spec_info, "ragged_verify_layout", None
+                ragged_layout = (
+                    forward_batch.spec_info.ragged_verify_layout
+                    if forward_batch.spec_info is not None
+                    else None
                 )
                 if ragged_layout is not None:
                     geometry = build_ragged_target_verify_geometry(
@@ -2877,7 +2879,9 @@ class FlashAttentionBackend(AttentionBackend):
         elif forward_mode.is_target_verify():
             if self.topk <= 1:
                 metadata = self.target_verify_metadata[bs]
-                ragged_layout = getattr(spec_info, "ragged_verify_layout", None)
+                ragged_layout = (
+                    spec_info.ragged_verify_layout if spec_info is not None else None
+                )
                 if ragged_layout is not None:
                     padded = ragged_layout.padded_to_bucket(padded_bs=bs)
                     geometry = build_ragged_target_verify_geometry(

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -13,6 +13,8 @@ from sglang.srt.layers.attention.linear.kernels.gdn_triton import TritonGDNKerne
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
     build_verify_intermediate_state_indices,
+    gather_ragged_verify_from_dense,
+    scatter_ragged_verify_to_dense,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.mem_cache.memory_pool import MambaPool
@@ -350,6 +352,12 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
     def __init__(self, model_runner: ModelRunner):
         super().__init__(model_runner)
+        # ReplaySSM verification still assumes a rectangular token layout.
+        # Keep graph-enabled ragged verification scoped to the path validated here.
+        self.supports_ragged_verify_graph = not (
+            model_runner.server_args.enable_linear_replayssm
+            or model_runner.server_args.enable_linear_replayssm_spec
+        )
         self.conv_states_shape = (
             model_runner.req_to_token_pool.mamba_pool.mamba_cache.conv[0].shape
         )
@@ -552,11 +560,25 @@ class GDNAttnBackend(MambaAttnBackendBase):
             state_cache_indices = cache_indices
 
         if is_target_verify:
-            batch_size = seq_len // forward_batch.spec_info.draft_token_num
             draft_token_num = forward_batch.spec_info.draft_token_num
-            mixed_qkv_reshaped = mixed_qkv.view(
-                batch_size, draft_token_num, -1
-            ).transpose(1, 2)
+            ragged_layout = forward_batch.spec_info.ragged_verify_layout
+            if ragged_layout is None:
+                batch_size = seq_len // draft_token_num
+                dense_token_indices = None
+                mixed_qkv_dense = mixed_qkv.view(batch_size, draft_token_num, -1)
+            else:
+                # Conv update and its per-step scratch require a dense
+                # [bs, draft_token_num] layout. Scatter packed ragged tokens to
+                # their step slots, then gather only real tokens back. Any graph
+                # tier leftovers share one value-irrelevant ghost row.
+                batch_size = query_start_loc.shape[0] - 1
+                mixed_qkv_dense, dense_token_indices = scatter_ragged_verify_to_dense(
+                    mixed_qkv,
+                    query_start_loc=query_start_loc,
+                    draft_token_num=draft_token_num,
+                )
+
+            mixed_qkv_reshaped = mixed_qkv_dense.transpose(1, 2)
             mixed_qkv_processed = causal_conv1d_update(
                 mixed_qkv_reshaped,
                 conv_states,
@@ -570,7 +592,15 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 retrieve_next_sibling=retrieve_next_sibling,
                 retrieve_parent_token=retrieve_parent_token,
             )
-            mixed_qkv = mixed_qkv_processed.transpose(1, 2).view(seq_len, -1)
+            if dense_token_indices is None:
+                mixed_qkv = mixed_qkv_processed.transpose(1, 2).reshape(
+                    batch_size * draft_token_num, -1
+                )
+            else:
+                mixed_qkv = gather_ragged_verify_from_dense(
+                    mixed_qkv_processed.transpose(1, 2),
+                    dense_token_indices=dense_token_indices,
+                )
         else:
             mixed_qkv = mixed_qkv.transpose(0, 1)
             if forward_metadata.has_mamba_track_mask:

--- a/python/sglang/srt/layers/attention/linear/kda_backend.py
+++ b/python/sglang/srt/layers/attention/linear/kda_backend.py
@@ -13,6 +13,8 @@ from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKerne
 from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
     build_verify_intermediate_state_indices,
+    gather_ragged_verify_from_dense,
+    scatter_ragged_verify_to_dense,
 )
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.utils import is_cpu, is_cuda, is_npu
@@ -327,29 +329,6 @@ class KDAKernelDispatcher:
             query_start_loc=query_start_loc,
             **kwargs,
         )
-
-
-def ragged_verify_dense_scatter_indices(
-    *,
-    query_start_loc: torch.Tensor,
-    seq_len: int,
-    draft_token_num: int,
-) -> torch.Tensor:
-    """Dense [bs, draft_token_num] slot index per packed ragged-verify token.
-
-    Rows never exceed draft_token_num under either layout variant (cap for
-    graph replay, planner construction for eager -- see
-    RaggedVerifyLayout.padded_to_bucket), so in-row offsets stay in-row;
-    tokens past the layout's coverage collapse into one ghost row at index
-    bs * draft_token_num.
-    """
-    batch_size = query_start_loc.shape[0] - 1
-    token_pos = torch.arange(seq_len, device=query_start_loc.device, dtype=torch.int32)
-    token_slots = torch.searchsorted(query_start_loc[1:], token_pos, right=True)
-    return (
-        token_slots * draft_token_num
-        + (token_pos - query_start_loc[token_slots]).to(torch.int64)
-    ).clamp_(max=batch_size * draft_token_num)
 
 
 class KDAAttnBackend(MambaAttnBackendBase):
@@ -790,20 +769,14 @@ class KDAAttnBackend(MambaAttnBackendBase):
             # [bs, draft_token_num] layout: scatter ragged tokens to their
             # step slots, gather back after (pad steps are never committed).
             # Uncovered tier-leftover tokens land in the ghost row (see
-            # ragged_verify_dense_scatter_indices); their values are pad
+            # scatter_ragged_verify_to_dense); their values are pad
             # garbage, discarded downstream (ghost collisions are
             # value-irrelevant).
             batch_size = query_start_loc.shape[0] - 1
-            num_dense_tokens = batch_size * draft_token_num
-            dense_token_indices = ragged_verify_dense_scatter_indices(
+            mixed_qkv_dense, dense_token_indices = scatter_ragged_verify_to_dense(
+                mixed_qkv,
                 query_start_loc=query_start_loc,
-                seq_len=seq_len,
                 draft_token_num=draft_token_num,
-            )
-            dense = mixed_qkv.new_zeros(num_dense_tokens + 1, mixed_qkv.shape[-1])
-            dense.index_copy_(0, dense_token_indices, mixed_qkv)
-            mixed_qkv_dense = dense[:num_dense_tokens].view(
-                batch_size, draft_token_num, -1
             )
 
         # causal_conv1d_update expects [.., dim, width]. KDA keeps dense conv-window
@@ -822,18 +795,15 @@ class KDAAttnBackend(MambaAttnBackendBase):
             retrieve_next_sibling=retrieve_next_sibling,
             retrieve_parent_token=retrieve_parent_token,
         )
-        mixed_qkv_flat = mixed_qkv_processed.transpose(1, 2).reshape(
-            batch_size * draft_token_num, -1
-        )
         if dense_token_indices is None:
-            mixed_qkv = mixed_qkv_flat
-        else:
-            # Ghost row (zeros) so uncovered tail tokens gather finite values.
-            padded_flat = mixed_qkv_flat.new_zeros(
-                batch_size * draft_token_num + 1, mixed_qkv_flat.shape[-1]
+            mixed_qkv = mixed_qkv_processed.transpose(1, 2).reshape(
+                batch_size * draft_token_num, -1
             )
-            padded_flat[: batch_size * draft_token_num] = mixed_qkv_flat
-            mixed_qkv = padded_flat[dense_token_indices]
+        else:
+            mixed_qkv = gather_ragged_verify_from_dense(
+                mixed_qkv_processed.transpose(1, 2),
+                dense_token_indices=dense_token_indices,
+            )
 
         q, k, v = mixed_qkv.split([layer.q_dim, layer.k_dim, layer.v_dim], dim=-1)
         q = q.unflatten(-1, (-1, layer.head_q_dim)).unsqueeze(0)  # n (h d) -> 1 n h d

--- a/python/sglang/srt/layers/attention/linear/utils.py
+++ b/python/sglang/srt/layers/attention/linear/utils.py
@@ -99,6 +99,72 @@ def resolve_linear_attn_backends(
     return backends
 
 
+def ragged_verify_dense_scatter_indices(
+    *,
+    query_start_loc,
+    seq_len: int,
+    draft_token_num: int,
+):
+    """Dense [bs, draft_token_num] slot index per packed ragged-verify token.
+
+    Rows never exceed draft_token_num under either layout variant (cap for
+    graph replay, planner construction for eager -- see
+    RaggedVerifyLayout.padded_to_bucket), so in-row offsets stay in-row;
+    tokens past the layout's coverage collapse into one ghost row at index
+    bs * draft_token_num.
+    """
+    import torch
+
+    batch_size = query_start_loc.shape[0] - 1
+    token_pos = torch.arange(seq_len, device=query_start_loc.device, dtype=torch.int32)
+    token_slots = torch.searchsorted(query_start_loc[1:], token_pos, right=True)
+    return (
+        token_slots * draft_token_num
+        + (token_pos - query_start_loc[token_slots]).to(torch.int64)
+    ).clamp_(max=batch_size * draft_token_num)
+
+
+def scatter_ragged_verify_to_dense(
+    values,
+    *,
+    query_start_loc,
+    draft_token_num: int,
+):
+    """Scatter packed ragged rows into ``[bs, draft_token_num, ...]``.
+
+    Graph-tier leftovers map to one extra ghost row. The returned dense tensor
+    excludes that row; callers retain the indices to gather processed values
+    back to the original packed order.
+    """
+    batch_size = query_start_loc.shape[0] - 1
+    num_dense_tokens = batch_size * draft_token_num
+    dense_token_indices = ragged_verify_dense_scatter_indices(
+        query_start_loc=query_start_loc,
+        seq_len=values.shape[0],
+        draft_token_num=draft_token_num,
+    )
+    dense_with_ghost = values.new_zeros((num_dense_tokens + 1, *values.shape[1:]))
+    dense_with_ghost.index_copy_(0, dense_token_indices, values)
+    dense = dense_with_ghost[:num_dense_tokens].view(
+        batch_size, draft_token_num, *values.shape[1:]
+    )
+    return dense, dense_token_indices
+
+
+def gather_ragged_verify_from_dense(dense_values, *, dense_token_indices):
+    """Gather processed dense rows back to their packed ragged order.
+
+    Appending a zero ghost row keeps uncovered graph-tier tokens finite while
+    preserving the same discard semantics as the scatter step.
+    """
+    flat_values = dense_values.reshape(-1, *dense_values.shape[2:])
+    flat_with_ghost = flat_values.new_zeros(
+        (flat_values.shape[0] + 1, *flat_values.shape[1:])
+    )
+    flat_with_ghost[:-1].copy_(flat_values)
+    return flat_with_ghost[dense_token_indices]
+
+
 def build_verify_intermediate_state_indices(
     pool_size: int, server_args: ServerArgs, device
 ):

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -128,6 +128,7 @@ class TritonAttnBackend(AttentionBackend):
     # CUDA-graph replay rebuilds metadata from preallocated kv_indptr/kv_indices
     # buffers; it never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = False
+    supports_ragged_verify_graph: bool = True
 
     # kv_indptr/qo_indptr are preallocated at (req pool + 1); an extend batch
     # can never carry more seqs than the pool.
@@ -517,13 +518,25 @@ class TritonAttnBackend(AttentionBackend):
         ):
             num_draft_tokens = int(spec_info.draft_token_num)
         qo_indptr = self.qo_indptr[: bs + 1]
-        qo_indptr[: bs + 1] = torch.arange(
-            0,
-            (1 + bs) * num_draft_tokens,
-            step=num_draft_tokens,
-            dtype=torch.int32,
-            device=self.device,
+        ragged_layout = (
+            spec_info.ragged_verify_layout if spec_info is not None else None
         )
+        if ragged_layout is None:
+            qo_indptr[: bs + 1] = torch.arange(
+                0,
+                (1 + bs) * num_draft_tokens,
+                step=num_draft_tokens,
+                dtype=torch.int32,
+                device=self.device,
+            )
+            verify_lens = num_draft_tokens
+        else:
+            if ragged_layout.bs != bs or ragged_layout.cap is None:
+                ragged_layout = ragged_layout.padded_to_bucket(
+                    padded_bs=bs, cap=num_draft_tokens
+                )
+            qo_indptr.copy_(ragged_layout.qo_indptr_device)
+            verify_lens = ragged_layout.verify_lens
         kv_indptr = self._fill_kv_indptr_and_indices(
             bs, seq_lens, req_pool_indices, self.cuda_graph_kv_indices
         )
@@ -557,7 +570,7 @@ class TritonAttnBackend(AttentionBackend):
             custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
         else:
             custom_mask = None
-        seq_mask_len = num_draft_tokens * (seq_lens + num_draft_tokens)
+        seq_mask_len = verify_lens * (seq_lens + verify_lens)
         mask_indptr = self.mask_indptr[: bs + 1]
         mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
         return (
@@ -858,13 +871,21 @@ class TritonAttnBackend(AttentionBackend):
                 and getattr(spec_info, "draft_token_num", None) is not None
             ):
                 num_draft_tokens = int(spec_info.draft_token_num)
-            qo_indptr = torch.arange(
-                0,
-                (1 + bs) * num_draft_tokens,
-                step=num_draft_tokens,
-                dtype=torch.int32,
-                device=self.device,
+            ragged_layout = (
+                spec_info.ragged_verify_layout if spec_info is not None else None
             )
+            if ragged_layout is None:
+                qo_indptr = torch.arange(
+                    0,
+                    (1 + bs) * num_draft_tokens,
+                    step=num_draft_tokens,
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+            else:
+                # Packed compact verify has variable query lengths; a uniform
+                # [0, N, 2N, ...] indptr can point past the packed q/k/v tensors.
+                qo_indptr = ragged_layout.qo_indptr_device
             # gpu_only: seq_lens_sum may be None; over-allocate is safe (ragged write).
             seq_lens_sum = forward_batch.seq_lens_sum
             if seq_lens_sum is None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4262,8 +4262,22 @@ class Scheduler(
             if self.draft_worker:
                 self.draft_worker.clear_cache_pool()
 
-            if empty_cache:
+            # DSpark's draft CUDA graph can retain allocator-owned addresses
+            # that are not otherwise kept live by Python tensors. Releasing
+            # the allocator cache here invalidates those addresses and makes
+            # the first post-flush replay fail with an illegal memory access.
+            # The logical KV/request pools above are still fully reset.
+            preserve_dspark_graph = self.spec_algorithm.is_dspark() and (
+                self.draft_worker.draft_model_runner.decode_cuda_graph_runner
+                is not None
+            )
+            if empty_cache and not preserve_dspark_graph:
                 current_platform.empty_cache()
+            elif empty_cache and self.metrics_reporter.is_stats_logging_rank:
+                logger.info(
+                    "Skipped emptying the device allocator cache to preserve "
+                    "captured DSpark draft CUDA graphs."
+                )
             # Per-DP-group leader logs once: ranks within a DP group are
             # state-synchronous, but DP groups may diverge.
             if self.metrics_reporter.is_stats_logging_rank:

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1084,10 +1084,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Keep positions flat so compact ragged verify layouts do not need
             # to satisfy a rectangular batch_size * width shape.
             self.mrope_positions = (
-                seq_positions.to(dtype=torch.int64)
-                .flatten()
-                .unsqueeze(0)
-                .repeat(3, 1)
+                seq_positions.to(dtype=torch.int64).flatten().unsqueeze(0).repeat(3, 1)
             )
             return
 
@@ -1118,9 +1115,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # repeat count fills the fixed graph shape. Passing output_size keeps
             # repeat_interleave capture-safe without reading the dynamic sum on
             # the host.
-            verify_lens = ragged_layout.verify_lens.to(
-                device=device, dtype=torch.int64
-            )
+            verify_lens = ragged_layout.verify_lens.to(device=device, dtype=torch.int64)
             ghost_len = verify_lens.new_full(
                 (1,), ragged_layout.graph_num_tokens
             ) - verify_lens.sum().reshape(1)
@@ -1139,10 +1134,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         else:
             seq_positions = seq_positions.view(batch_size, -1)
             next_input_positions = (
-                (seq_positions + mrope_delta_tensor)
-                .flatten()
-                .unsqueeze(0)
-                .repeat(3, 1)
+                (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
             )
 
         self.mrope_positions = next_input_positions

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1078,22 +1078,29 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # passes its own positions (uniform num_draft_tokens per request).
         if seq_positions is None:
             seq_positions = batch.spec_info.positions
-        seq_positions = seq_positions.view(batch_size, -1)
         # Split text-only and mixed batches here because SpecV2 text-only batches can avoid an extra D2H.
         if all(mm_input is None for mm_input in mm_inputs):
-            mrope_delta_tensor = torch.zeros(
-                (batch_size, 1), dtype=torch.int64, device=device
+            # Text-only speculative tokens have no per-request mRoPE delta.
+            # Keep positions flat so compact ragged verify layouts do not need
+            # to satisfy a rectangular batch_size * width shape.
+            self.mrope_positions = (
+                seq_positions.to(dtype=torch.int64)
+                .flatten()
+                .unsqueeze(0)
+                .repeat(3, 1)
             )
-        else:
-            mrope_deltas = [
-                (
-                    torch.zeros(1, dtype=torch.int64)
-                    if mm_inputs[i] is None
-                    else mm_inputs[i].mrope_position_delta.squeeze(0)
-                )
-                for i in range(batch_size)
-            ]
-            mrope_delta_tensor = torch.stack(mrope_deltas, dim=0).to(device=device)
+            return
+
+        seq_positions = seq_positions.view(batch_size, -1)
+        mrope_deltas = [
+            (
+                torch.zeros(1, dtype=torch.int64)
+                if mm_inputs[i] is None
+                else mm_inputs[i].mrope_position_delta.squeeze(0)
+            )
+            for i in range(batch_size)
+        ]
+        mrope_delta_tensor = torch.stack(mrope_deltas, dim=0).to(device=device)
         next_input_positions = (
             (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
         )

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1091,7 +1091,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             )
             return
 
-        seq_positions = seq_positions.view(batch_size, -1)
         mrope_deltas = [
             (
                 torch.zeros(1, dtype=torch.int64)
@@ -1101,9 +1100,50 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             for i in range(batch_size)
         ]
         mrope_delta_tensor = torch.stack(mrope_deltas, dim=0).to(device=device)
-        next_input_positions = (
-            (seq_positions + mrope_delta_tensor).flatten().unsqueeze(0).repeat(3, 1)
+        ragged_layout = getattr(
+            getattr(batch, "spec_info", None), "ragged_verify_layout", None
         )
+        if ragged_layout is not None:
+            flat_positions = seq_positions.to(dtype=torch.int64).flatten()
+            if flat_positions.numel() != ragged_layout.graph_num_tokens:
+                raise ValueError(
+                    "Speculative mRoPE positions must match the ragged CUDA Graph "
+                    f"tier: got {flat_positions.numel()} positions for "
+                    f"graph_num_tokens={ragged_layout.graph_num_tokens}."
+                )
+
+            # Expand each request's scalar mRoPE delta over its actual compact
+            # verify length. CUDA Graph tiers can contain ghost tokens after the
+            # real ragged stream, so append a zero-delta pseudo request whose
+            # repeat count fills the fixed graph shape. Passing output_size keeps
+            # repeat_interleave capture-safe without reading the dynamic sum on
+            # the host.
+            verify_lens = ragged_layout.verify_lens.to(
+                device=device, dtype=torch.int64
+            )
+            ghost_len = verify_lens.new_full(
+                (1,), ragged_layout.graph_num_tokens
+            ) - verify_lens.sum().reshape(1)
+            repeat_counts = torch.cat((verify_lens, ghost_len))
+            delta_values = torch.cat(
+                (mrope_delta_tensor.flatten(), mrope_delta_tensor.new_zeros(1))
+            )
+            per_token_delta = torch.repeat_interleave(
+                delta_values,
+                repeat_counts,
+                output_size=ragged_layout.graph_num_tokens,
+            )
+            next_input_positions = (
+                (flat_positions + per_token_delta).unsqueeze(0).repeat(3, 1)
+            )
+        else:
+            seq_positions = seq_positions.view(batch_size, -1)
+            next_input_positions = (
+                (seq_positions + mrope_delta_tensor)
+                .flatten()
+                .unsqueeze(0)
+                .repeat(3, 1)
+            )
 
         self.mrope_positions = next_input_positions
 

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -6,6 +6,8 @@ from typing import Iterable, List, Optional, Tuple
 import msgspec
 import torch
 import torch.nn.functional as F
+from torch import nn
+
 from sglang.kernels.ops.attention.dsv4 import fused_q_norm_rope, fused_rope_inplace
 from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
     is_unified_kv_triton,
@@ -57,7 +59,6 @@ from sglang.srt.speculative.ragged_verify import (
 )
 from sglang.srt.utils import add_prefix, is_blackwell_supported, is_npu
 from sglang.srt.utils.invariants import Bucket, InClosedRange, Invariant, expect
-from torch import nn
 
 logger = logging.getLogger(__name__)
 
@@ -109,9 +110,9 @@ class DSparkAttention(MqaAttentionBase):
             wo_b_reduce_results=True,
             rope_original_seq_len=0,
         )
-        assert self.compress_ratio == 0, (
-            "DSpark draft attention requires compress_ratio == 0."
-        )
+        assert (
+            self.compress_ratio == 0
+        ), "DSpark draft attention requires compress_ratio == 0."
         self.window_size = int(
             getattr(config, "sliding_window", None) or config.window_size
         )

--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -6,8 +6,6 @@ from typing import Iterable, List, Optional, Tuple
 import msgspec
 import torch
 import torch.nn.functional as F
-from torch import nn
-
 from sglang.kernels.ops.attention.dsv4 import fused_q_norm_rope, fused_rope_inplace
 from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
     is_unified_kv_triton,
@@ -59,6 +57,7 @@ from sglang.srt.speculative.ragged_verify import (
 )
 from sglang.srt.utils import add_prefix, is_blackwell_supported, is_npu
 from sglang.srt.utils.invariants import Bucket, InClosedRange, Invariant, expect
+from torch import nn
 
 logger = logging.getLogger(__name__)
 
@@ -88,7 +87,6 @@ def apply_rotary_emb(
 
 
 class DSparkAttention(MqaAttentionBase):
-
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -111,9 +109,9 @@ class DSparkAttention(MqaAttentionBase):
             wo_b_reduce_results=True,
             rope_original_seq_len=0,
         )
-        assert (
-            self.compress_ratio == 0
-        ), "DSpark draft attention requires compress_ratio == 0."
+        assert self.compress_ratio == 0, (
+            "DSpark draft attention requires compress_ratio == 0."
+        )
         self.window_size = int(
             getattr(config, "sliding_window", None) or config.window_size
         )
@@ -349,7 +347,6 @@ def _resolve_dspark_pool() -> DeepSeekV4TokenToKVPool:
 
 
 class MarkovW2ShardGeometry(msgspec.Struct, frozen=True):
-
     tp_size: int
     org_vocab_start: int
     org_vocab_end: int
@@ -358,7 +355,6 @@ class MarkovW2ShardGeometry(msgspec.Struct, frozen=True):
 
 
 class DSparkV4MarkovHead(nn.Module):
-
     markov_head_type = "vanilla"
 
     def __init__(self, *, vocab_size: int, markov_rank: int) -> None:
@@ -479,6 +475,12 @@ class DSparkV4MarkovHead(nn.Module):
         logits = self.project_bias(embed)
         return logits, embed
 
+    def map_sampled_to_target(self, sampled_tokens: torch.Tensor) -> torch.Tensor:
+        # run_markov_block contract: the dsv4 self-draft samples in the full
+        # target vocab (markov_w2 spans the target head's vocab), so a sampled
+        # id already IS a target id -- identity, no reduced-vocab d2t map here.
+        return sampled_tokens
+
     def sample_block(
         self,
         base_logits: torch.Tensor,
@@ -524,7 +526,6 @@ def build_dspark_v4_confidence_head(
 
 
 class DSparkV4Stage(DeepseekV4DecoderLayer):
-
     def __init__(
         self,
         config: DeepSeekV4Config,
@@ -667,6 +668,13 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         return DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason(
             hf_config, quant_config
         )
+
+    @property
+    def uses_reduced_draft_vocab(self) -> bool:
+        # DSparkWorkerV2 contract: the dsv4 self-draft samples in the full
+        # target vocab (markov_w2 spans the target head's vocab), so it never
+        # uses a reduced independent head or a draft->target scatter.
+        return False
 
     def __init__(
         self,
@@ -1010,12 +1018,12 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         stage_id, rest = parts[1], parts[2]
 
         if rest.startswith("markov_head."):
-            return f"markov_head.{rest[len('markov_head.'):]}"
+            return f"markov_head.{rest[len('markov_head.') :]}"
 
         if rest.startswith("confidence_head."):
             if self.confidence_head is None:
                 return None
-            return f"confidence_head.{rest[len('confidence_head.'):]}"
+            return f"confidence_head.{rest[len('confidence_head.') :]}"
 
         mapped_rest = rest
         mapped_rest = mapped_rest.replace("attn.", "self_attn.", 1)

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -5,6 +5,8 @@ from typing import Callable, Iterable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
+from torch import nn
+
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.environ import envs
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
@@ -19,7 +21,6 @@ from sglang.srt.speculative.ragged_verify import (
     read_ragged_verify_mode,
 )
 from sglang.srt.utils import add_prefix
-from torch import nn
 
 logger = logging.getLogger(__name__)
 

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -5,10 +5,9 @@ from typing import Callable, Iterable, Optional, Tuple
 
 import torch
 import torch.nn.functional as F
-from torch import nn
-
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.environ import envs
+from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dflash import DFlashDraftModel
 from sglang.srt.speculative.dflash_utils import can_dflash_slice_qkv_weight
@@ -19,6 +18,8 @@ from sglang.srt.speculative.ragged_verify import (
     RaggedVerifyMode,
     read_ragged_verify_mode,
 )
+from sglang.srt.utils import add_prefix
+from torch import nn
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,47 @@ def gather_and_crop_vocab(
 ) -> torch.Tensor:
     full_logits = tensor_model_parallel_all_gather(local_logits, dim=-1)
     return full_logits[..., : int(lm_head.org_vocab_size)]
+
+
+def build_independent_lm_head(
+    *, draft_vocab_size: int, hidden_size: int, quant_config, prefix: str
+) -> ParallelLMHead:
+    """The reduced, checkpoint-owned draft head of a speculators DSpark model.
+
+    A plain ParallelLMHead so the existing vocab-parallel weight loader shards
+    and pads it exactly like a target head; org_vocab_size == draft_vocab_size,
+    so compute_base_logits' gather_and_crop_vocab crops the all-gathered logits
+    back to draft space.
+    """
+    return ParallelLMHead(
+        draft_vocab_size,
+        hidden_size,
+        quant_config=quant_config,
+        prefix=prefix,
+    )
+
+
+def scatter_draft_logits_to_target(
+    draft_logits: torch.Tensor,
+    *,
+    draft_to_target: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Place each draft column j at target column draft_to_target[j], leaving
+    unmapped target columns at -inf (zero softmax mass). ``out`` is a
+    caller-owned target-width buffer whose leading dims match ``draft_logits``.
+    """
+    out.fill_(float("-inf"))
+    out.index_copy_(out.dim() - 1, draft_to_target, draft_logits)
+    return out
+
+
+def _is_dspark_d2t_weight(name: str) -> bool:
+    return name == "d2t" or name.endswith(".d2t")
+
+
+def _is_dspark_t2d_weight(name: str) -> bool:
+    return name == "t2d" or name.endswith(".t2d")
 
 
 def run_markov_block(
@@ -55,7 +97,12 @@ def run_markov_block(
             token_ids=prev_tokens,
             hidden_states=step_hidden,
         )
-        next_tokens = sampler(step_logits, step_idx)
+        sampled = sampler(step_logits, step_idx)
+        # Reduced-vocab checkpoints sample a draft-space id; map it to a target
+        # id before storing it and before it conditions the next step's
+        # markov_w1 (whose input vocabulary is the target vocabulary). Identity
+        # for full-vocab heads, so corrected_logits stays draft-space here.
+        next_tokens = head.map_sampled_to_target(sampled)
         sampled_tokens.append(next_tokens)
         corrected_logits.append(step_logits.unsqueeze(1))
         prev_tokens = next_tokens
@@ -66,19 +113,88 @@ def run_markov_block(
 
 
 class VanillaMarkov(nn.Module):
-
     markov_head_type = "vanilla"
 
-    def __init__(self, *, vocab_size: int, markov_rank: int) -> None:
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        draft_vocab_size: Optional[int] = None,
+    ) -> None:
         super().__init__()
+        # markov_w1 consumes the previously sampled TARGET token id, so its
+        # input row count is always the target vocab. markov_w2 emits the draft
+        # distribution: the reduced draft vocab when the checkpoint ships an
+        # independent head + d2t map, else the full (target) vocab.
         self.vocab_size = int(vocab_size)
         self.markov_rank = int(markov_rank)
         if self.markov_rank <= 0:
             raise ValueError(
                 f"VanillaMarkov requires markov_rank > 0, got {self.markov_rank}."
             )
+        self.draft_vocab_size = (
+            int(draft_vocab_size) if draft_vocab_size is not None else self.vocab_size
+        )
+        self.reduced_vocab = self.draft_vocab_size != self.vocab_size
         self.markov_w1 = nn.Embedding(self.vocab_size, self.markov_rank)
-        self.markov_w2 = nn.Linear(self.markov_rank, self.vocab_size, bias=False)
+        self.markov_w2 = nn.Linear(self.markov_rank, self.draft_vocab_size, bias=False)
+        # Absolute draft->target id map (target = draft + d2t[draft]); filled
+        # from the checkpoint's d2t table in load_weights. None (identity map)
+        # for full-vocab heads. Non-persistent: reconstructed from d2t on load,
+        # never read back from a saved state dict.
+        if self.reduced_vocab:
+            self.register_buffer(
+                "draft_to_target",
+                torch.arange(self.draft_vocab_size, dtype=torch.long),
+                persistent=False,
+            )
+        else:
+            self.draft_to_target = None
+        self._draft_to_target_loaded = False
+
+    def map_sampled_to_target(self, sampled_tokens: torch.Tensor) -> torch.Tensor:
+        """Map draft-space sampled ids to target-space ids; identity when the
+        head shares the full target vocab."""
+        if self.draft_to_target is None:
+            return sampled_tokens
+        return self.draft_to_target[sampled_tokens.long()]
+
+    @property
+    def draft_to_target_loaded(self) -> bool:
+        return self._draft_to_target_loaded
+
+    def load_draft_to_target(self, d2t: torch.Tensor) -> None:
+        """Load the checkpoint's d2t delta table (target = draft + d2t[draft]),
+        following the vLLM/speculators convention. Validates the geometry so a
+        mismatched or out-of-range table fails at load, not at sample time."""
+        if self.draft_to_target is None:
+            raise ValueError(
+                "DSpark markov head received a d2t table but was built for the "
+                "full target vocab (no reduced draft head)."
+            )
+        d2t = d2t.view(-1)
+        if d2t.numel() != self.draft_vocab_size:
+            raise ValueError(
+                f"DSpark d2t length {d2t.numel()} != draft_vocab_size "
+                f"{self.draft_vocab_size}."
+            )
+        draft_ids = torch.arange(self.draft_vocab_size, device=d2t.device)
+        target_ids = d2t.to(torch.long) + draft_ids
+        if int(target_ids.min()) < 0 or int(target_ids.max()) >= self.vocab_size:
+            raise ValueError(
+                "DSpark d2t maps outside the target vocab "
+                f"[0, {self.vocab_size}); got range "
+                f"[{int(target_ids.min())}, {int(target_ids.max())}]."
+            )
+        if torch.unique(target_ids).numel() != self.draft_vocab_size:
+            raise ValueError(
+                "DSpark d2t must map each draft token to a unique target token; "
+                "duplicate target ids cannot be represented by the corrected-logit "
+                "scatter."
+            )
+        self.draft_to_target.copy_(target_ids.to(self.draft_to_target.device))
+        self._draft_to_target_loaded = True
 
     def get_prev_embeddings(self, token_ids: torch.Tensor) -> torch.Tensor:
         return self.markov_w1(token_ids.long())
@@ -132,11 +248,21 @@ class VanillaMarkov(nn.Module):
 
 
 class GatedMarkovHead(VanillaMarkov):
-
     markov_head_type = "gated"
 
-    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int) -> None:
-        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        hidden_size: int,
+        draft_vocab_size: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            draft_vocab_size=draft_vocab_size,
+        )
         self.gate_proj = nn.Linear(int(hidden_size) + markov_rank, markov_rank)
 
     def compute_gate(
@@ -163,11 +289,21 @@ class GatedMarkovHead(VanillaMarkov):
 
 
 class RNNHead(VanillaMarkov):
-
     markov_head_type = "rnn"
 
-    def __init__(self, *, vocab_size: int, markov_rank: int, hidden_size: int) -> None:
-        super().__init__(vocab_size=vocab_size, markov_rank=markov_rank)
+    def __init__(
+        self,
+        *,
+        vocab_size: int,
+        markov_rank: int,
+        hidden_size: int,
+        draft_vocab_size: Optional[int] = None,
+    ) -> None:
+        super().__init__(
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            draft_vocab_size=draft_vocab_size,
+        )
         self.hidden_size = int(hidden_size)
         self.state_size = markov_rank
         self.joint_proj = nn.Linear(2 * markov_rank + self.hidden_size, 3 * markov_rank)
@@ -254,7 +390,11 @@ class RNNHead(VanillaMarkov):
             prev_emb = self.get_prev_embeddings(prev_tokens)
             state, bias = self._rnn_step(state, prev_emb, hidden_states[:, step_idx, :])
             step_logits = base_logits[:, step_idx, :] + bias
-            next_tokens = sampler(step_logits, step_idx)
+            sampled = sampler(step_logits, step_idx)
+            # Draft-space id -> target-space id (identity for full-vocab); the
+            # target id both gets stored and conditions the next RNN step's
+            # markov_w1. See run_markov_block for the rationale.
+            next_tokens = self.map_sampled_to_target(sampled)
             sampled_tokens.append(next_tokens)
             corrected_logits.append(step_logits.unsqueeze(1))
             prev_tokens = next_tokens
@@ -264,7 +404,9 @@ class RNNHead(VanillaMarkov):
         )
 
 
-def build_markov_head(config) -> Optional[nn.Module]:
+def build_markov_head(
+    config, *, draft_vocab_size: Optional[int] = None
+) -> Optional[nn.Module]:
     markov_rank = int(getattr(config, "markov_rank", 0))
     if markov_rank <= 0:
         raise ValueError(
@@ -272,23 +414,34 @@ def build_markov_head(config) -> Optional[nn.Module]:
             f"semi-AR draft); got markov_rank={markov_rank}."
         )
     markov_head_type = str(getattr(config, "markov_head_type", "vanilla")).lower()
+    # vocab_size is the target vocab (markov_w1 input); draft_vocab_size, when
+    # set, is the reduced markov_w2 output. They are equal for full-vocab heads.
     vocab_size = int(config.vocab_size)
     hidden_size = int(config.hidden_size)
     if markov_head_type == "vanilla":
-        return VanillaMarkov(vocab_size=vocab_size, markov_rank=markov_rank)
+        return VanillaMarkov(
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            draft_vocab_size=draft_vocab_size,
+        )
     if markov_head_type == "gated":
         return GatedMarkovHead(
-            vocab_size=vocab_size, markov_rank=markov_rank, hidden_size=hidden_size
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            hidden_size=hidden_size,
+            draft_vocab_size=draft_vocab_size,
         )
     if markov_head_type == "rnn":
         return RNNHead(
-            vocab_size=vocab_size, markov_rank=markov_rank, hidden_size=hidden_size
+            vocab_size=vocab_size,
+            markov_rank=markov_rank,
+            hidden_size=hidden_size,
+            draft_vocab_size=draft_vocab_size,
         )
     raise ValueError(f"Unsupported DSpark markov_head_type={markov_head_type!r}.")
 
 
 class DSparkConfidenceHead(nn.Module):
-
     def __init__(
         self,
         *,
@@ -354,15 +507,15 @@ def build_confidence_head(config) -> Optional[nn.Module]:
     )
 
 
+# embed_tokens is always shared from the target; lm_head is handled separately
+# (kept for a reduced draft head, skipped when the target head is shared).
 _DSPARK_SKIPPED_WEIGHT_PREFIXES = (
     "embed_tokens.",
-    "lm_head.",
     "rotary_emb.",
 )
 
 
 class DSparkDraftMixin:
-
     def __init__(self, config, quant_config=None, prefix: str = "") -> None:
         super().__init__(config=config, quant_config=quant_config, prefix=prefix)
         self._fused_kv_write_cache = None
@@ -382,15 +535,65 @@ class DSparkDraftMixin:
         # either way, since the caller always hands it exactly `gamma` real
         # draft-hidden slots regardless of which convention produced them.
         self.gamma = int(dspark_config.resolve_gamma(default=self.block_size))
-        self.markov_head = build_markov_head(config)
+        self.markov_head = build_markov_head(
+            config, draft_vocab_size=dspark_config.draft_vocab_size
+        )
         self.confidence_head = build_confidence_head(config)
-        self.lm_head: Optional[nn.Module] = None
+        # A speculators checkpoint with a reduced draft vocab ships its own
+        # small lm_head (loaded in load_weights); a full-vocab draft leaves this
+        # None and shares the target head via attach_shared_modules.
+        if self.markov_head.reduced_vocab:
+            self.lm_head: Optional[nn.Module] = build_independent_lm_head(
+                draft_vocab_size=int(self.markov_head.draft_vocab_size),
+                hidden_size=int(config.hidden_size),
+                quant_config=quant_config,
+                prefix=add_prefix("lm_head", prefix),
+            )
+        else:
+            self.lm_head = None
+        # Reused eager buffer for lifting draft-space corrected logits into
+        # target-vocab columns (reduced-vocab probabilistic verify only).
+        self._corrected_target_scratch: Optional[torch.Tensor] = None
+
+    @property
+    def uses_reduced_draft_vocab(self) -> bool:
+        return self.markov_head is not None and self.markov_head.reduced_vocab
 
     def attach_shared_modules(
         self, *, embed_tokens: nn.Module, lm_head: nn.Module
     ) -> None:
         self.embed_tokens = embed_tokens
-        self.lm_head = lm_head
+        # Full-vocab drafts share the target lm_head; a reduced-vocab draft keeps
+        # the independent head built (and loaded) for it in __init__.
+        if self.lm_head is None:
+            self.lm_head = lm_head
+
+    def scatter_corrected_to_target(
+        self, corrected_logits: torch.Tensor, *, target_width: int
+    ) -> torch.Tensor:
+        """Lift draft-space markov-corrected block logits into target-vocab
+        columns (unmapped columns -inf) so target-space rejection sampling and
+        the block-accept estimator index them by the same target ids the drafts
+        were mapped to. Reuses one eager scratch buffer; only ever called
+        outside cuda-graph capture (the folded accept path is greedy-only)."""
+        draft_to_target = self.markov_head.draft_to_target
+        assert draft_to_target is not None, "scatter requires a reduced draft head"
+        bs, gamma_rows, _ = corrected_logits.shape
+        need = (bs, gamma_rows, int(target_width))
+        buf = self._corrected_target_scratch
+        if (
+            buf is None
+            or tuple(buf.shape) != need
+            or buf.dtype != corrected_logits.dtype
+            or buf.device != corrected_logits.device
+        ):
+            buf = torch.empty(
+                need, dtype=corrected_logits.dtype, device=corrected_logits.device
+            )
+            self._corrected_target_scratch = buf
+        return scatter_draft_logits_to_target(
+            corrected_logits, draft_to_target=draft_to_target, out=buf
+        )
 
     def forward_embed(self, input_ids: torch.Tensor) -> torch.Tensor:
         # Embeds with the shared target embedding INSIDE the draft graph
@@ -401,21 +604,25 @@ class DSparkDraftMixin:
     def compute_base_logits(
         self, hidden: torch.Tensor
     ) -> tuple[torch.Tensor, Optional[torch.Tensor]]:
-        """Project the draft's raw final hidden through the target lm_head.
+        """Project the draft's raw final hidden through the lm_head into base
+        logits: target-vocab-wide for a shared head, draft-vocab-wide for a
+        reduced independent head (org_vocab_size == draft vocab).
 
         muP targets (Inkling) train the draft against a FOLDED head (weights
         pre-divided by logits_mup_width_multiplier) while serving attaches the
         target's unfolded head, so the division happens here — exactly once,
         keeping base logits in the scale the markov bias and confidence head
         were trained against. DSparkWorkerV2 wires the multiplier from the
-        target config; it stays None for non-muP targets.
+        target config; it stays None for non-muP targets. A reduced independent
+        head is the draft's own trained head (not the target's), so the folding
+        does not apply to it.
         """
         if self.lm_head is None:
             raise ValueError(
                 "DSpark dense draft requires the target lm_head "
                 "(call attach_shared_modules first)."
             )
-        if self.logits_mup_width_multiplier:
+        if self.logits_mup_width_multiplier and not self.uses_reduced_draft_vocab:
             hidden = hidden / self.logits_mup_width_multiplier
         weight = self.lm_head.weight
         if hidden.dtype != weight.dtype:
@@ -427,9 +634,25 @@ class DSparkDraftMixin:
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         markov_weights = []
         confidence_weights = []
+        lm_head_weights = []
         backbone_weights = []
         params_dict = dict(self.named_parameters())
+        reduced_vocab = self.uses_reduced_draft_vocab
         for name, loaded_weight in weights:
+            if _is_dspark_d2t_weight(name):
+                # Draft->target id map; only meaningful for a reduced draft head.
+                if reduced_vocab:
+                    self.markov_head.load_draft_to_target(loaded_weight)
+                continue
+            if _is_dspark_t2d_weight(name):
+                # Inverse (target->draft) map; training-only, never used at inference.
+                continue
+            if name.startswith("lm_head."):
+                # Keep the checkpoint's own head only for a reduced draft vocab;
+                # full-vocab drafts share the target head, so drop it here.
+                if reduced_vocab:
+                    lm_head_weights.append((name, loaded_weight))
+                continue
             if any(name.startswith(p) for p in _DSPARK_SKIPPED_WEIGHT_PREFIXES):
                 continue
             if name.startswith("confidence_head."):
@@ -453,9 +676,48 @@ class DSparkDraftMixin:
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
 
+        self._load_independent_lm_head(
+            lm_head_weights=lm_head_weights, params_dict=params_dict
+        )
         self._load_confidence_weights(
             confidence_weights=confidence_weights, params_dict=params_dict
         )
+        if reduced_vocab and not self.markov_head.draft_to_target_loaded:
+            raise ValueError(
+                "DSpark reduced-vocab draft (draft_vocab_size is set) requires a "
+                "d2t draft->target map in the checkpoint, but none was found. "
+                "Provide the speculators checkpoint's d2t table; the target head "
+                "cannot be substituted for a reduced draft vocab."
+            )
+
+    def _load_independent_lm_head(
+        self,
+        *,
+        lm_head_weights: list,
+        params_dict: dict,
+    ) -> None:
+        if not self.uses_reduced_draft_vocab:
+            return
+        loaded_names = set()
+        for name, loaded_weight in lm_head_weights:
+            if name not in params_dict:
+                raise ValueError(
+                    f"DSpark unexpected lm_head weight {name!r} not found in model "
+                    "parameters."
+                )
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_names.add(name)
+
+        expected = {name for name in params_dict if name.startswith("lm_head.")}
+        missing = expected - loaded_names
+        if missing:
+            raise ValueError(
+                "DSpark reduced-vocab draft is missing independent lm_head weights "
+                f"{sorted(missing)}. The checkpoint must ship its own reduced "
+                "lm_head; the shared target head cannot cover a reduced draft vocab."
+            )
 
     def _load_confidence_weights(
         self,
@@ -721,7 +983,6 @@ class DSparkDraftMixin:
 
 
 class DSparkDraftModel(DSparkDraftMixin, DFlashDraftModel):
-
     def prune_to_ctx_kv_injection(self) -> None:
         self.markov_head = None
         self.confidence_head = None

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -526,9 +526,9 @@ class DSparkDraftMixin:
                 "DSpark draft requires markov_rank > 0, "
                 f"got markov_rank={dspark_config.markov_rank}."
             )
-        # speculators-trained checkpoints (dspark_config.speculators_convention)
+        # Bonus-anchor checkpoints (dspark_config.bonus_anchor)
         # use a `gamma + 1`-wide draft block with the anchor as a separate
-        # bonus token, rather than DeepSpec's `gamma`-wide anchor-first block.
+        # bonus token, rather than the sampled-anchor `gamma`-wide block.
         # That width difference is handled downstream in dspark_draft.py's
         # DraftBlockProposer/DsparkDraftSampler (see `bonus_anchor` there),
         # not in this model class -- run_markov_block itself is unaffected

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -373,6 +373,14 @@ class DSparkDraftMixin:
                 "DSpark draft requires markov_rank > 0, "
                 f"got markov_rank={dspark_config.markov_rank}."
             )
+        # speculators-trained checkpoints (dspark_config.speculators_convention)
+        # use a `gamma + 1`-wide draft block with the anchor as a separate
+        # bonus token, rather than DeepSpec's `gamma`-wide anchor-first block.
+        # That width difference is handled downstream in dspark_draft.py's
+        # DraftBlockProposer/DsparkDraftSampler (see `bonus_anchor` there),
+        # not in this model class -- run_markov_block itself is unaffected
+        # either way, since the caller always hands it exactly `gamma` real
+        # draft-hidden slots regardless of which convention produced them.
         self.gamma = int(dspark_config.resolve_gamma(default=self.block_size))
         self.markov_head = build_markov_head(config)
         self.confidence_head = build_confidence_head(config)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2122,6 +2122,10 @@ class ServerArgs:
         "DSPARK only. Draft block size gamma (number of proposed draft tokens). The verify window is gamma + 1, so this sets --speculative-num-draft-tokens = gamma + 1. Omit to auto-infer gamma from the draft checkpoint block_size.",
         NS("spec"),
     ] = None
+    # Resolved from the draft checkpoint in _handle_dspark, not user-facing.
+    # __post_init__ projects it into the spec config bag before any scheduler
+    # process is forked, so every rank and CUDA-graph capture sees the same layout.
+    speculative_dspark_bonus_anchor: A[bool, Arg(no_cli=True), NS("spec")] = False
     speculative_dspark_sps_table_path: A[
         Optional[str],
         "DSPARK only. Path to a pre-profiled SPS cost table (JSON) built offline with "

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any, List, Optional
 
 import msgspec
+
 from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
 
 if TYPE_CHECKING:
@@ -424,9 +425,7 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     gamma = (
         int(prefixed_block_size)
         if prefixed_block_size is not None
-        else speculators_gamma
-        if speculators_gamma is not None
-        else base.block_size
+        else speculators_gamma if speculators_gamma is not None else base.block_size
     )
 
     if prefixed_target_layer_ids is not None:

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -341,11 +341,52 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     # dspark_draft.py's DraftBlockProposer and DsparkDraftSampler (see
     # `bonus_anchor` there) -- this function only resolves the config-level
     # facts (the flag, and the correct gamma to use for such checkpoints).
+    # Which of the two conventions a given speculators checkpoint uses is NOT
+    # implied by it being a speculators checkpoint: the trainer writes the
+    # choice into `sample_from_anchor`, and both values occur in the wild.
+    #   sample_from_anchor=False -> the anchor is a separate conditioning token
+    #                               -> gamma + 1 slots  (speculators_convention)
+    #   sample_from_anchor=True  -> the anchor is itself a trained prediction
+    #                               -> gamma slots      (DeepSpec layout)
+    # Keying off `speculators_model_type` alone (as this did originally) reads
+    # every dense speculators checkpoint one slot too wide, which is the exact
+    # mirror of the bug this flag was added to fix, so trust the explicit field
+    # first and fall back to the model-type heuristic only when it is absent.
     speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
-    speculators_convention = (
+    is_speculators_dspark = (
         isinstance(speculators_model_type, str)
         and speculators_model_type.lower() == "dspark"
     )
+    sample_from_anchor = _cfg_get(draft_hf_config, "sample_from_anchor", None)
+    if isinstance(sample_from_anchor, bool):
+        speculators_convention = not sample_from_anchor
+    else:
+        speculators_convention = is_speculators_dspark
+
+    # Cross-check against the block geometry, which encodes the same fact
+    # independently: a 1+N checkpoint ships block_size == speculative_tokens + 1
+    # (the extra slot is the anchor), a dense one ships them equal. Disagreement
+    # means one of the two fields is wrong, and guessing costs 2-3x acceptance,
+    # so fail loudly instead.
+    declared_block_size = _cfg_get(draft_hf_config, "block_size", None)
+    declared_tokens = _resolve_speculators_proposal_gamma(draft_hf_config)
+    if (
+        isinstance(sample_from_anchor, bool)
+        and declared_block_size is not None
+        and declared_tokens is not None
+    ):
+        geometry_convention = int(declared_block_size) == int(declared_tokens) + 1
+        if geometry_convention != speculators_convention:
+            raise ValueError(
+                "DSpark draft config is self-inconsistent: sample_from_anchor="
+                f"{sample_from_anchor} implies a "
+                f"{'gamma + 1' if speculators_convention else 'gamma'}-slot block, "
+                f"but block_size={int(declared_block_size)} vs "
+                f"speculative_tokens={int(declared_tokens)} implies a "
+                f"{'gamma + 1' if geometry_convention else 'gamma'}-slot block. "
+                "Fix the checkpoint config; running either way silently "
+                "misreads every draft slot."
+            )
 
     # speculators checkpoints ship their authoritative draft length as
     # speculators_config.proposal_methods[i].speculative_tokens, not as

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -57,6 +57,7 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     mask_token_id: Optional[int]
     markov_rank: int
     markov_head_type: Optional[str]
+    speculators_convention: bool
 
     def resolve_gamma(self, *, default: Optional[int] = None) -> Optional[int]:
         return self.gamma if self.gamma is not None else default
@@ -69,6 +70,7 @@ class DSparkRuntimeConfig(msgspec.Struct, frozen=True):
     gamma: int
     verify_num_draft_tokens: int
     mask_token_id: int
+    speculators_convention: bool
 
 
 def resolve_runtime_config(
@@ -121,12 +123,18 @@ def resolve_runtime_config(
         gamma=gamma,
         verify_num_draft_tokens=gamma + 1,
         mask_token_id=mask_token_id,
+        speculators_convention=draft_config.speculators_convention,
     )
 
 
-def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
-    """Load the draft checkpoint's hf config and read its DSpark gamma
-    (block_size). Raises on config-load failure; callers pick the fallback."""
+def read_draft_checkpoint_config(*, server_args: ServerArgs) -> DSparkDraftConfig:
+    """Load and parse the draft checkpoint's hf config.
+
+    Startup needs more than one fact out of this file -- gamma for the verify
+    window, and speculators_convention for the draft block width that sizes
+    CUDA-graph capture -- so it is parsed once and the caller picks fields off
+    the result. Raises on config-load failure; callers pick the fallback.
+    """
     from sglang.srt.utils.hf_transformers_utils import get_config
 
     draft_hf_config = get_config(
@@ -135,9 +143,7 @@ def read_draft_checkpoint_gamma(*, server_args: ServerArgs) -> Optional[int]:
         revision=server_args.speculative_draft_model_revision,
         model_override_args=json.loads(server_args.json_model_override_args),
     )
-    return parse_dspark_draft_config(draft_hf_config=draft_hf_config).resolve_gamma(
-        default=None
-    )
+    return parse_dspark_draft_config(draft_hf_config=draft_hf_config)
 
 
 def checkpoint_bundles_dspark_draft(hf_config: Any) -> bool:
@@ -182,6 +188,51 @@ def _get_dspark_config(config: Any) -> dict:
         return dict(cfg)
     except Exception:
         return {}
+
+
+def _get_speculators_config(config: Any) -> dict:
+    cfg = _cfg_get(config, "speculators_config", None)
+    if cfg is None:
+        return {}
+    if isinstance(cfg, dict):
+        return cfg
+    try:
+        return dict(cfg)
+    except Exception:
+        return {}
+
+
+def _resolve_speculators_proposal_gamma(config: Any) -> Optional[int]:
+    """speculators checkpoints carry their real draft length in
+    speculators_config.proposal_methods[i].speculative_tokens -- prefer this
+    over block_size (which counts the anchor+gamma block width, off by one
+    from gamma for speculators-trained checkpoints; see the comment on
+    speculators_convention below)."""
+    cfg = _get_speculators_config(config)
+    proposal_methods = cfg.get("proposal_methods") or []
+    if not isinstance(proposal_methods, (list, tuple)) or not proposal_methods:
+        return None
+
+    default_method = cfg.get("default_proposal_method")
+    selected = None
+    if default_method is not None:
+        for method in proposal_methods:
+            if _cfg_get(method, "proposal_type", None) == default_method:
+                selected = method
+                break
+    if selected is None:
+        selected = proposal_methods[0]
+
+    speculative_tokens = _cfg_get(selected, "speculative_tokens", None)
+    if speculative_tokens is None:
+        return None
+    gamma = int(speculative_tokens)
+    if gamma < 1:
+        raise ValueError(
+            "DSpark speculators_config speculative_tokens must be positive, "
+            f"got {gamma}."
+        )
+    return gamma
 
 
 def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
@@ -265,8 +316,49 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
             f"DSpark mask_token_id must be non-negative, got {mask_token_id}."
         )
 
+    # speculators (github.com/vllm-project/speculators)-trained DSpark
+    # checkpoints use a different block-slot convention than the
+    # DeepSpec-trained ones this file was originally written against:
+    # DeepSpec trains block slot k to predict anchor+k+1, with the anchor
+    # itself (slot 0) also a real, trained prediction -- the draft block is
+    # exactly `gamma` slots wide, anchor-first. speculators instead trains
+    # the anchor as a separate, untrained conditioning token and slot j
+    # (j=1..gamma) to predict anchor+j -- the draft block is `gamma + 1`
+    # slots wide, with slot 0 (the anchor) excluded from both the sampled
+    # draft tokens and block-accept verification. Feeding a speculators
+    # checkpoint through the DeepSpec-width path reads every real slot one
+    # position early, degrading accept length to ~1 regardless of the
+    # underlying model's real speculative quality.
+    #
+    # This mirrors vLLM's validated `dspark_bonus_anchor` fix
+    # (vllm-project/vllm#47093 -- vllm/transformers_utils/configs/
+    # speculators/algos.py + vllm/v1/worker/gpu/spec_decode/dspark/
+    # speculator.py's `sample_from_anchor` flag) rather than unconditionally
+    # widening every DSpark block: DeepSpec-trained checkpoints
+    # (speculators_convention=False) keep exactly the behavior they had
+    # before this field existed. Diagnosed by jessiewei7 on
+    # sgl-project/sglang#30261 (2026-07-09); the width fix itself lives in
+    # dspark_draft.py's DraftBlockProposer and DsparkDraftSampler (see
+    # `bonus_anchor` there) -- this function only resolves the config-level
+    # facts (the flag, and the correct gamma to use for such checkpoints).
+    speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
+    speculators_convention = (
+        isinstance(speculators_model_type, str)
+        and speculators_model_type.lower() == "dspark"
+    )
+
+    # speculators checkpoints ship their authoritative draft length as
+    # speculators_config.proposal_methods[i].speculative_tokens, not as
+    # block_size (which means the full anchor+gamma block width there, off
+    # by one from gamma for exactly the reason above). Prefer this over
+    # base.block_size when present -- it's the checkpoint's own stated
+    # value for "how many real draft tokens", not something inferred by
+    # subtracting one from block_size and hoping the convention holds.
+    speculators_gamma = _resolve_speculators_proposal_gamma(draft_hf_config)
     gamma = (
-        int(prefixed_block_size) if prefixed_block_size is not None else base.block_size
+        int(prefixed_block_size)
+        if prefixed_block_size is not None
+        else speculators_gamma if speculators_gamma is not None else base.block_size
     )
 
     if prefixed_target_layer_ids is not None:
@@ -292,4 +384,5 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         mask_token_id=mask_token_id,
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
+        speculators_convention=speculators_convention,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -5,7 +5,6 @@ import logging
 from typing import TYPE_CHECKING, Any, List, Optional
 
 import msgspec
-
 from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
 
 if TYPE_CHECKING:
@@ -58,12 +57,23 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     markov_rank: int
     markov_head_type: Optional[str]
     speculators_convention: bool
+    # None for the ordinary DSpark checkpoint that samples in the full target
+    # vocab and shares the target lm_head. A speculators-trained checkpoint with
+    # an independent, reduced-vocabulary head (RedHatAI/*-speculator.dspark)
+    # sets this to its draft vocab size (e.g. 32000); the draft then samples in
+    # draft space and maps back to target ids via the checkpoint's d2t table.
+    draft_vocab_size: Optional[int] = None
 
     def resolve_gamma(self, *, default: Optional[int] = None) -> Optional[int]:
         return self.gamma if self.gamma is not None else default
 
     def require_markov(self) -> bool:
         return int(self.markov_rank) > 0
+
+    def uses_reduced_draft_vocab(self, *, target_vocab_size: int) -> bool:
+        return self.draft_vocab_size is not None and int(self.draft_vocab_size) < int(
+            target_vocab_size
+        )
 
 
 class DSparkRuntimeConfig(msgspec.Struct, frozen=True):
@@ -200,6 +210,46 @@ def _get_speculators_config(config: Any) -> dict:
         return dict(cfg)
     except Exception:
         return {}
+
+
+def resolve_target_vocab_size(draft_hf_config: Any) -> Optional[int]:
+    """The draft transformer/embedding vocab, i.e. the target vocab the Markov
+    head's markov_w1 and the shared embedding operate in. Read from the same
+    nested/top-level locations as the rest of the draft config."""
+    text_config = _get_text_config(draft_hf_config)
+    raw = _cfg_get(
+        text_config, "vocab_size", _cfg_get(draft_hf_config, "vocab_size", None)
+    )
+    return int(raw) if raw is not None else None
+
+
+def resolve_draft_vocab_size(draft_hf_config: Any) -> Optional[int]:
+    """The reduced draft-head vocab for speculators DSpark checkpoints, or None
+    when the draft shares the full target vocab/head.
+
+    Kept as the single resolution point (used by both parse_dspark_draft_config
+    and the model's head construction) so the two never disagree on geometry.
+    """
+    dspark_cfg = _get_dspark_config(draft_hf_config)
+    text_config = _get_text_config(draft_hf_config)
+    raw = _cfg_get(draft_hf_config, "draft_vocab_size", None)
+    if raw is None:
+        raw = dspark_cfg.get(
+            "draft_vocab_size", _cfg_get(text_config, "draft_vocab_size", None)
+        )
+    if raw is None:
+        return None
+    value = int(raw)
+    if value <= 0:
+        raise ValueError(f"DSpark draft_vocab_size must be positive, got {value}.")
+    target_vocab_size = resolve_target_vocab_size(draft_hf_config)
+    if target_vocab_size is not None and value > target_vocab_size:
+        raise ValueError(
+            f"DSpark draft_vocab_size={value} exceeds the target vocab "
+            f"{target_vocab_size}; a reduced draft head cannot be larger than "
+            "the vocab its d2t table maps into."
+        )
+    return value
 
 
 def _resolve_speculators_proposal_gamma(config: Any) -> Optional[int]:
@@ -399,7 +449,9 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     gamma = (
         int(prefixed_block_size)
         if prefixed_block_size is not None
-        else speculators_gamma if speculators_gamma is not None else base.block_size
+        else speculators_gamma
+        if speculators_gamma is not None
+        else base.block_size
     )
 
     if prefixed_target_layer_ids is not None:
@@ -426,4 +478,5 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
         speculators_convention=speculators_convention,
+        draft_vocab_size=resolve_draft_vocab_size(draft_hf_config),
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_config.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_config.py
@@ -56,7 +56,7 @@ class DSparkDraftConfig(msgspec.Struct, frozen=True):
     mask_token_id: Optional[int]
     markov_rank: int
     markov_head_type: Optional[str]
-    speculators_convention: bool
+    bonus_anchor: bool
     # None for the ordinary DSpark checkpoint that samples in the full target
     # vocab and shares the target lm_head. A speculators-trained checkpoint with
     # an independent, reduced-vocabulary head (RedHatAI/*-speculator.dspark)
@@ -80,7 +80,7 @@ class DSparkRuntimeConfig(msgspec.Struct, frozen=True):
     gamma: int
     verify_num_draft_tokens: int
     mask_token_id: int
-    speculators_convention: bool
+    bonus_anchor: bool
 
 
 def resolve_runtime_config(
@@ -133,7 +133,7 @@ def resolve_runtime_config(
         gamma=gamma,
         verify_num_draft_tokens=gamma + 1,
         mask_token_id=mask_token_id,
-        speculators_convention=draft_config.speculators_convention,
+        bonus_anchor=draft_config.bonus_anchor,
     )
 
 
@@ -141,7 +141,7 @@ def read_draft_checkpoint_config(*, server_args: ServerArgs) -> DSparkDraftConfi
     """Load and parse the draft checkpoint's hf config.
 
     Startup needs more than one fact out of this file -- gamma for the verify
-    window, and speculators_convention for the draft block width that sizes
+    window, and bonus_anchor for the draft block width that sizes
     CUDA-graph capture -- so it is parsed once and the caller picks fields off
     the result. Raises on config-load failure; callers pick the fallback.
     """
@@ -256,8 +256,8 @@ def _resolve_speculators_proposal_gamma(config: Any) -> Optional[int]:
     """speculators checkpoints carry their real draft length in
     speculators_config.proposal_methods[i].speculative_tokens -- prefer this
     over block_size (which counts the anchor+gamma block width, off by one
-    from gamma for speculators-trained checkpoints; see the comment on
-    speculators_convention below)."""
+    from gamma for bonus-anchor checkpoints; see the layout resolution in
+    parse_dspark_draft_config below)."""
     cfg = _get_speculators_config(config)
     proposal_methods = cfg.get("proposal_methods") or []
     if not isinstance(proposal_methods, (list, tuple)) or not proposal_methods:
@@ -366,52 +366,27 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
             f"DSpark mask_token_id must be non-negative, got {mask_token_id}."
         )
 
-    # speculators (github.com/vllm-project/speculators)-trained DSpark
-    # checkpoints use a different block-slot convention than the
-    # DeepSpec-trained ones this file was originally written against:
-    # DeepSpec trains block slot k to predict anchor+k+1, with the anchor
-    # itself (slot 0) also a real, trained prediction -- the draft block is
-    # exactly `gamma` slots wide, anchor-first. speculators instead trains
-    # the anchor as a separate, untrained conditioning token and slot j
-    # (j=1..gamma) to predict anchor+j -- the draft block is `gamma + 1`
-    # slots wide, with slot 0 (the anchor) excluded from both the sampled
-    # draft tokens and block-accept verification. Feeding a speculators
-    # checkpoint through the DeepSpec-width path reads every real slot one
-    # position early, degrading accept length to ~1 regardless of the
-    # underlying model's real speculative quality.
-    #
-    # This mirrors vLLM's validated `dspark_bonus_anchor` fix
-    # (vllm-project/vllm#47093 -- vllm/transformers_utils/configs/
-    # speculators/algos.py + vllm/v1/worker/gpu/spec_decode/dspark/
-    # speculator.py's `sample_from_anchor` flag) rather than unconditionally
-    # widening every DSpark block: DeepSpec-trained checkpoints
-    # (speculators_convention=False) keep exactly the behavior they had
-    # before this field existed. Diagnosed by jessiewei7 on
-    # sgl-project/sglang#30261 (2026-07-09); the width fix itself lives in
-    # dspark_draft.py's DraftBlockProposer and DsparkDraftSampler (see
-    # `bonus_anchor` there) -- this function only resolves the config-level
-    # facts (the flag, and the correct gamma to use for such checkpoints).
-    # Which of the two conventions a given speculators checkpoint uses is NOT
-    # implied by it being a speculators checkpoint: the trainer writes the
-    # choice into `sample_from_anchor`, and both values occur in the wild.
-    #   sample_from_anchor=False -> the anchor is a separate conditioning token
-    #                               -> gamma + 1 slots  (speculators_convention)
-    #   sample_from_anchor=True  -> the anchor is itself a trained prediction
-    #                               -> gamma slots      (DeepSpec layout)
-    # Keying off `speculators_model_type` alone (as this did originally) reads
-    # every dense speculators checkpoint one slot too wide, which is the exact
-    # mirror of the bug this flag was added to fix, so trust the explicit field
-    # first and fall back to the model-type heuristic only when it is absent.
+    # sample_from_anchor determines the draft layout for every DSpark checkpoint:
+    # False uses a separate bonus anchor and gamma + 1 slots; True uses gamma
+    # sampled slots. Legacy Speculators configs omitted the field and defaulted
+    # to False, while native DSpark configs default to True. Checkpoint origin is
+    # therefore only a backward-compatible default, never an override.
     speculators_model_type = _cfg_get(draft_hf_config, "speculators_model_type", None)
     is_speculators_dspark = (
         isinstance(speculators_model_type, str)
         and speculators_model_type.lower() == "dspark"
     )
-    sample_from_anchor = _cfg_get(draft_hf_config, "sample_from_anchor", None)
-    if isinstance(sample_from_anchor, bool):
-        speculators_convention = not sample_from_anchor
+    raw_sample_from_anchor = _cfg_get(draft_hf_config, "sample_from_anchor", None)
+    if raw_sample_from_anchor is None:
+        sample_from_anchor = not is_speculators_dspark
+    elif isinstance(raw_sample_from_anchor, bool):
+        sample_from_anchor = raw_sample_from_anchor
     else:
-        speculators_convention = is_speculators_dspark
+        raise ValueError(
+            "DSpark sample_from_anchor must be a bool when set, got "
+            f"{raw_sample_from_anchor!r}."
+        )
+    bonus_anchor = not sample_from_anchor
 
     # Cross-check against the block geometry, which encodes the same fact
     # independently: a 1+N checkpoint ships block_size == speculative_tokens + 1
@@ -421,19 +396,19 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
     declared_block_size = _cfg_get(draft_hf_config, "block_size", None)
     declared_tokens = _resolve_speculators_proposal_gamma(draft_hf_config)
     if (
-        isinstance(sample_from_anchor, bool)
+        raw_sample_from_anchor is not None
         and declared_block_size is not None
         and declared_tokens is not None
     ):
-        geometry_convention = int(declared_block_size) == int(declared_tokens) + 1
-        if geometry_convention != speculators_convention:
+        geometry_bonus_anchor = int(declared_block_size) == int(declared_tokens) + 1
+        if geometry_bonus_anchor != bonus_anchor:
             raise ValueError(
                 "DSpark draft config is self-inconsistent: sample_from_anchor="
                 f"{sample_from_anchor} implies a "
-                f"{'gamma + 1' if speculators_convention else 'gamma'}-slot block, "
+                f"{'gamma + 1' if bonus_anchor else 'gamma'}-slot block, "
                 f"but block_size={int(declared_block_size)} vs "
                 f"speculative_tokens={int(declared_tokens)} implies a "
-                f"{'gamma + 1' if geometry_convention else 'gamma'}-slot block. "
+                f"{'gamma + 1' if geometry_bonus_anchor else 'gamma'}-slot block. "
                 "Fix the checkpoint config; running either way silently "
                 "misreads every draft slot."
             )
@@ -477,6 +452,6 @@ def parse_dspark_draft_config(*, draft_hf_config: Any) -> DSparkDraftConfig:
         mask_token_id=mask_token_id,
         markov_rank=markov_rank,
         markov_head_type=markov_head_type,
-        speculators_convention=speculators_convention,
+        bonus_anchor=bonus_anchor,
         draft_vocab_size=resolve_draft_vocab_size(draft_hf_config),
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -164,6 +164,31 @@ def sample_draft_block(
 
 
 class DraftBlockProposer:
+    """Runs the DSpark draft model's forward pass and samples its block.
+
+    ``bonus_anchor`` (from DSparkDraftConfig.speculators_convention, threaded
+    in by dspark_worker_v2.py) selects between two block layouts:
+
+    - False (DeepSpec, the original convention this class was written for):
+      the draft block is exactly ``gamma`` slots wide, anchor-first -- slot 0
+      IS the anchor token and is itself a real, trained draft prediction.
+      ``self.gamma`` (the real draft-token count used everywhere else in the
+      codebase -- verify window sizing, KV commit, accept-length accounting)
+      already equals the forward-pass width; no adjustment needed.
+    - True (speculators): the draft block is ``gamma + 1`` slots wide --
+      slot 0 is still the anchor token (the draft transformer must see it to
+      attend to), but it's an untrained conditioning token, not a draft
+      prediction, so its hidden state/logits are excluded before sampling.
+      Only this class's own internal forward-pass sizing changes
+      (``draft_width``); ``self.gamma`` itself, and everything downstream
+      that reads it, is unaffected.
+
+    Mirrors vLLM's validated `dspark_bonus_anchor`/`sample_from_anchor` fix
+    (vllm-project/vllm#47093) rather than unconditionally widening every
+    DSpark block the way an earlier draft of this fix did -- see the
+    docstring on ``speculators_convention`` in dspark_config.py.
+    """
+
     def __init__(
         self,
         *,
@@ -173,6 +198,7 @@ class DraftBlockProposer:
         mask_token_id: int,
         draft_block_spec_info,
         dp_moe_sync: bool = False,
+        bonus_anchor: bool = False,
     ) -> None:
         self.draft_model = draft_model
         self.draft_model_runner = draft_model_runner
@@ -181,6 +207,8 @@ class DraftBlockProposer:
         self._draft_block_spec_info = draft_block_spec_info
         self._draft_sampler = None
         self._dp_moe_sync = dp_moe_sync
+        self.bonus_anchor = bool(bonus_anchor)
+        self.draft_width = self.gamma + 1 if self.bonus_anchor else self.gamma
 
     def attach_draft_sampler(self, draft_sampler) -> None:
         self._draft_sampler = draft_sampler
@@ -263,8 +291,14 @@ class DraftBlockProposer:
                 folded_confidence = draft_sampler.confidence_out[:bs]
         else:
             with self._base_logits_context():
+                # fwd.draft_hidden_3d is always exactly gamma slots wide
+                # (DraftBlockProposer._run_forward already excludes the
+                # anchor's own hidden state when bonus_anchor is set) --
+                # base_logits must come from the same gamma real draft
+                # slots, never from the wider raw_hidden that includes the
+                # anchor under bonus_anchor.
                 base_logits, confidence_tap = self.draft_model.compute_base_logits(
-                    fwd.raw_hidden
+                    fwd.draft_hidden_3d.reshape(bs * self.gamma, -1)
                 )
                 base_logits = base_logits.view(bs, self.gamma, -1)
             draft_block = sample_draft_block(
@@ -319,17 +353,22 @@ class DraftBlockProposer:
         draft_sampler=None,
         sampling_info=None,
     ) -> DraftForwardResult:
-        gamma = self.gamma
+        draft_width = self.draft_width
         prefix_lens = batch.seq_lens
         positions_2d = verify_window.positions_2d
         verify_cache_loc_2d = verify_window.verify_cache_loc_2d
 
+        # draft_width == gamma (DeepSpec, anchor-first) or gamma + 1
+        # (speculators, anchor is a separate bonus/conditioning token) -- see
+        # this class's docstring. positions_2d/verify_cache_loc_2d are always
+        # allocated verify_num_draft_tokens (= gamma + 1) wide, so slicing to
+        # draft_width is in-bounds either way.
         draft_block_ids = torch.full(
-            (bs, gamma), int(self._mask_token_id), dtype=torch.long, device=device
+            (bs, draft_width), int(self._mask_token_id), dtype=torch.long, device=device
         )
         draft_block_ids[:, 0].copy_(draft_input.bonus_tokens.view(-1))
-        draft_positions = positions_2d[:, :gamma].reshape(-1)
-        draft_cache_loc = verify_cache_loc_2d[:, :gamma].reshape(-1)
+        draft_positions = positions_2d[:, :draft_width].reshape(-1)
+        draft_cache_loc = verify_cache_loc_2d[:, :draft_width].reshape(-1)
 
         draft_owns_embed = envs.SGLANG_DSPARK_EMBED_IN_GRAPH.get() and hasattr(
             self.draft_model, "forward_embed"
@@ -340,9 +379,15 @@ class DraftBlockProposer:
             draft_input_embeds = noise_embedding.view(-1, noise_embedding.shape[-1])
 
         if batch.seq_lens_cpu is not None:
-            draft_seq_lens_cpu = batch.seq_lens_cpu + gamma
+            draft_seq_lens_cpu = batch.seq_lens_cpu + draft_width
             draft_seq_lens_sum = int(draft_seq_lens_cpu.sum())
         elif draft_input.reserved_seq_lens_cpu is not None:
+            # TODO(bonus_anchor): reserved_seq_lens_cpu/reserved_seq_lens_sum
+            # come pre-computed from elsewhere (CUDA-graph-padded reservation
+            # sizing) and are used as-is here, unlike the branch above. Not
+            # verified against bonus_anchor=True -- if this path is ever hit
+            # for a speculators checkpoint, confirm the reservation already
+            # accounts for draft_width (gamma + 1), not just gamma.
             draft_seq_lens_cpu = draft_input.reserved_seq_lens_cpu
             draft_seq_lens_sum = int(draft_input.reserved_seq_lens_sum)
         else:
@@ -380,7 +425,20 @@ class DraftBlockProposer:
         raw_hidden = logits_output.hidden_states
         if raw_hidden is None:
             raise RuntimeError("DSpark draft model returned no hidden states.")
-        draft_hidden_3d = raw_hidden.view(bs, gamma, -1)
+        # draft_hidden_3d is always exactly gamma slots wide -- the real
+        # draft-hidden states callers (propose(), base_logits computation)
+        # consume, regardless of which convention produced them. Under
+        # bonus_anchor, slot 0 of the draft_width-wide forward output is the
+        # anchor's own hidden state and is excluded here, not downstream.
+        raw_hidden_3d = raw_hidden.view(bs, draft_width, -1)
+        # .contiguous(): downstream consumers of DraftForwardResult.draft_hidden_3d
+        # (propose()'s base_logits reshape, DraftProposal.draft_hidden feeding
+        # confidence/KV-inject code) are not all guaranteed to use .reshape()
+        # over .view() -- keep this slice's output actually contiguous rather
+        # than relying on every consumer tolerating a non-contiguous view.
+        draft_hidden_3d = (
+            raw_hidden_3d[:, 1:, :].contiguous() if self.bonus_anchor else raw_hidden_3d
+        )
         return DraftForwardResult(
             draft_block_ids=draft_block_ids,
             raw_hidden=raw_hidden,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 import msgspec
 import torch
+
 from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
     SampleStepTokens,
 )

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -6,7 +6,6 @@ from typing import Optional
 
 import msgspec
 import torch
-
 from sglang.kernels.ops.speculative.dspark.dspark_draft_model import (
     SampleStepTokens,
 )
@@ -393,7 +392,7 @@ class DraftBlockProposer:
         else:
             raise RuntimeError("DSpark decode expected batch.seq_lens_cpu, got None")
 
-        draft_num_tokens = bs * gamma
+        draft_num_tokens = bs * draft_width
         draft_forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,
             batch_size=bs,

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -165,16 +165,16 @@ def sample_draft_block(
 class DraftBlockProposer:
     """Runs the DSpark draft model's forward pass and samples its block.
 
-    ``bonus_anchor`` (from DSparkDraftConfig.speculators_convention, threaded
+    ``bonus_anchor`` (from DSparkDraftConfig.bonus_anchor, threaded
     in by dspark_worker_v2.py) selects between two block layouts:
 
-    - False (DeepSpec, the original convention this class was written for):
+    - False (sampled-anchor layout):
       the draft block is exactly ``gamma`` slots wide, anchor-first -- slot 0
       IS the anchor token and is itself a real, trained draft prediction.
       ``self.gamma`` (the real draft-token count used everywhere else in the
       codebase -- verify window sizing, KV commit, accept-length accounting)
       already equals the forward-pass width; no adjustment needed.
-    - True (speculators): the draft block is ``gamma + 1`` slots wide --
+    - True (bonus-anchor layout): the draft block is ``gamma + 1`` slots wide --
       slot 0 is still the anchor token (the draft transformer must see it to
       attend to), but it's an untrained conditioning token, not a draft
       prediction, so its hidden state/logits are excluded before sampling.
@@ -185,7 +185,7 @@ class DraftBlockProposer:
     Mirrors vLLM's validated `dspark_bonus_anchor`/`sample_from_anchor` fix
     (vllm-project/vllm#47093) rather than unconditionally widening every
     DSpark block the way an earlier draft of this fix did -- see the
-    docstring on ``speculators_convention`` in dspark_config.py.
+    layout resolution in dspark_config.py.
     """
 
     def __init__(

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -36,10 +36,13 @@ class DsparkDraftSampler:
         confidence_fn=None,
         out=None,
         folded_sampling: bool = True,
+        bonus_anchor: bool = False,
     ):
         self.model = model
         self.markov_head = model.markov_head
         self.gamma = int(gamma)
+        self.bonus_anchor = bool(bonus_anchor)
+        self.draft_width = self.gamma + 1 if self.bonus_anchor else self.gamma
         max_bs = int(max_bs)
         if out is not None:
             assert out.shape == (max_bs * self.gamma,) and out.dtype == torch.int64
@@ -91,10 +94,22 @@ class DsparkDraftSampler:
         self.greedy_mask[:bs].copy_((sampling_info.top_ks <= 1).view(-1)[:bs])
 
     def __call__(self, hidden_states, input_ids):
-        bs = hidden_states.shape[0] // self.gamma
-        base_logits, confidence_tap = self.model.compute_base_logits(hidden_states)
+        if hidden_states.shape[0] % self.draft_width != 0:
+            raise ValueError(
+                "DSpark draft sampler hidden-state rows must be divisible by "
+                f"draft_width={self.draft_width}, got {hidden_states.shape[0]}."
+            )
+        bs = hidden_states.shape[0] // self.draft_width
+        hidden_3d = hidden_states.view(bs, self.draft_width, -1)
+        input_ids_2d = input_ids.view(bs, self.draft_width)
+        anchor = input_ids_2d[:, 0]
+        draft_hidden = (
+            hidden_3d[:, 1:, :].contiguous() if self.bonus_anchor else hidden_3d
+        )
+        base_logits, confidence_tap = self.model.compute_base_logits(
+            draft_hidden.reshape(bs * self.gamma, -1)
+        )
         base_logits = base_logits.view(bs, self.gamma, -1)
-        anchor = input_ids.view(bs, self.gamma)[:, 0]
 
         if self.folded_sampling:
 
@@ -116,7 +131,7 @@ class DsparkDraftSampler:
         draft_tokens, corrected_logits = self.markov_head.sample_block(
             base_logits,
             first_prev_tokens=anchor,
-            hidden_states=hidden_states.view(bs, self.gamma, -1),
+            hidden_states=draft_hidden,
             sampler=sampler,
         )
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
@@ -126,7 +141,7 @@ class DsparkDraftSampler:
             )
         if self.confidence_out is not None:
             confidence = self.confidence_fn(
-                draft_hidden=hidden_states.view(bs, self.gamma, -1),
+                draft_hidden=draft_hidden,
                 anchor_tokens=anchor,
                 draft_tokens=draft_tokens,
                 confidence_tap=confidence_tap,
@@ -173,6 +188,7 @@ def maybe_build_draft_sampler(
     tp_rank: int,
     confidence_fn=None,
     out=None,
+    bonus_anchor: bool = False,
 ) -> Optional[DsparkDraftSampler]:
     """Build the graph-folded draft sampler, or None (reason logged) when the
     proposal must stay eager."""
@@ -204,4 +220,5 @@ def maybe_build_draft_sampler(
         confidence_fn=confidence_fn,
         out=out,
         folded_sampling=folded_sampling,
+        bonus_anchor=bonus_anchor,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -146,9 +146,9 @@ class TargetVerifyExecutor:
                     bs, self.verify_num_draft_tokens
                 )
                 row_ids = torch.arange(bs, device=target_predict.device)
-                bonus = target_predict[
-                    row_ids, correct_len.to(torch.int64)
-                ].to(torch.int64)
+                bonus = target_predict[row_ids, correct_len.to(torch.int64)].to(
+                    torch.int64
+                )
 
         finalized = FinalizeAcceptLens.execute(
             correct_len=correct_len,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -137,6 +137,18 @@ class TargetVerifyExecutor:
             correct_len = self._simulated_correct_len(
                 bs=bs, dtype=correct_len.dtype, device=correct_len.device
             )
+            # The simulated length replaces the real accept result, so its
+            # bonus must come from the target row at that simulated boundary.
+            # Reusing the pre-override bonus can emit a token from a later row
+            # even when simulate_acc_len=1 forces zero accepted drafts.
+            if sampling_info is None or sampling_info.is_all_greedy:
+                target_predict = torch.argmax(target_logits, dim=-1).view(
+                    bs, self.verify_num_draft_tokens
+                )
+                row_ids = torch.arange(bs, device=target_predict.device)
+                bonus = target_predict[
+                    row_ids, correct_len.to(torch.int64)
+                ].to(torch.int64)
 
         finalized = FinalizeAcceptLens.execute(
             correct_len=correct_len,

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 from typing import Optional
 
 import torch
+
 from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
     is_unified_kv_triton,
 )

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -4,7 +4,6 @@ from dataclasses import replace
 from typing import Optional
 
 import torch
-
 from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.env_gate import (
     is_unified_kv_triton,
 )
@@ -36,6 +35,7 @@ from sglang.srt.speculative.dspark_components.dspark_config import (
 )
 from sglang.srt.speculative.dspark_components.dspark_draft import (
     DraftBlockProposer,
+    DraftBlockResult,
     make_next_draft_input,
 )
 from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
@@ -74,7 +74,6 @@ _is_npu = is_npu()
 
 
 class DSparkWorkerV2(BaseSpecWorker):
-
     def __init__(
         self,
         server_args: ServerArgs,
@@ -229,6 +228,20 @@ class DSparkWorkerV2(BaseSpecWorker):
                 lm_head=lm_head,
             )
 
+        # Reduced-vocab speculators checkpoints (independent draft head + d2t)
+        # sample in draft space; the verify/accept and block-accept paths then
+        # lift the markov-corrected block into target-vocab columns. Full-vocab
+        # drafts (the common case) never touch the target-vocab scatter buffer.
+        self._reduced_draft_vocab = self.draft_model.uses_reduced_draft_vocab
+        if self.ps.tp_rank == 0 and self._reduced_draft_vocab:
+            logger.info(
+                "DSpark draft uses an independent reduced-vocab head "
+                "(draft_vocab_size=%s, target_vocab_size=%s); sampling draft-space "
+                "ids and mapping to target ids via the checkpoint d2t table.",
+                int(self.draft_model.markov_head.draft_vocab_size),
+                int(self.draft_model.markov_head.vocab_size),
+            )
+
         self._verify_planner = DSparkVerifyPlanner(
             draft_model=self.draft_model,
             gamma=self.gamma,
@@ -339,6 +352,33 @@ class DSparkWorkerV2(BaseSpecWorker):
         if hasattr(target_model, "get_input_embeddings"):
             return target_model.get_input_embeddings()
         return target_model.model.get_input_embeddings()
+
+    def _resolve_corrected_vocab_space(
+        self,
+        draft_block: DraftBlockResult,
+        *,
+        target_logits: Optional[torch.Tensor],
+    ) -> DraftBlockResult:
+        """Scatter draft-space markov-corrected block logits into target-vocab
+        columns for a reduced-vocab draft, so the target-space rejection sampler
+        and block-accept estimator index them by the mapped target ids. A no-op
+        for full-vocab drafts and for greedy folded proposals (corrected logits
+        are None there)."""
+        if (
+            not self._reduced_draft_vocab
+            or draft_block.corrected_logits is None
+            or target_logits is None
+        ):
+            return draft_block
+        corrected_target = self.draft_model.scatter_corrected_to_target(
+            draft_block.corrected_logits, target_width=int(target_logits.shape[-1])
+        )
+        return DraftBlockResult(
+            draft_tokens=draft_block.draft_tokens,
+            corrected_logits=corrected_target,
+            greedy_mask=draft_block.greedy_mask,
+            temperatures=draft_block.temperatures,
+        )
 
     @property
     def carries_confidence(self) -> bool:
@@ -739,6 +779,14 @@ class DSparkWorkerV2(BaseSpecWorker):
             )
             if grammar_mask is not None:
                 grammar_mask.apply(logits_output.next_token_logits)
+
+        # Reduced-vocab drafts: lift the draft-space corrected block into
+        # target-vocab columns once, so both accept_and_finalize and
+        # observe_verify_step below read it in the target space their token ids
+        # already live in. No-op for full-vocab / greedy-folded proposals.
+        draft_block = self._resolve_corrected_vocab_space(
+            draft_block, target_logits=logits_output.next_token_logits
+        )
 
         epilogue = self._verify_executor.verify_epilogue
         folded_accept = fold_eligible and run_compact and can_run_cuda_graph

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -154,6 +154,38 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
+        # speculators-trained checkpoints use a gamma+1-wide draft block
+        # (anchor is a separate bonus/conditioning token) instead of
+        # DeepSpec's gamma-wide anchor-first block -- see the docstring on
+        # DSparkDraftConfig.speculators_convention (dspark_config.py) and on
+        # DraftBlockProposer (dspark_draft.py). Threaded through to both the
+        # eager (DraftBlockProposer) and CUDA-graph-folded (DsparkDraftSampler)
+        # draft-sampling paths below.
+        self._bonus_anchor = runtime_config.speculators_convention
+        # The same fact is resolved twice by design: here from the draft config
+        # this worker actually loaded, and at startup onto ServerArgs (see
+        # _handle_dspark) because that is the only copy the CUDA-graph capture
+        # width can see. If they ever disagree the graph is captured at the
+        # wrong width, which surfaces far away as a draft-sampler ValueError
+        # during capture or a permanently eager draft forward. Fail here
+        # instead: this runs before init_attention_backends/init_cuda_graphs.
+        startup_bonus_anchor = bool(self.server_args.speculative_dspark_bonus_anchor)
+        if startup_bonus_anchor != bool(self._bonus_anchor):
+            raise ValueError(
+                "DSpark draft block layout was resolved inconsistently: the "
+                f"draft checkpoint says bonus_anchor={bool(self._bonus_anchor)} "
+                f"but startup resolution produced {startup_bonus_anchor}. The "
+                "CUDA-graph capture width is derived from the startup value, so "
+                "continuing would capture a mis-sized draft graph. Check that "
+                "--speculative-draft-model-path points at the checkpoint whose "
+                "config was read at startup."
+            )
+        if self.ps.tp_rank == 0 and self._bonus_anchor:
+            logger.info(
+                "DSpark draft checkpoint uses the speculators bonus-anchor "
+                "convention (gamma+1-wide draft block, anchor excluded from "
+                "sampling)."
+            )
 
         if self.ps.tp_rank == 0:
             logger.info(
@@ -171,8 +203,13 @@ class DSparkWorkerV2(BaseSpecWorker):
         self._block_pos_offsets = build_block_pos_offsets(
             length=self.verify_num_draft_tokens, device=self.device
         )
+        # This spec-info width drives the draft attention backend's qo_indptr.
+        # Keep downstream verification at gamma real predictions, but include
+        # the conditioning-only anchor in the draft forward's attention width
+        # for speculators checkpoints.
+        draft_attention_width = self.gamma + int(self._bonus_anchor)
         self._draft_block_spec_info = make_draft_block_spec_info(
-            draft_token_num=int(self.gamma), device=self.device
+            draft_token_num=int(draft_attention_width), device=self.device
         )
 
         if getattr(self.draft_model, "uses_own_vocab_modules", False):
@@ -229,6 +266,7 @@ class DSparkWorkerV2(BaseSpecWorker):
             mask_token_id=self._mask_token_id,
             draft_block_spec_info=self._draft_block_spec_info,
             dp_moe_sync=self._draft_is_moe and get_parallel().enable_dp_attention,
+            bonus_anchor=self._bonus_anchor,
         )
         self._verify_epilogue = None
         if (
@@ -398,6 +436,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 if self._verify_epilogue is not None
                 else None
             ),
+            bonus_anchor=self._bonus_anchor,
         )
 
     def clear_cache_pool(self):

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -153,14 +153,13 @@ class DSparkWorkerV2(BaseSpecWorker):
         self.verify_num_draft_tokens = runtime_config.verify_num_draft_tokens
         self.speculative_num_draft_tokens = self.verify_num_draft_tokens
         self._mask_token_id = runtime_config.mask_token_id
-        # speculators-trained checkpoints use a gamma+1-wide draft block
-        # (anchor is a separate bonus/conditioning token) instead of
-        # DeepSpec's gamma-wide anchor-first block -- see the docstring on
-        # DSparkDraftConfig.speculators_convention (dspark_config.py) and on
+        # Bonus-anchor checkpoints use a gamma+1-wide draft block instead of
+        # the sampled-anchor layout's gamma-wide block -- see the docstring on
+        # DSparkDraftConfig.bonus_anchor (dspark_config.py) and on
         # DraftBlockProposer (dspark_draft.py). Threaded through to both the
         # eager (DraftBlockProposer) and CUDA-graph-folded (DsparkDraftSampler)
         # draft-sampling paths below.
-        self._bonus_anchor = runtime_config.speculators_convention
+        self._bonus_anchor = runtime_config.bonus_anchor
         # The same fact is resolved twice by design: here from the draft config
         # this worker actually loaded, and at startup onto ServerArgs (see
         # _handle_dspark) because that is the only copy the CUDA-graph capture

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -233,8 +233,9 @@ class SpeculativeAlgorithm(Enum):
         # graph support. We can use it for target verify, or we can use it for
         # other cases which is not target verify but fixed length prefill.
         # Here, we expose this interface to allow the other use cases.
-        if self.is_dspark() and is_draft_worker:
-            return num_draft_tokens - 1
+        # DSpark's draft-worker width depends on its checkpoint layout, so it is
+        # resolved in spec_utils.resolve_num_tokens_per_req from the spec config
+        # bag. Keep this algorithm hook layout-agnostic.
         return num_draft_tokens
 
     def get_num_tokens_per_bs_for_target_verify(

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -118,6 +118,22 @@ def resolve_num_tokens_per_req(
     if phase == "target_verify":
         if num_draft_tokens is None:
             num_draft_tokens = spec.speculative_num_draft_tokens
+        if is_draft_worker:
+            # Custom algorithms may identify as DSpark while overriding the
+            # width hook below. Only the builtin owns this checkpoint-derived
+            # config-bag convention; plugins must retain their override.
+            from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+            if spec_algorithm is SpeculativeAlgorithm.DSPARK:
+                # DeepSpec runs a gamma-wide draft forward; speculators carries
+                # a separate conditioning anchor in slot 0 and therefore runs
+                # the full gamma + 1 verify window. Keep both outcomes in this
+                # resolver: the algorithm hook cannot see the checkpoint flag.
+                return (
+                    num_draft_tokens
+                    if spec.speculative_dspark_bonus_anchor
+                    else num_draft_tokens - 1
+                )
         return spec_algorithm.get_num_tokens_per_req_for_target_verify(
             num_draft_tokens, is_draft_worker
         )

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -16,9 +16,6 @@
 from pathlib import Path
 from typing import Optional
 
-from transformers import PretrainedConfig
-from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
-
 from sglang.srt.configs.model_config_parser_registry import (
     ModelConfigParserBase,
     get_model_config_parser,
@@ -26,6 +23,8 @@ from sglang.srt.configs.model_config_parser_registry import (
 )
 from sglang.srt.connector import create_remote_connector
 from sglang.srt.utils import is_remote_url, lru_cache_frozenset
+from transformers import PretrainedConfig
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
 from ..hf_transformers_patches import _ensure_gguf_version
 from .common import (
@@ -61,17 +60,66 @@ _LONGCAT_ARCHS = {
 }
 
 
-def _try_load_longcat_config(model, revision: Optional[str], **kwargs):
+def _normalize_speculators_draft_config_dict(config_dict: dict) -> Optional[dict]:
+    """Flatten a native speculators draft config into a Transformers config.
+
+    Speculators checkpoints keep the backbone config under
+    ``transformer_layer_config`` and intentionally omit a top-level
+    ``model_type``.  AutoConfig therefore rejects otherwise self-contained
+    public checkpoints before SGLang can inspect their draft metadata.
+    """
+    speculator_type = config_dict.get("speculators_model_type")
+    transformer_config = config_dict.get("transformer_layer_config")
+    if (
+        not isinstance(speculator_type, str)
+        or speculator_type.lower() != "dspark"
+        or not isinstance(transformer_config, dict)
+    ):
+        return None
+    if not transformer_config.get("model_type"):
+        return None
+
+    normalized = dict(transformer_config)
+    normalized.update(
+        {
+            key: value
+            for key, value in config_dict.items()
+            if key != "transformer_layer_config"
+        }
+    )
+    # The nested backbone owns model_type. A native speculators auto_map may
+    # use its own config runtime, which SGLang neither needs nor imports.
+    normalized["model_type"] = transformer_config["model_type"]
+    if "target_layer_ids" not in normalized and isinstance(
+        normalized.get("aux_hidden_state_layer_ids"), (list, tuple)
+    ):
+        normalized["target_layer_ids"] = normalized["aux_hidden_state_layer_ids"]
+    normalized.pop("auto_map", None)
+    return normalized
+
+
+def _try_load_special_config(model, revision: Optional[str], **kwargs):
+    """Handle configs that cannot go directly through AutoConfig.
+
+    Keep the format probe shared so the ordinary model path performs the same
+    single get_config_dict call it used for LongCat before DSpark support.
+    """
     config_dict, _ = PretrainedConfig.get_config_dict(
         model, revision=revision, **kwargs
     )
-    architectures = config_dict.get("architectures") or []
-    if not any(arch in _LONGCAT_ARCHS for arch in architectures):
-        return None
+    normalized = _normalize_speculators_draft_config_dict(config_dict)
+    if normalized is not None:
+        model_type = normalized.pop("model_type")
+        config = AutoConfig.for_model(model_type, **normalized)
+        config._name_or_path = model
+        return config
 
-    return _CONFIG_REGISTRY["longcat_flash"].from_pretrained(
-        model, revision=revision, **kwargs
-    )
+    architectures = config_dict.get("architectures") or []
+    if any(arch in _LONGCAT_ARCHS for arch in architectures):
+        return _CONFIG_REGISTRY["longcat_flash"].from_pretrained(
+            model, revision=revision, **kwargs
+        )
+    return None
 
 
 @register_model_config_parser("hf")
@@ -83,7 +131,7 @@ class HfModelConfigParser(ModelConfigParserBase):
         revision: Optional[str] = None,
         **kwargs,
     ):
-        config = _try_load_longcat_config(model, revision, **kwargs)
+        config = _try_load_special_config(model, revision, **kwargs)
         if config is None:
             config = AutoConfig.from_pretrained(
                 model,

--- a/python/sglang/srt/utils/hf_transformers/config.py
+++ b/python/sglang/srt/utils/hf_transformers/config.py
@@ -16,6 +16,9 @@
 from pathlib import Path
 from typing import Optional
 
+from transformers import PretrainedConfig
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+
 from sglang.srt.configs.model_config_parser_registry import (
     ModelConfigParserBase,
     get_model_config_parser,
@@ -23,8 +26,6 @@ from sglang.srt.configs.model_config_parser_registry import (
 )
 from sglang.srt.connector import create_remote_connector
 from sglang.srt.utils import is_remote_url, lru_cache_frozenset
-from transformers import PretrainedConfig
-from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
 
 from ..hf_transformers_patches import _ensure_gguf_version
 from .common import (

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.arg_groups.speculative_hook import (
     _handle_dspark,
@@ -58,6 +59,48 @@ class TestTargetCheckpointBundlesDsparkDraft(CustomTestCase):
 
 
 class TestDsparkDraftPathDefaulting(CustomTestCase):
+    @patch(
+        "sglang.srt.speculative.dspark_components.dspark_config.read_draft_checkpoint_config"
+    )
+    def test_draft_config_is_read_once_for_gamma_and_layout(self, read_config):
+        read_config.return_value = SimpleNamespace(
+            resolve_gamma=lambda *, default=None: 7,
+            speculators_convention=True,
+        )
+        server_args = _make_dspark_server_args(
+            model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
+        )
+        server_args.speculative_draft_model_path = "local-dspark-draft"
+        server_args.speculative_dspark_block_size = None
+        server_args.speculative_num_draft_tokens = None
+
+        _handle_dspark(server_args)
+
+        read_config.assert_called_once_with(server_args=server_args)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 8)
+        self.assertTrue(server_args.speculative_dspark_bonus_anchor)
+
+    @patch(
+        "sglang.srt.speculative.dspark_components.dspark_config.read_draft_checkpoint_config"
+    )
+    def test_explicit_gamma_still_reads_layout_once(self, read_config):
+        read_config.return_value = SimpleNamespace(
+            resolve_gamma=lambda *, default=None: 999,
+            speculators_convention=True,
+        )
+        server_args = _make_dspark_server_args(
+            model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
+        )
+        server_args.speculative_draft_model_path = "local-dspark-draft"
+        server_args.speculative_dspark_block_size = 7
+        server_args.speculative_num_draft_tokens = None
+
+        _handle_dspark(server_args)
+
+        read_config.assert_called_once_with(server_args=server_args)
+        self.assertEqual(server_args.speculative_num_draft_tokens, 8)
+        self.assertTrue(server_args.speculative_dspark_bonus_anchor)
+
     def test_bundled_checkpoint_defaults_draft_path_to_model_path(self):
         server_args = _make_dspark_server_args(
             model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()

--- a/test/registered/spec/dspark/test_dspark_draft_path_default.py
+++ b/test/registered/spec/dspark/test_dspark_draft_path_default.py
@@ -65,7 +65,7 @@ class TestDsparkDraftPathDefaulting(CustomTestCase):
     def test_draft_config_is_read_once_for_gamma_and_layout(self, read_config):
         read_config.return_value = SimpleNamespace(
             resolve_gamma=lambda *, default=None: 7,
-            speculators_convention=True,
+            bonus_anchor=True,
         )
         server_args = _make_dspark_server_args(
             model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()
@@ -86,7 +86,7 @@ class TestDsparkDraftPathDefaulting(CustomTestCase):
     def test_explicit_gamma_still_reads_layout_once(self, read_config):
         read_config.return_value = SimpleNamespace(
             resolve_gamma=lambda *, default=None: 999,
-            speculators_convention=True,
+            bonus_anchor=True,
         )
         server_args = _make_dspark_server_args(
             model_path=_BUNDLED_MODEL_PATH, hf_config=_bundled_hf_config()

--- a/test/registered/spec/dspark/test_dspark_kernel_parity.py
+++ b/test/registered/spec/dspark/test_dspark_kernel_parity.py
@@ -260,6 +260,7 @@ def _case_compact_layout(tc):
     gamma, t, bs = 5, 6, 64
     verify_lens = _ri(1, t + 1, (bs,), torch.int32)
     total = int(verify_lens.sum().item())
+    draft_tokens = _ri(0, VOCAB, (bs, gamma))
     for padded_total in (total, bs * t):  # exact and bucket padding
         tc._parity(
             dspark_verify_window.CompactRowIndex,
@@ -267,13 +268,20 @@ def _case_compact_layout(tc):
             padded_total=padded_total,
             device=DEVICE,
         )
-        tc._parity(
-            dspark_verify_window.CompactVerifyIds,
-            draft_block_ids=_ri(0, VOCAB, (bs, gamma)),
-            draft_tokens=_ri(0, VOCAB, (bs, gamma)),
-            layout=_layout(verify_lens, padded_total),
-            device=DEVICE,
-        )
+        # Both draft-block widths: DeepSpec keeps the anchor in a (bs, gamma)
+        # block, the speculators bonus-anchor convention in (bs, gamma + 1).
+        # draft_tokens stays (bs, gamma) either way, so the block-ids row
+        # stride must be read off that tensor -- an implementation that reuses
+        # gamma as the stride lands on the right anchor only for request 0 and
+        # walks back into the previous row for every later request.
+        for block_width in (gamma, gamma + 1):
+            tc._parity(
+                dspark_verify_window.CompactVerifyIds,
+                draft_block_ids=_ri(0, VOCAB, (bs, block_width)),
+                draft_tokens=draft_tokens,
+                layout=_layout(verify_lens, padded_total),
+                device=DEVICE,
+            )
 
 
 def _case_swa_page_indices(tc):

--- a/test/registered/spec/dspark/test_dspark_reduced_vocab.py
+++ b/test/registered/spec/dspark/test_dspark_reduced_vocab.py
@@ -1,0 +1,425 @@
+"""Reduced-vocabulary (independent-head) DSpark draft support.
+
+Speculators-trained DSpark checkpoints (e.g. RedHatAI/*-speculator.dspark) ship
+an independent, reduced-vocabulary lm_head plus a d2t draft->target map, instead
+of sharing the target head. These tests pin the invariants that make that work
+and that keep the ordinary full-vocab/shared-head path byte-for-byte unchanged:
+
+  - markov_w1 stays target-vocab-wide (its input is the previously sampled
+    target id) while markov_w2 / lm_head shrink to the draft vocab;
+  - a draft-space sampled id is mapped to a target id before it is stored AND
+    before it conditions the next Markov step (markov_w1);
+  - the markov-corrected block is lifted into target-vocab columns (unmapped
+    columns -inf) for target-space rejection sampling;
+  - inconsistent / missing reduced-vocab state fails loudly at load.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+from sglang.srt.models.dspark import (
+    GatedMarkovHead,
+    RNNHead,
+    _is_dspark_d2t_weight,
+    _is_dspark_t2d_weight,
+    build_independent_lm_head,
+    build_markov_head,
+    scatter_draft_logits_to_target,
+)
+from sglang.srt.speculative.dspark_components.dspark_config import (
+    parse_dspark_draft_config,
+    resolve_draft_vocab_size,
+)
+from sglang.srt.speculative.dspark_components.dspark_draft import sample_draft_block
+from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
+    DsparkDraftSampler,
+)
+from sglang.srt.utils.hf_transformers.config import (
+    _normalize_speculators_draft_config_dict,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+TARGET_VOCAB = 100
+DRAFT_VOCAB = 8
+MARKOV_RANK = 4
+HIDDEN = 16
+
+
+def _markov_config(*, head_type="vanilla"):
+    return SimpleNamespace(
+        markov_rank=MARKOV_RANK,
+        markov_head_type=head_type,
+        vocab_size=TARGET_VOCAB,
+        hidden_size=HIDDEN,
+    )
+
+
+def _reduced_vanilla_head(*, d2t_delta=None):
+    """A reduced VanillaMarkov with markov weights zeroed, so apply_step_logits
+    is the identity on base_logits (bias == 0). Lets a test drive the argmax
+    purely from crafted base_logits and read back the exact mapped ids."""
+    head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+    with torch.no_grad():
+        head.markov_w1.weight.zero_()
+        head.markov_w2.weight.zero_()
+    if d2t_delta is None:
+        # target = draft + 2  -> a non-identity, easily checked mapping.
+        d2t_delta = torch.full((DRAFT_VOCAB,), 2, dtype=torch.long)
+    head.load_draft_to_target(d2t_delta)
+    return head
+
+
+class TestMarkovHeadVocabGeometry(CustomTestCase):
+    """markov_w1 input == target vocab, markov_w2 output == draft vocab."""
+
+    def test_vanilla_reduced_is_asymmetric(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+        self.assertEqual(
+            tuple(head.markov_w1.weight.shape), (TARGET_VOCAB, MARKOV_RANK)
+        )
+        self.assertEqual(tuple(head.markov_w2.weight.shape), (DRAFT_VOCAB, MARKOV_RANK))
+        self.assertTrue(head.reduced_vocab)
+        self.assertEqual(head.draft_vocab_size, DRAFT_VOCAB)
+
+    def test_full_vocab_is_symmetric(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=None)
+        self.assertEqual(
+            tuple(head.markov_w1.weight.shape), (TARGET_VOCAB, MARKOV_RANK)
+        )
+        self.assertEqual(
+            tuple(head.markov_w2.weight.shape), (TARGET_VOCAB, MARKOV_RANK)
+        )
+        self.assertFalse(head.reduced_vocab)
+        self.assertIsNone(head.draft_to_target)
+
+    def test_draft_vocab_equal_to_target_is_not_reduced(self):
+        # A checkpoint that sets draft_vocab_size == vocab_size shares the full
+        # vocab (no reduction, no independent head, no mapping).
+        head = build_markov_head(_markov_config(), draft_vocab_size=TARGET_VOCAB)
+        self.assertFalse(head.reduced_vocab)
+        self.assertIsNone(head.draft_to_target)
+
+    def test_gated_and_rnn_reduced_shrink_only_w2(self):
+        for head_type, cls in (("gated", GatedMarkovHead), ("rnn", RNNHead)):
+            with self.subTest(head_type=head_type):
+                head = build_markov_head(
+                    _markov_config(head_type=head_type), draft_vocab_size=DRAFT_VOCAB
+                )
+                self.assertIsInstance(head, cls)
+                self.assertEqual(head.markov_w1.weight.shape[0], TARGET_VOCAB)
+                self.assertEqual(head.markov_w2.weight.shape[0], DRAFT_VOCAB)
+
+
+class TestDraftToTargetMapping(CustomTestCase):
+    def test_d2t_delta_becomes_absolute_map(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+        delta = torch.arange(DRAFT_VOCAB, dtype=torch.long)  # target = draft + draft
+        head.load_draft_to_target(delta)
+        expected = torch.arange(DRAFT_VOCAB) + delta
+        self.assertTrue(torch.equal(head.draft_to_target, expected))
+        self.assertTrue(head.draft_to_target_loaded)
+
+    def test_map_sampled_to_target_applies_map(self):
+        head = _reduced_vanilla_head()  # target = draft + 2
+        sampled = torch.tensor([0, 1, 7])
+        self.assertTrue(
+            torch.equal(head.map_sampled_to_target(sampled), torch.tensor([2, 3, 9]))
+        )
+
+    def test_full_vocab_map_is_identity(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=None)
+        sampled = torch.tensor([0, 5, 99])
+        self.assertTrue(torch.equal(head.map_sampled_to_target(sampled), sampled))
+
+    def test_wrong_length_d2t_raises(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+        with self.assertRaises(ValueError):
+            head.load_draft_to_target(torch.zeros(DRAFT_VOCAB + 1, dtype=torch.long))
+
+    def test_out_of_range_d2t_raises(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+        # Maps draft id 0 to target id TARGET_VOCAB (>= vocab) -> must reject.
+        delta = torch.zeros(DRAFT_VOCAB, dtype=torch.long)
+        delta[0] = TARGET_VOCAB
+        with self.assertRaises(ValueError):
+            head.load_draft_to_target(delta)
+
+    def test_duplicate_d2t_target_ids_raise(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=DRAFT_VOCAB)
+        delta = torch.zeros(DRAFT_VOCAB, dtype=torch.long)
+        delta[1] = -1  # draft ids 0 and 1 would both map to target id 0
+        with self.assertRaises(ValueError):
+            head.load_draft_to_target(delta)
+
+    def test_d2t_on_full_vocab_head_raises(self):
+        head = build_markov_head(_markov_config(), draft_vocab_size=None)
+        with self.assertRaises(ValueError):
+            head.load_draft_to_target(torch.zeros(TARGET_VOCAB, dtype=torch.long))
+
+    def test_weight_name_classification(self):
+        # d2t is loaded into the map; t2d (inverse, training-only) is dropped.
+        self.assertTrue(_is_dspark_d2t_weight("d2t"))
+        self.assertTrue(_is_dspark_d2t_weight("markov_head.d2t"))
+        self.assertTrue(_is_dspark_t2d_weight("t2d"))
+        self.assertTrue(_is_dspark_t2d_weight("model.t2d"))
+        # Guard the negative branch: a normal weight is neither.
+        self.assertFalse(_is_dspark_d2t_weight("lm_head.weight"))
+        self.assertFalse(_is_dspark_t2d_weight("lm_head.weight"))
+        self.assertFalse(_is_dspark_d2t_weight("t2d"))
+
+
+class TestSequentialGreedySampling(CustomTestCase):
+    """Greedy sample_block returns TARGET ids and feeds TARGET ids to the next
+    Markov step (markov_w1's input vocab is the target vocab)."""
+
+    def test_greedy_returns_target_ids_and_feeds_target_ids(self):
+        head = _reduced_vanilla_head()  # target = draft + 2, bias == 0
+        recorded = []
+        orig_prev_emb = head.get_prev_embeddings
+
+        def spy(token_ids):
+            recorded.append(token_ids.clone())
+            return orig_prev_emb(token_ids)
+
+        head.get_prev_embeddings = spy
+
+        # step 0 argmax -> draft id 1 (-> target 3); step 1 argmax -> draft id 0
+        # (-> target 2). bias is 0, so argmax is purely from base_logits.
+        base_logits = torch.zeros(1, 2, DRAFT_VOCAB)
+        base_logits[0, 0, 1] = 9.0
+        base_logits[0, 1, 0] = 9.0
+        anchor = torch.tensor([7])  # a target id
+
+        sampled, corrected = head.sample_block(
+            base_logits,
+            first_prev_tokens=anchor,
+            hidden_states=None,
+            sampler=lambda logits, i: torch.argmax(logits, dim=-1),
+        )
+
+        # Stored ids are target-space (mapped), not the raw draft ids 1/0.
+        self.assertTrue(torch.equal(sampled, torch.tensor([[3, 2]])))
+        # markov_w1 saw the anchor, then the mapped target id from step 0.
+        self.assertTrue(torch.equal(recorded[0], anchor))
+        self.assertTrue(torch.equal(recorded[1], torch.tensor([3])))
+        # corrected logits stay draft-space (they get lifted to target later).
+        self.assertEqual(corrected.shape, (1, 2, DRAFT_VOCAB))
+
+    def test_eager_sample_draft_block_maps_to_target(self):
+        head = _reduced_vanilla_head()
+        base_logits = torch.zeros(2, 3, DRAFT_VOCAB)
+        base_logits[:, :, 4] = 9.0  # every step argmax -> draft id 4 -> target 6
+        result = sample_draft_block(
+            base_logits=base_logits,
+            anchor_tokens=torch.tensor([7, 8]),
+            draft_hidden=torch.zeros(2, 3, HIDDEN),
+            sampling_info=None,
+            markov_head=head,
+            device=torch.device("cpu"),
+        )
+        self.assertTrue(torch.all(result.draft_tokens == 6))
+        self.assertEqual(result.corrected_logits.shape, (2, 3, DRAFT_VOCAB))
+
+
+class TestCorrectedScatterToTarget(CustomTestCase):
+    """Reduced-vocab probabilistic verify needs corrected logits in TARGET
+    columns; unmapped columns must be -inf (zero softmax mass)."""
+
+    def test_scatter_places_draft_columns_and_fills_neg_inf(self):
+        draft_to_target = torch.tensor([2, 5, 7])  # draft vocab 3 -> target vocab 10
+        draft_logits = torch.tensor([[[1.0, 2.0, 3.0]]])  # [1, 1, 3]
+        out = torch.empty(1, 1, 10)
+        scattered = scatter_draft_logits_to_target(
+            draft_logits, draft_to_target=draft_to_target, out=out
+        )
+        self.assertEqual(scattered.shape, (1, 1, 10))
+        # Mapped target columns carry the draft logits.
+        self.assertEqual(scattered[0, 0, 2].item(), 1.0)
+        self.assertEqual(scattered[0, 0, 5].item(), 2.0)
+        self.assertEqual(scattered[0, 0, 7].item(), 3.0)
+        # Every other (unmapped) target column is -inf.
+        mapped = {2, 5, 7}
+        for col in range(10):
+            if col not in mapped:
+                self.assertEqual(scattered[0, 0, col].item(), float("-inf"))
+
+    def test_softmax_of_scattered_matches_draft_softmax_on_mapped_ids(self):
+        # The derived property that makes target-space rejection sampling and the
+        # block-accept estimator correct: softmax over the scattered target row,
+        # read at the mapped id, equals the draft-space softmax at the draft id.
+        head = _reduced_vanilla_head()  # target = draft + 2
+        draft_logits = torch.randn(1, 1, DRAFT_VOCAB)
+        out = torch.empty(1, 1, TARGET_VOCAB)
+        scattered = scatter_draft_logits_to_target(
+            draft_logits, draft_to_target=head.draft_to_target, out=out
+        )
+        draft_probs = torch.softmax(draft_logits.float(), dim=-1)
+        target_probs = torch.softmax(scattered.float(), dim=-1)
+        for draft_id in range(DRAFT_VOCAB):
+            target_id = int(head.draft_to_target[draft_id])
+            self.assertAlmostEqual(
+                target_probs[0, 0, target_id].item(),
+                draft_probs[0, 0, draft_id].item(),
+                places=5,
+            )
+
+
+class TestReducedVocabConfig(CustomTestCase):
+    def test_normalize_native_speculators_config(self):
+        normalized = _normalize_speculators_draft_config_dict(
+            {
+                "architectures": ["Qwen3DSparkModel"],
+                "auto_map": {"": "config.DSparkSpeculatorConfig"},
+                "speculators_model_type": "dspark",
+                "draft_vocab_size": 32000,
+                "block_size": 8,
+                "aux_hidden_state_layer_ids": [2, 10, 20, 30, 37],
+                "transformer_layer_config": {
+                    "model_type": "qwen3",
+                    "hidden_size": 2048,
+                    "vocab_size": 248320,
+                },
+            }
+        )
+        self.assertEqual(normalized["model_type"], "qwen3")
+        self.assertEqual(normalized["architectures"], ["Qwen3DSparkModel"])
+        self.assertEqual(normalized["hidden_size"], 2048)
+        self.assertEqual(normalized["draft_vocab_size"], 32000)
+        self.assertEqual(normalized["target_layer_ids"], [2, 10, 20, 30, 37])
+        self.assertNotIn("auto_map", normalized)
+        self.assertNotIn("transformer_layer_config", normalized)
+
+    def test_does_not_normalize_other_speculators_formats(self):
+        self.assertIsNone(
+            _normalize_speculators_draft_config_dict(
+                {
+                    "speculators_model_type": "eagle",
+                    "transformer_layer_config": {"model_type": "qwen3"},
+                }
+            )
+        )
+
+    def test_resolve_from_top_level(self):
+        cfg = SimpleNamespace(draft_vocab_size=32000, vocab_size=248320)
+        self.assertEqual(resolve_draft_vocab_size(cfg), 32000)
+
+    def test_resolve_absent_is_none(self):
+        self.assertIsNone(resolve_draft_vocab_size(SimpleNamespace(vocab_size=100)))
+
+    def test_resolve_larger_than_target_raises(self):
+        cfg = SimpleNamespace(draft_vocab_size=300, vocab_size=100)
+        with self.assertRaises(ValueError):
+            resolve_draft_vocab_size(cfg)
+
+    def test_parse_surfaces_draft_vocab_and_reduced_flag(self):
+        cfg = SimpleNamespace(
+            architectures=["Qwen3DSparkModel"],
+            block_size=8,
+            markov_rank=256,
+            markov_head_type="vanilla",
+            mask_token_id=128799,
+            vocab_size=248320,
+            draft_vocab_size=32000,
+            sample_from_anchor=False,
+        )
+        parsed = parse_dspark_draft_config(draft_hf_config=cfg)
+        self.assertEqual(parsed.draft_vocab_size, 32000)
+        self.assertTrue(parsed.uses_reduced_draft_vocab(target_vocab_size=248320))
+
+    def test_parse_full_vocab_is_not_reduced(self):
+        cfg = SimpleNamespace(
+            architectures=["Qwen3DSparkModel"],
+            block_size=8,
+            markov_rank=256,
+            markov_head_type="vanilla",
+            mask_token_id=128799,
+            vocab_size=248320,
+        )
+        parsed = parse_dspark_draft_config(draft_hf_config=cfg)
+        self.assertIsNone(parsed.draft_vocab_size)
+        self.assertFalse(parsed.uses_reduced_draft_vocab(target_vocab_size=248320))
+
+
+class _StubReducedModel:
+    """Minimal draft-model stand-in for the graph-folded sampler: a real reduced
+    Markov head plus a fake draft-vocab lm_head and a compute_base_logits that
+    argmaxes to draft id 4."""
+
+    def __init__(self, head):
+        self.markov_head = head
+        self.lm_head = SimpleNamespace(
+            org_vocab_size=DRAFT_VOCAB,
+            weight=SimpleNamespace(dtype=torch.float32),
+        )
+
+    def compute_base_logits(self, hidden):
+        base = torch.zeros(hidden.shape[0], DRAFT_VOCAB)
+        base[:, 4] = 9.0
+        return base, None
+
+
+class TestFoldedSamplerReducedVocab(CustomTestCase):
+    def test_folded_buffer_stays_draft_space_and_maps_to_target(self):
+        head = _reduced_vanilla_head()  # target = draft + 2
+        sampler = DsparkDraftSampler(
+            model=_StubReducedModel(head),
+            gamma=2,
+            max_bs=2,
+            device="cpu",
+            folded_sampling=True,
+            bonus_anchor=False,
+        )
+        # The in-graph corrected-logits buffer must NOT balloon to the target
+        # vocab: it stays draft-space (org_vocab_size of the reduced head).
+        self.assertEqual(sampler.corrected_out.shape[1], DRAFT_VOCAB)
+
+        sampler.stage_sampling_params(bs=1, sampling_info=None)  # greedy
+        sampler(
+            hidden_states=torch.zeros(2, HIDDEN),  # bs=1, draft_width=gamma=2
+            input_ids=torch.tensor([7, 0]),
+        )
+        # Folded sampling also maps draft id 4 -> target id 6 before storing.
+        self.assertTrue(torch.all(sampler.out[:2] == 6))
+
+
+class TestIndependentLmHead(CustomTestCase):
+    """The reduced draft head is a plain ParallelLMHead sized to the draft vocab
+    and loaded with the standard vocab-parallel weight loader."""
+
+    def _build_head(self, draft_vocab, hidden):
+        # tp=1 CPU stand-in for the parallel context ParallelLMHead reads.
+        with patch(
+            "sglang.srt.layers.vocab_parallel_embedding.get_parallel",
+            return_value=SimpleNamespace(tp_rank=0, tp_size=1),
+        ):
+            return build_independent_lm_head(
+                draft_vocab_size=draft_vocab,
+                hidden_size=hidden,
+                quant_config=None,
+                prefix="lm_head",
+            )
+
+    def test_org_vocab_is_draft_vocab(self):
+        head = self._build_head(DRAFT_VOCAB, HIDDEN)
+        # org_vocab_size drives gather_and_crop_vocab -> logits stay draft-space.
+        self.assertEqual(head.org_vocab_size, DRAFT_VOCAB)
+        self.assertEqual(head.embedding_dim, HIDDEN)
+        self.assertGreaterEqual(head.weight.shape[0], DRAFT_VOCAB)
+
+    def test_weight_loader_populates_org_rows(self):
+        head = self._build_head(DRAFT_VOCAB, HIDDEN)
+        loaded = torch.randn(DRAFT_VOCAB, HIDDEN)
+        head.weight_loader(head.weight, loaded)
+        self.assertTrue(torch.equal(head.weight[:DRAFT_VOCAB], loaded))
+        # Padding rows past the org vocab are zero-filled.
+        if head.weight.shape[0] > DRAFT_VOCAB:
+            self.assertTrue(torch.all(head.weight[DRAFT_VOCAB:] == 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dspark_reduced_vocab.py
+++ b/test/registered/spec/dspark/test_dspark_reduced_vocab.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import torch
+
 from sglang.srt.models.dspark import (
     GatedMarkovHead,
     RNNHead,

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -30,11 +30,11 @@ def _base_dspark_hf_config(**overrides) -> SimpleNamespace:
     return SimpleNamespace(**fields)
 
 
-class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
+class TestDsparkAnchorLayoutDetection(CustomTestCase):
     def test_deepspec_checkpoint_not_flagged(self):
         # No speculators_model_type field at all -- the normal DeepSpec case.
         config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
-        self.assertFalse(config.speculators_convention)
+        self.assertFalse(config.bonus_anchor)
 
     def test_other_speculators_model_type_not_flagged(self):
         # speculators_model_type present but not "dspark" -- a different
@@ -42,13 +42,13 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
         config = parse_dspark_draft_config(
             draft_hf_config=_base_dspark_hf_config(speculators_model_type="eagle3")
         )
-        self.assertFalse(config.speculators_convention)
+        self.assertFalse(config.bonus_anchor)
 
     def test_speculators_dspark_checkpoint_flagged(self):
         config = parse_dspark_draft_config(
             draft_hf_config=_base_dspark_hf_config(speculators_model_type="dspark")
         )
-        self.assertTrue(config.speculators_convention)
+        self.assertTrue(config.bonus_anchor)
 
     def test_speculators_dspark_checkpoint_flagged_case_insensitive(self):
         # Checkpoint config values are author-controlled strings, not a
@@ -62,7 +62,7 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
                         speculators_model_type=variant
                     )
                 )
-                self.assertTrue(config.speculators_convention)
+                self.assertTrue(config.bonus_anchor)
 
     def test_non_string_speculators_model_type_not_flagged(self):
         # Malformed config where the field is present but not a string (e.g.
@@ -71,7 +71,7 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
         config = parse_dspark_draft_config(
             draft_hf_config=_base_dspark_hf_config(speculators_model_type=123)
         )
-        self.assertFalse(config.speculators_convention)
+        self.assertFalse(config.bonus_anchor)
 
 
 def _speculators_hf_config(
@@ -119,14 +119,14 @@ class TestSpeculatorsProposalGamma(CustomTestCase):
             draft_hf_config=_speculators_hf_config(block_size=8, speculative_tokens=7)
         )
         self.assertEqual(config.gamma, 7)
-        self.assertTrue(config.speculators_convention)
+        self.assertTrue(config.bonus_anchor)
 
     def test_gamma_falls_back_to_block_size_without_speculators_config(self):
         # DeepSpec-native checkpoints have no speculators_config at all --
         # gamma must still resolve from block_size as before.
         config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
         self.assertEqual(config.gamma, 5)  # dspark_block_size=5 in the fixture
-        self.assertFalse(config.speculators_convention)
+        self.assertFalse(config.bonus_anchor)
 
     def test_gamma_respects_default_proposal_method_selection(self):
         # Multiple proposal methods present; must pick the one named by
@@ -166,7 +166,7 @@ class TestDraftBlockWidth(CustomTestCase):
         )
         self.assertEqual(proposer.draft_width, 7)
 
-    def test_speculators_convention_draft_width_is_gamma_plus_one(self):
+    def test_bonus_anchor_draft_width_is_gamma_plus_one(self):
         proposer = DraftBlockProposer(
             draft_model=None,
             draft_model_runner=None,
@@ -281,7 +281,7 @@ class TestSampleFromAnchorIsAuthoritative(CustomTestCase):
                 block_size=16, speculative_tokens=16, sample_from_anchor=True
             )
         )
-        self.assertFalse(config.speculators_convention)
+        self.assertFalse(config.bonus_anchor)
         self.assertEqual(config.gamma, 16)
 
     def test_bonus_anchor_speculators_checkpoint_flagged(self):
@@ -291,7 +291,7 @@ class TestSampleFromAnchorIsAuthoritative(CustomTestCase):
                 block_size=16, speculative_tokens=15, sample_from_anchor=False
             )
         )
-        self.assertTrue(config.speculators_convention)
+        self.assertTrue(config.bonus_anchor)
         self.assertEqual(config.gamma, 15)
 
     def test_sample_from_anchor_overrides_model_type_heuristic(self):
@@ -307,9 +307,19 @@ class TestSampleFromAnchorIsAuthoritative(CustomTestCase):
                 block_size=8, speculative_tokens=7, sample_from_anchor=False
             )
         )
-        self.assertNotEqual(
-            dense.speculators_convention, bonus.speculators_convention
+        self.assertNotEqual(dense.bonus_anchor, bonus.bonus_anchor)
+
+    def test_explicit_bonus_anchor_without_speculators_model_type(self):
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(sample_from_anchor=False)
         )
+        self.assertTrue(config.bonus_anchor)
+
+    def test_invalid_sample_from_anchor_fails_fast(self):
+        with self.assertRaisesRegex(ValueError, "sample_from_anchor must be a bool"):
+            parse_dspark_draft_config(
+                draft_hf_config=_base_dspark_hf_config(sample_from_anchor="false")
+            )
 
     def test_geometry_disagreeing_with_flag_fails_fast(self):
         # sample_from_anchor says dense, geometry says 1+N. Silently picking

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -75,14 +75,18 @@ class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
 
 
 def _speculators_hf_config(
-    *, block_size: int, speculative_tokens: int, default_method: str = "greedy"
+    *,
+    block_size: int,
+    speculative_tokens: int,
+    default_method: str = "greedy",
+    **overrides,
 ) -> SimpleNamespace:
     # Matches the real structure of RedHatAI/GLM-5.2-speculator.dspark's
     # config.json (verified directly against the checkpoint on the Hub):
     # block_size is the full anchor+gamma block width, while
     # speculators_config.proposal_methods[i].speculative_tokens is the
     # authoritative gamma (real draft token count).
-    return SimpleNamespace(
+    fields = dict(
         architectures=["Qwen3DSparkModel"],
         block_size=block_size,
         markov_rank=256,
@@ -101,6 +105,8 @@ def _speculators_hf_config(
             ],
         },
     )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
 
 
 class TestSpeculatorsProposalGamma(CustomTestCase):
@@ -255,6 +261,65 @@ class TestDraftCaptureWidth(CustomTestCase):
                     spec_algorithm=SpeculativeAlgorithm.DSPARK,
                     is_draft_worker=True,
                 )
+
+
+class TestSampleFromAnchorIsAuthoritative(CustomTestCase):
+    """`speculators_model_type` alone does not determine the block layout.
+
+    Real speculators checkpoints ship both conventions: the trainer records the
+    choice in `sample_from_anchor`, and the block geometry
+    (block_size vs speculative_tokens) encodes the same fact independently.
+    """
+
+    def test_dense_speculators_checkpoint_not_flagged(self):
+        # Ground truth: /data/suzhan/models/qwen3_6_35b_a3b_dspark_test --
+        # speculators-trained but sample_from_anchor=True and
+        # block_size == speculative_tokens == 16, i.e. the dense DeepSpec
+        # layout. Flagging it would read a 17th slot that does not exist.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(
+                block_size=16, speculative_tokens=16, sample_from_anchor=True
+            )
+        )
+        self.assertFalse(config.speculators_convention)
+        self.assertEqual(config.gamma, 16)
+
+    def test_bonus_anchor_speculators_checkpoint_flagged(self):
+        # The 1+N case: sample_from_anchor=False and block_size == tokens + 1.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(
+                block_size=16, speculative_tokens=15, sample_from_anchor=False
+            )
+        )
+        self.assertTrue(config.speculators_convention)
+        self.assertEqual(config.gamma, 15)
+
+    def test_sample_from_anchor_overrides_model_type_heuristic(self):
+        # Both configs below are speculators_model_type="dspark"; only
+        # sample_from_anchor separates them.
+        dense = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(
+                block_size=8, speculative_tokens=8, sample_from_anchor=True
+            )
+        )
+        bonus = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(
+                block_size=8, speculative_tokens=7, sample_from_anchor=False
+            )
+        )
+        self.assertNotEqual(
+            dense.speculators_convention, bonus.speculators_convention
+        )
+
+    def test_geometry_disagreeing_with_flag_fails_fast(self):
+        # sample_from_anchor says dense, geometry says 1+N. Silently picking
+        # either one misreads every draft slot, so this must raise.
+        with self.assertRaises(ValueError):
+            parse_dspark_draft_config(
+                draft_hf_config=_speculators_hf_config(
+                    block_size=16, speculative_tokens=15, sample_from_anchor=True
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/dspark/test_dspark_speculators_convention.py
+++ b/test/registered/spec/dspark/test_dspark_speculators_convention.py
@@ -1,0 +1,261 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.speculative.dspark_components.dspark_config import (
+    parse_dspark_draft_config,
+)
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
+from sglang.srt.speculative.dspark_components.dspark_draft_sampler import (
+    DsparkDraftSampler,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import resolve_num_tokens_per_req
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _base_dspark_hf_config(**overrides) -> SimpleNamespace:
+    fields = dict(
+        architectures=["DeepseekV4ForCausalLM"],
+        dspark_block_size=5,
+        dspark_markov_rank=256,
+        dspark_markov_head_type="vanilla",
+        dspark_target_layer_ids=[40, 41, 42],
+        dspark_noise_token_id=128799,
+    )
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class TestDsparkSpeculatorsConventionDetection(CustomTestCase):
+    def test_deepspec_checkpoint_not_flagged(self):
+        # No speculators_model_type field at all -- the normal DeepSpec case.
+        config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
+        self.assertFalse(config.speculators_convention)
+
+    def test_other_speculators_model_type_not_flagged(self):
+        # speculators_model_type present but not "dspark" -- a different
+        # speculators-trained architecture, not the DSpark slot-shift case.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type="eagle3")
+        )
+        self.assertFalse(config.speculators_convention)
+
+    def test_speculators_dspark_checkpoint_flagged(self):
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type="dspark")
+        )
+        self.assertTrue(config.speculators_convention)
+
+    def test_speculators_dspark_checkpoint_flagged_case_insensitive(self):
+        # Checkpoint config values are author-controlled strings, not a
+        # validated enum -- a future speculators release or a different
+        # checkpoint author could write "DSpark"/"Dspark" instead of the
+        # lowercase "dspark" seen in every checkpoint verified so far.
+        for variant in ("DSpark", "DSPARK", "Dspark"):
+            with self.subTest(variant=variant):
+                config = parse_dspark_draft_config(
+                    draft_hf_config=_base_dspark_hf_config(
+                        speculators_model_type=variant
+                    )
+                )
+                self.assertTrue(config.speculators_convention)
+
+    def test_non_string_speculators_model_type_not_flagged(self):
+        # Malformed config where the field is present but not a string (e.g.
+        # accidentally set to a number or a dict) -- must not crash on
+        # .lower() and must not be treated as a match.
+        config = parse_dspark_draft_config(
+            draft_hf_config=_base_dspark_hf_config(speculators_model_type=123)
+        )
+        self.assertFalse(config.speculators_convention)
+
+
+def _speculators_hf_config(
+    *, block_size: int, speculative_tokens: int, default_method: str = "greedy"
+) -> SimpleNamespace:
+    # Matches the real structure of RedHatAI/GLM-5.2-speculator.dspark's
+    # config.json (verified directly against the checkpoint on the Hub):
+    # block_size is the full anchor+gamma block width, while
+    # speculators_config.proposal_methods[i].speculative_tokens is the
+    # authoritative gamma (real draft token count).
+    return SimpleNamespace(
+        architectures=["Qwen3DSparkModel"],
+        block_size=block_size,
+        markov_rank=256,
+        markov_head_type="vanilla",
+        mask_token_id=128799,
+        speculators_model_type="dspark",
+        speculators_config={
+            "algorithm": "dspark",
+            "default_proposal_method": default_method,
+            "proposal_methods": [
+                {
+                    "proposal_type": default_method,
+                    "speculative_tokens": speculative_tokens,
+                    "verifier_accept_k": 1,
+                }
+            ],
+        },
+    )
+
+
+class TestSpeculatorsProposalGamma(CustomTestCase):
+    def test_gamma_from_speculators_config_not_block_size(self):
+        # Ground truth: RedHatAI/GLM-5.2-speculator.dspark has block_size=8
+        # but speculative_tokens=7 -- gamma must be 7, not 8. Using
+        # block_size directly here is exactly the bug this whole fix exists
+        # to prevent (one draft slot too many, anchor read as a draft slot).
+        config = parse_dspark_draft_config(
+            draft_hf_config=_speculators_hf_config(block_size=8, speculative_tokens=7)
+        )
+        self.assertEqual(config.gamma, 7)
+        self.assertTrue(config.speculators_convention)
+
+    def test_gamma_falls_back_to_block_size_without_speculators_config(self):
+        # DeepSpec-native checkpoints have no speculators_config at all --
+        # gamma must still resolve from block_size as before.
+        config = parse_dspark_draft_config(draft_hf_config=_base_dspark_hf_config())
+        self.assertEqual(config.gamma, 5)  # dspark_block_size=5 in the fixture
+        self.assertFalse(config.speculators_convention)
+
+    def test_gamma_respects_default_proposal_method_selection(self):
+        # Multiple proposal methods present; must pick the one named by
+        # default_proposal_method, not just proposal_methods[0].
+        cfg = _speculators_hf_config(
+            block_size=17, speculative_tokens=16, default_method="probabilistic"
+        )
+        cfg.speculators_config["proposal_methods"] = [
+            {"proposal_type": "greedy", "speculative_tokens": 99},
+            {"proposal_type": "probabilistic", "speculative_tokens": 16},
+        ]
+        config = parse_dspark_draft_config(draft_hf_config=cfg)
+        self.assertEqual(config.gamma, 16)
+
+
+def _dummy_draft_model():
+    return SimpleNamespace(markov_head=SimpleNamespace())
+
+
+class TestDraftBlockWidth(CustomTestCase):
+    """draft_width is the one piece of state that must flip between gamma
+    (DeepSpec, anchor is itself a trained draft slot) and gamma + 1
+    (speculators, anchor is a separate untrained conditioning token) -- see
+    DraftBlockProposer's docstring. Every other consumer (verify window
+    sizing, KV commit, accept-length accounting) keeps reading plain gamma
+    unchanged; only the draft-forward-pass's own block construction differs.
+    """
+
+    def test_deepspec_convention_draft_width_equals_gamma(self):
+        proposer = DraftBlockProposer(
+            draft_model=None,
+            draft_model_runner=None,
+            gamma=7,
+            mask_token_id=0,
+            draft_block_spec_info=None,
+            bonus_anchor=False,
+        )
+        self.assertEqual(proposer.draft_width, 7)
+
+    def test_speculators_convention_draft_width_is_gamma_plus_one(self):
+        proposer = DraftBlockProposer(
+            draft_model=None,
+            draft_model_runner=None,
+            gamma=7,
+            mask_token_id=0,
+            draft_block_spec_info=None,
+            bonus_anchor=True,
+        )
+        self.assertEqual(proposer.draft_width, 8)
+
+    def test_draft_sampler_draft_width_matches_proposer(self):
+        for bonus_anchor, expected_width in ((False, 7), (True, 8)):
+            with self.subTest(bonus_anchor=bonus_anchor):
+                sampler = DsparkDraftSampler(
+                    model=_dummy_draft_model(),
+                    gamma=7,
+                    max_bs=4,
+                    device="cpu",
+                    bonus_anchor=bonus_anchor,
+                    folded_sampling=False,
+                )
+                self.assertEqual(sampler.draft_width, expected_width)
+                # The sampled-token output buffer stays gamma-wide regardless
+                # -- only the input hidden_states/input_ids width changes.
+                self.assertEqual(sampler.out.shape, (4 * 7,))
+
+
+class TestDraftCaptureWidth(CustomTestCase):
+    def _spec_config(self, *, bonus_anchor: bool):
+        return SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=8,
+            speculative_dspark_bonus_anchor=bonus_anchor,
+        )
+
+    def test_dspark_draft_width_has_one_derivation_point(self):
+        for bonus_anchor, expected_width in ((False, 7), (True, 8)):
+            with self.subTest(bonus_anchor=bonus_anchor):
+                with patch(
+                    "sglang.srt.speculative.spec_utils.get_spec",
+                    return_value=self._spec_config(bonus_anchor=bonus_anchor),
+                ):
+                    width = resolve_num_tokens_per_req(
+                        phase="target_verify",
+                        spec_algorithm=SpeculativeAlgorithm.DSPARK,
+                        is_draft_worker=True,
+                    )
+                self.assertEqual(width, expected_width)
+
+    def test_target_worker_keeps_full_verify_window(self):
+        with patch(
+            "sglang.srt.speculative.spec_utils.get_spec",
+            return_value=self._spec_config(bonus_anchor=True),
+        ):
+            width = resolve_num_tokens_per_req(
+                phase="target_verify",
+                spec_algorithm=SpeculativeAlgorithm.DSPARK,
+                is_draft_worker=False,
+            )
+        self.assertEqual(width, 8)
+
+    def test_dspark_like_plugin_keeps_its_width_override(self):
+        def custom_width(num_tokens, _):
+            return num_tokens + 2
+
+        plugin_algorithm = SimpleNamespace(
+            is_dspark=lambda: True,
+            get_num_tokens_per_req_for_target_verify=custom_width,
+        )
+        with patch(
+            "sglang.srt.speculative.spec_utils.get_spec",
+            return_value=self._spec_config(bonus_anchor=False),
+        ):
+            width = resolve_num_tokens_per_req(
+                phase="target_verify",
+                spec_algorithm=plugin_algorithm,
+                is_draft_worker=True,
+            )
+        self.assertEqual(width, 10)
+
+    def test_missing_declared_layout_field_fails_fast(self):
+        spec_config = SimpleNamespace(
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=8,
+        )
+        with patch(
+            "sglang.srt.speculative.spec_utils.get_spec", return_value=spec_config
+        ):
+            with self.assertRaises(AttributeError):
+                resolve_num_tokens_per_req(
+                    phase="target_verify",
+                    spec_algorithm=SpeculativeAlgorithm.DSPARK,
+                    is_draft_worker=True,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/dspark/test_dspark_sps_profiler.py
+++ b/test/registered/spec/dspark/test_dspark_sps_profiler.py
@@ -1,9 +1,11 @@
 import unittest
 
 from sglang.benchmark.dspark_sps_profiler import (
+    ADDITIVE_M_BIN_WIDTH,
     LoadInfo,
     ServerContext,
     SpsRow,
+    build_additive_table_from_cells,
     build_request_count_sweep,
     build_table_from_summaries,
     count_aligned_steps,
@@ -221,6 +223,16 @@ class TestTableAssembly(CustomTestCase):
         )
         self.assertEqual(table.sample_batch_tokens, [32])
         self.assertAlmostEqual(table.sample_steps_per_sec[0], 50.0)
+
+    def test_additive_fit_keeps_low_batch_budget_resolution(self):
+        cells = [
+            {"bs": bs, "M": m, "T": 0.001 + bs * 0.0001 + m * 0.00001}
+            for bs in (1, 2)
+            for m in (8, 16, 24, 32)
+        ]
+        table = build_additive_table_from_cells(cells=cells)
+        self.assertEqual(ADDITIVE_M_BIN_WIDTH, 8)
+        self.assertEqual(table.m_probes, [8, 16, 24, 32])
 
 
 class TestSweepHelpers(CustomTestCase):

--- a/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
+++ b/test/registered/spec/dspark/test_ragged_verify_backend_capability.py
@@ -28,15 +28,31 @@ class TestRaggedVerifyGraphCapability(CustomTestCase):
         from sglang.srt.layers.attention.flashattention_backend import (
             FlashAttentionBackend,
         )
+        from sglang.srt.layers.attention.linear.kda_backend import KDAAttnBackend
+        from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
         from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
 
         for backend in (
             TRTLLMHAAttnBackend,
             DeepseekV4AttnBackend,
             FlashAttentionBackend,
+            TritonAttnBackend,
+            KDAAttnBackend,
         ):
             with self.subTest(backend=backend.__name__):
                 self.assertTrue(backend.supports_ragged_verify_graph)
+
+    def test_gdn_capability_stays_instance_conditional(self):
+        """GDN is the one ragged-capable backend whose answer depends on
+        server_args (ReplaySSM keeps the graph path off), so it is derived per
+        instance in __init__. Promoting it to an unconditional class attribute
+        would silently enable ragged graphs for the ReplaySSM configuration,
+        which no other test covers; the class must keep inheriting the
+        conservative base default."""
+        from sglang.srt.layers.attention.linear.gdn_backend import GDNAttnBackend
+
+        self.assertNotIn("supports_ragged_verify_graph", GDNAttnBackend.__dict__)
+        self.assertFalse(GDNAttnBackend.supports_ragged_verify_graph)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_executor/test_linear_attention_ragged_verify.py
+++ b/test/registered/unit/model_executor/test_linear_attention_ragged_verify.py
@@ -1,0 +1,92 @@
+"""CPU tests for linear-attention ragged verify layout helpers."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.linear.utils import (
+    gather_ragged_verify_from_dense,
+    ragged_verify_dense_scatter_indices,
+    scatter_ragged_verify_to_dense,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestLinearAttentionRaggedVerify(CustomTestCase):
+    def test_maps_packed_tokens_to_dense_request_steps(self):
+        query_start_loc = torch.tensor([0, 3, 4, 8], dtype=torch.int32)
+
+        indices = ragged_verify_dense_scatter_indices(
+            query_start_loc=query_start_loc,
+            seq_len=8,
+            draft_token_num=4,
+        )
+
+        expected = torch.tensor([0, 1, 2, 4, 8, 9, 10, 11], dtype=torch.int64)
+        torch.testing.assert_close(indices, expected)
+
+    def test_maps_uncovered_graph_tier_tokens_to_ghost_row(self):
+        query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+
+        indices = ragged_verify_dense_scatter_indices(
+            query_start_loc=query_start_loc,
+            seq_len=5,
+            draft_token_num=4,
+        )
+
+        expected = torch.tensor([0, 1, 4, 8, 8], dtype=torch.int64)
+        torch.testing.assert_close(indices, expected)
+
+    def test_scatter_and_gather_preserve_packed_token_order(self):
+        query_start_loc = torch.tensor([0, 3, 4, 8], dtype=torch.int32)
+        packed = torch.arange(1, 17, dtype=torch.float32).view(8, 2)
+
+        dense, indices = scatter_ragged_verify_to_dense(
+            packed,
+            query_start_loc=query_start_loc,
+            draft_token_num=4,
+        )
+
+        expected_dense = torch.tensor(
+            [
+                [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0], [0.0, 0.0]],
+                [[7.0, 8.0], [0.0, 0.0], [0.0, 0.0], [0.0, 0.0]],
+                [
+                    [9.0, 10.0],
+                    [11.0, 12.0],
+                    [13.0, 14.0],
+                    [15.0, 16.0],
+                ],
+            ]
+        )
+        torch.testing.assert_close(dense, expected_dense)
+        # Production callers pass causal_conv1d_update(...).transpose(1, 2),
+        # which is non-contiguous. Preserve reshape (not view) support here.
+        conv_layout = (dense + 100).transpose(1, 2).contiguous()
+        processed = conv_layout.transpose(1, 2)
+        self.assertFalse(processed.is_contiguous())
+        gathered = gather_ragged_verify_from_dense(
+            processed, dense_token_indices=indices
+        )
+        torch.testing.assert_close(gathered, packed + 100)
+
+    def test_gather_maps_uncovered_graph_tier_tokens_to_zero_ghost(self):
+        query_start_loc = torch.tensor([0, 2, 3], dtype=torch.int32)
+        packed = torch.arange(1, 6, dtype=torch.float32).unsqueeze(-1)
+
+        dense, indices = scatter_ragged_verify_to_dense(
+            packed,
+            query_start_loc=query_start_loc,
+            draft_token_num=4,
+        )
+        gathered = gather_ragged_verify_from_dense(dense, dense_token_indices=indices)
+
+        expected = torch.tensor([[1.0], [2.0], [3.0], [0.0], [0.0]])
+        torch.testing.assert_close(gathered, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_spec_mrope_positions.py
+++ b/test/registered/unit/model_executor/test_spec_mrope_positions.py
@@ -75,6 +75,80 @@ class TestSpecMropePositions(CustomTestCase):
         expected = expected_1d.unsqueeze(0).repeat(3, 1)
         torch.testing.assert_close(forward_batch.mrope_positions, expected)
 
+    def test_multimodal_ragged_deltas_follow_request_lengths(self):
+        batch_size = 3
+        positions = torch.tensor([4, 5, 10, 20, 21, 22], dtype=torch.int64)
+        forward_batch = _forward_batch(batch_size)
+        ragged_layout = SimpleNamespace(
+            verify_lens=torch.tensor([2, 1, 3], dtype=torch.int32),
+            graph_num_tokens=6,
+        )
+        batch = SimpleNamespace(
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[2]])),
+                None,
+                SimpleNamespace(mrope_position_delta=torch.tensor([[7]])),
+            ],
+            spec_info=SimpleNamespace(ragged_verify_layout=ragged_layout),
+        )
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        forward_batch.compute_spec_mrope_positions(
+            model_runner, batch, seq_positions=positions
+        )
+
+        expected_1d = torch.tensor([6, 7, 10, 27, 28, 29], dtype=torch.int64)
+        expected = expected_1d.unsqueeze(0).repeat(3, 1)
+        torch.testing.assert_close(forward_batch.mrope_positions, expected)
+
+    def test_multimodal_ragged_graph_padding_uses_zero_delta(self):
+        batch_size = 2
+        positions = torch.tensor([4, 5, 10, 0, 0], dtype=torch.int64)
+        forward_batch = _forward_batch(batch_size)
+        ragged_layout = SimpleNamespace(
+            verify_lens=torch.tensor([2, 1], dtype=torch.int32),
+            graph_num_tokens=5,
+        )
+        batch = SimpleNamespace(
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[2]])),
+                SimpleNamespace(mrope_position_delta=torch.tensor([[7]])),
+            ],
+            spec_info=SimpleNamespace(ragged_verify_layout=ragged_layout),
+        )
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        forward_batch.compute_spec_mrope_positions(
+            model_runner, batch, seq_positions=positions
+        )
+
+        expected_1d = torch.tensor([6, 7, 17, 0, 0], dtype=torch.int64)
+        expected = expected_1d.unsqueeze(0).repeat(3, 1)
+        torch.testing.assert_close(forward_batch.mrope_positions, expected)
+
+    def test_multimodal_ragged_positions_must_match_graph_tier(self):
+        batch_size = 2
+        forward_batch = _forward_batch(batch_size)
+        ragged_layout = SimpleNamespace(
+            verify_lens=torch.tensor([2, 1], dtype=torch.int32),
+            graph_num_tokens=5,
+        )
+        batch = SimpleNamespace(
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[2]])),
+                None,
+            ],
+            spec_info=SimpleNamespace(ragged_verify_layout=ragged_layout),
+        )
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        with self.assertRaisesRegex(ValueError, "graph_num_tokens=5"):
+            forward_batch.compute_spec_mrope_positions(
+                model_runner,
+                batch,
+                seq_positions=torch.tensor([4, 5, 10], dtype=torch.int64),
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/model_executor/test_spec_mrope_positions.py
+++ b/test/registered/unit/model_executor/test_spec_mrope_positions.py
@@ -1,0 +1,80 @@
+"""CPU tests for speculative mRoPE position construction."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _forward_batch(batch_size: int) -> ForwardBatch:
+    return ForwardBatch(
+        forward_mode=ForwardMode.TARGET_VERIFY,
+        batch_size=batch_size,
+        input_ids=torch.empty(0, dtype=torch.int64),
+        req_pool_indices=torch.arange(batch_size, dtype=torch.int32),
+        seq_lens=torch.ones(batch_size, dtype=torch.int32),
+        out_cache_loc=torch.empty(0, dtype=torch.int64),
+        seq_lens_sum=batch_size,
+    )
+
+
+class TestSpecMropePositions(CustomTestCase):
+    def test_text_only_ragged_positions_stay_flat(self):
+        batch_size = 7
+        positions = torch.arange(32, dtype=torch.int32)
+        forward_batch = _forward_batch(batch_size)
+        batch = SimpleNamespace(multimodal_inputs=[None] * batch_size)
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        forward_batch.compute_spec_mrope_positions(
+            model_runner, batch, seq_positions=positions
+        )
+
+        expected = positions.to(dtype=torch.int64).unsqueeze(0).repeat(3, 1)
+        torch.testing.assert_close(forward_batch.mrope_positions, expected)
+        self.assertEqual(forward_batch.mrope_positions.shape, (3, 32))
+        self.assertEqual(forward_batch.mrope_positions.dtype, torch.int64)
+
+    def test_text_only_rectangular_positions_are_unchanged(self):
+        batch_size = 2
+        positions = torch.tensor([[4, 5, 6], [10, 11, 12]], dtype=torch.int64)
+        forward_batch = _forward_batch(batch_size)
+        batch = SimpleNamespace(multimodal_inputs=[None] * batch_size)
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        forward_batch.compute_spec_mrope_positions(
+            model_runner, batch, seq_positions=positions
+        )
+
+        expected = positions.flatten().unsqueeze(0).repeat(3, 1)
+        torch.testing.assert_close(forward_batch.mrope_positions, expected)
+
+    def test_multimodal_rectangular_delta_behavior_is_unchanged(self):
+        batch_size = 2
+        positions = torch.tensor([[4, 5, 6], [10, 11, 12]], dtype=torch.int64)
+        forward_batch = _forward_batch(batch_size)
+        batch = SimpleNamespace(
+            multimodal_inputs=[
+                SimpleNamespace(mrope_position_delta=torch.tensor([[2]])),
+                SimpleNamespace(mrope_position_delta=torch.tensor([[7]])),
+            ]
+        )
+        model_runner = SimpleNamespace(device=torch.device("cpu"))
+
+        forward_batch.compute_spec_mrope_positions(
+            model_runner, batch, seq_positions=positions
+        )
+
+        expected_1d = torch.tensor([6, 7, 8, 17, 18, 19], dtype=torch.int64)
+        expected = expected_1d.unsqueeze(0).repeat(3, 1)
+        torch.testing.assert_close(forward_batch.mrope_positions, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Suggested title: [Feature][DSpark] Support native Speculators checkpoints and ragged multimodal CUDA graphs -->

> **Status:** implementation, public-checkpoint compatibility, and paired
> fixed-output performance tests are complete. Greedy target-output equivalence
> remains unresolved, so this PR does not claim lossless output.

## Motivation

This PR extends SGLang's DSpark path to run native Speculators checkpoints end
to end in eager mode, CUDA Graph replay, and ragged multimodal verification. It
covers the checkpoint config and weight formats, both DSpark anchor layouts,
independent draft vocabularies, and the runtime paths needed to verify them.

Native Speculators checkpoints are not limited to the shared-vocabulary layout
that DSpark originally supported in SGLang. They may contain an independent
reduced-vocabulary LM head plus a draft-to-target (`d2t`) mapping. For example,
the public
[`RedHatAI/Qwen3.6-35B-A3B-speculator.dspark`](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-speculator.dspark)
checkpoint has:

- target vocabulary: 248,320 tokens;
- draft `lm_head`: 32,000 tokens;
- `markov_w1`: target-vocabulary input;
- `markov_w2`: draft-vocabulary output;
- `d2t`: a 32,000-entry mapping from sampled draft IDs to target IDs.

Treating these tensors as a shared-vocabulary model either fails during loading
or feeds/scatters IDs in the wrong vocabulary space.

Speculators checkpoints can also use either DSpark draft-block layout:

- `sample_from_anchor=false`: the anchor is only a conditioning token. The draft
  forward has `gamma + 1` slots, and slot 0 is excluded from sampling and
  verification.
- `sample_from_anchor=true`: the anchor is a trained prediction. The draft
  forward has `gamma` slots.

Using the wrong width does not always crash; it can shift real draft positions
and reduce the acceptance length toward 1.

After checkpoint loading and draft geometry were working, mixed image/text
validation exposed separate problems in ragged mRoPE and linear attention. The
ragged-path changes make multimodal verification work under CUDA Graphs.

During the same validation, I found a pre-existing interaction between
`/flush_cache` and DSpark draft CUDA Graphs: emptying the allocator cache can
invalidate addresses retained by a captured graph. This is included as a
separate DSpark graph-lifecycle fix.

## Modifications

- Normalize the native Speculators DSpark config format, whose backbone lives
  under `transformer_layer_config`, without importing checkpoint-side remote
  config code. This path is gated on `speculators_model_type=dspark` and reuses
  the existing config-dictionary fetch.
- Load an independent tensor-parallel `ParallelLMHead` when
  `draft_vocab_size != target_vocab_size`; preserve the original shared-head
  path for full-vocabulary DSpark checkpoints.
- Support the asymmetric Markov geometry: `markov_w1` consumes target IDs while
  `markov_w2` and the draft LM head produce draft-vocabulary logits.
- Map sampled draft IDs through `d2t` before storing tokens or feeding the next
  Markov step. For probabilistic acceptance, scatter draft probabilities into
  target-vocabulary columns and leave unmapped target tokens at `-inf`.
- Validate mapping shape/range and fail early for unsupported reduced-vocabulary
  checkpoints without `d2t`. Load `t2d` as checkpoint metadata without using it
  in the decode path.
- Read authoritative `gamma` and `sample_from_anchor` metadata, reject
  inconsistent checkpoint geometry at startup, and propagate the same draft
  width through eager execution and CUDA Graph replay.
- Keep verification, KV commit, and acceptance accounting at `gamma` real draft
  tokens. Only the draft forward width changes.
- Build speculative mRoPE positions from each request's actual verify length;
  CUDA Graph padding uses zero-delta ghost positions.
- Add packed-to-dense scatter/gather support for ragged linear attention and
  declare ragged CUDA Graph support per attention backend.
- Preserve captured DSpark draft graph allocations across `/flush_cache` while
  still clearing logical request, KV, radix, grammar, and metrics state.
- Use an 8-token SPS `M` bin for compact scheduling and recompute the simulated
  bonus token at the acceptance boundary.
- Add regression coverage for full/reduced vocabularies, configuration
  normalization, tensor-parallel LM heads, Markov shapes, `d2t` mapping,
  corrected-logit scatter, both checkpoint layouts, CUDA Graphs, ragged mRoPE,
  linear attention, cache flushing, and SPS fitting.

## Status

- [x] Bonus-anchor and dense anchor-first checkpoint layouts
- [x] Full-vocabulary DSpark checkpoint regression
- [x] Independent reduced-vocabulary LM head
- [x] Draft-to-target vocabulary mapping and probabilistic corrected logits
- [x] Eager and CUDA Graph draft-width propagation
- [x] TP=1 and TP=2 public RedHat checkpoint inference
- [x] Greedy and non-greedy sampling
- [x] Ragged multimodal mRoPE and linear-attention layouts
- [x] DSpark CUDA Graph behavior after `/flush_cache`
- [ ] Greedy token-level equivalence with target-only decoding
- [x] Same-GPU paired performance benchmark at concurrency 1 and 8

## Correctness Tests

On the PR branch rebased onto upstream `main` on 2026-08-13, the focused suite
reports `212 passed, 54 subtests passed`; the reduced-vocabulary file reports
`26 passed, 2 subtests passed`. Python compilation, formatting, focused Ruff
checks, and `git diff --check` also pass.

The public-checkpoint validation uses
[`RedHatAI/Qwen3.6-35B-A3B-NVFP4`](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-NVFP4)
as the target and
[`RedHatAI/Qwen3.6-35B-A3B-speculator.dspark`](https://huggingface.co/RedHatAI/Qwen3.6-35B-A3B-speculator.dspark)
as the draft. All reported runs used NVIDIA RTX PRO 5000 72GB Blackwell GPUs
(driver 580.126.20); each run used one GPU, and paired performance measurements
reused the same physical GPU. The environment has PyTorch 2.13.0+cu130, Transformers 5.12.1,
and FlashInfer 0.6.17. The official workloads are MT-Bench (80 two-turn
conversations, 160 requests) and the MMSpec test split (600 conversations, 723
turns). Correctness runs compare target-only autoregressive (AR) decoding with
DSpark under greedy decoding at concurrency 1.

| Workload | AR repeat | DSpark completed | Exact first-turn AR/DSpark token sequences |
| --- | ---: | ---: | ---: |
| MT-Bench | 160/160 | 160/160 | 8/80 |
| MMSpec | 723/723 | 723/723 | 18/600 |

The AR repeat is exact on both workloads, confirming a deterministic
baseline. DSpark completes every request, but target-output equivalence is not
established. A separate 20-prompt eager probe also mismatches on all 20 prompts,
so disabling decode CUDA Graph does not remove the divergence; its cause remains
unresolved.

Acceptance is aggregated from raw server counters. The acceptance length below
includes the target bonus token.

| Workload | Draft acceptance rate | Acceptance length including bonus |
| --- | ---: | ---: |
| MT-Bench | 32.863% | 3.6257 |
| MMSpec | 24.956% | 2.9925 |

Separate focused lanes also pass TP=1 and TP=2 inference, greedy and non-greedy
sampling, ragged multimodal CUDA Graph replay, and a post-`/flush_cache` request.

## Fixed-output Performance

The formal fixed-output benchmark consists of three same-GPU paired repeats
with service restart and unmeasured warm-up before each mode:

- MT-Bench first turns with exactly 256 output tokens per request;
- a deterministic 20-per-topic MMSpec subset with exactly 128 output tokens per
  request;
- closed-loop concurrency 1 and 8;
- pair order `target -> DSpark`, `DSpark -> target`, `target -> DSpark`.

All 2,400 measured requests completed with the required output length. Values
below are medians across the three runs; the interval is the range of the three
paired throughput ratios. The raw service logs and result manifests bind these
runs to the reported source commit and execution-environment freeze; strict
reanalyzing after the provenance audit produced an identical summary.

| Workload | C | Target tok/s | DSpark tok/s | Paired throughput | p50 E2E target -> DSpark |
| --- | ---: | ---: | ---: | ---: | ---: |
| MT-Bench | 1 | 151.64 | 262.32 | 1.730x [1.726, 1.741] | 1.687s -> 1.008s |
| MT-Bench | 8 | 715.30 | 942.30 | 1.317x [1.300, 1.327] | 2.853s -> 2.076s |
| MMSpec | 1 | 132.89 | 178.49 | 1.343x [1.343, 1.346] | 0.937s -> 0.715s |
| MMSpec | 8 | 467.98 | 519.74 | 1.111x [1.110, 1.124] | 2.086s -> 1.754s |

The gain is not uniform across the latency distribution. MT-Bench C=8 p99 E2E
regresses in all three repeats (paired target/DSpark ratios 0.906-0.920).
MMSpec C=8 has about 9% higher p50 TPOT and mixed p99 E2E results (paired
ratios 0.938-1.092, median 0.961). This supports a stable fixed-output
throughput and p50 E2E improvement under the reported configuration, not a
universal tail-latency improvement.

SSE chunk gaps are not reported as token-level ITL because one speculative
event can expose multiple tokens. TPOT is client-observed and amortized from
the first to last token-bearing event.

## Known limitation

Greedy token-level equivalence with target-only decoding has not been established
for the tested public checkpoint. The reported results demonstrate checkpoint
compatibility, request completion, online acceptance, and fixed-output
performance, but do not support a lossless-output claim.

## Related work

- Original SGLang DSpark implementation: [#30261](https://github.com/sgl-project/sglang/pull/30261)
- Bonus-anchor checkpoint layout: [#30982](https://github.com/sgl-project/sglang/pull/30982)
- vLLM Speculators checkpoint support: [vLLM #47093](https://github.com/vllm-project/vllm/pull/47093)

Thanks to the authors and reviewers of these changes for the checkpoint-layout
analysis and reference behavior.



## Contributors

Engine Architecture Group 5, Engine Infrastructure Department, Xiaohongshu
(RedNote): Su Zhan, Fei Ziyu, Hong Chenchen, Luo Zhaokai, Jin Huayi.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32136288277](https://github.com/sgl-project/sglang/actions/runs/32136288277)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32136288017](https://github.com/sgl-project/sglang/actions/runs/32136288017)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->