### PR TITLE
[Kimi-K3] Support direct SiTU activation in MegaMoE

### DIFF
--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -133,6 +133,7 @@ logger = logging.getLogger(__name__)
 _is_hip = is_hip()
 _is_npu = is_npu()
 _aiter_k3_opt = get_bool_env_var("SGLANG_AITER_K3_OPT")
+_DEEPGEMM_SUPPORT_SITU_NO_HACK = get_bool_env_var("_DEEPGEMM_SUPPORT_SITU_NO_HACK")
 _k3_shared_experts_attn_tp = envs.SGLANG_K3_SHARED_EXPERTS_ATTN_TP.get()
 _k3_dense_mlp_attn_tp = envs.SGLANG_K3_DENSE_MLP_ATTN_TP.get()
 
@@ -796,16 +797,24 @@ class KimiK3MoE(nn.Module):
             dtype=torch.bfloat16,
             device=routed_input.device,
         )
+        # TODO: Remove this temporary compatibility branch once OSS DeepGEMM
+        # supports activation="situ" directly.
+        if _DEEPGEMM_SUPPORT_SITU_NO_HACK:
+            activation_kwargs = {"activation": "situ"}
+        else:
+            activation_kwargs = {
+                "activation": "swiglu",
+                # Sentinel: selects the K3 SiTU branch in the DeepGEMM mega kernel
+                # (beta=4.0 / linear_beta=25.0 baked in).
+                "activation_clamp": _K3_MEGA_SITU_SENTINEL_CLAMP,
+            }
         deep_gemm.fp8_fp4_mega_moe(
             y,
             self.experts.mega_l1_weights,
             self.experts.mega_l2_weights,
             buf,
             recipe=(1, 1, 32),
-            activation="swiglu",
-            # Sentinel: selects the K3 SiTU branch in the DeepGEMM mega kernel
-            # (beta=4.0 / linear_beta=25.0 baked in).
-            activation_clamp=_K3_MEGA_SITU_SENTINEL_CLAMP,
+            **activation_kwargs,
             fast_math=True,
         )
         y = y[:num_tokens]


### PR DESCRIPTION
## Motivation

Kimi-K3 MegaMoE currently reaches SiTU through the sentinel-compatible DeepGEMM API. DeepGEMM builds that expose SiTU directly should use `activation="situ"` without the sentinel clamp, while older builds must keep working.

## Modifications

Add a temporary `_DEEPGEMM_SUPPORT_SITU_NO_HACK` compatibility switch. The default preserves the existing sentinel path; enabling it selects the direct SiTU activation API.

## Accuracy Tests

- Focused MegaMoE SiTU correctness validation: passed (1 test).
- `python3 -m py_compile python/sglang/srt/models/kimi_k3.py`
- `pre-commit run --files python/sglang/srt/models/kimi_k3.py`

## Speed Tests and Profiling

Not run; this only selects between two APIs for the same fused SiTU path.

## Checklist

- [x] Format the code with pre-commit.
- [ ] Add unit tests (covered by the focused correctness validation above).
- [ ] Update documentation (temporary compatibility switch only).
- [ ] Provide accuracy and speed benchmark results (accuracy checked; performance not rerun).
- [x] Follow the SGLang code style guidance.

## Original commits

- `c7b7ee2bf5`
- `069c38cf9d`
- `231e4c94fb`
- `8659c7a838`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31755745424](https://github.com/sgl-project/sglang/actions/runs/31755745424)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31755744850](https://github.com/sgl-project/sglang/actions/runs/31755744850)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->