### PR TITLE
[DRAFT][PD] Add conditional aggregation to decode workers

### DIFF
--- a/docs/docs/advanced_features/pd_disaggregation.mdx
+++ b/docs/docs/advanced_features/pd_disaggregation.mdx
@@ -28,6 +28,12 @@ When you need to profile prefill or decode workers in PD disaggregation mode, pl
 
 For deploying PD disaggregation at scale with load balancing and fault tolerance, SGLang provides a router. The router can distribute requests between prefill and decode instances using various routing policies. For detailed information on setting up routing with PD disaggregation, including configuration options and deployment patterns, see the [SGLang Model Gateway (former Router)](./sgl_model_gateway#prefill-decode-disaggregation).
 
+### Conditional Aggregation
+
+Conditional aggregation lets a PD router send selected requests directly to a decode worker. The decode worker runs both prefill and decode for those requests while continuing to accept transferred KV cache from prefill workers for other requests.
+
+Add `--disaggregation-decode-enable-conditional-agg` to each decode worker. The router marks a local-prefill request with `do_local_prefill=true` and omits the disaggregation bootstrap fields. Requests without this marker keep the normal remote-prefill path.
+
 
 ## Mooncake
 ### Requirements

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1368,6 +1368,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         return (
             len(self.scheduler.running_batch.reqs)
             + len(self.transfer_queue.queue)
+            + len(self.scheduler.disagg_decode_prebuilt_queue)
             + len(self.scheduler.waiting_queue)
             + extra_reserved_reqs
         )
@@ -2157,7 +2158,7 @@ class SchedulerDisaggregationDecodeMixin:
 
             # Get the next batch to run
             plan = self.get_next_disagg_decode_batch_to_run(
-                running_batch=self.running_batch
+                running_batch=self.running_batch, last_batch=self.last_batch
             )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
@@ -2196,7 +2197,7 @@ class SchedulerDisaggregationDecodeMixin:
 
             # Get the next batch to run
             plan = self.get_next_disagg_decode_batch_to_run(
-                running_batch=self.running_batch
+                running_batch=self.running_batch, last_batch=self.last_batch
             )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
@@ -2247,13 +2248,20 @@ class SchedulerDisaggregationDecodeMixin:
 
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_disagg_decode_batch_to_run(
-        self: Scheduler, running_batch: ScheduleBatch
+        self: Scheduler,
+        running_batch: ScheduleBatch,
+        last_batch: Optional[ScheduleBatch],
     ) -> NextBatchPlan:
         """Process prebuilt batch and schedule the next decode batch."""
+        local_chunk_stalled = self._conditional_local_chunk_is_stalled()
         # Process pending prebuilt batch: output processing + filter + merge
-        new_prebuilt_batch = self.get_new_prebuilt_batch(running_batch)
+        new_prebuilt_batch = (
+            self.get_new_prebuilt_batch(running_batch)
+            if not (self.conditional_agg_enabled and self.chunked_req is not None)
+            or local_chunk_stalled
+            else None
+        )
         if new_prebuilt_batch:
-            assert self.chunked_req is None
             self.batch_result_processor.process_batch_result_prebuilt(
                 new_prebuilt_batch
             )
@@ -2265,6 +2273,43 @@ class SchedulerDisaggregationDecodeMixin:
                         running_batch.hisparse_coordinator = self.hisparse_coordinator
                 else:
                     running_batch.merge_batch(new_prebuilt_batch)
+
+        if self.conditional_agg_enabled:
+            if local_chunk_stalled:
+                # A chunked prefill normally must run on every pass, but remote
+                # decode preallocation can consume the next chunk's pages. Run
+                # transferred requests until enough pages are free. The normal
+                # decision path must still stash the completed chunk and merge
+                # last_batch before prefill is suppressed.
+                return self.get_next_batch_to_run(
+                    running_batch=running_batch,
+                    last_batch=last_batch,
+                    allow_prefill=False,
+                )
+
+            # Remote preallocation and KV transfer can release capacity without
+            # changing the running batch. Retry local-prefill admission only
+            # after capacity has increased; clearing batch_is_full on every
+            # pass can over-admit chunked prefills and exhaust the KV pool.
+            if self.waiting_queue and running_batch.batch_is_full:
+                capacity = (
+                    self.token_to_kv_pool_allocator.available_size(),
+                    self.req_to_token_pool.available_size(),
+                )
+                full_capacity = self._conditional_agg_full_capacity
+                if full_capacity is not None and any(
+                    current > previous
+                    for current, previous in zip(capacity, full_capacity)
+                ):
+                    running_batch.batch_is_full = False
+                    self._conditional_agg_full_capacity = None
+                elif full_capacity is None:
+                    self._conditional_agg_full_capacity = capacity
+            else:
+                self._conditional_agg_full_capacity = None
+            return self.get_next_batch_to_run(
+                running_batch=running_batch, last_batch=last_batch
+            )
 
         # Schedule decode batch
         if running_batch.is_empty():
@@ -2278,6 +2323,21 @@ class SchedulerDisaggregationDecodeMixin:
             set_schedule_time_batch(ret)
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
+    def _conditional_local_chunk_is_stalled(self: Scheduler) -> bool:
+        if not self.conditional_agg_enabled or self.chunked_req is None:
+            return False
+
+        remaining_tokens = len(self.chunked_req.full_untruncated_fill_ids) - len(
+            self.chunked_req.prefix_indices
+        )
+        next_chunk_tokens = min(
+            remaining_tokens,
+            self.max_prefill_tokens,
+            self.chunked_prefill_size or remaining_tokens,
+        )
+        required_tokens = next_chunk_tokens + self.token_to_kv_pool_allocator.page_size
+        return self.token_to_kv_pool_allocator.available_size() < required_tokens
+
     def get_new_prebuilt_batch(
         self: Scheduler, running_batch: ScheduleBatch
     ) -> Optional[ScheduleBatch]:
@@ -2287,11 +2347,16 @@ class SchedulerDisaggregationDecodeMixin:
             for req in ready_grammar_requests:
                 self._add_request_to_queue(req)
 
-        if len(self.waiting_queue) == 0:
+        prebuilt_queue = (
+            self.disagg_decode_prebuilt_queue
+            if self.conditional_agg_enabled
+            else self.waiting_queue
+        )
+        if len(prebuilt_queue) == 0:
             return None
 
         if self.enable_priority_scheduling:
-            self.policy.calc_priority(self.waiting_queue, running_batch)
+            self.policy.calc_priority(prebuilt_queue, running_batch)
 
         curr_batch_size = running_batch.batch_size()
 
@@ -2299,12 +2364,12 @@ class SchedulerDisaggregationDecodeMixin:
 
         num_not_used_batch = batch_size - curr_batch_size
 
-        # pop req from waiting queue
+        # Pop requests from the queue of transferred KV.
         can_run_list: List[Req] = []
-        waiting_queue: List[Req] = []
+        remaining_prebuilt: List[Req] = []
 
-        for i in range(len(self.waiting_queue)):
-            req = self.waiting_queue[i]
+        for i in range(len(prebuilt_queue)):
+            req = prebuilt_queue[i]
             # we can only add at least `num_not_used_batch` new batch to the running queue
             if i < num_not_used_batch:
                 can_run_list.append(req)
@@ -2322,9 +2387,12 @@ class SchedulerDisaggregationDecodeMixin:
                 if req.kv_committed_len is not None:
                     req.set_extend_range(len(req.prefix_indices), req.kv_committed_len)
             else:
-                waiting_queue.append(req)
+                remaining_prebuilt.append(req)
 
-        self.waiting_queue = waiting_queue
+        if self.conditional_agg_enabled:
+            self.disagg_decode_prebuilt_queue = remaining_prebuilt
+        else:
+            self.waiting_queue = remaining_prebuilt
         if len(can_run_list) == 0:
             return None
 
@@ -2354,12 +2422,23 @@ class SchedulerDisaggregationDecodeMixin:
         if get_disagg().disaggregation_decode_enable_offload_kvcache:
             self.decode_offload_manager.check_offload_progress()
 
-        # try to resume retracted requests if there are enough space for another `num_reserved_decode_tokens` decode steps
-        resumed_reqs = self.disagg_decode_prealloc_queue.resume_retracted_reqs()
-        self.waiting_queue.extend(resumed_reqs)
-        if len(self.disagg_decode_prealloc_queue.retracted_queue) > 0:
-            # if there are still retracted requests, we do not allocate new requests
-            return
+        local_chunk_active = (
+            self.conditional_agg_enabled and self.chunked_req is not None
+        )
+        prebuilt_queue = (
+            self.disagg_decode_prebuilt_queue
+            if self.conditional_agg_enabled
+            else self.waiting_queue
+        )
+        if not local_chunk_active:
+            # Try to resume retracted requests if there is enough space for
+            # another `num_reserved_decode_tokens` decode steps.
+            resumed_reqs = self.disagg_decode_prealloc_queue.resume_retracted_reqs()
+            prebuilt_queue.extend(resumed_reqs)
+            if len(self.disagg_decode_prealloc_queue.retracted_queue) > 0:
+                # If there are still retracted requests, do not allocate new
+                # requests.
+                return
 
         if not hasattr(self, "polling_count"):
             self.polling_count = 0
@@ -2368,8 +2447,9 @@ class SchedulerDisaggregationDecodeMixin:
         self.polling_count = (self.polling_count + 1) % self.polling_interval
 
         if self.polling_count % self.polling_interval == 0:
-            req_conns, _ = self.disagg_decode_prealloc_queue.pop_preallocated()
-            self.disagg_decode_transfer_queue.extend(req_conns)
+            if not local_chunk_active:
+                req_conns, _ = self.disagg_decode_prealloc_queue.pop_preallocated()
+                self.disagg_decode_transfer_queue.extend(req_conns)
             transferred_reqs = (
                 self.disagg_decode_transfer_queue.pop_transferred()
             )  # the requests which kv has arrived
@@ -2377,4 +2457,4 @@ class SchedulerDisaggregationDecodeMixin:
                 for req in transferred_reqs:
                     # Direct-to-host: KV data already in host pool, skip staging
                     self.hisparse_coordinator.admit_request_direct(req)
-            self.waiting_queue.extend(transferred_reqs)
+            prebuilt_queue.extend(transferred_reqs)

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -392,6 +392,7 @@ class Engine(EngineScoreMixin, EngineBase):
         bootstrap_room: Optional[Union[List[int], int]] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        do_local_prefill: bool = False,
         # Deprecated: use routed_dp_rank instead
         data_parallel_rank: Optional[int] = None,
         external_trace_header: Optional[Dict] = None,
@@ -436,6 +437,7 @@ class Engine(EngineScoreMixin, EngineBase):
             bootstrap_room=bootstrap_room,
             routed_dp_rank=routed_dp_rank,
             disagg_prefill_dp_rank=disagg_prefill_dp_rank,
+            do_local_prefill=do_local_prefill,
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,
@@ -505,6 +507,7 @@ class Engine(EngineScoreMixin, EngineBase):
         bootstrap_room: Optional[Union[List[int], int]] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        do_local_prefill: bool = False,
         # Deprecated: use routed_dp_rank instead
         data_parallel_rank: Optional[int] = None,
         external_trace_header: Optional[Dict] = None,
@@ -549,6 +552,7 @@ class Engine(EngineScoreMixin, EngineBase):
             bootstrap_room=bootstrap_room,
             routed_dp_rank=routed_dp_rank,
             disagg_prefill_dp_rank=disagg_prefill_dp_rank,
+            do_local_prefill=do_local_prefill,
             external_trace_header=external_trace_header,
             rid=rid,
             session_id=session_id,

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -275,6 +275,8 @@ class GenerateReqInput:
     data_parallel_rank: Optional[int] = None
     # For PD disagg — hint telling decode which prefill DP worker has the KV cache
     disagg_prefill_dp_rank: Optional[int] = None
+    # For conditional aggregation — prefill this request on the decode worker.
+    do_local_prefill: bool = False
     # Routing key for routing-key schedule policy
     routing_key: Optional[str] = None
     # Conversation id used for tracking requests
@@ -914,6 +916,7 @@ class GenerateReqInput:
             ),
             routed_dp_rank=self.routed_dp_rank,
             disagg_prefill_dp_rank=self.disagg_prefill_dp_rank,
