### PR TITLE
fix(docs): fix typos in DP for multimodal encoder doc

### DIFF
--- a/docs/docs/advanced_features/dp_for_multi_modal_encoder.mdx
+++ b/docs/docs/advanced_features/dp_for_multi_modal_encoder.mdx
@@ -3,11 +3,11 @@ title: "DP for Multi-Modal Encoder in SGLang"
 metatags:
     description: "Data parallelism for VLM vision encoder in SGLang: reduce TTFT, boost throughput. Supports Qwen2.5-VL, Qwen3-VL, InternVL, GLM-4.5V/4.6V."
 ---
-A typical VLM architecture involves two main components: an multi-modal encoder and a text decoder.
+A typical VLM architecture involves two main components: a multi-modal encoder and a text decoder.
 
 Most VLMs utilize a Vision Transformer (ViT) as their multi-modal encoder, it is responsible for processing visual data, extracting features (objects, colors, textures, etc.), and transforming them into a format that can be understood by the model.
 
-The text deocoder is based on LLM. It processes textual data and generates output based on the encoded visual features.
+The text decoder is based on LLM. It processes textual data and generates output based on the encoded visual features.
 
 However, since the size of ViT is very small compared to language decoders,
 there is relatively little gain from TP. On the other hand, TP incurs significant communication


### PR DESCRIPTION
## What does this PR do?

Fixes two typos in `docs/docs/advanced_features/dp_for_multi_modal_encoder.mdx`:

1. `deocoder` → `decoder` (line 10)
2. `an multi-modal encoder` → `a multi-modal encoder` (line 6, grammar fix: "a" before consonant sound)

## Changes

- Line 6: `an multi-modal` → `a multi-modal`
- Line 10: `deocoder` → `decoder`

## Checklist

- [x] No code changes, documentation only
- [x] Verified the diff is minimal and correct

Made with [Proma](https://proma.cool) · [GitHub](https://github.com/proma-ai/Proma)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #31764802157](https://github.com/sgl-project/sglang/actions/runs/31764802157)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #31764802114](https://github.com/sgl-project/sglang/actions/runs/31764802114)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->