### PR TITLE
Fix DSpark draft logits when the target lm_head is quantized

### DIFF
--- a/python/sglang/srt/models/deepseek_v4_dspark.py
+++ b/python/sglang/srt/models/deepseek_v4_dspark.py
@@ -43,6 +43,7 @@ from sglang.srt.models.dspark import (
     DSparkConfidenceHead,
     StepSampler,
     gather_and_crop_vocab,
+    project_through_lm_head,
     run_markov_block,
 )
 from sglang.srt.runtime_context import get_parallel
@@ -771,10 +772,10 @@ class DeepseekV4ForCausalLMDSpark(nn.Module):
         last = self.stages[-1]
         x = last.norm(x_post_hc)
         weight = self.lm_head.weight
-        if self._use_fp32_lm_head:
+        if self._use_fp32_lm_head and weight.is_floating_point():
             local_logits = F.linear(x.float(), weight.float())
         else:
-            local_logits = torch.matmul(x.to(weight.dtype), weight.T)
+            local_logits = project_through_lm_head(x, self.lm_head)
         if self._opt_markov_w2_tp_shard:
             return local_logits
         return gather_and_crop_vocab(local_logits, self.lm_head)

--- a/python/sglang/srt/models/dspark.py
+++ b/python/sglang/srt/models/dspark.py
@@ -9,6 +9,7 @@ from torch import nn
 
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.environ import envs
+from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.dflash import DFlashDraftModel
 from sglang.srt.speculative.dflash_utils import can_dflash_slice_qkv_weight
@@ -30,6 +31,16 @@ def gather_and_crop_vocab(
 ) -> torch.Tensor:
     full_logits = tensor_model_parallel_all_gather(local_logits, dim=-1)
     return full_logits[..., : int(lm_head.org_vocab_size)]
+
+
+def project_through_lm_head(hidden: torch.Tensor, lm_head: nn.Module) -> torch.Tensor:
+    """Project draft hidden states through the target head; a quantized head
+    stores `weight` packed, so it needs its own kernel instead of a matmul."""
+    quant_method = lm_head.quant_method
+    if should_apply_lm_head_quant_method(lm_head, quant_method):
+        return quant_method.apply(lm_head, hidden, None)
+    weight = lm_head.weight
+    return torch.matmul(hidden.to(weight.dtype), weight.T)
 
 
 def run_markov_block(
@@ -409,10 +420,7 @@ class DSparkDraftMixin:
             )
         if self.logits_mup_width_multiplier:
             hidden = hidden / self.logits_mup_width_multiplier
-        weight = self.lm_head.weight
-        if hidden.dtype != weight.dtype:
-            hidden = hidden.to(weight.dtype)
-        local_logits = torch.matmul(hidden, weight.T)
+        local_logits = project_through_lm_head(hidden, self.lm_head)
         base_logits = gather_and_crop_vocab(local_logits, self.lm_head)
         return base_logits, None
 

--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -17,6 +17,15 @@ logger = logging.getLogger(__name__)
 _CAPTURE_HEADROOM_GB = 1.0
 
 
+def _base_logits_dtype(model) -> torch.dtype:
+    """Dtype of the block logits; a quantized head's packed `weight` carries no
+    logits dtype, its kernel emits the activation (draft param) dtype instead."""
+    weight = model.lm_head.weight
+    if weight.is_floating_point():
+        return weight.dtype
+    return next(model.markov_head.parameters()).dtype
+
+
 def greedy_step_sampler(step_logits: torch.Tensor, step_idx: int) -> torch.Tensor:
     del step_idx
     return torch.argmax(step_logits, dim=-1)
@@ -70,7 +79,7 @@ class DsparkDraftSampler:
             )
             self.corrected_out = torch.empty(
                 (max_bs * self.gamma, vocab),
-                dtype=model.lm_head.weight.dtype,
+                dtype=_base_logits_dtype(model),
                 device=device,
             )
 
@@ -144,7 +153,7 @@ def _resolve_folded_sampling(*, model, gamma, max_bs, device, tp_rank) -> bool:
         return True
     vocab = int(model.lm_head.org_vocab_size)
     noise_bytes = max_bs * vocab * 4
-    logits_bytes = max_bs * gamma * vocab * model.lm_head.weight.dtype.itemsize
+    logits_bytes = max_bs * gamma * vocab * _base_logits_dtype(model).itemsize
     need_gb = (noise_bytes + logits_bytes) / (1 << 30)
     available_gb = get_available_gpu_memory(device, torch.cuda.current_device())
     if available_gb - need_gb >= _CAPTURE_HEADROOM_GB:


### PR DESCRIPTION
The DSpark draft borrows the target's `lm_head` and projected through it with a dense matmul on `.weight`. When the target checkpoint quantizes `lm_head` (e.g. a ModelOpt NVFP4 export), that weight is packed `uint8` of shape `[vocab, hidden / 2]`, so the matmul gets the wrong K and the `hidden.to(weight.dtype)` cast reinterprets bf16 activations as `uint8`.

The server dies during draft CUDA graph capture:

```
File "python/sglang/srt/models/dspark.py", line 415, in compute_base_logits
    local_logits = torch.matmul(hidden, weight.T)
RuntimeError: mat1 and mat2 shapes cannot be multiplied (51x5120 and 2560x248320)
```

Not capture-specific — the eager proposal path fails the same way; capture is just first to reach it.

## Fix

- `models/dspark.py`: new `project_through_lm_head()` — dispatch to `quant_method.apply` when the head is quantized, using `should_apply_lm_head_quant_method`, the same gate the target's own logits path uses. Dense matmul otherwise.
- `dspark_draft_sampler.py`: the static `corrected_out` buffer and the folded-sampling memory probe took their dtype from `lm_head.weight.dtype` — `uint8` for a packed head, so a uint8 logits buffer in the CUDA graph and a 2x undercount in the probe. Both now use the dtype the projection actually emits.
- `deepseek_v4_dspark.py`: same bug in `_logits_from_x_post_hc`, plus `--enable-fp32-lm-head` calling `.float()` on packed codes.

## Tests

27B NVFP4 (W4A4) checkpoint with a quantized `lm_head`, one RTX PRO 6000 Blackwell (SM120). The server does not start before this patch; after it, draft capture completes and generation is correct.

Accept length and output throughput at bs=1, greedy, with MTP on the same checkpoint for reference:

| dataset | DSpark accept len | MTP accept len | DSpark tok/s | MTP tok/s |
|---|---|---|---|---|
| math500 | 3.62 | 3.57 | 168.3 | 167.9 |
| humaneval | 5.79 | 3.74 | 300.6 | 178.2 |
| mbpp | 4.31 | 3.46 | 204.5 | 164.7 |
| mtbench | 2.13 | 2.69 | 99.4 | 121.0 |
