### PR TITLE
[Fix] Work around xgrammar 0.2.1 negative integer minimum in Kimi-K3 structural tags

### DIFF
--- a/python/sglang/srt/function_call/kimik3_structural_tag.py
+++ b/python/sglang/srt/function_call/kimik3_structural_tag.py
@@ -274,6 +274,33 @@ def _value_format(
 ) -> Format:
     if loose_string and json_type == "string":
         return AnyTextFormat()
+    # XGrammar 0.2.1 miscompiles a one-sided negative integer lower bound:
+    # {"type": "integer", "minimum": -N} accepts the incomplete value "-"
+    # and rejects every valid negative integer. Splitting the range at zero
+    # avoids that converter bug without weakening the schema.
+    if (
+        json_type == "integer"
+        and isinstance(schema, dict)
+        and "maximum" not in schema
+        and "exclusiveMaximum" not in schema
+        and "multipleOf" not in schema
+    ):
+        lower_bounds = []
+        minimum = schema.get("minimum")
+        if isinstance(minimum, int) and not isinstance(minimum, bool):
+            lower_bounds.append(minimum)
+        exclusive_minimum = schema.get("exclusiveMinimum")
+        if isinstance(exclusive_minimum, int) and not isinstance(
+            exclusive_minimum, bool
+        ):
+            lower_bounds.append(exclusive_minimum + 1)
+        if lower_bounds and max(lower_bounds) < 0:
+            negative = dict(schema)
+            negative["maximum"] = -1
+            nonnegative = dict(schema)
+            nonnegative.pop("exclusiveMinimum", None)
+            nonnegative["minimum"] = 0
+            schema = {"anyOf": [negative, nonnegative]}
     return JSONSchemaFormat(
         json_schema=schema,
         style="qwen_xml" if json_type == "string" else "json",

--- a/test/registered/unit/function_call/test_kimik3_structural_tag.py
+++ b/test/registered/unit/function_call/test_kimik3_structural_tag.py
@@ -379,6 +379,39 @@ def test_strict_schema_handles_number_enums_and_all_of_integer_constraints():
     )
 
 
+def test_strict_schema_handles_one_sided_negative_integer_minimum():
+    tool = Tool(
+        type="function",
+        function=Function(
+            name="submit",
+            strict=True,
+            parameters={
+                "type": "object",
+                "properties": {
+                    "value": {
+                        "type": "integer",
+                        "minimum": -1000000,
+                    }
+                },
+                "required": ["value"],
+                "additionalProperties": False,
+            },
+        ),
+    )
+    grammar = _grammar([tool], tool_choice="required")
+
+    for value in ("-1000000", "-999999", "-1", "0", "1000001"):
+        assert _accepts(
+            grammar,
+            _tools_section(_call("submit", 1, _argument("value", "number", value))),
+        )
+    for value in ("-", "-1000001", "1.5"):
+        assert not _accepts(
+            grammar,
+            _tools_section(_call("submit", 1, _argument("value", "number", value))),
+        )
+
+
 def test_strict_schema_preserves_additional_properties_default():
     tool = Tool(
         type="function",


### PR DESCRIPTION
## Motivation

XGrammar 0.2.1 (the version pinned in `python/pyproject.toml`) miscompiles a JSON schema integer with a one-sided **negative** lower bound: `{"type": "integer", "minimum": -N}` produces a grammar that accepts the incomplete literal `"-"` and rejects every valid negative integer. Any Kimi-K3 tool whose parameter schema uses such a bound gets structurally-invalid tool calls under constrained decoding.

## Modifications

`kimik3_structural_tag.py::_value_format`: when an integer schema has only a negative lower bound (no `maximum`/`exclusiveMaximum`/`multipleOf`), split the range at zero into `anyOf: [{... maximum: -1}, {... minimum: 0}]`. Semantically identical schema, but each branch is a form the converter compiles correctly. Schemas with an upper bound or `multipleOf` are left untouched.

Unit tests cover the rewrite and the untouched cases (`test_kimik3_structural_tag.py`, runs against the real pinned xgrammar).

This is deliberately scoped as a converter-side workaround; the underlying bug belongs to xgrammar's JSON-schema-to-grammar conversion and the workaround can be dropped once the pin moves past a fixed release.

## Accuracy Tests

N/A — affects only grammar compilation for constrained tool-call decoding; the accepted language is the schema's original semantics.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31746756454](https://github.com/sgl-project/sglang/actions/runs/31746756454)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31746756300](https://github.com/sgl-project/sglang/actions/runs/31746756300)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->