+            do_local_prefill=self.do_local_prefill,
             conversation_id=self.conversation_id,
             http_worker_ipc=self.http_worker_ipc,
             require_reasoning=self.require_reasoning,
@@ -1000,6 +1003,8 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     routed_dp_rank: Optional[int] = None
     # For PD disagg — hint telling decode which prefill DP worker has the KV cache
     disagg_prefill_dp_rank: Optional[int] = None
+    # For conditional aggregation — prefill this request on the decode worker.
+    do_local_prefill: bool = False
 
     # Routing key for routing-key schedule policy
     routing_key: Optional[str] = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -842,6 +842,7 @@ class Req(ReqDllmMixin):
         disagg_mode: Optional[DisaggregationMode] = None,
         routed_dp_rank: Optional[int] = None,
         disagg_prefill_dp_rank: Optional[int] = None,
+        do_local_prefill: bool = False,
         vocab_size: Optional[int] = None,
         priority: Optional[int] = None,
         metrics_collector: Optional[SchedulerMetricsCollector] = None,
@@ -1164,6 +1165,7 @@ class Req(ReqDllmMixin):
 
         self.routed_dp_rank: Optional[int] = routed_dp_rank
         self.disagg_prefill_dp_rank: Optional[int] = disagg_prefill_dp_rank
