### PR TITLE
[MoE] Route every trtllm-gen MoE call site through one PDL guard

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -52,7 +52,9 @@ _TRTLLM_MOE_PDL_MAX_TOKENS = envs.SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS.get()
 
 
 def trtllm_moe_enable_pdl(num_tokens: int) -> bool:
-    return num_tokens <= _TRTLLM_MOE_PDL_MAX_TOKENS
+    from sglang.kernels.jit.utils import is_arch_support_pdl
+
+    return is_arch_support_pdl() and num_tokens <= _TRTLLM_MOE_PDL_MAX_TOKENS
 
 
 @dataclass
@@ -78,7 +80,6 @@ def finalize_flashinfer_trtllm_deferred_output(
     deferred_output: FlashInferTrtllmDeferredFinalizeOutput,
     shared_output: torch.Tensor,
 ) -> torch.Tensor:
-    from sglang.kernels.jit.utils import is_arch_support_pdl
     from sglang.kernels.ops.moe.moe_finalize_fuse_shared import moe_finalize_fuse_shared
 
     return moe_finalize_fuse_shared(
@@ -87,8 +88,7 @@ def finalize_flashinfer_trtllm_deferred_output(
         deferred_output.expert_weights,
         shared_output,
         deferred_output.top_k,
-        enable_pdl=is_arch_support_pdl()
-        and trtllm_moe_enable_pdl(deferred_output.expert_weights.shape[0]),
+        enable_pdl=trtllm_moe_enable_pdl(deferred_output.expert_weights.shape[0]),
     )
 
 

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -51,6 +51,23 @@ _deferred_finalize_enabled: contextvars.ContextVar[bool] = contextvars.ContextVa
 _TRTLLM_MOE_PDL_MAX_TOKENS = envs.SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS.get()
 
 
+def trtllm_moe_enable_pdl(num_tokens: int) -> bool:
+    """Whether to run the trtllm-gen MoE with programmatic dependent launch.
+
+    PDL on these kernels can leave the consumer's grid-dependency wait
+    unreleased when another stream overlaps the launch, stranding the whole TP
+    group at its next collective (see 6a1d1f4422, landed in #31681). The
+    consumer is the finalize kernel, launched with one block per token, so the
+    pressure it puts on the producer GEMM grows with the token count -- and
+    large calls gain nothing from PDL to begin with.
+
+    Every trtllm-gen MoE call site should route its PDL decision through here
+    rather than passing a literal or leaving the argument off, which lets
+    FlashInfer default it to on with no ceiling.
+    """
+    return num_tokens <= _TRTLLM_MOE_PDL_MAX_TOKENS
+
+
 @dataclass
 class FlashInferTrtllmDeferredFinalizeOutput:
     gemm2_out: torch.Tensor
@@ -77,13 +94,17 @@ def finalize_flashinfer_trtllm_deferred_output(
     from sglang.kernels.jit.utils import is_arch_support_pdl
     from sglang.kernels.ops.moe.moe_finalize_fuse_shared import moe_finalize_fuse_shared
 
+    # Same producer (the trtllm-gen GEMM2) as the in-op finalize this replaces,
+    # so it takes the same token ceiling on top of the arch check.
+    num_tokens = deferred_output.expert_weights.shape[0]
+
     return moe_finalize_fuse_shared(
         deferred_output.gemm2_out,
         deferred_output.expanded_idx_to_permuted_idx,
         deferred_output.expert_weights,
         shared_output,
         deferred_output.top_k,
-        enable_pdl=is_arch_support_pdl(),
+        enable_pdl=is_arch_support_pdl() and trtllm_moe_enable_pdl(num_tokens),
     )
 
 
@@ -1087,7 +1108,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
             activation_type=activation_type,
             tune_max_num_tokens=next_power_of_2(hs_fp4.shape[0]),
             output=symm_output,
-            enable_pdl=hs_fp4.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
+            enable_pdl=trtllm_moe_enable_pdl(hs_fp4.shape[0]),
         )[0]
     else:
         assert TopKOutputChecker.format_is_bypassed(topk_output)
@@ -1131,7 +1152,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
             do_finalize=not defer_finalize,
             activation_type=activation_type,
             tune_max_num_tokens=next_power_of_2(hs_fp4.shape[0]),
-            enable_pdl=hs_fp4.shape[0] <= _TRTLLM_MOE_PDL_MAX_TOKENS,
+            enable_pdl=trtllm_moe_enable_pdl(hs_fp4.shape[0]),
         )
         if not defer_finalize:
             moe_kwargs["output"] = symm_output

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -52,19 +52,6 @@ _TRTLLM_MOE_PDL_MAX_TOKENS = envs.SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS.get()
 
 
 def trtllm_moe_enable_pdl(num_tokens: int) -> bool:
