### PR TITLE
[AMD][CI] Fix stage-b: AttributeError on multimodal embedding requests

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1046,7 +1046,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 obj.audio_data = [obj.audio_data]
             if contains_mm_input:
                 self._validate_mm_limits(obj)
-                self._normalize_mm_content_hashes(obj)
+                # mm_content_hashes is a GenerateReqInput field; EmbeddingReqInput
+                # has no such attribute.
+                if isinstance(obj, GenerateReqInput):
+                    self._normalize_mm_content_hashes(obj)
 
             mm_inputs = None
             mm_processor_input = (


### PR DESCRIPTION
## Motivation

Every multimodal embedding request currently fails on `main`:

```
File "python/sglang/srt/managers/tokenizer_manager.py", line 1161, in _normalize_mm_content_hashes
    explicit = obj.mm_content_hashes
AttributeError: 'EmbeddingReqInput' object has no attribute 'mm_content_hashes'
```

Reproducer:

```python
engine = Engine(model_path=..., enable_multimodal=True, is_embedding=True)
engine.encode([text], image_data=[image_url])
```

#34398 added `_normalize_mm_content_hashes`, annotated `obj: GenerateReqInput`. Its call site in `_tokenize_one_request` sits under `if contains_mm_input:`, which is reached by both request types. `mm_content_hashes` is declared on `GenerateReqInput` (`io_struct.py`) and not on `EmbeddingReqInput`, so the embedding path dereferences a field that does not exist.

Caught by `test_piecewise_cuda_graph_support_1_gpu.py::TestPiecewiseCudaGraphQwen25VLEmbedding::test_embedding` on ROCm 7.2 `stage-b` ([job](https://github.com/sgl-project/sglang/actions/runs/31683169293/job/94400789597)).

## Modifications

Guard the call to the type the helper is annotated for:

```python
if contains_mm_input:
    self._validate_mm_limits(obj)
    if isinstance(obj, GenerateReqInput):
        self._normalize_mm_content_hashes(obj)
```

This restores the pre-#34398 behaviour on the embedding path and leaves generate untouched. Nothing is lost for embeddings: `EmbeddingReqInput` has no `mm_content_hashes` field, so such a request can never supply content hashes in the first place.

Extending content-addressed preprocessing caching to the embedding path would be a feature change rather than a bug fix — it needs the field on `EmbeddingReqInput` plus the batch-split plumbing `GenerateReqInput` has in `__getitem__` and `_normalize_mm_hashes`. Happy to do that instead if #34398's author prefers that direction.

## Accuracy Tests

Not applicable — restores a code path that currently raises unconditionally; no scoring behaviour changes.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

No new test added: `TestPiecewiseCudaGraphQwen25VLEmbedding::test_embedding` already covers this exact case and is the test that surfaced it.

Worth noting separately — that test is registered `register_cuda_ci(stage="nightly")` but `register_amd_ci(suite="stage-b-test-1-gpu-large-amd")`, so on NVIDIA it only runs nightly while it is PR-blocking on AMD. AMD PR CI happened to be down at `stage-a` for the whole window between #34398 landing and now, which is why this went unnoticed. Whether this case should also gate NVIDIA PR CI is a separate question.

## CI Results

- [**PR Test Base — run 31758833829**](https://github.com/sgl-project/sglang/actions/runs/31758833829) ✅
- [**Lint — run 31758833693**](https://github.com/sgl-project/sglang/actions/runs/31758833693) ✅
- [**ROCm 7.2 target shard — `stage-b-test-1-gpu-large (2)`**](https://github.com/sgl-project/sglang/actions/runs/31758833891/job/94647589996) ✅

On the current head (`236ee53c`, after merging `main` including #34768), the target AMD shard completed successfully. It ran the exact covering test, `test_piecewise_cuda_graph_support_1_gpu.py::TestPiecewiseCudaGraphQwen25VLEmbedding::test_embedding`, and reported **12/12 passed** with zero `mm_content_hashes` `AttributeError`s.

For the direct before/after, [the same shard without this fix](https://github.com/sgl-project/sglang/actions/runs/31742250192/job/94596113282) reported **2/12 passed** and failed with `AttributeError: 'EmbeddingReqInput' object has no attribute 'mm_content_hashes'`.

The [full ROCm 7.2 run](https://github.com/sgl-project/sglang/actions/runs/31758833891) remains red on unrelated MI35x, 2-GPU Triton/graph-capture, performance, and disaggregation failures; the changed path and its covering test are green. [`PR Test (Xeon)`](https://github.com/sgl-project/sglang/actions/runs/31758833706) still fails because that workflow does not install the `sgl-eval` executable required by `test_cpu_graph.py`, which is unrelated to this tokenizer change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31758833829](https://github.com/sgl-project/sglang/actions/runs/31758833829)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31758833740](https://github.com/sgl-project/sglang/actions/runs/31758833740)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->