+        self.do_local_prefill = do_local_prefill
 
         # the start index of the sent kv cache
         # We want to send it chunk by chunk for chunked prefill.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1281,11 +1281,17 @@ class Scheduler(
         self.disagg_prefill_inflight_queue = None
         self.disagg_decode_prealloc_queue = None
         self.disagg_decode_transfer_queue = None
+        self.disagg_decode_prebuilt_queue = None
 
         self.disaggregation_mode = DisaggregationMode(get_disagg().disaggregation_mode)
         self.transfer_backend = TransferBackend(
             get_disagg().disaggregation_transfer_backend
         )
+        self.conditional_agg_enabled = (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and get_disagg().disaggregation_decode_enable_conditional_agg
+        )
+        self._conditional_agg_full_capacity: Optional[Tuple[int, int]] = None
 
         # In rust-server mode the KV bootstrap registry is already serving on
         # the rust api listener (maybe_init_rust_server runs before this
@@ -1374,6 +1380,9 @@ class Scheduler(
                 num_reserved_decode_tokens=get_disagg().num_reserved_decode_tokens,
                 transfer_backend=self.transfer_backend,
             )
+            # Conditional aggregation reserves waiting_queue for requests that
+            # the decode worker must prefill locally.
+            self.disagg_decode_prebuilt_queue: List[Req] = []
 
         elif self.disaggregation_mode == DisaggregationMode.PREFILL:
             # *2 for the headroom.
