### PR TITLE
[AMD][CI] Restore gfx942 Grok-1 INT4 and Grok-2 schedules

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -41,7 +41,7 @@ on:
           - nightly-2-gpu-mi35x-glm51-mxfp4-rocm720
           # 2-GPU DeepSeek-R1-MXFP4 TP2 (MI35x only)
           - nightly-2-gpu-mi35x-deepseek-r1-mxfp4-tp2-rocm720
-          # 8-GPU GPT-OSS (MI30x + MI35x)
+          # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
           - nightly-accuracy-8-gpu-rocm720
           - nightly-accuracy-8-gpu-mi35x-rocm720
           # 8-GPU Grok1-INT4 (MI30x + MI35x)
@@ -465,7 +465,7 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU GPT-OSS (MI30x + MI35x)
+  # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
   # ==============================================================================
 
   nightly-accuracy-8-gpu-rocm720:
@@ -2077,7 +2077,7 @@ jobs:
       - nightly-4-gpu-rocm720
       - nightly-2-gpu-mi35x-glm51-mxfp4-rocm720
       - nightly-2-gpu-mi35x-deepseek-r1-mxfp4-tp2-rocm720
-      # 8-GPU GPT-OSS (MI30x + MI35x)
+      # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
       - nightly-accuracy-8-gpu-rocm720
       - nightly-accuracy-8-gpu-mi35x-rocm720
       # 8-GPU Grok1-INT4 (MI30x + MI35x)

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -44,9 +44,11 @@ on:
           # 8-GPU GPT-OSS (MI30x + MI35x)
           - nightly-accuracy-8-gpu-rocm720
           - nightly-accuracy-8-gpu-mi35x-rocm720
-          # 8-GPU Grok1-INT4 (MI35x)
+          # 8-GPU Grok1-INT4 (MI30x + MI35x)
+          - nightly-8-gpu-grok1-int4-rocm720
           - nightly-8-gpu-mi35x-grok1-int4-rocm720
-          # 8-GPU Grok2 (MI35x)
+          # 8-GPU Grok2 (MI30x + MI35x)
+          - nightly-8-gpu-grok2-rocm720
           - nightly-8-gpu-mi35x-grok2-rocm720
           # 8-GPU DeepSeek-V3.x (MI30x)
           - nightly-8-gpu-deepseek-v31-rocm720
@@ -533,8 +535,53 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU Grok1-INT4 (MI35x)
+  # 8-GPU Grok1-INT4 (MI30x + MI35x)
   # ==============================================================================
+
+  nightly-8-gpu-grok1-int4-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok1-int4-rocm720,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Accuracy Test ROCm 7.2 (8-GPU Grok1-INT4)
+        timeout-minutes: 60
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-grok1-int4 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test ROCm 7.2 (8-GPU Grok1-INT4)
+        timeout-minutes: 60
+        continue-on-error: true
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-grok1-int4 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
 
   nightly-8-gpu-mi35x-grok1-int4-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-grok1-int4-rocm720,'))
@@ -585,8 +632,53 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU Grok2 (MI35x)
+  # 8-GPU Grok2 (MI30x + MI35x)
   # ==============================================================================
+
+  nightly-8-gpu-grok2-rocm720:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok2-rocm720,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (ROCm 7.2)
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm720
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Accuracy Test ROCm 7.2 (8-GPU Grok2)
+        timeout-minutes: 60
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-grok2 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test ROCm 7.2 (8-GPU Grok2)
+        timeout-minutes: 60
+        continue-on-error: true
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-grok2 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
 
   nightly-8-gpu-mi35x-grok2-rocm720:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-grok2-rocm720,'))
@@ -1988,9 +2080,11 @@ jobs:
       # 8-GPU GPT-OSS (MI30x + MI35x)
       - nightly-accuracy-8-gpu-rocm720
       - nightly-accuracy-8-gpu-mi35x-rocm720
-      # 8-GPU Grok1-INT4 (MI35x)
+      # 8-GPU Grok1-INT4 (MI30x + MI35x)
+      - nightly-8-gpu-grok1-int4-rocm720
       - nightly-8-gpu-mi35x-grok1-int4-rocm720
