### PR TITLE
Fix Mamba state donation misalignment in unified radix cache under DCP

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -218,7 +218,9 @@ class MambaComponent(TreeComponent):
         result: InsertResult,
         cache_actions: list[CacheAction | ComponentAction],
     ) -> None:
-        assert params.mamba_value is not None
+        if params.mamba_value is None:
+            result.mamba_exist = True
+            return
         if is_new_leaf:
             node.component_data[self.component_type].value = params.mamba_value
             self.tree_core.lru_lists[self.component_type].insert_mru(node)
@@ -524,6 +526,10 @@ class MambaComponent(TreeComponent):
     ) -> Optional[int]:
         if self.cache.enable_mamba_extra_buffer:
             cache_len = req.mamba_last_track_seqlen
+            if cache_len is not None and cache_len % self.cache.page_size != 0:
+                if is_finished:
+                    return None
+                return cache_len - cache_len % self.cache.page_size
         else:
             cache_len = token_ids_len
             # ReplaySSM (no_buffer): `temporal[slot]` lags the live state by the

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -704,6 +704,10 @@ class UnifiedRadixCache(BasePrefixCache):
             ).page_aligned(self.page_size)
             page_aligned_len = len(radix_key)
             values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
+            assert (
+                insert_params.mamba_value is None
+                or page_aligned_len == effective_cache_len
+            ), f"{page_aligned_len=}, {effective_cache_len=}, {req.mamba_last_track_seqlen=}"
 
             insert_params.key = radix_key
             insert_params.value = values
@@ -797,6 +801,9 @@ class UnifiedRadixCache(BasePrefixCache):
         ).page_aligned(self.page_size)
         page_aligned_len = len(radix_key)
         values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
+        assert (
+            insert_params.mamba_value is None or page_aligned_len == effective_cache_len
+        ), f"{page_aligned_len=}, {effective_cache_len=}, {req.mamba_last_track_seqlen=}"
 
         insert_params.key = radix_key
         insert_params.value = values


### PR DESCRIPTION
## Motivation

# DO NOT MERGE, There's an ISSUE

On hybrid linear-attention models (e.g. Kimi-K3, 69 KDA + 24 MLA layers) served with `--dcp-size > 1` and the Mamba radix cache (`--mamba-radix-cache-strategy extra_buffer`), resuming a request from a cached prefix produces logits that **deterministically diverge** from a fresh prefill of the same token sequence (per-token |dlogprob| up to 6.9, 157/1081 positions with |dlp| > 2 in our repro), starting exactly at the resume boundary and decaying over the following ~700 tokens.

Root cause: DCP widens the tree page to `allocator_page_size * dcp_size`, but the Mamba state-tracking grid is not widened. On insert, the radix key is floored to the widened page while the donated recurrent state still encodes `mamba_last_track_seqlen` (`S`) tokens, so a state can hang up to `tree_page - 1` tokens ahead of its node (384 in our measurements). The match side trusts node depth == state depth, so on a warm hit the tokens in between are fed through the linear-attention layers a second time (double-counted in the recurrent state). Without DCP the two grids coincide, which is why the bug is DCP-only. The legacy `mamba_radix_cache.py` had `assert cache_len == page_aligned_len` guarding exactly this; the unified-cache path lost it.

## Modifications

- `MambaComponent.prepare_for_caching_req` (extra_buffer branch): skip the Mamba donation when `mamba_last_track_seqlen` is not aligned to the tree page. Finished requests insert a KV-only node; unfinished chunked handoffs clamp `effective_cache_len` to the last aligned boundary. The existing consensus clamp then falls back to the previous aligned Mamba node and recomputes the gap, restoring bit-exactness.
- `MambaComponent.commit_insert_component_data`: handle Mamba-less inserts (previously `assert params.mamba_value is not None`).
- Restore the legacy invariant at both insert sites in `unified_radix_cache.py`: any insert carrying a Mamba value must satisfy `page_aligned_len == effective_cache_len`, so this class of misalignment fails loudly in the future.

No behavior change without DCP (donations are always aligned there). Reuse density under DCP is the same as widening the track grid to the tree page would give.

## Verification

8xB300, Kimi-K3, sglang `fad376d3ee` + this patch. Warm-vs-cold teacher-forced logprob comparison on a real 161,167-token multi-turn prompt (+683-token continuation): cold = flush_cache then score the full sequence via `/generate` with `return_logprob`; warm = flush_cache, prefill the prompt alone, then score the full sequence (cache-resume path).

| config | before | after |
|---|---|---|
| `--tp-size 8 --dcp-size 8`, resume boundary | 289/1081 positions dlp>0.5, 157 dlp>2, max 6.9 | **0 / 0**, resume falls back to last aligned checkpoint (`cached_tokens` 160768 -> 147456) |
| same, earlier boundary (window 13.9K) | — | 0 / 0 |
| no DCP (regression) | 0 / 0 | 0 / 0 |