-    """Whether to run the trtllm-gen MoE with programmatic dependent launch.
-
-    PDL on these kernels can leave the consumer's grid-dependency wait
-    unreleased when another stream overlaps the launch, stranding the whole TP
-    group at its next collective (see 6a1d1f4422, landed in #31681). The
-    consumer is the finalize kernel, launched with one block per token, so the
-    pressure it puts on the producer GEMM grows with the token count -- and
-    large calls gain nothing from PDL to begin with.
-
-    Every trtllm-gen MoE call site should route its PDL decision through here
-    rather than passing a literal or leaving the argument off, which lets
-    FlashInfer default it to on with no ceiling.
-    """
     return num_tokens <= _TRTLLM_MOE_PDL_MAX_TOKENS
 
 
@@ -94,17 +81,14 @@ def finalize_flashinfer_trtllm_deferred_output(
     from sglang.kernels.jit.utils import is_arch_support_pdl
     from sglang.kernels.ops.moe.moe_finalize_fuse_shared import moe_finalize_fuse_shared
 
-    # Same producer (the trtllm-gen GEMM2) as the in-op finalize this replaces,
-    # so it takes the same token ceiling on top of the arch check.
-    num_tokens = deferred_output.expert_weights.shape[0]
-
     return moe_finalize_fuse_shared(
         deferred_output.gemm2_out,
         deferred_output.expanded_idx_to_permuted_idx,
         deferred_output.expert_weights,
         shared_output,
         deferred_output.top_k,
-        enable_pdl=is_arch_support_pdl() and trtllm_moe_enable_pdl(num_tokens),
+        enable_pdl=is_arch_support_pdl()
+        and trtllm_moe_enable_pdl(deferred_output.expert_weights.shape[0]),
     )
 
 

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -1434,6 +1434,10 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         if self._fi_kernel == "cutlass_sm120":
             return self._apply_sm120_cutlass(layer, dispatch_output)
         if self.use_flashinfer:
+            from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+                trtllm_moe_enable_pdl,
+            )
+
             # When bf16 mode is enabled, we don't need to quantize the input,
             # TRT-LLM automatically handles quantization in the kernel implementation and pipelines it with GEMM operations,
             # which can theoretically improve performance
@@ -1591,6 +1595,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                         tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
                         output=symm_output,
                         do_finalize=not defer_finalize,
+                        enable_pdl=trtllm_moe_enable_pdl(x_quant.shape[0]),
                     )
                     if defer_finalize:
                         from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
@@ -1650,6 +1655,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     local_num_experts=layer.num_local_experts,
                     tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
                     output=symm_output,
+                    enable_pdl=trtllm_moe_enable_pdl(x_quant.shape[0]),
                 )
                 return StandardCombineInput(hidden_states=symm_output)
 
@@ -1682,6 +1688,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                 True,  # do finalize
                 tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
                 output=symm_output,
+                enable_pdl=trtllm_moe_enable_pdl(x_quant.shape[0]),
             )[0]
             return StandardCombineInput(hidden_states=trtllm_gen_output)
         if _use_aiter:

--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -319,6 +319,10 @@ class Mxfp4FlashinferTrtllmMoEMethod:
         else:
             raise NotImplementedError(f"Unsupported mxfp4 moe precision: {precision}")
 
+        from sglang.srt.layers.moe.moe_runner.flashinfer_trtllm import (
+            trtllm_moe_enable_pdl,
+        )
+
         with use_symmetric_memory(
             get_tp_group(), disabled=not is_allocation_symmetric()
         ):