-      # 8-GPU Grok2 (MI35x)
+      # 8-GPU Grok2 (MI30x + MI35x)
+      - nightly-8-gpu-grok2-rocm720
       - nightly-8-gpu-mi35x-grok2-rocm720
       # 8-GPU DeepSeek-V3.x (MI30x)
       - nightly-8-gpu-deepseek-v31-rocm720

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -41,7 +41,7 @@ on:
           - nightly-2-gpu-mi35x-glm51-mxfp4
           # 2-GPU DeepSeek-R1-MXFP4 TP2 (MI35x only)
           - nightly-2-gpu-mi35x-deepseek-r1-mxfp4-tp2
-          # 8-GPU GPT-OSS (MI30x + MI35x)
+          # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
           - nightly-accuracy-8-gpu
           - nightly-accuracy-8-gpu-mi35x
           # 8-GPU Grok1-INT4 (MI30x + MI35x)
@@ -469,7 +469,7 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU GPT-OSS (MI30x + MI35x)
+  # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
   # ==============================================================================
 
   nightly-accuracy-8-gpu:
@@ -1884,7 +1884,7 @@ jobs:
       - nightly-4-gpu
       - nightly-2-gpu-mi35x-glm51-mxfp4
       - nightly-2-gpu-mi35x-deepseek-r1-mxfp4-tp2
-      # 8-GPU GPT-OSS (MI30x + MI35x)
+      # 8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)
       - nightly-accuracy-8-gpu
       - nightly-accuracy-8-gpu-mi35x
       # 8-GPU Grok1-INT4 (MI30x + MI35x)

--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -44,9 +44,11 @@ on:
           # 8-GPU GPT-OSS (MI30x + MI35x)
           - nightly-accuracy-8-gpu
           - nightly-accuracy-8-gpu-mi35x
-          # 8-GPU Grok1-INT4 (MI35x)
+          # 8-GPU Grok1-INT4 (MI30x + MI35x)
+          - nightly-8-gpu-grok1-int4
           - nightly-8-gpu-mi35x-grok1-int4
-          # 8-GPU Grok2 (MI35x)
+          # 8-GPU Grok2 (MI30x + MI35x)
+          - nightly-8-gpu-grok2
           - nightly-8-gpu-mi35x-grok2
           # 8-GPU DeepSeek-V3.x (MI30x)
           - nightly-8-gpu-deepseek-v31
@@ -536,8 +538,53 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU Grok1-INT4 (MI35x)
+  # 8-GPU Grok1-INT4 (MI30x + MI35x)
   # ==============================================================================
+
+  nightly-8-gpu-grok1-int4:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok1-int4,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Accuracy Test (8-GPU Grok1-INT4)
+        timeout-minutes: 60
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-grok1-int4 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test (8-GPU Grok1-INT4)
+        timeout-minutes: 60
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-grok1-int4 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
 
   nightly-8-gpu-mi35x-grok1-int4:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-grok1-int4,'))
@@ -588,8 +635,53 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU Grok2 (MI35x)
+  # 8-GPU Grok2 (MI30x + MI35x)
   # ==============================================================================
+
+  nightly-8-gpu-grok2:
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-grok2,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Accuracy Test (8-GPU Grok2)
+        timeout-minutes: 60
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-grok2 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Performance Test (8-GPU Grok2)
+        timeout-minutes: 60
+        continue-on-error: true  # Perf test failure doesn't fail the job if accuracy passed
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e RCCL_MSCCL_ENABLE=0 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-grok2 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
 
   nightly-8-gpu-mi35x-grok2:
     if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-grok2,'))
@@ -1795,9 +1887,11 @@ jobs:
       # 8-GPU GPT-OSS (MI30x + MI35x)
       - nightly-accuracy-8-gpu
       - nightly-accuracy-8-gpu-mi35x
-      # 8-GPU Grok1-INT4 (MI35x)
+      # 8-GPU Grok1-INT4 (MI30x + MI35x)
+      - nightly-8-gpu-grok1-int4
       - nightly-8-gpu-mi35x-grok1-int4
