### PR TITLE
[DSA] Optimize TRTLLM prefill RoPE/FP8 quantization

### DIFF
--- a/python/sglang/kernels/ops/attention/__init__.py
+++ b/python/sglang/kernels/ops/attention/__init__.py
@@ -111,6 +111,7 @@ del _mod, _fn
 # Generic attention kernels migrated in Phase 2.5 (RFC #29630).
 for _mod, _fn in [
     ("utils", "mla_quantize_and_rope_for_fp8"),
+    ("utils", "mla_split_quantize_and_rope_for_fp8"),
     ("utils", "launch_reshape_and_cache_flash"),
     ("utils", "launch_reshape_and_cache_shuffle_5d"),
     ("flash_mla_sm120", "flash_mla_with_kvcache_sm120"),

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -16,7 +16,7 @@ from sglang.kernels.ops.attention.pad import (
     seqlens_expand_triton as seqlens_expand_triton,
 )
 from sglang.kernels.ops.kvcache.cache_ops import (
-    cast_q_nope_to_fp8 as cast_q_nope_to_fp8,
+    cast_qk_nope_to_fp8 as cast_qk_nope_to_fp8,
 )
 from sglang.kernels.ops.kvcache.cache_ops import (
     concat_and_cast_mha_k_kernel as concat_and_cast_mha_k_kernel,
@@ -198,9 +198,8 @@ def mla_split_quantize_and_rope_for_fp8(
 
     FlashInfer applies RoPE and writes the Q/K RoPE components directly to
     FP8, preserving the default path's FP32-to-FP8 rounding. A strided Triton
-    kernel writes only the q-nope prefix, while the much smaller k-nope uses a
-    regular converting copy. The returned tensors are byte-identical to
-    :func:`mla_quantize_and_rope_for_fp8`.
+    kernel writes the Q and K no-RoPE components in one launch. The returned
+    tensors are byte-identical to :func:`mla_quantize_and_rope_for_fp8`.
     """
     import flashinfer.rope
 
@@ -217,7 +216,14 @@ def mla_split_quantize_and_rope_for_fp8(
     k_rope_out = k_rope.new_empty(k_rope.shape, dtype=attn_dtype)
     k_nope_out = k_nope.new_empty(k_nope.shape, dtype=attn_dtype)
 
-    cast_q_nope_to_fp8(q_out, q_nope)
+    enable_pdl = is_arch_support_pdl()
+    cast_qk_nope_to_fp8(
+        q_out,
+        q_nope,
+        k_nope_out,
+        k_nope,
+        enable_pdl=enable_pdl,
+    )
     q_nope_empty = q_nope[..., :0]
     k_nope_empty = k_nope[..., :0]
     flashinfer.rope.rope_quantize_fp8(
@@ -235,9 +241,8 @@ def mla_split_quantize_and_rope_for_fp8(
         k_nope_out=k_nope_out[..., :0],
         quant_scale_q=1.0,
         quant_scale_kv=1.0,
-        enable_pdl=is_arch_support_pdl(),
+        enable_pdl=enable_pdl,
     )
-    k_nope_out.copy_(k_nope)
     return q_out, k_nope_out, k_rope_out
 
 

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -16,6 +16,9 @@ from sglang.kernels.ops.attention.pad import (
     seqlens_expand_triton as seqlens_expand_triton,
 )
 from sglang.kernels.ops.kvcache.cache_ops import (
+    cast_q_nope_to_fp8 as cast_q_nope_to_fp8,
+)
+from sglang.kernels.ops.kvcache.cache_ops import (
     concat_and_cast_mha_k_kernel as concat_and_cast_mha_k_kernel,
 )
 from sglang.kernels.ops.kvcache.cache_ops import (
@@ -177,6 +180,64 @@ def mla_quantize_and_rope_for_fp8(
         enable_pdl=is_arch_support_pdl(),
     )
 
+    return q_out, k_nope_out, k_rope_out
+
+
+def mla_split_quantize_and_rope_for_fp8(
+    q_nope: torch.Tensor,
+    q_rope: torch.Tensor,
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    pos_ids: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    is_neox: bool,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split MLA RoPE/FP8 conversion to avoid reprocessing the large q-nope.
+
+    FlashInfer applies RoPE and writes the Q/K RoPE components directly to
+    FP8, preserving the default path's FP32-to-FP8 rounding. A strided Triton
+    kernel writes only the q-nope prefix, while the much smaller k-nope uses a
+    regular converting copy. The returned tensors are byte-identical to
+    :func:`mla_quantize_and_rope_for_fp8`.
+    """
+    import flashinfer.rope
+
+    assert q_nope.shape[-1] == kv_lora_rank
+    assert q_rope.shape[-1] == qk_rope_head_dim
+    attn_dtype = torch.float8_e4m3fn
+    q_len, num_heads = q_rope.shape[:2]
+    q_out = q_rope.new_empty(
+        q_len,
+        num_heads,
+        kv_lora_rank + qk_rope_head_dim,
+        dtype=attn_dtype,
+    )
+    k_rope_out = k_rope.new_empty(k_rope.shape, dtype=attn_dtype)
+    k_nope_out = k_nope.new_empty(k_nope.shape, dtype=attn_dtype)
+
+    cast_q_nope_to_fp8(q_out, q_nope)
+    q_nope_empty = q_nope[..., :0]
+    k_nope_empty = k_nope[..., :0]
+    flashinfer.rope.rope_quantize_fp8(
+        q_rope=q_rope,
+        k_rope=k_rope,
+        q_nope=q_nope_empty,
+        k_nope=k_nope_empty,
+        cos_sin_cache=cos_sin_cache,
+        pos_ids=pos_ids,
+        is_neox=is_neox,
+        quantize_dtype=attn_dtype,
+        q_rope_out=q_out[..., kv_lora_rank:],
+        k_rope_out=k_rope_out,
+        q_nope_out=q_out[..., :0],
+        k_nope_out=k_nope_out[..., :0],
+        quant_scale_q=1.0,
+        quant_scale_kv=1.0,
+        enable_pdl=is_arch_support_pdl(),
+    )
+    k_nope_out.copy_(k_nope)
     return q_out, k_nope_out, k_rope_out
 
 

--- a/python/sglang/kernels/ops/kvcache/cache_ops.py
+++ b/python/sglang/kernels/ops/kvcache/cache_ops.py
@@ -323,69 +323,112 @@ def concat_and_cast_q_fp8_pad(q_fp8_pad, q_nope, q_rope, num_heads):
 
 
 @triton.jit
-def cast_q_nope_to_fp8_kernel(
+def cast_qk_nope_to_fp8_kernel(
     q_fp8_ptr,  # [num_tokens, H, NOPE+ROPE] fp8 (dst; nope prefix only)
     q_nope_ptr,  # [num_tokens, H, NOPE] bf16
+    k_fp8_ptr,  # [num_tokens, NOPE] fp8
+    k_nope_ptr,  # [num_tokens, NOPE] bf16
     q_fp8_s0,
     q_fp8_s1,
     q_nope_s0,
     q_nope_s1,
+    k_fp8_s0,
+    k_nope_s0,
     H: tl.constexpr,
     NOPE: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_NOPE: tl.constexpr,
+    ENABLE_PDL: tl.constexpr,
 ):
-    """Cast q-nope into an FP8 query prefix without touching its RoPE tail."""
+    """Cast Q/K no-RoPE components to FP8 in one program per token."""
     token = tl.program_id(0)
     head = tl.arange(0, BLOCK_H)
     col = tl.arange(0, BLOCK_NOPE)
+
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     mask = (head[:, None] < H) & (col[None, :] < NOPE)
     value = tl.load(
-        q_nope_ptr
-        + token * q_nope_s0
-        + head[:, None] * q_nope_s1
-        + col[None, :],
+        q_nope_ptr + token * q_nope_s0 + head[:, None] * q_nope_s1 + col[None, :],
         mask=mask,
     )
     tl.store(
-        q_fp8_ptr
-        + token * q_fp8_s0
-        + head[:, None] * q_fp8_s1
-        + col[None, :],
+        q_fp8_ptr + token * q_fp8_s0 + head[:, None] * q_fp8_s1 + col[None, :],
         value,
         mask=mask,
     )
 
+    # The Q tile is 64x512 at the production shape. Reuse this CTA for the
+    # single 512-wide K row so the split path does not need a third launch.
+    k_mask = col < NOPE
+    k_value = tl.load(
+        k_nope_ptr + token * k_nope_s0 + col,
+        mask=k_mask,
+    )
+    tl.store(
+        k_fp8_ptr + token * k_fp8_s0 + col,
+        k_value,
+        mask=k_mask,
+    )
 
-def cast_q_nope_to_fp8(q_fp8: torch.Tensor, q_nope: torch.Tensor) -> None:
-    """Cast ``q_nope`` into ``q_fp8[..., :q_nope.shape[-1]]``.
+    # Keep the trigger after both output stores: the following RoPE kernel can
+    # in turn trigger a consumer that reads k_fp8.
+    if ENABLE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
 
-    The destination may reserve a tail for a separate RoPE kernel. Both source
-    and destination may use arbitrary token/head strides, but their feature
-    dimensions must be contiguous.
+
+def cast_qk_nope_to_fp8(
+    q_fp8: torch.Tensor,
+    q_nope: torch.Tensor,
+    k_fp8: torch.Tensor,
+    k_nope: torch.Tensor,
+    *,
+    enable_pdl: bool = False,
+) -> None:
+    """Cast Q/K no-RoPE components into their FP8 destinations.
+
+    ``q_fp8`` may reserve a tail for a separate RoPE kernel. Sources and
+    destinations may use arbitrary outer strides, but their feature dimensions
+    must be contiguous.
     """
+    assert q_fp8.ndim == q_nope.ndim == 3
+    assert k_fp8.ndim == k_nope.ndim == 2
     num_tokens, num_heads, nope_dim = q_nope.shape
+    assert num_heads > 0 and nope_dim > 0
     assert q_fp8.shape[:2] == (num_tokens, num_heads)
     assert q_fp8.shape[-1] >= nope_dim
-    assert q_fp8.dtype == torch.float8_e4m3fn
+    assert k_nope.shape == (num_tokens, nope_dim)
+    assert k_fp8.shape == k_nope.shape
+    assert q_fp8.dtype == k_fp8.dtype == torch.float8_e4m3fn
+    assert q_nope.dtype == k_nope.dtype
     assert q_nope.dtype in (torch.float16, torch.bfloat16)
+    assert q_fp8.device == q_nope.device == k_fp8.device == k_nope.device
     assert q_fp8.stride(-1) == q_nope.stride(-1) == 1
+    assert k_fp8.stride(-1) == k_nope.stride(-1) == 1
     if num_tokens == 0:
         return
     block_h = triton.next_power_of_2(num_heads)
     block_nope = triton.next_power_of_2(nope_dim)
-    cast_q_nope_to_fp8_kernel[(num_tokens,)](
+    extra_kwargs = {"launch_pdl": True} if enable_pdl else {}
+    cast_qk_nope_to_fp8_kernel[(num_tokens,)](
         q_fp8,
         q_nope,
+        k_fp8,
+        k_nope,
         q_fp8.stride(0),
         q_fp8.stride(1),
         q_nope.stride(0),
         q_nope.stride(1),
+        k_fp8.stride(0),
+        k_nope.stride(0),
         H=num_heads,
         NOPE=nope_dim,
         BLOCK_H=block_h,
         BLOCK_NOPE=block_nope,
+        ENABLE_PDL=enable_pdl,
         num_warps=8,
+        **extra_kwargs,
     )
 
 

--- a/python/sglang/kernels/ops/kvcache/cache_ops.py
+++ b/python/sglang/kernels/ops/kvcache/cache_ops.py
@@ -323,6 +323,73 @@ def concat_and_cast_q_fp8_pad(q_fp8_pad, q_nope, q_rope, num_heads):
 
 
 @triton.jit
+def cast_q_nope_to_fp8_kernel(
+    q_fp8_ptr,  # [num_tokens, H, NOPE+ROPE] fp8 (dst; nope prefix only)
+    q_nope_ptr,  # [num_tokens, H, NOPE] bf16
+    q_fp8_s0,
+    q_fp8_s1,
+    q_nope_s0,
+    q_nope_s1,
+    H: tl.constexpr,
+    NOPE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_NOPE: tl.constexpr,
+):
+    """Cast q-nope into an FP8 query prefix without touching its RoPE tail."""
+    token = tl.program_id(0)
+    head = tl.arange(0, BLOCK_H)
+    col = tl.arange(0, BLOCK_NOPE)
+    mask = (head[:, None] < H) & (col[None, :] < NOPE)
+    value = tl.load(
+        q_nope_ptr
+        + token * q_nope_s0
+        + head[:, None] * q_nope_s1
+        + col[None, :],
+        mask=mask,
+    )
+    tl.store(
+        q_fp8_ptr
+        + token * q_fp8_s0
+        + head[:, None] * q_fp8_s1
+        + col[None, :],
+        value,
+        mask=mask,
+    )
+
+
+def cast_q_nope_to_fp8(q_fp8: torch.Tensor, q_nope: torch.Tensor) -> None:
+    """Cast ``q_nope`` into ``q_fp8[..., :q_nope.shape[-1]]``.
+
+    The destination may reserve a tail for a separate RoPE kernel. Both source
+    and destination may use arbitrary token/head strides, but their feature
+    dimensions must be contiguous.
+    """
+    num_tokens, num_heads, nope_dim = q_nope.shape
+    assert q_fp8.shape[:2] == (num_tokens, num_heads)
+    assert q_fp8.shape[-1] >= nope_dim
+    assert q_fp8.dtype == torch.float8_e4m3fn
+    assert q_nope.dtype in (torch.float16, torch.bfloat16)
+    assert q_fp8.stride(-1) == q_nope.stride(-1) == 1
+    if num_tokens == 0:
+        return
+    block_h = triton.next_power_of_2(num_heads)
+    block_nope = triton.next_power_of_2(nope_dim)
+    cast_q_nope_to_fp8_kernel[(num_tokens,)](
+        q_fp8,
+        q_nope,
+        q_fp8.stride(0),
+        q_fp8.stride(1),
+        q_nope.stride(0),
+        q_nope.stride(1),
+        H=num_heads,
+        NOPE=nope_dim,
+        BLOCK_H=block_h,
+        BLOCK_NOPE=block_nope,
+        num_warps=8,
+    )
+
+
+@triton.jit
 def absorbed_bmm_concat_cast_q_fp8_kernel(
     qout_ptr,  # [num_tokens, pad_heads, N+ROPE] fp8 (dst; only [:, :H, :] written)
     a_ptr,  # q_nope (pre-absorb) [num_tokens, H, K] bf16

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1248,6 +1248,11 @@ class Envs:
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)
+    # Opt-in B200 TRTLLM sparse-prefill path: split MLA RoPE/FP8 conversion so
+    # the large absorbed q-nope tensor is converted by a dedicated strided
+    # cast and FlashInfer only processes the 64-d RoPE components. The split
+    # is byte-identical to the fused RopeQuantize path.
+    SGLANG_ENABLE_DSA_TRTLLM_SPLIT_ROPE_QUANTIZE = EnvBool(False)
     # Opt-in perf path for --dsa-prefill-backend flashmla_sparse_q8: fuse the
     # absorbed q bmm with the nope/rope concat + fp8 cast so q is written
     # directly in fp8 ("born fp8") and the standalone concat-cast kernel

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1248,11 +1248,6 @@ class Envs:
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)
-    # Opt-in B200 TRTLLM sparse-prefill path: split MLA RoPE/FP8 conversion so
-    # the large absorbed q-nope tensor is converted by a dedicated strided
-    # cast and FlashInfer only processes the 64-d RoPE components. The split
-    # is byte-identical to the fused RopeQuantize path.
-    SGLANG_ENABLE_DSA_TRTLLM_SPLIT_ROPE_QUANTIZE = EnvBool(False)
     # Opt-in perf path for --dsa-prefill-backend flashmla_sparse_q8: fuse the
     # absorbed q bmm with the nope/rope concat + fp8 cast so q is written
     # directly in fp8 ("born fp8") and the standalone concat-cast kernel

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -31,6 +31,7 @@ from sglang.kernels.ops.attention.dsa.transform_index import (
 from sglang.kernels.ops.attention.utils import (
     concat_mla_absorb_q_general,
     mla_quantize_and_rope_for_fp8,
+    mla_split_quantize_and_rope_for_fp8,
     q8kv8_topk_length_from_indices,
     seqlens_expand_triton,
 )
@@ -404,6 +405,9 @@ class DeepseekSparseAttnBackend(
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
         self.kv_cache_dtype = model_runner.kv_cache_dtype
+        self._trtllm_split_rope_quantize = (
+            envs.SGLANG_ENABLE_DSA_TRTLLM_SPLIT_ROPE_QUANTIZE.get()
+        )
 
         # `flashmla_sparse_q8` = the native FP8 SM90 sparse-prefill kernel. It always
         # runs FP8 (requires fp8_e4m3 KV) and is SM90-only, so validate both at
@@ -3149,7 +3153,25 @@ class DeepseekSparseAttnBackend(
                         forward_batch, rope_positions
                     )
 
-            q, k, k_rope = mla_quantize_and_rope_for_fp8(
+            quantize_and_rope = (
+                mla_split_quantize_and_rope_for_fp8
+                if (
+                    self._trtllm_split_rope_quantize
+                    and is_prefill
+                    and forward_batch.forward_mode == ForwardMode.EXTEND
+                    and self.device_sm_major == 10
+                    and self.kv_lora_rank == 512
+                    and self.qk_rope_head_dim == 64
+                    # The split is correct for other head counts, but it only
+                    # outperformed the fused path at the measured 64-head
+                    # DP-attention shape on SM100.
+                    and q.shape[1] == 64
+                    and q.shape[-1] == self.kv_lora_rank
+                    and q_rope.shape[-1] == self.qk_rope_head_dim
+                )
+                else mla_quantize_and_rope_for_fp8
+            )
+            q, k, k_rope = quantize_and_rope(
                 q,
                 q_rope,
                 k.squeeze(1),

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -87,6 +87,16 @@ from sglang.srt.utils import (
 _DSA_TRITON_PREFILL = get_bool_env_var("SGLANG_DSA_TRITON_PREFILL")
 _IS_GFX95 = is_gfx95_supported()
 
+# The split path saves bandwidth only once the local query shard is large
+# enough to amortize its extra launch. Keep capability-specific entries so a
+# future Blackwell variant is not silently enabled with an unmeasured cutoff.
+_TRTLLM_SPLIT_ROPE_QUANTIZE_MIN_TOKENS_BY_CAPABILITY = {
+    # Keep the intended DP8 chunk size on B200 until its crossover is measured
+    # directly; B300 was benchmarked down to the 4K boundary below.
+    (10, 0): 8192,  # B200 / SM100
+    (10, 3): 4096,  # B300 / SM103
+}
+
 if is_cuda():
     import deep_gemm
 
@@ -405,9 +415,6 @@ class DeepseekSparseAttnBackend(
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
         self.kv_cache_dtype = model_runner.kv_cache_dtype
-        self._trtllm_split_rope_quantize = (
-            envs.SGLANG_ENABLE_DSA_TRTLLM_SPLIT_ROPE_QUANTIZE.get()
-        )
 
         # `flashmla_sparse_q8` = the native FP8 SM90 sparse-prefill kernel. It always
         # runs FP8 (requires fp8_e4m3 KV) and is SM90-only, so validate both at
@@ -3109,6 +3116,37 @@ class DeepseekSparseAttnBackend(
 
         return o
 
+    def _should_use_trtllm_split_rope_quantize(
+        self,
+        q: torch.Tensor,
+        q_rope: torch.Tensor,
+        forward_mode: ForwardMode,
+        is_prefill: bool,
+    ) -> bool:
+        min_tokens = _TRTLLM_SPLIT_ROPE_QUANTIZE_MIN_TOKENS_BY_CAPABILITY.get(
+            self.device_capability
+        )
+        return bool(
+            is_prefill
+            # MIXED takes the same forward-extend path as ordinary prefill.
+            # Keep speculative/dLLM/split-prefill modes on the default kernel
+            # until their launch shapes are benchmarked independently.
+            and forward_mode in (ForwardMode.EXTEND, ForwardMode.MIXED)
+            and min_tokens is not None
+            and q.ndim == 3
+            and q_rope.ndim == 3
+            # This is the local row count after DP/CP sharding: it is the work
+            # size seen by both quantization kernels and therefore the relevant
+            # crossover, rather than the global prompt length.
+            and q.shape[0] >= min_tokens
+            and self.kv_lora_rank == 512
+            and self.qk_rope_head_dim == 64
+            and q.shape[1] == 64
+            and q.shape[-1] == self.kv_lora_rank
+            and q_rope.shape[:2] == q.shape[:2]
+            and q_rope.shape[-1] == self.qk_rope_head_dim
+        )
+
     def _forward_trtllm(
         self,
         q: torch.Tensor,
@@ -3155,19 +3193,11 @@ class DeepseekSparseAttnBackend(
 
             quantize_and_rope = (
                 mla_split_quantize_and_rope_for_fp8
-                if (
-                    self._trtllm_split_rope_quantize
-                    and is_prefill
-                    and forward_batch.forward_mode == ForwardMode.EXTEND
-                    and self.device_sm_major == 10
-                    and self.kv_lora_rank == 512
-                    and self.qk_rope_head_dim == 64
-                    # The split is correct for other head counts, but it only
-                    # outperformed the fused path at the measured 64-head
-                    # DP-attention shape on SM100.
-                    and q.shape[1] == 64
-                    and q.shape[-1] == self.kv_lora_rank
-                    and q_rope.shape[-1] == self.qk_rope_head_dim
+                if self._should_use_trtllm_split_rope_quantize(
+                    q,
+                    q_rope,
+                    forward_batch.forward_mode,
+                    is_prefill,
                 )
                 else mla_quantize_and_rope_for_fp8
             )

--- a/test/registered/kernels/ops/attention/test_mla_split_quantize_rope_fp8.py
+++ b/test/registered/kernels/ops/attention/test_mla_split_quantize_rope_fp8.py
@@ -1,0 +1,192 @@
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large"
+)
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200"
+)
+
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+FP8_DTYPE = torch.float8_e4m3fn
+
+NUM_HEADS = 64
+KV_LORA_RANK = 512
+ROPE_DIM = 64
+Q_PROJ_NOPE_DIM = 192
+
+
+def _fp8_bytes(tensor: torch.Tensor) -> torch.Tensor:
+    return tensor.contiguous().view(torch.uint8)
+
+
+def _make_cos_sin_cache(max_position: int) -> torch.Tensor:
+    inv_freq = 1.0 / (
+        10000.0
+        ** (
+            torch.arange(0, ROPE_DIM, 2, device=DEVICE, dtype=torch.float32)
+            / ROPE_DIM
+        )
+    )
+    positions = torch.arange(max_position, device=DEVICE, dtype=torch.float32)
+    freqs = torch.outer(positions, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1)
+
+
+def _make_production_strided_inputs(num_tokens: int):
+    generator = torch.Generator(device=DEVICE).manual_seed(20260812 + num_tokens)
+
+    # The absorbed BMM produces contiguous [H, T, 512], which is transposed
+    # without a copy before q quantization. Keep its exact production strides.
+    q_nope_storage = torch.randn(
+        (NUM_HEADS, num_tokens, KV_LORA_RANK),
+        generator=generator,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    q_nope = q_nope_storage.transpose(0, 1)
+
+    # q_rope is a suffix view of the BF16 q projection. GLM uses a 192-wide
+    # pre-RoPE projection component, so its head stride is 192 + 64.
+    q_proj = torch.randn(
+        (num_tokens, NUM_HEADS, Q_PROJ_NOPE_DIM + ROPE_DIM),
+        generator=generator,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    q_rope = q_proj[
+        ..., Q_PROJ_NOPE_DIM : Q_PROJ_NOPE_DIM + ROPE_DIM
+    ]
+
+    # k_nope and k_rope are sibling views of the latent-cache projection and
+    # are squeezed to two dimensions before entering the TRTLLM MLA backend.
+    k_storage = torch.randn(
+        (num_tokens, KV_LORA_RANK + ROPE_DIM),
+        generator=generator,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    k_nope = k_storage[:, :KV_LORA_RANK]
+    k_rope = k_storage[
+        :, KV_LORA_RANK : KV_LORA_RANK + ROPE_DIM
+    ]
+
+    assert q_nope.stride() == (
+        KV_LORA_RANK,
+        num_tokens * KV_LORA_RANK,
+        1,
+    )
+    assert q_rope.stride(1) != ROPE_DIM
+    assert k_nope.stride(0) != KV_LORA_RANK
+    return q_nope, q_rope, k_nope, k_rope
+
+
+class TestMlaSplitQuantizeRopeFp8(CustomTestCase):
+    def assert_fp8_bytes_equal(
+        self, actual: torch.Tensor, expected: torch.Tensor, component: str
+    ) -> None:
+        self.assertEqual(actual.dtype, FP8_DTYPE)
+        self.assertEqual(actual.shape, expected.shape)
+        self.assertTrue(
+            torch.equal(_fp8_bytes(actual), _fp8_bytes(expected)),
+            f"{component} is not byte-identical",
+        )
+
+    def test_q_nope_only_cast_honors_input_and_output_strides(self):
+        from sglang.kernels.ops.kvcache.cache_ops import cast_q_nope_to_fp8
+
+        for num_tokens in (1, 257):
+            with self.subTest(num_tokens=num_tokens):
+                q_nope, _, _, _ = _make_production_strided_inputs(num_tokens)
+
+                # Pad the output head/feature storage. Bytes outside the
+                # 512-wide q-nope prefix must not be touched; the reduced
+                # FlashInfer launch fills the tail.
+                output_storage = torch.empty(
+                    (num_tokens, NUM_HEADS + 3, KV_LORA_RANK + ROPE_DIM + 16),
+                    device=DEVICE,
+                    dtype=FP8_DTYPE,
+                )
+                output_storage.view(torch.uint8).fill_(0xA5)
+                expected_storage = output_storage.view(torch.uint8).clone()
+                q_fp8 = output_storage[
+                    :, :NUM_HEADS, : KV_LORA_RANK + ROPE_DIM
+                ]
+
+                expected_nope = q_nope.to(FP8_DTYPE)
+                expected_storage[
+                    :, :NUM_HEADS, :KV_LORA_RANK
+                ].copy_(_fp8_bytes(expected_nope))
+
+                cast_q_nope_to_fp8(q_fp8, q_nope)
+                torch.cuda.synchronize()
+
+                self.assertTrue(
+                    torch.equal(output_storage.view(torch.uint8), expected_storage),
+                    "cast must write exactly the active q-nope prefix",
+                )
+
+    def test_split_helper_is_byte_identical_to_flashinfer_helper(self):
+        from sglang.kernels.ops.attention.utils import (
+            mla_quantize_and_rope_for_fp8,
+            mla_split_quantize_and_rope_for_fp8,
+        )
+
+        cos_sin_cache = _make_cos_sin_cache(max_position=1024)
+        for num_tokens in (1, 37):
+            q_nope, q_rope, k_nope, k_rope = _make_production_strided_inputs(
+                num_tokens
+            )
+            pos_ids = (
+                torch.arange(num_tokens, device=DEVICE, dtype=torch.int64) * 17 + 3
+            ) % cos_sin_cache.shape[0]
+
+            for is_neox in (False, True):
+                with self.subTest(num_tokens=num_tokens, is_neox=is_neox):
+                    reference = mla_quantize_and_rope_for_fp8(
+                        q_nope,
+                        q_rope,
+                        k_nope,
+                        k_rope,
+                        pos_ids,
+                        cos_sin_cache,
+                        is_neox,
+                        KV_LORA_RANK,
+                        ROPE_DIM,
+                    )
+                    split = mla_split_quantize_and_rope_for_fp8(
+                        q_nope,
+                        q_rope,
+                        k_nope,
+                        k_rope,
+                        pos_ids,
+                        cos_sin_cache,
+                        is_neox,
+                        KV_LORA_RANK,
+                        ROPE_DIM,
+                    )
+                    torch.cuda.synchronize()
+
+                    for component, actual, expected in zip(
+                        ("q", "k_nope", "k_rope"), split, reference
+                    ):
+                        self.assert_fp8_bytes_equal(actual, expected, component)
+
+                    self.assertTrue(
+                        torch.equal(
+                            _fp8_bytes(split[0][..., :KV_LORA_RANK]),
+                            _fp8_bytes(q_nope.to(FP8_DTYPE)),
+                        ),
+                        "split q-nope prefix must use the exact BF16-to-FP8 cast",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/attention/test_mla_split_quantize_rope_fp8.py
+++ b/test/registered/kernels/ops/attention/test_mla_split_quantize_rope_fp8.py
@@ -5,12 +5,8 @@ import torch
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(
-    est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large"
-)
-register_cuda_ci(
-    est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200"
-)
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
 
 
 DEVICE = "cuda"
@@ -30,10 +26,7 @@ def _fp8_bytes(tensor: torch.Tensor) -> torch.Tensor:
 def _make_cos_sin_cache(max_position: int) -> torch.Tensor:
     inv_freq = 1.0 / (
         10000.0
-        ** (
-            torch.arange(0, ROPE_DIM, 2, device=DEVICE, dtype=torch.float32)
-            / ROPE_DIM
-        )
+        ** (torch.arange(0, ROPE_DIM, 2, device=DEVICE, dtype=torch.float32) / ROPE_DIM)
     )
     positions = torch.arange(max_position, device=DEVICE, dtype=torch.float32)
     freqs = torch.outer(positions, inv_freq)
@@ -61,9 +54,7 @@ def _make_production_strided_inputs(num_tokens: int):
         device=DEVICE,
         dtype=DTYPE,
     )
-    q_rope = q_proj[
-        ..., Q_PROJ_NOPE_DIM : Q_PROJ_NOPE_DIM + ROPE_DIM
-    ]
+    q_rope = q_proj[..., Q_PROJ_NOPE_DIM : Q_PROJ_NOPE_DIM + ROPE_DIM]
 
     # k_nope and k_rope are sibling views of the latent-cache projection and
     # are squeezed to two dimensions before entering the TRTLLM MLA backend.
@@ -74,9 +65,7 @@ def _make_production_strided_inputs(num_tokens: int):
         dtype=DTYPE,
     )
     k_nope = k_storage[:, :KV_LORA_RANK]
-    k_rope = k_storage[
-        :, KV_LORA_RANK : KV_LORA_RANK + ROPE_DIM
-    ]
+    k_rope = k_storage[:, KV_LORA_RANK : KV_LORA_RANK + ROPE_DIM]
 
     assert q_nope.stride() == (
         KV_LORA_RANK,
@@ -99,39 +88,107 @@ class TestMlaSplitQuantizeRopeFp8(CustomTestCase):
             f"{component} is not byte-identical",
         )
 
-    def test_q_nope_only_cast_honors_input_and_output_strides(self):
-        from sglang.kernels.ops.kvcache.cache_ops import cast_q_nope_to_fp8
+    def test_qk_nope_cast_honors_input_and_output_strides(self):
+        from sglang.kernels.jit.utils import is_arch_support_pdl
+        from sglang.kernels.ops.kvcache.cache_ops import cast_qk_nope_to_fp8
 
         for num_tokens in (1, 257):
-            with self.subTest(num_tokens=num_tokens):
-                q_nope, _, _, _ = _make_production_strided_inputs(num_tokens)
+            q_nope, _, k_nope, _ = _make_production_strided_inputs(num_tokens)
+            pdl_modes = (False, True) if is_arch_support_pdl() else (False,)
+            for enable_pdl in pdl_modes:
+                with self.subTest(num_tokens=num_tokens, enable_pdl=enable_pdl):
+                    # Pad both destinations. Bytes outside the Q prefix and K
+                    # row must not be touched by the combined conversion.
+                    q_output_storage = torch.empty(
+                        (
+                            num_tokens,
+                            NUM_HEADS + 3,
+                            KV_LORA_RANK + ROPE_DIM + 16,
+                        ),
+                        device=DEVICE,
+                        dtype=FP8_DTYPE,
+                    )
+                    q_output_storage.view(torch.uint8).fill_(0xA5)
+                    expected_q_storage = q_output_storage.view(torch.uint8).clone()
+                    q_fp8 = q_output_storage[:, :NUM_HEADS, : KV_LORA_RANK + ROPE_DIM]
 
-                # Pad the output head/feature storage. Bytes outside the
-                # 512-wide q-nope prefix must not be touched; the reduced
-                # FlashInfer launch fills the tail.
-                output_storage = torch.empty(
-                    (num_tokens, NUM_HEADS + 3, KV_LORA_RANK + ROPE_DIM + 16),
-                    device=DEVICE,
-                    dtype=FP8_DTYPE,
-                )
-                output_storage.view(torch.uint8).fill_(0xA5)
-                expected_storage = output_storage.view(torch.uint8).clone()
-                q_fp8 = output_storage[
-                    :, :NUM_HEADS, : KV_LORA_RANK + ROPE_DIM
-                ]
+                    k_output_storage = torch.empty(
+                        (num_tokens, KV_LORA_RANK + 16),
+                        device=DEVICE,
+                        dtype=FP8_DTYPE,
+                    )
+                    k_output_storage.view(torch.uint8).fill_(0x5A)
+                    expected_k_storage = k_output_storage.view(torch.uint8).clone()
+                    k_fp8 = k_output_storage[:, :KV_LORA_RANK]
 
-                expected_nope = q_nope.to(FP8_DTYPE)
-                expected_storage[
-                    :, :NUM_HEADS, :KV_LORA_RANK
-                ].copy_(_fp8_bytes(expected_nope))
+                    expected_q_storage[:, :NUM_HEADS, :KV_LORA_RANK].copy_(
+                        _fp8_bytes(q_nope.to(FP8_DTYPE))
+                    )
+                    expected_k_storage[:, :KV_LORA_RANK].copy_(
+                        _fp8_bytes(k_nope.to(FP8_DTYPE))
+                    )
 
-                cast_q_nope_to_fp8(q_fp8, q_nope)
-                torch.cuda.synchronize()
+                    cast_qk_nope_to_fp8(
+                        q_fp8,
+                        q_nope,
+                        k_fp8,
+                        k_nope,
+                        enable_pdl=enable_pdl,
+                    )
+                    torch.cuda.synchronize()
 
-                self.assertTrue(
-                    torch.equal(output_storage.view(torch.uint8), expected_storage),
-                    "cast must write exactly the active q-nope prefix",
-                )
+                    self.assertTrue(
+                        torch.equal(
+                            q_output_storage.view(torch.uint8), expected_q_storage
+                        ),
+                        "cast must write exactly the active q-nope prefix",
+                    )
+                    self.assertTrue(
+                        torch.equal(
+                            k_output_storage.view(torch.uint8), expected_k_storage
+                        ),
+                        "cast must write exactly the active k-nope row",
+                    )
+
+    def test_qk_nope_cast_matches_all_bf16_bit_patterns(self):
+        from sglang.kernels.jit.utils import is_arch_support_pdl
+        from sglang.kernels.ops.kvcache.cache_ops import cast_qk_nope_to_fp8
+
+        # Two production-shaped tokens contain exactly all 2^16 BF16 bit
+        # patterns, including zeros, subnormals, rounding boundaries, infinities,
+        # and NaNs. This locks down the byte-level conversion contract.
+        bf16_values = (
+            torch.arange(1 << 16, device=DEVICE, dtype=torch.int32)
+            .to(torch.uint16)
+            .view(DTYPE)
+        )
+        q_nope = bf16_values.view(NUM_HEADS, 2, KV_LORA_RANK).transpose(0, 1)
+        k_nope = bf16_values[: 2 * KV_LORA_RANK].view(2, KV_LORA_RANK)
+        q_fp8 = torch.empty(
+            (2, NUM_HEADS, KV_LORA_RANK + ROPE_DIM),
+            device=DEVICE,
+            dtype=FP8_DTYPE,
+        )
+        k_fp8 = torch.empty_like(k_nope, dtype=FP8_DTYPE)
+
+        cast_qk_nope_to_fp8(
+            q_fp8,
+            q_nope,
+            k_fp8,
+            k_nope,
+            enable_pdl=is_arch_support_pdl(),
+        )
+        torch.cuda.synchronize()
+
+        self.assertTrue(
+            torch.equal(
+                _fp8_bytes(q_fp8[..., :KV_LORA_RANK]),
+                _fp8_bytes(q_nope.to(FP8_DTYPE)),
+            )
+        )
+        self.assertTrue(
+            torch.equal(_fp8_bytes(k_fp8), _fp8_bytes(k_nope.to(FP8_DTYPE)))
+        )
 
     def test_split_helper_is_byte_identical_to_flashinfer_helper(self):
         from sglang.kernels.ops.attention.utils import (
@@ -141,9 +198,7 @@ class TestMlaSplitQuantizeRopeFp8(CustomTestCase):
 
         cos_sin_cache = _make_cos_sin_cache(max_position=1024)
         for num_tokens in (1, 37):
-            q_nope, q_rope, k_nope, k_rope = _make_production_strided_inputs(
-                num_tokens
-            )
+            q_nope, q_rope, k_nope, k_rope = _make_production_strided_inputs(num_tokens)
             pos_ids = (
                 torch.arange(num_tokens, device=DEVICE, dtype=torch.int64) * 17 + 3
             ) % cos_sin_cache.shape[0]
@@ -186,6 +241,136 @@ class TestMlaSplitQuantizeRopeFp8(CustomTestCase):
                         ),
                         "split q-nope prefix must use the exact BF16-to-FP8 cast",
                     )
+
+    def test_split_helper_pdl_chain_to_kv_writer(self):
+        from sglang.kernels.jit.utils import is_arch_support_pdl
+        from sglang.kernels.ops.attention.utils import (
+            mla_split_quantize_and_rope_for_fp8,
+        )
+        from sglang.kernels.ops.kvcache.set_mla_kv_buffer import set_mla_kv_buffer
+
+        if not is_arch_support_pdl():
+            self.skipTest("PDL requires SM90 or newer")
+
+        num_tokens = 768
+        q_nope, q_rope, k_nope, k_rope = _make_production_strided_inputs(num_tokens)
+        cos_sin_cache = _make_cos_sin_cache(max_position=1024)
+        pos_ids = torch.arange(num_tokens, device=DEVICE, dtype=torch.int64)
+
+        _, k_nope_fp8, k_rope_fp8 = mla_split_quantize_and_rope_for_fp8(
+            q_nope,
+            q_rope,
+            k_nope,
+            k_rope,
+            pos_ids,
+            cos_sin_cache,
+            False,
+            KV_LORA_RANK,
+            ROPE_DIM,
+        )
+        kv_buffer = torch.empty(
+            (num_tokens, KV_LORA_RANK + ROPE_DIM),
+            device=DEVICE,
+            dtype=FP8_DTYPE,
+        )
+        loc = torch.arange(num_tokens, device=DEVICE, dtype=torch.int64)
+
+        # Launch the real PDL-aware TMA cache writer immediately, with no
+        # synchronization between the split helper and this dependent read.
+        set_mla_kv_buffer(kv_buffer, loc, k_nope_fp8, k_rope_fp8)
+        torch.cuda.synchronize()
+
+        expected = torch.cat((k_nope_fp8, k_rope_fp8), dim=-1)
+        self.assert_fp8_bytes_equal(kv_buffer, expected, "packed_kv")
+
+    def test_split_dispatch_policy(self):
+        from sglang.srt.layers.attention.dsa_backend import (
+            DeepseekSparseAttnBackend,
+        )
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.device_capability = (10, 3)
+        backend.kv_lora_rank = KV_LORA_RANK
+        backend.qk_rope_head_dim = ROPE_DIM
+
+        def should_use(
+            *,
+            num_tokens=4096,
+            num_heads=NUM_HEADS,
+            nope_dim=KV_LORA_RANK,
+            rope_dim=ROPE_DIM,
+            mode=ForwardMode.EXTEND,
+            is_prefill=True,
+        ):
+            q = torch.empty(
+                (num_tokens, num_heads, nope_dim), device="meta", dtype=DTYPE
+            )
+            q_rope = torch.empty(
+                (num_tokens, num_heads, rope_dim), device="meta", dtype=DTYPE
+            )
+            return backend._should_use_trtllm_split_rope_quantize(
+                q, q_rope, mode, is_prefill
+            )
+
+        self.assertFalse(should_use(num_tokens=4095))
+        self.assertTrue(should_use(num_tokens=4096))
+        self.assertTrue(should_use(mode=ForwardMode.MIXED))
+
+        for mode in (
+            ForwardMode.DECODE,
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND_V2,
+            ForwardMode.SPLIT_PREFILL,
+            ForwardMode.DLLM_EXTEND,
+        ):
+            with self.subTest(mode=mode):
+                self.assertFalse(should_use(mode=mode))
+
+        self.assertFalse(should_use(is_prefill=False))
+        self.assertFalse(should_use(num_heads=32))
+        self.assertFalse(should_use(nope_dim=256))
+        self.assertFalse(should_use(rope_dim=32))
+
+        scalar = torch.empty((), device="meta", dtype=DTYPE)
+        valid_q = torch.empty(
+            (4096, NUM_HEADS, KV_LORA_RANK), device="meta", dtype=DTYPE
+        )
+        valid_q_rope = torch.empty(
+            (4096, NUM_HEADS, ROPE_DIM), device="meta", dtype=DTYPE
+        )
+        self.assertFalse(
+            backend._should_use_trtllm_split_rope_quantize(
+                scalar, valid_q_rope, ForwardMode.EXTEND, True
+            )
+        )
+        mismatched_q_rope = torch.empty(
+            (4095, NUM_HEADS, ROPE_DIM), device="meta", dtype=DTYPE
+        )
+        self.assertFalse(
+            backend._should_use_trtllm_split_rope_quantize(
+                valid_q, mismatched_q_rope, ForwardMode.EXTEND, True
+            )
+        )
+
+        backend.kv_lora_rank = 256
+        self.assertFalse(should_use())
+        backend.kv_lora_rank = KV_LORA_RANK
+        backend.qk_rope_head_dim = 32
+        self.assertFalse(should_use())
+        backend.qk_rope_head_dim = ROPE_DIM
+
+        for capability, num_tokens, expected in (
+            ((10, 0), 4096, False),
+            ((10, 0), 8192, True),
+            ((10, 3), 4096, True),
+            ((9, 0), 8192, False),
+            ((10, 1), 8192, False),
+            ((11, 0), 8192, False),
+        ):
+            with self.subTest(capability=capability, num_tokens=num_tokens):
+                backend.device_capability = capability
+                self.assertEqual(should_use(num_tokens=num_tokens), expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

On GLM-5.2 NVFP4 with TRTLLM DSA prefill, the fused `RopeQuantize` path also processes the large 512-wide no-RoPE Q component. At the DP8 prefill shape this is bandwidth-expensive; splitting no-RoPE conversion from the 64-wide RoPE work reduces kernel time once the local token count is large enough.

## Modifications

- Add a Triton kernel that casts the Q and K no-RoPE components from BF16 to FP8 in one launch, while FlashInfer handles only the RoPE components.
- Preserve the fused path's FP8 output byte-for-byte and chain the split work with PDL.
- Enable the split path automatically for TRTLLM DSA `EXTEND`/`MIXED` prefill at the production shape: >=4K local tokens on B300 (SM103) and >=8K on B200 (SM100). Smaller or unsupported shapes keep the existing path; no environment flag is required.
- Add coverage for strided inputs/outputs, all BF16 bit patterns, byte identity, PDL handoff to the KV writer, and dispatch thresholds.

## Accuracy Tests

GLM-5.2 NVFP4 GSM8K, `max_tokens=4096`:

| Revision | Accuracy |
|---|---:|
| main | 95% |
| this PR | 95% |

## Speed Tests and Profiling

B300, production Q/K strides and local token counts:

| Local tokens | Fused | Split | Speedup |
|---:|---:|---:|---:|
| 2K | 54.3 us | 55.0 us | 0.99x |
| 4K | 99.3 us | 85.0 us | 1.17x |
| 8K | 189.4 us | 156.3 us | 1.21x |

The 2K case is intentionally gated off. Across five profiled prefill steps, RoPE/quantization time decreased from 33.38 ms to 25.80 ms (-22.7%).

End-to-end TTFT, GLM-5.2 NVFP4, B300 TP8/DP8/EP8, radix cache disabled, OSL=1, 8 warmups per shape, 16 measured requests, concurrency=1:

| ISL | Fused TTFT | Split TTFT | Improvement |
|---:|---:|---:|---:|
| 4K | 435.23 ms | 433.36 ms | 0.43% |
| 8K | 639.48 ms | 636.01 ms | 0.54% |
| 16K | 1103.97 ms | 1096.92 ms | 0.64% |
| 64K | 4061.20 ms | 4048.44 ms | 0.31% |

The smaller end-to-end gain is expected because RoPE/quantization is only a small portion of total prefill latency.

## Checklist

- [x] Format your code according to the [Format Code Using pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-using-pre-commit).
- [x] Add unit tests according to the [Test the Change](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-change).
- [x] Update documentation as needed. (N/A: internal kernel dispatch)
- [x] Provide accuracy and speed results.
- [x] Follow the SGLang code style.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31725140348](https://github.com/sgl-project/sglang/actions/runs/31725140348)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31725140050](https://github.com/sgl-project/sglang/actions/runs/31725140050)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->