### PR TITLE
[CI] Disable the prefill CUDA graph on the P worker of test_kimi_linear_pd_dcp4

### DIFF
--- a/test/registered/disaggregation/test_kimi_linear_pd_dcp4.py
+++ b/test/registered/disaggregation/test_kimi_linear_pd_dcp4.py
@@ -306,6 +306,8 @@ class TestKimiLinearPDDCP4(GSM8KMixin, PDDisaggregationServerBase):
             str(PHYSICAL_PAGE_SIZE),
             "--chunked-prefill-size",
             str(CHUNKED_PREFILL_SIZE),
+            "--cuda-graph-backend-prefill",
+            "disabled",
             "--mem-fraction-static",
             "0.80",
         ]


### PR DESCRIPTION
## Motivation

In `test/registered/disaggregation/test_kimi_linear_pd_dcp4.py`, both the monolithic reference server (`_monolithic_reference_args`) and the decode worker (`start_decode`) already launch with `--cuda-graph-backend-prefill disabled`. The prefill worker (`start_prefill`) was the only launch in the test left on the CUDA default, so it captured the breakable prefill CUDA graph (BCG) while everything it is compared against ran prefill eagerly.

## Modifications

Pass `--cuda-graph-backend-prefill disabled` to the P worker as well. This matches the reference server, the D worker, and the sibling `test_disaggregation_kimi_linear.py`, which disables both prefill and decode graphs.

Test-only change; no runtime code touched.

## Checklist

- [x] Format the code with pre-commit (`black` / `isort` / `ruff`).
- [x] Test-only change to an existing nightly `8-gpu-b200` registered test; no new test added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31747741780](https://github.com/sgl-project/sglang/actions/runs/31747741780)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31747741691](https://github.com/sgl-project/sglang/actions/runs/31747741691)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->