### PR TITLE
[Fix] Guard conditional top-logprob keys in the completions echo path

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1540,9 +1540,12 @@ class OpenAIServingChat(OpenAIServingBase):
                 audio_tokens[index] = content["meta_info"].get("audio_tokens", 0)
                 video_tokens[index] = content["meta_info"].get("video_tokens", 0)
 
+                finish_reason = content["meta_info"].get("finish_reason", None)
+                finish_reason_type = finish_reason["type"] if finish_reason else None
+
                 # Handle logprobs
                 choice_logprobs = None
-                if request.logprobs:
+                if request.logprobs and finish_reason_type != "abort":
                     n_prev_token = n_prev_tokens.get(index, 0)
                     total_output_logprobs = content["meta_info"][
                         "output_token_logprobs_length"
@@ -1552,9 +1555,6 @@ class OpenAIServingChat(OpenAIServingBase):
                             content, n_prev_token, total_output_logprobs
                         ).model_dump()
                     n_prev_tokens[index] = total_output_logprobs
-
-                finish_reason = content["meta_info"].get("finish_reason", None)
-                finish_reason_type = finish_reason["type"] if finish_reason else None
 
                 # Track finish_reason for each index
                 if finish_reason_type:

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -265,6 +265,9 @@ class OpenAIServingCompletion(OpenAIServingBase):
                     "cached_tokens_details", None
                 )
 
+                finish_reason = content["meta_info"].get("finish_reason", None)
+                finish_reason_type = finish_reason["type"] if finish_reason else None
+
                 is_first_chunk = index not in stream_offsets
                 offset = stream_offsets.get(index, 0)
                 # Handle echo for first chunk
@@ -275,7 +278,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
 
                 # Handle logprobs
                 logprobs = None
-                if request.logprobs is not None:
+                if request.logprobs is not None and finish_reason_type != "abort":
                     # The first chunk and echo is enabled.
                     if is_first_chunk and request.echo:
                         input_token_logprobs = content["meta_info"][
@@ -338,8 +341,6 @@ class OpenAIServingCompletion(OpenAIServingBase):
                 else:
                     delta = text[offset:]
                 stream_offsets[index] = len(content["text"])
-                finish_reason = content["meta_info"].get("finish_reason", None)
-                finish_reason_type = finish_reason["type"] if finish_reason else None
 
                 # Abort with an explicit error status_code is a system error
                 # (timeout, OOM, validation): emit a streaming error chunk.

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1962,6 +1962,8 @@ class ServingChatTestCase(unittest.TestCase):
             temperature=0.7,
             max_tokens=100,
             stream=True,
+            logprobs=True,
+            top_logprobs=5,
         )
 
         with patch(

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -253,6 +253,7 @@ class ServingCompletionTestCase(unittest.TestCase):
             prompt="Hello world",
             max_tokens=100,
             stream=True,
+            logprobs=5,
         )
 
         adapted_request, _ = self.sc._convert_to_internal_request(req)


### PR DESCRIPTION
## Motivation

`POST /v1/completions` with `{"echo": true, "logprobs": 0}` returns a 500.

`logprobs=0` is valid input -- `CompletionRequest.logprobs` is `Optional[int]` with no
bounds. It maps to `return_logprob=True` with `top_logprobs_num=0`, so
`add_logprob_to_meta_info` never writes the `input_top_logprobs` / `output_top_logprobs`
keys. Both echo branches read `meta_info["input_top_logprobs"]` by direct subscript, so the
request raises `KeyError`.

The underlying issue is a gate mismatch, not just a missing `.get()`. The request side
decides whether to compute input logprobs with a truthiness test:

```python
if request.echo and request.logprobs:
    logprob_start_len = 0
```

while the read side gates on `is not None`. `logprobs=0` falls between the two: input
logprobs were never requested, yet the echo branch still reads them.

These two subscripts are also the only places left in the OpenAI entrypoints that read a
conditional logprob key without `.get()` -- `serving_chat.py`, `serving_responses.py`,
`serving_rerank.py` and the three sibling arguments of the same
`to_openai_style_logprobs()` call already tolerate an absent key.

## Modifications

- Align the echo read gate with the request-side gate on both the streaming and
  non-streaming paths, so `logprobs=0` no longer enters the echo branch.
- Read `input_top_logprobs` with `.get(..., None)`, matching the other three
  `to_openai_style_logprobs` arguments.
- Let the `echo` + `logprobs` incompatibility warning fire for `logprobs=0` as well.
- Add regression tests for `{"echo": true, "logprobs": 0}` on both paths.

An earlier revision of this PR guarded streaming logprob assembly behind
`finish_reason_type != "abort"`. That guard is dropped here: the `KeyError` it worked
around was fixed by #34627, which removed the early return in `convert_logprob_style`, so
`output_token_logprobs_length` is now always present. Keeping the guard would only drop
valid logprobs from graceful-abort terminal chunks, which `serving_chat.py` deliberately
routes through the normal chunk path.

## Accuracy Tests

N/A -- error-path fix, no model-output changes.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #35291345762](https://github.com/sgl-project/sglang/actions/runs/35291345762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35291345423](https://github.com/sgl-project/sglang/actions/runs/35291345423)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35291345534](https://github.com/sgl-project/sglang/actions/runs/35291345534)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->