### PR TITLE
[Fix] Make the DSpark draft num_token_non_padded host-to-device copy non-blocking

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_draft.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft.py
@@ -355,8 +355,8 @@ class DraftBlockProposer:
             spec_algorithm=SpeculativeAlgorithm.DSPARK,
             spec_info=self._draft_block_spec_info,
             capture_hidden_mode=CaptureHiddenMode.NULL,
-            num_token_non_padded=torch.tensor(
-                draft_num_tokens, dtype=torch.int32, device=device
+            num_token_non_padded=torch.tensor(draft_num_tokens, dtype=torch.int32).to(
+                device, non_blocking=True
             ),
             num_token_non_padded_cpu=draft_num_tokens,
         )


### PR DESCRIPTION
The DSpark draft `ForwardBatch` builds `num_token_non_padded` with `torch.tensor(..., device=device)`, whose pageable source makes PyTorch follow the `cudaMemcpyAsync` with a `cudaStreamSynchronize` on every decode step. A profile shows 21 such syncs totaling 71.4 ms (~3.5 ms per step, 42% of an 8.4 ms step) purely blocking the CPU from running ahead. Deferring the transfer with `.to(device, non_blocking=True)` removes it, matching how `global_num_tokens_gpu` is already built a few lines below.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #31750290163](https://github.com/sgl-project/sglang/actions/runs/31750290163)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31750289721](https://github.com/sgl-project/sglang/actions/runs/31750289721)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->