### PR TITLE
[Diffusion] Add @triple-mu as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,9 +5,9 @@
 /docs @wisclmy0611 @zijiexia @Richardczl98 @JustinTong0323 @sogalin
 /python/pyproject.toml @merrymercy @Fridge003 @ispobock
 /python/sglang/kernels @DarkSharpness @BBuf @celve @HydraQYH @yuan-luo
-/python/sglang/kernels/ops/diffusion @yingluosanqian @BBuf @mickqian
+/python/sglang/kernels/ops/diffusion @yingluosanqian @BBuf @mickqian @triple-mu
 /python/sglang/kernels/ops/attention/fla @yizhang2077 @hebiao064 @yuan-luo
-/python/sglang/multimodal_gen @mickqian @ping1jing2 @HaiShaw @yichiche @AgainstEntropy @BBuf
+/python/sglang/multimodal_gen @mickqian @ping1jing2 @HaiShaw @yichiche @AgainstEntropy @BBuf @triple-mu
 /python/sglang/multimodal_gen/runtime/cache @DefTruth
 /python/sglang/multimodal_gen/runtime/layers/quantization/ @OrangeRedeng @TallMessiWu
 /python/sglang/multimodal_gen/test/server/ascend  @ping1jing2 @ssshinigami @Makcum888e @e-martirosian


### PR DESCRIPTION
## Summary

- add `@triple-mu` as a code owner for the SGLang diffusion runtime and models
- add `@triple-mu` as a code owner for diffusion kernels

## Why

This expands reviewer coverage for diffusion changes across both the main
`multimodal_gen` tree and the diffusion-specific kernel tree.

## Validation

- `git diff --check`
- confirmed that the GitHub account `@triple-mu` exists

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31715400832](https://github.com/sgl-project/sglang/actions/runs/31715400832)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31715400255](https://github.com/sgl-project/sglang/actions/runs/31715400255)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->