### PR TITLE
[AMD] Fix Triton 3.7 gfx950 extend-attention spills

### DIFF
--- a/python/sglang/kernels/ops/attention/extend_attention.py
+++ b/python/sglang/kernels/ops/attention/extend_attention.py
@@ -35,6 +35,14 @@ if _is_cuda:
 _is_hip = is_hip()
 _is_gfx95 = _is_hip and is_gfx95_supported()
 
+try:
+    _triton_version_parts = tuple(
+        int(part) for part in triton.__version__.split(".")[:2]
+    )
+except (AttributeError, ValueError):
+    _triton_version_parts = (0, 0)
+_is_triton_ge_37 = _triton_version_parts >= (3, 7)
+
 
 def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
     """
@@ -65,7 +73,14 @@ def _get_block_sizes_for_extend_attention(Lq: int, Lv: int):
 
     # Determine BLOCK_M, BLOCK_N, and num_warps based on hardware
     if _is_hip:
-        if _is_gfx95 and 128 < Lq <= 256:
+        if _is_gfx95 and _is_triton_ge_37 and Lq == 576 and Lv == 512:
+            # Triton 3.7's N64 codegen reaches 512 VGPRs and spills 472 bytes
+            # of scratch on gfx950. N32 keeps BLOCK_M/launch work unchanged,
+            # uses <=433 VGPRs without scratch, and restores the isolated
+            # late-prefill kernel from ~12.57 ms to ~5.24 ms.
+            BLOCK_M, BLOCK_N = (64, 32)
+            num_warps = 4
+        elif _is_gfx95 and 128 < Lq <= 256:
             # gfx950 (CDNA4), 128 < head_dim <= 256: a larger query tile halves KV bytes
             # streamed per call (each workgroup reads the whole prefix); 8 warps
             # hide the loads. Measured on MI350X head_dim 256: -36% kernel time,

--- a/test/registered/attention/test_triton_attention_kernels.py
+++ b/test/registered/attention/test_triton_attention_kernels.py
@@ -335,10 +335,70 @@ class TestTritonAttention(CustomTestCase):
         self.assertEqual(
             ea._get_block_sizes_for_extend_attention(256, 256)[3:], expected
         )
-        # head_dim > 256: falls back to the default on all HIP archs
-        self.assertEqual(
-            ea._get_block_sizes_for_extend_attention(576, 576)[3:], (64, 64, 4)
-        )
+        # head_dim > 256 falls back to the default unless the automatic
+        # Triton-3.7 gfx950 Lq=576/Lv=512 spill workaround applies.
+        with unittest.mock.patch.object(ea, "_is_triton_ge_37", True):
+            expected = (64, 32, 4) if ea._is_gfx95 else (64, 64, 4)
+            self.assertEqual(
+                ea._get_block_sizes_for_extend_attention(576, 512)[3:],
+                expected,
+            )
+        with unittest.mock.patch.object(ea, "_is_triton_ge_37", False):
+            self.assertEqual(
+                ea._get_block_sizes_for_extend_attention(576, 512)[3:],
+                (64, 64, 4),
+            )
+
+    def test_extend_attention_triton37_lq576_n32(self):
+        from sglang.kernels.ops.attention import extend_attention as ea
+
+        if not (ea._is_gfx95 and ea._is_triton_ge_37):
+            self.skipTest("Triton >=3.7 gfx950-only spill workaround")
+
+        device = get_device()
+        dtype = torch.bfloat16
+        extend_lens = [32, 23]
+        prefix_lens = [64, 96]
+        h_q, h_kv, l_q, l_v = 12, 1, 576, 512
+        n_ext, n_prefix = sum(extend_lens), sum(prefix_lens)
+
+        q = torch.randn(n_ext, h_q, l_q, dtype=dtype, device=device)
+        k = torch.randn(n_ext, h_kv, l_q, dtype=dtype, device=device)
+        v = torch.randn(n_ext, h_kv, l_v, dtype=dtype, device=device)
+        k_buffer = torch.randn(n_prefix, h_kv, l_q, dtype=dtype, device=device)
+        v_buffer = torch.randn(n_prefix, h_kv, l_v, dtype=dtype, device=device)
+        qo_indptr = torch.tensor([0, 32, 55], dtype=torch.int32, device=device)
+        kv_indptr = torch.tensor([0, 64, 160], dtype=torch.int32, device=device)
+        kv_indices = torch.arange(n_prefix, dtype=torch.int64, device=device)
+        reference = torch.empty(n_ext, h_q, l_v, dtype=dtype, device=device)
+        candidate = torch.empty_like(reference)
+
+        def run(output):
+            extend_attention_fwd(
+                q,
+                k,
+                v,
+                output,
+                k_buffer,
+                v_buffer,
+                qo_indptr,
+                kv_indptr,
+                kv_indices,
+                None,
+                True,
+                None,
+                max(extend_lens),
+                1.0,
+                1.0,
+                sm_scale=1.0 / (l_q**0.5),
+                extend_seq_lens_cpu=extend_lens,
+            )
+
+        with unittest.mock.patch.object(ea, "_is_triton_ge_37", False):
+            run(reference)
+        with unittest.mock.patch.object(ea, "_is_triton_ge_37", True):
+            run(candidate)
+        torch.testing.assert_close(candidate, reference, atol=2e-2, rtol=1e-2)
 
     def test_compact_extend_attention_tile_count(self):
         self.assertEqual(


### PR DESCRIPTION
Use an N32 tile for the gfx950 Lq576/Lv512 extend-attention specialization on Triton 3.7+ to eliminate register spilling and recover Kimi-K3 prefill performance, while preserving the existing Triton 3.6 configuration.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On MI355X/gfx950, Triton 3.7 regresses the `extend_attention.py::_fwd_kernel` specialization for `Lq=576`, `Lv=512`, `BLOCK_M=64`, `BLOCK_N=64`, and `num_warps=4`:

- VGPR usage increases from 483 to 512.
- The kernel gains a 472-byte private segment and 186 scratch load/store instructions.
- Rank-0 late-prefill p50 increases from 5.99 ms to 13.78 ms (+130%).
- The kernel adds 187.17 ms, explaining 84.34% of the measured 221.93 ms prefill-span increase.
- Kimi-K3 C32 throughput drops from the 6.19k tok/s range to 5.88k tok/s.

Reducing `BLOCK_N` to 32 preserves `BLOCK_M` and the launch grid while lowering KV-tile register pressure.

## Modifications

- Detect Triton 3.7+ from `triton.__version__`.
- On gfx950 only, select `(BLOCK_M, BLOCK_N, num_warps) = (64, 32, 4)` for `Lq=576/Lv=512` when using Triton 3.7+.
- Keep the existing `(64, 64, 4)` tile for Triton 3.6 and all non-matching architectures/shapes.
- Add block-selection coverage for both Triton version paths.
- Add a numerical N64-vs-N32 test for the gfx950 `Lq=576/Lv=512` shape.

## Accuracy Tests

Focused correctness:

- `test_extend_attention_block_sizes`: passed.
- `test_extend_attention_triton37_lq576_n32`: passed.
- Maximum absolute N64-vs-N32 difference: `0.00390625` (`atol=2e-2`, `rtol=1e-2`).

Full GSM8K control (1319 requested examples; 5 are reserved for few-shot prompting, so 1314 are scored):

| Configuration | Correct | Score |
| --- | ---: | ---: |
| Triton 3.7 N64 baseline | 1251 / 1314 | 0.95205479 |
| Triton 3.7 N32 candidate | 1252 / 1314 | 0.95281583 |

The candidate does not regress full-set GSM8K accuracy. Maximum token capacity remains `933883`.

## Speed Tests and Profiling

Environment:

- 8x AMD Instinct MI355X / gfx950
- Torch 2.9.1 + ROCm 7.2
- Triton 3.7
- Kimi-K3 BF16, TP8

Isolated matched late-prefill shape (`B=2`, extend lengths `[8192, 7661]`, `Hq/Hkv=12/1`, `Lq/Lv=576/512`):

| Configuration | p50 | VGPR | Private segment | Scratch instructions |
| --- | ---: | ---: | ---: | ---: |
| N64 baseline | 12.57 ms | 512 | 472-484 B | 186-214 |
| N32 candidate | 5.24 ms | 392-433 | 0 B | 0 |

The candidate improves isolated p50 by 58.3% and removes all scratch spilling.

Serving benchmark: random 8192-input/1024-output requests, 64 warmups, no radix cache.

| Concurrency | Triton 3.7 baseline | N32 candidate | Delta |
| --- | ---: | ---: | ---: |
| C2 | 970.53 tok/s | 973.94 tok/s | +0.35% |
| C4 | 1718.97 tok/s | 1748.71 tok/s | +1.73% |
| C8 | 2839.40 tok/s | 2901.37 tok/s | +2.18% |
| C16 | 4309.25 tok/s | 4460.33 tok/s | +3.51% |
| C32 | 5881.93 tok/s | 6198.56 tok/s | +5.38% |

The N32 tile restores the full C2-C32 endpoint matrix. Triton 3.6 retains N64 because N32 regresses the isolated Triton 3.6 shape by 17.2% (5.34 ms to 6.26 ms).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run --all-files` passes.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing API or configuration change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31702557591](https://github.com/sgl-project/sglang/actions/runs/31702557591)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31703233934](https://github.com/sgl-project/sglang/actions/runs/31703233934)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->