### PR TITLE
fix(muse-glimmer): parse required/named tool calls natively

### DIFF
--- a/python/sglang/srt/function_call/muse_glimmer_detector.py
+++ b/python/sglang/srt/function_call/muse_glimmer_detector.py
@@ -252,15 +252,8 @@ class MuseGlimmerDetector(BaseFormatDetector):
         return False
 
     def parses_required_natively(self) -> bool:
-        """Muse Glimmer only ever emits ATEM tool calls.
-
-        For ``tool_choice="required"`` / a named tool the default path forces a
-        JSON-array grammar (via ``JsonArrayParser``) that the model does not emit
-        for tool calls; when it produces its native ATEM block instead, the JSON
-        parser cannot read it and the call leaks to the client as content with
-        zero tool calls. Returning True routes required/named through this
-        detector's native ATEM parsing, the same path ``auto`` already uses.
-        """
+        """The model only ever emits ATEM tool calls, so the JSON-array grammar
+        the default required/named path forces cannot parse its output."""
         return True
 
     def structure_info(self) -> _GetInfoFunc:

--- a/python/sglang/srt/function_call/muse_glimmer_detector.py
+++ b/python/sglang/srt/function_call/muse_glimmer_detector.py
@@ -251,6 +251,18 @@ class MuseGlimmerDetector(BaseFormatDetector):
     def supports_structural_tag(self) -> bool:
         return False
 
+    def parses_required_natively(self) -> bool:
+        """Muse Glimmer only ever emits ATEM tool calls.
+
+        For ``tool_choice="required"`` / a named tool the default path forces a
+        JSON-array grammar (via ``JsonArrayParser``) that the model does not emit
+        for tool calls; when it produces its native ATEM block instead, the JSON
+        parser cannot read it and the call leaks to the client as content with
+        zero tool calls. Returning True routes required/named through this
+        detector's native ATEM parsing, the same path ``auto`` already uses.
+        """
+        return True
+
     def structure_info(self) -> _GetInfoFunc:
         return lambda name: StructureInfo(
             begin=f'{FUNCTION_CALLS_OPEN}\n{INVOKE_OPEN} name="{name}">',


### PR DESCRIPTION
## Motivation

Muse Glimmer only ever emits ATEM (`<atem:function_calls>`) tool calls. With `tool_choice="required"` or a named tool, the current path routes to `JsonArrayParser` and constrains generation with a JSON-array grammar. The model
does not emit that JSON format for tool calls, so when it produces its native ATEM block instead, `JsonArrayParser` cannot parse it - the call leaks to the client as `content` with `finish_reason="stop"` and zero `tool_calls`.

This reproduces on `main`. It is deterministic on a turn whose message history already contains a prior assistant `tool_calls` turn (both streaming and non-streaming, at the default `--stream-interval`): the model opens a tool channel and writes native ATEM, which the JSON path drops. `tool_choice="auto"` is unaffected - it already parses the native ATEM through `MuseGlimmerDetector`.

## Modifications

`MuseGlimmerDetector.parses_required_natively()` now returns `True`. This routes`required`/named `tool_choice` through the detector's native ATEM parsing - the same path `tool_choice="auto"` already uses - instead of the JSON-array grammar. Single-file change; no other behavior is altered.

## Accuracy Tests

Verified before/after on `main` serving `Muse-Glimmer-30B` (BF16, single GPU), `--tool-call-parser muse --reasoning-parser muse`, default `--stream-interval`:

| tool_choice | before | after |
|---|---|---|
| `auto` (single + multi-turn) | tool call returned | tool call returned (unchanged) |
| `required` / named, single-turn | tool call returned | tool call returned |
| `required` / named, multi-turn (prior tool_calls turn) | **0 tool calls, ATEM leaked as content** | tool call returned |

Existing `test/registered/unit/function_call/` suite passes with the change.

## Speed Tests and Profiling

No inference-speed impact - the change only selects which parser handles the already-generated output for `required`/named `tool_choice`.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [ ] Add unit tests (recommend a regression case for the multi-turn `required`/named path).
- [ ] Update documentation - n/a.
- [ ] Provide accuracy and speed benchmark results - see above; no speed impact.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31792190115](https://github.com/sgl-project/sglang/actions/runs/31792190115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #31792189989](https://github.com/sgl-project/sglang/actions/runs/31792189989)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->