### PR TITLE
[PD] Clean up stale staging watermark subscribers

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1025,6 +1025,9 @@ class CommonKVManager(BaseKVManager):
             keys_to_remove = [
                 k for k in self.connection_pool if k.startswith(failed_bootstrap_addr)
             ]
+            stale_bootstrap_info_groups = [
+                list(self.connection_pool[k]) for k in keys_to_remove
+            ]
             # Collect TCP endpoints from cached bootstrap_infos before deletion
             stale_endpoints = set()
             for k in keys_to_remove:
@@ -1042,6 +1045,10 @@ class CommonKVManager(BaseKVManager):
                 failed_bootstrap_addr, []
             )
             self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)
+
+        staging_handler = getattr(self, "_staging_handler", None)
+        if staging_handler is not None:
+            staging_handler.unregister_wm_subscribers(stale_bootstrap_info_groups)
 
         for endpoint in stale_endpoints:
             CommonKVReceiver.disconnect_endpoint(endpoint)

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -94,6 +94,7 @@ class DecodeStagingHandler:
         # before unregister runs, but release_room still needs it.
         self._room_to_receiver: dict = {}
         self._wm_subscribers: dict = {}
+        self._wm_subscribers_lock = threading.Lock()
         # room -> chunk_idx -> [(page_start, num_pages, writer_id)] fan-in
         # arrivals; handler-owned so room teardown can purge them.
         self._writer_counts: dict = {}
@@ -103,8 +104,23 @@ class DecodeStagingHandler:
         if receiver is None or not receiver.bootstrap_infos:
             return
         key = tuple(str(bi) for bi in receiver.bootstrap_infos)
-        if key not in self._wm_subscribers:
+        # Receivers are request-scoped. Refresh an existing endpoint entry so
+        # watermark sends never retain a receiver from an earlier request.
+        with self._wm_subscribers_lock:
             self._wm_subscribers[key] = (receiver, session_id)
+
+    def unregister_wm_subscribers(self, bootstrap_info_groups) -> int:
+        """Remove watermark subscribers owned by a failed prefill node."""
+        keys = {
+            tuple(str(bootstrap_info) for bootstrap_info in bootstrap_infos)
+            for bootstrap_infos in bootstrap_info_groups
+            if bootstrap_infos
+        }
+        with self._wm_subscribers_lock:
+            removed = sum(key in self._wm_subscribers for key in keys)
+            for key in keys:
+                self._wm_subscribers.pop(key, None)
+        return removed
 
     def num_writers_for(self, receiver) -> int:
         """Compute all TP and PP writers expected for a staging chunk."""
@@ -447,7 +463,9 @@ class DecodeStagingHandler:
         wm_round, wm_tail = post_wm
         wm_round_b = str(wm_round).encode("ascii")
         wm_tail_b = str(wm_tail).encode("ascii")
-        for _key, (receiver, session_id) in list(self._wm_subscribers.items()):
+        with self._wm_subscribers_lock:
+            subscribers = list(self._wm_subscribers.values())
+        for receiver, session_id in subscribers:
             sid_b = session_id.encode("ascii")
             for bootstrap_info in receiver.bootstrap_infos:
                 try:

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -13,7 +13,10 @@ import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import CommonKVManager
-from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
+from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingHandler,
+    PrefillStagingContext,
+)
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
     KVArgsRegisterInfo,
@@ -685,10 +688,11 @@ class TestNixlNodeFailure(CustomTestCase):
         mgr.connection_lock = threading.Lock()
         # Connection keys are "{addr}_{dp_rank}_{cp_rank}_{tp_rank}".
         mgr.connection_pool = {
-            "10.0.0.1:8998_0_0_0": [{"rank_ip": "10.0.0.1"}],
-            "10.0.0.1:8998_0_0_1": [{"rank_ip": "10.0.0.1"}],
-            "10.0.0.2:8998_0_0_0": [{"rank_ip": "10.0.0.2"}],
+            "10.0.0.1:8998_0_0_0": [{"rank_ip": "10.0.0.1", "rank_port": 1}],
+            "10.0.0.1:8998_0_0_1": [{"rank_ip": "10.0.0.1", "rank_port": 2}],
+            "10.0.0.2:8998_0_0_0": [{"rank_ip": "10.0.0.2", "rank_port": 3}],
         }
