### PR TITLE
[Fix] Require JSON booleans for response_format json_schema.strict

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -53,6 +53,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    StrictBool,
     field_serializer,
     field_validator,
     model_serializer,
@@ -219,7 +220,10 @@ class JsonSchemaResponseFormat(BaseModel):
     description: Optional[str] = None
     # use alias to workaround pydantic conflict
     schema_: Optional[Dict[str, object]] = Field(alias="schema", default=None)
-    strict: Optional[bool] = None
+    # The OpenAI wire contract accepts JSON booleans only; StrictBool rejects
+    # the values lax pydantic would coerce ("yes", "on", 0, 1, ...), matching
+    # OpenAI's 422 behavior. Omitted (None) keeps its meaning.
+    strict: Optional[StrictBool] = None
 
 
 class ResponseFormat(BaseModel):

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -114,6 +114,42 @@ class TestCompletionRequest(unittest.TestCase):
 class TestChatCompletionRequest(unittest.TestCase):
     """Test ChatCompletionRequest protocol model"""
 
+    def test_json_schema_strict_requires_json_boolean(self):
+        base_request = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "response_format": {
+                "type": "json_schema",
+                "json_schema": {
+                    "name": "answer",
+                    "schema": {"type": "object"},
+                },
+            },
+        }
+
+        for strict in (True, False, None):
+            with self.subTest(strict=strict):
+                response_format = dict(base_request["response_format"])
+                response_format["json_schema"] = {
+                    **response_format["json_schema"],
+                    "strict": strict,
+                }
+                request = ChatCompletionRequest.model_validate(
+                    {**base_request, "response_format": response_format}
+                )
+                self.assertIs(request.response_format.json_schema.strict, strict)
+
+        for strict in ("yes", "false", 0, 1):
+            with self.subTest(strict=strict), self.assertRaises(ValidationError):
+                response_format = dict(base_request["response_format"])
+                response_format["json_schema"] = {
+                    **response_format["json_schema"],
+                    "strict": strict,
+                }
+                ChatCompletionRequest.model_validate(
+                    {**base_request, "response_format": response_format}
+                )
+
     def test_basic_chat_completion_request(self):
         """Test basic chat completion request"""
         messages = [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## Motivation

`JsonSchemaResponseFormat.strict` is declared `Optional[bool]`, so pydantic validates it in lax mode and silently accepts non-boolean JSON values: `"yes"`/`"on"` → `True`, `"no"`/`"off"`/`"false"` → `False`, and `0`/`1`/`1.0` are coerced likewise. The OpenAI wire contract for `response_format.json_schema.strict` accepts JSON booleans only — the same payloads are rejected with a 422 by OpenAI.

Since `strict` gates the constrained-decoding opt-out (see the `strict is not False` check in `to_sampling_params`), silently coercing out-of-contract values means a malformed client payload can toggle whether schema enforcement happens at all, instead of failing loudly at validation like it would against OpenAI.

## Modifications

- `protocol.py`: `strict: Optional[bool] = None` → `strict: Optional[StrictBool] = None`. Non-boolean values now fail request validation with a 422 instead of being coerced. The `None` default (field omitted) is unchanged, so existing behavior for requests that don't send `strict` is untouched.
- `test_protocol.py`: round-trips `True`/`False`/`None` and asserts `"yes"`, `"false"`, `0`, `1` are rejected.

Adapted from a fix running in production since late July (the production variant also changed the default; this PR deliberately keeps `None` to preserve upstream's omitted-vs-explicit-false distinction).

## Accuracy Tests

N/A — request-validation change only.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31747577488](https://github.com/sgl-project/sglang/actions/runs/31747577488)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31747577306](https://github.com/sgl-project/sglang/actions/runs/31747577306)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->