### PR TITLE
[Kimi-K3] Fix deferred GPU preprocessing backend metadata

### DIFF
--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -273,6 +273,7 @@ class KimiK3GPUProcessorWrapper(KimiGPUProcessorWrapper):
             input_text, resize_configs, original_input_ids, image_sizes
         )
         deferred_config = {
+            "backend": "gpu",
             "image_mean": list(self._image_mean),
             "image_std": list(self._image_std),
             "transparent_bg_config": self._transparent_bg_config,

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -687,6 +687,30 @@ def test_kimi_k3_epd_rebuild_uses_the_same_media_contract():
     )
 
 
+def test_kimi_k3_normal_deferred_config_selects_gpu_backend():
+    processor = KimiK3GPUProcessorWrapper(
+        _HFProcessor(),
+        image_token="<|media_pad|>",
+        image_token_id=99,
+        patch_size=14,
+        merge_kernel_size=2,
+        in_patch_limit=16384,
+        patch_limit_on_one_side=256,
+        fixed_output_tokens=None,
+        image_mean=[0.5, 0.5, 0.5],
+        image_std=[0.5, 0.5, 0.5],
+        transparent_bg_config=None,
+    )
+
+    _, _, deferred_config = processor.prepare_deferred(
+        "<|media_pad|>",
+        [torch.zeros((3, 32, 32), dtype=torch.uint8)],
+        [99],
+    )
+
+    assert deferred_config["backend"] == "gpu"
+
+
 def test_kimi_k3_cpu_transport_defers_gpu_preprocessing():
     from sglang.srt.multimodal.kimi_k3_image_processing import (
         DEFERRED_PREPROCESSING_KEY,
@@ -718,6 +742,7 @@ def test_kimi_k3_cpu_transport_defers_gpu_preprocessing():
                     },
                 ],
                 {
+                    "backend": "gpu",
                     "image_mean": [0.5, 0.5, 0.5],
                     "image_std": [0.5, 0.5, 0.5],
                     "transparent_bg_config": None,
@@ -753,6 +778,10 @@ def test_kimi_k3_cpu_transport_defers_gpu_preprocessing():
     assert all(item.pad_value is not None for item in output.mm_items)
     assert all(
         DEFERRED_PREPROCESSING_KEY in item.model_specific_data
+        for item in output.mm_items
+    )
+    assert all(
+        item.model_specific_data[DEFERRED_PREPROCESSING_KEY]["backend"] == "gpu"
         for item in output.mm_items
     )
 

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -687,8 +687,12 @@ def test_kimi_k3_epd_rebuild_uses_the_same_media_contract():
     )
 
 
-def test_kimi_k3_normal_deferred_config_selects_gpu_backend():
-    processor = KimiK3GPUProcessorWrapper(
+def test_kimi_k3_normal_deferred_output_declares_gpu_backend():
+    from sglang.srt.multimodal.kimi_k3_image_processing import (
+        DEFERRED_PREPROCESSING_KEY,
+    )
+
+    wrapper = KimiK3GPUProcessorWrapper(
         _HFProcessor(),
         image_token="<|media_pad|>",
         image_token_id=99,
@@ -701,13 +705,18 @@ def test_kimi_k3_normal_deferred_config_selects_gpu_backend():
         image_std=[0.5, 0.5, 0.5],
         transparent_bg_config=None,
     )
+    processor = object.__new__(KimiK3ImageProcessor)
+    processor.mm_tokens = SimpleNamespace(image_token_id=99)
+    processor.mm_feature_transport = "cpu"
+    processor.use_cuda_ipc = False
+    processor._processor = wrapper
+    image = torch.zeros((3, 32, 32), dtype=torch.uint8)
 
-    _, _, deferred_config = processor.prepare_deferred(
-        "<|media_pad|>",
-        [torch.zeros((3, 32, 32), dtype=torch.uint8)],
-        [99],
+    output = processor._build_deferred_output(
+        SimpleNamespace(input_text="<|media_pad|>", images=[image], input_ids=[99])
     )
 
+    deferred_config = output.mm_items[0].model_specific_data[DEFERRED_PREPROCESSING_KEY]
     assert deferred_config["backend"] == "gpu"
 
 


### PR DESCRIPTION
## Summary

- declare `backend: gpu` in Kimi-K3's regular-serving deferred preprocessing metadata
- add regression coverage for the producer contract and the resulting multimodal item metadata

## Root cause

The regular tokenizer-side deferred path stores CHW `uint8` images for owner-side GPU preprocessing, but its metadata omitted `backend`. `KimiK3ForConditionalGeneration` requires that field when materializing deferred images, so the warmup image request failed with `KeyError: 'backend'` after weights were loaded.

The EPD producer already sets the corresponding backend explicitly. This change makes the regular serving producer carry the same required discriminator.

## Why existing tests missed it

The regular deferred-output test mocked `prepare_deferred`, while the model-side test used a separate hand-written complete config. Both layers passed independently, but no test exercised the real producer-to-item boundary. The new regression test uses the real wrapper output through `_build_deferred_output`, so required metadata cannot silently diverge at that boundary again.

Fixes the regression reported in https://github.com/sgl-project/sglang/pull/33921#issuecomment-5280016395.

## Validation

- `python3 -m py_compile` for the modified source and test
- pre-commit hooks for the modified files
- registered CPU regression test covers the real normal-serving producer through `_build_deferred_output`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #31701187137](https://github.com/sgl-project/sglang/actions/runs/31701187137)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31701186530](https://github.com/sgl-project/sglang/actions/runs/31701186530)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->