Server logs clean (no new asserts/tracebacks) in all runs.

<details><summary>Full analysis & reproduction write-up (instrumented root-cause report)</summary>

# [Bug] DCP (`--dcp-size > 1`) + prefix-cache resume produces deterministic logprob divergence on hybrid-Mamba models (Kimi-K3)

## Summary

On a hybrid linear-attention model (Kimi-K3: 69 KDA + 24 MLA layers) served with
`--dcp-size 8` and the Mamba radix cache (`--mamba-radix-cache-strategy extra_buffer`),
**resuming a request from a cached prefix produces logits that deterministically diverge
from a fresh full prefill of the same token sequence**. The divergence is large
(per-token |Δlogprob| up to **6.9**, 157 of 1081 positions with |Δlp| > 2), starts exactly
at the cache-resume boundary, decays over the following ~700 tokens, and is **bit-identical
across repeated runs** — i.e. it is a structural bookkeeping defect, not nondeterminism or
bf16 reduction noise.

Removing `--dcp-size` (plain TP8, all other flags identical) makes the same experiment
**bit-exact** (0 differing positions out of 13.9K compared).

This violates the bit-exactness contract that the recently added radix-cache consistency
tests enforce (#34356, #34607) — but those tests do not cover `dcp_size > 1`.

## Environment

- sglang HEAD `fad376d3ee` (2026-08-13), image `lmsysorg/sglang:latest`
- 8× NVIDIA B300 SXM6, single node
- torch 2.13.0, flashinfer-python 0.6.17, fla-core 0.5.2, sglang-kernel 0.4.6.post1
- Model: `moonshotai/Kimi-K3` (rev `9f62e4e9`), hybrid KDA/MLA, mxfp4 routed experts
- Relevant resolved server args (from the log):
  `page_size=64` (auto: "CuteDSL MLA only supports page_size of 32 or 64"),
  `chunked_prefill_size=16384`, `mamba_track_interval=256`,
  `mamba_radix_cache_strategy='extra_buffer'`, `uses_mamba_radix_cache=True`,
  `attention_backend='flashinfer'`, `decode_attention_backend='cutedsl_mla'`,
  `prefill_attention_backend='trtllm_mla'`, `linear_attn_backend='triton'`,
  `dcp_comm_backend='a2a'`, `dcp_replicate_q_proj=True`

## Launch commands

Corrupt configuration (also reproduces with `--enable-hierarchical-cache`, results
bit-identical with/without it — hicache is not involved):

```bash
sglang serve --model-path /models/Kimi-K3 --trust-remote-code \
  --tp-size 8 --dcp-size 8 --mem-fraction-static 0.85 \
  --reasoning-parser kimi_k3 --tool-call-parser kimi_k3 \
  --mamba-full-memory-ratio 1.24 --mamba-radix-cache-strategy extra_buffer \
  --disable-overlap-schedule --port 30000
```

Clean configuration: identical except **remove `--dcp-size 8`**.

## Reproduction

Requires a long prompt (we used a real ~161K-token multi-turn agent conversation;
any prompt long enough to span several chunked-prefill boundaries should work, e.g.
≥ 32K tokens — the effect was observed with resume boundaries at ~147K–161K).

Protocol (script below):

1. `POST /flush_cache`, then score the full sequence `prompt_ids + out_ids`
   via `/generate` with `max_new_tokens=0, return_logprob=true,
   logprob_start_len=START` → **cold** per-position logprobs.
2. `POST /flush_cache`, then send `prompt_ids` alone with `max_new_tokens=1`
   (populates the radix + mamba caches), then score the full sequence again →
   **warm** (cache-resume) per-position logprobs.
3. Compare cold vs warm at identical positions.

```python
import json, time, urllib.request

URL = "http://127.0.0.1:30000"

def post(path, payload):
    req = urllib.request.Request(URL + path, data=json.dumps(payload).encode(),
                                 headers={"Content-Type": "application/json"})
    return json.loads(urllib.request.urlopen(req, timeout=3600).read())

def flush():
    urllib.request.urlopen(urllib.request.Request(
        URL + "/flush_cache", data=b"{}",
        headers={"Content-Type": "application/json"}), timeout=120).read()
    time.sleep(2)

def score(seq, start):
    m = post("/generate", {"input_ids": seq,
        "sampling_params": {"max_new_tokens": 0},
        "return_logprob": True, "logprob_start_len": start})["meta_info"]
    return ([(start + i, it[1], it[0]) for i, it in
             enumerate(m["input_token_logprobs"])
             if it is not None and it[0] is not None], m["cached_tokens"])

seq = json.load(open("long_seq.json"))      # >= ~150K token ids
plen = len(seq) - 1024                      # treat last 1024 as "output"
start = plen - 399                          # align window to resume boundary

flush(); cold, _ = score(seq, start)
flush(); post("/generate", {"input_ids": seq[:plen],
                            "sampling_params": {"max_new_tokens": 1}})
warm, cached = score(seq, start)

cm = dict((p, lp) for p, t, lp in cold)
diffs = [(p, cm[p], lp) for p, t, lp in warm if abs(lp - cm[p]) > 0.5]
print("cached_at_score:", cached, "n>0.5:", len(diffs),
      "n>2:", sum(1 for _, a, b in diffs if abs(a - b) > 2),
      "max:", max((abs(a - b) for _, a, b in diffs), default=0))
```

## Observed results

Same 161,167-token prompt + 683-token continuation, same script, three server configs.
`cached_at_score` = `meta_info.cached_tokens` of the warm scoring request.

| # | config | cached_at_score | window (rel. to resume) | n cmp | \|Δlp\|>0.5 | \|Δlp\|>2 | max \|Δlp\| |
|---|---|---|---|---|---|---|---|
| B | dcp8 + extra_buffer + hicache | 160768 | +0 … +1081 | 1081 | 289 | **157** | **6.92** |
| D | dcp8 + extra_buffer | 160768 | +0 … +1081 | 1081 | 289 | **157** | **6.92** (positions and values identical to B) |
| E | tp8 (no dcp) + extra_buffer | **147456** | +512 … +14400 (two runs) | 13881 / 13369 | **0** | **0** | 0.00 |

Additional controls, all on the corrupt config:

- **cold vs cold repeated**: max |Δlp| = 0.0 over 1630 positions — the server is
  bit-deterministic for fresh prefill; only the cache-resume path diverges.
- **warm repeated 3×** (flush → prefill → score each time): the divergence is
  bit-identical every time (same positions, same values, e.g. max 6.916 at the
  same position). Deterministic, not a race.
- Example per-position rows (corrupt config, positions are ~370 tokens after the
  resume point): cold −5.641 → warm −0.001; cold −9.504 → warm −16.420;
  cold −14.619 → warm −9.248. Both directions, i.e. not a uniform shift.
- The divergence decays with distance from the resume boundary: a window starting
  +9.6K after a resume at 147456 showed 0 diffs (consistent with the KDA
  forgetting rate washing out a wrong initial recurrent state).

## Analysis / mechanism (code-verified)

The defect is an **insert-time misalignment between the Mamba state-tracking grid
and the DCP-widened tree page**, plus a missing match-side validation:

1. **DCP widens the tree page.** `kv_cache_builder.py` sets the TreeCache page to
   `allocator_page_size * dcp_size` when DCP is on — here `64 × 8 = 512`.
2. **The Mamba checkpoint grid is not widened.** State tracking
   (`schedule_batch.py`; grid = `mamba_cache_chunk_size` =
   `max(fla_chunk=64, allocator_page_size=64) = 64` here, measured `S` values
   confirm the 64 grid on the prefill/extend path) stays on the narrow grid and
   has no DCP-awareness.
3. **Insert floors the key, not the state.** In `unified_radix_cache.py`
   (extra_buffer path), the Mamba component's `cache_len` is
   `req.mamba_last_track_seqlen` (= `S`, on the narrow grid), while the node key
   is `.page_aligned(page_size)` — floored to the widened 512 page. A KDA state
   that encodes `S` tokens of history gets attached to a node of depth
   `floor(S, 512)`, i.e. the state can be **ahead of its node by up to
   `tree_page − 1` tokens** (384 in our repro, measured). The legacy
   `mamba_radix_cache.py` had an `assert cache_len == page_aligned_len` guarding
   exactly this; the unified-cache path does not.
4. **Match side never re-checks.** The Mamba validator only tests that a node
   carries a state, not that the state's semantic depth equals the node depth. A
   warm request that hits such a node resumes with KV prefix = node depth `D`
   while the recurrent state already encodes `[0, S)`; the extend then feeds
   tokens `[D, S)` into the KDA layers **a second time** (double-counted in the
   recurrent state) → wrong logits from the resume point, decaying with the KDA
   forgetting rate.
5. Without DCP the two grids coincide (`S == D`), so the same path is bit-exact.

We confirmed the mechanism with an instrumented build (logging
`token_ids_len / effective_cache_len / page_aligned_len / mamba_last_track_seqlen`
at both insert sites in `unified_radix_cache.py`, and
`full_kv_hit_length / mamba_boundary_len` in
`MambaComponent.finalize_match_result_in_tree_core`), one warm repro per config:

**Corrupt (dcp8, tree page = 512).** Donation at the warm prefill request's
finish (prompt = 161167 tokens):

```
cache_finished insert: token_ids_len=161167 effective_cache_len=161152
                       page_aligned_len=160768 mamba_last_track=161152
```

The state is tracked at `S = floor₆₄(161167) = 161152` (64-token prefill track
grid), but the node key is floored to the DCP-widened page:
`floor₅₁₂(161152) = 160768`. **A state encoding 161152 tokens hangs on a node of
depth 160768 — misaligned by 384 tokens.** The warm scoring request then matches
it at face value:

```
match: full_kv_hit=160768 mamba_boundary=160768
```

so tokens `[160768, 161152)` are fed through the KDA layers a second time
(double-counted in the recurrent state) — divergence onset exactly at 160768,
as observed.

**Clean (tp8, tree page = 64).** The same donation is aligned
(`page_aligned_len = 161152 = mamba_last_track`), and the warm scoring request
logs:

```
match: full_kv_hit=160768 mamba_boundary=147456
```

Full-KV also matches 160768 tokens (a partial-edge match into the
`147456 → 161152` edge), but the partial match never reaches the node carrying
the state, so the Mamba boundary falls back to the last chunked-prefill handoff
donation at `147456 = 9 × 16384`. The consensus clamp resumes everything from
147456 and recomputes the gap → bit-exact, with `cached_tokens = 147456` as
observed. All chunk-handoff donations are inherently aligned
(`16384 % 512 = 0`), which is why only the request-finish donation triggers the
bug in this repro; any other donation at an `S` not aligned to the widened page
(retraction, decode-boundary tracks) hits the same path.

So the failure needs both halves: the **insert-time floor misalignment**
(DCP-only, step 3) and the **match-side trust** that node depth == state depth
(step 4). The clean config is saved not by any depth check — there is none —
but by the grids coinciding.

Note: the existing DCP consistency test (#33112,
`test_unified_radix_cache_kl_dcp.py`) only asserts `cached_tokens` flooring to
the widened page and uses `kl_threshold=0.01`, so it cannot catch this
misalignment; #34356 / #34607 are bit-exact but do not run with `dcp_size > 1`.

## Impact

- Any hybrid-Mamba model served with `dcp_size > 1` + radix cache silently gets
  wrong logits for the first ~hundreds of tokens after every prefix-cache resume —
  which in multi-turn agent serving is nearly **every follow-up request**.
- |Δlp| up to ~7 materially reshapes the sampled distribution. With default
  sampling (Kimi-K3 ships no `temperature`/`top_p` in `generation_config.json`,
  so T=1.0 full-vocab), this measurably increases deep-tail token hits right where
  the new turn's generation begins.
- Found while investigating garbled long-context production output of a Kimi-K3
  deployment running `--dcp-size 8`. (The dominant root cause there turned out to
  be the model's own fat-tailed distribution at very long context sampled without
  top_p — but this cache-resume divergence is an independent, deterministic
  correctness defect that compounds it.)

## Suggested fixes / tests

1. Minimal fix: align Mamba checkpoint donation/validation to
   `lcm(mamba_cache_chunk_size, tree_page)` under DCP — either widen the track
   grid to the (widened) tree page, or simply **do not attach a Mamba value when
   `S % tree_page != 0`** (the existing consensus clamp then falls back to the
   previous valid node and recomputes the gap, preserving bit-exactness at the
   cost of sparser Mamba reuse points). Note the two options are equivalent in
   reuse density — with a 64-token track grid and a 512 tree page, both keep
   exactly the 1-in-8 tracks that land on widened-page boundaries — so the
   choice is about implementation surface, not cache effectiveness.
2. Restore the legacy `mamba_radix_cache.py` invariant
   (`assert cache_len == page_aligned_len`) in the unified-cache insert path so
   this class of misalignment fails loudly.
3. Extend the bit-exact radix-cache consistency tests (#34356 hicache logprob
   test, #34607 unified radix KL test) to run with `dcp_size > 1`, and tighten
   #33112 beyond `kl_threshold=0.01` at resume points that are not aligned to
   the widened page.

## Related

- #29792 [HiCache] Fix Mamba track-boundary bookkeeping under overlap scheduling
  (same bug family, different variant)
- #33639 [Hicache] Support Mamba branching in Unified Radix Cache with HiCache
- #33112 DCP consistency test `test_unified_radix_cache_kl_dcp.py`
  (kl_threshold=0.01 — cannot detect this misalignment)
- #34356 bit-exact hicache logprob-consistency test (no `dcp_size > 1` coverage)
- #34607 bit-exact unified radix cache KL test for hybrid SWA + mamba
  (no `dcp_size > 1` coverage)
- #34161 fix: preserve GQA head mapping in Triton DCP prefill

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31733692840](https://github.com/sgl-project/sglang/actions/runs/31733692840)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31733692453](https://github.com/sgl-project/sglang/actions/runs/31733692453)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->