-      # 8-GPU Grok2 (MI35x)
+      # 8-GPU Grok2 (MI30x + MI35x)
+      - nightly-8-gpu-grok2
       - nightly-8-gpu-mi35x-grok2
       # 8-GPU DeepSeek-V3.x (MI30x)
       - nightly-8-gpu-deepseek-v31


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Follow up to merged [#34643](https://github.com/sgl-project/sglang/pull/34643). Keep the gfx942/MI30x Grok-1 INT4 and Grok-2 scheduled jobs; only Grok-1 FP8 should remain removed on gfx942.

Combined with #34643, the net difference from the pre-#34643 workflows is therefore just the removal of the Grok-1 FP8 step embedded in the MI30x GPT-OSS job.

## Modifications

In both AMD nightly workflows:

- restore the gfx942 Grok-1 INT4 accuracy+performance job
- restore the gfx942 Grok-2 accuracy+performance job
- restore their `workflow_dispatch` options and `check-all-jobs` dependencies
- keep the Grok-1 FP8 embedded step removed, and drop only that clause from the GPT-OSS section comment

Affected files:

- `.github/workflows/nightly-test-amd-rocm720.yml`
- `.github/workflows/nightly-test-amd.yml`

MI35x jobs and all test files are unchanged.

### Verified net effect versus pre-#34643 main

`#34643` was the only commit to touch these two workflows since then, so the diff below is the exact combined effect of both PRs. Per workflow it is:

- the 9-line `Accuracy Test (8-GPU Grok1-FP8)` step removed from the MI30x GPT-OSS job
- three section comments changed from `8-GPU GPT-OSS (MI30x mixes Grok1-FP8; MI35x mixes Qwen3-Coder-Next)` to `8-GPU GPT-OSS (MI35x mixes Qwen3-Coder-Next)`

Nothing else differs. Mechanically checked against pre-#34643:

| Check | Result |
|---|---|
| Jobs added / removed | none / none |
| Job bodies changed | only `nightly-accuracy-8-gpu[-rocm720]` (the Grok-1 FP8 step) |
| Grok-1 INT4 and Grok-2 blocks | byte-identical |
| `job_select` options, including order | identical |
| `check-all-jobs` needs, including order | identical |
| Stale options / needs, duplicate job names | none |

### AITER Scout

`amd-aiter-scout.yml` calls these same two nightly workflows with `job_filter: all`, so its nightly AITER runs inherit the restored gfx942 Grok-1 INT4/Grok-2 coverage automatically. No separate AITER-specific job definition is needed.

### Note on Grok-1 FP8 coverage

`nightly-amd-accuracy-8-gpu-grok1-fp8` is now dispatched by no workflow, so `test_grok1_fp8_eval_amd.py` joins the already-unscheduled `test_grok1_fp8_perf.py` as registered-but-not-run. That is the intended outcome: the files stay available for manual runs and re-enablement, and only the scheduled dispatch is gone.

## Accuracy Tests

No test, model, kernel, launch configuration, or threshold changes. This restores workflow scheduling only.

Validation completed:
- workflow YAML parsing
- duplicate workflow job-name check
- registered-test validation
- codespell on both workflows
- the pre-#34643 comparison table above

## Speed Tests and Profiling

Median recent gfx942 timings (`ROCm 7.2 / ROCm 7.0`):

| Coverage restored | Accuracy | Perf | Total job |
|---|---:|---:|---:|
| Grok-1 INT4 | 11.4 / 11.9 min | 3.4 / 3.6 min | 71.4 / 70.3 min |
| Grok-2 | 15.3 / 17.9 min | 0 / 0 min | 74.8 / 41.8 min |

Grok-2 perf currently does not start because its accuracy step fails. Restoring these jobs adds approximately 34.5 GPU-hours per paired ROCm 7.0/7.2 run. The combined net saving from #34643 plus this follow-up is approximately 4.6 GPU-hours per pair, from removing only the Grok-1 FP8 steps.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pr-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fb8c607c-a213-472c-8c96-8b8150a77e6c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb8c607c-a213-472c-8c96-8b8150a77e6c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31738168930](https://github.com/sgl-project/sglang/actions/runs/31738168930)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31738168682](https://github.com/sgl-project/sglang/actions/runs/31738168682)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->