@@ -2413,6 +2422,7 @@ class Scheduler(
                 disagg_mode=self.disaggregation_mode,
                 routed_dp_rank=recv_req.routed_dp_rank,
                 disagg_prefill_dp_rank=recv_req.disagg_prefill_dp_rank,
+                do_local_prefill=recv_req.do_local_prefill,
                 vocab_size=self.model_config.vocab_size,
                 priority=recv_req.priority,
                 metrics_collector=(
@@ -2440,6 +2450,7 @@ class Scheduler(
                 if (
                     recv_req.bootstrap_room is None
                     and self.transfer_backend != TransferBackend.FAKE
+                    and not (self.conditional_agg_enabled and req.do_local_prefill)
                 ):
                     error_msg = (
                         f"Invalid request: Disaggregated request received without "
@@ -2728,11 +2739,19 @@ class Scheduler(
             )
             req.time_stats.set_prefill_bootstrap_queue_entry_time()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
-            self.disagg_decode_prealloc_queue.add(req, is_retracted=is_retracted)
-            if not is_retracted:
-                req.time_stats.set_decode_prealloc_queue_entry_time()
+            if self.conditional_agg_enabled and req.do_local_prefill:
+                self._prefetch_kvcache(req)
+                self.waiting_queue.append(req)
+                if is_retracted:
+                    req.time_stats.set_retract_time()
+                else:
+                    req.time_stats.set_wait_queue_entry_time()
             else:
-                req.time_stats.set_retract_time()
+                self.disagg_decode_prealloc_queue.add(req, is_retracted=is_retracted)
+                if is_retracted:
+                    req.time_stats.set_retract_time()
+                else:
+                    req.time_stats.set_decode_prealloc_queue_entry_time()
         else:
             raise ValueError(f"Invalid {self.disaggregation_mode=}")
 
@@ -3010,7 +3029,10 @@ class Scheduler(
 
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_batch_to_run(
-        self, running_batch: ScheduleBatch, last_batch: Optional[ScheduleBatch]
+        self,
+        running_batch: ScheduleBatch,
+        last_batch: Optional[ScheduleBatch],
+        allow_prefill: bool = True,
     ) -> NextBatchPlan:
         self.process_pending_chunked_abort()
 
@@ -3098,7 +3120,9 @@ class Scheduler(
             if running_batch.is_empty():
                 running_batch.batch_is_full = False
 
-        if self.dllm_config is not None:
+        if not allow_prefill:
+            new_batch = None
+        elif self.dllm_config is not None:
             new_batch = self.get_new_batch_dllm(running_batch)
         else:
             prefill_plan = self.get_new_batch_prefill(running_batch)
@@ -4093,6 +4117,8 @@ class Scheduler(
 
         # Waiting queues: waiting + bootstrapping + preallocation + kv transfer (decode)
         idle &= len(self.waiting_queue) == 0
+        if (prebuilt_queue := self.disagg_decode_prebuilt_queue) is not None:
+            idle &= len(prebuilt_queue) == 0
 
         if (
             for_health_check
@@ -4456,8 +4482,12 @@ class Scheduler(
                 # to release prefetch events associated with the request
                 self.tree_cache.release_aborted_request(req.rid)
             self.ipc_channels.send_to_tokenizer.send_output(AbortReq(rid=req.rid), req)
-            # For disaggregation decode mode, the request in the waiting queue has KV cache allocated.
-            if self.disaggregation_mode == DisaggregationMode.DECODE:
+            # Remote-prefilled decode requests have KV allocated. A local-prefill
+            # request can still be waiting for its first allocation.
+            if (
+                self.disaggregation_mode == DisaggregationMode.DECODE
+                and req.req_pool_idx is not None
+            ):
                 release_kv_cache(req, self.tree_cache)
             # For disaggregation prefill mode, free the metadata buffer index
             if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -4525,6 +4555,22 @@ class Scheduler(
                         req.disagg_kv_sender.abort()
 
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
+            if self.disagg_decode_prebuilt_queue:
+                remaining_prebuilt = []
+                for req in self.disagg_decode_prebuilt_queue:
+                    if recv_req.abort_all or req.rid.startswith(recv_req.rid):
+                        logger.debug(f"Abort prebuilt queue request. {req.rid=}")
+                        if self.enable_hicache_storage:
+                            self.tree_cache.release_aborted_request(req.rid)
+                        self.ipc_channels.send_to_tokenizer.send_output(
+                            AbortReq(rid=req.rid), req
+                        )
+                        if req.req_pool_idx is not None:
+                            release_kv_cache(req, self.tree_cache)
+                    else:
+                        remaining_prebuilt.append(req)
+                self.disagg_decode_prebuilt_queue = remaining_prebuilt
+
             # Abort requests that have not yet finished preallocation
             for decode_req in self.disagg_decode_prealloc_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
@@ -4632,11 +4678,14 @@ class Scheduler(
         self.running_batch.reqs = []
         for req in retract_reqs:
             if self.disaggregation_mode == DisaggregationMode.DECODE:
-                if req.output_ids:
-                    req.pd_rebootstrap_forced_output_id = req.output_ids.pop()
-                req.pd_rebootstrap_in_progress = True
-                req.time_stats.set_retract_time()
-                self.disagg_decode_prealloc_queue.hold_rebootstrap(req)
+                if self.conditional_agg_enabled and req.do_local_prefill:
+                    self._add_request_to_queue(req, is_retracted=True)
+                else:
+                    if req.output_ids:
+                        req.pd_rebootstrap_forced_output_id = req.output_ids.pop()
+                    req.pd_rebootstrap_in_progress = True
+                    req.time_stats.set_retract_time()
+                    self.disagg_decode_prealloc_queue.hold_rebootstrap(req)
             else:
                 self._add_request_to_queue(req)
         self.running_batch.batch_is_full = False

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -414,7 +414,7 @@ class SchedulerPPMixin:
 
                 # get batch to run and proxy tensors if needed
                 plan = self.get_next_disagg_decode_batch_to_run(
-                    running_batch=self.running_batch
+                    running_batch=self.running_batch, last_batch=self.last_batch
                 )
                 self.running_batch = plan.running_batch
                 batch = plan.batch_to_run

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1429,6 +1429,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 return_indexer_topk=obj.return_indexer_topk,
                 routed_dp_rank=obj.routed_dp_rank,
                 disagg_prefill_dp_rank=obj.disagg_prefill_dp_rank,
+                do_local_prefill=obj.do_local_prefill,
                 priority=obj.priority,
                 extra_key=obj.extra_key,
                 cache_salt=obj.cache_salt,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3093,6 +3093,11 @@ class ServerArgs:
         "Enable async KV cache offloading on decode server (PD mode).",
         NS("disagg"),
     ] = False
+    disaggregation_decode_enable_conditional_agg: A[
+        bool,
+        "Enable conditional aggregation on the decode server (PD mode). Requests with do_local_prefill set are prefilled locally instead of receiving KV from a prefill worker.",
+        NS("disagg"),
+    ] = False
     num_reserved_decode_tokens: A[
         int,
         "Number of decode tokens that will have memory reserved when adding new request to the running batch.",

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -252,6 +252,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
             queue=[], retracted_queue=[object()]
         )
         scheduler.disagg_decode_transfer_queue = SimpleNamespace(queue=[])
+        scheduler.disagg_decode_prebuilt_queue = []
         scheduler.decode_offload_manager = None
         scheduler.enable_hisparse = False
         scheduler.enable_hierarchical_cache = False

--- a/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
+++ b/test/registered/unit/managers/test_priority_scheduling_disaggregation.py
@@ -34,6 +34,8 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
         scheduler.model_config = SimpleNamespace(num_key_value_heads=8)
         scheduler.disagg_prefill_bootstrap_queue = MagicMock()
         scheduler.disagg_decode_prealloc_queue = MagicMock()
+        scheduler.disagg_decode_prebuilt_queue = []
+        scheduler.conditional_agg_enabled = False
         scheduler.ipc_channels = MagicMock()
         return scheduler
 
@@ -66,6 +68,31 @@ class TestDisaggregationPriorityQueueing(unittest.TestCase):
             req, is_retracted=False
         )
         req.time_stats.set_decode_prealloc_queue_entry_time.assert_called_once()
+
+    def test_decode_local_prefill_uses_standard_waiting_queue(self):
+        scheduler = self._new_scheduler(DisaggregationMode.DECODE)
+        scheduler.conditional_agg_enabled = True
+        req = self._new_req(priority=None)
+        req.do_local_prefill = True
+
+        scheduler._add_request_to_queue(req)
+
+        self.assertEqual(scheduler.waiting_queue, [req])
+        scheduler._prefetch_kvcache.assert_called_once_with(req)
+        scheduler.disagg_decode_prealloc_queue.add.assert_not_called()
+        req.time_stats.set_wait_queue_entry_time.assert_called_once()
+
+    def test_retracted_decode_local_prefill_returns_to_waiting_queue(self):
+        scheduler = self._new_scheduler(DisaggregationMode.DECODE)
+        scheduler.conditional_agg_enabled = True
+        req = self._new_req(priority=None)
+        req.do_local_prefill = True
+
+        scheduler._add_request_to_queue(req, is_retracted=True)
+
+        self.assertEqual(scheduler.waiting_queue, [req])
+        scheduler.disagg_decode_prealloc_queue.add.assert_not_called()
+        req.time_stats.set_retract_time.assert_called_once()
 
     def test_priority_disabled_abort_validation_applies_to_decode_mode(self):
         scheduler = self._new_scheduler(DisaggregationMode.DECODE)
@@ -418,6 +445,7 @@ class TestDecodePrebuiltPriority(unittest.TestCase):
         scheduler = Scheduler.__new__(Scheduler)
         scheduler.grammar_manager = MagicMock()
         scheduler.grammar_manager.has_waiting_grammars.return_value = False
+        scheduler.conditional_agg_enabled = False
         original_waiting_queue = [MagicMock(rid="low"), MagicMock(rid="high")]
         scheduler.waiting_queue = original_waiting_queue
         scheduler.waiting_queue[0].priority = 1
@@ -443,11 +471,14 @@ class TestDecodePrebuiltPriority(unittest.TestCase):
         new_batch = MagicMock()
         # get_new_prebuilt_batch reads the published disagg config
         # (disaggregation_decode_enable_radix_cache).
-        with patch(
-            "sglang.srt.disaggregation.decode.ScheduleBatch.init_new",
-            return_value=new_batch,
-        ) as init_new, get_context().override_server_args(
-            disaggregation_decode_enable_radix_cache=False
+        with (
+            patch(
+                "sglang.srt.disaggregation.decode.ScheduleBatch.init_new",
+                return_value=new_batch,
+            ) as init_new,
+            get_context().override_server_args(
+                disaggregation_decode_enable_radix_cache=False
+            ),
         ):
             ret = SchedulerDisaggregationDecodeMixin.get_new_prebuilt_batch(
                 scheduler, scheduler.running_batch

--- a/test/registered/unit/managers/test_scheduler_decision_batch_params.py
+++ b/test/registered/unit/managers/test_scheduler_decision_batch_params.py
@@ -1,5 +1,6 @@
 import inspect
 import unittest
+from unittest.mock import ANY, MagicMock, patch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
@@ -46,6 +47,146 @@ class TestDecisionMethodsHaveNoHiddenBatchChannel(unittest.TestCase):
                         "explicitly and return it via NextBatchPlan instead."
                     ),
                 )
+
+
+class TestConditionalAggregationBatchDecision(unittest.TestCase):
+    def test_conditional_aggregation_uses_standard_scheduler(self):
+        scheduler = MagicMock()
+        scheduler.conditional_agg_enabled = True
+        scheduler.chunked_req = None
+        scheduler.waiting_queue = []
+        scheduler._conditional_local_chunk_is_stalled.return_value = False
+        scheduler.get_new_prebuilt_batch.return_value = None
+        expected_plan = MagicMock()
+        scheduler.get_next_batch_to_run.return_value = expected_plan
+        running_batch = MagicMock()
+        last_batch = MagicMock()
+
+        plan = SchedulerDisaggregationDecodeMixin.get_next_disagg_decode_batch_to_run(
+            scheduler, running_batch, last_batch
+        )
+
+        self.assertIs(plan, expected_plan)
+        scheduler.get_next_batch_to_run.assert_called_once_with(
+            running_batch=running_batch, last_batch=last_batch
+        )
+
+    def test_chunked_local_prefill_defers_prebuilt_absorption(self):
+        scheduler = MagicMock()
+        scheduler.conditional_agg_enabled = True
+        scheduler.chunked_req = MagicMock()
+        scheduler.waiting_queue = []
+        scheduler._conditional_local_chunk_is_stalled.return_value = False
+        expected_plan = MagicMock()
+        scheduler.get_next_batch_to_run.return_value = expected_plan
+
+        plan = SchedulerDisaggregationDecodeMixin.get_next_disagg_decode_batch_to_run(
+            scheduler, MagicMock(), MagicMock()
+        )
+
+        self.assertIs(plan, expected_plan)
+        scheduler.get_new_prebuilt_batch.assert_not_called()
+
+    def test_conditional_local_wait_rechecks_full_batch_after_capacity_increases(self):
+        scheduler = MagicMock()
+        scheduler.conditional_agg_enabled = True
+        scheduler.chunked_req = None
+        scheduler.waiting_queue = [MagicMock()]
+        scheduler._conditional_local_chunk_is_stalled.return_value = False
+        scheduler._conditional_agg_full_capacity = None
+        scheduler.token_to_kv_pool_allocator.available_size.side_effect = [
+            27_008,
+            70_848,
+        ]
+        scheduler.req_to_token_pool.available_size.return_value = 54
+        scheduler.get_new_prebuilt_batch.return_value = None
+        expected_plan = MagicMock()
+        scheduler.get_next_batch_to_run.return_value = expected_plan
+        running_batch = MagicMock()
+        running_batch.batch_is_full = True
+        last_batch = MagicMock()
+
+        first_plan = (
+            SchedulerDisaggregationDecodeMixin.get_next_disagg_decode_batch_to_run(
+                scheduler, running_batch, last_batch
+            )
+        )
+
+        self.assertIs(first_plan, expected_plan)
+        self.assertTrue(running_batch.batch_is_full)
+        self.assertEqual(scheduler._conditional_agg_full_capacity, (27_008, 54))
+
+        second_plan = (
+            SchedulerDisaggregationDecodeMixin.get_next_disagg_decode_batch_to_run(
+                scheduler, running_batch, last_batch
+            )
+        )
+
+        self.assertIs(second_plan, expected_plan)
+        self.assertFalse(running_batch.batch_is_full)
+        self.assertIsNone(scheduler._conditional_agg_full_capacity)
+        scheduler.get_next_batch_to_run.assert_called_with(
+            running_batch=running_batch, last_batch=last_batch
+        )
+
+    def test_conditional_local_chunk_defers_remote_preallocation(self):
+        scheduler = MagicMock()
+        scheduler.enable_decode_hicache = False
+        scheduler.conditional_agg_enabled = True
+        scheduler.chunked_req = MagicMock()
+        scheduler.disagg_decode_prebuilt_queue = []
+        scheduler.polling_count = 0
+        scheduler.polling_interval = 1
+        transferred_req = MagicMock()
+        scheduler.disagg_decode_transfer_queue.pop_transferred.return_value = [
+            transferred_req
+        ]
+
+        with patch("sglang.srt.disaggregation.decode.get_disagg") as get_disagg:
+            get_disagg.return_value.disaggregation_decode_enable_offload_kvcache = False
+            SchedulerDisaggregationDecodeMixin.process_decode_queue(scheduler)
+
+        scheduler.disagg_decode_prealloc_queue.resume_retracted_reqs.assert_not_called()
+        scheduler.disagg_decode_prealloc_queue.pop_preallocated.assert_not_called()
+        scheduler.disagg_decode_transfer_queue.pop_transferred.assert_called_once_with()
+        self.assertEqual(
+            scheduler.disagg_decode_prebuilt_queue,
+            [transferred_req],
+        )
+
+    def test_conditional_local_chunk_waits_for_capacity(self):
+        scheduler = MagicMock()
+        scheduler.conditional_agg_enabled = True
+        scheduler.chunked_req.full_untruncated_fill_ids = list(range(32_768))
+        scheduler.chunked_req.prefix_indices = list(range(16_384))
+        scheduler.max_prefill_tokens = 16_384
+        scheduler.chunked_prefill_size = 16_384
+        scheduler.token_to_kv_pool_allocator.page_size = 64
+        scheduler.token_to_kv_pool_allocator.available_size.return_value = 0
+        scheduler._conditional_local_chunk_is_stalled.return_value = True
+        scheduler.get_new_prebuilt_batch.return_value = None
+        expected_plan = MagicMock()
+        scheduler.get_next_batch_to_run.return_value = expected_plan
+        running_batch = MagicMock()
+        running_batch.is_empty.return_value = True
+
+        plan = SchedulerDisaggregationDecodeMixin.get_next_disagg_decode_batch_to_run(
+            scheduler, running_batch, MagicMock()
+        )
+
+        self.assertIs(plan, expected_plan)
+        scheduler.get_new_prebuilt_batch.assert_called_once_with(running_batch)
+        scheduler.get_next_batch_to_run.assert_called_once_with(
+            running_batch=running_batch,
+            last_batch=ANY,
+            allow_prefill=False,
+        )
+
+        self.assertTrue(
+            SchedulerDisaggregationDecodeMixin._conditional_local_chunk_is_stalled(
+                scheduler
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_pause_generation.py
+++ b/test/registered/unit/managers/test_scheduler_pause_generation.py
@@ -44,6 +44,7 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         scheduler.hisparse_coordinator = MagicMock()
         scheduler.result_queue = deque()
         scheduler.disaggregation_mode = DisaggregationMode.NULL
+        scheduler.conditional_agg_enabled = False
         # Support _kv_snap diagnostic logging in patched schedulers
         scheduler.token_to_kv_pool_allocator = MagicMock()
         scheduler.token_to_kv_pool_allocator.available_size.return_value = 1000
@@ -463,6 +464,29 @@ class TestSchedulerPauseGeneration(unittest.TestCase):
         # the device->host KV offload rather than offload-then-delete it.
         mock_retract_all.assert_called_once()
         self.assertEqual(mock_retract_all.call_args.kwargs["offload_kv"], False)
+
+    def test_pd_decode_local_prefill_retracts_locally(self):
+        scheduler = self._new_scheduler()
+        scheduler.disaggregation_mode = DisaggregationMode.DECODE
+        scheduler.conditional_agg_enabled = True
+        scheduler.last_batch = None
+        scheduler._add_request_to_queue = MagicMock()
+        scheduler.disagg_decode_prealloc_queue = MagicMock()
+
+        req = SimpleNamespace(
+            finished=lambda: False,
+            output_ids=[10, 11, 12],
+            do_local_prefill=True,
+            time_stats=MagicMock(),
+        )
+        scheduler.running_batch.reqs = [req]
+
+        with patch("sglang.srt.managers.scheduler.retract_all"):
+            scheduler.pause_generation(PauseGenerationReqInput(mode="retract"))
+
+        scheduler._add_request_to_queue.assert_called_once_with(req, is_retracted=True)
+        scheduler.disagg_decode_prealloc_queue.hold_rebootstrap.assert_not_called()
+        self.assertEqual(req.output_ids, [10, 11, 12])
 
     def test_pd_decode_continue_releases_held_rebootstrap(self):
         """continue_generation must enqueue staged rebootstrap reqs on resume."""


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This change ports the [conditional aggregation POC](https://github.com/ishandhanani/sglang/pull/7) onto current main and lets a router select decode-local prefill per request. It lets one decode pool serve local-prefill requests while it continues to accept transferred KV for normal PD requests.

### How This Was Implemented

- Add `do_local_prefill` to generation inputs and carry it through tokenizer and scheduler request state.
- Add the opt-in `--disaggregation-decode-enable-conditional-agg` decode-worker flag.
- Keep local-prefill requests in `waiting_queue` and transferred requests in a separate `disagg_decode_prebuilt_queue`.
- Coordinate local chunked prefill with remote preallocation, KV transfer, capacity recovery, retraction, abort, and idle detection.

<details>
<summary>Walkthrough</summary>

#### Mental model

The router chooses the path for each request. A marked request uses the decode worker's normal prefill scheduler, while an unmarked request keeps the existing PD transfer path.

```mermaid
flowchart LR
    R["PD router"] -->|"do_local_prefill=true"| L["Decode local waiting queue"]
    R -->|"bootstrap fields"| P["Prefill worker"]
    P -->|"KV transfer"| T["Decode prebuilt queue"]
    L --> S["Shared decode scheduler"]
    T --> S
    S --> G["Decode generation"]
```

#### State and ordering

Local-prefill requests use `waiting_queue`, and transferred requests use `disagg_decode_prebuilt_queue`. While a local chunk is active, the scheduler defers remote preallocation and normal prebuilt absorption. If the next local chunk cannot fit, the scheduler runs ready transferred work until KV pages become available, then retries local admission.

#### Request lifecycle

The tokenizer carries the marker to the scheduler. The scheduler prefetches radix-cache state and admits a marked request through the normal local-prefill path. Retraction returns that request to the same local queue without PD rebootstrap. Abort logic releases KV only after the request owns an allocation.

Unmarked requests retain the existing decode preallocation, transfer, and prebuilt-batch flow. Pipeline-parallel scheduling carries `last_batch` through both paths.

#### Boundaries and limitations

The feature is opt-in and does not implement router policy. Existing PD behavior stays unchanged when the flag is off or the marker is false. The B200 run used TP2 plus EP2 on each worker and kept decode radix cache disabled. Decode-local prefill used Triton prefill attention while normal decode used FlashInfer.

</details>

### Validation

- `.venv/bin/python -m pytest -q test/registered/unit/disaggregation/test_decode_queue_cleanup.py test/registered/unit/managers/test_priority_scheduling_disaggregation.py test/registered/unit/managers/test_scheduler_decision_batch_params.py test/registered/unit/managers/test_scheduler_pause_generation.py` — 49 passed and 3 subtests passed.
- Broad SGLang disaggregation and manager suite — 578 passed, 4 skipped, and 606 subtests passed.
- Ruff, Black, `py_compile`, and diff checks passed.
- Dynamo integration — 134 Python tests, 24 conditional-policy Rust tests, and Rust binding `cargo check` passed.
- B200 end-to-end — both counted AIPerf arms completed 28/28 requests with 0 errors and 0 cancellations; the conditional arm exercised 22 decode-local-prefill routes.

### Benchmark Results

One prefill worker and one decode worker ran on four B200 GPUs, with TP2 and EP2 on each worker. The workload was AIPerf `semianalysis_cc_traces_weka_with_subagents_256k` at concurrency 28 using `nvidia/Qwen3-235B-A22B-Instruct-2507-NVFP4`; the prefill worker was restarted before each arm, and decode radix cache stayed disabled.

| Metric | Control | Conditional | Delta |
|---|---:|---:|---:|
| Request throughput | 0.1651 req/s | 0.1747 req/s | +5.8% |
| Output throughput | 44.41 tok/s | 48.67 tok/s | +9.6% |
| Total token throughput | 3,392.52 tok/s | 3,591.50 tok/s | +5.9% |
| Average TTFT | 20,945.69 ms | 19,122.37 ms | -8.7% |
| p50 TTFT | 609.50 ms | 533.11 ms | -12.5% |
| p90 TTFT | 68,598.84 ms | 64,902.70 ms | -5.4% |
| p50 request latency | 910.60 ms | 826.73 ms | -9.2% |
| p90 request latency | 77,634.88 ms | 73,937.50 ms | -4.8% |
| Average ITL | 13.49 ms | 20.19 ms | +49.6% |

Both arms used the same 28 conversation IDs and identical 20,277-token mean ISL; actual mean OSL was 269.0 control and 278.6 conditional. For the 22 requests that took the conditional path, a conversation-ID-paired comparison shows 36.2% lower average TTFT with only 0.3% OSL difference; their average ITL regressed 62.5% because local prefill shares the decode GPUs.
<!-- codex-pr-description:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31746207936](https://github.com/sgl-project/sglang/actions/runs/31746207936)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31746207325](https://github.com/sgl-project/sglang/actions/runs/31746207325)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #31746207623](https://github.com/sgl-project/sglang/actions/runs/31746207623)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