@@ -361,6 +365,7 @@ class Mxfp4FlashinferTrtllmMoEMethod:
             do_finalize=True,
             tune_max_num_tokens=next_power_of_2(x_quant.shape[0]),
             output=symm_output,
+            enable_pdl=trtllm_moe_enable_pdl(num_tokens),
         )[0]
 
         return StandardCombineInput(hidden_states=output)


### PR DESCRIPTION
## Motivation

PDL on the trtllm-gen MoE can leave its grid-dependency wait unreleased when another stream overlaps the launch. The stalled rank never reaches its next collective, so the entire TP group hangs. `6a1d1f4422` (landed in #31681) identified this and capped PDL by token count via `SGLANG_TRTLLM_MOE_PDL_MAX_TOKENS` — but only at the two fp4 call sites in `moe_runner/flashinfer_trtllm.py`.

The mxfp4 call sites never passed `enable_pdl` at all. FlashInfer then defaults it to `device_support_pdl()` — on for SM90+, with no ceiling. **The env var cannot reach those paths at any setting.**

That includes the Kimi-K3 SiTU routed path, where a TP8 SM103 engine hangs during long-context prefill at the default `--chunked-prefill-size 16384`, twice the existing 8192 threshold.

## Evidence

From an 8-rank CUDA coredump taken by the watchdog while the ranks were still wedged:

- **All 5,296 warps** of the finalize kernel (`moe::dev::finalize::finalizeKernelVecLoad<KernelParams<bfloat16_t,bfloat16_t,4,true>>` — trailing `true` is `UsePdl`) sit at **one** PC: `+5200`, the `ACQBULK` that implements `cudaGridDependencySynchronize()`. Zero divergence across the whole grid.
- Its producer GEMM has **26 of 82,236 CTAs** resident. All 148 SMs are at their block limit: 122 SMs × 5 finalize CTAs + 26 SMs × (2 finalize + 1 GEMM) = 662 finalize CTAs, exactly as observed.
- The producer runs 2-CTA clusters (`c2x1x1`); every cluster pair occupies consecutive SM ids, so placement needs a co-schedulable SM pair that never appears.
- The other seven ranks spin in `all_reduce_pull_norm_kernel` on an unbounded semaphore loop with no timeout, waiting for the eighth participant.
- The finalize grid is launched with `numBlocks = data.numTokens` (`trtllm_fused_moe_dev_kernel.cu:1034`), one block per token.

## Changes

Add `trtllm_moe_enable_pdl(num_tokens)` next to the threshold it reads, and route every call site through it so a new one cannot silently inherit PDL-on:

- `mxfp4.py` — SiTU routed (the path that hangs), SiTU bypassed-topk, and block-scale (GPT-OSS)
- `mxfp4_flashinfer_trtllm_moe.py` — fp4 routed
- the deferred-finalize path, which fuses the shared-expert add into sglang's own `moe_finalize_fuse_shared` and gated PDL on `is_arch_support_pdl()` alone. Kimi-K3 takes this branch, and its PDL consumer is a different kernel from FlashInfer's in-op finalize, so threading `enable_pdl` into the trtllm call would not have covered it.
- the two already-capped sites, now sharing the one definition

`trtllm_bf16_moe` is deliberately untouched: no call site passes `enable_pdl` today, so its signature is unverified from this tree.

## Threshold value is out of scope

The coredump suggests 8192 may be too high: the finalize kernel's SM footprint is clamped by occupancy at ~740 resident blocks (148 SMs × 5) rather than scaling with token count, so an 8192-token grid floods the machine as thoroughly as the 16384-token one that hangs. That would leave 740–8192 nominally capped but still in the flood regime.

It is not settled enough to move the constant. `tune_max_num_tokens=next_power_of_2(num_tokens)` may select a different GEMM tactic at 8192 than at 16384, which would account for the soak result behind the current default without the occupancy model holding.

This PR restores the knob's reach. Retuning it belongs in a separate change, after a tactic comparison at both sizes.

## Testing
[TODO]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
