### PR TITLE
[DSpark] Fix EP1 decode performance regression

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -49,6 +49,14 @@ _DRAFT_PROBS = Invariant(
 )
 
 
+def _make_num_token_non_padded(
+    num_tokens: int, device: str | torch.device
+) -> Optional[torch.Tensor]:
+    if not enable_num_token_non_padded():
+        return None
+    return torch.tensor(num_tokens, dtype=torch.int32, device=device)
+
+
 class DraftBlockResult(msgspec.Struct, frozen=True):
     draft_tokens: torch.Tensor
     corrected_logits: Optional[torch.Tensor]
@@ -355,9 +363,7 @@ class DraftBlockProposer:
             spec_algorithm=SpeculativeAlgorithm.DSPARK,
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
-            num_token_non_padded=torch.tensor(
-                draft_num_tokens, dtype=torch.int32, device=device
-            ),
+            num_token_non_padded=_make_num_token_non_padded(draft_num_tokens, device),
             num_token_non_padded_cpu=draft_num_tokens,
         )
         self._fill_dp_moe_sync_metadata(draft_forward_batch, batch)

--- a/test/registered/spec/dspark/test_dspark_dp_tier.py
+++ b/test/registered/spec/dspark/test_dspark_dp_tier.py
@@ -5,10 +5,7 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.srt.speculative.dspark_components.dspark_draft import (
-    DraftBlockProposer,
-    _make_num_token_non_padded,
-)
+from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
 from sglang.srt.speculative.dspark_components.dspark_planner import (
     dp_global_verify_tier_num_tokens,
     local_verify_tier_num_tokens,
@@ -88,25 +85,6 @@ class TestDraftDpSyncMetadata(CustomTestCase):
         self.assertEqual(forward_batch.num_token_non_padded.dtype, torch.int32)
         self.assertEqual(forward_batch.num_token_non_padded_cpu, 6)
         self.assertTrue(forward_batch.can_run_dp_cuda_graph)
-
-
-class TestDraftForwardNumTokenNonPadded(CustomTestCase):
-    def test_omits_device_scalar_without_token_padding(self):
-        with patch(
-            "sglang.srt.speculative.dspark_components.dspark_draft.enable_num_token_non_padded",
-            return_value=False,
-        ):
-            self.assertIsNone(_make_num_token_non_padded(2, "cpu"))
-
-    def test_preserves_device_scalar_with_token_padding(self):
-        with patch(
-            "sglang.srt.speculative.dspark_components.dspark_draft.enable_num_token_non_padded",
-            return_value=True,
-        ):
-            num_token_non_padded = _make_num_token_non_padded(2, "cpu")
-
-        self.assertEqual(num_token_non_padded.item(), 2)
-        self.assertEqual(num_token_non_padded.dtype, torch.int32)
 
 
 class TestBusyIdleGraphKeyIdentity(CustomTestCase):

--- a/test/registered/spec/dspark/test_dspark_dp_tier.py
+++ b/test/registered/spec/dspark/test_dspark_dp_tier.py
@@ -5,7 +5,10 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.srt.speculative.dspark_components.dspark_draft import DraftBlockProposer
+from sglang.srt.speculative.dspark_components.dspark_draft import (
+    DraftBlockProposer,
+    _make_num_token_non_padded,
+)
 from sglang.srt.speculative.dspark_components.dspark_planner import (
     dp_global_verify_tier_num_tokens,
     local_verify_tier_num_tokens,
@@ -85,6 +88,25 @@ class TestDraftDpSyncMetadata(CustomTestCase):
         self.assertEqual(forward_batch.num_token_non_padded.dtype, torch.int32)
         self.assertEqual(forward_batch.num_token_non_padded_cpu, 6)
         self.assertTrue(forward_batch.can_run_dp_cuda_graph)
+
+
+class TestDraftForwardNumTokenNonPadded(CustomTestCase):
+    def test_omits_device_scalar_without_token_padding(self):
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_draft.enable_num_token_non_padded",
+            return_value=False,
+        ):
+            self.assertIsNone(_make_num_token_non_padded(2, "cpu"))
+
+    def test_preserves_device_scalar_with_token_padding(self):
+        with patch(
+            "sglang.srt.speculative.dspark_components.dspark_draft.enable_num_token_non_padded",
+            return_value=True,
+        ):
+            num_token_non_padded = _make_num_token_non_padded(2, "cpu")
+
+        self.assertEqual(num_token_non_padded.item(), 2)
+        self.assertEqual(num_token_non_padded.dtype, torch.int32)
 
 
 class TestBusyIdleGraphKeyIdentity(CustomTestCase):


### PR DESCRIPTION
## Motivation

#33465 made `DraftBlockProposer` construct a CUDA `int32` scalar on every speculative decoding step.

`num_token_non_padded` is only consumed when `enable_num_token_non_padded()` is true. For MoE EP size 1, the predicate is false, so the device allocation is unused.

## Modifications

- Return `None` instead of constructing the device scalar when token padding is disabled.
- Preserve the existing `int32` device scalar when token padding is enabled.
- Add unit coverage for both paths.

## Accuracy Tests

This does not change model arithmetic. The focused test verifies:

- The disabled path returns `None`.
- The enabled path preserves the existing scalar value and `torch.int32` dtype.

Passed during the Linux image build:

```bash
uv run --no-project python test/registered/spec/dspark/test_dspark_dp_tier.py
```

The changed files also pass the repository-pinned Black, Ruff, and isort checks.

## Speed Tests and Profiling

Hardware and workload:

- 2× RTX PRO 6000 Blackwell (SM120), TP2
- DeepSeek-V4-Flash-0731 with DSpark
- Fixed 16,384-token inputs
- 2,048 requested output tokens
- Temperature 0
- 128 scheduler steps per capture
- Mean timeline duration across both ranks

All step times are milliseconds per scheduler step; lower is faster. The final column is the reduction from the after-#33465 control to the fixed build.

| C | Before #33465 | After #33465 | Fixed | Step-time reduction |
|---:|---:|---:|---:|---:|
| 1 | 14.744 ms | 15.681 ms | 14.605 ms | 6.86% |
| 8 | 32.979 ms | 35.399 ms | 32.119 ms | 9.27% |

The post-fix capture used the same post-#33465 source stack, launch configuration, and fixed token inputs as the post-#33465 control, with only this patch added.

Every capture retained 127 complete target-plus-draft graph replay pairs. Graph kernel counts were identical between corresponding controls.

## Checklist

- [x] Format the changed files with the repository-pinned tools.
- [x] Add focused unit tests.
- [x] Provide matched profiling results.
- [x] Follow the SGLang code-style guidance.
- [x] Documentation is not required for this internal allocation change.

Prepared with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31754996272](https://github.com/sgl-project/sglang/actions/runs/31754996272)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31754996074](https://github.com/sgl-project/sglang/actions/runs/31754996074)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->