### PR TITLE
replace LM head GEMM dtype to fp32 instead of bf16

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -703,27 +703,22 @@ class LogitsProcessor(nn.Module):
         elif should_apply_lm_head_quant_method(lm_head, quant_method):
             logits = quant_method.apply(lm_head, hidden_states, embedding_bias)
         elif hasattr(lm_head, "weight"):
-            # Normal linear layer
-            if self.use_fp32_lm_head:
-                # Avoid materializing FP32 copies for same-dtype CUDA FP16/BF16
-                # inputs. Retain explicit FP32 casts for unsupported devices or
-                # dtype combinations.
-                use_mm_out_dtype = (
-                    hidden_states.is_cuda
-                    and hidden_states.dtype == lm_head.weight.dtype
-                    and hidden_states.dtype in (torch.float16, torch.bfloat16)
+            # Normal linear layer. Keep the GEMM's FP32 accumulator instead of
+            # rounding to BF16 and widening again in _copy_logits_to_buffer
+            use_mm_out_dtype = (
+                hidden_states.is_cuda
+                and hidden_states.dtype == lm_head.weight.dtype
+                and hidden_states.dtype in (torch.float16, torch.bfloat16)
+            )
+            if use_mm_out_dtype and self.rl_on_policy_target is None:
+                logits = torch.mm(
+                    hidden_states, lm_head.weight.T, out_dtype=torch.float32
                 )
-                if use_mm_out_dtype:
-                    logits = torch.mm(
-                        hidden_states,
-                        lm_head.weight.T,
-                        out_dtype=torch.float32,
-                    )
-                else:
-                    logits = torch.matmul(
-                        hidden_states.to(torch.float32),
-                        lm_head.weight.to(torch.float32).T,
-                    )
+            elif self.use_fp32_lm_head:
+                logits = torch.matmul(
+                    hidden_states.to(torch.float32),
+                    lm_head.weight.to(torch.float32).T,
+                )
             elif use_intel_amx_backend(lm_head):
                 logits = torch.ops.sgl_kernel.weight_packed_linear(
                     hidden_states.to(lm_head.weight.dtype),

--- a/test/registered/rl/test_fp32_lm_head.py
+++ b/test/registered/rl/test_fp32_lm_head.py
@@ -158,19 +158,27 @@ class TestLMHeadFP32(unittest.TestCase):
             "matmul",
         )
 
+    # With the flag off, CUDA FP16/BF16 still uses the FP32-output GEMM.
     def test_flag_false_fp16_path(self):
+        expected_operation = "mm" if torch.cuda.is_available() else "matmul"
         self._run_case(
-            torch.float16, False, torch.float16, torch.float16, torch.float16, "matmul"
+            torch.float16,
+            False,
+            torch.float16,
+            torch.float16,
+            torch.float16,
+            expected_operation,
         )
 
     def test_flag_false_bf16_path(self):
+        expected_operation = "mm" if torch.cuda.is_available() else "matmul"
         self._run_case(
             torch.bfloat16,
             False,
             torch.bfloat16,
             torch.bfloat16,
             torch.bfloat16,
-            "matmul",
+            expected_operation,
         )
 
 


### PR DESCRIPTION
WIP for #33627 ;u;

## Motivation

the `_compute_lm_head` function in `python/sglang/srt/layers/logits_processor.py` performs GEMMs internally fp32 but returns them in bf16 format before casting them back as fp32 objects in `_copy_logits_to_buffer` so there's no need to truncate things into bf16 in the first place.

#33627 already shows that removing the bf16 cast can improve accuracy and decode time for TP=1 but benchmarking is still needed for more TP variants across popular OSS models 

## Modifications

<!-- Detail the changes made in this pull request. -->

logits = torch.mm(hidden_states, lm_head.weight.T, out_dtype=torch.float32) 


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #31764078189](https://github.com/sgl-project/sglang/actions/runs/31764078189)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31764078098](https://github.com/sgl-project/sglang/actions/runs/31764078098)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->