### PR TITLE
[CI] Fix test_resolution_is_reproducible after cuda_ipc became opt-in

### DIFF
--- a/test/registered/unit/server_args/test_resolution_is_reproducible.py
+++ b/test/registered/unit/server_args/test_resolution_is_reproducible.py
@@ -151,6 +151,26 @@ _SHAPES = (
 if torch.cuda.is_available():
     _SHAPES = _SHAPES + (("deepseek_dsa", _DEEPSEEK_MINI_CONFIG, {}),)
 
+# Since #34662 made cuda_ipc opt-in, no auto-resolution reaches the handler's
+# cuda_ipc arm any more -- an explicit request is the only way in, so without
+# this shape that arm (two raises and the pool-budget logging) is resolved by
+# nothing in this file. It is also the only shape whose env write differs from
+# what the *next* resolution would pick on its own, which is what keeps the
+# sticky-carry assertion in `test_a_resolution_does_not_leak_into_the_next`
+# from being vacuous. Gated on `is_cuda()` rather than
+# `torch.cuda.is_available()`: the handler raises for cuda_ipc off NVIDIA CUDA,
+# ROCm included.
+_CUDA_IPC_SHAPES = ()
+if is_cuda():
+    _CUDA_IPC_SHAPES = (
+        (
+            "multimodal_cuda_ipc",
+            _MULTIMODAL_MINI_CONFIG,
+            dict(mm_feature_transport="cuda_ipc"),
+        ),
+    )
+    _SHAPES = _SHAPES + _CUDA_IPC_SHAPES
+
 # The one field a previous resolution genuinely dictates for the next one in
 # this process: `_handle_multimodal_feature_transport` writes
 # SGLANG_USE_CUDA_IPC_TRANSPORT so tokenizer workers inherit the decision, and
@@ -298,6 +318,11 @@ class TestResolutionIsReproducible(CustomTestCase):
             ("multimodal", _MULTIMODAL_MINI_CONFIG, {}),
             ("torch_compile", _MINI_CONFIG, dict(enable_torch_compile=True)),
         )
+        # Auto-resolution picks cpu on every runner this case runs on now that
+        # cuda_ipc is opt-in, so the auto shape above writes what the next
+        # resolution would have picked anyway; the explicit shape is what makes
+        # the carry observable at all.
+        intermediates += _CUDA_IPC_SHAPES
         if torch.cuda.is_available():
             # Same device gate as _SHAPES: the DSA arm probes the device
             # capability during resolution.
@@ -321,7 +346,7 @@ class TestResolutionIsReproducible(CustomTestCase):
                 # against `default_before`, so clearing it here does not skew
                 # that comparison.
                 envs.SGLANG_USE_CUDA_IPC_TRANSPORT.clear()
-                self._resolved(self._config_dir(config), **kwargs)
+                intermediate = self._resolved(self._config_dir(config), **kwargs)
                 after = self._resolved(model_path)
                 without_sticky = lambda snapshot: {
                     k: v
@@ -332,15 +357,21 @@ class TestResolutionIsReproducible(CustomTestCase):
                     without_sticky(self._comparable(after)),
                     without_sticky(self._comparable(default_before)),
                 )
-                if label == "multimodal":
-                    # And the documented exception, asserted rather than
-                    # assumed: the multimodal handler's env write does reach
-                    # the next resolution. What it carries is the
-                    # intermediate's own device-dependent selection — cuda_ipc
-                    # on single-node CUDA, cpu on the CPU/ROCm runners (the
-                    # same `is_cuda()` gate the handler branches on).
-                    expected = "cuda_ipc" if is_cuda() else "cpu"
-                    self.assertEqual(after.mm_feature_transport, expected)
+                # And the documented exception, asserted rather than assumed,
+                # for every intermediate: each one runs the transport handler,
+                # so each one writes the variable the next resolution reads.
+                # What carries is the legacy *boolean*, not the tri-state field
+                # -- the handler writes 1 only for cuda_ipc -- so every other
+                # selection comes back as cpu, which is what keeps this honest
+                # if a cuda_vmm shape is ever added (its carry is cpu, not
+                # cuda_vmm). The `cuda_ipc` shape is the one whose carry
+                # differs from the cpu that `default_before` resolved to.
+                expected = (
+                    "cuda_ipc"
+                    if intermediate.mm_feature_transport == "cuda_ipc"
+                    else "cpu"
+                )
+                self.assertEqual(after.mm_feature_transport, expected)
 
     def test_resolving_a_sibling_leaves_the_first_alone(self):
         for label, config, kwargs in _SHAPES:


