### PR TITLE
perf(moe): add RTX 5080 Granite FP8 Triton config

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=40,N=512,device_name=NVIDIA_GeForce_RTX_5080,dtype=fp8_w8a8.json
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/configs/triton_3_6_0/E=40,N=512,device_name=NVIDIA_GeForce_RTX_5080,dtype=fp8_w8a8.json
@@ -1,0 +1,146 @@
+{
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 5
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 2
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 256,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "128": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 64,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "256": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 32,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
**Incremental review:** [Files changed](https://github.com/sgl-project/sglang/pull/34750/files) against `main`.

## Motivation

SGLang does not currently ship a Triton FP8 MoE configuration for the NVIDIA
GeForce RTX 5080 and the `E=40,N=512` Granite MoE shape. The fallback heuristic
leaves measurable kernel and serving performance on the table.

## Modifications

Add one Triton 3.6.0 FP8 W8A8 configuration file for:

- GPU: NVIDIA GeForce RTX 5080 (SM120)
- model: `ibm-granite/granite-3.1-3b-a800m-instruct`
- MoE shape: E=40, N=512, top-k=8
- TP=1, EP=1
- M points: 1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 256, 512, 1024,
  1536, 2048, 3072, 4096

The official tuner searched its full 1,920-configuration default space at each
of the 18 M points (34,560 candidate evaluations total). Post-tune candidates
were remeasured three times per M point; the M=8 one-pass winner was rejected
after it regressed consistently and was replaced with the stable fastest result
from a rotated nine-measurement comparison.

## Accuracy Tests

- 10/10 deterministic Granite smoke responses were byte-identical between the
  default and tuned servers.
- `test/registered/unit/layers/moe/test_fused_moe_triton_config.py`: 2 passed.

## Speed Tests and Profiling

Environment:

- physical NVIDIA GeForce RTX 5080 16 GB (SM120)
- driver 591.74; CUDA driver/runtime 13.1 / 13.0
- PyTorch 2.11.0+cu130; Triton 3.6.0
- `shared_memory_per_block_optin=101376`
- measurements: clean SGLang `74c032234201aa0ed64b7a58c738d9ea393e319c`
- submission: rebased onto `ea7a6e0e997d00708a8f6f4502225f50578974ef`

Official full tuner invocation:

```bash
python benchmark/kernels/fused_moe_triton/tuning_fused_moe_triton.py \
  --model ibm-granite/granite-3.1-3b-a800m-instruct \
  --tp-size 1 \
  --ep-size 1 \
  --dtype fp8_w8a8 \
  --batch-sizes 1 2 4 8 16 24 32 48 64 96 128 256 512 1024 1536 2048 3072 4096 \
  --tune
```

Official fused-MoE benchmark, three alternating-order runs per config and M:

- all 18/18 M points improved in all three runs;
- geometric-mean speedup: 1.138x;
- minimum/maximum mean speedup: 1.037x / 1.757x;
- M=8: +4.08%; M=512 through 4096: +11.60%-11.88%.

Real-model serving: 64 requests, 512 input + 128 output tokens, concurrency 8,
8 warm-up requests, same seed per pair, 10 pairs with alternating execution
order, radix cache disabled.

| Metric | Default | Tuned | Change |
|---|---:|---:|---:|
| Output throughput | 1301.26 tok/s | 1329.81 tok/s | +2.194% |
| Mean TTFT | 44.72 ms | 41.95 ms | -6.19% |
| Mean TPOT | 5.828 ms | 5.718 ms | -1.89% |
| Mean E2E | 784.92 ms | 768.04 ms | -2.15% |

Output-throughput gain was positive in 10/10 pairs, with 0.075 percentage-point
standard deviation.

## Checklist

- [x] Format checked (`git diff --check`).
- [x] Existing configuration unit tests pass.
- [x] Accuracy and real-model speed results are provided above.
- [x] No documentation change is required for this config-only addition.
- [x] The change contains only one generated configuration JSON file.

AI assistance disclosure: experiment orchestration and report drafting used
Codex; all tuning, measurements, and validation results were produced on
physical RTX 5080 hardware.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33374514646](https://github.com/sgl-project/sglang/actions/runs/33374514646)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33374514330](https://github.com/sgl-project/sglang/actions/runs/33374514330)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33374514547](https://github.com/sgl-project/sglang/actions/runs/33374514547)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->