### PR TITLE
fix: support Qwen3_5MoeForCausalLM in fused MoE tuning utils

### DIFF
--- a/benchmark/kernels/fused_moe_triton/common_utils.py
+++ b/benchmark/kernels/fused_moe_triton/common_utils.py
@@ -82,6 +82,7 @@ def get_model_config(
         "Qwen3MoeForCausalLM",
         "Qwen3NextForCausalLM",
         "Qwen3VLMoeForConditionalGeneration",
+        "Qwen3_5MoeForCausalLM",
         "Qwen3_5MoeForConditionalGeneration",
         "InternS2PreviewForConditionalGeneration",
         "MellumForCausalLM",


### PR DESCRIPTION
## Problem

`get_model_config` in `benchmark/kernels/fused_moe_triton/common_utils.py` does not recognize the `Qwen3_5MoeForCausalLM` architecture (used by Qwen3.8). It falls through to the default Mixtral branch, which reads `num_local_experts` from a config object that has no such attribute:

```
AttributeError: 'Qwen3_5MoeTextConfig' object has no attribute 'num_local_experts'
```

This crashes `tuning_fused_moe_triton.py` (and the sep variant) for Qwen3.8-family models.

## Fix

Add `Qwen3_5MoeForCausalLM` to the Qwen3 branch so `num_experts // ep_size`, `num_experts_per_tok`, and `moe_intermediate_size` are read correctly, matching the serving-side support in `sglang/srt/models/qwen3_5_text.py`.

## Verification

- Reproduced the crash by running `tuning_fused_moe_triton.py --model Qwen3.8-2.4T-A95B-FP8 --tp-size 8 --dtype fp8_w8a8 --tune` on 8x NVIDIA H20 (triton 3.7.1).
- With this one-line change the tuning run proceeds normally.
- A companion PR will add the tuned H20 `fp8_w8a8` configs for Qwen3.8's E=512 shape.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31705857436](https://github.com/sgl-project/sglang/actions/runs/31705857436)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31705857175](https://github.com/sgl-project/sglang/actions/runs/31705857175)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->