### PR TITLE
fix(deepseek_v2): don't coerce unscaled MLA models onto deepseek_yarn

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1707,6 +1707,20 @@ class DeepseekV2MoE(nn.Module):
         state.hidden_states_mlp_output = final_hidden_states
 
 
+def _has_rope_scaling(rope_scaling) -> bool:
+    """True only when RoPE scaling is actually configured.
+
+    transformers v5 exposes config.rope_scaling as an alias of rope_parameters,
+    which is always populated (rope_type="default" when unscaled). Plain
+    truthiness therefore no longer distinguishes scaled from unscaled configs,
+    and using it as such coerces unscaled MLA models onto the deepseek_yarn path.
+    """
+    if not rope_scaling:
+        return False
+    rope_type = rope_scaling.get("rope_type") or rope_scaling.get("type")
+    return rope_type not in (None, "default")
+
+
 class DeepseekV2AttentionMLA(
     nn.Module,
     DeepseekMHAForwardMixin,
@@ -1772,7 +1786,7 @@ class DeepseekV2AttentionMLA(
         self.kv_cache_dtype = get_model().kv_cache_dtype
 
         # NOTE modification to rope_scaling must be done early enough, b/c e.g. Indexer needs it
-        if rope_scaling:
+        if _has_rope_scaling(rope_scaling):
             rope_scaling["rope_type"] = "deepseek_yarn"
 
         # For tensor parallel attention
@@ -1884,11 +1898,13 @@ class DeepseekV2AttentionMLA(
                 device=get_device().device,
             )
 
-            if rope_scaling and rope_scaling.get("apply_yarn_scaling", True):
+            if _has_rope_scaling(rope_scaling) and rope_scaling.get(
+                "apply_yarn_scaling", True
+            ):
                 self.scaling = compute_mla_mscale_scaling(rope_scaling, self.scaling)
         else:
             self.rotary_emb = None
-        self.use_deepseek_yarn_rope = rope_scaling is not None
+        self.use_deepseek_yarn_rope = _has_rope_scaling(rope_scaling)
 
         self.attn_mqa = RadixAttention(
             self.num_local_heads,


### PR DESCRIPTION
## Motivation

`DeepseekV2AttentionMLA` treats a truthy `rope_scaling` as "scaling is
configured":

```python
# python/sglang/srt/models/deepseek_v2.py
if rope_scaling:
    rope_scaling["rope_type"] = "deepseek_yarn"
```

That held on transformers v4, where unscaled models had `rope_scaling = None`.
On v5, `config.rope_scaling` aliases `rope_parameters` and is **always**
populated — for GLM-4.7-Flash:

```python
{'rope_theta': 1000000, 'partial_rotary_factor': 1.0, 'rope_type': 'default'}
```

So every unscaled MLA model is now coerced onto the YaRN path and reaches
branches expecting keys its config never carried (notably
`original_max_position_embeddings`).

This repo already recognises the v5 aliasing — `rotary_embedding/factory.py::_get_rope_param`
documents it and warns + defaults. That handles the symptom; this PR removes the
coercion that makes the fallback necessary. On ROCm the same config is fatal
rather than a warning, because aiter's vendored `get_rope` has no equivalent
fallback (see ROCm/aiter#4742).

## Modifications

Adds `_has_rope_scaling()`, true only when `rope_type`/`type` is neither `None`
nor `"default"`, and uses it at the three sites that made the v4 assumption:

| Line | Before |
| --- | --- |
| 1775 | `if rope_scaling:` |
| 1887 | `if rope_scaling and rope_scaling.get("apply_yarn_scaling", True):` |
| 1891 | `self.use_deepseek_yarn_rope = rope_scaling is not None` |

Scope: configs declaring `rope_type="yarn"`/`"deepseek_yarn"` (DeepSeek, Kimi,
etc.) are unaffected and still take the YaRN path. Only configs explicitly
declaring `default` stop being coerced.

Line 1891 feeds `hardware_backend/npu/modules/deepseek_v2_attention_mla_npu.py`,
where the same issue is latent — unscaled MLA models currently get YaRN
attention on Ascend NPU.

## Accuracy Tests

GLM-4.7-Flash on 8x MI355X, ROCm 7.2, transformers 5.12.1, `SGLANG_USE_AITER=1`.

Without the change the model runs YaRN with defaulted parameters. That path is
numerically a no-op for this config — `factor` defaults to 1.0, so
`compute_mla_mscale_scaling` returns the base scaling unchanged:

```
compute_mla_mscale_scaling({'rope_type':'deepseek_yarn', ...}, 0.1234) -> 0.1234
```

so this change is not expected to move accuracy for GLM-4.7-Flash; it removes an
incorrect code path and the warning that came with it. For a model whose config
*does* supply `factor`, the coercion would have applied real YaRN scaling that
the model was not trained with — that is the case this prevents.

Verified end to end: 8 engines initialize (`max_total_num_tokens=2870263`,
`context_len=202752`) and a GRPO training loop runs (rollout -> backward ->
weight sync).

## Speed Tests and Profiling

Not applicable — no kernel or scheduling changes. The modified lines execute
once per attention module at construction time.

## Checklist

- [x] Change is limited to the rope_scaling predicate; no numerics change for
      configs that declare an actual scaling type
- [x] Verified on ROCm (MI355X); NPU path not tested — no hardware available
- [x] Companion fallback for aiter's vendored `get_rope`: ROCm/aiter#4742
