### PR TITLE
[AMD] CI: pin antlr4-python3-runtime back after lmms-eval (unblocks ROCm 7.2 stage-b evals)

### DIFF
--- a/scripts/ci/amd/amd_ci_install_dependency.sh
+++ b/scripts/ci/amd/amd_ci_install_dependency.sh
@@ -150,6 +150,12 @@ else
   docker exec ci_sglang git config --global --add safe.directory /lmms-eval
   install_with_retry docker exec -w /lmms-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .
 
+  # lmms-eval v0.4.1 pulls latex2sympy2, which pins antlr4-python3-runtime==4.7.2
+  # and uninstalls the 4.9.3 that sgl-eval's latex2sympy2_extended requires, so
+  # every `sgl-eval run mmlu` dies with "Unsupported ANTLR version 4.7.2". Pin it
+  # back, the same way the CUDA installer does after its own lmms-eval install.
+  install_with_retry docker exec ci_sglang pip install --cache-dir=/sgl-data/pip-cache "antlr4-python3-runtime==4.9.3" --force-reinstall --no-deps
+
   git_clone_with_retry https://github.com/akao-amd/human-eval.git human-eval
   docker cp human-eval ci_sglang:/
   install_with_retry docker exec -w /human-eval ci_sglang pip install --cache-dir=/sgl-data/pip-cache -e .


### PR DESCRIPTION
## Motivation

Now that #34689 unblocked ROCm 7.2 `stage-a`, `stage-b` runs for the first time — and every shard that calls `run_eval` fails:

```
RuntimeError: sgl-eval failed with exit code 1: sgl-eval run mmlu --base-url http://127.0.0.1:11000/v1 ...
ImportError: Unsupported ANTLR version 4.7.2, only 4.9.3, 4.11.0, and 4.13.2 runtime versions are supported.
```

This is a dependency-ordering conflict in `scripts/ci/amd/amd_ci_install_dependency.sh`, not a test failure.

sgl-eval installs first (line 139) and brings in `antlr4-python3-runtime-4.9.3` via `math_verify[antlr4_9_3]` and `latex2sympy2_extended-1.11.0`. lmms-eval v0.4.1 installs twelve lines later, pulls `latex2sympy2`, which pins `antlr4-python3-runtime==4.7.2` and uninstalls 4.9.3. pip says so plainly in the install log of [this ROCm 7.2 run](https://github.com/sgl-project/sglang/actions/runs/31738748858/job/94576920853):

```
Installing collected packages: ... latex2sympy2 ... lmms_eval
  Attempting uninstall: antlr4-python3-runtime
    Found existing installation: antlr4-python3-runtime 4.9.3
    Successfully uninstalled antlr4-python3-runtime-4.9.3
latex2sympy2-extended 1.11.0 requires antlr4-python3-runtime<=4.13.2,>=4.9.3,
  but you have antlr4-python3-runtime 4.7.2 which is incompatible.
```

At runtime, `sgl_eval._vendored.nemo_skills.math_grader` imports `latex2sympy2_extended.antlr_parser`, which rejects 4.7.2.

This is the same conflict the CUDA path hit when #34477 introduced sgl-eval, and `scripts/ci/cuda/ci_install_dependency.sh` already pins it back after its own lmms-eval install. AMD never got the equivalent because `stage-a` was dying earlier on the sgl-eval install syntax bug, so these tests never ran. NPU is unaffected — its installer never installs lmms-eval.

## Modifications

Pin `antlr4-python3-runtime==4.9.3` back immediately after the lmms-eval install, mirroring the existing CUDA fix.

- Placed right after lmms-eval because that is the last step in this script that touches antlr — verified against the install log, nothing later re-downgrades it.
- `--force-reinstall --no-deps` so lmms-eval's other dependencies are left alone. This accepts the same trade-off the CUDA path already accepts: lmms-eval's own `latex2sympy2` wants 4.7.2, and sgl-eval's requirement wins.
- Inside the `SKIP_TT_DEPS` else-branch on purpose: with test-time deps skipped, lmms-eval never installs and there is nothing to clobber.
- The spec contains no whitespace, so it survives `install_with_retry`'s `eval` intact — the trap #34689 just fixed.

## Accuracy Tests

Not applicable — CI installer only, no model or kernel code touched. The change restores the `sgl-eval run mmlu` path that the accuracy tests themselves depend on, so a green ROCm 7.2 `stage-b` is the validation. Needs a `run-ci`-labelled ROCm 7.2 run to confirm.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## CI Results

[**`PR Test ROCm 7.2 (AMD)` — run 31742250192**](https://github.com/sgl-project/sglang/actions/runs/31742250192)

The antlr conflict is gone. `stage-b-test-1-gpu-small` now passes 13 of 14 shards; before this change, shards 0, 1, 4, 7, 9, 11, 12 and 13 all died on `ImportError: Unsupported ANTLR version 4.7.2`. Across every job still failing in this run that ImportError appears **zero** times, and each install log shows `antlr4-python3-runtime-4.9.3` still in place after lmms-eval.

The five remaining failures each have a distinct, unrelated cause:

| Job | Test | Failure |
|---|---|---|
| [stage-b-1gpu-small (1)](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113543) | `test_torch_compile.py` | `HIPBLAS_STATUS_INTERNAL_ERROR` on `hipblasCreate` → `Capture cuda graph failed`, server exited -9 |
| [stage-b-1gpu-large (1)](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113371) | `test_bench_serving_1gpu_part2.py` | `AssertionError: 50.68962424993515 not less than 50` — perf threshold, marginal |
| [stage-b-1gpu-large (2)](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113282) | `test_piecewise_cuda_graph_support_1_gpu.py` | `AttributeError: 'EmbeddingReqInput' object has no attribute 'mm_content_hashes'` — separate bug, fixed by #34769 |
| [stage-b-2gpu-large (1)](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113261) | `test_bench_one_batch_2gpu.py` | `Triton Error [HIP] Code: 900` → scheduler died during init |
| [mi35x-disaggregation](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113302) | `test_disaggregation_pp.py` | `Cannot connect to host 127.0.0.1:11200`, `Internal Server Error` |

Other legs: [PR Test Base](https://github.com/sgl-project/sglang/actions/runs/31742250165) ✅, [Lint](https://github.com/sgl-project/sglang/actions/runs/31742249726) ✅, [PR Test (Xeon)](https://github.com/sgl-project/sglang/actions/runs/31742250046) ✅. `PR Test Extra` / `Extra (AMD)` red is the `run-ci-extra` opt-in label gate, not a test failure.

cc @hnyls2002 (#34477) @kangwangamd @bingxche @HaiShaw