### PR DESCRIPTION
## Motivation

`test/registered/unit/server_args/test_resolution_is_reproducible.py` is failing on the GPU
registrations (seen on `base-b-test-1-gpu-small`, `1-gpu-5090`):

```
FAIL: test_a_resolution_does_not_leak_into_the_next (intermediate='multimodal')
  File "test/registered/unit/server_args/test_resolution_is_reproducible.py", line 343
    self.assertEqual(after.mm_feature_transport, expected)
AssertionError: 'cpu' != 'cuda_ipc'
```

#34662 (`69bf601e3c`, "fix: restore VLM nightly regression coverage") made CUDA IPC opt-in: the
`nnodes == 1` arm of `_handle_multimodal_feature_transport` now resolves to `cpu` instead of
`cuda_ipc`, because even an idle IPC pool consumes HBM that would otherwise back the KV cache. That
PR updated the CLI help text and the `TestMultimodalFeatureTransport` cases in `test_server_args.py`,
but this test still asserted `expected = "cuda_ipc" if is_cuda() else "cpu"`. The CPU and ROCm
registrations kept passing because they already expect `cpu`, so only the CUDA runners went red.

The policy change itself is intentional, so the fix belongs in the test.

There is a second, quieter consequence worth calling out. With auto-resolution now picking `cpu`
everywhere, the multimodal intermediate writes exactly what the next resolution would have picked on
its own, so the documented `_STICKY_ACROSS_RESOLUTIONS` exception no longer pins anything observable.
Flipping the expectation to `cpu` and stopping there would have left a green but vacuous assertion.

## Modifications

Test-only; no runtime behaviour is changed.

1. **Add a CUDA-gated `multimodal_cuda_ipc` shape** (`_CUDA_IPC_SHAPES`) that requests
   `mm_feature_transport="cuda_ipc"` explicitly. Post-#34662 this is the only construction under
   which the `SGLANG_USE_CUDA_IPC_TRANSPORT` carry is observable — the handler writes `1` only for
   `cuda_ipc`, and the following text-only resolution adopts it via the `legacy_ipc_is_set` branch —
   and it is also the only remaining coverage of the handler's `cuda_ipc` arm, which no
   auto-resolution reaches any more. It is wired into `_SHAPES` (dual-resolve and sibling matrices)
   as well as the leak test's `intermediates`. Gated on `is_cuda()` rather than
   `torch.cuda.is_available()` because the handler raises for `cuda_ipc` off NVIDIA CUDA, ROCm
   included.

2. **Generalize the sticky assertion** to run for every intermediate instead of only the
   `label == "multimodal"` one (every resolution runs the transport handler, so
   `after.mm_feature_transport` is pinned for all of them), and derive the expected value from what
   the intermediate itself resolved to rather than from its kwargs. What carries is the legacy
   *boolean*, not the tri-state field, so any non-`cuda_ipc` selection — including a `cuda_vmm` shape
   if one is ever added — carries `cpu`.

### Verification

| Run | Result |
| --- | --- |
| CUDA host, this branch | 4 tests / 16 subtests pass |
| No visible NVIDIA device (both gates drop out) | 4 tests / 10 subtests pass |
| Pre-change, CUDA host | fails at `intermediate='multimodal'` — reproduces the CI failure |
| Mutation check: handler's env write stubbed to always `set("0")` | fails at `intermediate='multimodal_cuda_ipc'`, so the new shape genuinely guards the carry rather than passing trivially |
| Mutation check: hypothetical explicit `cuda_vmm` intermediate | passes under the new derivation; would have wrongly demanded `cuda_vmm` under a kwargs-derived expectation |
| Sibling suites: `test_server_args.py` (142), `test_mm_process_config.py` (42) | pass |
| `pre-commit run --files <file>` | clean |

## Accuracy Tests

Not applicable — this changes a `ServerArgs` resolution unit test only; no kernel, model forward, or
output path is touched.

## Speed Tests and Profiling

Not applicable — no inference path is touched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). <!-- N/A: no user-facing behaviour change; #34662 already updated the --mm-feature-transport help text. -->
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). <!-- N/A: test-only change, see sections above. -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31710106430](https://github.com/sgl-project/sglang/actions/runs/31710106430)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31710105883](https://github.com/sgl-project/sglang/actions/runs/31710105883)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->