### PR TITLE
fix(xpu): use index_copy_ instead of masked_scatter_ in mm-embed merge

### DIFF
--- a/python/sglang/srt/managers/mm_utils.py
+++ b/python/sglang/srt/managers/mm_utils.py
@@ -488,7 +488,20 @@ def embed_mm_inputs(
     # 4. scatter embeddings into input embedding
     # masked_scatter_ avoids the cudaStreamSynchronize that torch.where triggers.
     def _scatter(dest, mask, src):
-        dest.masked_scatter_(mask.expand_as(dest), src.to(dest.device, dest.dtype))
+        src = src.to(dest.device, dest.dtype)
+        if dest.device.type == "xpu":
+            # torch-xpu-ops masked_scatter_ enforces its `totalElements <= srcSize_`
+            # size check with SYCL_KERNEL_ASSERT (Indexing.cpp:436), which aborts
+            # the process uncatchably instead of raising RuntimeError like the
+            # CUDA kernel does. dest is [N, H], mask is [N, 1] bool, src is [K, H].
+            # Move mask -> long index list on CPU and use index_copy_, which is a
+            # well-behaved XPU op. The D2H sync introduced by materializing the
+            # index list is already paid upstream in _adjust_embedding_length.
+            idx = torch.nonzero(mask.squeeze(-1).cpu(), as_tuple=False).squeeze(-1)
+            idx = idx.to(dest.device)
+            dest.index_copy_(0, idx, src)
+            return
+        dest.masked_scatter_(mask.expand_as(dest), src)
 
     for i, modality, embedding, mask in zip(
         range(len(embeddings)), modalities, embeddings, masks


### PR DESCRIPTION
## Summary
`embed_mm_inputs._scatter` in `python/sglang/srt/managers/mm_utils.py` calls `dest.masked_scatter_(mask.expand_as(dest), src)` on the multimodal embed merge path (e.g. DeepSeek-OCR).

On Intel XPU (torch 2.13+xpu, oneAPI DPC++ 2026.1) that reaches `torch-xpu-ops/src/ATen/native/xpu/sycl/Indexing.cpp:436`, where the size check `totalElements <= srcSize_` is enforced with `SYCL_KERNEL_ASSERT`. On any mismatch (or transient async state) the SYCL kernel calls `abort()` and the process dies with `Fatal Python error: Aborted` at the next `torch.xpu.stream.synchronize()` — uncatchable, so the scheduler cannot recover. The CUDA equivalent uses `CUDA_KERNEL_ASSERT` and surfaces as a Python `RuntimeError` (which the existing try/except at the call site is designed for).

## Fix
On XPU only, translate the bool mask to a long index list (materialized on CPU) and use `dest.index_copy_(0, idx, src)`. The extra D2H sync is already paid upstream in `_adjust_embedding_length` (`mask.sum().item()`), so no measurable overhead. CUDA/CPU paths unchanged.

## Repro
Intel Data Center GPU Max 1550, `deepseek-ai/DeepSeek-OCR`, `--device xpu --attention-backend intel_xpu`.

Before:
```
torch-xpu-ops/src/ATen/native/xpu/sycl/Indexing.cpp:436:
  Assertion `totalElements <= srcSize_` failed.
Fatal Python error: Aborted
```
After: `test/registered/xpu/test_deepseek_ocr.py::TestDeepSeekOCR::test_moe` completes in ~35s.

## Follow-up
Recommend filing an issue against `intel/torch-xpu-ops` — the `MaskedScatterSizeCheckFunctor` should use a host-side `TORCH_CHECK` (or a device-error flag) rather than `abort()` so this class of mismatch is catchable on XPU as it is on CUDA.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31721479444](https://github.com/sgl-project/sglang/actions/runs/31721479444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31721479340](https://github.com/sgl-project/sglang/actions/runs/31721479340)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->