### PR TITLE
feat(rust-server): add model extension hooks

### DIFF
--- a/python/sglang/srt/managers/rust_server.py
+++ b/python/sglang/srt/managers/rust_server.py
@@ -373,19 +373,6 @@ class RustServer:
         os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
 
         server_args = scheduler.server_args
-        # `TokenizerManager` merges these under each request's own sampling params
-        # (`{**preferred, **obj.sampling_params}`), and this server replaces that
-        # manager wholesale — so honouring the flag is not implemented here yet.
-        # Refuse rather than run: silently dropping it means generating with
-        # sampling the operator did not configure, and `/get_model_info` would go on
-        # advertising values no request ever receives.
-        if server_args.preferred_sampling_params:
-            raise ValueError(
-                "SGLANG_RUST_SERVER does not yet apply --preferred-sampling-params "
-                "(the Python TokenizerManager merges it into every request; the rust "
-                "ingress has no equivalent). Launch without SGLANG_RUST_SERVER, or "
-                "drop --preferred-sampling-params and send those values per request."
-            )
         http_addr = f"{server_args.host}:{server_args.port}"
 
         # Per-DP-rank HTTP port with client load balancing. `None` when DP is off,
@@ -470,6 +457,13 @@ class RustServer:
         """
         self.server.wait_ingress(timeout_ms)
 
+    def _build_native_mm(self, entry):
+        assert self.mm_spec is not None
+        return NativeMmHost.build_native_mm(self.mm_spec, entry)
+
+    def _prepare_native_mm_for_dispatch(self, mm_inputs) -> None:
+        """Model-package hook for an owned device feature transport."""
+
     def drain(self, max_recv: int) -> List[Any]:
         """Ingress: non-blocking drain of the in-process ring → list of decoded
         request objects. The scheduler's request receiver calls this instead of
@@ -519,7 +513,8 @@ class RustServer:
                 # path. `None` for a text-only request on a multimodal model.
                 native = self.server.take_mm(obj.rid)
                 if native is not None:
-                    obj.mm_inputs = NativeMmHost.build_native_mm(self.mm_spec, native)
+                    obj.mm_inputs = self._build_native_mm(native)
+                    self._prepare_native_mm_for_dispatch(obj.mm_inputs)
             out.append(obj)
         return out
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7758,6 +7758,15 @@ class ServerArgs:
                 "and min_new_tokens are unavailable."
             )
 