+        mgr._staging_handler = MagicMock()
         mgr.prefill_info_table = {
             "10.0.0.1:8998": object(),
             "10.0.0.2:8998": object(),
@@ -725,6 +729,12 @@ class TestNixlNodeFailure(CustomTestCase):
         self.assertIn(3, mgr.failure_records)
         self.assertIn(4, mgr.failure_records)
         self.assertNotIn(5, mgr.failure_records)
+        mgr._staging_handler.unregister_wm_subscribers.assert_called_once_with(
+            [
+                [{"rank_ip": "10.0.0.1", "rank_port": 1}],
+                [{"rank_ip": "10.0.0.1", "rank_port": 2}],
+            ]
+        )
 
     def test_late_failed_update_does_not_resurrect_cleared_room(self):
         mgr = object.__new__(CommonKVManager)
@@ -733,6 +743,45 @@ class TestNixlNodeFailure(CustomTestCase):
         CommonKVManager.update_status(mgr, 9, KVPoll.Failed)
 
         self.assertNotIn(9, mgr.request_status)
+
+
+class TestStagingWatermarkSubscriberLifecycle(CustomTestCase):
+    def _make_handler(self):
+        handler = object.__new__(DecodeStagingHandler)
+        handler._wm_subscribers = {}
+        handler._wm_subscribers_lock = threading.Lock()
+        return handler
+
+    def test_register_refreshes_request_scoped_receiver(self):
+        handler = self._make_handler()
+        bootstrap_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        old_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+        new_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+
+        handler.register_wm_subscriber(old_receiver, "old-session")
+        handler.register_wm_subscriber(new_receiver, "new-session")
+
+        self.assertEqual(
+            list(handler._wm_subscribers.values()),
+            [(new_receiver, "new-session")],
+        )
+
+    def test_unregister_removes_only_failed_prefill_subscribers(self):
+        handler = self._make_handler()
+        failed_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        healthy_infos = [{"rank_ip": "10.0.0.2", "rank_port": 5678}]
+        failed_receiver = SimpleNamespace(bootstrap_infos=failed_infos)
+        healthy_receiver = SimpleNamespace(bootstrap_infos=healthy_infos)
+        handler.register_wm_subscriber(failed_receiver, "failed-session")
+        handler.register_wm_subscriber(healthy_receiver, "healthy-session")
+
+        removed = handler.unregister_wm_subscribers([failed_infos])
+
+        self.assertEqual(removed, 1)
+        self.assertEqual(
+            list(handler._wm_subscribers.values()),
+            [(healthy_receiver, "healthy-session")],
+        )
 
 
 class TestNixlStaging(CustomTestCase):


### PR DESCRIPTION
## Motivation

Fixes #34737.

In heterogeneous-TP disaggregated serving, the decode-side staging watermark subscriber registry outlives individual prefill connections. When a prefill node fails or restarts, `CommonKVManager._handle_node_failure()` removes its connection-pool entries and cached sockets but leaves its subscriber in `DecodeStagingHandler._wm_subscribers`.

Every staging allocation release then continues broadcasting to the stale receiver. #31144 bounds each ZMQ send, but the default timeout is one second and stale entries can accumulate. #31217 handles room/allocation teardown but does not prune this process-lifetime registry. #29978 addresses retry/replay of staging control messages and is complementary.

The issue was observed with SGLang's heterogeneous-TP staging/scatter path using the NIXL backend, in a topology with prefill TP=2 and decode TP=1.

## Modifications

- Remove watermark subscribers associated with a prefill node when heartbeat failure cleanup evicts that node's bootstrap-info groups.
- Refresh the request-scoped receiver/session when the same endpoint registers again instead of retaining the first receiver forever.
- Protect subscriber registration, removal, and broadcast snapshots with a lock; socket I/O remains outside the lock.
- Add CPU unit coverage for node-failure cleanup, receiver refresh, and selective subscriber removal.

The cleanup is implemented in the common disaggregation layer, so it applies to both the NIXL and Mooncake staging paths.

## Accuracy Tests

Not applicable. This changes staging control-plane lifecycle only and does not modify model execution or outputs.

## Speed Tests and Profiling

No throughput benchmark was run for this focused lifecycle fix.

The change removes sends to failed prefill endpoints. On current `main`, each such send can otherwise wait up to `SGLANG_DISAGGREGATION_ZMQ_SEND_TIMEOUT` (one second by default) on every staging allocation release.

Validation performed:

- `uvx pre-commit run --files python/sglang/srt/disaggregation/common/conn.py python/sglang/srt/disaggregation/common/staging_handler.py test/registered/unit/disaggregation/test_nixl_backend_basic.py`
- Focused standalone subscriber lifecycle smoke test
- Read-only validation of the original failure topology: two TP=2 prefills and one TP=1 decode using the NIXL backend on SGLang 0.5.16
- In the deployment carrying the equivalent lifecycle cleanup, a failed prefill subscriber was removed before the existing teardown path released 11 outstanding staging allocations

## Checklist

- [x] Format code according to the SGLang pre-commit configuration.
- [x] Add unit tests for the changed control paths.
- [x] Documentation is not required for this internal lifecycle fix.
- [x] Accuracy testing is not applicable because model outputs are unchanged.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31700109001](https://github.com/sgl-project/sglang/actions/runs/31700109001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31700108916](https://github.com/sgl-project/sglang/actions/runs/31700108916)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->