### PR TITLE
Fix FP8 MLA KV scale propagation

### DIFF
--- a/python/sglang/kernels/jit/csrc/elementwise/set_mla_kv_concat_q.cuh
+++ b/python/sglang/kernels/jit/csrc/elementwise/set_mla_kv_concat_q.cuh
@@ -14,6 +14,7 @@
 #include <dlpack/dlpack.h>
 #include <tvm/ffi/container/tensor.h>
 
+#include <cmath>
 #include <cstdint>
 #include <cuda_fp8.h>
 
@@ -328,6 +329,7 @@ struct SetMlaKVConcatQFp8Params {
   // (loc % world == rank) writes. world=1/rank=0 = identity (non-DCP).
   int32_t dcp_world_size;
   int32_t dcp_rank;
+  float quant_scale_kv;
   // Q quantize + concat side.
   const bf16_t* __restrict__ q_nope;
   const bf16_t* __restrict__ q_rope;
@@ -343,17 +345,19 @@ struct SetMlaKVConcatQFp8Params {
 };
 
 // 2x bf16 -> 2x fp8 e4m3, float-mediated cvt.rn NOSAT (matches aten: overflow -> NaN).
-SGL_DEVICE uint16_t bf16x2_to_fp8x2(const bf16x2_t v) {
+SGL_DEVICE uint16_t bf16x2_to_fp8x2(const bf16x2_t v, float scale) {
   const float2 f = __bfloat1622float2(v);
-  return __nv_cvt_float2_to_fp8x2(f, __NV_NOSAT, __NV_E4M3);
+  return __nv_cvt_float2_to_fp8x2(make_float2(f.x * scale, f.y * scale), __NV_NOSAT, __NV_E4M3);
 }
 
 // Convert 8 bf16 (one int4 load) to 8 fp8 packed in a uint2.
-SGL_DEVICE uint2 bf16x8_to_fp8x8(const int4 v) {
+SGL_DEVICE uint2 bf16x8_to_fp8x8(const int4 v, float scale) {
   const bf16x2_t* p = reinterpret_cast<const bf16x2_t*>(&v);
   uint2 out;
-  out.x = static_cast<uint32_t>(bf16x2_to_fp8x2(p[0])) | (static_cast<uint32_t>(bf16x2_to_fp8x2(p[1])) << 16);
-  out.y = static_cast<uint32_t>(bf16x2_to_fp8x2(p[2])) | (static_cast<uint32_t>(bf16x2_to_fp8x2(p[3])) << 16);
+  out.x =
+      static_cast<uint32_t>(bf16x2_to_fp8x2(p[0], scale)) | (static_cast<uint32_t>(bf16x2_to_fp8x2(p[1], scale)) << 16);
+  out.y =
+      static_cast<uint32_t>(bf16x2_to_fp8x2(p[2], scale)) | (static_cast<uint32_t>(bf16x2_to_fp8x2(p[3], scale)) << 16);
   return out;
 }
 
@@ -388,15 +392,15 @@ __global__ void set_mla_kv_concat_q_fp8_kernel(const __grid_constant__ SetMlaKVC
     // nope: 512 bf16 -> 512 fp8; 16 elems/lane (2 int4 loads -> 1 int4 store).
     {
       const int4* src = reinterpret_cast<const int4*>(nope_src);
-      uint2 lo = bf16x8_to_fp8x8(src[lane_id * 2]);
-      uint2 hi = bf16x8_to_fp8x8(src[lane_id * 2 + 1]);
+      uint2 lo = bf16x8_to_fp8x8(src[lane_id * 2], params.quant_scale_kv);
+      uint2 hi = bf16x8_to_fp8x8(src[lane_id * 2 + 1], params.quant_scale_kv);
       reinterpret_cast<int4*>(&smem[warp_in_cta][0])[lane_id] =
           make_int4(static_cast<int>(lo.x), static_cast<int>(lo.y), static_cast<int>(hi.x), static_cast<int>(hi.y));
     }
     // rope: 64 bf16 -> 64 fp8; 2 elems/lane.
     {
       const bf16x2_t v = reinterpret_cast<const bf16x2_t*>(rope_src)[lane_id];
-      reinterpret_cast<uint16_t*>(&smem[warp_in_cta][kFp8NopeDim])[lane_id] = bf16x2_to_fp8x2(v);
+      reinterpret_cast<uint16_t*>(&smem[warp_in_cta][kFp8NopeDim])[lane_id] = bf16x2_to_fp8x2(v, params.quant_scale_kv);
     }
 
     // TMA reads smem via the async proxy; fence so it can't observe stale sts.
@@ -427,14 +431,14 @@ __global__ void set_mla_kv_concat_q_fp8_kernel(const __grid_constant__ SetMlaKVC
 
     {
       const int4* src = reinterpret_cast<const int4*>(a_row);
-      uint2 lo = bf16x8_to_fp8x8(src[lane_id * 2]);
-      uint2 hi = bf16x8_to_fp8x8(src[lane_id * 2 + 1]);
+      uint2 lo = bf16x8_to_fp8x8(src[lane_id * 2], 1.0f);
+      uint2 hi = bf16x8_to_fp8x8(src[lane_id * 2 + 1], 1.0f);
       reinterpret_cast<int4*>(o_row)[lane_id] =
           make_int4(static_cast<int>(lo.x), static_cast<int>(lo.y), static_cast<int>(hi.x), static_cast<int>(hi.y));
     }
     {
       const bf16x2_t v = reinterpret_cast<const bf16x2_t*>(b_row)[lane_id];
-      reinterpret_cast<uint16_t*>(o_row + kFp8NopeDim)[lane_id] = bf16x2_to_fp8x2(v);
+      reinterpret_cast<uint16_t*>(o_row + kFp8NopeDim)[lane_id] = bf16x2_to_fp8x2(v, 1.0f);
     }
   }
 
@@ -456,7 +460,8 @@ struct SetMlaKVConcatQFp8Kernel {
       tvm::ffi::TensorView q_out,
       int64_t num_warps_per_block,
       int64_t dcp_world_size,
-      int64_t dcp_rank) {
+      int64_t dcp_rank,
+      double quant_scale_kv) {
     using namespace host;
 
     auto B = SymbolicSize{"batch_size"};
@@ -526,6 +531,8 @@ struct SetMlaKVConcatQFp8Kernel {
     CHECK_HOST(D_buf.unwrap() >= kFp8RowBytes) << "kv_buffer last dim too small";
     CHECK_HOST(dcp_world_size >= 1 && dcp_rank >= 0 && dcp_rank < dcp_world_size)
         << "invalid dcp world/rank: " << dcp_world_size << "/" << dcp_rank;
+    CHECK_HOST(std::isfinite(quant_scale_kv) && quant_scale_kv > 0.0)
+        << "quant_scale_kv must be finite and positive; got " << quant_scale_kv;
     CHECK_HOST(S_loc.unwrap() == 1) << "loc must be contiguous; got stride " << S_loc.unwrap();
 
     // Alignment tripwires (mirrored by python covered() so uncovered layouts
@@ -562,6 +569,7 @@ struct SetMlaKVConcatQFp8Kernel {
         .batch_size = batch,
         .dcp_world_size = static_cast<int32_t>(dcp_world_size),
         .dcp_rank = static_cast<int32_t>(dcp_rank),
+        .quant_scale_kv = static_cast<float>(quant_scale_kv),
         .q_nope = static_cast<const bf16_t*>(q_nope.data_ptr()),
         .q_rope = static_cast<const bf16_t*>(q_rope.data_ptr()),
         .q_out = static_cast<uint8_t*>(q_out.data_ptr()),

--- a/python/sglang/kernels/ops/attention/set_mla_kv_concat_q.py
+++ b/python/sglang/kernels/ops/attention/set_mla_kv_concat_q.py
@@ -270,6 +270,7 @@ def set_mla_kv_concat_q_fp8(
     num_warps: int = 0,
     dcp_world_size: int = 1,
     dcp_rank: int = 0,
+    quant_scale_kv: float = 1.0,
 ) -> torch.Tensor:
     """Quantize bf16 [k_nope | k_rope] rows to fp8-e4m3 and scatter them into
     ``kv_buffer`` at ``loc``, and return the fp8 concatenated query
@@ -314,5 +315,6 @@ def set_mla_kv_concat_q_fp8(
         num_warps,
         dcp_world_size,
         dcp_rank,
+        quant_scale_kv,
     )
     return q_out

--- a/python/sglang/kernels/ops/attention/utils.py
+++ b/python/sglang/kernels/ops/attention/utils.py
@@ -1,3 +1,5 @@
+import math
+
 import torch
 import triton
 import triton.language as tl
@@ -104,6 +106,7 @@ def mla_quantize_and_rope_for_fp8(
     is_neox: bool,
     kv_lora_rank: int,
     qk_rope_head_dim: int,
+    kv_descale: float = 1.0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     import flashinfer.rope
 
@@ -129,6 +132,9 @@ def mla_quantize_and_rope_for_fp8(
             is_neox: Whether to use NeoX-style RoPE (interleaved) or GPT-style (half rotation)
             kv_lora_rank: Dimension of the no-position-encoding component
             qk_rope_head_dim: Dimension of the RoPE component
+            kv_descale: Static per-tensor scale used to restore the cached
+                latent K/V values during attention. Cache writes multiply by
+                its reciprocal.
 
         Returns:
             tuple: (merged_q_out, k_nope_out, k_rope_out) quantized to FP8
@@ -152,6 +158,12 @@ def mla_quantize_and_rope_for_fp8(
     k_rope_out = k_rope.new_empty(k_rope.shape, dtype=attn_dtype)
     k_nope_out = k_nope.new_empty(k_nope.shape, dtype=attn_dtype)
 
+    kv_descale = float(kv_descale)
+    if not math.isfinite(kv_descale) or kv_descale <= 0.0:
+        raise ValueError(
+            f"MLA KV descale must be finite and positive, got {kv_descale!r}"
+        )
+
     # Apply RoPE and quantize all components in a single fused kernel call
     # This kernel handles:
     # 1. RoPE application to q_rope and k_rope using cos_sin_cache and positions
@@ -171,9 +183,10 @@ def mla_quantize_and_rope_for_fp8(
         k_rope_out=k_rope_out,
         q_nope_out=q_out[..., :kv_lora_rank],  # Nope part goes to beginning
         k_nope_out=k_nope_out,
-        # Quantization scales (set to 1.0 for no additional scaling)
+        # FlashInfer's quant_scale_kv is a quantization multiplier. Attention
+        # consumes k/v descales, so cache write and read must be reciprocal.
         quant_scale_q=1.0,
-        quant_scale_kv=1.0,
+        quant_scale_kv=1.0 / kv_descale,
         enable_pdl=is_arch_support_pdl(),
     )
 
@@ -185,11 +198,26 @@ def mla_quantize_without_rope_for_fp8(
     q_rope: torch.Tensor,
     k_nope: torch.Tensor,
     k_rope: torch.Tensor,
+    kv_descale: float = 1.0,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Quantize MLA components to FP8 without applying rotary embeddings."""
+    """Quantize MLA components to FP8 without applying rotary embeddings.
+
+    Query components retain unit scaling. The shared latent K/V cache row and
+    its rotary tail are multiplied by ``1 / kv_descale`` before conversion.
+    """
     attn_dtype = torch.float8_e4m3fn
+    kv_descale = float(kv_descale)
+    if not math.isfinite(kv_descale) or kv_descale <= 0.0:
+        raise ValueError(
+            f"MLA KV descale must be finite and positive, got {kv_descale!r}"
+        )
+    quant_scale_kv = 1.0 / kv_descale
     q = concat_mla_absorb_q_general(q_nope, q_rope).to(attn_dtype)
-    return q, k_nope.to(attn_dtype), k_rope.to(attn_dtype)
+    return (
+        q,
+        (k_nope * quant_scale_kv).to(attn_dtype),
+        (k_rope * quant_scale_kv).to(attn_dtype),
+    )
 
 
 def concat_mla_absorb_q_general(q_nope, q_rope):

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3246,12 +3246,8 @@ class DeepseekSparseAttnBackend(
 
         q_scale = 1.0
         if self.kv_cache_dtype == torch.float8_e4m3fn:
-            k_scale, _ = require_mla_kv_cache_scales(
-                layer, path="dsa_trtllm_bmm1"
-            )
-            _, v_scale = require_mla_kv_cache_scales(
-                layer, path="dsa_trtllm_bmm2"
-            )
+            k_scale, _ = require_mla_kv_cache_scales(layer, path="dsa_trtllm_bmm1")
+            _, v_scale = require_mla_kv_cache_scales(layer, path="dsa_trtllm_bmm2")
         else:
             k_scale = v_scale = 1.0
         bmm1_scale = q_scale * k_scale * layer.scaling

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -61,6 +61,7 @@ from sglang.srt.layers.attention.dsa.utils import (
 from sglang.srt.layers.attention.trtllm_mla_backend import (
     grow_multi_ctas_kv_counter_buffer_if_needed,
     make_persistent_multi_ctas_kv_counter_buffer,
+    require_mla_kv_cache_scales,
 )
 from sglang.srt.layers.cp.base import get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
@@ -1920,6 +1921,16 @@ class DeepseekSparseAttnBackend(
                 is_prefill=True,
             )
 
+        if self.kv_cache_dtype == torch.float8_e4m3fn and not self.use_mha:
+            k_scale, _ = require_mla_kv_cache_scales(
+                layer, path=f"unsupported_dsa_{dsa_impl}_prefill"
+            )
+            if k_scale != 1.0:
+                raise RuntimeError(
+                    f"DSA {dsa_impl} prefill does not expose calibrated FP8 MLA "
+                    "read scales; use dsa_prefill_impl=trtllm"
+                )
+
         if k is not None:
             assert v is not None
             if save_kv_cache:
@@ -2219,6 +2230,16 @@ class DeepseekSparseAttnBackend(
                 is_neox,
                 llama_4_scaling,
             )
+
+        if self.kv_cache_dtype == torch.float8_e4m3fn and not self.use_mha:
+            k_scale, _ = require_mla_kv_cache_scales(
+                layer, path=f"unsupported_dsa_{self.dsa_decode_impl}_decode"
+            )
+            if k_scale != 1.0:
+                raise RuntimeError(
+                    f"DSA {self.dsa_decode_impl} decode does not expose calibrated "
+                    "FP8 MLA read scales; use dsa_decode_impl=trtllm"
+                )
 
         if k is not None:
             assert v is not None
@@ -3149,6 +3170,9 @@ class DeepseekSparseAttnBackend(
                         forward_batch, rope_positions
                     )
 
+            k_scale, _ = require_mla_kv_cache_scales(
+                layer, path="dsa_trtllm_rope_write"
+            )
             q, k, k_rope = mla_quantize_and_rope_for_fp8(
                 q,
                 q_rope,
@@ -3159,6 +3183,7 @@ class DeepseekSparseAttnBackend(
                 is_neox,
                 self.kv_lora_rank,
                 self.qk_rope_head_dim,
+                kv_descale=k_scale,
             )
             if save_kv_cache and dsa_use_prefill_cp(forward_batch):
                 if is_cp_v2_active(forward_batch):
@@ -3220,11 +3245,15 @@ class DeepseekSparseAttnBackend(
             )
 
         q_scale = 1.0
-        k_scale = (
-            layer.k_scale_float
-            if getattr(layer, "k_scale_float", None) is not None
-            else 1.0
-        )
+        if self.kv_cache_dtype == torch.float8_e4m3fn:
+            k_scale, _ = require_mla_kv_cache_scales(
+                layer, path="dsa_trtllm_bmm1"
+            )
+            _, v_scale = require_mla_kv_cache_scales(
+                layer, path="dsa_trtllm_bmm2"
+            )
+        else:
+            k_scale = v_scale = 1.0
         bmm1_scale = q_scale * k_scale * layer.scaling
 
         batch_size = page_table_1.shape[0]
@@ -3265,6 +3294,7 @@ class DeepseekSparseAttnBackend(
             max_seq_len=metadata.max_seq_len_k,
             sparse_mla_top_k=self.dsa_index_topk,
             bmm1_scale=bmm1_scale,
+            bmm2_scale=v_scale,
             backend="trtllm-gen",
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
             multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -89,6 +89,82 @@ TRTLLM_BLOCK_CONSTRAINT = 128
 TRTLLM_MLA_MAX_BATCH_SIZE = 8192
 
 
+def require_mla_kv_cache_scales(
+    layer: RadixAttention, *, path: str
+) -> tuple[float, float]:
+    """Return coherent MLA cache descales or fail before a corrupt FP8 access.
+
+    MLA stores the compressed latent row once and consumes it as K-nope in
+    BMM1 and V in BMM2. The rotary K tail shares that storage row. Therefore a
+    single quantization scale must cover all three consumers.
+    """
+    k_scale = getattr(layer, "k_scale_float", None)
+    v_scale = getattr(layer, "v_scale_float", None)
+    if k_scale is None or v_scale is None:
+        raise RuntimeError(
+            f"FP8 MLA KV cache requires both k_scale and v_scale on layer "
+            f"{getattr(layer, 'layer_id', '?')} ({path})"
+        )
+    k_scale = float(k_scale)
+    v_scale = float(v_scale)
+    if (
+        not math.isfinite(k_scale)
+        or not math.isfinite(v_scale)
+        or k_scale <= 0.0
+        or v_scale <= 0.0
+    ):
+        raise RuntimeError(
+            f"FP8 MLA KV cache scales must be finite and positive, got "
+            f"k={k_scale!r}, v={v_scale!r} on layer "
+            f"{getattr(layer, 'layer_id', '?')} ({path})"
+        )
+    if not math.isclose(k_scale, v_scale, rel_tol=1e-7, abs_tol=0.0):
+        raise RuntimeError(
+            "MLA uses one compressed latent KV cache row, so k_scale and "
+            f"v_scale must match; got k={k_scale!r}, v={v_scale!r} on layer "
+            f"{getattr(layer, 'layer_id', '?')} ({path})"
+        )
+
+    return k_scale, v_scale
+
+
+def quantize_mla_kv_for_cache(
+    k: torch.Tensor,
+    k_rope: torch.Tensor,
+    layer: RadixAttention,
+    *,
+    path: str,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize the shared latent+rotary MLA cache with reciprocal scaling."""
+    k_scale, _ = require_mla_kv_cache_scales(layer, path=path)
+    if k.dtype == torch.float8_e4m3fn or k_rope.dtype == torch.float8_e4m3fn:
+        raise RuntimeError(
+            "quantize_mla_kv_for_cache expects unquantized tensors, got "
+            f"k={k.dtype}, k_rope={k_rope.dtype} ({path})"
+        )
+    scale = getattr(layer, "k_scale", None)
+    if not isinstance(scale, torch.Tensor) or scale.numel() != 1:
+        raise RuntimeError(
+            f"FP8 MLA KV cache requires a scalar k_scale tensor ({path})"
+        )
+
+    def quantize(value: torch.Tensor) -> torch.Tensor:
+        quantized, _ = scaled_fp8_quant(
+            value.reshape(-1, value.shape[-1]).contiguous(), scale
+        )
+        return quantized.reshape(value.shape)
+
+    k_fp8 = quantize(k)
+    k_rope_fp8 = quantize(k_rope)
+    if k_fp8.dtype != torch.float8_e4m3fn or k_rope_fp8.dtype != torch.float8_e4m3fn:
+        raise RuntimeError(
+            f"FP8 MLA KV cache quantization returned wrong dtype ({path})"
+        )
+    if k_scale != float(scale.item()):
+        raise RuntimeError(f"FP8 MLA KV cache tensor/float scale mismatch ({path})")
+    return k_fp8, k_rope_fp8
+
+
 def _multi_ctas_kv_counter_bytes(
     device: torch.device, num_q_heads: int, batch_size: int
 ) -> int:
@@ -119,29 +195,11 @@ def grow_multi_ctas_kv_counter_buffer_if_needed(
 def _quantize_fp8_qkv(q, k, v, layer):
     q = q.to(torch.float8_e4m3fn)
 
-    k_scale = getattr(layer, "k_scale_float", None)
-    if k_scale is None:
-        k_scale = 1.0
-    if k_scale != 1.0:
-        assert hasattr(layer, "k_scale"), "k_scale is not set"
-        k_2d, _ = scaled_fp8_quant(
-            k.reshape(-1, k.shape[-1]).contiguous(), layer.k_scale
-        )
-        k = k_2d.reshape(k.shape)
-    else:
-        k = k.to(torch.float8_e4m3fn)
-
-    v_scale = getattr(layer, "v_scale_float", None)
-    if v_scale is None:
-        v_scale = 1.0
-    if v_scale != 1.0:
-        assert hasattr(layer, "v_scale"), "v_scale is not set"
-        v_2d, _ = scaled_fp8_quant(
-            v.reshape(-1, v.shape[-1]).contiguous(), layer.v_scale
-        )
-        v = v_2d.reshape(v.shape)
-    else:
-        v = v.to(torch.float8_e4m3fn)
+    k_scale, v_scale = require_mla_kv_cache_scales(layer, path="regular_prefill")
+    k_2d, _ = scaled_fp8_quant(k.reshape(-1, k.shape[-1]).contiguous(), layer.k_scale)
+    k = k_2d.reshape(k.shape)
+    v_2d, _ = scaled_fp8_quant(v.reshape(-1, v.shape[-1]).contiguous(), layer.v_scale)
+    v = v_2d.reshape(v.shape)
 
     return q, k, v, k_scale, v_scale
 
@@ -810,11 +868,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         applies when the KV cache stores FP8."""
         q_scale = 1.0
         if self.data_type == torch.float8_e4m3fn:
-            k_scale = (
-                layer.k_scale_float
-                if getattr(layer, "k_scale_float", None) is not None
-                else 1.0
-            )
+            k_scale, _ = require_mla_kv_cache_scales(layer, path="decode_bmm1")
         else:
             if getattr(layer, "k_scale_float", None) is not None:
                 logger.warning_once(
@@ -825,6 +879,12 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 )
             k_scale = 1.0
         return q_scale * k_scale * layer.scaling
+
+    def _compute_decode_bmm2_scale(self, layer: RadixAttention) -> float:
+        if self.data_type != torch.float8_e4m3fn:
+            return 1.0
+        _, v_scale = require_mla_kv_cache_scales(layer, path="decode_bmm2")
+        return v_scale
 
     def _dense_q_indptr(self, bs: int, draft_token_num: int) -> torch.Tensor:
         """Query indptr for a dense [bs, draft_token_num] verify batch."""
@@ -869,6 +929,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         #   For BF16/FP16 KV cache, k_scale must be 1.0 since values are unscaled.
         # - softmax_scale: Attention softmax scaling = 1/sqrt(head_dim), pre-computed as layer.scaling
         bmm1_scale = self._compute_decode_bmm1_scale(layer)
+        bmm2_scale = self._compute_decode_bmm2_scale(layer)
         seq_lens_i32 = (
             seq_lens if seq_lens.dtype == torch.int32 else seq_lens.to(torch.int32)
         )
@@ -889,6 +950,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             seq_lens=seq_lens_i32,
             max_seq_len=max_seq_len,
             bmm1_scale=bmm1_scale,
+            bmm2_scale=bmm2_scale,
             skip_softmax_threshold_scale_factor=envs.SGLANG_SKIP_SOFTMAX_DECODE_THRESHOLD_SCALE_FACTOR.get(),
             **extra_kwargs,
         )
@@ -1020,6 +1082,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         ):
             return None
         parallel = get_parallel()
+        k_scale, _ = require_mla_kv_cache_scales(layer, path="fused_no_rope_write")
         return set_mla_kv_concat_q_fp8(
             kv_buffer=kv_2d,
             loc=loc,
@@ -1031,6 +1094,7 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             # (identity when attn_dcp_size == 1).
             dcp_world_size=parallel.attn_dcp_size,
             dcp_rank=parallel.attn_dcp_rank,
+            quant_scale_kv=1.0 / k_scale,
         )
 
     def forward_decode(
@@ -1073,10 +1137,20 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                             k_rope=k_rope,
                         )
                 if fused_fp8_query is None:
+                    k_scale, _ = require_mla_kv_cache_scales(
+                        layer, path="decode_no_rope_write"
+                    )
                     q, k, k_rope = mla_quantize_without_rope_for_fp8(
-                        q, q_rope, k.squeeze(1), k_rope.squeeze(1)
+                        q,
+                        q_rope,
+                        k.squeeze(1),
+                        k_rope.squeeze(1),
+                        kv_descale=k_scale,
                     )
             else:
+                k_scale, _ = require_mla_kv_cache_scales(
+                    layer, path="decode_rope_write"
+                )
                 q, k, k_rope = mla_quantize_and_rope_for_fp8(
                     q,
                     q_rope,
@@ -1087,15 +1161,24 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     is_neox,
                     self.kv_lora_rank,
                     self.qk_rope_head_dim,
+                    kv_descale=k_scale,
                 )
             merge_query = False
 
         # Save KV cache if requested (the fused fp8 path already wrote it)
         query = fused_fp8_query
         if query is None and save_kv_cache:
-            assert (
-                k is not None and k_rope is not None
-            ), "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            assert k is not None and k_rope is not None, (
+                "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            )
+            cache_k, cache_k_rope = k, k_rope
+            if self.data_type == torch.float8_e4m3fn:
+                if k.dtype == torch.float8_e4m3fn:
+                    require_mla_kv_cache_scales(layer, path="decode_fp8_cache_write")
+                else:
+                    cache_k, cache_k_rope = quantize_mla_kv_for_cache(
+                        k, k_rope, layer, path="decode_cache_write"
+                    )
             if self._decode_dense_loc is not None:
                 # cuda-graph path: dense write loc precomputed out-of-graph, so
                 # the in-graph write captures no translate allocation.
@@ -1105,14 +1188,18 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     query = self._set_kv_and_concat_q_fused(
                         layer=layer,
                         loc=self._decode_dense_loc,
-                        k=k,
-                        k_rope=k_rope,
+                        k=cache_k,
+                        k_rope=cache_k_rope,
                         q=q,
                         q_rope=q_rope,
                     )
                 if query is None:
                     self.token_to_kv_pool.set_mla_kv_buffer(
-                        layer, self._decode_dense_loc, k, k_rope, loc_is_dense=True
+                        layer,
+                        self._decode_dense_loc,
+                        cache_k,
+                        cache_k_rope,
+                        loc_is_dense=True,
                     )
             else:
                 # eager (or static pool): the pool's _full_translate handles it.
@@ -1126,14 +1213,17 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     query = self._set_kv_and_concat_q_fused(
                         layer=layer,
                         loc=forward_batch.out_cache_loc,
-                        k=k,
-                        k_rope=k_rope,
+                        k=cache_k,
+                        k_rope=cache_k_rope,
                         q=q,
                         q_rope=q_rope,
                     )
                 if query is None:
                     self.token_to_kv_pool.set_mla_kv_buffer(
-                        layer, forward_batch.out_cache_loc, k, k_rope
+                        layer,
+                        forward_batch.out_cache_loc,
+                        cache_k,
+                        cache_k_rope,
                     )
 
         # Prepare query tensor inline (already built when the fused save-KV
@@ -1223,6 +1313,15 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
             and self.forward_prefill_metadata is not None
             and self.forward_prefill_metadata.fallback_to_flashinfer_impl
         ):
+            if self.data_type == torch.float8_e4m3fn:
+                k_scale, _ = require_mla_kv_cache_scales(
+                    layer, path="unsupported_flashinfer_mla_prefill_fallback"
+                )
+                if k_scale != 1.0:
+                    raise RuntimeError(
+                        "FlashInfer MLA prefill fallback does not expose calibrated "
+                        "FP8 latent-cache scale handling; use TRT-LLM MLA prefill"
+                    )
             return super().forward_extend(
                 q, k, v, layer, forward_batch, save_kv_cache, q_rope, k_rope
             )
@@ -1234,10 +1333,20 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         ) and forward_batch.forward_mode.is_target_verify():
             assert q_rope is not None and k_rope is not None
             if cos_sin_cache is None:
+                k_scale, _ = require_mla_kv_cache_scales(
+                    layer, path="target_verify_no_rope_write"
+                )
                 q, k, k_rope = mla_quantize_without_rope_for_fp8(
-                    q, q_rope, k.squeeze(1), k_rope.squeeze(1)
+                    q,
+                    q_rope,
+                    k.squeeze(1),
+                    k_rope.squeeze(1),
+                    kv_descale=k_scale,
                 )
             else:
+                k_scale, _ = require_mla_kv_cache_scales(
+                    layer, path="target_verify_rope_write"
+                )
                 q, k, k_rope = mla_quantize_and_rope_for_fp8(
                     q,
                     q_rope,
@@ -1248,21 +1357,37 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                     is_neox,
                     self.kv_lora_rank,
                     self.qk_rope_head_dim,
+                    kv_descale=k_scale,
                 )
             merge_query = False
 
         # Save KV cache if requested
         if save_kv_cache:
-            assert (
-                k is not None and k_rope is not None
-            ), "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            assert k is not None and k_rope is not None, (
+                "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
+            )
+            cache_k, cache_k_rope = k, k_rope
+            if self.data_type == torch.float8_e4m3fn:
+                if k.dtype == torch.float8_e4m3fn:
+                    require_mla_kv_cache_scales(layer, path="extend_fp8_cache_write")
+                else:
+                    cache_k, cache_k_rope = quantize_mla_kv_for_cache(
+                        k, k_rope, layer, path="extend_cache_write"
+                    )
             if self._decode_dense_loc is not None:
                 self.token_to_kv_pool.set_mla_kv_buffer(
-                    layer, self._decode_dense_loc, k, k_rope, loc_is_dense=True
+                    layer,
+                    self._decode_dense_loc,
+                    cache_k,
+                    cache_k_rope,
+                    loc_is_dense=True,
                 )
             else:
                 self.token_to_kv_pool.set_mla_kv_buffer(
-                    layer, forward_batch.out_cache_loc, k, k_rope
+                    layer,
+                    forward_batch.out_cache_loc,
+                    cache_k,
+                    cache_k_rope,
                 )
 
         # TODO refactor to avoid code duplication

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1168,9 +1168,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
         # Save KV cache if requested (the fused fp8 path already wrote it)
         query = fused_fp8_query
         if query is None and save_kv_cache:
-            assert k is not None and k_rope is not None, (
-                "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
-            )
+            assert (
+                k is not None and k_rope is not None
+            ), "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
             cache_k, cache_k_rope = k, k_rope
             if self.data_type == torch.float8_e4m3fn:
                 if k.dtype == torch.float8_e4m3fn:
@@ -1363,9 +1363,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
 
         # Save KV cache if requested
         if save_kv_cache:
-            assert k is not None and k_rope is not None, (
-                "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
-            )
+            assert (
+                k is not None and k_rope is not None
+            ), "For populating trtllm_mla kv cache, both k_nope and k_rope should be not None."
             cache_k, cache_k_rope = k, k_rope
             if self.data_type == torch.float8_e4m3fn:
                 if k.dtype == torch.float8_e4m3fn:

--- a/test/registered/kernels/ops/test_kimi_k3_prerequisite_ops.py
+++ b/test/registered/kernels/ops/test_kimi_k3_prerequisite_ops.py
@@ -177,9 +177,7 @@ class TestKimiK3PrerequisiteOps(CustomTestCase):
             )
         )
         self.assertTrue(
-            torch.equal(
-                scaled_query.view(torch.uint8), fp8_query_ref.view(torch.uint8)
-            )
+            torch.equal(scaled_query.view(torch.uint8), fp8_query_ref.view(torch.uint8))
         )
 
     def test_replayssm_ring_fold(self):

--- a/test/registered/kernels/ops/test_kimi_k3_prerequisite_ops.py
+++ b/test/registered/kernels/ops/test_kimi_k3_prerequisite_ops.py
@@ -156,6 +156,32 @@ class TestKimiK3PrerequisiteOps(CustomTestCase):
             )
         )
 
+        # A calibrated MLA cache stores latent K/V divided by its descale,
+        # while query quantization remains unit-scaled.
+        kv_descale = 0.25
+        scaled_pool = torch.zeros_like(fp8_pool)
+        scaled_query = set_mla_kv_concat_q_fp8(
+            scaled_pool,
+            loc,
+            k_nope,
+            k_rope,
+            q_nope,
+            q_rope,
+            quant_scale_kv=1.0 / kv_descale,
+        )
+        scaled_row = torch.cat([k_nope, k_rope], dim=-1)
+        scaled_row = (scaled_row / kv_descale).to(torch.float8_e4m3fn)
+        self.assertTrue(
+            torch.equal(
+                scaled_pool[loc].view(torch.uint8), scaled_row.view(torch.uint8)
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                scaled_query.view(torch.uint8), fp8_query_ref.view(torch.uint8)
+            )
+        )
+
     def test_replayssm_ring_fold(self):
         batch_size, num_steps = 8, 4
         num_value_heads, num_key_heads = 8, 2

--- a/test/registered/unit/layers/attention/test_trtllm_mla_fp8_scales.py
+++ b/test/registered/unit/layers/attention/test_trtllm_mla_fp8_scales.py
@@ -1,0 +1,138 @@
+import math
+import sys
+import types
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+import torch
+
+from sglang.kernels.ops.attention import utils as attention_utils
+from sglang.srt.layers.attention import trtllm_mla_backend
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _layer(k_scale=0.25, v_scale=0.25, scaling=0.125):
+    return SimpleNamespace(
+        layer_id=3,
+        k_scale=torch.tensor(k_scale),
+        v_scale=torch.tensor(v_scale),
+        k_scale_float=k_scale,
+        v_scale_float=v_scale,
+        scaling=scaling,
+    )
+
+
+def test_require_mla_kv_cache_scales_rejects_invalid_shared_scales():
+    with pytest.raises(RuntimeError, match="requires both"):
+        trtllm_mla_backend.require_mla_kv_cache_scales(
+            SimpleNamespace(layer_id=0), path="test"
+        )
+
+    for value in (0.0, -1.0, math.inf, math.nan):
+        with pytest.raises(RuntimeError, match="finite and positive"):
+            trtllm_mla_backend.require_mla_kv_cache_scales(
+                _layer(k_scale=value, v_scale=value), path="test"
+            )
+
+    with pytest.raises(RuntimeError, match="must match"):
+        trtllm_mla_backend.require_mla_kv_cache_scales(
+            _layer(k_scale=0.25, v_scale=0.5), path="test"
+        )
+
+
+def test_trtllm_mla_decode_propagates_k_and_v_descales(monkeypatch):
+    captured = {}
+
+    def fake_decode(**kwargs):
+        captured.update(kwargs)
+        return torch.empty_like(kwargs["query"])
+
+    monkeypatch.setattr(
+        trtllm_mla_backend,
+        "flashinfer",
+        SimpleNamespace(
+            decode=SimpleNamespace(
+                trtllm_batch_decode_with_kv_cache_mla=fake_decode
+            )
+        ),
+        raising=False,
+    )
+
+    backend = trtllm_mla_backend.TRTLLMMLABackend.__new__(
+        trtllm_mla_backend.TRTLLMMLABackend
+    )
+    backend.data_type = torch.float8_e4m3fn
+    backend.backend = "trtllm-gen"
+    backend.workspace_buffer = torch.empty(1)
+    backend.qk_nope_head_dim = 8
+    backend.kv_lora_rank = 8
+    backend.qk_rope_head_dim = 4
+    backend._multi_ctas_kv_counter_buffer = torch.empty(1)
+
+    query = torch.empty((1, 1, 1, 12), dtype=torch.float8_e4m3fn)
+    kv_cache = torch.empty((1, 1, 1, 12), dtype=torch.float8_e4m3fn)
+    backend._run_decode_kernel(
+        query=query,
+        kv_cache=kv_cache,
+        block_tables=torch.zeros((1, 1, 1), dtype=torch.int32),
+        seq_lens=torch.ones(1, dtype=torch.int64),
+        max_seq_len=1,
+        layer=_layer(k_scale=0.25, v_scale=0.25, scaling=0.125),
+    )
+
+    assert captured["bmm1_scale"] == pytest.approx(0.25 * 0.125)
+    assert captured["bmm2_scale"] == pytest.approx(0.25)
+
+
+def test_mla_no_rope_quantization_uses_reciprocal_descale():
+    q_nope = torch.tensor([[[1.0, 2.0]]], dtype=torch.bfloat16)
+    q_rope = torch.tensor([[[3.0]]], dtype=torch.bfloat16)
+    k_nope = torch.tensor([[[0.5, 1.0]]], dtype=torch.bfloat16)
+    k_rope = torch.tensor([[[1.5]]], dtype=torch.bfloat16)
+
+    q, k, k_rope_out = attention_utils.mla_quantize_without_rope_for_fp8(
+        q_nope, q_rope, k_nope, k_rope, kv_descale=0.5
+    )
+
+    torch.testing.assert_close(q.float(), torch.tensor([[[1.0, 2.0, 3.0]]]))
+    torch.testing.assert_close(k.float(), k_nope.float() * 2.0)
+    torch.testing.assert_close(k_rope_out.float(), k_rope.float() * 2.0)
+
+
+def test_mla_rope_quantization_forwards_reciprocal_descale():
+    captured = {}
+
+    def fake_rope_quantize_fp8(**kwargs):
+        captured.update(kwargs)
+
+    flashinfer = types.ModuleType("flashinfer")
+    flashinfer_rope = types.ModuleType("flashinfer.rope")
+    flashinfer_rope.mla_rope_quantize_fp8 = fake_rope_quantize_fp8
+    flashinfer.rope = flashinfer_rope
+
+    inputs = {
+        "q_nope": torch.zeros((1, 1, 2), dtype=torch.bfloat16),
+        "q_rope": torch.zeros((1, 1, 2), dtype=torch.bfloat16),
+        "k_nope": torch.zeros((1, 1, 2), dtype=torch.bfloat16),
+        "k_rope": torch.zeros((1, 1, 2), dtype=torch.bfloat16),
+        "pos_ids": torch.zeros(1, dtype=torch.int64),
+        "cos_sin_cache": torch.zeros((1, 4), dtype=torch.bfloat16),
+    }
+
+    with mock.patch.dict(
+        sys.modules,
+        {"flashinfer": flashinfer, "flashinfer.rope": flashinfer_rope},
+    ), mock.patch.object(attention_utils, "is_arch_support_pdl", return_value=False):
+        attention_utils.mla_quantize_and_rope_for_fp8(
+            **inputs,
+            is_neox=False,
+            kv_lora_rank=2,
+            qk_rope_head_dim=2,
+            kv_descale=0.25,
+        )
+
+    assert captured["quant_scale_q"] == 1.0
+    assert captured["quant_scale_kv"] == pytest.approx(4.0)

--- a/test/registered/unit/layers/attention/test_trtllm_mla_fp8_scales.py
+++ b/test/registered/unit/layers/attention/test_trtllm_mla_fp8_scales.py
@@ -54,9 +54,7 @@ def test_trtllm_mla_decode_propagates_k_and_v_descales(monkeypatch):
         trtllm_mla_backend,
         "flashinfer",
         SimpleNamespace(
-            decode=SimpleNamespace(
-                trtllm_batch_decode_with_kv_cache_mla=fake_decode
-            )
+            decode=SimpleNamespace(trtllm_batch_decode_with_kv_cache_mla=fake_decode)
         ),
         raising=False,
     )


### PR DESCRIPTION
## Motivation

Calibrated FP8 MLA KV cache values must use the same scale convention when
they are written and read. Some MLA and DSA paths wrote the cache with unit
scale, restored only the K scale in BMM1, and omitted the V scale in BMM2.
That makes non-unit calibration inconsistent across the attention operation.

For the existing SGLang scale convention, `k_scale` and `v_scale` are
descales. Cache writes therefore multiply by the reciprocal descale, BMM1
applies the K descale with the attention softmax scale, and BMM2 applies the V
descale.

MLA stores one compressed latent row that is consumed as K in BMM1 and V in
BMM2. The K and V descales for that shared row must therefore agree.

## Modifications

- Propagate a non-unit KV quantization multiplier through the fused MLA cache
  writer.
- Apply reciprocal descales in the fused-RoPE and no-RoPE cache-write paths.
- Pass K descales to BMM1 and V descales to BMM2 for TRT-LLM MLA and DSA.
- Cover regular prefill, decode, target verification, and draft extension.
- Reject missing, non-finite, non-positive, or inconsistent shared MLA
  descales instead of silently using an incoherent scale contract.
- Reject calibrated non-unit scales on fallback paths that do not expose the
  required read scales.

This uses the existing `RadixAttention.k_scale`, `v_scale`,
`k_scale_float`, and `v_scale_float` attributes. It does not introduce a new
model-specific scale format.

## Accuracy Tests

The included synthetic tests verify:

- invalid or inconsistent shared MLA scales fail closed;
- the no-RoPE cache path multiplies K and rotary K by the reciprocal descale;
- the fused RoPE path receives the reciprocal descale;
- TRT-LLM MLA decode receives the expected non-unit BMM1 and BMM2 scales; and
- the fused GPU writer scales cached K while retaining unit-scaled query
  quantization.

## Speed Tests and Profiling

This is a scale-correctness change. No performance claim is made in this PR.

## Validation

- Python syntax compilation for the changed Python files
- registered-test registry validation
- package registered-test placement validation
- whitespace validation
- repository Clang formatting validation for the changed CUDA header

The new synthetic tests are registered for the relevant upstream CI suites.

## Checklist

- [x] Add focused unit tests.
- [x] No user-facing documentation change is required.
- [x] Follow the existing SGLang KV-scale attributes and backend structure.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31745650167](https://github.com/sgl-project/sglang/actions/runs/31745650167)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31745649743](https://github.com/sgl-project/sglang/actions/runs/31745649743)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->