+    def _rust_server_supports_cuda_vmm(self) -> bool:
+        """Whether an external Rust-server integration owns CUDA-VMM handoff.
+
+        The OSS native multimodal adapter does not. Model packages may override
+        this capability only when their scheduler-side drain creates and owns
+        the CUDA-VMM transport lifecycle.
+        """
+        return False
+
     def _handle_multimodal_feature_transport(self):
         """Resolve multimodal feature transport before tokenizer workers start.
 
@@ -7870,7 +7879,10 @@ class ServerArgs:
                     "--mm-feature-transport=cuda_vmm does not support pipeline "
                     "parallelism."
                 )
-            if envs.SGLANG_RUST_SERVER.get():
+            if (
+                envs.SGLANG_RUST_SERVER.get()
+                and not self._rust_server_supports_cuda_vmm()
+            ):
                 raise ValueError(
                     "--mm-feature-transport=cuda_vmm is not supported with "
                     "SGLANG_RUST_SERVER."

--- a/rust/sglang-mm/Cargo.toml
+++ b/rust/sglang-mm/Cargo.toml
@@ -47,7 +47,12 @@ pyo3 = { workspace = true, optional = true }
 numpy = { version = "0.29", optional = true }
 
 base64 = "0.22"
-blake3 = "1"
+# A model-package server can link this core beside another dependency graph
+# that also uses blake3. On aarch64, blake3's default NEON implementation
+# exports unmangled C symbols, so two independently resolved feature instances
+# collide in the final cdylib. Keep this core on the pure-Rust implementation;
+# content hashes are a small part of media preprocessing and remain identical.
+blake3 = { version = "1", features = ["pure"] }
 half = "2.4"
 # The formats the Python (PIL) path commonly accepts; all pure-Rust decoders.
 image = { version = "0.25", default-features = false, features = [

--- a/rust/sglang-server/src/api_server.rs
+++ b/rust/sglang-server/src/api_server.rs
@@ -30,6 +30,7 @@ struct AppState {
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
     chat_formatter: Option<openai::ChatFormatter>,
+    chat_processor: Option<Arc<dyn crate::NativeChatProcessor>>,
     /// Egress heartbeat (bumped per drained ring frame).
     egress_activity: ActivityCounter,
 }
@@ -39,18 +40,23 @@ pub async fn serve(
     senders: Senders,
     egress_buf: usize,
     server_args: Arc<ServerArgs>,
+    chat_processor: Option<Arc<dyn crate::NativeChatProcessor>>,
     egress_activity: ActivityCounter,
     // The SAME set ingress releases from — see `Ingress::on_abort`. Constructing a
     // local one here would leave the api server admitting rids that nothing ever
     // releases.
     shutdown: flume::Receiver<()>,
 ) {
-    let chat_formatter = openai::load_chat_support(&server_args);
+    let chat_formatter = chat_processor
+        .is_none()
+        .then(|| openai::load_chat_support(&server_args))
+        .flatten();
     let state = AppState {
         senders,
         egress_buf,
         server_args: server_args.clone(),
         chat_formatter,
+        chat_processor,
         egress_activity,
     };
     // Each endpoint module registers its own routes and merges here.

--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -76,10 +76,8 @@ async fn model_info(State(state): State<AppState>) -> Response {
         "model_path": sa.model_path,
         "tokenizer_path": sa.tokenizer_path,
         "is_generation": true,
-        // Python's `TokenizerManager` merges this into every request
-        // (`{**preferred, **client}`); this server has no equivalent yet, so
-        // `RustServer.launch` REFUSES to start when it is set. It can therefore
-        // only be null here — echoing it keeps the field's shape.
+        // Native `/generate` applies this beneath each client's explicit
+        // sampling fields, matching Python's `{**preferred, **client}` merge.
         "preferred_sampling_params": sa.preferred_sampling_params,
         "weight_version": serde_json::Value::Null,
     });

--- a/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
+++ b/rust/sglang-server/src/api_server/disaggregation/bootstrap.rs
@@ -442,6 +442,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(ServerArgs::from_json(server_args_json).unwrap()),
+            chat_processor: None,
         };
         (crate::runtime::start(cfg).expect("start runtime"), addr)
     }

--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -148,7 +148,7 @@ async fn generate(
     State(state): State<AppState>,
     body: Result<Json<GenerateBody>, JsonRejection>,
 ) -> Response {
-    let body = match body {
+    let mut body = match body {
         Ok(Json(body)) => body,
         // A body that fails to parse has no readable `stream` flag, so this one
         // can only answer unary — as Python's does (FastAPI rejects before its
@@ -158,6 +158,15 @@ async fn generate(
         }
     };
     let stream = body.stream;
+    if let Some(preferred) = &state.server_args.preferred_sampling_params
+        && let Err(error) = body.apply_preferred_sampling(preferred)
+    {
+        return native_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            &error.to_string(),
+            stream,
+        );
+    }
     // Fan `text`/`input_ids`/`sampling_params` (scalar or list) into per-request
     // payloads. `is_batch` = list form → the response is a JSON array.
     let (mut payloads, is_batch) = match body.into_requests() {
@@ -170,7 +179,10 @@ async fn generate(
     };
     // Media I/O (URL downloads, file reads) happens here, on the API runtime
     // — never on the MM worker pool (see `prefetch`).
-    if let Err(e) = super::prefetch::prefetch_all(&mut payloads).await {
+    if let Err(e) =
+        super::prefetch::prefetch_all(&mut payloads, &state.server_args.limit_mm_data_per_request)
+            .await
+    {
         return native_error(StatusCode::BAD_REQUEST, &e, stream);
     }
     if !is_batch {

--- a/rust/sglang-server/src/api_server/openai/chat.rs
+++ b/rust/sglang-server/src/api_server/openai/chat.rs
@@ -36,8 +36,9 @@ use super::{
     AppState, ChatFormatter, collect_output, contains_media, error_payload, indexed_egress_stream,
     openai_error, submit_generation, unix_seconds_u32,
 };
+use crate::NativeChatOutput;
 use crate::ids::Rid;
-use crate::message::{ChunkExtras, EgressItem, GenerateRequest, OneOrMany, SamplingParams};
+use crate::message::{ChunkExtras, EgressItem, GenerateRequest, MmData, OneOrMany, SamplingParams};
 
 pub(super) fn routes() -> Router<AppState> {
     Router::new().route("/v1/chat/completions", post(chat_completions))
@@ -45,13 +46,17 @@ pub(super) fn routes() -> Router<AppState> {
 
 async fn chat_completions(
     State(state): State<AppState>,
-    body: Result<Json<CreateChatCompletionRequest>, JsonRejection>,
+    body: Result<Json<serde_json::Value>, JsonRejection>,
 ) -> Response {
-    let request = match body {
+    let raw_request = match body {
         Ok(Json(request)) => request,
         Err(rejection) => {
             return openai_error(StatusCode::BAD_REQUEST, rejection.body_text(), false);
         }
+    };
+    let request: CreateChatCompletionRequest = match serde_json::from_value(raw_request.clone()) {
+        Ok(request) => request,
+        Err(error) => return openai_error(StatusCode::BAD_REQUEST, error.to_string(), false),
     };
     if request.model != state.server_args.served_model_name {
         return openai_error(
@@ -63,7 +68,9 @@ async fn chat_completions(
     if request.messages.is_empty() {
         return openai_error(StatusCode::BAD_REQUEST, "messages cannot be empty", false);
     }
-    if serde_json::to_value(&request.messages).is_ok_and(|messages| contains_media(&messages)) {
+    if state.chat_processor.is_none()
+        && serde_json::to_value(&request.messages).is_ok_and(|messages| contains_media(&messages))
+    {
         return openai_error(
             StatusCode::BAD_REQUEST,
             "image, audio, video, and file message content is not supported",
@@ -113,7 +120,7 @@ async fn chat_completions(
     let parser = tools_enabled
         .then(|| state.server_args.tool_call_parser.clone())
         .flatten();
-    if tools_enabled && parser.is_none() {
+    if tools_enabled && parser.is_none() && state.chat_processor.is_none() {
         return openai_error(
             StatusCode::BAD_REQUEST,
             "tool calls require --tool-call-parser",
@@ -136,7 +143,7 @@ async fn chat_completions(
     });
     let tools_slice = tools.as_deref().unwrap_or_default();
 
-    let (request, prompt) = match prepare_chat_request(&state, request).await {
+    let (request, prompt) = match prepare_chat_request(&state, request, raw_request).await {
         Ok(prepared) => prepared,
         Err(response) => return response,
     };
@@ -184,9 +191,24 @@ async fn chat_completions(
                 .expect("chat prompt exists until the last choice")
                 .clone()
         };
-        let native = GenerateRequest {
+        let (text, input_ids, mm) = match choice_prompt {
+            PreparedChatPrompt::Text(prompt) => (Some(prompt), None, None),
+            PreparedChatPrompt::Native(output) => {
+                let mm = MmData {
+                    image_data: output.image_data,
+                    video_data: output.video_data,
+                    audio_data: output.audio_data,
+                    multimodal_placeholders: output.multimodal_placeholders,
+                    ..Default::default()
+                };
+                (None, Some(output.input_ids), Some(Box::new(mm)))
+            }
+        };
+        let mut native = GenerateRequest {
             rid: rid.clone(),
-            text: Some(choice_prompt),
+            text,
+            input_ids,
+            mm,
             // Rendered templates own their special tokens — the pool must not
             // add another BOS/EOS (Python's `add_special_tokens=False`).
             skip_special_tokens: true,
@@ -198,6 +220,14 @@ async fn chat_completions(
             return_text_in_logprobs: want_logprobs.then_some(true),
             ..Default::default()
         };
+        if let Err(error) = super::super::prefetch::prefetch_all(
+            std::slice::from_mut(&mut native),
+            &state.server_args.limit_mm_data_per_request,
+        )
+        .await
+        {
+            return openai_error(StatusCode::BAD_REQUEST, error, false);
+        }
         let rx = match submit_generation(&state, native, stream, &mut guard).await {
             Ok(rx) => rx,
             Err(response) => return response,
@@ -242,14 +272,47 @@ async fn chat_completions(
     }
 }
 
-/// Render the chat template for an OpenAI request, mapping a missing
-/// formatter or a render failure to the standard 400. The rendered prompt is
-/// submitted as text — the tokenizer pool encodes it (with
-/// `skip_special_tokens`, since the template owns its special tokens).
+#[derive(Clone)]
+pub(super) enum PreparedChatPrompt {
+    Text(String),
+    Native(NativeChatOutput),
+}
+
+/// Render the chat template with either the default formatter or a model-owned
+/// processor, mapping failures to the standard OpenAI 400 response.
 pub(super) async fn prepare_chat_request(
     state: &AppState,
     mut request: CreateChatCompletionRequest,
-) -> Result<(CreateChatCompletionRequest, String), Response> {
+    raw_request: serde_json::Value,
+) -> Result<(CreateChatCompletionRequest, PreparedChatPrompt), Response> {
+    if let Some(processor) = state.chat_processor.clone() {
+        let request_json = raw_request.to_string();
+        let output = tokio::task::spawn_blocking(move || processor.process(&request_json))
+            .await
+            .map_err(|error| {
+                openai_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("chat processor task failed: {error}"),
+                    false,
+                )
+            })?
+            .map_err(|error| {
+                openai_error(
+                    StatusCode::BAD_REQUEST,
+                    format!("chat template render failed: {error}"),
+                    false,
+                )
+            })?;
+        if output.input_ids.is_empty() {
+            return Err(openai_error(
+                StatusCode::BAD_REQUEST,
+                "chat template produced no input tokens",
+                false,
+            ));
+        }
+        return Ok((request, PreparedChatPrompt::Native(output)));
+    }
+
     let Some(formatter) = state.chat_formatter.clone() else {
         return Err(openai_error(
             StatusCode::BAD_REQUEST,
@@ -269,7 +332,7 @@ pub(super) async fn prepare_chat_request(
             false,
         )
     })?;
-    Ok((request, prompt))
+    Ok((request, PreparedChatPrompt::Text(prompt)))
 }
 
 /// Full sampling resolution for an OpenAI request, mirroring the Python

--- a/rust/sglang-server/src/api_server/openai/test_utils.rs
+++ b/rust/sglang-server/src/api_server/openai/test_utils.rs
@@ -111,6 +111,7 @@ pub(super) fn app_state(senders: Senders) -> super::AppState {
         egress_buf: 8,
         server_args: server_args(),
         chat_formatter: None,
+        chat_processor: None,
         egress_activity: Default::default(),
     }
 }

--- a/rust/sglang-server/src/api_server/prefetch.rs
+++ b/rust/sglang-server/src/api_server/prefetch.rs
@@ -1,13 +1,14 @@
 //! Resolve I/O-backed media sources on the API runtime, before MM dispatch.
 //!
-//! The MM worker pool is fixed, core-pinned CPU capacity: a slow image host — or
+//! The MM worker pool is fixed, core-pinned CPU capacity: a slow media host — or
 //! a file on a hanging network mount — must never occupy it, and a request's
-//! images must download concurrently, not in `n * REQUEST_TIMEOUT`. URLs and
+//! media must download concurrently, not in `n * REQUEST_TIMEOUT`. URLs and
 //! file paths resolve here through `sglang-mm`'s `fetch_bytes_budgeted` (one
 //! owner for proxy/timeout/cap semantics) and ride out-of-band as
 //! [`crate::message::MmData::prefetched`], which
 //! [`crate::message::mm_payload::to_mm_input`] swaps back in.
 
+use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -29,18 +30,49 @@ static PERMITS: Semaphore = Semaphore::const_new(32);
 /// enforced *here* rather than in `sglang_mm::driver::process`, where 64 sources
 /// of 64 MiB would already be resident. The driver keeps its own checks as the
 /// backstop for callers without a prefetch layer.
-pub async fn prefetch_all(requests: &mut [GenerateRequest]) -> Result<(), String> {
+pub async fn prefetch_all(
+    requests: &mut [GenerateRequest],
+    modality_limits: &BTreeMap<String, usize>,
+) -> Result<(), String> {
     // The item budget rejects before a single byte is fetched.
     let plan = |mm: &Option<Box<MmData>>| -> Result<Vec<String>, String> {
-        let Some(image_data) = mm.as_deref().and_then(|m| m.image_data.as_ref()) else {
+        let Some(mm) = mm.as_deref() else {
             return Ok(Vec::new());
         };
-        if item_count(image_data) > MAX_ITEMS_PER_REQUEST {
+        // Fixed modality order is part of the handoff contract: external
+        // processors walk image, video, then audio and consume this vector in
+        // the same order.
+        let values = [
+            ("image", mm.image_data.as_ref()),
+            ("video", mm.video_data.as_ref()),
+            ("audio", mm.audio_data.as_ref()),
+        ];
+        let items = values
+            .iter()
+            .filter_map(|(_, value)| *value)
+            .map(item_count)
+            .sum::<usize>();
+        if items > MAX_ITEMS_PER_REQUEST {
             return Err(format!(
                 "multimodal request exceeds {MAX_ITEMS_PER_REQUEST} media items"
             ));
         }
-        Ok(io_sources(image_data))
+        for (modality, value) in values {
+            let count = value.map(item_count).unwrap_or_default();
+            if let Some(limit) = modality_limits.get(modality)
+                && count > *limit
+            {
+                let display = modality[..1].to_uppercase() + &modality[1..];
+                return Err(format!(
+                    "{display} count {count} exceeds limit {limit} per request."
+                ));
+            }
+        }
+        Ok(values
+            .iter()
+            .filter_map(|(_, value)| *value)
+            .flat_map(io_sources)
+            .collect())
     };
     let plans = requests
         .iter()
@@ -121,6 +153,36 @@ mod tests {
         }
     }
 
+    #[tokio::test]
+    async fn mixed_modalities_preserve_image_video_audio_order() {
+        let base = std::env::temp_dir().join(format!("sglang-prefetch-mm-{}", std::process::id()));
+        std::fs::create_dir_all(&base).unwrap();
+        let paths = [base.join("image"), base.join("video"), base.join("audio")];
+        for (path, body) in
+            paths
+                .iter()
+                .zip([b"image".as_ref(), b"video".as_ref(), b"audio".as_ref()])
+        {
+            std::fs::write(path, body).unwrap();
+        }
+        let mut requests = vec![GenerateRequest {
+            mm: Some(Box::new(MmData {
+                image_data: Some(Value::from(paths[0].display().to_string())),
+                video_data: Some(Value::from(paths[1].display().to_string())),
+                audio_data: Some(Value::from(paths[2].display().to_string())),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }];
+        prefetch_all(&mut requests, &BTreeMap::new()).await.unwrap();
+        std::fs::remove_dir_all(base).ok();
+        let fetched = &requests[0].mm.as_ref().unwrap().prefetched;
+        assert_eq!(
+            fetched.iter().map(Bytes::as_ref).collect::<Vec<_>>(),
+            vec![b"image".as_ref(), b"video".as_ref(), b"audio".as_ref()]
+        );
+    }
+
     /// URLs and file paths resolve concurrently into `prefetched` in source
     /// order; CPU-only sources and mm-free requests are untouched.
     #[tokio::test]
@@ -137,7 +199,7 @@ mod tests {
             ])),
             GenerateRequest::default(),
         ];
-        prefetch_all(&mut requests).await.unwrap();
+        prefetch_all(&mut requests, &BTreeMap::new()).await.unwrap();
         std::fs::remove_file(&path).ok();
         let fetched = &requests[0].mm.as_ref().unwrap().prefetched;
         // The one-shot server answers in accept order, so contents may swap
@@ -151,7 +213,10 @@ mod tests {
     #[tokio::test]
     async fn failed_download_rejects() {
         let mut requests = vec![mm_request(Value::from("http://127.0.0.1:1/nope.png"))];
-        let err = prefetch_all(&mut requests).await.err().unwrap();
+        let err = prefetch_all(&mut requests, &BTreeMap::new())
+            .await
+            .err()
+            .unwrap();
         assert!(err.contains("media fetch"), "{err}");
     }
 
@@ -163,11 +228,33 @@ mod tests {
             .map(|i| Value::from(format!("/definitely/not/here-{i}.png")))
             .collect();
         let mut requests = vec![mm_request(Value::Array(sources))];
-        let err = prefetch_all(&mut requests).await.err().unwrap();
+        let err = prefetch_all(&mut requests, &BTreeMap::new())
+            .await
+            .err()
+            .unwrap();
         assert_eq!(
             err,
             format!("multimodal request exceeds {MAX_ITEMS_PER_REQUEST} media items")
         );
+        assert!(requests[0].mm.as_ref().unwrap().prefetched.is_empty());
+    }
+
+    #[tokio::test]
+    async fn per_modality_budget_rejects_before_fetching() {
+        let mut requests = vec![GenerateRequest {
+            mm: Some(Box::new(MmData {
+                image_data: Some(Value::Array(vec![
+                    Value::from("/definitely/not/here-0.png"),
+                    Value::from("/definitely/not/here-1.png"),
+                ])),
+                video_data: Some(Value::Array(vec![Value::from("/definitely/not/here.mp4")])),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }];
+        let limits = BTreeMap::from([("image".to_owned(), 1), ("video".to_owned(), 1)]);
+        let err = prefetch_all(&mut requests, &limits).await.err().unwrap();
+        assert_eq!(err, "Image count 2 exceeds limit 1 per request.");
         assert!(requests[0].mm.as_ref().unwrap().prefetched.is_empty());
     }
 

--- a/rust/sglang-server/src/chat.rs
+++ b/rust/sglang-server/src/chat.rs
@@ -1,0 +1,25 @@
+//! Optional model-package chat preprocessing.
+//!
+//! The default server renders Hugging Face or legacy templates internally.
+//! External model packages can instead return an already-tokenized prompt and
+//! opaque media sources while retaining the shared OpenAI response pipeline.
+
+use std::fmt::Debug;
+
+/// One chat request after a model package has rendered and tokenized it.
+#[derive(Clone, Debug, Default)]
+pub struct NativeChatOutput {
+    pub input_ids: Vec<i32>,
+    pub image_data: Option<rmpv::Value>,
+    pub video_data: Option<rmpv::Value>,
+    pub audio_data: Option<rmpv::Value>,
+    pub multimodal_placeholders: Option<rmpv::Value>,
+}
+
+/// Model-owned chat rendering boundary.
+///
+/// The raw JSON is intentional: private extensions may carry message metadata
+/// that is not part of the public OpenAI schema and must survive rendering.
+pub trait NativeChatProcessor: Debug + Send + Sync + 'static {
+    fn process(&self, request_json: &str) -> Result<NativeChatOutput, String>;
+}

--- a/rust/sglang-server/src/lib.rs
+++ b/rust/sglang-server/src/lib.rs
@@ -11,6 +11,7 @@
 //! All are non-blocking, so the GIL is never held across a wait.
 
 mod api_server;
+mod chat;
 mod detokenizer;
 mod environ;
 mod error;
@@ -23,6 +24,15 @@ mod runtime;
 mod tokenizer;
 mod tokenizer_manager;
 mod utils;
+
+pub use chat::{NativeChatOutput, NativeChatProcessor};
+pub use message::MmWorkItem;
+pub use message::mm_payload::{ResolvedMediaWork, resolve_media_work};
+pub use mm::{
+    GenericMmItem, GenericMmSidecarEntry, GenericTensor, GenericTensorData, MmProcessOutput,
+    MmSidecarEntry, NativeMmProcessor,
+};
+pub use tokenizer::TextTokenizer;
 
 use std::net::SocketAddr;
 
@@ -37,7 +47,7 @@ use crate::runtime::{Runtime, RuntimeConfig};
 /// (zero-copy into numpy), or one POSIX segment name per item when the scheduler
 /// broadcasts across TP ranks and Python wraps each in a `ShmPointerMMData`.
 #[pyclass(frozen, get_all)]
-struct MmHandoff {
+pub struct MmHandoff {
     features: Option<Py<numpy::PyArray1<f32>>>,
     shm_names: Option<Vec<String>>,
     grids: Vec<(u32, u32, u32)>,
@@ -45,12 +55,30 @@ struct MmHandoff {
     offsets: Vec<(u32, u32)>,
     mrope: Py<numpy::PyArray1<i64>>,
     mrope_delta: i64,
+    generic_items: Vec<Py<GenericMmItemHandoff>>,
+    metadata_json: Option<String>,
+}
+
+/// One model-agnostic MM item. Exactly one numeric feature field is populated;
+/// `shape` gives its logical dimensions and the owning model package interprets
+/// the opaque JSON metadata.
+#[pyclass(frozen, get_all)]
+pub struct GenericMmItemHandoff {
+    modality: String,
+    feature_f32: Option<Py<numpy::PyArray1<f32>>>,
+    feature_i64: Option<Py<numpy::PyArray1<i64>>>,
+    feature_u8: Option<Py<numpy::PyArray1<u8>>>,
+    feature_u16: Option<Py<numpy::PyArray1<u16>>>,
+    shape: Vec<usize>,
+    hash: u64,
+    offsets: Vec<(u32, u32)>,
+    metadata_json: String,
 }
 
 /// Columnar ingress batch handed to Python by [`Server::recv_requests`].
 /// `frozen`: immutable snapshot, so field access never contends on a borrow.
 #[pyclass(frozen, get_all)]
-struct IngressBatch {
+pub struct IngressBatch {
     /// One msgpack scalar header per request (`input_ids` omitted).
     headers: Vec<Py<PyBytes>>,
     /// The raw-data plane today just all requests' raw little-endian int64
@@ -63,7 +91,7 @@ struct IngressBatch {
 /// Handle owned by the Python scheduler process. Construct once via
 /// [`Server::start`], then poll it from the scheduler event loop.
 #[pyclass]
-struct Server {
+pub struct Server {
     rt: Runtime,
 }
 
@@ -82,7 +110,7 @@ impl Server {
     // pyo3 `#[new]` constructor: the wide arg list is the Python-facing boot
     // surface (all optional overrides), not a call-site ergonomics problem.
     #[allow(clippy::too_many_arguments)]
-    fn start(
+    pub fn start(
         http_addr: Option<String>,
         ingress_ring_cap: usize,
         egress_ring_cap: usize,
@@ -90,45 +118,15 @@ impl Server {
         cores: Option<Vec<usize>>,
         server_args_json: &str,
     ) -> PyResult<Self> {
-        // Static server metadata (server_args + model_config) dumped by the
-        // scheduler; parse and validate mandatory fields now so a bad/missing
-        // field is a boot error, not a request-time 500.
-        let server_args: runtime::ServerArgs = runtime::ServerArgs::from_json(server_args_json)
-            .map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "bad server_args_json: {e}"
-                ))
-            })?;
-        server_args.validate_mandatory().map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("server_args: {e}"))
-        })?;
-        // The HTTP listen address, tokenizer source/threads/shards all live in the
-        // `server_args` blob; resolve them from there so the scheduler doesn't
-        // re-pass them. The explicit params stay as optional overrides for
-        // standalone callers (tests) that construct a `Server` without a full
-        // `server_args`.
-        let http_addr: SocketAddr = http_addr
-            .unwrap_or_else(|| server_args.bind())
-            .parse()
-            .map_err(|e| {
-                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("bad http_addr: {e}"))
-            })?;
-
-        let cfg = RuntimeConfig {
-            rust_server_args: runtime::RustServerServerArgs {
-                http_addr,
-                api_worker_num: server_args.api_worker_num(),
-                ingress_ring_cap,
-                egress_ring_cap,
-                channel_cap,
-                cores,
-            },
-            server_args: std::sync::Arc::new(server_args),
-        };
-        let rt = runtime::start(cfg).map_err(|e| {
-            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("runtime start failed: {e}"))
-        })?;
-        Ok(Server { rt })
+        Self::start_with_chat_processor(
+            http_addr,
+            ingress_ring_cap,
+            egress_ring_cap,
+            channel_cap,
+            cores,
+            server_args_json,
+            None,
+        )
     }
 
     /// Non-blocking drain of the ingress ring, returned **columnar** as an
@@ -144,7 +142,7 @@ impl Server {
     /// thread was runnable, to cover ~0.2 µs of work. Held, the whole call is a
     /// fraction of a microsecond on an empty ring.
     #[pyo3(signature = (max = 256))]
-    fn recv_requests(&self, py: Python<'_>, max: usize) -> PyResult<IngressBatch> {
+    pub fn recv_requests(&self, py: Python<'_>, max: usize) -> PyResult<IngressBatch> {
         let cols = self.rt.ingress.drain(max);
         let headers = cols
             .headers
@@ -175,7 +173,7 @@ impl Server {
     /// parked, and `flume` wakes the moment a request is pushed, so this adds no
     /// latency to real requests — only the idle wait is bounded by `timeout_ms`.
     #[pyo3(signature = (timeout_ms = 1000))]
-    fn wait_ingress(&self, py: Python<'_>, timeout_ms: u64) -> bool {
+    pub fn wait_ingress(&self, py: Python<'_>, timeout_ms: u64) -> bool {
         py.detach(|| {
             self.rt
                 .ingress
@@ -198,20 +196,20 @@ impl Server {
     /// The slow path keeps its detach because a full ring genuinely parks: the
     /// scheduler must feel backpressure rather than drop output it has already
     /// committed to. It essentially never fires — measured headroom is ~100×.
-    fn push_batch(&self, py: Python<'_>, header: &[u8], data_cols: Vec<PyBackedBytes>) -> bool {
+    pub fn push_batch(&self, py: Python<'_>, header: &[u8], data_cols: Vec<PyBackedBytes>) -> bool {
         let cols: Vec<&[u8]> = data_cols.iter().map(|d| d.as_ref()).collect();
         self.push_frame(py, crate::message::frame_egress_batch_cols(header, &cols))
     }
 
     /// Push a control-request result. Blocks for backpressure; `False` only on
     /// shutdown.
-    fn push_result(&self, py: Python<'_>, rid: &str, payload: &[u8]) -> bool {
+    pub fn push_result(&self, py: Python<'_>, rid: &str, payload: &[u8]) -> bool {
         self.push_frame(py, crate::message::frame_egress_result(rid, payload))
     }
 
     /// Route a terminal failure back to request `rid`. Blocks for backpressure;
     /// `False` only on shutdown.
-    fn push_error(&self, py: Python<'_>, rid: &str, message: &str) -> bool {
+    pub fn push_error(&self, py: Python<'_>, rid: &str, message: &str) -> bool {
         self.push_frame(py, crate::message::frame_egress_error(rid, message))
     }
 
@@ -220,7 +218,7 @@ impl Server {
     /// Image-only requests are processed entirely in Rust and parked for
     /// [`Server::take_mm`]; anything the pipeline cannot serve is rejected back to
     /// the client — there is no Python fallback.
-    fn start_mm_workers(&self, spec_json: &str, workers: usize) -> PyResult<()> {
+    pub fn start_mm_workers(&self, spec_json: &str, workers: usize) -> PyResult<()> {
         let ctx = mm::Context::new(
             spec_json,
             self.rt.tokenizer.clone(),
@@ -239,37 +237,154 @@ impl Server {
     /// decode steps, so any per-byte work here — memcpy or hashing, tens of MB
     /// per image-heavy request — would stall every running request's ITL. Hence
     /// the worker-precomputed `hashes`.
-    fn take_mm(&self, py: Python<'_>, rid: &str) -> Option<MmHandoff> {
+    pub fn take_mm(&self, py: Python<'_>, rid: &str) -> PyResult<Option<MmHandoff>> {
         use numpy::IntoPyArray;
 
-        let res = self.rt.mm_sidecar.take(rid)?;
-        let (features, shm_names) = match res.features {
-            mm::FeatureStore::Inline(v) => (Some(v.into_pyarray(py).unbind()), None),
-            // The segments — and the duty to unlink — move to Python here;
-            // `materialize()` unlinks after the post-broadcast clone on each rank.
-            mm::FeatureStore::Shm(segments) => (
-                None,
-                Some(segments.into_iter().map(|s| s.into_name()).collect()),
-            ),
+        let Some(res) = self.rt.mm_sidecar.take(rid) else {
+            return Ok(None);
         };
-        Some(MmHandoff {
-            features,
-            shm_names,
-            grids: res.grids.iter().map(|g| (g[0], g[1], g[2])).collect(),
-            hashes: res.hashes,
-            offsets: res.offsets,
-            mrope: res.mrope.into_pyarray(py).unbind(),
-            mrope_delta: res.mrope_delta,
-        })
+        match res {
+            mm::MmSidecarEntry::Qwen(res) => {
+                let (features, shm_names) = match res.features {
+                    mm::FeatureStore::Inline(v) => (Some(v.into_pyarray(py).unbind()), None),
+                    // The segments — and the duty to unlink — move to Python here;
+                    // `materialize()` unlinks after the post-broadcast clone on each rank.
+                    mm::FeatureStore::Shm(segments) => (
+                        None,
+                        Some(segments.into_iter().map(|s| s.into_name()).collect()),
+                    ),
+                };
+                Ok(Some(MmHandoff {
+                    features,
+                    shm_names,
+                    grids: res.grids.iter().map(|g| (g[0], g[1], g[2])).collect(),
+                    hashes: res.hashes,
+                    offsets: res.offsets,
+                    mrope: res.mrope.into_pyarray(py).unbind(),
+                    mrope_delta: res.mrope_delta,
+                    generic_items: Vec::new(),
+                    metadata_json: None,
+                }))
+            }
+            mm::MmSidecarEntry::Generic(res) => {
+                let mut items = Vec::with_capacity(res.items.len());
+                for item in res.items {
+                    let (feature_f32, feature_i64, feature_u8, feature_u16) =
+                        match item.feature.data {
+                            mm::GenericTensorData::F32(v) => {
+                                (Some(v.into_pyarray(py).unbind()), None, None, None)
+                            }
+                            mm::GenericTensorData::I64(v) => {
+                                (None, Some(v.into_pyarray(py).unbind()), None, None)
+                            }
+                            mm::GenericTensorData::U8(v) => {
+                                (None, None, Some(v.into_pyarray(py).unbind()), None)
+                            }
+                            mm::GenericTensorData::U16(v) => {
+                                (None, None, None, Some(v.into_pyarray(py).unbind()))
+                            }
+                        };
+                    items.push(Py::new(
+                        py,
+                        GenericMmItemHandoff {
+                            modality: item.modality,
+                            feature_f32,
+                            feature_i64,
+                            feature_u8,
+                            feature_u16,
+                            shape: item.feature.shape,
+                            hash: item.hash,
+                            offsets: item.offsets,
+                            metadata_json: item.metadata_json,
+                        },
+                    )?);
+                }
+                Ok(Some(MmHandoff {
+                    features: None,
+                    shm_names: None,
+                    grids: Vec::new(),
+                    hashes: Vec::new(),
+                    offsets: Vec::new(),
+                    mrope: Vec::<i64>::new().into_pyarray(py).unbind(),
+                    mrope_delta: 0,
+                    generic_items: items,
+                    metadata_json: Some(res.metadata_json),
+                }))
+            }
+        }
     }
 
     /// Signal all threads to stop (best effort).
-    fn shutdown(&self) {
+    pub fn shutdown(&self) {
         self.rt.request_shutdown();
     }
 }
 
 impl Server {
+    /// Boot the frontend with an optional model-package chat renderer.
+    #[allow(clippy::too_many_arguments)]
+    pub fn start_with_chat_processor(
+        http_addr: Option<String>,
+        ingress_ring_cap: usize,
+        egress_ring_cap: usize,
+        channel_cap: usize,
+        cores: Option<Vec<usize>>,
+        server_args_json: &str,
+        chat_processor: Option<std::sync::Arc<dyn NativeChatProcessor>>,
+    ) -> PyResult<Self> {
+        // Parse and validate static metadata at boot, not on the first request.
+        let server_args: runtime::ServerArgs = runtime::ServerArgs::from_json(server_args_json)
+            .map_err(|error| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                    "bad server_args_json: {error}"
+                ))
+            })?;
+        server_args.validate_mandatory().map_err(|error| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("server_args: {error}"))
+        })?;
+        let http_addr: SocketAddr = http_addr
+            .unwrap_or_else(|| server_args.bind())
+            .parse()
+            .map_err(|error| {
+                PyErr::new::<pyo3::exceptions::PyValueError, _>(format!("bad http_addr: {error}"))
+            })?;
+
+        let cfg = RuntimeConfig {
+            rust_server_args: runtime::RustServerServerArgs {
+                http_addr,
+                api_worker_num: server_args.api_worker_num(),
+                ingress_ring_cap,
+                egress_ring_cap,
+                channel_cap,
+                cores,
+            },
+            server_args: std::sync::Arc::new(server_args),
+            chat_processor,
+        };
+        let rt = runtime::start(cfg).map_err(|error| {
+            PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "runtime start failed: {error}"
+            ))
+        })?;
+        Ok(Server { rt })
+    }
+
+    /// Start the shared worker pool with a processor supplied by an external
+    /// model package. The default Python API uses [`Server::start_mm_workers`]
+    /// and therefore retains the built-in Qwen registry behavior.
+    pub fn start_mm_workers_with_processor(
+        &self,
+        processor: std::sync::Arc<dyn NativeMmProcessor>,
+        workers: usize,
+    ) {
+        let ctx = mm::Context::with_processor(
+            processor,
+            self.rt.tokenizer.clone(),
+            self.rt.mm_sidecar.clone(),
+        );
+        self.rt.spawn_mm_pool(workers, std::sync::Arc::new(ctx));
+    }
+
     /// Hand one already-framed egress message to the ring: GIL-held when it fits,
     /// detaching only to park on a full ring. Shared by every push path — they
     /// differ solely in how the frame is built. `false` only on shutdown.
@@ -291,6 +406,17 @@ impl Server {
 static LOG_GUARD: std::sync::OnceLock<tracing_appender::non_blocking::WorkerGuard> =
     std::sync::OnceLock::new();
 
+/// Register the Python boundary value types used by [`Server`]. External
+/// model-package modules call this once before exposing a wrapper server; the
+/// default `_core` module uses the same function, so the two surfaces cannot
+/// drift as new boundary types are added.
+pub fn register_boundary_types(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<IngressBatch>()?;
+    m.add_class::<MmHandoff>()?;
+    m.add_class::<GenericMmItemHandoff>()?;
+    Ok(())
+}
+
 #[pymodule]
 fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Initialize tracing once; ignore if already set by the host process.
@@ -308,7 +434,6 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
         .with_writer(writer)
         .try_init();
     m.add_class::<Server>()?;
-    m.add_class::<IngressBatch>()?;
-    m.add_class::<MmHandoff>()?;
+    register_boundary_types(m)?;
     Ok(())
 }

--- a/rust/sglang-server/src/message/mm_payload.rs
+++ b/rust/sglang-server/src/message/mm_payload.rs
@@ -11,6 +11,96 @@ use sglang_mm::driver::{ImageSource, MmInput};
 
 use super::request::MmWorkItem;
 
+/// Fully resolved media payload for an external native MM component. All I/O
+/// sources were prefetched on the async API layer; data URLs and bare base64
+/// are decoded here on the MM worker.
+pub struct ResolvedMediaWork {
+    pub text: Option<String>,
+    pub input_ids: Option<Vec<i32>>,
+    pub images: Vec<Vec<u8>>,
+    pub videos: Vec<Vec<u8>>,
+    pub audios: Vec<Vec<u8>>,
+    pub multimodal_placeholders: Option<Value>,
+}
+
+/// Resolve image/video/audio values in the prefetch contract's fixed modality
+/// order. This is the generic loader seam used by external processors.
+pub fn resolve_media_work(work: MmWorkItem) -> Result<ResolvedMediaWork, String> {
+    let mut prefetched = work.prefetched.iter();
+    let images = collect_media(work.image_data.as_ref(), &mut prefetched, "image_data")?;
+    let videos = collect_media(work.video_data.as_ref(), &mut prefetched, "video_data")?;
+    let audios = collect_media(work.audio_data.as_ref(), &mut prefetched, "audio_data")?;
+    if prefetched.next().is_some() {
+        return Err("media prefetch produced more payloads than the request consumes".into());
+    }
+    Ok(ResolvedMediaWork {
+        text: work.text,
+        input_ids: work.input_ids,
+        images,
+        videos,
+        audios,
+        multimodal_placeholders: work.multimodal_placeholders,
+    })
+}
+
+fn collect_media(
+    value: Option<&Value>,
+    prefetched: &mut std::slice::Iter<Bytes>,
+    field: &str,
+) -> Result<Vec<Vec<u8>>, String> {
+    fn one(
+        value: &Value,
+        prefetched: &mut std::slice::Iter<Bytes>,
+        field: &str,
+        out: &mut Vec<Vec<u8>>,
+    ) -> Result<(), String> {
+        match value {
+            Value::Nil => Ok(()),
+            Value::String(value) => {
+                let source = value
+                    .as_str()
+                    .ok_or_else(|| format!("non-utf8 {field} source"))?;
+                if is_io_source(source) {
+                    out.push(
+                        prefetched
+                            .next()
+                            .ok_or_else(|| format!("I/O-backed {field} source was not prefetched"))?
+                            .to_vec(),
+                    );
+                } else {
+                    out.push(sglang_mm::common::fetch::fetch_bytes(source)?);
+                }
+                Ok(())
+            }
+            Value::Binary(bytes) => {
+                out.push(bytes.clone());
+                Ok(())
+            }
+            Value::Array(values) => {
+                for value in values {
+                    one(value, prefetched, field, out)?;
+                }
+                Ok(())
+            }
+            Value::Map(entries) => {
+                let source = entries
+                    .iter()
+                    .find(|(key, _)| key.as_str() == Some("url"))
+                    .map(|(_, value)| value)
+                    .ok_or_else(|| format!("{field} object requires a url field"))?;
+                one(source, prefetched, field, out)
+            }
+            _ => Err(format!("unsupported {field} shape")),
+        }
+    }
+
+    let mut out = Vec::new();
+    if let Some(value) = value {
+        one(value, prefetched, field, &mut out)?;
+    }
+    Ok(out)
+}
+
 /// True for sources the API layer must resolve before MM dispatch: I/O — network
 /// *or* disk, since a network mount can hang past any HTTP timeout — never runs
 /// on the fixed MM worker pool (see `api_server::prefetch`). `data:` and bare
@@ -26,16 +116,25 @@ pub fn is_io_source(src: &str) -> bool {
 /// The I/O-backed sources of an `image_data` value, in `collect_images` order.
 pub fn io_sources(value: &Value) -> Vec<String> {
     let mut out = Vec::new();
-    let mut walk = |value: &Value| {
-        if let Some(src) = value.as_str().filter(|s| is_io_source(s)) {
-            out.push(src.to_owned());
+    fn walk(value: &Value, out: &mut Vec<String>) {
+        match value {
+            Value::String(value) => {
+                if let Some(src) = value.as_str().filter(|s| is_io_source(s)) {
+                    out.push(src.to_owned());
+                }
+            }
+            Value::Array(values) => values.iter().for_each(|value| walk(value, out)),
+            Value::Map(entries) => {
+                if let Some((_, source)) =
+                    entries.iter().find(|(key, _)| key.as_str() == Some("url"))
+                {
+                    walk(source, out);
+                }
+            }
+            _ => {}
         }
-    };
-    if let Value::Array(values) = value {
-        values.iter().for_each(&mut walk);
-    } else {
-        walk(value);
     }
+    walk(value, &mut out);
     out
 }
 
@@ -56,6 +155,9 @@ pub fn to_mm_input(work: MmWorkItem) -> Result<MmInput, String> {
     let present = |v: &Option<Value>| v.as_ref().is_some_and(value_present);
     if present(&work.video_data) || present(&work.audio_data) {
         return Err("unsupported modality: video/audio input".into());
+    }
+    if present(&work.multimodal_placeholders) {
+        return Err("unsupported multimodal_placeholders contract for this processor".into());
     }
     let mut images = Vec::new();
     if let Some(image_data) = &work.image_data {
@@ -202,6 +304,32 @@ mod tests {
 
         let err = to_mm_input(image_work(image)).err().unwrap();
         assert!(err.contains("not prefetched"), "{err}");
+    }
+
+    #[test]
+    fn generic_media_accepts_structured_url_items() {
+        let structured = |url: &str| {
+            Value::Map(vec![
+                (Value::from("url"), Value::from(url)),
+                (Value::from("max_dynamic_patch"), Value::from(16)),
+            ])
+        };
+        let work = MmWorkItem {
+            image_data: Some(structured("https://example.test/image.png")),
+            video_data: Some(structured("file:///tmp/video.mp4")),
+            audio_data: Some(Value::from("data:audio/wav;base64,YQ==")),
+            prefetched: vec![Bytes::from_static(b"image"), Bytes::from_static(b"video")],
+            ..Default::default()
+        };
+
+        assert_eq!(
+            io_sources(work.image_data.as_ref().unwrap()),
+            vec!["https://example.test/image.png"]
+        );
+        let resolved = resolve_media_work(work).unwrap();
+        assert_eq!(resolved.images, vec![b"image".to_vec()]);
+        assert_eq!(resolved.videos, vec![b"video".to_vec()]);
+        assert_eq!(resolved.audios, vec![b"a".to_vec()]);
     }
 
     #[test]

--- a/rust/sglang-server/src/message/request.rs
+++ b/rust/sglang-server/src/message/request.rs
@@ -123,9 +123,27 @@ pub struct GenerateBody {
     pub video_data: Option<rmpv::Value>,
     #[serde(default)]
     pub audio_data: Option<rmpv::Value>,
+    /// Optional compact placeholder contract used by pre-tokenized multimodal
+    /// clients. Kept opaque here; the selected MM component validates and
+    /// expands it against its own token vocabulary.
+    #[serde(default)]
+    pub multimodal_placeholders: Option<rmpv::Value>,
 }
 
 impl GenerateBody {
+    /// Apply the operator's launch-time sampling defaults beneath the request's
+    /// own values, matching Python TokenizerManager's
+    /// `{**preferred_sampling_params, **request.sampling_params}` merge.
+    pub fn apply_preferred_sampling(&mut self, preferred: &serde_json::Value) -> Result<(), Error> {
+        match &mut self.sampling_params {
+            Some(params) => params.apply_preferred(preferred),
+            None => SamplingParamsInput::from_preferred(preferred).map(|params| {
+                self.sampling_params = Some(params);
+            }),
+        }
+        .map_err(|e| Error::Validation(format!("invalid preferred_sampling_params: {e}")))
+    }
+
     /// Validate, normalize and fan the body into one [`GenerateRequest`] per
     /// prompt + `is_batch` (list form — a 1-element list is still a batch → JSON
     /// array response). The Rust counterpart of Python
@@ -155,6 +173,7 @@ impl GenerateBody {
             image_data,
             video_data,
             audio_data,
+            multimodal_placeholders,
             mm_hashes,
             // Unported `GenerateReqInput` fields land here and are dropped, as they
             // are on the Python path.
@@ -357,6 +376,8 @@ impl GenerateBody {
             .map_err(|e| Error::Validation(format!("video_data: {e}")))?;
         let audios = split_mm_column(audio_data, n, is_batch, MmBroadcast::AsIs)
             .map_err(|e| Error::Validation(format!("audio_data: {e}")))?;
+        let placeholders = split_placeholder_column(multimodal_placeholders, n, is_batch)
+            .map_err(|e| Error::Validation(format!("multimodal_placeholders: {e}")))?;
 
         // Every column above is exactly `n` long, so zip them by value: each
         // request takes ownership of its cell, with no indexing or bounds checks.
@@ -378,6 +399,7 @@ impl GenerateBody {
             images,
             videos,
             audios,
+            placeholders,
         )
         .map(
             |(
@@ -398,6 +420,7 @@ impl GenerateBody {
                 image_data,
                 video_data,
                 audio_data,
+                multimodal_placeholders,
             )| GenerateRequest {
                 rid,
                 text,
@@ -424,7 +447,7 @@ impl GenerateBody {
                 decode_tp_size,
                 routed_dp_rank,
                 disagg_prefill_dp_rank,
-                mm: pack_mm(image_data, video_data, audio_data),
+                mm: pack_mm(image_data, video_data, audio_data, multimodal_placeholders),
             },
         )
         .collect();
@@ -449,16 +472,54 @@ fn pack_mm(
     image_data: Option<rmpv::Value>,
     video_data: Option<rmpv::Value>,
     audio_data: Option<rmpv::Value>,
+    multimodal_placeholders: Option<rmpv::Value>,
 ) -> Option<Box<MmData>> {
-    if image_data.is_none() && video_data.is_none() && audio_data.is_none() {
+    if image_data.is_none()
+        && video_data.is_none()
+        && audio_data.is_none()
+        && multimodal_placeholders.is_none()
+    {
         return None;
     }
     Some(Box::new(MmData {
         image_data,
         video_data,
         audio_data,
+        multimodal_placeholders,
         ..Default::default()
     }))
+}
+
+fn split_placeholder_column(
+    value: Option<rmpv::Value>,
+    n: usize,
+    is_batch: bool,
+) -> Result<Vec<Option<rmpv::Value>>, String> {
+    let Some(value) = value else {
+        return Ok(vec![None; n]);
+    };
+    let rmpv::Value::Array(items) = value else {
+        return Err("must be a list".into());
+    };
+    if items.is_empty() {
+        return Ok(vec![Some(rmpv::Value::Array(Vec::new())); n]);
+    }
+    if matches!(items.first(), Some(rmpv::Value::Map(_))) {
+        if is_batch {
+            return Err("must be a list of lists for batch processing".into());
+        }
+        return Ok(vec![Some(rmpv::Value::Array(items))]);
+    }
+    if !matches!(items.first(), Some(rmpv::Value::Array(_))) {
+        return Err("entries must be objects, or lists of objects for a batch".into());
+    }
+    if items.len() != n {
+        return Err(format!(
+            "list length {} does not match batch size {n}",
+            items.len()
+        ));
+    }
+    Ok(items.into_iter().map(Some).collect())
 }
 
 /// How a scalar mm value broadcasts across a batch: images become a one-image
@@ -532,6 +593,7 @@ pub struct MmWorkItem {
     pub image_data: Option<rmpv::Value>,
     pub video_data: Option<rmpv::Value>,
     pub audio_data: Option<rmpv::Value>,
+    pub multimodal_placeholders: Option<rmpv::Value>,
     /// See [`MmData::prefetched`].
     pub prefetched: Vec<Bytes>,
     /// See [`GenerateBody::mm_hashes`].
@@ -644,6 +706,7 @@ pub struct MmData {
     pub image_data: Option<rmpv::Value>,
     pub video_data: Option<rmpv::Value>,
     pub audio_data: Option<rmpv::Value>,
+    pub multimodal_placeholders: Option<rmpv::Value>,
     /// Bytes of `image_data`'s I/O-backed sources, resolved by
     /// `api_server::prefetch` in `mm_payload::io_sources` order so MM workers
     /// never block on I/O. Out-of-band: the values above stay as the client
@@ -666,6 +729,7 @@ impl GenerateRequest {
             mm_value_present(&mm.image_data)
                 || mm_value_present(&mm.video_data)
                 || mm_value_present(&mm.audio_data)
+                || mm_value_present(&mm.multimodal_placeholders)
         })
     }
 
@@ -682,6 +746,7 @@ impl GenerateRequest {
             work.image_data = m.image_data.take();
             work.video_data = m.video_data.take();
             work.audio_data = m.audio_data.take();
+            work.multimodal_placeholders = m.multimodal_placeholders.take();
             work.prefetched = std::mem::take(&mut m.prefetched);
             work.mm_hashes = std::mem::take(&mut m.mm_hashes);
         }
@@ -1017,6 +1082,30 @@ mod tests {
         let video = ps[1].mm.as_ref().unwrap().video_data.clone().unwrap();
         assert_eq!(video.as_str(), Some("v"));
         assert!(ps[1].has_multimodal());
+    }
+
+    #[test]
+    fn compact_mm_placeholders_follow_meta_batch_shape() {
+        let single = r#"{"input_ids":[9],"image_data":"u","multimodal_placeholders":[{"type":"image","token_index":0,"item_index":0}]}"#;
+        let (reqs, is_batch) = requests(single).unwrap();
+        assert!(!is_batch);
+        let value = reqs[0]
+            .mm
+            .as_ref()
+            .unwrap()
+            .multimodal_placeholders
+            .as_ref()
+            .unwrap();
+        assert_eq!(value.as_array().unwrap().len(), 1);
+
+        let batched = r#"{"input_ids":[[9],[8]],"image_data":["u","v"],"multimodal_placeholders":[[{"type":"image","token_index":0,"item_index":0}],[{"type":"image","token_index":0,"item_index":0}]]}"#;
+        let (reqs, is_batch) = requests(batched).unwrap();
+        assert!(is_batch);
+        assert_eq!(reqs.len(), 2);
+        assert!(reqs.iter().all(|request| request.has_multimodal()));
+
+        let invalid = r#"{"input_ids":[[9],[8]],"image_data":["u","v"],"multimodal_placeholders":[{"type":"image","token_index":0,"item_index":0}]}"#;
+        assert!(requests(invalid).is_err());
     }
 
     /// A scalar broadcast is budget-checked before the deep clones (16 MiB ×

--- a/rust/sglang-server/src/message/sampling.rs
+++ b/rust/sglang-server/src/message/sampling.rs
@@ -26,7 +26,7 @@
 //!   * `n > 1` (parallel sampling) is rejected — the rust egress maps one rid to
 //!     one response, so every sample past the first would be dropped.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use serde::de::value::{MapAccessDeserializer, SeqAccessDeserializer};
@@ -217,6 +217,12 @@ pub struct SamplingParams {
     /// Set by `normalize`; tells the scheduler its own pass can early-return.
     #[serde(skip_deserializing)]
     pub is_normalized: bool,
+    /// API fields that were present in the request object. Serde defaults erase
+    /// that distinction, but the server needs it to apply operator-provided
+    /// preferred sampling params with the same precedence as Python:
+    /// `preferred | request`.
+    #[serde(skip)]
+    pub(crate) explicit_fields: BTreeSet<String>,
 }
 
 /// The `/generate` body's `sampling_params`: one object (broadcast to every
@@ -247,17 +253,78 @@ impl<'de> Deserialize<'de> for SamplingParamsInput {
             }
 
             fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<Self::Value, A::Error> {
-                SamplingParams::deserialize(MapAccessDeserializer::new(map))
+                let value = serde_json::Value::deserialize(MapAccessDeserializer::new(map))?;
+                sampling_params_from_value(value)
                     .map(|p| SamplingParamsInput::One(Box::new(p)))
+                    .map_err(serde::de::Error::custom)
             }
 
             fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<Self::Value, A::Error> {
-                Vec::deserialize(SeqAccessDeserializer::new(seq)).map(SamplingParamsInput::Many)
+                let values =
+                    Vec::<serde_json::Value>::deserialize(SeqAccessDeserializer::new(seq))?;
+                values
+                    .into_iter()
+                    .map(sampling_params_from_value)
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(SamplingParamsInput::Many)
+                    .map_err(serde::de::Error::custom)
             }
         }
 
         deserializer.deserialize_any(InputVisitor)
     }
+}
+
+fn sampling_params_from_value(value: serde_json::Value) -> Result<SamplingParams, String> {
+    let explicit_fields = value
+        .as_object()
+        .ok_or_else(|| "sampling_params must be an object".to_string())?
+        .keys()
+        .cloned()
+        .collect();
+    let mut params: SamplingParams = serde_json::from_value(value).map_err(|e| e.to_string())?;
+    params.explicit_fields = explicit_fields;
+    Ok(params)
+}
+
+impl SamplingParamsInput {
+    /// Merge launch-time preferred params beneath request params. A request key
+    /// wins even when it explicitly carries the type's normal default or null.
+    pub fn apply_preferred(&mut self, preferred: &serde_json::Value) -> Result<(), String> {
+        match self {
+            Self::One(params) => apply_preferred_to_one(params, preferred),
+            Self::Many(params) => params
+                .iter_mut()
+                .try_for_each(|params| apply_preferred_to_one(params, preferred)),
+        }
+    }
+
+    /// Parse preferred params when a request omitted `sampling_params` entirely.
+    pub fn from_preferred(preferred: &serde_json::Value) -> Result<Self, String> {
+        sampling_params_from_value(preferred.clone()).map(|params| Self::One(Box::new(params)))
+    }
+}
+
+fn apply_preferred_to_one(
+    params: &mut SamplingParams,
+    preferred: &serde_json::Value,
+) -> Result<(), String> {
+    let mut merged = preferred
+        .as_object()
+        .ok_or_else(|| "preferred_sampling_params must be a JSON object".to_string())?
+        .clone();
+    let request = serde_json::to_value(&*params)
+        .map_err(|e| e.to_string())?
+        .as_object()
+        .cloned()
+        .expect("SamplingParams serializes as an object");
+    for field in &params.explicit_fields {
+        if let Some(value) = request.get(field) {
+            merged.insert(field.clone(), value.clone());
+        }
+    }
+    *params = sampling_params_from_value(serde_json::Value::Object(merged))?;
+    Ok(())
 }
 
 impl Default for SamplingParams {
@@ -297,6 +364,7 @@ impl Default for SamplingParams {
             stop_str_max_len: 0,
             stop_regex_max_len: 0,
             is_normalized: false,
+            explicit_fields: BTreeSet::new(),
         }
     }
 }
@@ -994,5 +1062,36 @@ mod tests {
         let json = serde_json::json!({ "stop": stops }).to_string();
         let err = norm_err(&json).to_string();
         assert!(err.contains("at most"), "{err}");
+    }
+
+    #[test]
+    fn preferred_params_fill_only_omitted_request_fields() {
+        let preferred = serde_json::json!({
+            "temperature": 0.25,
+            "top_p": 0.75,
+            "max_new_tokens": 4096
+        });
+        let mut input: SamplingParamsInput =
+            serde_json::from_str(r#"{"temperature": 1.0, "top_p": null}"#).unwrap();
+        input.apply_preferred(&preferred).unwrap();
+        let SamplingParamsInput::One(params) = input else {
+            panic!("expected scalar params")
+        };
+        assert_eq!(params.temperature, 1.0, "explicit default wins");
+        assert_eq!(params.top_p, 1.0, "explicit null keeps the type default");
+        assert_eq!(params.max_new_tokens, Some(4096), "omitted uses preferred");
+    }
+
+    #[test]
+    fn preferred_params_apply_to_every_batched_object() {
+        let preferred = serde_json::json!({"temperature": 0.25, "top_p": 0.75});
+        let mut input: SamplingParamsInput =
+            serde_json::from_str(r#"[{"temperature": 0.5}, {"top_p": 0.9}]"#).unwrap();
+        input.apply_preferred(&preferred).unwrap();
+        let SamplingParamsInput::Many(params) = input else {
+            panic!("expected batched params")
+        };
+        assert_eq!((params[0].temperature, params[0].top_p), (0.5, 0.75));
+        assert_eq!((params[1].temperature, params[1].top_p), (0.25, 0.9));
     }
 }

--- a/rust/sglang-server/src/mm.rs
+++ b/rust/sglang-server/src/mm.rs
@@ -134,17 +134,72 @@ fn parse_caller_hash(entry: &str) -> Option<u64> {
     u64::from_str_radix(&hex[hex.len().saturating_sub(16)..], 16).ok()
 }
 
-/// One parked result: the buffers the drain-time Python adapter needs (the
-/// expanded `input_ids` travel separately, via `TmEvent::MmEncoded`). The qwen
-/// drain shape (`sglang_mm::qwen_vl::pack_drain`); generalizes to a
-/// named-tensor handoff once a family needs a different one.
-pub struct MmSidecarEntry {
+/// The existing Qwen-specific drain shape. It remains the default OSS adapter;
+/// external model packages use [`GenericMmSidecarEntry`] instead.
+pub struct QwenMmSidecarEntry {
     pub features: FeatureStore,
     pub grids: Vec<[u32; 3]>,
     pub hashes: Vec<u64>,
     pub offsets: Vec<(u32, u32)>,
     pub mrope: Vec<i64>,
     pub mrope_delta: i64,
+}
+
+/// Numeric storage owned by a generic multimodal item. The worker creates these
+/// vectors off the Python scheduler thread; the PyO3 drain wraps them into NumPy
+/// without copying.
+pub enum GenericTensorData {
+    F32(Vec<f32>),
+    I64(Vec<i64>),
+    U8(Vec<u8>),
+    U16(Vec<u16>),
+}
+
+/// One model-agnostic tensor with an explicit logical shape.
+pub struct GenericTensor {
+    pub shape: Vec<usize>,
+    pub data: GenericTensorData,
+}
+
+/// One modality item produced by an external MM component. `metadata_json` is
+/// interpreted only by the owning model package; the OSS runtime transports it
+/// opaquely and never branches on private fields.
+pub struct GenericMmItem {
+    pub modality: String,
+    pub feature: GenericTensor,
+    pub hash: u64,
+    pub offsets: Vec<(u32, u32)>,
+    pub metadata_json: String,
+}
+
+/// Generic sidecar for external model packages. Request-level metadata carries
+/// the owning processor's special-token and position information.
+pub struct GenericMmSidecarEntry {
+    pub items: Vec<GenericMmItem>,
+    pub metadata_json: String,
+}
+
+/// One parked result. The default path stays Qwen-shaped for compatibility;
+/// external processors use the generic, modality-tagged representation.
+pub enum MmSidecarEntry {
+    Qwen(QwenMmSidecarEntry),
+    Generic(GenericMmSidecarEntry),
+}
+
+/// Complete result of one native MM processor invocation.
+pub struct MmProcessOutput {
+    pub input_ids: Vec<i32>,
+    pub sidecar: MmSidecarEntry,
+}
+
+/// Injectable native MM component. Implementations run on the fixed Rust MM
+/// worker pool and must not retain request-scoped Python objects.
+pub trait NativeMmProcessor: Send + Sync {
+    fn process(
+        &self,
+        work: crate::message::MmWorkItem,
+        tokenizer: Option<&dyn TextTokenizer>,
+    ) -> Result<MmProcessOutput, String>;
 }
 
 /// Where a result's feature buffers live between worker and drain.
@@ -178,14 +233,10 @@ impl Sidecar {
 
 /// Shared state of the mm path, built once at `start_mm_workers`.
 pub struct Context {
-    pub family: Box<dyn sglang_mm::pipeline::MmFamilyProcessor>,
+    pub processor: Arc<dyn NativeMmProcessor>,
     /// `None` under `skip_tokenizer_init` (requests must carry `input_ids`).
     pub tokenizer: Option<Arc<dyn TextTokenizer>>,
     pub sidecar: Sidecar,
-    /// Park feature buffers in POSIX shm. Set by the Python launcher
-    /// (`NativeMmHost._use_feature_shm`) exactly when the scheduler broadcasts
-    /// across TP ranks and will unwrap `ShmPointerMMData`.
-    pub feature_shm: bool,
 }
 
 impl Context {
@@ -194,15 +245,73 @@ impl Context {
         tokenizer: Option<Arc<dyn TextTokenizer>>,
         sidecar: Sidecar,
     ) -> Result<Self, String> {
+        Ok(Self {
+            processor: Arc::new(QwenMmProcessor::new(spec_json)?),
+            tokenizer,
+            sidecar,
+        })
+    }
+
+    pub fn with_processor(
+        processor: Arc<dyn NativeMmProcessor>,
+        tokenizer: Option<Arc<dyn TextTokenizer>>,
+        sidecar: Sidecar,
+    ) -> Self {
+        Self {
+            processor,
+            tokenizer,
+            sidecar,
+        }
+    }
+}
+
+struct QwenMmProcessor {
+    family: Box<dyn sglang_mm::pipeline::MmFamilyProcessor>,
+    feature_shm: bool,
+}
+
+impl QwenMmProcessor {
+    fn new(spec_json: &str) -> Result<Self, String> {
         let feature_shm = serde_json::from_str::<serde_json::Value>(spec_json)
             .ok()
             .and_then(|v| v.get("feature_shm").and_then(|b| b.as_bool()))
             .unwrap_or(false);
         Ok(Self {
             family: sglang_mm::registry::pipeline_from_spec(spec_json)?,
-            tokenizer,
-            sidecar,
             feature_shm,
+        })
+    }
+}
+
+impl NativeMmProcessor for QwenMmProcessor {
+    fn process(
+        &self,
+        work: crate::message::MmWorkItem,
+        tokenizer: Option<&dyn TextTokenizer>,
+    ) -> Result<MmProcessOutput, String> {
+        let input = crate::message::mm_payload::to_mm_input(work)?;
+        let output = sglang_mm::driver::process(self.family.as_ref(), input, |text| {
+            let tokenizer = tokenizer.ok_or_else(|| {
+                "skip_tokenizer_init is set: multimodal text prompts require input_ids".to_string()
+            })?;
+            tokenizer.encode(text).map_err(|error| error.to_string())
+        })?;
+        let drain = sglang_mm::qwen_vl::pack_drain(output)?;
+        let features = if self.feature_shm {
+            park_features_in_shm(&drain.features, &drain.grids)
+        } else {
+            FeatureStore::Inline(drain.features)
+        };
+        Ok(MmProcessOutput {
+            input_ids: drain.input_ids,
+            sidecar: MmSidecarEntry::Qwen(QwenMmSidecarEntry {
+                features,
+                grids: drain.grids,
+                hashes: drain.hashes,
+                offsets: drain.offsets,
+                mrope: drain.mrope,
+                mrope_delta: drain.mrope_delta,
+            }),
         })
     }
 }
@@ -215,32 +324,19 @@ fn process(
     mut work: crate::message::MmWorkItem,
 ) -> Result<Vec<i32>, String> {
     let caller_hashes = std::mem::take(&mut work.mm_hashes);
-    let input = crate::message::mm_payload::to_mm_input(work)?;
-    let output = sglang_mm::driver::process(ctx.family.as_ref(), input, |text| {
-        let tokenizer = ctx.tokenizer.as_ref().ok_or_else(|| {
-            "skip_tokenizer_init is set: multimodal text prompts require input_ids".to_string()
-        })?;
-        tokenizer.encode(text).map_err(|error| error.to_string())
-    })?;
-    let mut drain = sglang_mm::qwen_vl::pack_drain(output)?;
-    apply_caller_hashes(&mut drain.hashes, &caller_hashes);
-    let features = if ctx.feature_shm {
-        park_features_in_shm(&drain.features, &drain.grids)
-    } else {
-        FeatureStore::Inline(drain.features)
-    };
-    ctx.sidecar.park(
-        rid.as_str().to_owned(),
-        MmSidecarEntry {
-            features,
-            grids: drain.grids,
-            hashes: drain.hashes,
-            offsets: drain.offsets,
-            mrope: drain.mrope,
-            mrope_delta: drain.mrope_delta,
-        },
-    );
-    Ok(drain.input_ids)
+    let mut output = ctx.processor.process(work, ctx.tokenizer.as_deref())?;
+    match &mut output.sidecar {
+        MmSidecarEntry::Qwen(entry) => apply_caller_hashes(&mut entry.hashes, &caller_hashes),
+        MmSidecarEntry::Generic(entry) => {
+            let mut hashes: Vec<u64> = entry.items.iter().map(|item| item.hash).collect();
+            apply_caller_hashes(&mut hashes, &caller_hashes);
+            for (item, hash) in entry.items.iter_mut().zip(hashes) {
+                item.hash = hash;
+            }
+        }
+    }
+    ctx.sidecar.park(rid.as_str().to_owned(), output.sidecar);
+    Ok(output.input_ids)
 }
 
 /// Split the flat feature buffer per item (`t*h*w` rows per grid) and park each

--- a/rust/sglang-server/src/runtime.rs
+++ b/rust/sglang-server/src/runtime.rs
@@ -316,6 +316,7 @@ pub fn start(cfg: RuntimeConfig) -> Result<Runtime, String> {
                     senders,
                     cfg.rust_server_args.channel_cap,
                     cfg.server_args.clone(),
+                    cfg.chat_processor.clone(),
                     // Egress heartbeat watched by `/health_generate`.
                     api_activity,
                     shutdown_rx,
@@ -370,6 +371,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            chat_processor: None,
         };
         // Bind is synchronous in `start`, so the port is already accepting.
         let rt = start(cfg).expect("start runtime");
@@ -410,6 +412,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            chat_processor: None,
         };
         let rt = start(cfg).expect("start runtime");
 
@@ -455,6 +458,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            chat_processor: None,
         };
         let rt = start(cfg).expect("start runtime");
 
@@ -516,6 +520,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            chat_processor: None,
         };
         let err = match start(cfg) {
             Ok(_) => panic!("bind conflict must fail startup, got Ok"),
@@ -549,6 +554,7 @@ mod tests {
                 ..Default::default()
             },
             server_args: Arc::new(server_args),
+            chat_processor: None,
         };
         let err = match start(cfg) {
             Ok(_) => panic!("an incomplete model_config must not boot, got Ok"),

--- a/rust/sglang-server/src/runtime/config.rs
+++ b/rust/sglang-server/src/runtime/config.rs
@@ -3,8 +3,11 @@
 //! dump ([`ServerArgs`] / [`ModelConfig`]), and the [`RuntimeConfig`] pairing
 //! them for `runtime::start`.
 
+use std::collections::BTreeMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
+
+use serde::Deserialize;
 
 /// Boot knobs specific to the embedded rust server — none of these exist in
 /// the Python `server_args` dump (see [`ServerArgs`]); they arrive as explicit
@@ -42,6 +45,9 @@ pub struct RuntimeConfig {
     /// config-endpoint metadata). `Arc` so cloning the config (and, downstream,
     /// each `AppState`) is cheap; immutable after construction.
     pub server_args: Arc<ServerArgs>,
+    /// Optional model-package renderer for chat templates the OSS server does
+    /// not own. Native `/generate` and the default chat formatter are unchanged.
+    pub chat_processor: Option<Arc<dyn crate::NativeChatProcessor>>,
 }
 
 impl Default for RuntimeConfig {
@@ -51,6 +57,7 @@ impl Default for RuntimeConfig {
             server_args: Arc::new(
                 ServerArgs::from_json("{}").expect("empty server_args blob parses"),
             ),
+            chat_processor: None,
         }
     }
 }
@@ -133,6 +140,11 @@ pub struct ServerArgs {
     /// field silently missing.
     #[serde(default)]
     pub enable_return_hidden_states: bool,
+    /// Per-modality media-count limits from `--limit-mm-data-per-request`.
+    /// The scheduler validates the keys at startup; ingress enforces the
+    /// counts before fetching or preprocessing any media.
+    #[serde(default, deserialize_with = "deserialize_optional_map")]
+    pub limit_mm_data_per_request: BTreeMap<String, usize>,
     /// Output slots reserved per request on top of its input (eagle stores draft
     /// tokens there). Not a `server_args` field — `TokenizerManager` derives it and
     /// `RustServer._build_server_args` stamps it in, so both sides count alike.
@@ -220,6 +232,13 @@ fn default_worker_num() -> usize {
     1
 }
 
+fn deserialize_optional_map<'de, D>(deserializer: D) -> Result<BTreeMap<String, usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<BTreeMap<String, usize>>::deserialize(deserializer).map(Option::unwrap_or_default)
+}
+
 impl ServerArgs {
     /// Parse the blob; errors on malformed JSON or a wrongly-typed field.
     pub fn from_json(s: &str) -> Result<Self, String> {
@@ -245,6 +264,10 @@ impl ServerArgs {
                 "unknown disaggregation_mode '{}' in server_args",
                 self.disaggregation_mode
             ));
+        }
+        if let Some(preferred) = &self.preferred_sampling_params {
+            crate::message::SamplingParamsInput::from_preferred(preferred)
+                .map_err(|e| format!("invalid preferred_sampling_params: {e}"))?;
         }
         Ok(())
     }
@@ -296,5 +319,16 @@ impl ServerArgs {
     pub fn api_worker_num(&self) -> usize {
         4.max(self.tokenizer_worker_num)
             .max(self.detokenizer_worker_num)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ServerArgs;
+
+    #[test]
+    fn null_multimodal_limits_match_an_unset_map() {
+        let args = ServerArgs::from_json(r#"{"limit_mm_data_per_request":null}"#).unwrap();
+        assert!(args.limit_mm_data_per_request.is_empty());
     }
 }

--- a/rust/sglang-server/src/tokenizer_manager/ingress.rs
+++ b/rust/sglang-server/src/tokenizer_manager/ingress.rs
@@ -227,7 +227,7 @@ impl Ingress {
                 // Validate, then register the sink before the request leaves Rust.
                 // Failures move to `Failed` and fall through to the reject arm.
                 RequestState::Received => {
-                    if let Err(e) = validate(&mut req, &self.limits) {
+                    if let Err(e) = validate(&mut req, &self.limits, self.mm.enabled) {
                         let _ = req.state.apply(Event::Error(e)); // → Failed
                         continue;
                     }
@@ -352,7 +352,8 @@ impl Ingress {
                 // a text request has no ids yet.
                 RequestState::PreSendValidating => {
                     if let RequestKind::Generate(g) = &mut req.kind
-                        && let Err(e) = check_total_tokens(g, &self.limits)
+                        && let Err(e) = validate_input_ids(g, &self.limits)
+                            .and_then(|()| check_total_tokens(g, &self.limits))
                     {
                         let _ = req.state.apply(Event::Error(e)); // → Failed
                         continue;
@@ -572,7 +573,7 @@ impl Ingress {
 /// `Received → Validating` + admissibility check. Under `skip_tokenizer_init` a
 /// generate request must already carry token ids (no tokenizer to byte-encode
 /// text); control requests carry none and are exempt.
-fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
+fn validate(req: &mut Request, limits: &Limits, mm_enabled: bool) -> Result<(), Error> {
     let (skip_tokenizer_init, vocab_size) = (limits.skip_tokenizer_init, limits.vocab_size);
     let _ = req
         .state
@@ -605,7 +606,13 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
     // reaches the embedding lookup and kills the scheduler process, so 400
     // here instead — mirroring the Python `TokenizerManager` validation.
     if let RequestKind::Generate(g) = &req.kind {
-        if let Some(ids) = &g.input_ids {
+        // A model-owned MM processor may accept a compact sentinel outside the
+        // vocabulary and normalize it while expanding media placeholders. The
+        // final IDs are checked unconditionally in PreSendValidating, before
+        // anything reaches the scheduler.
+        if !(mm_enabled && g.has_multimodal())
+            && let Some(ids) = &g.input_ids
+        {
             for &id in ids {
                 if id < 0 || id as u64 >= vocab_size {
                     return Err(Error::Validation(format!(
@@ -652,6 +659,20 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
         ));
     }
 
+    Ok(())
+}
+
+fn validate_input_ids(g: &GenerateRequest, limits: &Limits) -> Result<(), Error> {
+    if let Some(ids) = &g.input_ids {
+        for &id in ids {
+            if id < 0 || id as u64 >= limits.vocab_size {
+                return Err(Error::Validation(format!(
+                    "input_ids contains out-of-vocabulary token id {id}; valid range is [0, {})",
+                    limits.vocab_size
+                )));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -1075,7 +1096,7 @@ mod tests {
             r
         };
         let disabled = test_limits();
-        let err = validate(&mut req(true), &disabled).unwrap_err();
+        let err = validate(&mut req(true), &disabled, false).unwrap_err();
         assert_eq!(err.http_status(), 400);
         assert!(
             err.to_string().contains("--enable-return-hidden-states"),
@@ -1084,12 +1105,12 @@ mod tests {
         // Not asking for them (the client sent `false`, or sent nothing and
         // `into_requests` resolved the default), or asking on a server that
         // supports them, is fine.
-        assert!(validate(&mut req(false), &disabled).is_ok());
+        assert!(validate(&mut req(false), &disabled, false).is_ok());
         let enabled = Limits {
             enable_return_hidden_states: true,
             ..test_limits()
         };
-        assert!(validate(&mut req(true), &enabled).is_ok());
+        assert!(validate(&mut req(true), &enabled, false).is_ok());
     }
 
     /// End-to-end through `drive`: an over-context request is rejected on the way
@@ -1235,14 +1256,14 @@ mod tests {
     fn oversized_rid_is_rejected() {
         let mut req = generate_req(51, SamplingParams::default());
         req.rid = "x".repeat(MAX_RID_LEN + 1).into();
-        let err = validate(&mut req, &test_limits()).expect_err("must be rejected");
+        let err = validate(&mut req, &test_limits(), false).expect_err("must be rejected");
         assert_eq!(err.http_status(), 400);
         assert!(err.to_string().contains("over the"), "{err}");
 
         // A uuid-sized rid — what Python mints — is nowhere near the cap.
         let mut req = generate_req(52, SamplingParams::default());
         req.rid = "0123456789abcdef0123456789abcdef".into();
-        assert!(validate(&mut req, &test_limits()).is_ok());
+        assert!(validate(&mut req, &test_limits(), false).is_ok());
     }
 
     /// A request rejected BEFORE `register_detok` must not send `Deregister`: the
@@ -1350,6 +1371,27 @@ mod tests {
             Err(_) | Ok(DetokMsg::Deregister { .. }) => {}
             Ok(_) => panic!("out-of-vocab token_ids_logprob must not be admitted"),
         }
+    }
+
+    #[test]
+    fn multimodal_processor_may_normalize_a_sentinel_before_final_validation() {
+        let mut req = generate_req(24, SamplingParams::default());
+        let RequestKind::Generate(g) = &mut req.kind else {
+            unreachable!()
+        };
+        g.input_ids = Some(vec![-103]);
+        g.mm = Some(Box::new(crate::message::MmData {
+            audio_data: Some(rmpv::Value::from("audio.wav")),
+            ..Default::default()
+        }));
+
+        assert!(validate(&mut req, &test_limits(), true).is_ok());
+        let RequestKind::Generate(g) = &mut req.kind else {
+            unreachable!()
+        };
+        assert!(validate_input_ids(g, &test_limits()).is_err());
+        g.input_ids = Some(vec![70]);
+        assert!(validate_input_ids(g, &test_limits()).is_ok());
     }
 
     /// A valid request is registered and handed onward — never deregistered.
@@ -1488,14 +1530,14 @@ mod tests {
         // The worker parks its result, as it always does before MmEncoded.
         ingress.mm.sidecar.park(
             "mm-gone".into(),
-            crate::mm::MmSidecarEntry {
+            crate::mm::MmSidecarEntry::Qwen(crate::mm::QwenMmSidecarEntry {
                 features: crate::mm::FeatureStore::Inline(vec![]),
                 grids: vec![],
                 hashes: vec![],
                 offsets: vec![],
                 mrope: vec![],
                 mrope_delta: 0,
-            },
+            }),
         );
         ingress.on_abort(AbortSource::Guard("mm-gone".to_string().into()));
         assert_eq!(consumer.drain(16).headers.len(), 1, "only the AbortReq");


### PR DESCRIPTION
## Motivation

The native Rust API server currently owns a Qwen-specific multimodal path and built-in chat rendering. Model packages need stable extension boundaries to reuse the native HTTP, request lifecycle, tokenizer, and egress implementation without forking the server.

## Modifications

- Add injectable native multimodal and chat preprocessing interfaces while preserving the built-in Qwen behavior.
- Add typed generic multimodal sidecars plus image, video, and audio media prefetch and per-modality limits.
- Support preferred sampling defaults, compact multimodal placeholders, and final post-processing token validation.
- Expose the existing Python boundary types so an external Rust crate can wrap the shared server.

## Accuracy Tests

The default Qwen path remains the built-in implementation and its Rust unit coverage passes. This extension-only change is not intended to alter model outputs.

## Speed Tests and Profiling

Not applicable to the default server path; the new hooks are inactive unless an external model package supplies them.

## Testing

- cargo test -p sglang-server (248 passed)
- cargo clippy -p sglang-server --all-targets -- -D warnings
- pre-commit on all changed files

## Original commits

- ec985590af

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the contribution guide.
- [ ] Update documentation according to the contribution guide.
- [ ] Provide accuracy and speed benchmark results according to the contribution guide.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31718403745](https://github.com/sgl-project/sglang/actions/runs/31718403745)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31718403356](https://github.com/sgl-project/sglang/actions/runs/31718403356)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->